### PR TITLE
Fix GLM nextn layer package quantization

### DIFF
--- a/crates/skippy-model-package/src/main.rs
+++ b/crates/skippy-model-package/src/main.rs
@@ -1188,22 +1188,30 @@ fn write_package_artifact(
         tensors,
     );
     let path = out_dir.join(&spec.relative_path);
-    write_stage_artifact(source, &stage, &path)?;
     let relative_path = spec.relative_path.display().to_string();
-    run_artifact_hook(artifact_hook, &path, &relative_path)?;
-    let artifact_info = ModelInfo::open(&path)
+    if path.exists() {
+        println!("package resume: reusing existing artifact {relative_path}");
+    } else {
+        write_stage_artifact(source, &stage, &path)?;
+        run_artifact_hook(artifact_hook, &path, &relative_path)?;
+    }
+    package_artifact_from_path(&path, relative_path)
+}
+
+fn package_artifact_from_path(path: &Path, relative_path: String) -> Result<PackageArtifact> {
+    let artifact_info = ModelInfo::open(path)
         .with_context(|| format!("open package artifact {}", path.display()))?;
     let artifact_tensors = artifact_info
         .tensors()
         .with_context(|| format!("read package artifact tensors {}", path.display()))?;
-    let metadata = fs::metadata(&path)
-        .with_context(|| format!("read artifact metadata {}", path.display()))?;
+    let metadata =
+        fs::metadata(path).with_context(|| format!("read artifact metadata {}", path.display()))?;
     let artifact = PackageArtifact {
         path: relative_path,
         tensor_count: artifact_tensors.len(),
         tensor_bytes: artifact_tensors.iter().map(|tensor| tensor.byte_size).sum(),
         artifact_bytes: metadata.len(),
-        sha256: file_sha256(&path)?,
+        sha256: file_sha256(path)?,
     };
     Ok(artifact)
 }

--- a/crates/skippy-quantize/src/main.rs
+++ b/crates/skippy-quantize/src/main.rs
@@ -695,13 +695,18 @@ fn quantize_layer_package(args: QuantizeLayerPackageArgs) -> Result<()> {
         args.skippy_model_package_bin.display()
     );
     if args.package_dir.exists() {
-        ensure!(
-            args.replace_package,
-            "package dir already exists: {}; pass --replace-package to overwrite it",
-            args.package_dir.display()
-        );
-        fs::remove_dir_all(&args.package_dir)
-            .with_context(|| format!("remove package dir {}", args.package_dir.display()))?;
+        if args.replace_package {
+            fs::remove_dir_all(&args.package_dir)
+                .with_context(|| format!("remove package dir {}", args.package_dir.display()))?;
+        } else {
+            let manifest_path = args.package_dir.join("model-package.json");
+            ensure!(
+                !manifest_path.exists(),
+                "package dir already contains {}; pass --replace-package to overwrite it",
+                manifest_path.display()
+            );
+            print_path_event("↻", "Resuming incomplete package", &args.package_dir);
+        }
     }
 
     let manifest = quant_manifest_from_args(&args.init)?;

--- a/crates/skippy-runtime/src/runtime_events.rs
+++ b/crates/skippy-runtime/src/runtime_events.rs
@@ -355,7 +355,7 @@ fn abi_features_bitmask() -> Option<u64> {
     }
     #[cfg(not(feature = "dynamic-native-runtime"))]
     {
-        Some(unsafe { skippy_ffi::skippy_abi_features() })
+        Some(skippy_ffi::skippy_abi_features())
     }
 }
 

--- a/third_party/llama.cpp/patches/0112-Allow-quantizing-nextn-FFN-tensors.patch
+++ b/third_party/llama.cpp/patches/0112-Allow-quantizing-nextn-FFN-tensors.patch
@@ -1,0 +1,25 @@
+From 92de7b0a9d863a6eeef0e8512cf7fe01f5db943c Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Wed, 24 Jun 2026 09:28:38 +1000
+Subject: [PATCH] Allow quantizing nextn FFN tensors
+
+---
+ src/llama-quant.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/llama-quant.cpp b/src/llama-quant.cpp
+index d4e7738a..0fe62d6b 100644
+--- a/src/llama-quant.cpp
++++ b/src/llama-quant.cpp
+@@ -847,7 +847,7 @@ static void init_quantize_state_counters(quantize_state_impl & qs, std::vector<t
+             qs.has_tied_embeddings = false;
+         }
+     }
+-    qs.n_ffn_down = qs.n_ffn_gate = qs.n_ffn_up = (int)qs.model.hparams.n_layer();
++    qs.n_ffn_down = qs.n_ffn_gate = qs.n_ffn_up = (int)qs.model.hparams.n_layer_all;
+ }
+ 
+ //
+-- 
+2.54.0 (Apple Git-156)
+


### PR DESCRIPTION
## Summary
- Allow llama quantization heuristics to see native nextn/MTP FFN tensors by using `n_layer_all` for FFN layer bounds.
- Make `skippy-model-package write-package` reuse existing package artifacts so interrupted package creation can resume and still write `model-package.json`.
- Let `skippy-quantize quantize-layer-package` resume incomplete package directories without `--replace-package`, while still requiring `--replace-package` for complete package manifests.

## Validation
- `scripts/prepare-llama.sh pinned` in a clean temp checkout applies through new patch `0112-Allow-quantizing-nextn-FFN-tensors.patch`.
- `just skippy-quantize-standalone-release-build cpu`
- `just with-lld cargo build --release --locked -p skippy-model-package`
- `just with-lld cargo test -p skippy-model-package -p skippy-quantize`
- `just with-lld cargo clippy -p skippy-model-package -p skippy-quantize --all-targets -- -D warnings`
- GLM 5.2 layer 078 smoke quant succeeded: BF16 slice 18.55 GiB -> Q2_K/MTP-Q8 3.48 GiB, including `blk.78.ffn_down_exps.weight`.
- Full local GLM 5.2 package resume completed and `skippy-model-package preflight --verify-sha256 --stages 2` passed for `/Users/lab/glm52-work/packages/GLM-5.2-Q2_K-MTP-Q8-layers`.

## Note
- `just with-lld cargo test -p skippy-runtime -p skippy-model-package -p skippy-quantize` still exposes the existing `skippy-runtime::tests::invalid_selected_backend_device_fails_before_model_open` native-runtime fixture failure on this host. The package/quantize focused tests pass.