### PR TITLE
Batch Skippy decode across concurrent requests

### DIFF
--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -1,6 +1,6 @@
 pub const ABI_VERSION_MAJOR: u32 = 0;
 pub const ABI_VERSION_MINOR: u32 = 1;
-pub const ABI_VERSION_PATCH: u32 = 26;
+pub const ABI_VERSION_PATCH: u32 = 27;
 
 use std::ffi::{c_char, c_int, c_void};
 
@@ -500,8 +500,9 @@ mod dynamic {
         skippy_prefill_chunk_frame_with_positions(session: *mut Session, token_ids: *const i32, token_count: usize, positions: *const i32, position_count: usize, input_desc: *const ActivationDesc, input_payload: *const c_void, output_desc: *mut ActivationDesc, output_payload: *mut c_void, output_payload_capacity: usize, out_output_payload_bytes: *mut usize, out_error: *mut *mut Error) -> Status;
         skippy_prefill_chunk_frame_sampled_with_positions(session: *mut Session, token_ids: *const i32, token_count: usize, positions: *const i32, position_count: usize, sampling: *const SamplingConfig, input_desc: *const ActivationDesc, input_payload: *const c_void, output_desc: *mut ActivationDesc, output_payload: *mut c_void, output_payload_capacity: usize, out_output_payload_bytes: *mut usize, out_predicted_token: *mut i32, out_error: *mut *mut Error) -> Status;
         skippy_decode_step_frame(session: *mut Session, token_id: i32, input_desc: *const ActivationDesc, input_payload: *const c_void, output_desc: *mut ActivationDesc, output_payload: *mut c_void, output_payload_capacity: usize, out_output_payload_bytes: *mut usize, out_predicted_token: *mut i32, out_error: *mut *mut Error) -> Status;
-        skippy_verify_tokens_frame(session: *mut Session, token_ids: *const i32, token_count: usize, input_desc: *const ActivationDesc, input_payload: *const c_void, output_desc: *mut ActivationDesc, output_payload: *mut c_void, output_payload_capacity: usize, out_output_payload_bytes: *mut usize, output_tokens: *mut i32, output_token_capacity: usize, out_token_count: *mut usize, out_error: *mut *mut Error) -> Status;
         skippy_decode_step_frame_sampled(session: *mut Session, token_id: i32, sampling: *const SamplingConfig, input_desc: *const ActivationDesc, input_payload: *const c_void, output_desc: *mut ActivationDesc, output_payload: *mut c_void, output_payload_capacity: usize, out_output_payload_bytes: *mut usize, out_predicted_token: *mut i32, out_error: *mut *mut Error) -> Status;
+        skippy_decode_step_frame_batch_sampled(sessions: *const *mut Session, token_ids: *const i32, sampling: *const *const SamplingConfig, input_descs: *const *const ActivationDesc, input_payloads: *const *const c_void, output_descs: *mut ActivationDesc, output_payloads: *const *mut c_void, output_payload_capacities: *const usize, out_output_payload_bytes: *mut usize, out_predicted_tokens: *mut i32, predicted_token_capacity: usize, request_count: usize, out_error: *mut *mut Error) -> Status;
+        skippy_verify_tokens_frame(session: *mut Session, token_ids: *const i32, token_count: usize, input_desc: *const ActivationDesc, input_payload: *const c_void, output_desc: *mut ActivationDesc, output_payload: *mut c_void, output_payload_capacity: usize, out_output_payload_bytes: *mut usize, output_tokens: *mut i32, output_token_capacity: usize, out_token_count: *mut usize, out_error: *mut *mut Error) -> Status;
         skippy_session_copy_output_activation_frame(session: *mut Session, token_count: usize, output_desc: *mut ActivationDesc, output_payload: *mut c_void, output_payload_capacity: usize, out_output_payload_bytes: *mut usize, out_error: *mut *mut Error) -> Status;
         skippy_session_last_token_signal(session: *mut Session, out_signal: *mut TokenSignal, out_error: *mut *mut Error) -> Status;
         skippy_session_signal_window(session: *mut Session, window_tokens: u32, out_window: *mut GenerationSignalWindow, out_error: *mut *mut Error) -> Status;
@@ -823,6 +824,22 @@ unsafe extern "C" {
         output_payload_capacity: usize,
         out_output_payload_bytes: *mut usize,
         out_predicted_token: *mut i32,
+        out_error: *mut *mut Error,
+    ) -> Status;
+
+    pub fn skippy_decode_step_frame_batch_sampled(
+        sessions: *const *mut Session,
+        token_ids: *const i32,
+        sampling: *const *const SamplingConfig,
+        input_descs: *const *const ActivationDesc,
+        input_payloads: *const *const c_void,
+        output_descs: *mut ActivationDesc,
+        output_payloads: *const *mut c_void,
+        output_payload_capacities: *const usize,
+        out_output_payload_bytes: *mut usize,
+        out_predicted_tokens: *mut i32,
+        predicted_token_capacity: usize,
+        request_count: usize,
         out_error: *mut *mut Error,
     ) -> Status;
 

--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -1,6 +1,6 @@
 pub const ABI_VERSION_MAJOR: u32 = 0;
 pub const ABI_VERSION_MINOR: u32 = 1;
-pub const ABI_VERSION_PATCH: u32 = 25;
+pub const ABI_VERSION_PATCH: u32 = 26;
 
 use std::ffi::{c_char, c_int, c_void};
 
@@ -494,6 +494,7 @@ mod dynamic {
         skippy_decode_step(session: *mut Session, token_id: i32, input_activation: *const c_void, input_activation_bytes: usize, output_activation: *mut c_void, output_activation_capacity: usize, out_output_activation_bytes: *mut usize, out_predicted_token: *mut i32, out_error: *mut *mut Error) -> Status;
         skippy_verify_tokens(session: *mut Session, token_ids: *const i32, token_count: usize, output_tokens: *mut i32, output_token_capacity: usize, out_token_count: *mut usize, out_error: *mut *mut Error) -> Status;
         skippy_decode_step_sampled(session: *mut Session, token_id: i32, sampling: *const SamplingConfig, input_activation: *const c_void, input_activation_bytes: usize, output_activation: *mut c_void, output_activation_capacity: usize, out_output_activation_bytes: *mut usize, out_predicted_token: *mut i32, out_error: *mut *mut Error) -> Status;
+        skippy_decode_batch_sampled(sessions: *const *mut Session, token_ids: *const i32, sampling: *const *const SamplingConfig, request_count: usize, out_predicted_tokens: *mut i32, predicted_token_capacity: usize, out_error: *mut *mut Error) -> Status;
         skippy_prefill_chunk_frame(session: *mut Session, token_ids: *const i32, token_count: usize, input_desc: *const ActivationDesc, input_payload: *const c_void, output_desc: *mut ActivationDesc, output_payload: *mut c_void, output_payload_capacity: usize, out_output_payload_bytes: *mut usize, out_error: *mut *mut Error) -> Status;
         skippy_prefill_chunk_frame_sampled(session: *mut Session, token_ids: *const i32, token_count: usize, sampling: *const SamplingConfig, input_desc: *const ActivationDesc, input_payload: *const c_void, output_desc: *mut ActivationDesc, output_payload: *mut c_void, output_payload_capacity: usize, out_output_payload_bytes: *mut usize, out_predicted_token: *mut i32, out_error: *mut *mut Error) -> Status;
         skippy_prefill_chunk_frame_with_positions(session: *mut Session, token_ids: *const i32, token_count: usize, positions: *const i32, position_count: usize, input_desc: *const ActivationDesc, input_payload: *const c_void, output_desc: *mut ActivationDesc, output_payload: *mut c_void, output_payload_capacity: usize, out_output_payload_bytes: *mut usize, out_error: *mut *mut Error) -> Status;
@@ -709,6 +710,16 @@ unsafe extern "C" {
         output_activation_capacity: usize,
         out_output_activation_bytes: *mut usize,
         out_predicted_token: *mut i32,
+        out_error: *mut *mut Error,
+    ) -> Status;
+
+    pub fn skippy_decode_batch_sampled(
+        sessions: *const *mut Session,
+        token_ids: *const i32,
+        sampling: *const *const SamplingConfig,
+        request_count: usize,
+        out_predicted_tokens: *mut i32,
+        predicted_token_capacity: usize,
         out_error: *mut *mut Error,
     ) -> Status;
 

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -1053,6 +1053,21 @@ impl From<RawActivationDesc> for ActivationDesc {
     }
 }
 
+fn empty_raw_activation_desc() -> RawActivationDesc {
+    RawActivationDesc {
+        version: 0,
+        dtype: ActivationDType::Unknown,
+        layout: ActivationLayout::Opaque,
+        producer_stage_index: -1,
+        layer_start: 0,
+        layer_end: 0,
+        token_count: 0,
+        sequence_count: 0,
+        payload_bytes: 0,
+        flags: 0,
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ActivationFrame {
     pub desc: ActivationDesc,
@@ -1196,6 +1211,18 @@ pub struct DecodeBatchRequest<'a> {
     pub session: &'a mut StageSession,
     pub token_id: i32,
     pub sampling: Option<&'a SamplingConfig>,
+}
+
+pub struct DecodeFrameBatchRequest<'a> {
+    pub session: &'a mut StageSession,
+    pub token_id: i32,
+    pub sampling: Option<&'a SamplingConfig>,
+    pub input: Option<&'a ActivationFrame>,
+}
+
+pub struct DecodeFrameBatchOutput {
+    pub predicted_token: i32,
+    pub output: ActivationFrame,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2990,6 +3017,148 @@ impl StageSession {
             .checked_add(1)
             .context("session token count overflow")?;
         Ok((predicted_token, output_desc, output_payload))
+    }
+
+    pub fn decode_step_frame_batch_sampled(
+        requests: &mut [DecodeFrameBatchRequest<'_>],
+    ) -> Result<Vec<DecodeFrameBatchOutput>> {
+        Self::decode_step_frame_batch_sampled_raw(requests, &vec![0; requests.len()])
+    }
+
+    fn decode_step_frame_batch_sampled_raw(
+        requests: &mut [DecodeFrameBatchRequest<'_>],
+        output_capacities: &[usize],
+    ) -> Result<Vec<DecodeFrameBatchOutput>> {
+        if requests.is_empty() {
+            return Ok(Vec::new());
+        }
+        let sessions = requests
+            .iter_mut()
+            .map(|request| request.session.raw)
+            .collect::<Vec<_>>();
+        let token_ids = requests
+            .iter()
+            .map(|request| request.token_id)
+            .collect::<Vec<_>>();
+        let raw_sampling = requests
+            .iter()
+            .map(|request| request.sampling.map(SamplingConfig::as_raw))
+            .collect::<Vec<_>>();
+        let sampling = raw_sampling
+            .iter()
+            .map(|sampling| {
+                sampling
+                    .as_ref()
+                    .map_or(ptr::null(), |sampling| sampling as *const RawSamplingConfig)
+            })
+            .collect::<Vec<_>>();
+        let input_descs = requests
+            .iter()
+            .map(|request| request.input.map(|frame| frame.desc.as_raw()))
+            .collect::<Vec<_>>();
+        let input_desc_ptrs = input_descs
+            .iter()
+            .map(|desc| {
+                desc.as_ref()
+                    .map_or(ptr::null(), |desc| desc as *const RawActivationDesc)
+            })
+            .collect::<Vec<_>>();
+        let input_payloads = requests
+            .iter()
+            .map(|request| {
+                request
+                    .input
+                    .map_or(ptr::null(), |frame| frame.payload.as_ptr().cast())
+            })
+            .collect::<Vec<_>>();
+        let mut output_descs = vec![empty_raw_activation_desc(); requests.len()];
+        let mut output_payloads = output_capacities
+            .iter()
+            .map(|capacity| vec![0_u8; *capacity])
+            .collect::<Vec<_>>();
+        let output_payload_ptrs = output_payloads
+            .iter_mut()
+            .map(|payload| payload.as_mut_ptr().cast())
+            .collect::<Vec<_>>();
+        let mut output_bytes = vec![0_usize; requests.len()];
+        let mut predicted_tokens = vec![0_i32; requests.len()];
+        let mut error = ptr::null_mut();
+        let status = unsafe {
+            skippy_ffi::skippy_decode_step_frame_batch_sampled(
+                sessions.as_ptr(),
+                token_ids.as_ptr(),
+                sampling.as_ptr(),
+                input_desc_ptrs.as_ptr(),
+                input_payloads.as_ptr(),
+                output_descs.as_mut_ptr(),
+                output_payload_ptrs.as_ptr(),
+                output_capacities.as_ptr(),
+                output_bytes.as_mut_ptr(),
+                predicted_tokens.as_mut_ptr(),
+                predicted_tokens.len(),
+                requests.len(),
+                &mut error,
+            )
+        };
+        if status == Status::BufferTooSmall {
+            free_error(error);
+            error = ptr::null_mut();
+            if output_bytes
+                .iter()
+                .zip(output_capacities.iter())
+                .any(|(required, capacity)| required > capacity)
+            {
+                return Self::decode_step_frame_batch_sampled_raw(requests, &output_bytes);
+            }
+        }
+        if status == Status::Unsupported {
+            free_error(error);
+            return Self::decode_step_frame_batch_sampled_serial(requests);
+        }
+        ensure_ok(status, error)?;
+        for request in requests.iter_mut() {
+            request.session.token_count = request
+                .session
+                .token_count
+                .checked_add(1)
+                .context("session token count overflow")?;
+        }
+        Ok(output_payloads
+            .into_iter()
+            .zip(output_descs)
+            .zip(output_bytes)
+            .zip(predicted_tokens)
+            .map(|(((mut payload, desc), bytes), predicted_token)| {
+                payload.truncate(bytes);
+                DecodeFrameBatchOutput {
+                    predicted_token,
+                    output: ActivationFrame {
+                        desc: desc.into(),
+                        payload,
+                    },
+                }
+            })
+            .collect())
+    }
+
+    fn decode_step_frame_batch_sampled_serial(
+        requests: &mut [DecodeFrameBatchRequest<'_>],
+    ) -> Result<Vec<DecodeFrameBatchOutput>> {
+        requests
+            .iter_mut()
+            .map(|request| {
+                let (predicted_token, output) = request.session.decode_step_frame_sampled(
+                    request.token_id,
+                    request.sampling,
+                    request.input,
+                    0,
+                )?;
+                Ok(DecodeFrameBatchOutput {
+                    predicted_token,
+                    output,
+                })
+            })
+            .collect()
     }
 
     pub fn verify_tokens_frame(

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -1192,6 +1192,12 @@ pub struct StageSession {
     token_count: u64,
 }
 
+pub struct DecodeBatchRequest<'a> {
+    pub session: &'a mut StageSession,
+    pub token_id: i32,
+    pub sampling: Option<&'a SamplingConfig>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MediaInput {
     pub bytes: Vec<u8>,
@@ -2549,6 +2555,55 @@ impl StageSession {
             .checked_add(1)
             .context("session token count overflow")?;
         Ok(predicted_token)
+    }
+
+    pub fn decode_batch_sampled(requests: &mut [DecodeBatchRequest<'_>]) -> Result<Vec<i32>> {
+        if requests.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        let sessions = requests
+            .iter_mut()
+            .map(|request| request.session.raw)
+            .collect::<Vec<_>>();
+        let token_ids = requests
+            .iter()
+            .map(|request| request.token_id)
+            .collect::<Vec<_>>();
+        let raw_sampling = requests
+            .iter()
+            .map(|request| request.sampling.map(SamplingConfig::as_raw))
+            .collect::<Vec<_>>();
+        let sampling = raw_sampling
+            .iter()
+            .map(|sampling| {
+                sampling
+                    .as_ref()
+                    .map_or(ptr::null(), |sampling| sampling as *const RawSamplingConfig)
+            })
+            .collect::<Vec<_>>();
+        let mut predicted_tokens = vec![0_i32; requests.len()];
+        let mut error = ptr::null_mut();
+        let status = unsafe {
+            skippy_ffi::skippy_decode_batch_sampled(
+                sessions.as_ptr(),
+                token_ids.as_ptr(),
+                sampling.as_ptr(),
+                requests.len(),
+                predicted_tokens.as_mut_ptr(),
+                predicted_tokens.len(),
+                &mut error,
+            )
+        };
+        ensure_ok(status, error)?;
+        for request in requests {
+            request.session.token_count = request
+                .session
+                .token_count
+                .checked_add(1)
+                .context("session token count overflow")?;
+        }
+        Ok(predicted_tokens)
     }
 
     pub fn last_token_signal(&mut self) -> Result<TokenSignal> {

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -39,12 +39,14 @@ use skippy_runtime::{
 };
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 
+mod decode_batcher;
 pub(crate) mod direct_return;
 pub(crate) mod forwarding;
 mod options;
 mod socket;
 mod wire;
 
+pub(crate) use self::decode_batcher::DecodeFrameBatcher;
 pub use self::direct_return::PredictionReturnHub;
 pub use self::direct_return::PredictionReturnListener;
 pub(crate) use self::direct_return::PredictionReturnReceiver;
@@ -197,6 +199,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
     );
     telemetry.emit("stage.binary_server_start", lifecycle_attrs(&config));
     let runtime = load_runtime(&config)?.context("binary stage server requires model_path")?;
+    let decode_frame_batcher = DecodeFrameBatcher::new(runtime.clone(), max_inflight);
     {
         let timer = Instant::now();
         let sessions = runtime
@@ -295,6 +298,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
         let config = config.clone();
         let topology = topology.clone();
         let runtime = runtime.clone();
+        let decode_frame_batcher = decode_frame_batcher.clone();
         let kv = kv.clone();
         let telemetry = telemetry.clone();
         let prediction_returns = prediction_returns.clone();
@@ -315,6 +319,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
                     &config,
                     topology.as_ref(),
                     &runtime,
+                    &decode_frame_batcher,
                     kv.as_ref(),
                     &telemetry,
                     &mut upstream,
@@ -357,6 +362,7 @@ fn handle_binary_connection(
     config: &StageConfig,
     topology: Option<&StageTopology>,
     runtime: &Arc<Mutex<RuntimeState>>,
+    decode_frame_batcher: &DecodeFrameBatcher,
     kv: Option<&Arc<KvStageIntegration>>,
     telemetry: &Telemetry,
     upstream: &mut TcpStream,
@@ -824,6 +830,8 @@ fn handle_binary_connection(
         let mut runtime_lock_acquires = 0usize;
         let mut runtime_sessions_before = None;
         let mut runtime_sessions_after = None;
+        let mut decode_batch_size = 1usize;
+        let mut decode_batch_wait_ms = 0.0;
         let input_activation_bytes = message.activation.len();
         let (predicted_token, predicted_tokens, output, compute_ms) = if restored_prefill {
             let now = now_unix_nanos() as u64;
@@ -873,7 +881,22 @@ fn handle_binary_connection(
             }
             compute_start_unix_nanos = now_unix_nanos() as u64;
             let compute_started = Instant::now();
-            let result = {
+            let result = if is_decode_frame_batch_candidate(&message, executable_token_ids) {
+                let token_id = executable_token_ids
+                    .first()
+                    .copied()
+                    .unwrap_or(message.state.current_token);
+                let sampling = runtime_sampling_config(message.sampling.as_ref());
+                let outcome = decode_frame_batcher
+                    .decode(&session_key, token_id, sampling.as_ref(), input)
+                    .context("execute batched binary decode frame")?;
+                runtime_lock_wait_ms = outcome.runtime_lock_wait_ms;
+                runtime_lock_hold_ms = outcome.runtime_lock_hold_ms;
+                runtime_lock_acquires = 1;
+                decode_batch_size = outcome.batch_size;
+                decode_batch_wait_ms = outcome.batch_wait_ms;
+                (outcome.predicted, Vec::new(), outcome.output)
+            } else {
                 let lock_started = Instant::now();
                 let mut runtime = runtime.lock().expect("runtime lock poisoned");
                 runtime_lock_wait_ms = elapsed_ms(lock_started);
@@ -918,6 +941,14 @@ fn handle_binary_connection(
         decode_attrs.insert(
             "llama_stage.runtime_lock_acquires".to_string(),
             json!(runtime_lock_acquires),
+        );
+        decode_attrs.insert(
+            "llama_stage.decode_batch_size".to_string(),
+            json!(decode_batch_size),
+        );
+        decode_attrs.insert(
+            "llama_stage.decode_batch_wait_ms".to_string(),
+            json!(decode_batch_wait_ms),
         );
         if let Some(stats) = runtime_sessions_before.as_ref() {
             insert_runtime_session_stats(
@@ -3269,6 +3300,18 @@ pub(crate) fn run_binary_stage_message(
             bail!("message kind is not executable")
         }
     }
+}
+
+fn is_decode_frame_batch_candidate(message: &StageWireMessage, token_ids: &[i32]) -> bool {
+    matches!(
+        message.kind,
+        WireMessageKind::DecodeEmbd
+            | WireMessageKind::DecodeReadout
+            | WireMessageKind::DecodeLightCtx
+            | WireMessageKind::DecodeReplayEmbd
+            | WireMessageKind::DecodeReplayFinalEmbd
+    ) && message.token_count == 1
+        && token_ids.len() == 1
 }
 
 fn runtime_sampling_config(sampling: Option<&StageSamplingConfig>) -> Option<SamplingConfig> {

--- a/crates/skippy-server/src/binary_transport/decode_batcher.rs
+++ b/crates/skippy-server/src/binary_transport/decode_batcher.rs
@@ -1,0 +1,223 @@
+use std::{
+    collections::VecDeque,
+    sync::{
+        Arc, Condvar, Mutex, Weak,
+        atomic::{AtomicUsize, Ordering},
+        mpsc as std_mpsc,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use anyhow::{Result, anyhow};
+use skippy_runtime::{ActivationFrame, SamplingConfig};
+
+use crate::runtime_state::{RuntimeDecodeFrameBatchRequest, RuntimeState};
+
+const DECODE_FRAME_BATCH_MAX_WAIT: Duration = Duration::from_micros(200);
+
+pub(crate) struct DecodeFrameBatcher {
+    shared: Arc<DecodeFrameBatcherShared>,
+}
+
+struct DecodeFrameBatcherShared {
+    runtime: Arc<Mutex<RuntimeState>>,
+    state: Mutex<DecodeFrameBatcherState>,
+    ready: Condvar,
+    max_batch_size: usize,
+    owner_count: AtomicUsize,
+}
+
+#[derive(Default)]
+struct DecodeFrameBatcherState {
+    pending: VecDeque<PendingDecodeFrame>,
+    stopping: bool,
+}
+
+struct PendingDecodeFrame {
+    session_id: String,
+    token_id: i32,
+    sampling: Option<SamplingConfig>,
+    input: Option<ActivationFrame>,
+    enqueued_at: Instant,
+    reply: std_mpsc::SyncSender<Result<DecodeFrameBatchOutcome>>,
+}
+
+pub(crate) struct DecodeFrameBatchOutcome {
+    pub(crate) predicted: i32,
+    pub(crate) output: ActivationFrame,
+    pub(crate) batch_size: usize,
+    pub(crate) batch_wait_ms: f64,
+    pub(crate) runtime_lock_wait_ms: f64,
+    pub(crate) runtime_lock_hold_ms: f64,
+}
+
+impl DecodeFrameBatcher {
+    pub(crate) fn new(runtime: Arc<Mutex<RuntimeState>>, max_batch_size: usize) -> Self {
+        let shared = Arc::new(DecodeFrameBatcherShared {
+            runtime,
+            state: Mutex::new(DecodeFrameBatcherState::default()),
+            ready: Condvar::new(),
+            max_batch_size: max_batch_size.max(1),
+            owner_count: AtomicUsize::new(1),
+        });
+        let worker = Arc::downgrade(&shared);
+        thread::spawn(move || DecodeFrameBatcherShared::run_worker(worker));
+        Self { shared }
+    }
+
+    pub(crate) fn decode(
+        &self,
+        session_id: &str,
+        token_id: i32,
+        sampling: Option<&SamplingConfig>,
+        input: Option<ActivationFrame>,
+    ) -> Result<DecodeFrameBatchOutcome> {
+        let (reply, receiver) = std_mpsc::sync_channel(1);
+        self.shared.enqueue(PendingDecodeFrame {
+            session_id: session_id.to_string(),
+            token_id,
+            sampling: sampling.cloned(),
+            input,
+            enqueued_at: Instant::now(),
+            reply,
+        })?;
+        receiver
+            .recv()
+            .map_err(|error| anyhow!("decode frame batcher stopped: {error}"))?
+    }
+}
+
+impl Clone for DecodeFrameBatcher {
+    fn clone(&self) -> Self {
+        self.shared.owner_count.fetch_add(1, Ordering::Relaxed);
+        Self {
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl Drop for DecodeFrameBatcher {
+    fn drop(&mut self) {
+        if self.shared.owner_count.fetch_sub(1, Ordering::AcqRel) == 1
+            && let Ok(mut state) = self.shared.state.lock()
+        {
+            state.stopping = true;
+            self.shared.ready.notify_all();
+        }
+    }
+}
+
+impl DecodeFrameBatcherShared {
+    fn enqueue(&self, pending: PendingDecodeFrame) -> Result<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| anyhow!("decode frame batcher lock poisoned"))?;
+        state.pending.push_back(pending);
+        self.ready.notify_one();
+        Ok(())
+    }
+
+    fn run_worker(shared: Weak<Self>) {
+        while let Some(shared) = shared.upgrade() {
+            let Some(batch) = shared.wait_for_batch() else {
+                break;
+            };
+            shared.run_batch(batch);
+        }
+    }
+
+    fn wait_for_batch(&self) -> Option<Vec<PendingDecodeFrame>> {
+        let mut state = self
+            .state
+            .lock()
+            .expect("decode frame batcher lock poisoned");
+        while state.pending.is_empty() && !state.stopping {
+            state = self
+                .ready
+                .wait(state)
+                .expect("decode frame batcher lock poisoned");
+        }
+        if state.pending.is_empty() && state.stopping {
+            return None;
+        }
+        if self.max_batch_size > 1 && state.pending.len() < self.max_batch_size {
+            let wait = self
+                .ready
+                .wait_timeout(state, DECODE_FRAME_BATCH_MAX_WAIT)
+                .expect("decode frame batcher lock poisoned");
+            state = wait.0;
+        }
+        let batch_size = self.max_batch_size.min(state.pending.len());
+        Some(state.pending.drain(..batch_size).collect())
+    }
+
+    fn run_batch(&self, batch: Vec<PendingDecodeFrame>) {
+        let batch_size = batch.len();
+        let batch_wait_ms = batch
+            .iter()
+            .map(|pending| pending.enqueued_at.elapsed().as_secs_f64() * 1000.0)
+            .fold(0.0, f64::max);
+        let lock_started = Instant::now();
+        let runtime_result = self
+            .runtime
+            .lock()
+            .map_err(|_| anyhow!("runtime lock poisoned while running decode frame batch"));
+        let runtime_lock_wait_ms = elapsed_ms(lock_started);
+        let result = runtime_result.and_then(|mut runtime| {
+            let hold_started = Instant::now();
+            let requests = batch
+                .iter()
+                .map(|pending| RuntimeDecodeFrameBatchRequest {
+                    session_id: pending.session_id.as_str(),
+                    token_id: pending.token_id,
+                    sampling: pending.sampling.as_ref(),
+                    input: pending.input.as_ref(),
+                })
+                .collect::<Vec<_>>();
+            let outputs = runtime.decode_frame_batch_sampled(&requests)?;
+            Ok((outputs, elapsed_ms(hold_started)))
+        });
+        Self::send_batch_replies(
+            batch,
+            batch_size,
+            batch_wait_ms,
+            runtime_lock_wait_ms,
+            result,
+        );
+    }
+
+    fn send_batch_replies(
+        batch: Vec<PendingDecodeFrame>,
+        batch_size: usize,
+        batch_wait_ms: f64,
+        runtime_lock_wait_ms: f64,
+        result: Result<(Vec<skippy_runtime::DecodeFrameBatchOutput>, f64)>,
+    ) {
+        match result {
+            Ok((outputs, runtime_lock_hold_ms)) => {
+                for (pending, output) in batch.into_iter().zip(outputs) {
+                    let _ = pending.reply.send(Ok(DecodeFrameBatchOutcome {
+                        predicted: output.predicted_token,
+                        output: output.output,
+                        batch_size,
+                        batch_wait_ms,
+                        runtime_lock_wait_ms,
+                        runtime_lock_hold_ms,
+                    }));
+                }
+            }
+            Err(error) => {
+                let error = error.to_string();
+                for pending in batch {
+                    let _ = pending.reply.send(Err(anyhow!(error.clone())));
+                }
+            }
+        }
+    }
+}
+
+fn elapsed_ms(started: Instant) -> f64 {
+    started.elapsed().as_secs_f64() * 1000.0
+}

--- a/crates/skippy-server/src/binary_transport/decode_batcher.rs
+++ b/crates/skippy-server/src/binary_transport/decode_batcher.rs
@@ -6,15 +6,13 @@ use std::{
         mpsc as std_mpsc,
     },
     thread,
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use anyhow::{Result, anyhow};
 use skippy_runtime::{ActivationFrame, SamplingConfig};
 
 use crate::runtime_state::{RuntimeDecodeFrameBatchRequest, RuntimeState};
-
-const DECODE_FRAME_BATCH_MAX_WAIT: Duration = Duration::from_micros(200);
 
 pub(crate) struct DecodeFrameBatcher {
     shared: Arc<DecodeFrameBatcherShared>,
@@ -99,9 +97,10 @@ impl Clone for DecodeFrameBatcher {
 
 impl Drop for DecodeFrameBatcher {
     fn drop(&mut self) {
-        if self.shared.owner_count.fetch_sub(1, Ordering::AcqRel) == 1
-            && let Ok(mut state) = self.shared.state.lock()
-        {
+        if self.shared.owner_count.fetch_sub(1, Ordering::AcqRel) != 1 {
+            return;
+        }
+        if let Ok(mut state) = self.shared.state.lock() {
             state.stopping = true;
             self.shared.ready.notify_all();
         }
@@ -141,13 +140,6 @@ impl DecodeFrameBatcherShared {
         }
         if state.pending.is_empty() && state.stopping {
             return None;
-        }
-        if self.max_batch_size > 1 && state.pending.len() < self.max_batch_size {
-            let wait = self
-                .ready
-                .wait_timeout(state, DECODE_FRAME_BATCH_MAX_WAIT)
-                .expect("decode frame batcher lock poisoned");
-            state = wait.0;
         }
         let batch_size = self.max_batch_size.min(state.pending.len());
         Some(state.pending.drain(..batch_size).collect())

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -57,9 +57,9 @@ use tokio::{
 
 use crate::{
     binary_transport::{
-        PredictionReturnHub, PredictionReturnReceiver, WireCondition, connect_binary_downstream,
-        forwarded_stage_message, forwarded_stage_message_timed, run_binary_stage_message,
-        write_stage_message_conditioned,
+        DecodeFrameBatcher, PredictionReturnHub, PredictionReturnReceiver, WireCondition,
+        connect_binary_downstream, forwarded_stage_message, forwarded_stage_message_timed,
+        run_binary_stage_message, write_stage_message_conditioned,
     },
     cli::ServeOpenAiArgs,
     config::{load_json, validate_config},
@@ -171,6 +171,8 @@ pub async fn serve_openai(args: ServeOpenAiArgs) -> Result<()> {
     let kv = KvStageIntegration::from_config(&config)?.map(Arc::new);
     let ctx_size = usize::try_from(config.ctx_size).unwrap_or(usize::MAX);
     let decode_batcher = DecodeBatcher::new(runtime.clone(), args.generation_concurrency);
+    let decode_frame_batcher =
+        DecodeFrameBatcher::new(runtime.clone(), args.generation_concurrency);
     let backend = Arc::new(StageOpenAiBackend {
         runtime,
         config,
@@ -189,6 +191,7 @@ pub async fn serve_openai(args: ServeOpenAiArgs) -> Result<()> {
         hook_policy: None,
         kv,
         decode_batcher,
+        decode_frame_batcher,
     });
     let app: Router = instrumented_openai_router(backend, telemetry.clone());
 
@@ -517,6 +520,8 @@ pub fn embedded_openai_backend(args: EmbeddedOpenAiArgs) -> Result<EmbeddedOpenA
     let kv = KvStageIntegration::from_config(&args.config)?.map(Arc::new);
     let ctx_size = usize::try_from(args.config.ctx_size).unwrap_or(usize::MAX);
     let decode_batcher = DecodeBatcher::new(args.runtime.clone(), args.generation_concurrency);
+    let decode_frame_batcher =
+        DecodeFrameBatcher::new(args.runtime.clone(), args.generation_concurrency);
     let backend: Arc<dyn OpenAiBackend> = Arc::new(StageOpenAiBackend {
         runtime: args.runtime,
         config: args.config.clone(),
@@ -535,6 +540,7 @@ pub fn embedded_openai_backend(args: EmbeddedOpenAiArgs) -> Result<EmbeddedOpenA
         hook_policy: args.hook_policy,
         kv,
         decode_batcher,
+        decode_frame_batcher,
     });
     let openai_guardrails = args
         .openai_guardrails
@@ -574,6 +580,7 @@ struct StageOpenAiBackend {
     hook_policy: Option<Arc<dyn OpenAiHookPolicy>>,
     kv: Option<Arc<KvStageIntegration>>,
     decode_batcher: DecodeBatcher,
+    decode_frame_batcher: DecodeFrameBatcher,
 }
 
 struct GenerationQueueReservation {

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -69,6 +69,7 @@ use crate::{
 };
 
 mod backend;
+mod decode_batcher;
 mod embedded_execution;
 mod embedded_generation;
 mod generation_flow;
@@ -81,7 +82,10 @@ mod speculative;
 mod util;
 mod wire_messages;
 
-use self::{prefill::*, request::*, speculative::*, util::*, wire_messages::*};
+use self::{
+    decode_batcher::DecodeBatcher, prefill::*, request::*, speculative::*, util::*,
+    wire_messages::*,
+};
 
 static OPENAI_GENERATION_COUNTER: AtomicU64 = AtomicU64::new(1);
 
@@ -166,6 +170,7 @@ pub async fn serve_openai(args: ServeOpenAiArgs) -> Result<()> {
     }
     let kv = KvStageIntegration::from_config(&config)?.map(Arc::new);
     let ctx_size = usize::try_from(config.ctx_size).unwrap_or(usize::MAX);
+    let decode_batcher = DecodeBatcher::new(runtime.clone(), args.generation_concurrency);
     let backend = Arc::new(StageOpenAiBackend {
         runtime,
         config,
@@ -183,6 +188,7 @@ pub async fn serve_openai(args: ServeOpenAiArgs) -> Result<()> {
         generation_queue_limit: args.generation_concurrency,
         hook_policy: None,
         kv,
+        decode_batcher,
     });
     let app: Router = instrumented_openai_router(backend, telemetry.clone());
 
@@ -510,6 +516,7 @@ pub fn embedded_openai_backend(args: EmbeddedOpenAiArgs) -> Result<EmbeddedOpenA
     .context("prewarm embedded OpenAI runtime sessions")?;
     let kv = KvStageIntegration::from_config(&args.config)?.map(Arc::new);
     let ctx_size = usize::try_from(args.config.ctx_size).unwrap_or(usize::MAX);
+    let decode_batcher = DecodeBatcher::new(args.runtime.clone(), args.generation_concurrency);
     let backend: Arc<dyn OpenAiBackend> = Arc::new(StageOpenAiBackend {
         runtime: args.runtime,
         config: args.config.clone(),
@@ -527,6 +534,7 @@ pub fn embedded_openai_backend(args: EmbeddedOpenAiArgs) -> Result<EmbeddedOpenA
         generation_queue_limit: args.generation_concurrency,
         hook_policy: args.hook_policy,
         kv,
+        decode_batcher,
     });
     let openai_guardrails = args
         .openai_guardrails
@@ -565,6 +573,7 @@ struct StageOpenAiBackend {
     generation_queue_limit: usize,
     hook_policy: Option<Arc<dyn OpenAiHookPolicy>>,
     kv: Option<Arc<KvStageIntegration>>,
+    decode_batcher: DecodeBatcher,
 }
 
 struct GenerationQueueReservation {

--- a/crates/skippy-server/src/frontend/decode_batcher.rs
+++ b/crates/skippy-server/src/frontend/decode_batcher.rs
@@ -1,0 +1,210 @@
+use std::{
+    collections::VecDeque,
+    sync::{
+        Arc, Condvar, Mutex, Weak,
+        atomic::{AtomicUsize, Ordering},
+        mpsc as std_mpsc,
+    },
+    thread,
+    time::{Duration, Instant},
+};
+
+use super::*;
+use crate::runtime_state::RuntimeDecodeBatchRequest;
+
+const DECODE_BATCH_MAX_WAIT: Duration = Duration::from_micros(200);
+
+pub(super) struct DecodeBatcher {
+    shared: Arc<DecodeBatcherShared>,
+}
+
+struct DecodeBatcherShared {
+    runtime: Arc<Mutex<RuntimeState>>,
+    state: Mutex<DecodeBatcherState>,
+    ready: Condvar,
+    max_batch_size: usize,
+    owner_count: AtomicUsize,
+}
+
+#[derive(Default)]
+struct DecodeBatcherState {
+    pending: VecDeque<PendingDecode>,
+    stopping: bool,
+}
+
+struct PendingDecode {
+    session_id: String,
+    token_id: i32,
+    sampling: Option<SamplingConfig>,
+    enqueued_at: Instant,
+    reply: std_mpsc::SyncSender<OpenAiResult<DecodeBatchOutcome>>,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct DecodeBatchOutcome {
+    pub predicted: i32,
+    pub batch_size: usize,
+    pub batch_wait_ms: f64,
+    pub runtime_lock_wait_ms: f64,
+    pub runtime_lock_hold_ms: f64,
+}
+
+impl DecodeBatcher {
+    pub(super) fn new(runtime: Arc<Mutex<RuntimeState>>, max_batch_size: usize) -> Self {
+        let shared = Arc::new(DecodeBatcherShared {
+            runtime,
+            state: Mutex::new(DecodeBatcherState::default()),
+            ready: Condvar::new(),
+            max_batch_size: max_batch_size.max(1),
+            owner_count: AtomicUsize::new(1),
+        });
+        let worker = Arc::downgrade(&shared);
+        thread::spawn(move || DecodeBatcherShared::run_worker(worker));
+        Self { shared }
+    }
+
+    pub(super) fn decode(
+        &self,
+        session_id: &str,
+        token_id: i32,
+        sampling: Option<&SamplingConfig>,
+    ) -> OpenAiResult<DecodeBatchOutcome> {
+        let (reply, receiver) = std_mpsc::sync_channel(1);
+        self.shared.enqueue(PendingDecode {
+            session_id: session_id.to_string(),
+            token_id,
+            sampling: sampling.cloned(),
+            enqueued_at: Instant::now(),
+            reply,
+        })?;
+        receiver
+            .recv()
+            .map_err(|error| OpenAiError::backend(format!("decode batcher stopped: {error}")))?
+    }
+}
+
+impl Clone for DecodeBatcher {
+    fn clone(&self) -> Self {
+        self.shared.owner_count.fetch_add(1, Ordering::Relaxed);
+        Self {
+            shared: self.shared.clone(),
+        }
+    }
+}
+
+impl Drop for DecodeBatcher {
+    fn drop(&mut self) {
+        if self.shared.owner_count.fetch_sub(1, Ordering::AcqRel) == 1
+            && let Ok(mut state) = self.shared.state.lock()
+        {
+            state.stopping = true;
+            self.shared.ready.notify_all();
+        }
+    }
+}
+
+impl DecodeBatcherShared {
+    fn enqueue(&self, pending: PendingDecode) -> OpenAiResult<()> {
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| OpenAiError::backend("decode batcher lock poisoned"))?;
+        state.pending.push_back(pending);
+        self.ready.notify_one();
+        Ok(())
+    }
+
+    fn run_worker(shared: Weak<Self>) {
+        while let Some(shared) = shared.upgrade() {
+            let Some(batch) = shared.wait_for_batch() else {
+                break;
+            };
+            shared.run_batch(batch);
+        }
+    }
+
+    fn wait_for_batch(&self) -> Option<Vec<PendingDecode>> {
+        let mut state = self.state.lock().expect("decode batcher lock poisoned");
+        while state.pending.is_empty() && !state.stopping {
+            state = self
+                .ready
+                .wait(state)
+                .expect("decode batcher lock poisoned");
+        }
+        if state.pending.is_empty() && state.stopping {
+            return None;
+        }
+        if self.max_batch_size > 1 && state.pending.len() < self.max_batch_size {
+            let wait = self
+                .ready
+                .wait_timeout(state, DECODE_BATCH_MAX_WAIT)
+                .expect("decode batcher lock poisoned");
+            state = wait.0;
+        }
+        let batch_size = self.max_batch_size.min(state.pending.len());
+        Some(state.pending.drain(..batch_size).collect())
+    }
+
+    fn run_batch(&self, batch: Vec<PendingDecode>) {
+        let batch_size = batch.len();
+        let batch_wait_ms = batch
+            .iter()
+            .map(|pending| pending.enqueued_at.elapsed().as_secs_f64() * 1000.0)
+            .fold(0.0, f64::max);
+        let lock_timer = PhaseTimer::start();
+        let runtime_result = self
+            .runtime
+            .lock()
+            .map_err(|_| OpenAiError::backend("runtime lock poisoned while running decode batch"));
+        let runtime_lock_wait_ms = lock_timer.elapsed_ms();
+        let result = runtime_result.and_then(|mut runtime| {
+            let hold_timer = PhaseTimer::start();
+            let requests = batch
+                .iter()
+                .map(|pending| RuntimeDecodeBatchRequest {
+                    session_id: pending.session_id.as_str(),
+                    token_id: pending.token_id,
+                    sampling: pending.sampling.as_ref(),
+                })
+                .collect::<Vec<_>>();
+            let predicted = runtime
+                .decode_batch_sampled(&requests)
+                .map_err(openai_backend_error)?;
+            Ok((predicted, hold_timer.elapsed_ms()))
+        });
+        Self::send_batch_replies(
+            batch,
+            batch_size,
+            batch_wait_ms,
+            runtime_lock_wait_ms,
+            result,
+        );
+    }
+
+    fn send_batch_replies(
+        batch: Vec<PendingDecode>,
+        batch_size: usize,
+        batch_wait_ms: f64,
+        runtime_lock_wait_ms: f64,
+        result: OpenAiResult<(Vec<i32>, f64)>,
+    ) {
+        match result {
+            Ok((predicted, runtime_lock_hold_ms)) => {
+                for (pending, predicted) in batch.into_iter().zip(predicted) {
+                    let _ = pending.reply.send(Ok(DecodeBatchOutcome {
+                        predicted,
+                        batch_size,
+                        batch_wait_ms,
+                        runtime_lock_wait_ms,
+                        runtime_lock_hold_ms,
+                    }));
+                }
+            }
+            Err(error) => {
+                for pending in batch {
+                    let _ = pending.reply.send(Err(error.clone()));
+                }
+            }
+        }
+    }
+}

--- a/crates/skippy-server/src/frontend/decode_batcher.rs
+++ b/crates/skippy-server/src/frontend/decode_batcher.rs
@@ -6,13 +6,11 @@ use std::{
         mpsc as std_mpsc,
     },
     thread,
-    time::{Duration, Instant},
+    time::Instant,
 };
 
 use super::*;
 use crate::runtime_state::RuntimeDecodeBatchRequest;
-
-const DECODE_BATCH_MAX_WAIT: Duration = Duration::from_micros(200);
 
 pub(super) struct DecodeBatcher {
     shared: Arc<DecodeBatcherShared>,
@@ -94,9 +92,10 @@ impl Clone for DecodeBatcher {
 
 impl Drop for DecodeBatcher {
     fn drop(&mut self) {
-        if self.shared.owner_count.fetch_sub(1, Ordering::AcqRel) == 1
-            && let Ok(mut state) = self.shared.state.lock()
-        {
+        if self.shared.owner_count.fetch_sub(1, Ordering::AcqRel) != 1 {
+            return;
+        }
+        if let Ok(mut state) = self.shared.state.lock() {
             state.stopping = true;
             self.shared.ready.notify_all();
         }
@@ -133,13 +132,6 @@ impl DecodeBatcherShared {
         }
         if state.pending.is_empty() && state.stopping {
             return None;
-        }
-        if self.max_batch_size > 1 && state.pending.len() < self.max_batch_size {
-            let wait = self
-                .ready
-                .wait_timeout(state, DECODE_BATCH_MAX_WAIT)
-                .expect("decode batcher lock poisoned");
-            state = wait.0;
         }
         let batch_size = self.max_batch_size.min(state.pending.len());
         Some(state.pending.drain(..batch_size).collect())

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -585,8 +585,8 @@ impl StageOpenAiBackend {
             let mut decode_runtime_lock_hold_ms = 0.0;
             let mut decode_runtime_lock_hold_max_ms = 0.0_f64;
             let mut decode_runtime_lock_acquires = 0usize;
-            let mut decode_runtime_sessions_before = None;
-            let mut decode_runtime_sessions_after = None;
+            let mut decode_batch_size_max = 1usize;
+            let mut decode_batch_wait_ms = 0.0;
             let mut decode_forward_write_ms = 0.0;
             let mut decode_forward_activation_encode_ms = 0.0;
             let mut decode_output_activation_bytes = 0usize;
@@ -1114,39 +1114,22 @@ impl StageOpenAiBackend {
                     raw_bytes: Vec::new(),
                 };
                 let stage0_timer = PhaseTimer::start();
-                let token_runtime_lock_wait_ms;
-                let token_runtime_lock_hold_ms;
-                let output = {
-                    let lock_timer = PhaseTimer::start();
-                    let mut runtime = self
-                        .runtime
-                        .lock()
-                        .map_err(|_| OpenAiError::backend("runtime lock poisoned"))?;
-                    let lock_wait_ms = lock_timer.elapsed_ms();
-                    token_runtime_lock_wait_ms = lock_wait_ms;
-                    decode_runtime_lock_wait_ms += lock_wait_ms;
-                    decode_runtime_lock_wait_max_ms =
-                        decode_runtime_lock_wait_max_ms.max(lock_wait_ms);
-                    decode_runtime_lock_acquires += 1;
-                    let lock_hold_timer = PhaseTimer::start();
-                    decode_runtime_sessions_before.get_or_insert_with(|| runtime.session_stats());
-                    let output = run_binary_stage_message(
-                        &mut runtime,
-                        &session_key,
-                        &message,
-                        &[current],
-                        None,
-                        false,
-                    )
-                    .map_err(openai_backend_error)?
-                    .2;
-                    decode_runtime_sessions_after = Some(runtime.session_stats());
-                    token_runtime_lock_hold_ms = lock_hold_timer.elapsed_ms();
-                    decode_runtime_lock_hold_ms += token_runtime_lock_hold_ms;
-                    decode_runtime_lock_hold_max_ms =
-                        decode_runtime_lock_hold_max_ms.max(token_runtime_lock_hold_ms);
-                    output
-                };
+                let batch_outcome = self
+                    .decode_frame_batcher
+                    .decode(&session_key, current, Some(request.sampling), None)
+                    .map_err(openai_backend_error)?;
+                let token_runtime_lock_wait_ms = batch_outcome.runtime_lock_wait_ms;
+                let token_runtime_lock_hold_ms = batch_outcome.runtime_lock_hold_ms;
+                decode_runtime_lock_wait_ms += token_runtime_lock_wait_ms;
+                decode_runtime_lock_wait_max_ms =
+                    decode_runtime_lock_wait_max_ms.max(token_runtime_lock_wait_ms);
+                decode_runtime_lock_hold_ms += token_runtime_lock_hold_ms;
+                decode_runtime_lock_hold_max_ms =
+                    decode_runtime_lock_hold_max_ms.max(token_runtime_lock_hold_ms);
+                decode_runtime_lock_acquires += 1;
+                decode_batch_size_max = decode_batch_size_max.max(batch_outcome.batch_size);
+                decode_batch_wait_ms += batch_outcome.batch_wait_ms;
+                let output = batch_outcome.output;
                 let stage0_compute_ms = stage0_timer.elapsed_ms();
                 decode_stage0_compute_ms += stage0_compute_ms;
                 let forwarded = forwarded_stage_message_timed(
@@ -1229,6 +1212,14 @@ impl StageOpenAiBackend {
                     json!(token_runtime_lock_hold_ms),
                 );
                 token_attrs.insert(
+                    "llama_stage.decode_batch_size".to_string(),
+                    json!(batch_outcome.batch_size),
+                );
+                token_attrs.insert(
+                    "llama_stage.decode_batch_wait_ms".to_string(),
+                    json!(batch_outcome.batch_wait_ms),
+                );
+                token_attrs.insert(
                     "llama_stage.output_activation_bytes".to_string(),
                     json!(output.payload.len()),
                 );
@@ -1284,20 +1275,14 @@ impl StageOpenAiBackend {
                 "llama_stage.runtime_lock_acquires".to_string(),
                 json!(decode_runtime_lock_acquires),
             );
-            if let Some(stats) = decode_runtime_sessions_before.as_ref() {
-                Self::insert_runtime_session_stats(
-                    &mut decode_attrs,
-                    "llama_stage.runtime_sessions_before",
-                    stats,
-                );
-            }
-            if let Some(stats) = decode_runtime_sessions_after.as_ref() {
-                Self::insert_runtime_session_stats(
-                    &mut decode_attrs,
-                    "llama_stage.runtime_sessions_after",
-                    stats,
-                );
-            }
+            decode_attrs.insert(
+                "llama_stage.decode_batch_size_max".to_string(),
+                json!(decode_batch_size_max),
+            );
+            decode_attrs.insert(
+                "llama_stage.decode_batch_wait_ms".to_string(),
+                json!(decode_batch_wait_ms),
+            );
             decode_attrs.insert(
                 "llama_stage.forward_write_ms".to_string(),
                 json!(decode_forward_write_ms),

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -717,6 +717,8 @@ impl StageOpenAiBackend {
             let mut decode_runtime_lock_wait_ms = 0.0;
             let mut decode_runtime_lock_hold_ms = 0.0;
             let mut decode_runtime_lock_acquires = 0usize;
+            let mut decode_batch_size_max = 1usize;
+            let mut decode_batch_wait_ms = 0.0;
             let mut decode_forward_write_ms = 0.0;
             let mut decode_downstream_wait_ms = 0.0;
             let mut decode_output_activation_bytes = 0usize;
@@ -753,29 +755,16 @@ impl StageOpenAiBackend {
                 )?;
                 let token_timer = PhaseTimer::start();
                 let stage0_timer = PhaseTimer::start();
-                let output = {
-                    let lock_timer = PhaseTimer::start();
-                    let mut runtime = self
-                        .runtime
-                        .lock()
-                        .map_err(|_| OpenAiError::backend("runtime lock poisoned"))?;
-                    let lock_wait_ms = lock_timer.elapsed_ms();
-                    decode_runtime_lock_wait_ms += lock_wait_ms;
-                    decode_runtime_lock_acquires += 1;
-                    let hold_timer = PhaseTimer::start();
-                    let output = run_binary_stage_message(
-                        &mut runtime,
-                        &session_key,
-                        &message,
-                        &[current],
-                        None,
-                        false,
-                    )
-                    .map_err(openai_backend_error)?
-                    .2;
-                    decode_runtime_lock_hold_ms += hold_timer.elapsed_ms();
-                    output
-                };
+                let batch_outcome = self
+                    .decode_frame_batcher
+                    .decode(&session_key, current, Some(&request.sampling), None)
+                    .map_err(openai_backend_error)?;
+                decode_runtime_lock_wait_ms += batch_outcome.runtime_lock_wait_ms;
+                decode_runtime_lock_hold_ms += batch_outcome.runtime_lock_hold_ms;
+                decode_runtime_lock_acquires += 1;
+                decode_batch_size_max = decode_batch_size_max.max(batch_outcome.batch_size);
+                decode_batch_wait_ms += batch_outcome.batch_wait_ms;
+                let output = batch_outcome.output;
                 let stage0_compute_ms = stage0_timer.elapsed_ms();
                 decode_stage0_compute_ms += stage0_compute_ms;
                 let forwarded = forwarded_stage_message_timed(
@@ -829,6 +818,14 @@ impl StageOpenAiBackend {
                     "llama_stage.downstream_wait_ms".to_string(),
                     json!(downstream_wait_ms),
                 );
+                token_attrs.insert(
+                    "llama_stage.decode_batch_size".to_string(),
+                    json!(batch_outcome.batch_size),
+                );
+                token_attrs.insert(
+                    "llama_stage.decode_batch_wait_ms".to_string(),
+                    json!(batch_outcome.batch_wait_ms),
+                );
                 token_attrs.insert("llama_stage.predicted_token".to_string(), json!(current));
                 token_attrs.insert("llama_stage.message_kind".to_string(), json!("DecodeEmbd"));
                 self.emit_openai_phase("stage.openai_decode_token", token_timer, token_attrs);
@@ -854,6 +851,14 @@ impl StageOpenAiBackend {
             decode_attrs.insert(
                 "llama_stage.runtime_lock_acquires".to_string(),
                 json!(decode_runtime_lock_acquires),
+            );
+            decode_attrs.insert(
+                "llama_stage.decode_batch_size_max".to_string(),
+                json!(decode_batch_size_max),
+            );
+            decode_attrs.insert(
+                "llama_stage.decode_batch_wait_ms".to_string(),
+                json!(decode_batch_wait_ms),
             );
             decode_attrs.insert(
                 "llama_stage.forward_write_ms".to_string(),

--- a/crates/skippy-server/src/frontend/local_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation.rs
@@ -409,59 +409,46 @@ impl StageOpenAiBackend {
                 }
                 let decode_step = decoded_tokens;
                 let token_timer = PhaseTimer::start();
-                let token_runtime_lock_wait_ms;
-                let token_runtime_lock_hold_ms;
-                let token_decode_ms;
                 let token_signal_ms;
                 let token_signal;
                 let signal_window;
-                current = {
-                    let lock_timer = PhaseTimer::start();
+                let decode_call_timer = PhaseTimer::start();
+                let outcome = self.decode_batcher.decode(
+                    &session_id,
+                    current,
+                    request.sampling.enabled.then_some(request.sampling),
+                )?;
+                current = outcome.predicted;
+                let token_batch_size = outcome.batch_size;
+                let token_batch_wait_ms = outcome.batch_wait_ms;
+                let token_runtime_lock_wait_ms = outcome.runtime_lock_wait_ms;
+                let token_runtime_lock_hold_ms = outcome.runtime_lock_hold_ms;
+                runtime_lock_wait_ms += token_runtime_lock_wait_ms;
+                runtime_lock_wait_max_ms = runtime_lock_wait_max_ms.max(token_runtime_lock_wait_ms);
+                runtime_lock_hold_ms += token_runtime_lock_hold_ms;
+                runtime_lock_hold_max_ms = runtime_lock_hold_max_ms.max(token_runtime_lock_hold_ms);
+                runtime_lock_acquires += 1;
+                let token_decode_ms = if emit_token_debug {
+                    decode_call_timer.elapsed_ms()
+                } else {
+                    0.0
+                };
+                if generation_hooks_active {
+                    let signal_timer = PhaseTimer::start();
                     let mut runtime = self
                         .runtime
                         .lock()
                         .map_err(|_| OpenAiError::backend("runtime lock poisoned"))?;
-                    let lock_wait_ms = lock_timer.elapsed_ms();
-                    token_runtime_lock_wait_ms = lock_wait_ms;
-                    runtime_lock_wait_ms += lock_wait_ms;
-                    runtime_lock_wait_max_ms = runtime_lock_wait_max_ms.max(lock_wait_ms);
-                    runtime_lock_acquires += 1;
-                    let hold_timer = PhaseTimer::start();
                     runtime_sessions_before.get_or_insert_with(|| runtime.session_stats());
-                    let decode_call_timer = PhaseTimer::start();
-                    let predicted = runtime
-                        .decode_sampled(
-                            &session_id,
-                            current,
-                            request.sampling.enabled.then_some(request.sampling),
-                        )
-                        .map_err(openai_backend_error)?;
-                    token_decode_ms = if emit_token_debug {
-                        decode_call_timer.elapsed_ms()
-                    } else {
-                        0.0
-                    };
-                    if generation_hooks_active {
-                        let signal_timer = PhaseTimer::start();
-                        token_signal = runtime.last_token_signal(&session_id).ok();
-                        signal_window = runtime.signal_window(&session_id, 16).ok();
-                        token_signal_ms = signal_timer.elapsed_ms();
-                    } else {
-                        token_signal = None;
-                        signal_window = None;
-                        token_signal_ms = 0.0;
-                    }
+                    token_signal = runtime.last_token_signal(&session_id).ok();
+                    signal_window = runtime.signal_window(&session_id, 16).ok();
                     runtime_sessions_after = Some(runtime.session_stats());
-                    token_runtime_lock_hold_ms = if emit_token_debug {
-                        hold_timer.elapsed_ms()
-                    } else {
-                        0.0
-                    };
-                    runtime_lock_hold_ms += token_runtime_lock_hold_ms;
-                    runtime_lock_hold_max_ms =
-                        runtime_lock_hold_max_ms.max(token_runtime_lock_hold_ms);
-                    predicted
-                };
+                    token_signal_ms = signal_timer.elapsed_ms();
+                } else {
+                    token_signal = None;
+                    signal_window = None;
+                    token_signal_ms = 0.0;
+                }
                 if generation_hooks_active
                     && let Some(injected_current) = self.maybe_run_generation_hooks(
                         &session_id,
@@ -494,6 +481,14 @@ impl StageOpenAiBackend {
                     token_attrs.insert(
                         "llama_stage.decode_call_ms".to_string(),
                         json!(token_decode_ms),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.decode_batch_size".to_string(),
+                        json!(token_batch_size),
+                    );
+                    token_attrs.insert(
+                        "llama_stage.decode_batch_wait_ms".to_string(),
+                        json!(token_batch_wait_ms),
                     );
                     token_attrs.insert("llama_stage.signal_ms".to_string(), json!(token_signal_ms));
                     token_attrs.insert(

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -1086,6 +1086,7 @@ fn local_openai_backend(config: StageConfig) -> Result<StageOpenAiBackend> {
     let runtime = load_runtime(&config)?.context("load smoke runtime")?;
     let ctx_size = usize::try_from(config.ctx_size).unwrap_or(usize::MAX);
     let decode_batcher = DecodeBatcher::new(runtime.clone(), 1);
+    let decode_frame_batcher = DecodeFrameBatcher::new(runtime.clone(), 1);
     Ok(StageOpenAiBackend {
         runtime,
         telemetry: Telemetry::new(
@@ -1109,6 +1110,7 @@ fn local_openai_backend(config: StageConfig) -> Result<StageOpenAiBackend> {
         hook_policy: None,
         kv: None,
         decode_batcher,
+        decode_frame_batcher,
     })
 }
 
@@ -1267,6 +1269,7 @@ async fn real_multimodal_split_smoke_when_fixture_is_set() -> Result<()> {
     let runtime = load_runtime(&stage0_config)?.context("load stage-0 smoke runtime")?;
     let ctx_size = usize::try_from(stage0_config.ctx_size).unwrap_or(usize::MAX);
     let decode_batcher = DecodeBatcher::new(runtime.clone(), 1);
+    let decode_frame_batcher = DecodeFrameBatcher::new(runtime.clone(), 1);
     let backend = StageOpenAiBackend {
         runtime,
         telemetry,
@@ -1294,6 +1297,7 @@ async fn real_multimodal_split_smoke_when_fixture_is_set() -> Result<()> {
         hook_policy: None,
         kv: None,
         decode_batcher,
+        decode_frame_batcher,
     };
     let response = backend
         .chat_completion(multimodal_chat_request(&fixture)?)

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -1085,6 +1085,7 @@ fn multimodal_stage_config(
 fn local_openai_backend(config: StageConfig) -> Result<StageOpenAiBackend> {
     let runtime = load_runtime(&config)?.context("load smoke runtime")?;
     let ctx_size = usize::try_from(config.ctx_size).unwrap_or(usize::MAX);
+    let decode_batcher = DecodeBatcher::new(runtime.clone(), 1);
     Ok(StageOpenAiBackend {
         runtime,
         telemetry: Telemetry::new(
@@ -1107,6 +1108,7 @@ fn local_openai_backend(config: StageConfig) -> Result<StageOpenAiBackend> {
         generation_queue_limit: 1,
         hook_policy: None,
         kv: None,
+        decode_batcher,
     })
 }
 
@@ -1264,6 +1266,7 @@ async fn real_multimodal_split_smoke_when_fixture_is_set() -> Result<()> {
         .context("create split smoke lane pool")?;
     let runtime = load_runtime(&stage0_config)?.context("load stage-0 smoke runtime")?;
     let ctx_size = usize::try_from(stage0_config.ctx_size).unwrap_or(usize::MAX);
+    let decode_batcher = DecodeBatcher::new(runtime.clone(), 1);
     let backend = StageOpenAiBackend {
         runtime,
         telemetry,
@@ -1290,6 +1293,7 @@ async fn real_multimodal_split_smoke_when_fixture_is_set() -> Result<()> {
         generation_queue_limit: 1,
         hook_policy: None,
         kv: None,
+        decode_batcher,
     };
     let response = backend
         .chat_completion(multimodal_chat_request(&fixture)?)

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -7,10 +7,11 @@ use std::{
 use anyhow::{Context, Result, bail};
 use skippy_protocol::{FlashAttentionType, LoadMode, StageConfig};
 use skippy_runtime::{
-    ActivationFrame, DecodeBatchRequest, FlashAttentionType as RuntimeFlashAttentionType,
-    GenerationSignalWindow, MediaInput, MediaPrefill, MediaPrefillFrame, RuntimeConfig,
-    RuntimeKvPage, RuntimeKvPageDesc, RuntimeLoadMode, SamplingConfig, StageModel, StageSession,
-    StageSessionCheckpoint, TokenSignal, parse_cache_type,
+    ActivationFrame, DecodeBatchRequest, DecodeFrameBatchOutput, DecodeFrameBatchRequest,
+    FlashAttentionType as RuntimeFlashAttentionType, GenerationSignalWindow, MediaInput,
+    MediaPrefill, MediaPrefillFrame, RuntimeConfig, RuntimeKvPage, RuntimeKvPageDesc,
+    RuntimeLoadMode, SamplingConfig, StageModel, StageSession, StageSessionCheckpoint, TokenSignal,
+    parse_cache_type,
 };
 
 use crate::package::select_package_parts;
@@ -94,6 +95,13 @@ pub struct RuntimeDecodeBatchRequest<'a> {
     pub session_id: &'a str,
     pub token_id: i32,
     pub sampling: Option<&'a SamplingConfig>,
+}
+
+pub struct RuntimeDecodeFrameBatchRequest<'a> {
+    pub session_id: &'a str,
+    pub token_id: i32,
+    pub sampling: Option<&'a SamplingConfig>,
+    pub input: Option<&'a ActivationFrame>,
 }
 
 #[derive(Debug, Clone)]
@@ -306,6 +314,54 @@ impl RuntimeState {
         Ok(output)
     }
 
+    pub fn decode_frame_batch_sampled(
+        &mut self,
+        requests: &[RuntimeDecodeFrameBatchRequest<'_>],
+    ) -> Result<Vec<DecodeFrameBatchOutput>> {
+        if requests.is_empty() {
+            return Ok(Vec::new());
+        }
+        Self::ensure_unique_frame_batch_sessions(requests)?;
+        for request in requests {
+            self.session(request.session_id)?;
+        }
+
+        let mut lane_sessions = Vec::with_capacity(requests.len());
+        for request in requests {
+            let lane_session = self.sessions.remove(request.session_id).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "session {} was not active after admission",
+                    request.session_id
+                )
+            })?;
+            lane_sessions.push((request.session_id.to_string(), lane_session));
+        }
+
+        let result = {
+            let mut decode_requests = lane_sessions
+                .iter_mut()
+                .zip(requests.iter())
+                .map(|((_, lane_session), request)| DecodeFrameBatchRequest {
+                    session: &mut lane_session.session,
+                    token_id: request.token_id,
+                    sampling: request.sampling,
+                    input: request.input,
+                })
+                .collect::<Vec<_>>();
+            StageSession::decode_step_frame_batch_sampled(&mut decode_requests)
+        };
+
+        for (session_id, lane_session) in lane_sessions {
+            self.sessions.insert(session_id, lane_session);
+        }
+        if result.is_ok() {
+            for request in requests {
+                self.add_session_tokens(request.session_id, 1);
+            }
+        }
+        result
+    }
+
     pub fn verify_frame(
         &mut self,
         session_id: &str,
@@ -371,6 +427,21 @@ impl RuntimeState {
         for request in requests {
             if !seen.insert(request.session_id) {
                 bail!("duplicate session {} in decode batch", request.session_id);
+            }
+        }
+        Ok(())
+    }
+
+    fn ensure_unique_frame_batch_sessions(
+        requests: &[RuntimeDecodeFrameBatchRequest<'_>],
+    ) -> Result<()> {
+        let mut seen = BTreeSet::new();
+        for request in requests {
+            if !seen.insert(request.session_id) {
+                bail!(
+                    "duplicate session {} in decode frame batch",
+                    request.session_id
+                );
             }
         }
         Ok(())

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -1,5 +1,5 @@
 use std::{
-    collections::BTreeMap,
+    collections::{BTreeMap, BTreeSet},
     sync::{Arc, Mutex},
     time::Instant,
 };
@@ -7,10 +7,10 @@ use std::{
 use anyhow::{Context, Result, bail};
 use skippy_protocol::{FlashAttentionType, LoadMode, StageConfig};
 use skippy_runtime::{
-    ActivationFrame, FlashAttentionType as RuntimeFlashAttentionType, GenerationSignalWindow,
-    MediaInput, MediaPrefill, MediaPrefillFrame, RuntimeConfig, RuntimeKvPage, RuntimeKvPageDesc,
-    RuntimeLoadMode, SamplingConfig, StageModel, StageSession, StageSessionCheckpoint, TokenSignal,
-    parse_cache_type,
+    ActivationFrame, DecodeBatchRequest, FlashAttentionType as RuntimeFlashAttentionType,
+    GenerationSignalWindow, MediaInput, MediaPrefill, MediaPrefillFrame, RuntimeConfig,
+    RuntimeKvPage, RuntimeKvPageDesc, RuntimeLoadMode, SamplingConfig, StageModel, StageSession,
+    StageSessionCheckpoint, TokenSignal, parse_cache_type,
 };
 
 use crate::package::select_package_parts;
@@ -90,6 +90,12 @@ pub struct RuntimeSessionDropStats {
     pub stats_after: RuntimeSessionStats,
 }
 
+pub struct RuntimeDecodeBatchRequest<'a> {
+    pub session_id: &'a str,
+    pub token_id: i32,
+    pub sampling: Option<&'a SamplingConfig>,
+}
+
 #[derive(Debug, Clone)]
 struct ResidentLanePrefix {
     page_id: String,
@@ -161,6 +167,53 @@ impl RuntimeState {
         let token = session.decode_step_sampled(token_id, sampling)?;
         self.add_session_tokens(session_id, 1);
         Ok(token)
+    }
+
+    pub fn decode_batch_sampled(
+        &mut self,
+        requests: &[RuntimeDecodeBatchRequest<'_>],
+    ) -> Result<Vec<i32>> {
+        if requests.is_empty() {
+            return Ok(Vec::new());
+        }
+        Self::ensure_unique_batch_sessions(requests)?;
+        for request in requests {
+            self.session(request.session_id)?;
+        }
+
+        let mut lane_sessions = Vec::with_capacity(requests.len());
+        for request in requests {
+            let lane_session = self.sessions.remove(request.session_id).ok_or_else(|| {
+                anyhow::anyhow!(
+                    "session {} was not active after admission",
+                    request.session_id
+                )
+            })?;
+            lane_sessions.push((request.session_id.to_string(), lane_session));
+        }
+
+        let result = {
+            let mut decode_requests = lane_sessions
+                .iter_mut()
+                .zip(requests.iter())
+                .map(|((_, lane_session), request)| DecodeBatchRequest {
+                    session: &mut lane_session.session,
+                    token_id: request.token_id,
+                    sampling: request.sampling,
+                })
+                .collect::<Vec<_>>();
+            StageSession::decode_batch_sampled(&mut decode_requests)
+        };
+
+        for (session_id, lane_session) in lane_sessions {
+            self.sessions.insert(session_id, lane_session);
+        }
+        if result.is_ok() {
+            for request in requests {
+                self.add_session_tokens(request.session_id, 1);
+            }
+        }
+        result
     }
 
     pub fn session_batch_size(&mut self, session_id: &str) -> Result<usize> {
@@ -311,6 +364,16 @@ impl RuntimeState {
             .get_mut(session_id)
             .expect("session inserted above")
             .session)
+    }
+
+    fn ensure_unique_batch_sessions(requests: &[RuntimeDecodeBatchRequest<'_>]) -> Result<()> {
+        let mut seen = BTreeSet::new();
+        for request in requests {
+            if !seen.insert(request.session_id) {
+                bail!("duplicate session {} in decode batch", request.session_id);
+            }
+        }
+        Ok(())
     }
 
     fn active_session(&mut self, session_id: &str) -> Result<&mut StageSession> {

--- a/third_party/llama.cpp/patches/0083-Add-skippy-batched-decode-ABI.patch
+++ b/third_party/llama.cpp/patches/0083-Add-skippy-batched-decode-ABI.patch
@@ -1,0 +1,237 @@
+From 3158ebaa1a26bd5eb6b1ba1288f7f5aa2d65f356 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Fri, 5 Jun 2026 17:30:13 +1000
+Subject: [PATCH 83/83] Add skippy batched decode ABI
+
+---
+ include/skippy.h        |   9 +++
+ include/skippy/common.h |   2 +-
+ src/skippy.cpp          | 122 +++++++++++++++++++++++++++++++---------
+ 3 files changed, 105 insertions(+), 28 deletions(-)
+
+diff --git a/include/skippy.h b/include/skippy.h
+index 84173c02..f3911de7 100644
+--- a/include/skippy.h
++++ b/include/skippy.h
+@@ -263,6 +263,15 @@ LLAMA_API enum skippy_status skippy_decode_step_sampled(
+         llama_token * out_predicted_token,
+         struct skippy_error ** out_error);
+ 
++LLAMA_API enum skippy_status skippy_decode_batch_sampled(
++        struct skippy_session * const * sessions,
++        const llama_token * token_ids,
++        const struct skippy_sampling_config * const * sampling,
++        size_t request_count,
++        llama_token * out_predicted_tokens,
++        size_t predicted_token_capacity,
++        struct skippy_error ** out_error);
++
+ LLAMA_API enum skippy_status skippy_prefill_chunk_frame(
+         struct skippy_session * session,
+         const llama_token * token_ids,
+diff --git a/include/skippy/common.h b/include/skippy/common.h
+index a680d342..e75a7e22 100644
+--- a/include/skippy/common.h
++++ b/include/skippy/common.h
+@@ -26,7 +26,7 @@ extern "C" {
+ 
+ #define SKIPPY_ABI_VERSION_MAJOR 0
+ #define SKIPPY_ABI_VERSION_MINOR 1
+-#define SKIPPY_ABI_VERSION_PATCH 25
++#define SKIPPY_ABI_VERSION_PATCH 26
+ 
+ enum skippy_feature {
+     SKIPPY_FEATURE_RUNTIME_SLICE          = 1 << 0,
+diff --git a/src/skippy.cpp b/src/skippy.cpp
+index f0f14820..df816f66 100644
+--- a/src/skippy.cpp
++++ b/src/skippy.cpp
+@@ -1085,23 +1085,6 @@ static enum skippy_status skippy_verify_token_batch(
+     return status;
+ }
+ 
+-static llama_token skippy_greedy_sample(skippy_session * session) {
+-    const llama_vocab * vocab = llama_model_get_vocab(session->stage_model->model);
+-    const int32_t n_vocab = llama_vocab_n_tokens(vocab);
+-    const float * logits = llama_get_logits_ith(session->ctx, -1);
+-
+-    llama_token best = 0;
+-    float best_logit = -std::numeric_limits<float>::infinity();
+-    for (int32_t token = 0; token < n_vocab; ++token) {
+-        if (logits[token] > best_logit) {
+-            best_logit = logits[token];
+-            best = token;
+-        }
+-    }
+-
+-    return best;
+-}
+-
+ static llama_token skippy_greedy_sample_ith(skippy_session * session, int32_t index) {
+     const llama_vocab * vocab = llama_model_get_vocab(session->stage_model->model);
+     const int32_t n_vocab = llama_vocab_n_tokens(vocab);
+@@ -1122,6 +1105,10 @@ static llama_token skippy_greedy_sample_ith(skippy_session * session, int32_t in
+     return best;
+ }
+ 
++static llama_token skippy_greedy_sample(skippy_session * session) {
++    return skippy_greedy_sample_ith(session, -1);
++}
++
+ static bool skippy_compute_token_signal(
+         skippy_session * session,
+         int32_t logits_index,
+@@ -1406,14 +1393,14 @@ static void skippy_sync_chat_sampling_history(skippy_session * session) {
+     }
+ }
+ 
+-static llama_token skippy_chat_sample_token(skippy_session * session) {
++static llama_token skippy_chat_sample_token(skippy_session * session, int32_t logits_index) {
+     skippy_sync_chat_sampling_history(session);
+ 
+     const llama_vocab * vocab = llama_model_get_vocab(session->stage_model->model);
+     const int32_t n_vocab = llama_vocab_n_tokens(vocab);
+-    const float * logits = llama_get_logits_ith(session->ctx, -1);
++    const float * logits = llama_get_logits_ith(session->ctx, logits_index);
+     if (logits == nullptr) {
+-        return skippy_greedy_sample(session);
++        return skippy_greedy_sample_ith(session, logits_index);
+     }
+ 
+     std::vector<llama_token_data> candidates;
+@@ -1438,25 +1425,26 @@ static llama_token skippy_chat_sample_token(skippy_session * session) {
+     }
+     llama_sampler_apply(session->sampling_chain, &cur);
+     if (cur.selected < 0 || static_cast<size_t>(cur.selected) >= cur.size) {
+-        return skippy_greedy_sample(session);
++        return skippy_greedy_sample_ith(session, logits_index);
+     }
+     return cur.data[cur.selected].id;
+ }
+ 
+-static llama_token skippy_sample_token(
++static llama_token skippy_sample_token_ith(
+         skippy_session * session,
+-        const skippy_sampling_config * sampling) {
++        const skippy_sampling_config * sampling,
++        int32_t logits_index) {
+     if (session != nullptr && session->sampling_chain != nullptr) {
+-        return skippy_chat_sample_token(session);
++        return skippy_chat_sample_token(session, logits_index);
+     }
+     if (!skippy_sampling_enabled(sampling)) {
+-        return skippy_greedy_sample(session);
++        return skippy_greedy_sample_ith(session, logits_index);
+     }
+ 
+     llama_sampler_chain_params chain_params = llama_sampler_chain_default_params();
+     llama_sampler * sampler = llama_sampler_chain_init(chain_params);
+     if (sampler == nullptr) {
+-        return skippy_greedy_sample(session);
++        return skippy_greedy_sample_ith(session, logits_index);
+     }
+ 
+     const int32_t penalty_last_n = sampling->penalty_last_n == 0 ? -1 : sampling->penalty_last_n;
+@@ -1502,11 +1490,17 @@ static llama_token skippy_sample_token(
+     for (const llama_token token : session->token_history) {
+         llama_sampler_accept(sampler, token);
+     }
+-    llama_token token = llama_sampler_sample(sampler, session->ctx, -1);
++    llama_token token = llama_sampler_sample(sampler, session->ctx, logits_index);
+     llama_sampler_free(sampler);
+     return token;
+ }
+ 
++static llama_token skippy_sample_token(
++        skippy_session * session,
++        const skippy_sampling_config * sampling) {
++    return skippy_sample_token_ith(session, sampling, -1);
++}
++
+ static enum skippy_status skippy_prepare_empty_activation_frame(
+         skippy_session * session,
+         size_t token_count,
+@@ -2573,6 +2567,80 @@ enum skippy_status skippy_decode_step_sampled(
+     return skippy_success(out_error);
+ }
+ 
++enum skippy_status skippy_decode_batch_sampled(
++        struct skippy_session * const * sessions,
++        const llama_token * token_ids,
++        const struct skippy_sampling_config * const * sampling,
++        size_t request_count,
++        llama_token * out_predicted_tokens,
++        size_t predicted_token_capacity,
++        struct skippy_error ** out_error) {
++    if (sessions == nullptr || token_ids == nullptr || request_count == 0 || out_predicted_tokens == nullptr) {
++        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "sessions, token_ids, request_count, and out_predicted_tokens are required");
++        return SKIPPY_STATUS_INVALID_ARGUMENT;
++    }
++    if (predicted_token_capacity < request_count) {
++        skippy_set_error(out_error, SKIPPY_STATUS_BUFFER_TOO_SMALL, "predicted token output buffer is too small");
++        return SKIPPY_STATUS_BUFFER_TOO_SMALL;
++    }
++    if (request_count > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
++        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "request_count exceeds int32_t range");
++        return SKIPPY_STATUS_INVALID_ARGUMENT;
++    }
++
++    skippy_session * first = sessions[0];
++    if (first == nullptr || first->ctx == nullptr || first->stage_model == nullptr) {
++        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "sessions must be active");
++        return SKIPPY_STATUS_INVALID_ARGUMENT;
++    }
++    if (skippy_is_filtered(first) && first->stage_model->config.layer_start > 0) {
++        skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, "batched token decode requires the first runtime slice or a full model");
++        return SKIPPY_STATUS_UNSUPPORTED;
++    }
++
++    const int32_t n_tokens = static_cast<int32_t>(request_count);
++    llama_batch batch = llama_batch_init(n_tokens, 0, 1);
++    batch.n_tokens = n_tokens;
++    for (int32_t i = 0; i < n_tokens; ++i) {
++        skippy_session * session = sessions[i];
++        if (session == nullptr || session->ctx != first->ctx || session->stage_model != first->stage_model) {
++            llama_batch_free(batch);
++            skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "all sessions must belong to the same stage model");
++            return SKIPPY_STATUS_INVALID_ARGUMENT;
++        }
++        if (skippy_is_filtered(session) && session->stage_model->config.layer_start > 0) {
++            llama_batch_free(batch);
++            skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, "batched token decode requires the first runtime slice or a full model");
++            return SKIPPY_STATUS_UNSUPPORTED;
++        }
++        batch.token[i] = token_ids[i];
++        batch.pos[i] = session->n_past;
++        batch.n_seq_id[i] = 1;
++        batch.seq_id[i][0] = session->seq_id;
++        batch.logits[i] = 1;
++    }
++
++    skippy_graph_filter_scope graph_filter_scope(&first->stage_model->config);
++    const int32_t rc = llama_decode(first->ctx, batch);
++    if (rc != 0) {
++        llama_batch_free(batch);
++        skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "llama_decode failed");
++        return SKIPPY_STATUS_RUNTIME_ERROR;
++    }
++    llama_batch_free(batch);
++
++    for (int32_t i = 0; i < n_tokens; ++i) {
++        skippy_session * session = sessions[i];
++        session->n_past += 1;
++        skippy_record_tokens(session, &token_ids[i], 1);
++        skippy_record_signal(session, i);
++        const skippy_sampling_config * request_sampling = sampling != nullptr ? sampling[i] : nullptr;
++        out_predicted_tokens[i] = skippy_sample_token_ith(session, request_sampling, i);
++    }
++
++    return skippy_success(out_error);
++}
++
+ enum skippy_status skippy_verify_tokens(
+         struct skippy_session * session,
+         const llama_token * token_ids,
+-- 
+2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0084-Add-skippy-batched-activation-decode-ABI.patch
+++ b/third_party/llama.cpp/patches/0084-Add-skippy-batched-activation-decode-ABI.patch
@@ -1,0 +1,238 @@
+From a0c272d3fab3544543da92cc1f3db8734b2ad731 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Fri, 5 Jun 2026 17:51:05 +1000
+Subject: [PATCH] Add skippy batched activation decode ABI
+
+---
+ include/skippy.h        |  15 ++++
+ include/skippy/common.h |   2 +-
+ src/skippy.cpp          | 174 ++++++++++++++++++++++++++++++++++++++++
+ 3 files changed, 190 insertions(+), 1 deletion(-)
+
+diff --git a/include/skippy.h b/include/skippy.h
+index f3911de7..b30c631e 100644
+--- a/include/skippy.h
++++ b/include/skippy.h
+@@ -353,6 +353,21 @@ LLAMA_API enum skippy_status skippy_decode_step_frame_sampled(
+         llama_token * out_predicted_token,
+         struct skippy_error ** out_error);
+ 
++LLAMA_API enum skippy_status skippy_decode_step_frame_batch_sampled(
++        struct skippy_session * const * sessions,
++        const llama_token * token_ids,
++        const struct skippy_sampling_config * const * sampling,
++        const struct skippy_activation_desc * const * input_descs,
++        const void * const * input_payloads,
++        struct skippy_activation_desc * output_descs,
++        void * const * output_payloads,
++        const size_t * output_payload_capacities,
++        size_t * out_output_payload_bytes,
++        llama_token * out_predicted_tokens,
++        size_t predicted_token_capacity,
++        size_t request_count,
++        struct skippy_error ** out_error);
++
+ LLAMA_API enum skippy_status skippy_verify_tokens_frame(
+         struct skippy_session * session,
+         const llama_token * token_ids,
+diff --git a/include/skippy/common.h b/include/skippy/common.h
+index e75a7e22..c13d8caa 100644
+--- a/include/skippy/common.h
++++ b/include/skippy/common.h
+@@ -26,7 +26,7 @@ extern "C" {
+ 
+ #define SKIPPY_ABI_VERSION_MAJOR 0
+ #define SKIPPY_ABI_VERSION_MINOR 1
+-#define SKIPPY_ABI_VERSION_PATCH 26
++#define SKIPPY_ABI_VERSION_PATCH 27
+ 
+ enum skippy_feature {
+     SKIPPY_FEATURE_RUNTIME_SLICE          = 1 << 0,
+diff --git a/src/skippy.cpp b/src/skippy.cpp
+index df816f66..3dfe75a0 100644
+--- a/src/skippy.cpp
++++ b/src/skippy.cpp
+@@ -2947,6 +2947,180 @@ enum skippy_status skippy_decode_step_frame_sampled(
+     return skippy_copy_output_activation_frame(session, 1, output_payload, input_desc, input_payload, out_error);
+ }
+ 
++enum skippy_status skippy_decode_step_frame_batch_sampled(
++        struct skippy_session * const * sessions,
++        const llama_token * token_ids,
++        const struct skippy_sampling_config * const * sampling,
++        const struct skippy_activation_desc * const * input_descs,
++        const void * const * input_payloads,
++        struct skippy_activation_desc * output_descs,
++        void * const * output_payloads,
++        const size_t * output_payload_capacities,
++        size_t * out_output_payload_bytes,
++        llama_token * out_predicted_tokens,
++        size_t predicted_token_capacity,
++        size_t request_count,
++        struct skippy_error ** out_error) {
++    if (sessions == nullptr || token_ids == nullptr || request_count == 0 || out_predicted_tokens == nullptr) {
++        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "sessions, token_ids, request_count, and out_predicted_tokens are required");
++        return SKIPPY_STATUS_INVALID_ARGUMENT;
++    }
++    if (predicted_token_capacity < request_count) {
++        skippy_set_error(out_error, SKIPPY_STATUS_BUFFER_TOO_SMALL, "predicted token output buffer is too small");
++        return SKIPPY_STATUS_BUFFER_TOO_SMALL;
++    }
++    if (request_count > static_cast<size_t>(std::numeric_limits<int32_t>::max())) {
++        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "request_count exceeds int32_t range");
++        return SKIPPY_STATUS_INVALID_ARGUMENT;
++    }
++
++    skippy_session * first = sessions[0];
++    if (first == nullptr || first->ctx == nullptr || first->stage_model == nullptr) {
++        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "sessions must be active");
++        return SKIPPY_STATUS_INVALID_ARGUMENT;
++    }
++
++    const int32_t n_tokens = static_cast<int32_t>(request_count);
++    const int32_t n_embd = llama_model_n_embd(first->stage_model->model);
++    const int32_t n_embd_inp = llama_model_n_embd_inp(first->stage_model->model);
++    const int32_t n_pos_per_embd = first->stage_model->model->hparams.n_pos_per_embd();
++    const bool activation_input = skippy_is_filtered(first) && first->stage_model->config.layer_start > 0;
++    const bool request_logits = first->stage_model->config.include_output;
++
++    if (activation_input && (input_descs == nullptr || input_payloads == nullptr)) {
++        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "batched downstream decode requires activation frame inputs");
++        return SKIPPY_STATUS_INVALID_ARGUMENT;
++    }
++
++    const size_t hidden_bytes_per_request = skippy_activation_hidden_bytes(first, 1);
++    for (int32_t i = 0; i < n_tokens; ++i) {
++        skippy_session * session = sessions[i];
++        if (session == nullptr || session->ctx != first->ctx || session->stage_model != first->stage_model) {
++            skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "all sessions must belong to the same stage model");
++            return SKIPPY_STATUS_INVALID_ARGUMENT;
++        }
++        const skippy_activation_desc * input_desc = input_descs != nullptr ? input_descs[i] : nullptr;
++        const void * input_payload = input_payloads != nullptr ? input_payloads[i] : nullptr;
++        enum skippy_status status = skippy_validate_frame_input(session, input_desc, input_payload, 1, out_error);
++        if (status != SKIPPY_STATUS_OK) {
++            return status;
++        }
++        if (input_desc != nullptr && input_desc->flags != 0) {
++            skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, "batched activation decode does not support activation sidebands yet");
++            return SKIPPY_STATUS_UNSUPPORTED;
++        }
++        if (skippy_output_activation_flags(session, input_desc) != 0) {
++            skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, "batched activation decode does not support output activation sidebands yet");
++            return SKIPPY_STATUS_UNSUPPORTED;
++        }
++        status = skippy_prepare_output_activation_frame(
++                session,
++                1,
++                output_payloads != nullptr ? output_payloads[i] : nullptr,
++                output_payload_capacities != nullptr ? output_payload_capacities[i] : 0,
++                out_output_payload_bytes != nullptr ? &out_output_payload_bytes[i] : nullptr,
++                output_descs != nullptr ? &output_descs[i] : nullptr,
++                input_desc,
++                out_error);
++        if (status != SKIPPY_STATUS_OK) {
++            return status;
++        }
++    }
++
++    std::vector<float> embd_storage;
++    std::vector<llama_token> token_storage;
++    if (activation_input) {
++        embd_storage.resize(static_cast<size_t>(n_tokens)*n_embd_inp);
++        for (int32_t i = 0; i < n_tokens; ++i) {
++            const skippy_activation_desc * input_desc = input_descs[i];
++            const void * input_payload = input_payloads[i];
++            float * dst = embd_storage.data() + static_cast<size_t>(i)*n_embd_inp;
++            if ((input_desc->flags & SKIPPY_ACTIVATION_FLAG_GEMMA3N_ALTUP) != 0) {
++                return SKIPPY_STATUS_UNSUPPORTED;
++            } else if (n_embd_inp == n_embd) {
++                std::memcpy(dst, input_payload, hidden_bytes_per_request);
++            } else {
++                std::memcpy(dst, input_payload, static_cast<size_t>(n_embd)*sizeof(float));
++                std::memset(dst + n_embd, 0, static_cast<size_t>(n_embd_inp - n_embd)*sizeof(float));
++            }
++        }
++    } else {
++        token_storage.assign(token_ids, token_ids + request_count);
++    }
++
++    std::vector<llama_pos> pos_storage(static_cast<size_t>(n_tokens)*n_pos_per_embd);
++    std::vector<int32_t> n_seq_id_storage(n_tokens, 1);
++    std::vector<llama_seq_id> seq_id_values(n_tokens);
++    std::vector<llama_seq_id *> seq_id_storage(n_tokens, nullptr);
++    std::vector<int8_t> logits_storage(n_tokens);
++    for (int32_t i = 0; i < n_tokens; ++i) {
++        skippy_session * session = sessions[i];
++        seq_id_values[i] = session->seq_id;
++        seq_id_storage[i] = &seq_id_values[i];
++        logits_storage[i] = request_logits ? 1 : 0;
++        if (n_pos_per_embd == 4) {
++            const llama_pos position = session->n_past;
++            pos_storage[               i] = position;
++            pos_storage[    n_tokens + i] = position;
++            pos_storage[2 * n_tokens + i] = position;
++            pos_storage[3 * n_tokens + i] = 0;
++        } else {
++            pos_storage[i] = session->n_past;
++        }
++    }
++
++    llama_batch batch = {
++        /*n_tokens =*/ n_tokens,
++        /*token    =*/ activation_input ? nullptr : token_storage.data(),
++        /*embd     =*/ activation_input ? embd_storage.data() : nullptr,
++        /*pos      =*/ pos_storage.data(),
++        /*n_seq_id =*/ n_seq_id_storage.data(),
++        /*seq_id   =*/ seq_id_storage.data(),
++        /*logits   =*/ logits_storage.data(),
++    };
++
++    skippy_activation_tokens_scope activation_tokens_scope(token_ids, request_count);
++    skippy_graph_filter_scope graph_filter_scope(&first->stage_model->config);
++    const int32_t rc = llama_decode(first->ctx, batch);
++    if (rc != 0) {
++        skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "llama_decode failed");
++        return SKIPPY_STATUS_RUNTIME_ERROR;
++    }
++
++    float * embeddings = nullptr;
++    if (skippy_emits_activation_frame(first)) {
++        embeddings = llama_get_embeddings(first->ctx);
++        if (embeddings == nullptr) {
++            skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "llama embeddings output was not available");
++            return SKIPPY_STATUS_RUNTIME_ERROR;
++        }
++    }
++
++    for (int32_t i = 0; i < n_tokens; ++i) {
++        skippy_session * session = sessions[i];
++        session->n_past += 1;
++        if (!activation_input) {
++            skippy_record_tokens(session, &token_ids[i], 1);
++        }
++        if (request_logits) {
++            skippy_record_signal(session, i);
++            const skippy_sampling_config * request_sampling = sampling != nullptr ? sampling[i] : nullptr;
++            out_predicted_tokens[i] = skippy_sample_token_ith(session, request_sampling, i);
++        } else {
++            out_predicted_tokens[i] = -1;
++        }
++
++        if (embeddings != nullptr && output_payloads != nullptr && output_payloads[i] != nullptr) {
++            std::memcpy(
++                    output_payloads[i],
++                    embeddings + static_cast<size_t>(i)*n_embd,
++                    hidden_bytes_per_request);
++        }
++    }
++
++    return skippy_success(out_error);
++}
++
+ enum skippy_status skippy_verify_tokens_frame(
+         struct skippy_session * session,
+         const llama_token * token_ids,
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
## Summary

Skippy can now batch decode work across concurrent requests instead of forcing each active lane through an independent single-request `llama_decode` call. This is the decode-side counterpart to the lane/runtime work already on `main`: when multiple requests are decoding at the same time, stage 0 and downstream split stages can execute already-queued one-token decode work as one native batch.

This PR originally used a fixed 200 us rendezvous window to encourage batch formation. The local benchmark showed that was not a good enough tradeoff, so this PR now takes the safer easy win: **no intentional decode wait**. The batchers drain whatever work has already accumulated; if only one request is ready, it runs immediately.

The updated local benchmark is still not a convincing performance/throughput win. It improves the concurrency-2 result slightly versus `main`, but concurrency 4 remains slower on aggregate completion tok/s. This should stay draft unless a larger multi-stage benchmark proves the target topology benefits.

## Merge recommendation

Do **not** merge this PR as-is as a general performance/throughput improvement.

The implementation proves that cross-request decode batching can form real native decode batches, and the no-wait policy removes the earlier fixed rendezvous latency tax. However, the current local benchmark still does not show a convincing throughput win: concurrency 2 is only +0.9%, and concurrency 4 is -5.8% on completion tok/s on the local two-stage Qwen3-8B setup.

Recommended next step: keep this PR draft and use it as the experiment branch for a larger multi-stage run. Merge criteria should be a clear win on the target shape, for example a four-stage larger-model benchmark showing improved aggregate tok/s without a material TPOT/TTFT regression. If the larger run is also neutral, we should close this PR or rework batching into a fully adaptive production policy.

## What changed

- Added local/full-model cross-request token decode batching for stage sessions.
- Added a native `skippy_decode_step_frame_batch_sampled` ABI for batched one-token activation-frame decode.
- Bumped the Skippy native ABI mirror to `0.1.27`.
- Added Rust runtime and server wrappers for batched activation-frame decode.
- Added a shared binary-stage decode-frame batcher so downstream stages can batch across independent request connections.
- Routed embedded stage 0 split decode through the same frame batcher before activation forwarding.
- Removed the fixed 200 us decode rendezvous wait. Batching is now opportunistic only: already-queued work batches, single ready work runs immediately.
- Added decode batch telemetry: batch size and batch wait time are emitted on decode spans.

## Architecture

Before this branch, split decode still had a per-request hot path even when the runtime had multiple lanes:

```mermaid
sequenceDiagram
    participant R1 as Request 1
    participant R2 as Request 2
    participant S0 as Stage 0
    participant S1 as Downstream Stage
    participant N as Native llama.cpp

    R1->>S0: decode token
    S0->>N: llama_decode(batch=1)
    S0->>S1: activation frame
    S1->>N: llama_decode(batch=1)
    S1-->>S0: predicted token

    R2->>S0: decode token
    S0->>N: llama_decode(batch=1)
    S0->>S1: activation frame
    S1->>N: llama_decode(batch=1)
    S1-->>S0: predicted token
```

After this branch, each stage keeps the existing request/session protocol but coalesces decode work that is already queued at the stage runtime boundary:

```mermaid
sequenceDiagram
    participant R1 as Request 1
    participant R2 as Request 2
    participant B0 as Stage 0 decode batcher
    participant S0 as Stage 0 native runtime
    participant B1 as Downstream decode batcher
    participant S1 as Downstream native runtime

    R1->>B0: decode token
    R2->>B0: decode token
    B0->>S0: llama_decode(batch=2)
    B0-->>R1: activation frame
    B0-->>R2: activation frame

    R1->>B1: activation frame
    R2->>B1: activation frame
    B1->>S1: llama_decode(batch=2)
    B1-->>R1: predicted token
    B1-->>R2: predicted token
```

If only one request is queued when the batcher wakes, the batcher does not sleep to wait for another request. That makes the policy safer for low-concurrency and fast-local topologies, but it also means fewer batches form unless requests naturally align.

## Benchmark

Local benchmark date: 2026-06-05.

Setup:

- Branches compared: `main` vs `skippy-cross-request-decode-batching` at commit `bb3af8fa6`.
- Model: cached `unsloth/Qwen3-8B-GGUF`, two artifact-slice stages, layers `0..18` and `18..36`.
- Runtime: local loopback split, `activation_wire_dtype=f16`, `activation_width=4096`, `lane_count=4`, `openai_generation_concurrency=4`.
- Corpus: `crates/skippy-bench/corpora/kv_mixed_prompts.jsonl`, first 8 prompts.
- Request shape: `max_tokens=24`, streaming chat completions, `temperature=0`, `seed=123`, `enable_thinking=false`.
- Perf runs used `--telemetry-level off`; a separate debug run used stderr telemetry only to prove batch formation.
- `main` baseline is unchanged from the prior PR benchmark; the branch side was rerun after removing the fixed rendezvous wait.

Updated no-wait perf result:

| concurrency | main completion tok/s | PR completion tok/s | delta | main TTFT p95 ms | PR TTFT p95 ms | delta |
|---:|---:|---:|---:|---:|---:|---:|
| 2 | 46.42 | 46.82 | +0.9% | 242.0 | 227.3 | -6.1% |
| 4 | 54.56 | 51.40 | -5.8% | 435.5 | 471.9 | +8.3% |

Telemetry proof from the no-wait debug run on this branch:

| observed decode batch size | event count |
|---:|---:|
| 1 | 533 |
| 2 | 24 |

Interpretation:

- The no-wait policy removes the deliberate 200 us latency tax.
- Opportunistic batches still form, but fewer than with the fixed wait policy.
- On this local two-stage 8B setup, the change is roughly neutral at concurrency 2 and still loses aggregate throughput at concurrency 4.
- This benchmark is probably not representative of the target four-stage / larger-model path: it runs both stages on one machine over loopback, with no LAN/WAN delay and a much smaller model than the target large split deployment.

## Protocol

The external OpenAI API is unchanged. The existing binary stage wire messages remain single-request messages; this PR batches at the stage runtime boundary across multiple active connections rather than requiring a batched wire envelope.

The native Skippy ABI is extended with `skippy_decode_step_frame_batch_sampled`, so Skippy ABI patch version moves from `0.1.26` to `0.1.27`. Older native runtimes without this symbol are not compatible with this Rust runtime.

Activation sideband families currently fall back to the existing single-frame decode path when the native batch ABI returns `Unsupported`.

## Validation

- `just build`
- `just with-lld cargo build -p skippy-server -p skippy-bench`
- `cargo fmt --all -- --check`
- `cargo test -p skippy-server --lib`
- `cargo test -p skippy-runtime --lib`
- `cargo test -p skippy-ffi --lib`
- `cargo clippy -p skippy-ffi --all-targets -- -D warnings`
- `cargo clippy -p skippy-runtime --all-targets -- -D warnings`
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `git diff --check`
- Local `skippy-bench chat-corpus` comparison above

