### PR TITLE
Let clients mark stable prompt anchors for Skippy cache

### DIFF
--- a/crates/mesh-llm-host-runtime/src/sdk.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk.rs
@@ -426,6 +426,7 @@ impl EmbeddedServingController {
             reasoning_effort: None,
             prompt_cache_key: None,
             prompt_cache_retention: None,
+            prompt_cache_anchor_tokens: None,
             stream_options: None,
             extra: BTreeMap::new(),
         };

--- a/crates/openai-frontend/src/chat.rs
+++ b/crates/openai-frontend/src/chat.rs
@@ -39,6 +39,7 @@ pub struct ChatCompletionRequest {
     pub reasoning_effort: Option<ReasoningEffort>,
     pub prompt_cache_key: Option<String>,
     pub prompt_cache_retention: Option<PromptCacheRetention>,
+    pub prompt_cache_anchor_tokens: Option<u32>,
     pub stream_options: Option<StreamOptions>,
     #[serde(flatten)]
     pub extra: BTreeMap<String, Value>,

--- a/crates/openai-frontend/src/completions.rs
+++ b/crates/openai-frontend/src/completions.rs
@@ -35,6 +35,7 @@ pub struct CompletionRequest {
     pub reasoning_effort: Option<ReasoningEffort>,
     pub prompt_cache_key: Option<String>,
     pub prompt_cache_retention: Option<PromptCacheRetention>,
+    pub prompt_cache_anchor_tokens: Option<u32>,
     pub stream_options: Option<StreamOptions>,
     #[serde(flatten)]
     pub extra: BTreeMap<String, Value>,

--- a/crates/openai-frontend/src/guardrails/retry.rs
+++ b/crates/openai-frontend/src/guardrails/retry.rs
@@ -39,6 +39,7 @@ pub(crate) fn build_retry_request(
     );
     if attempt_index > 0 {
         retry_request.prompt_cache_key = None;
+        retry_request.prompt_cache_anchor_tokens = None;
     }
     retry_request
 }

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -978,7 +978,7 @@ fn handle_binary_connection(
             }
         }
 
-        if let Some(full_prompt_tokens) = decode_record_tokens_sideband(&message) {
+        if let Some(record_sideband) = decode_record_tokens_sideband(&message) {
             let mut runtime = runtime.lock().expect("runtime lock poisoned");
             let record = maybe_record_binary_full_prefill(
                 config,
@@ -987,10 +987,26 @@ fn handle_binary_connection(
                 telemetry,
                 &session_key,
                 &message,
-                full_prompt_tokens,
+                record_sideband.tokens,
             );
+            let anchor_record = record_sideband
+                .anchor_token_count
+                .and_then(|token_count| record_sideband.tokens.get(..token_count))
+                .map(|anchor_tokens| {
+                    maybe_record_binary_full_prefill(
+                        config,
+                        &mut runtime,
+                        kv,
+                        telemetry,
+                        &session_key,
+                        &message,
+                        anchor_tokens,
+                    )
+                })
+                .unwrap_or_default();
             drop(runtime);
             add_binary_record_stats(&mut message_reply_stats, config, &record);
+            add_binary_record_stats(&mut message_reply_stats, config, &anchor_record);
         }
 
         let mut forward_write_ms = 0.0;
@@ -3377,7 +3393,12 @@ fn decode_execution_token(message: &StageWireMessage, token_count: usize) -> Opt
     Some(message.state.current_token)
 }
 
-fn decode_record_tokens_sideband(message: &StageWireMessage) -> Option<&[i32]> {
+struct DecodeRecordSideband<'a> {
+    tokens: &'a [i32],
+    anchor_token_count: Option<usize>,
+}
+
+fn decode_record_tokens_sideband(message: &StageWireMessage) -> Option<DecodeRecordSideband<'_>> {
     if message.kind != WireMessageKind::DecodeEmbd
         || message.token_count != 1
         || message.state.prompt_token_count <= 0
@@ -3392,7 +3413,22 @@ fn decode_record_tokens_sideband(message: &StageWireMessage) -> Option<&[i32]> {
     {
         return None;
     }
-    Some(message.tokens.as_slice())
+    Some(DecodeRecordSideband {
+        tokens: message.tokens.as_slice(),
+        anchor_token_count: decode_record_anchor_token_count(message, expected_token_count),
+    })
+}
+
+fn decode_record_anchor_token_count(
+    message: &StageWireMessage,
+    record_token_count: usize,
+) -> Option<usize> {
+    let [anchor_token_count] = message.positions.as_slice() else {
+        return None;
+    };
+    let anchor_token_count = usize::try_from(*anchor_token_count).ok()?;
+    (anchor_token_count > 0 && anchor_token_count < record_token_count)
+        .then_some(anchor_token_count)
 }
 
 fn add_binary_record_stats(

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -978,7 +978,7 @@ fn handle_binary_connection(
             }
         }
 
-        if let Some(full_prompt_tokens) = decode_full_prompt_sideband(&message) {
+        if let Some(full_prompt_tokens) = decode_record_tokens_sideband(&message) {
             let mut runtime = runtime.lock().expect("runtime lock poisoned");
             let record = maybe_record_binary_full_prefill(
                 config,
@@ -3377,16 +3377,17 @@ fn decode_execution_token(message: &StageWireMessage, token_count: usize) -> Opt
     Some(message.state.current_token)
 }
 
-fn decode_full_prompt_sideband(message: &StageWireMessage) -> Option<&[i32]> {
+fn decode_record_tokens_sideband(message: &StageWireMessage) -> Option<&[i32]> {
     if message.kind != WireMessageKind::DecodeEmbd
         || message.token_count != 1
-        || message.state.decode_step != 0
         || message.state.prompt_token_count <= 0
     {
         return None;
     }
     let prompt_token_count = usize::try_from(message.state.prompt_token_count).ok()?;
-    if message.tokens.len() != prompt_token_count
+    let decode_step = usize::try_from(message.state.decode_step).ok()?;
+    let expected_token_count = prompt_token_count.checked_add(decode_step)?;
+    if message.tokens.len() != expected_token_count
         || message.tokens.last().copied() != Some(message.state.current_token)
     {
         return None;

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -978,6 +978,21 @@ fn handle_binary_connection(
             }
         }
 
+        if let Some(full_prompt_tokens) = decode_full_prompt_sideband(&message) {
+            let mut runtime = runtime.lock().expect("runtime lock poisoned");
+            let record = maybe_record_binary_full_prefill(
+                config,
+                &mut runtime,
+                kv,
+                telemetry,
+                &session_key,
+                &message,
+                full_prompt_tokens,
+            );
+            drop(runtime);
+            add_binary_record_stats(&mut message_reply_stats, config, &record);
+        }
+
         let mut forward_write_ms = 0.0;
         let mut forward_activation_encode_ms = 0.0;
         let mut downstream_wait_ms = 0.0;
@@ -2098,6 +2113,19 @@ fn handle_binary_restore_prefill_decode_control(
                 .context("restore-decode downstream miss ACK")?;
             return Ok(());
         }
+        {
+            let mut runtime = runtime.lock().expect("runtime lock poisoned");
+            let record = maybe_record_binary_full_prefill(
+                config,
+                &mut runtime,
+                kv,
+                telemetry,
+                session_id,
+                message,
+                message.tokens.as_slice(),
+            );
+            add_binary_record_stats(&mut control_stats, config, &record);
+        }
         let mut attrs = binary_message_attrs(config, wire_session_id, message);
         attrs.insert("skippy.kv.control_hit".to_string(), json!(true));
         attrs.insert(
@@ -2127,6 +2155,19 @@ fn handle_binary_restore_prefill_decode_control(
         return Ok(());
     }
 
+    {
+        let mut runtime = runtime.lock().expect("runtime lock poisoned");
+        let record = maybe_record_binary_full_prefill(
+            config,
+            &mut runtime,
+            kv,
+            telemetry,
+            session_id,
+            message,
+            message.tokens.as_slice(),
+        );
+        add_binary_record_stats(&mut control_stats, config, &record);
+    }
     let mut attrs = binary_message_attrs(config, wire_session_id, message);
     attrs.insert("skippy.kv.control_hit".to_string(), json!(true));
     attrs.insert(
@@ -3303,6 +3344,9 @@ fn token_sideband_or_fill(message: &StageWireMessage) -> Result<Vec<i32>> {
         .token_count
         .try_into()
         .context("negative token_count")?;
+    if let Some(token) = decode_execution_token(message, token_count) {
+        return Ok(vec![token]);
+    }
     if message.tokens.len() == token_count {
         return Ok(message.tokens.clone());
     }
@@ -3315,6 +3359,55 @@ fn token_sideband_or_fill(message: &StageWireMessage) -> Result<Vec<i32>> {
         0
     };
     Ok(vec![fill; token_count])
+}
+
+fn decode_execution_token(message: &StageWireMessage, token_count: usize) -> Option<i32> {
+    if !matches!(
+        message.kind,
+        WireMessageKind::DecodeEmbd
+            | WireMessageKind::DecodeReadout
+            | WireMessageKind::DecodeLightCtx
+            | WireMessageKind::DecodeReplayEmbd
+            | WireMessageKind::DecodeReplayFinalEmbd
+    ) || token_count != 1
+        || message.state.current_token == skippy_protocol::binary::LLAMA_TOKEN_NULL
+    {
+        return None;
+    }
+    Some(message.state.current_token)
+}
+
+fn decode_full_prompt_sideband(message: &StageWireMessage) -> Option<&[i32]> {
+    if message.kind != WireMessageKind::DecodeEmbd
+        || message.token_count != 1
+        || message.state.decode_step != 0
+        || message.state.prompt_token_count <= 0
+    {
+        return None;
+    }
+    let prompt_token_count = usize::try_from(message.state.prompt_token_count).ok()?;
+    if message.tokens.len() != prompt_token_count
+        || message.tokens.last().copied() != Some(message.state.current_token)
+    {
+        return None;
+    }
+    Some(message.tokens.as_slice())
+}
+
+fn add_binary_record_stats(
+    reply_stats: &mut StageReplyStats,
+    config: &StageConfig,
+    record: &BinaryKvRecordResult,
+) {
+    if record.recorded_pages > 0 {
+        reply_stats.kv_recorded_pages += record.recorded_pages as i64;
+        reply_stats.kv_record_stage_mask |= stage_mask(config.stage_index);
+    }
+    if record.recorded_activations > 0 {
+        reply_stats.kv_recorded_bytes = reply_stats
+            .kv_recorded_bytes
+            .saturating_add(record.recorded_activation_bytes as i64);
+    }
 }
 
 #[cfg(test)]

--- a/crates/skippy-server/src/binary_transport/tests.rs
+++ b/crates/skippy-server/src/binary_transport/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    binary_full_prefill_record_identities, decode_full_prompt_sideband,
+    binary_full_prefill_record_identities, decode_record_tokens_sideband,
     prepare_binary_stage_connection, restore_prefill_decode_as_decode_message,
     token_sideband_or_fill,
 };
@@ -173,22 +173,36 @@ fn first_decode_message_with_full_prompt_sideband() -> StageWireMessage {
 }
 
 #[test]
-fn decode_full_prompt_sideband_records_metadata_without_changing_exec_token() {
+fn decode_record_tokens_sideband_records_metadata_without_changing_exec_token() {
     let message = first_decode_message_with_full_prompt_sideband();
 
     let exec_tokens = token_sideband_or_fill(&message).unwrap();
-    let prompt_tokens = decode_full_prompt_sideband(&message).unwrap();
+    let prompt_tokens = decode_record_tokens_sideband(&message).unwrap();
 
     assert_eq!(exec_tokens, vec![104]);
     assert_eq!(prompt_tokens, &[101, 102, 103, 104]);
 }
 
 #[test]
-fn decode_full_prompt_sideband_requires_first_decode() {
+fn decode_record_tokens_sideband_accepts_decode_checkpoint() {
+    let mut message = first_decode_message_with_full_prompt_sideband();
+    message.state.decode_step = 1;
+    message.state.current_token = 201;
+    message.tokens.push(201);
+
+    assert_eq!(
+        decode_record_tokens_sideband(&message).unwrap(),
+        &[101, 102, 103, 104, 201]
+    );
+    assert_eq!(token_sideband_or_fill(&message).unwrap(), vec![201]);
+}
+
+#[test]
+fn decode_record_tokens_sideband_rejects_wrong_checkpoint_len() {
     let mut message = first_decode_message_with_full_prompt_sideband();
     message.state.decode_step = 1;
 
-    assert!(decode_full_prompt_sideband(&message).is_none());
+    assert!(decode_record_tokens_sideband(&message).is_none());
     assert_eq!(token_sideband_or_fill(&message).unwrap(), vec![104]);
 }
 

--- a/crates/skippy-server/src/binary_transport/tests.rs
+++ b/crates/skippy-server/src/binary_transport/tests.rs
@@ -177,10 +177,11 @@ fn decode_record_tokens_sideband_records_metadata_without_changing_exec_token() 
     let message = first_decode_message_with_full_prompt_sideband();
 
     let exec_tokens = token_sideband_or_fill(&message).unwrap();
-    let prompt_tokens = decode_record_tokens_sideband(&message).unwrap();
+    let record_sideband = decode_record_tokens_sideband(&message).unwrap();
 
     assert_eq!(exec_tokens, vec![104]);
-    assert_eq!(prompt_tokens, &[101, 102, 103, 104]);
+    assert_eq!(record_sideband.tokens, &[101, 102, 103, 104]);
+    assert_eq!(record_sideband.anchor_token_count, None);
 }
 
 #[test]
@@ -190,11 +191,22 @@ fn decode_record_tokens_sideband_accepts_decode_checkpoint() {
     message.state.current_token = 201;
     message.tokens.push(201);
 
-    assert_eq!(
-        decode_record_tokens_sideband(&message).unwrap(),
-        &[101, 102, 103, 104, 201]
-    );
+    let record_sideband = decode_record_tokens_sideband(&message).unwrap();
+    assert_eq!(record_sideband.tokens, &[101, 102, 103, 104, 201]);
+    assert_eq!(record_sideband.anchor_token_count, None);
     assert_eq!(token_sideband_or_fill(&message).unwrap(), vec![201]);
+}
+
+#[test]
+fn decode_record_tokens_sideband_accepts_anchor_position() {
+    let mut message = first_decode_message_with_full_prompt_sideband();
+    message.positions = vec![3];
+
+    let record_sideband = decode_record_tokens_sideband(&message).unwrap();
+
+    assert_eq!(record_sideband.tokens, &[101, 102, 103, 104]);
+    assert_eq!(record_sideband.anchor_token_count, Some(3));
+    assert_eq!(token_sideband_or_fill(&message).unwrap(), vec![104]);
 }
 
 #[test]

--- a/crates/skippy-server/src/binary_transport/tests.rs
+++ b/crates/skippy-server/src/binary_transport/tests.rs
@@ -1,6 +1,7 @@
 use super::{
-    binary_full_prefill_record_identities, prepare_binary_stage_connection,
-    restore_prefill_decode_as_decode_message,
+    binary_full_prefill_record_identities, decode_full_prompt_sideband,
+    prepare_binary_stage_connection, restore_prefill_decode_as_decode_message,
+    token_sideband_or_fill,
 };
 use std::{
     io,
@@ -148,6 +149,47 @@ fn prefill_message() -> StageWireMessage {
         activation: Vec::new(),
         raw_bytes: Vec::new(),
     }
+}
+
+fn first_decode_message_with_full_prompt_sideband() -> StageWireMessage {
+    let mut state = StageStateHeader::new(WireMessageKind::DecodeEmbd, WireActivationDType::F16);
+    state.prompt_token_count = 4;
+    state.decode_step = 0;
+    state.current_token = 104;
+    StageWireMessage {
+        kind: WireMessageKind::DecodeEmbd,
+        pos_start: 3,
+        token_count: 1,
+        state,
+        request_id: 11,
+        session_id: 13,
+        sampling: None,
+        chat_sampling_metadata: None,
+        tokens: vec![101, 102, 103, 104],
+        positions: Vec::new(),
+        activation: Vec::new(),
+        raw_bytes: Vec::new(),
+    }
+}
+
+#[test]
+fn decode_full_prompt_sideband_records_metadata_without_changing_exec_token() {
+    let message = first_decode_message_with_full_prompt_sideband();
+
+    let exec_tokens = token_sideband_or_fill(&message).unwrap();
+    let prompt_tokens = decode_full_prompt_sideband(&message).unwrap();
+
+    assert_eq!(exec_tokens, vec![104]);
+    assert_eq!(prompt_tokens, &[101, 102, 103, 104]);
+}
+
+#[test]
+fn decode_full_prompt_sideband_requires_first_decode() {
+    let mut message = first_decode_message_with_full_prompt_sideband();
+    message.state.decode_step = 1;
+
+    assert!(decode_full_prompt_sideband(&message).is_none());
+    assert_eq!(token_sideband_or_fill(&message).unwrap(), vec![104]);
 }
 
 #[test]

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -76,6 +76,7 @@ mod generation_flow;
 mod local_generation;
 mod prefill;
 mod prefix_cache;
+mod prompt_anchor;
 mod prompting;
 mod request;
 mod speculative;
@@ -1045,6 +1046,7 @@ impl OpenAiGenerationIds {
 struct OpenAiCacheHints {
     prompt_cache_key: Option<String>,
     prompt_cache_retention: Option<String>,
+    prompt_cache_anchor_tokens: Option<u32>,
 }
 
 impl OpenAiCacheHints {
@@ -1060,6 +1062,7 @@ impl OpenAiCacheHints {
                 .prompt_cache_retention
                 .map(prompt_cache_retention_label)
                 .map(ToString::to_string),
+            prompt_cache_anchor_tokens: request.prompt_cache_anchor_tokens,
         }
     }
 
@@ -1075,6 +1078,7 @@ impl OpenAiCacheHints {
                 .prompt_cache_retention
                 .map(prompt_cache_retention_label)
                 .map(ToString::to_string),
+            prompt_cache_anchor_tokens: request.prompt_cache_anchor_tokens,
         }
     }
 
@@ -1640,6 +1644,7 @@ struct EmbeddedStageZeroGeneration<'a> {
     speculative_window: usize,
     adaptive_speculative_window: bool,
     prompt_token_ids: &'a [i32],
+    prompt_anchor_token_count: Option<usize>,
     max_tokens: u32,
     sampling: &'a SamplingConfig,
     chat_sampling_metadata: Option<&'a str>,

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -107,6 +107,7 @@ pub const CONTEXT_BUDGET_MAX_TOKENS: u32 = u32::MAX;
 pub const DEFAULT_EMBEDDED_MAX_TOKENS: u32 = 4096;
 const GENERATION_ADMISSION_TIMEOUT: Duration = Duration::from_secs(10);
 const GENERATION_RETRY_AFTER_SECS: u64 = 1;
+const MAX_EXACT_REPLAY_TOKENS: usize = 8;
 
 pub async fn serve_openai(args: ServeOpenAiArgs) -> Result<()> {
     let config = load_json::<StageConfig>(&args.config)
@@ -1688,6 +1689,7 @@ struct EmbeddedStageExecution {
 
 struct EmbeddedFusedFirstDecode {
     predicted: i32,
+    predicted_tokens: Vec<i32>,
     reply_stats: StageReplyStats,
     execution: EmbeddedExecutionStats,
     elapsed_ms: f64,

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -1668,6 +1668,7 @@ struct EmbeddedLocalOutput {
     runtime_lock_hold_ms: f64,
 }
 
+#[derive(Default)]
 struct EmbeddedExecutionStats {
     stage0_compute_ms: f64,
     runtime_lock_wait_ms: f64,
@@ -1690,6 +1691,8 @@ struct EmbeddedFusedFirstDecode {
     reply_stats: StageReplyStats,
     execution: EmbeddedExecutionStats,
     elapsed_ms: f64,
+    token_phase: &'static str,
+    message_kind: &'static str,
 }
 
 struct EmbeddedSessionControl {

--- a/crates/skippy-server/src/frontend/backend.rs
+++ b/crates/skippy-server/src/frontend/backend.rs
@@ -305,6 +305,12 @@ impl StageOpenAiBackend {
                 json!(retention),
             );
         }
+        if let Some(anchor_tokens) = ids.cache.prompt_cache_anchor_tokens {
+            attrs.insert(
+                "openai.prompt_cache_anchor_tokens".to_string(),
+                json!(anchor_tokens),
+            );
+        }
         attrs
     }
 

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -479,6 +479,15 @@ impl StageOpenAiBackend {
                 "skippy.kv.chain_cache_hit_stage_mask".to_string(),
                 json!(prefill_chain_cache_stats.kv_hit_stage_mask),
             );
+            super::prefix_cache::insert_chain_prefix_cache_savings_attrs(
+                &mut prefill_attrs,
+                super::prefix_cache::chain_prefix_cache_savings(
+                    &prefill_chain_cache_stats,
+                    prefill_chain_restored_tokens,
+                    request.wire_dtype,
+                    request.activation_width,
+                ),
+            );
             self.emit_openai_phase("stage.openai_prefill", prefill_timer, prefill_attrs);
 
             if let Some(message) = generation_config_message(

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -148,6 +148,26 @@ impl StageOpenAiBackend {
                     );
                     cache_stats.hit_kind = Some("chain_prefix");
                 }
+                if prefill_chain_restored_tokens == 0
+                    && let Some(anchor_restore) = self.try_restore_embedded_split_prompt_anchor(
+                        &request,
+                        &session_key,
+                        downstream,
+                    )?
+                {
+                    prefill_chain_restored_tokens = anchor_restore.restored_tokens;
+                    prefill_chain_cache_stats = anchor_restore.stats;
+                    cache_stats.cached_prompt_tokens =
+                        saturating_u32(prefill_chain_restored_tokens);
+                    cache_stats.matched_prefix_tokens =
+                        saturating_u32(prefill_chain_restored_tokens);
+                    cache_stats.suffix_prefill_tokens = saturating_u32(
+                        prefill_tokens
+                            .len()
+                            .saturating_sub(prefill_chain_restored_tokens),
+                    );
+                    cache_stats.hit_kind = Some("chain_prompt_anchor");
+                }
                 let mut pos_start = prefill_chain_restored_tokens.min(prefill_tokens.len());
                 let mut chunk_index = 0usize;
                 while pos_start < prefill_tokens.len() {
@@ -1070,6 +1090,10 @@ impl StageOpenAiBackend {
                     message_tokens.len() == context_tokens.len() && message_tokens.len() > 1;
                 let records_full_prompt_checkpoint =
                     decode_step == 0 && message_tokens.len() == request.prompt_token_ids.len();
+                let message_positions = super::prompt_anchor::prompt_anchor_positions(
+                    request.prompt_anchor_token_count,
+                    context_tokens.len(),
+                );
                 let message = StageWireMessage {
                     kind: WireMessageKind::DecodeEmbd,
                     pos_start: i32::try_from(prefill_token_count + decode_step as usize)
@@ -1081,7 +1105,7 @@ impl StageOpenAiBackend {
                     sampling: wire_sampling.clone(),
                     chat_sampling_metadata: None,
                     tokens: message_tokens,
-                    positions: Vec::new(),
+                    positions: message_positions,
                     activation: Vec::new(),
                     raw_bytes: Vec::new(),
                 };
@@ -1169,12 +1193,26 @@ impl StageOpenAiBackend {
                             chat_sampling_metadata: request.chat_sampling_metadata,
                         },
                     )?;
+                    if decode_step == 0 {
+                        self.record_embedded_stage0_prompt_anchor(
+                            &session_key,
+                            request.ids,
+                            request.prompt_token_ids,
+                            request.prompt_anchor_token_count,
+                        )?;
+                    }
                 } else if records_full_prompt_checkpoint {
                     self.record_embedded_stage0_full_prompt_first_token(
                         &session_key,
                         request.ids,
                         request.prompt_token_ids,
                         reply.predicted,
+                    )?;
+                    self.record_embedded_stage0_prompt_anchor(
+                        &session_key,
+                        request.ids,
+                        request.prompt_token_ids,
+                        request.prompt_anchor_token_count,
                     )?;
                 }
                 current = reply.predicted;

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -72,11 +72,31 @@ impl StageOpenAiBackend {
                         .prompt_token_ids
                         .last()
                         .expect("checked non-empty prompt");
-                    if let Some(cached) = self.try_restore_embedded_split_full_prompt_first_token(
+                    if let Some(cached) = self.try_restore_embedded_split_exact_replay(
                         &request,
                         &session_key,
                         downstream,
                     )? {
+                        prefill_chain_cache_restored = true;
+                        prefill_chain_restored_tokens = request
+                            .prompt_token_ids
+                            .len()
+                            .saturating_add(cached.predicted_tokens.len().saturating_sub(1));
+                        prefill_chain_cache_stats = cached.reply_stats;
+                        cache_stats.cached_prompt_tokens =
+                            saturating_u32(request.prompt_token_ids.len());
+                        cache_stats.matched_prefix_tokens =
+                            saturating_u32(request.prompt_token_ids.len());
+                        cache_stats.suffix_prefill_tokens = 0;
+                        cache_stats.hit_kind = Some("chain_exact_replay");
+                        fused_first_decode = Some(cached);
+                    } else if let Some(cached) = self
+                        .try_restore_embedded_split_full_prompt_first_token(
+                            &request,
+                            &session_key,
+                            downstream,
+                        )?
+                    {
                         prefill_chain_cache_restored = true;
                         prefill_chain_restored_tokens = request.prompt_token_ids.len();
                         prefill_chain_cache_stats = cached.reply_stats;
@@ -549,11 +569,11 @@ impl StageOpenAiBackend {
                 .last()
                 .expect("checked non-empty prompt");
             let mut context_tokens = request.prompt_token_ids.to_vec();
+            let mut exact_replay_tokens = Vec::new();
             let mut fused_reached_stop = false;
             if let Some(fused) = fused_first_decode.take() {
                 current = fused.predicted;
-                decoded_tokens = 1;
-                context_tokens.push(current);
+                decoded_tokens = fused.predicted_tokens.len();
                 decode_stage0_compute_ms += fused.execution.stage0_compute_ms;
                 decode_runtime_lock_wait_ms += fused.execution.runtime_lock_wait_ms;
                 decode_runtime_lock_wait_max_ms =
@@ -569,56 +589,104 @@ impl StageOpenAiBackend {
                     .saturating_add(fused.execution.forward_activation_bytes);
                 decode_forward_write_ms += fused.execution.forward_write_ms;
                 decode_downstream_wait_ms += fused.execution.downstream_wait_ms;
-                let mut token_attrs = self.openai_attrs(request.ids);
-                token_attrs.insert("llama_stage.decode_step".to_string(), json!(0));
-                token_attrs.insert(
-                    "llama_stage.decode_token_phase".to_string(),
-                    json!(fused.token_phase),
-                );
-                token_attrs.insert(
-                    "llama_stage.message_kind".to_string(),
-                    json!(fused.message_kind),
-                );
-                token_attrs.insert(
-                    "llama_stage.elapsed_ms".to_string(),
-                    json!(fused.elapsed_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.stage0_compute_ms".to_string(),
-                    json!(fused.execution.stage0_compute_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.runtime_lock_wait_ms".to_string(),
-                    json!(fused.execution.runtime_lock_wait_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.runtime_lock_hold_ms".to_string(),
-                    json!(fused.execution.runtime_lock_hold_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.output_activation_bytes".to_string(),
-                    json!(fused.execution.output_activation_bytes),
-                );
-                token_attrs.insert(
-                    "llama_stage.forward_activation_bytes".to_string(),
-                    json!(fused.execution.forward_activation_bytes),
-                );
-                token_attrs.insert(
-                    "llama_stage.activation_encode_ms".to_string(),
-                    json!(fused.execution.activation_encode_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.forward_write_ms".to_string(),
-                    json!(fused.execution.forward_write_ms),
-                );
-                token_attrs.insert(
-                    "llama_stage.downstream_wait_ms".to_string(),
-                    json!(fused.execution.downstream_wait_ms),
-                );
-                token_attrs.insert("llama_stage.predicted_token".to_string(), json!(current));
-                self.telemetry
-                    .emit_debug("stage.openai_decode_token", token_attrs);
-                fused_reached_stop = on_token(current)? == TokenControl::Stop;
+                for (index, token) in fused.predicted_tokens.iter().copied().enumerate() {
+                    current = token;
+                    exact_replay_tokens.push(current);
+                    context_tokens.push(current);
+                    let mut token_attrs = self.openai_attrs(request.ids);
+                    token_attrs.insert("llama_stage.decode_step".to_string(), json!(index));
+                    token_attrs.insert(
+                        "llama_stage.decode_token_phase".to_string(),
+                        json!(fused.token_phase),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.message_kind".to_string(),
+                        json!(fused.message_kind),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.elapsed_ms".to_string(),
+                        json!(if index == 0 { fused.elapsed_ms } else { 0.0 }),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.cached_replay_token_index".to_string(),
+                        json!(index),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.cached_replay_token_count".to_string(),
+                        json!(fused.predicted_tokens.len()),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.stage0_compute_ms".to_string(),
+                        json!(if index == 0 {
+                            fused.execution.stage0_compute_ms
+                        } else {
+                            0.0
+                        }),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.runtime_lock_wait_ms".to_string(),
+                        json!(if index == 0 {
+                            fused.execution.runtime_lock_wait_ms
+                        } else {
+                            0.0
+                        }),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.runtime_lock_hold_ms".to_string(),
+                        json!(if index == 0 {
+                            fused.execution.runtime_lock_hold_ms
+                        } else {
+                            0.0
+                        }),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.output_activation_bytes".to_string(),
+                        json!(if index == 0 {
+                            fused.execution.output_activation_bytes
+                        } else {
+                            0
+                        }),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.forward_activation_bytes".to_string(),
+                        json!(if index == 0 {
+                            fused.execution.forward_activation_bytes
+                        } else {
+                            0
+                        }),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.activation_encode_ms".to_string(),
+                        json!(if index == 0 {
+                            fused.execution.activation_encode_ms
+                        } else {
+                            0.0
+                        }),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.forward_write_ms".to_string(),
+                        json!(if index == 0 {
+                            fused.execution.forward_write_ms
+                        } else {
+                            0.0
+                        }),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.downstream_wait_ms".to_string(),
+                        json!(if index == 0 {
+                            fused.execution.downstream_wait_ms
+                        } else {
+                            0.0
+                        }),
+                    );
+                    token_attrs.insert("llama_stage.predicted_token".to_string(), json!(current));
+                    self.telemetry
+                        .emit_debug("stage.openai_decode_token", token_attrs);
+                    if on_token(current)? == TokenControl::Stop {
+                        fused_reached_stop = true;
+                        break;
+                    }
+                }
             }
             let max_speculative_window = request.speculative_window.max(1);
             let mut adaptive_window = if request.adaptive_speculative_window {
@@ -997,10 +1065,11 @@ impl StageOpenAiBackend {
                     .map_err(|_| OpenAiError::backend("decode step exceeds i32"))?;
                 state.current_token = current;
                 state.source_stage_index = -1;
-                let message_tokens =
-                    decode_sideband_tokens(decode_step, request.prompt_token_ids, current);
-                let records_full_prompt_sideband =
-                    message_tokens.len() == request.prompt_token_ids.len();
+                let message_tokens = decode_sideband_tokens(&context_tokens, current);
+                let records_replay_checkpoint =
+                    message_tokens.len() == context_tokens.len() && message_tokens.len() > 1;
+                let records_full_prompt_checkpoint =
+                    decode_step == 0 && message_tokens.len() == request.prompt_token_ids.len();
                 let message = StageWireMessage {
                     kind: WireMessageKind::DecodeEmbd,
                     pos_start: i32::try_from(prefill_token_count + decode_step as usize)
@@ -1085,7 +1154,22 @@ impl StageOpenAiBackend {
                         reply.kind
                     )));
                 }
-                if decode_step == 0 && records_full_prompt_sideband {
+                if records_replay_checkpoint
+                    && super::prefix_cache::request_allows_exact_replay(&request)
+                {
+                    self.record_embedded_stage0_replay_checkpoint(
+                        super::prefix_cache::EmbeddedReplayCheckpointRecord {
+                            session_id: &session_key,
+                            ids: request.ids,
+                            prompt_token_ids: request.prompt_token_ids,
+                            checkpoint_token_ids: &context_tokens,
+                            predicted_tokens: &exact_replay_tokens,
+                            predicted: reply.predicted,
+                            sampling: request.sampling,
+                            chat_sampling_metadata: request.chat_sampling_metadata,
+                        },
+                    )?;
+                } else if records_full_prompt_checkpoint {
                     self.record_embedded_stage0_full_prompt_first_token(
                         &session_key,
                         request.ids,
@@ -1095,6 +1179,7 @@ impl StageOpenAiBackend {
                 }
                 current = reply.predicted;
                 decoded_tokens += 1;
+                exact_replay_tokens.push(current);
                 context_tokens.push(current);
                 let mut token_attrs = self.openai_attrs(request.ids);
                 token_attrs.insert("llama_stage.decode_step".to_string(), json!(decode_step));
@@ -1272,12 +1357,11 @@ impl StageOpenAiBackend {
     }
 }
 
-fn decode_sideband_tokens(decode_step: u32, prompt_token_ids: &[i32], current: i32) -> Vec<i32> {
-    if decode_step == 0
-        && prompt_token_ids.len() <= skippy_protocol::binary::MAX_STAGE_SIDEBAND_VALUES
-        && prompt_token_ids.last().copied() == Some(current)
+fn decode_sideband_tokens(context_token_ids: &[i32], current: i32) -> Vec<i32> {
+    if context_token_ids.len() <= skippy_protocol::binary::MAX_STAGE_SIDEBAND_VALUES
+        && context_token_ids.last().copied() == Some(current)
     {
-        return prompt_token_ids.to_vec();
+        return context_token_ids.to_vec();
     }
     vec![current]
 }

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -72,7 +72,22 @@ impl StageOpenAiBackend {
                         .prompt_token_ids
                         .last()
                         .expect("checked non-empty prompt");
-                    if let Some(fused) = self.try_restore_embedded_split_prefill_and_decode(
+                    if let Some(cached) = self.try_restore_embedded_split_full_prompt_first_token(
+                        &request,
+                        &session_key,
+                        downstream,
+                    )? {
+                        prefill_chain_cache_restored = true;
+                        prefill_chain_restored_tokens = request.prompt_token_ids.len();
+                        prefill_chain_cache_stats = cached.reply_stats;
+                        cache_stats.cached_prompt_tokens =
+                            saturating_u32(request.prompt_token_ids.len());
+                        cache_stats.matched_prefix_tokens =
+                            saturating_u32(request.prompt_token_ids.len());
+                        cache_stats.suffix_prefill_tokens = 0;
+                        cache_stats.hit_kind = Some("chain_full_prompt_first_token");
+                        fused_first_decode = Some(cached);
+                    } else if let Some(fused) = self.try_restore_embedded_split_prefill_and_decode(
                         &request,
                         &session_key,
                         downstream,
@@ -558,11 +573,11 @@ impl StageOpenAiBackend {
                 token_attrs.insert("llama_stage.decode_step".to_string(), json!(0));
                 token_attrs.insert(
                     "llama_stage.decode_token_phase".to_string(),
-                    json!("fused-restore"),
+                    json!(fused.token_phase),
                 );
                 token_attrs.insert(
                     "llama_stage.message_kind".to_string(),
-                    json!("TryRestorePrefillDecode"),
+                    json!(fused.message_kind),
                 );
                 token_attrs.insert(
                     "llama_stage.elapsed_ms".to_string(),
@@ -982,6 +997,10 @@ impl StageOpenAiBackend {
                     .map_err(|_| OpenAiError::backend("decode step exceeds i32"))?;
                 state.current_token = current;
                 state.source_stage_index = -1;
+                let message_tokens =
+                    decode_sideband_tokens(decode_step, request.prompt_token_ids, current);
+                let records_full_prompt_sideband =
+                    message_tokens.len() == request.prompt_token_ids.len();
                 let message = StageWireMessage {
                     kind: WireMessageKind::DecodeEmbd,
                     pos_start: i32::try_from(prefill_token_count + decode_step as usize)
@@ -992,7 +1011,7 @@ impl StageOpenAiBackend {
                     session_id,
                     sampling: wire_sampling.clone(),
                     chat_sampling_metadata: None,
-                    tokens: vec![current],
+                    tokens: message_tokens,
                     positions: Vec::new(),
                     activation: Vec::new(),
                     raw_bytes: Vec::new(),
@@ -1065,6 +1084,14 @@ impl StageOpenAiBackend {
                         "expected predicted-token reply from downstream, got {:?}",
                         reply.kind
                     )));
+                }
+                if decode_step == 0 && records_full_prompt_sideband {
+                    self.record_embedded_stage0_full_prompt_first_token(
+                        &session_key,
+                        request.ids,
+                        request.prompt_token_ids,
+                        reply.predicted,
+                    )?;
                 }
                 current = reply.predicted;
                 decoded_tokens += 1;
@@ -1243,4 +1270,14 @@ impl StageOpenAiBackend {
         result?;
         Ok(cache_stats)
     }
+}
+
+fn decode_sideband_tokens(decode_step: u32, prompt_token_ids: &[i32], current: i32) -> Vec<i32> {
+    if decode_step == 0
+        && prompt_token_ids.len() <= skippy_protocol::binary::MAX_STAGE_SIDEBAND_VALUES
+        && prompt_token_ids.last().copied() == Some(current)
+    {
+        return prompt_token_ids.to_vec();
+    }
+    vec![current]
 }

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -51,6 +51,25 @@ impl StageOpenAiBackend {
         }
         let max_tokens = max_tokens.resolve(prompt_token_ids.len(), self.ctx_size)?;
         let chat_sampling_metadata = prompt.chat_parse_metadata.as_deref();
+        let prompt_anchor_token_count =
+            prompt_cache_anchor_token_count(&ids, prompt_token_ids.len());
+        if let Some(anchor_tokens) = prompt_anchor_token_count {
+            let mut anchor_attrs = self.openai_attrs(&ids);
+            anchor_attrs.insert(
+                "skippy.kv.decision".to_string(),
+                json!("prompt_anchor_requested"),
+            );
+            anchor_attrs.insert(
+                "skippy.kv.anchor_token_count".to_string(),
+                json!(anchor_tokens),
+            );
+            anchor_attrs.insert(
+                "llama_stage.prompt_token_count".to_string(),
+                json!(prompt_token_ids.len()),
+            );
+            self.telemetry
+                .emit("stage.openai_kv_lookup_decision", anchor_attrs);
+        }
 
         let mut collector =
             TextGenerationCollector::new(self.runtime.clone(), stop_values, on_text_chunk);
@@ -109,6 +128,7 @@ impl StageOpenAiBackend {
                     speculative_window: self.speculative_window,
                     adaptive_speculative_window: self.adaptive_speculative_window,
                     prompt_token_ids: &prompt_token_ids,
+                    prompt_anchor_token_count,
                     max_tokens,
                     sampling: &sampling,
                     chat_sampling_metadata,
@@ -932,4 +952,18 @@ impl StageOpenAiBackend {
         result?;
         collector.finish(prompt_tokens, GenerationCacheStats::default())
     }
+}
+
+pub(super) fn prompt_cache_anchor_token_count(
+    ids: &OpenAiGenerationIds,
+    prompt_token_count: usize,
+) -> Option<usize> {
+    let anchor_tokens = ids.cache.prompt_cache_anchor_tokens? as usize;
+    if ids.cache.prompt_cache_key.is_none()
+        || anchor_tokens == 0
+        || anchor_tokens >= prompt_token_count
+    {
+        return None;
+    }
+    Some(anchor_tokens)
 }

--- a/crates/skippy-server/src/frontend/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/prefix_cache.rs
@@ -62,6 +62,47 @@ fn estimated_activation_bytes(
         .unwrap_or(0)
 }
 
+pub(super) fn request_allows_exact_replay(request: &EmbeddedStageZeroGeneration<'_>) -> bool {
+    request.draft.is_none() && request.sampling.temperature <= 0.0
+}
+
+fn exact_replay_cache_key(
+    identity: &crate::kv_integration::PrefillKvIdentity,
+    sampling: &SamplingConfig,
+    chat_sampling_metadata: Option<&str>,
+) -> String {
+    use std::fmt::Write as _;
+
+    let mut digest = Sha256::new();
+    digest.update(b"skippy-exact-replay-v1");
+    digest.update(identity.page_id.as_bytes());
+    digest.update([u8::from(sampling.enabled)]);
+    digest.update(sampling.seed.to_le_bytes());
+    digest.update(sampling.temperature.to_bits().to_le_bytes());
+    digest.update(sampling.top_p.to_bits().to_le_bytes());
+    digest.update(sampling.top_k.to_le_bytes());
+    digest.update(sampling.min_p.to_bits().to_le_bytes());
+    digest.update(sampling.presence_penalty.to_bits().to_le_bytes());
+    digest.update(sampling.frequency_penalty.to_bits().to_le_bytes());
+    digest.update(sampling.repeat_penalty.to_bits().to_le_bytes());
+    digest.update(sampling.penalty_last_n.to_le_bytes());
+    for bias in &sampling.logit_bias {
+        digest.update(b"logit-bias");
+        digest.update(bias.token_id.to_le_bytes());
+        digest.update(bias.bias.to_bits().to_le_bytes());
+    }
+    if let Some(metadata) = chat_sampling_metadata {
+        digest.update(b"chat-sampling-metadata");
+        digest.update(metadata.as_bytes());
+    }
+    let digest = digest.finalize();
+    let mut suffix = String::with_capacity(digest.len() * 2);
+    for byte in digest {
+        let _ = write!(&mut suffix, "{byte:02x}");
+    }
+    format!("{}:replay:{suffix}", identity.page_id)
+}
+
 pub(super) fn stage0_prefill_record_identities(
     kv: &KvStageIntegration,
     config: &StageConfig,
@@ -79,6 +120,17 @@ pub(super) fn stage0_full_prefill_record_identities(
     token_ids: &[i32],
 ) -> Vec<crate::kv_integration::PrefillKvIdentity> {
     stage0_prefill_record_identities(kv, config, base, 0, token_ids)
+}
+
+pub(super) struct EmbeddedReplayCheckpointRecord<'a> {
+    pub(super) session_id: &'a str,
+    pub(super) ids: &'a OpenAiGenerationIds,
+    pub(super) prompt_token_ids: &'a [i32],
+    pub(super) checkpoint_token_ids: &'a [i32],
+    pub(super) predicted_tokens: &'a [i32],
+    pub(super) predicted: i32,
+    pub(super) sampling: &'a SamplingConfig,
+    pub(super) chat_sampling_metadata: Option<&'a str>,
 }
 
 impl StageOpenAiBackend {
@@ -445,6 +497,180 @@ impl StageOpenAiBackend {
         Ok(recorded_state || recorded_token)
     }
 
+    pub(super) fn record_embedded_stage0_replay_checkpoint(
+        &self,
+        record: EmbeddedReplayCheckpointRecord<'_>,
+    ) -> OpenAiResult<bool> {
+        let Some(kv) = self.kv.as_ref() else {
+            return Ok(false);
+        };
+        if record.prompt_token_ids.is_empty()
+            || record.checkpoint_token_ids.is_empty()
+            || record.predicted_tokens.len() >= MAX_EXACT_REPLAY_TOKENS
+            || !kv.should_record()
+        {
+            return Ok(false);
+        }
+        let base = self.local_kv_message_base(record.session_id, record.ids);
+        let prompt_identity = kv.prefill_identity(&self.config, &base, 0, record.prompt_token_ids);
+        let replay_cache_key = exact_replay_cache_key(
+            &prompt_identity,
+            record.sampling,
+            record.chat_sampling_metadata,
+        );
+        let recorded_state = self.record_embedded_stage0_full_prefill(
+            record.session_id,
+            record.ids,
+            record.checkpoint_token_ids,
+        )?;
+        let recorded_replay = kv.record_cached_replay_tokens(
+            &replay_cache_key,
+            &prompt_identity,
+            record.predicted_tokens,
+            record.predicted,
+            MAX_EXACT_REPLAY_TOKENS,
+        );
+        let mut attrs = self.openai_attrs(record.ids);
+        attrs.insert(
+            "skippy.kv.decision".to_string(),
+            json!("stage0_exact_replay_record"),
+        );
+        attrs.insert(
+            "skippy.kv.prompt_token_count".to_string(),
+            json!(record.prompt_token_ids.len()),
+        );
+        attrs.insert(
+            "skippy.kv.checkpoint_token_count".to_string(),
+            json!(record.checkpoint_token_ids.len()),
+        );
+        attrs.insert(
+            "skippy.kv.replay_token_count".to_string(),
+            json!(recorded_replay.unwrap_or(record.predicted_tokens.len())),
+        );
+        attrs.insert(
+            "skippy.kv.predicted_token".to_string(),
+            json!(record.predicted),
+        );
+        attrs.insert(
+            "skippy.kv.recorded_page_id".to_string(),
+            json!(prompt_identity.page_id),
+        );
+        attrs.insert(
+            "skippy.kv.recorded_state".to_string(),
+            json!(recorded_state),
+        );
+        attrs.insert(
+            "skippy.kv.recorded_replay".to_string(),
+            json!(recorded_replay.is_some()),
+        );
+        self.telemetry
+            .emit("stage.openai_kv_record_decision", attrs);
+        Ok(recorded_state || recorded_replay.is_some())
+    }
+
+    pub(super) fn try_restore_embedded_split_exact_replay(
+        &self,
+        request: &EmbeddedStageZeroGeneration<'_>,
+        session_key: &str,
+        downstream: &mut TcpStream,
+    ) -> OpenAiResult<Option<EmbeddedFusedFirstDecode>> {
+        let Some(kv) = self.kv.as_ref() else {
+            return Ok(None);
+        };
+        if request.prompt_token_ids.is_empty()
+            || !kv.should_lookup()
+            || !request_allows_exact_replay(request)
+        {
+            return Ok(None);
+        }
+        let timer = PhaseTimer::start();
+        let base = self.local_kv_message_base(session_key, request.ids);
+        let prompt_identity =
+            kv.prefill_identity(request.config, &base, 0, request.prompt_token_ids);
+        let replay_cache_key = exact_replay_cache_key(
+            &prompt_identity,
+            request.sampling,
+            request.chat_sampling_metadata,
+        );
+        let replay_tokens =
+            kv.lookup_cached_replay_tokens(&replay_cache_key, request.max_tokens as usize);
+        if replay_tokens.len() < 2 {
+            return Ok(None);
+        }
+
+        for replay_len in (2..=replay_tokens.len()).rev() {
+            let mut checkpoint_tokens = request.prompt_token_ids.to_vec();
+            checkpoint_tokens.extend_from_slice(&replay_tokens[..replay_len - 1]);
+            let Some(restore) = self.try_restore_embedded_split_prefill(
+                request,
+                session_key,
+                downstream,
+                &checkpoint_tokens,
+            )?
+            else {
+                continue;
+            };
+            if restore.restored_tokens < checkpoint_tokens.len() {
+                continue;
+            }
+            let replay = replay_tokens[..replay_len].to_vec();
+            let mut attrs = self.openai_attrs(request.ids);
+            attrs.insert(
+                "skippy.kv.decision".to_string(),
+                json!("chain_exact_replay_hit"),
+            );
+            attrs.insert(
+                "skippy.kv.prompt_token_count".to_string(),
+                json!(request.prompt_token_ids.len()),
+            );
+            attrs.insert(
+                "skippy.kv.checkpoint_token_count".to_string(),
+                json!(checkpoint_tokens.len()),
+            );
+            attrs.insert(
+                "skippy.kv.replay_token_count".to_string(),
+                json!(replay.len()),
+            );
+            attrs.insert(
+                "skippy.kv.restored_tokens".to_string(),
+                json!(restore.restored_tokens),
+            );
+            attrs.insert(
+                "skippy.kv.hit_page_id".to_string(),
+                json!(prompt_identity.page_id),
+            );
+            attrs.insert(
+                "skippy.kv.lookup_hits".to_string(),
+                json!(restore.stats.kv_lookup_hits),
+            );
+            attrs.insert(
+                "skippy.kv.hit_stage_mask".to_string(),
+                json!(restore.stats.kv_hit_stage_mask),
+            );
+            insert_chain_prefix_cache_savings_attrs(
+                &mut attrs,
+                chain_prefix_cache_savings(
+                    &restore.stats,
+                    checkpoint_tokens.len(),
+                    request.wire_dtype,
+                    request.activation_width,
+                ),
+            );
+            self.telemetry
+                .emit("stage.openai_kv_lookup_decision", attrs);
+            return Ok(Some(EmbeddedFusedFirstDecode {
+                predicted: *replay.last().expect("checked replay length"),
+                predicted_tokens: replay,
+                reply_stats: restore.stats,
+                execution: EmbeddedExecutionStats::default(),
+                elapsed_ms: timer.elapsed_ms(),
+                token_phase: "exact-replay-cache",
+                message_kind: "TryRestorePrefill",
+            }));
+        }
+        Ok(None)
+    }
+
     pub(super) fn try_restore_embedded_split_full_prompt_first_token(
         &self,
         request: &EmbeddedStageZeroGeneration<'_>,
@@ -507,6 +733,7 @@ impl StageOpenAiBackend {
             .emit("stage.openai_kv_lookup_decision", attrs);
         Ok(Some(EmbeddedFusedFirstDecode {
             predicted,
+            predicted_tokens: vec![predicted],
             reply_stats: restore.stats,
             execution: EmbeddedExecutionStats::default(),
             elapsed_ms: timer.elapsed_ms(),
@@ -792,6 +1019,7 @@ impl StageOpenAiBackend {
         )?;
         Ok(Some(EmbeddedFusedFirstDecode {
             predicted: downstream_reply.predicted,
+            predicted_tokens: vec![downstream_reply.predicted],
             reply_stats,
             execution: EmbeddedExecutionStats {
                 stage0_compute_ms,

--- a/crates/skippy-server/src/frontend/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/prefix_cache.rs
@@ -1,5 +1,67 @@
 use super::*;
 
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(super) struct ChainPrefixCacheSavings {
+    pub(super) hit_stage_count: u32,
+    pub(super) stage0_activation_bytes_avoided: usize,
+    pub(super) interstage_activation_bytes_avoided_estimate: usize,
+}
+
+pub(super) fn chain_prefix_cache_savings(
+    stats: &StageReplyStats,
+    restored_tokens: usize,
+    wire_dtype: WireActivationDType,
+    activation_width: i32,
+) -> ChainPrefixCacheSavings {
+    let hit_stage_count = prefix_cache_hit_stage_count(stats.kv_hit_stage_mask);
+    let stage0_activation_bytes_avoided =
+        estimated_activation_bytes(wire_dtype, restored_tokens, activation_width);
+    let interstage_activation_bytes_avoided_estimate =
+        stage0_activation_bytes_avoided.saturating_mul(hit_stage_count.saturating_sub(1) as usize);
+    ChainPrefixCacheSavings {
+        hit_stage_count,
+        stage0_activation_bytes_avoided,
+        interstage_activation_bytes_avoided_estimate,
+    }
+}
+
+pub(super) fn insert_chain_prefix_cache_savings_attrs(
+    attrs: &mut BTreeMap<String, Value>,
+    savings: ChainPrefixCacheSavings,
+) {
+    attrs.insert(
+        "skippy.kv.chain_cache_hit_stage_count".to_string(),
+        json!(savings.hit_stage_count),
+    );
+    attrs.insert(
+        "skippy.kv.chain_cache_stage0_activation_bytes_avoided".to_string(),
+        json!(savings.stage0_activation_bytes_avoided),
+    );
+    attrs.insert(
+        "skippy.kv.chain_cache_interstage_activation_bytes_avoided_estimate".to_string(),
+        json!(savings.interstage_activation_bytes_avoided_estimate),
+    );
+}
+
+fn prefix_cache_hit_stage_count(hit_stage_mask: i64) -> u32 {
+    if hit_stage_mask <= 0 {
+        return 0;
+    }
+    (hit_stage_mask as u64).count_ones()
+}
+
+fn estimated_activation_bytes(
+    wire_dtype: WireActivationDType,
+    token_count: usize,
+    activation_width: i32,
+) -> usize {
+    let Ok(token_count) = i32::try_from(token_count) else {
+        return 0;
+    };
+    skippy_protocol::binary::activation_wire_bytes(wire_dtype, token_count, activation_width)
+        .unwrap_or(0)
+}
+
 pub(super) fn stage0_prefill_record_identities(
     kv: &KvStageIntegration,
     config: &StageConfig,
@@ -417,6 +479,15 @@ impl StageOpenAiBackend {
             "skippy.kv.hit_stage_mask".to_string(),
             json!(restore_stats.kv_hit_stage_mask),
         );
+        insert_chain_prefix_cache_savings_attrs(
+            &mut attrs,
+            chain_prefix_cache_savings(
+                &restore_stats,
+                restored_tokens,
+                request.wire_dtype,
+                request.activation_width,
+            ),
+        );
         self.telemetry
             .emit("stage.openai_kv_lookup_decision", attrs);
         Ok(Some(ChainPrefixRestore {
@@ -576,6 +647,15 @@ impl StageOpenAiBackend {
             "skippy.kv.hit_stage_mask".to_string(),
             json!(reply_stats.kv_hit_stage_mask),
         );
+        insert_chain_prefix_cache_savings_attrs(
+            &mut attrs,
+            chain_prefix_cache_savings(
+                &reply_stats,
+                prefill_tokens.len(),
+                request.wire_dtype,
+                request.activation_width,
+            ),
+        );
         self.telemetry
             .emit("stage.openai_kv_lookup_decision", attrs);
         Ok(Some(EmbeddedFusedFirstDecode {
@@ -619,5 +699,46 @@ impl StageOpenAiBackend {
         {
             let _ = recv_reply(&mut *downstream);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn chain_prefix_cache_savings_counts_confirmed_stage_hits() {
+        let stats = StageReplyStats {
+            kv_hit_stage_mask: openai_stage_mask(0)
+                | openai_stage_mask(1)
+                | openai_stage_mask(2)
+                | openai_stage_mask(3),
+            ..Default::default()
+        };
+
+        let savings = chain_prefix_cache_savings(&stats, 256, WireActivationDType::F16, 5120);
+
+        assert_eq!(savings.hit_stage_count, 4);
+        assert_eq!(savings.stage0_activation_bytes_avoided, 2_621_440);
+        assert_eq!(
+            savings.interstage_activation_bytes_avoided_estimate,
+            7_864_320
+        );
+    }
+
+    #[test]
+    fn chain_prefix_cache_savings_uses_wire_dtype() {
+        let stats = StageReplyStats {
+            kv_hit_stage_mask: openai_stage_mask(0) | openai_stage_mask(1),
+            ..Default::default()
+        };
+
+        let q8 = chain_prefix_cache_savings(&stats, 256, WireActivationDType::Q8, 5120);
+        let f32 = chain_prefix_cache_savings(&stats, 256, WireActivationDType::F32, 5120);
+
+        assert_eq!(q8.stage0_activation_bytes_avoided, 1_311_744);
+        assert_eq!(q8.interstage_activation_bytes_avoided_estimate, 1_311_744);
+        assert_eq!(f32.stage0_activation_bytes_avoided, 5_242_880);
+        assert_eq!(f32.interstage_activation_bytes_avoided_estimate, 5_242_880);
     }
 }

--- a/crates/skippy-server/src/frontend/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/prefix_cache.rs
@@ -339,8 +339,22 @@ impl StageOpenAiBackend {
             identities
                 .iter()
                 .map(|identity| {
-                    kv.record_resident_prefix(&mut runtime, session_id, identity, token_ids)
-                        .map_err(openai_backend_error)
+                    let token_count = identity
+                        .identity
+                        .token_count
+                        .try_into()
+                        .unwrap_or(usize::MAX)
+                        .min(token_ids.len());
+                    if token_count == token_ids.len() {
+                        let _ = kv.record_exact_state(&mut runtime, session_id, identity);
+                    }
+                    kv.record_resident_prefix(
+                        &mut runtime,
+                        session_id,
+                        identity,
+                        &token_ids[..token_count],
+                    )
+                    .map_err(openai_backend_error)
                 })
                 .collect::<OpenAiResult<Vec<_>>>()?
         };
@@ -387,6 +401,118 @@ impl StageOpenAiBackend {
                 .emit("stage.openai_kv_record_decision", attrs);
         }
         Ok(recorded_any)
+    }
+
+    pub(super) fn record_embedded_stage0_full_prompt_first_token(
+        &self,
+        session_id: &str,
+        ids: &OpenAiGenerationIds,
+        token_ids: &[i32],
+        predicted: i32,
+    ) -> OpenAiResult<bool> {
+        let Some(kv) = self.kv.as_ref() else {
+            return Ok(false);
+        };
+        if token_ids.is_empty() || !kv.should_record() {
+            return Ok(false);
+        }
+        let base = self.local_kv_message_base(session_id, ids);
+        let identity = kv.prefill_identity(&self.config, &base, 0, token_ids);
+        let recorded_state =
+            self.record_embedded_stage0_full_prefill(session_id, ids, token_ids)?;
+        let recorded_token = kv.record_cached_first_token(&identity, predicted);
+        let mut attrs = self.openai_attrs(ids);
+        attrs.insert(
+            "skippy.kv.decision".to_string(),
+            json!("stage0_full_prompt_first_token_record"),
+        );
+        attrs.insert("skippy.kv.token_count".to_string(), json!(token_ids.len()));
+        attrs.insert("skippy.kv.predicted_token".to_string(), json!(predicted));
+        attrs.insert(
+            "skippy.kv.recorded_page_id".to_string(),
+            json!(identity.page_id),
+        );
+        attrs.insert(
+            "skippy.kv.recorded_state".to_string(),
+            json!(recorded_state),
+        );
+        attrs.insert(
+            "skippy.kv.recorded_first_token".to_string(),
+            json!(recorded_token),
+        );
+        self.telemetry
+            .emit("stage.openai_kv_record_decision", attrs);
+        Ok(recorded_state || recorded_token)
+    }
+
+    pub(super) fn try_restore_embedded_split_full_prompt_first_token(
+        &self,
+        request: &EmbeddedStageZeroGeneration<'_>,
+        session_key: &str,
+        downstream: &mut TcpStream,
+    ) -> OpenAiResult<Option<EmbeddedFusedFirstDecode>> {
+        let Some(kv) = self.kv.as_ref() else {
+            return Ok(None);
+        };
+        if request.prompt_token_ids.is_empty() || !kv.should_lookup() {
+            return Ok(None);
+        }
+        let timer = PhaseTimer::start();
+        let base = self.local_kv_message_base(session_key, request.ids);
+        let identity = kv.prefill_identity(request.config, &base, 0, request.prompt_token_ids);
+        let Some(predicted) = kv.lookup_cached_first_token(&identity) else {
+            return Ok(None);
+        };
+        let Some(restore) = self.try_restore_embedded_split_prefill(
+            request,
+            session_key,
+            downstream,
+            request.prompt_token_ids,
+        )?
+        else {
+            return Ok(None);
+        };
+        if restore.restored_tokens < request.prompt_token_ids.len() {
+            return Ok(None);
+        }
+        let mut attrs = self.openai_attrs(request.ids);
+        attrs.insert(
+            "skippy.kv.decision".to_string(),
+            json!("chain_full_prompt_first_token_hit"),
+        );
+        attrs.insert(
+            "skippy.kv.restored_tokens".to_string(),
+            json!(restore.restored_tokens),
+        );
+        attrs.insert("skippy.kv.predicted_token".to_string(), json!(predicted));
+        attrs.insert("skippy.kv.hit_page_id".to_string(), json!(identity.page_id));
+        attrs.insert(
+            "skippy.kv.lookup_hits".to_string(),
+            json!(restore.stats.kv_lookup_hits),
+        );
+        attrs.insert(
+            "skippy.kv.hit_stage_mask".to_string(),
+            json!(restore.stats.kv_hit_stage_mask),
+        );
+        insert_chain_prefix_cache_savings_attrs(
+            &mut attrs,
+            chain_prefix_cache_savings(
+                &restore.stats,
+                restore.restored_tokens,
+                request.wire_dtype,
+                request.activation_width,
+            ),
+        );
+        self.telemetry
+            .emit("stage.openai_kv_lookup_decision", attrs);
+        Ok(Some(EmbeddedFusedFirstDecode {
+            predicted,
+            reply_stats: restore.stats,
+            execution: EmbeddedExecutionStats::default(),
+            elapsed_ms: timer.elapsed_ms(),
+            token_phase: "full-prompt-cache",
+            message_kind: "TryRestorePrefill",
+        }))
     }
 
     pub(super) fn try_restore_embedded_split_prefill(
@@ -658,6 +784,12 @@ impl StageOpenAiBackend {
         );
         self.telemetry
             .emit("stage.openai_kv_lookup_decision", attrs);
+        self.record_embedded_stage0_full_prompt_first_token(
+            session_key,
+            request.ids,
+            request.prompt_token_ids,
+            downstream_reply.predicted,
+        )?;
         Ok(Some(EmbeddedFusedFirstDecode {
             predicted: downstream_reply.predicted,
             reply_stats,
@@ -672,6 +804,8 @@ impl StageOpenAiBackend {
                 downstream_wait_ms,
             },
             elapsed_ms: timer.elapsed_ms(),
+            token_phase: "fused-restore",
+            message_kind: "TryRestorePrefillDecode",
         }))
     }
 

--- a/crates/skippy-server/src/frontend/prompt_anchor.rs
+++ b/crates/skippy-server/src/frontend/prompt_anchor.rs
@@ -1,0 +1,107 @@
+use super::*;
+
+pub(super) fn prompt_anchor_positions(
+    anchor_token_count: Option<usize>,
+    context_token_count: usize,
+) -> Vec<i32> {
+    let Some(anchor_token_count) = anchor_token_count else {
+        return Vec::new();
+    };
+    if anchor_token_count == 0 || anchor_token_count >= context_token_count {
+        return Vec::new();
+    }
+    let Ok(anchor_token_count) = i32::try_from(anchor_token_count) else {
+        return Vec::new();
+    };
+    vec![anchor_token_count]
+}
+
+impl StageOpenAiBackend {
+    pub(super) fn try_restore_embedded_split_prompt_anchor(
+        &self,
+        request: &EmbeddedStageZeroGeneration<'_>,
+        session_key: &str,
+        downstream: &mut TcpStream,
+    ) -> OpenAiResult<Option<ChainPrefixRestore>> {
+        let Some(anchor_token_count) = request.prompt_anchor_token_count else {
+            return Ok(None);
+        };
+        let Some(anchor_tokens) = request.prompt_token_ids.get(..anchor_token_count) else {
+            return Ok(None);
+        };
+        let Some(restore) = self.try_restore_embedded_split_prefill(
+            request,
+            session_key,
+            downstream,
+            anchor_tokens,
+        )?
+        else {
+            return Ok(None);
+        };
+        if restore.restored_tokens < anchor_tokens.len() {
+            return Ok(None);
+        }
+        let mut attrs = self.openai_attrs(request.ids);
+        attrs.insert(
+            "skippy.kv.decision".to_string(),
+            json!("chain_prompt_anchor_hit"),
+        );
+        attrs.insert(
+            "skippy.kv.anchor_token_count".to_string(),
+            json!(anchor_tokens.len()),
+        );
+        attrs.insert(
+            "skippy.kv.restored_tokens".to_string(),
+            json!(restore.restored_tokens),
+        );
+        attrs.insert(
+            "skippy.kv.lookup_hits".to_string(),
+            json!(restore.stats.kv_lookup_hits),
+        );
+        attrs.insert(
+            "skippy.kv.hit_stage_mask".to_string(),
+            json!(restore.stats.kv_hit_stage_mask),
+        );
+        super::prefix_cache::insert_chain_prefix_cache_savings_attrs(
+            &mut attrs,
+            super::prefix_cache::chain_prefix_cache_savings(
+                &restore.stats,
+                anchor_tokens.len(),
+                request.wire_dtype,
+                request.activation_width,
+            ),
+        );
+        self.telemetry
+            .emit("stage.openai_kv_lookup_decision", attrs);
+        Ok(Some(restore))
+    }
+
+    pub(super) fn record_embedded_stage0_prompt_anchor(
+        &self,
+        session_id: &str,
+        ids: &OpenAiGenerationIds,
+        prompt_token_ids: &[i32],
+        anchor_token_count: Option<usize>,
+    ) -> OpenAiResult<bool> {
+        let Some(anchor_token_count) = anchor_token_count else {
+            return Ok(false);
+        };
+        let Some(anchor_tokens) = prompt_token_ids.get(..anchor_token_count) else {
+            return Ok(false);
+        };
+        let recorded = self.record_embedded_stage0_full_prefill(session_id, ids, anchor_tokens)?;
+        let mut attrs = self.openai_attrs(ids);
+        attrs.insert(
+            "skippy.kv.decision".to_string(),
+            json!("stage0_prompt_anchor_record"),
+        );
+        attrs.insert(
+            "skippy.kv.anchor_token_count".to_string(),
+            json!(anchor_tokens.len()),
+        );
+        attrs.insert("skippy.kv.recorded_anchor".to_string(), json!(recorded));
+        self.telemetry
+            .emit("stage.openai_kv_record_decision", attrs);
+        Ok(recorded)
+    }
+}

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -2030,6 +2030,39 @@ fn generation_ids_are_unique_under_fast_creation() {
 }
 
 #[test]
+fn prompt_cache_anchor_requires_cache_key_and_valid_prefix() {
+    let request: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "test",
+        "messages": [{"role": "user", "content": "hello"}],
+        "prompt_cache_key": "agent-tools-v1",
+        "prompt_cache_anchor_tokens": 128
+    }))
+    .unwrap();
+    let ids = OpenAiGenerationIds::new(OpenAiCacheHints::from_chat_request(&request));
+
+    assert_eq!(
+        generation_flow::prompt_cache_anchor_token_count(&ids, 256),
+        Some(128)
+    );
+    assert_eq!(
+        generation_flow::prompt_cache_anchor_token_count(&ids, 128),
+        None
+    );
+
+    let request_without_key: ChatCompletionRequest = serde_json::from_value(json!({
+        "model": "test",
+        "messages": [{"role": "user", "content": "hello"}],
+        "prompt_cache_anchor_tokens": 64
+    }))
+    .unwrap();
+    let ids = OpenAiGenerationIds::new(OpenAiCacheHints::from_chat_request(&request_without_key));
+    assert_eq!(
+        generation_flow::prompt_cache_anchor_token_count(&ids, 256),
+        None
+    );
+}
+
+#[test]
 fn prefill_chunk_schedule_parses_and_repeats_last_size() {
     let schedule = PrefillChunkSchedule::parse(Some("128, 256,512"))
         .unwrap()

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeSet,
+    collections::{BTreeMap, BTreeSet},
     fs,
     path::Path,
     path::PathBuf,
@@ -55,6 +55,7 @@ impl KvStageIntegration {
                 cache_config.max_entries.clamp(1, 512),
                 cache_config.max_bytes,
             ))),
+            first_tokens: Arc::new(Mutex::new(BTreeMap::new())),
         }))
     }
 }

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -56,6 +56,7 @@ impl KvStageIntegration {
                 cache_config.max_bytes,
             ))),
             first_tokens: Arc::new(Mutex::new(BTreeMap::new())),
+            replay_tokens: Arc::new(Mutex::new(BTreeMap::new())),
         }))
     }
 }

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -47,6 +47,7 @@ pub struct KvStageIntegration {
     pub(crate) resident: Arc<Mutex<ResidentPrefixCache>>,
     pub(crate) activations: Arc<Mutex<ResidentActivationCache<ActivationFrame>>>,
     pub(crate) exact_states: Arc<Mutex<ExactStateCache<ExactStateExtra>>>,
+    pub(crate) first_tokens: Arc<Mutex<BTreeMap<String, i32>>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -251,6 +252,29 @@ impl KvStageIntegration {
 
     fn lookup_candidate_token_counts(&self, token_count: u64) -> Vec<u64> {
         self.candidate_policy.candidate_token_counts(token_count)
+    }
+
+    pub fn record_cached_first_token(&self, identity: &PrefillKvIdentity, predicted: i32) -> bool {
+        if !self.should_record() || identity.identity.token_count < self.candidate_policy.min_tokens
+        {
+            return false;
+        }
+        self.first_tokens
+            .lock()
+            .expect("first-token cache lock poisoned")
+            .insert(identity.page_id.clone(), predicted)
+            .is_none()
+    }
+
+    pub fn lookup_cached_first_token(&self, identity: &PrefillKvIdentity) -> Option<i32> {
+        if !self.should_lookup() {
+            return None;
+        }
+        self.first_tokens
+            .lock()
+            .expect("first-token cache lock poisoned")
+            .get(&identity.page_id)
+            .copied()
     }
 }
 

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -48,6 +48,7 @@ pub struct KvStageIntegration {
     pub(crate) activations: Arc<Mutex<ResidentActivationCache<ActivationFrame>>>,
     pub(crate) exact_states: Arc<Mutex<ExactStateCache<ExactStateExtra>>>,
     pub(crate) first_tokens: Arc<Mutex<BTreeMap<String, i32>>>,
+    pub(crate) replay_tokens: Arc<Mutex<BTreeMap<String, Vec<i32>>>>,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -275,6 +276,48 @@ impl KvStageIntegration {
             .expect("first-token cache lock poisoned")
             .get(&identity.page_id)
             .copied()
+    }
+
+    pub fn record_cached_replay_tokens(
+        &self,
+        cache_key: &str,
+        identity: &PrefillKvIdentity,
+        previous: &[i32],
+        predicted: i32,
+        max_replay_tokens: usize,
+    ) -> Option<usize> {
+        if !self.should_record()
+            || max_replay_tokens == 0
+            || previous.len() >= max_replay_tokens
+            || identity.identity.token_count < self.candidate_policy.min_tokens
+        {
+            return None;
+        }
+        let mut replay_tokens = self
+            .replay_tokens
+            .lock()
+            .expect("replay-token cache lock poisoned");
+        let entry = replay_tokens.entry(cache_key.to_string()).or_default();
+        if entry.len() > previous.len() {
+            return Some(entry.len().min(max_replay_tokens));
+        }
+        if entry.as_slice() != previous {
+            return None;
+        }
+        entry.push(predicted);
+        Some(entry.len())
+    }
+
+    pub fn lookup_cached_replay_tokens(&self, cache_key: &str, max_tokens: usize) -> Vec<i32> {
+        if !self.should_lookup() || max_tokens == 0 {
+            return Vec::new();
+        }
+        self.replay_tokens
+            .lock()
+            .expect("replay-token cache lock poisoned")
+            .get(cache_key)
+            .map(|tokens| tokens.iter().copied().take(max_tokens).collect())
+            .unwrap_or_default()
     }
 }
 


### PR DESCRIPTION
Long agentic prompts can now tell Skippy which token prefix is intended to stay stable across turns. The request can carry `prompt_cache_anchor_tokens` alongside `prompt_cache_key`, and Skippy records that exact prefix as a resident cache anchor while leaving the existing exact/full/generic prefix restore path in charge.

This is aimed at tool-heavy and long-context sessions where the beginning of the prompt is durable, but the tail keeps changing with tool results, scratchpad state, or retrieved context.

## Why

The previous prefix-cache work made repeated prompts much cheaper when the runtime could discover and replay an exact cached prefix. That helps, but it still leaves the client unable to say: "this many tokens are the stable system/tool/session prefix; please keep this boundary hot."

For agent workloads, that boundary is often known at request construction time. Making it explicit gives Skippy a durable cache target that is independent of the changing suffix.

## Before

```mermaid
sequenceDiagram
    participant Client
    participant Stage0
    participant Stage1
    participant Stage2

    Client->>Stage0: prompt_cache_key + full prompt
    Stage0->>Stage1: prefill chunks
    Stage1->>Stage2: prefill chunks
    Stage2-->>Stage0: decode replies
    Note over Stage0,Stage2: Cache records discovered exact/grid prefixes

    Client->>Stage0: same prefix + changed suffix
    Stage0->>Stage0: find best discovered prefix
    Stage0->>Stage1: restore prefix, then prefill suffix
```

The runtime could reuse what it discovered, but the client had no protocol surface for naming the stable prefix that should survive changing prompt tails.

## After

```mermaid
sequenceDiagram
    participant Client
    participant Stage0
    participant Stage1
    participant Stage2

    Client->>Stage0: prompt_cache_key + prompt_cache_anchor_tokens=N
    Stage0->>Stage0: validate N is a strict token prefix
    Stage0->>Stage1: prefill/decode as normal
    Stage0->>Stage0: record explicit N-token anchor
    Stage0->>Stage1: decode sideband carries N
    Stage1->>Stage1: record the same anchor prefix
    Stage1->>Stage2: decode sideband carries N
    Stage2->>Stage2: record the same anchor prefix

    Client->>Stage0: same key + changed suffix + N
    Stage0->>Stage0: prefer existing exact/full/generic restore
    Stage0->>Stage1: use anchor restore only if no prefix restored
```

The anchor is conservative by design:

- ignored without `prompt_cache_key`
- ignored when zero or not a strict prefix of the prompt
- exact-token only; no lossy approximation
- existing exact/full/generic prefix restore is preferred
- anchor restore is attempted only when no prefix was restored by the existing cache path

## Performance

This PR adds the control-plane and cache-policy hook for stable prompt anchors. It does not claim a universal wall-clock speedup from the local benchmark shape, because the existing multi-token replay cache already captured nearly the same prefix in that run.

Local sanity benchmark:

- model: Qwen3 0.6B Q4_K_M
- topology: 3 local Skippy stages
- context: 8192
- prompt: synthetic 35-line agent transcript with a shared stable prefix and changing suffix
- output: `max_tokens=4`
- cache grid: 256-token shared-prefix stride
- requested anchor: 1600 tokens

| Scenario | Cold TTFT | Warm TTFT median | Warm elapsed median | Observed cache behavior |
|---|---:|---:|---:|---|
| Existing prefix cache | 26.72s | 1.53s | 1.62s | 1536-token generic/grid restore |
| Anchor hint requested | 28.50s | 1.63s | 1.76s | anchor recorded; existing 1536-token restore still preferred |

The important result here is correctness and safety: the anchor hint records cleanly and does not force a worse restore path over an already-good generic prefix restore. The expected win is in workloads where the useful stable prefix is not already captured by the grid, or where cache retention should favor a long-lived agent prefix over volatile prompt tails.

## Protocol

Adds an optional OpenAI-compatible request extension:

- `prompt_cache_anchor_tokens`

It is additive on the HTTP request surface. Existing clients do not need to send it. New servers only honor it when paired with `prompt_cache_key`.

Inside Skippy, downstream stages learn the requested anchor through the existing decode-record sideband shape, so this does not add a mesh protobuf field or a new public stream type. Mixed-version staged chains should not rely on this hint until all Skippy stages are updated, because older stages will not record or restore the anchor.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `just with-lld cargo test -p skippy-server --lib`
- `just with-lld cargo clippy -p skippy-server --all-targets -- -D warnings`
- `just with-lld cargo clippy -p openai-frontend --all-targets -- -D warnings`
- `just with-lld cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `just with-lld cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `just build`

Benchmark/sanity run output was captured under:

- `/tmp/prompt-anchor-cache-bench-20260604-203642`
