### PR TITLE
Stream emulated tool-call prose incrementally

### DIFF
--- a/crates/skippy-server/src/frontend/prompting.rs
+++ b/crates/skippy-server/src/frontend/prompting.rs
@@ -291,13 +291,8 @@ pub(super) fn parse_emulated_chat_output(
     is_partial: bool,
 ) -> Option<ParsedChatMessage> {
     let allowed = request_allowed_tool_names(request);
-    let scan_text = if is_partial {
-        text.rsplit_once('\n')
-            .map(|(head, _)| head)
-            .unwrap_or_default()
-    } else {
-        text
-    };
+    let partial_scan = is_partial.then(|| tool_emulation::partial_emulation_text(text));
+    let scan_text = partial_scan.as_deref().unwrap_or(text);
     let parse = tool_emulation::parse_emulated_tool_calls(scan_text, &allowed);
     let tool_calls = if is_partial || parse.tool_calls.is_empty() {
         None

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -1251,6 +1251,40 @@ fn emulated_output_partial_withholds_tool_calls_and_incomplete_line() {
 }
 
 #[test]
+fn emulated_output_partial_streams_single_line_prose() {
+    let request = tool_request();
+    let parsed = parse_emulated_chat_output("The capital is Canber", &request, true)
+        .expect("emulated parse");
+
+    assert!(parsed.tool_calls.is_none());
+    assert_eq!(parsed.content.as_deref(), Some("The capital is Canber"));
+}
+
+#[test]
+fn emulated_output_partial_withholds_possible_marker_suffix() {
+    let request = tool_request();
+    let parsed =
+        parse_emulated_chat_output("Let me check. TOOL_", &request, true).expect("emulated parse");
+
+    assert!(parsed.tool_calls.is_none());
+    assert_eq!(parsed.content.as_deref(), Some("Let me check."));
+}
+
+#[test]
+fn emulated_output_partial_ignores_marker_inside_completed_thinking() {
+    let request = tool_request();
+    let parsed = parse_emulated_chat_output(
+        "<think>TOOL_CALL {\"name\":\"lookup\"}</think>The answer is Syd",
+        &request,
+        true,
+    )
+    .expect("emulated parse");
+
+    assert!(parsed.tool_calls.is_none());
+    assert_eq!(parsed.content.as_deref(), Some("The answer is Syd"));
+}
+
+#[test]
 fn emulated_output_respects_allowed_tool_names() {
     let request = tool_request();
     // "search" is not an allowed tool for this request (only "lookup" is).

--- a/crates/skippy-server/src/frontend/tool_emulation.rs
+++ b/crates/skippy-server/src/frontend/tool_emulation.rs
@@ -426,6 +426,32 @@ pub(super) fn parse_emulated_tool_calls(text: &str, allowed_names: &[String]) ->
     }
 }
 
+/// Return generated text that is safe to expose during partial emulated
+/// tool-call parsing.
+///
+/// Completed reasoning blocks are removed before marker detection. Once a
+/// marker is visible, its payload remains private until final parsing emits a
+/// structured call. Without a complete marker, only a trailing prefix that
+/// could still grow into `TOOL_CALL` is retained.
+pub(super) fn partial_emulation_text(text: &str) -> String {
+    let mut scannable = strip_think_blocks(text);
+    if let Some(marker_start) = scannable.find(TOOL_CALL_MARKER) {
+        return scannable[..marker_start].to_string();
+    }
+
+    let max_prefix_len = TOOL_CALL_MARKER.len().min(scannable.len());
+    for prefix_len in (1..=max_prefix_len).rev() {
+        let Some(suffix) = scannable.get(scannable.len() - prefix_len..) else {
+            continue;
+        };
+        if TOOL_CALL_MARKER.starts_with(suffix) {
+            scannable.truncate(scannable.len() - prefix_len);
+            return scannable;
+        }
+    }
+    scannable
+}
+
 /// Removes `<think>...</think>` spans so a reasoning model's scratchpad never
 /// triggers or hides a tool call. An unterminated `<think>` drops the rest.
 fn strip_think_blocks(text: &str) -> String {


### PR DESCRIPTION
## What changed

- replace newline-based partial buffering with marker-aware buffering
- stream ordinary single-line prose immediately
- retain only a possible trailing `TOOL_CALL` marker prefix
- withhold a detected marker and payload until final structured parsing
- ignore markers inside completed `<think>` blocks

## Why

The previous partial parser discarded the entire final line. Models commonly generate answers without newlines, so tool-enabled streaming requests that did not call a tool could produce no content until completion.

## Impact

Normal prose regains incremental TTFT while incomplete emulated tool calls remain hidden from client-visible text.

## Validation

- `cargo test -p skippy-server --lib` — 204 passed
- `cargo clippy -p skippy-server --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming responses involving emulated tool calls.
  * Prevented incomplete or marker-like text from appearing as tool calls before parsing is complete.
  * Preserved regular prose when streaming ends mid-line.
  * Ignored tool-call markers appearing within in-progress reasoning sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->