### PR TITLE
fix(ci): stabilize CUDA 13 native runtime build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -403,10 +403,14 @@ jobs:
             cuda_major: '12'
             cuda_architectures: '75;80;86;87;89;90'
             cuda_architectures_cache: '75_80_86_87_89_90'
+            cmake_build_parallel_level: ''
           - cuda_version: '13.1.2'
             cuda_major: '13'
             cuda_architectures: '75;80;86;87;89;90;100;103;120;121'
             cuda_architectures_cache: '75_80_86_87_89_90_100_103_120_121'
+            # Limit concurrent multi-architecture nvcc invocations in this
+            # expanded CUDA 13 lane.
+            cmake_build_parallel_level: 2
     container:
       image: nvidia/cuda:${{ matrix.cuda_version }}-devel-ubuntu24.04
     env:
@@ -415,6 +419,7 @@ jobs:
       LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-dynamic-cuda-sm${{ matrix.cuda_architectures_cache }}
       MESH_NATIVE_RUNTIME_TARGET: x86_64-unknown-linux-gnu
       MESH_LLM_CUDA_TOOLKIT_MAJOR: ${{ matrix.cuda_major }}
+      CMAKE_BUILD_PARALLEL_LEVEL: ${{ matrix.cmake_build_parallel_level }}
     steps:
       - name: Install base packages
         run: |


### PR DESCRIPTION
## Summary

Caps CMake build parallelism at two processes for the expanded CUDA 13 native-runtime matrix.

## Root cause

The release job [Build native runtime Linux x86_64 CUDA (13)](https://github.com/Mesh-LLM/mesh-llm/actions/runs/29173214598/job/86597672652) crashed inside `nvcc` while compiling a multi-architecture FlashAttention template after the llama.cpp pin update.

## Validation

- Parsed all GitHub workflow and action YAML files
- Checked workflow step IDs and pull-request trigger placement
- `GIT_MASTER=1 git diff --check`
- `cargo run -p xtask -- repo-consistency release-targets`

A canary Release workflow run is being triggered on this branch to exercise the exact CUDA 13 lane without publishing artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Linux CUDA builds by limiting parallel compilation for CUDA 13.1.2.
  * Preserved existing parallel build behavior for CUDA 12.9.2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->