### PR TITLE
Remove emulated response content logging

### DIFF
--- a/crates/skippy-server/src/frontend/prompting.rs
+++ b/crates/skippy-server/src/frontend/prompting.rs
@@ -139,9 +139,6 @@ impl StageOpenAiBackend {
         if tool_calls_requested(request)
             && !tool_emulation::template_supports_native_tool_calls(metadata)
         {
-            if !is_partial {
-                eprintln!("EMU_RAW_TEXT<<<{}>>>", text);
-            }
             return Ok(parse_emulated_chat_output(text, request, is_partial));
         }
 


### PR DESCRIPTION
## What changed

Removed the unconditional stderr dump of completed model output from the server-side tool-call emulation parser.

## Why

The debug statement emitted the entire generated response for every non-streaming emulated tool request. Model responses may contain private user data, tool results, credentials, or proprietary content, and stderr is commonly persisted by service managers.

## Impact

Tool-call parsing and telemetry behavior are unchanged, but response content is no longer copied into process logs.

## Validation

- `cargo test -p skippy-server --lib`
- 201 tests passed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed an unnecessary debug message that could appear when processing emulated tool-call responses.
  * Preserved existing tool-call parsing behavior for both complete and partial responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->