### PR TITLE
Improve plugin documentation

### DIFF
--- a/website/src/docs/pages/developing-plugins.md
+++ b/website/src/docs/pages/developing-plugins.md
@@ -4,160 +4,232 @@ title: Developing Plugins
 
 # Developing Plugins
 
-The primary design goal is very low boilerplate. The preferred DSL is surface-first, organized by the host projection the plugin contributes to.
+Build a plugin when an integration needs its own process, dependencies, release cadence, or local state. The plugin API is Rust-first and manifest-driven: you declare what the plugin contributes, then attach typed handlers for the behavior it owns.
 
-## DSL Sections
+This guide describes the current author API in the `mesh-llm-plugin` crate. The [Plugin Architecture](/docs/pages/plugin-architecture/) page explains the runtime model behind it.
 
-- `provides` — stable capability contracts
-- `mcp` — MCP tools, resources, prompts, and attached external MCP servers
-- `http` — local HTTP routes
-- `inference` — attached external inference endpoints or plugin-hosted providers
-- `mesh` — mesh channels the plugin may send and receive on
-- `events` — mesh events the host may deliver to the plugin
+## Choose a contribution surface
 
-Lifecycle hooks stay local to the plugin definition:
+Start by deciding what your plugin adds to the host:
 
-- `startup_policy`
-- `health`
-- `on_initialized`
-- `on_channel_message`
-- `on_mesh_event`
+| Surface | Use it for | Typical declarations |
+| --- | --- | --- |
+| `mcp` | Tools, resources, prompts, completions, or an external MCP server | `mcp::tool`, `mcp::resource`, `mcp::external_stdio` |
+| `http` | Plugin-owned HTTP operations mounted by the host | `http::get`, `http::post`, `.stream_request()`, `.stream_response()` |
+| `inference` | An attached OpenAI-compatible endpoint or a provider managed by the plugin | `inference::openai_http`, `inference::provider` |
+| `provides` | A stable capability contract that core or another plugin can consume | `capability("object-store.v1")` |
+| `mesh` | Plugin-specific peer-to-peer messages | `mesh::channel("notes.v1")` |
+| `events` | Mesh lifecycle events delivered by the host | `events::peer_up()`, `events::peer_down()` |
 
-Each section is self-contained. If a plugin contributes something to a host surface, it is declared in the section for that surface.
+MCP and HTTP are host projections. A plugin does not need to implement an MCP server, HTTP server, or socket protocol itself.
 
-## Example Plugin
+## Start a Rust plugin
+
+Create a binary crate and depend on `mesh-llm-plugin` at a version compatible with the mesh-llm release you target. Keep the host and plugin protocol versions aligned; the host rejects incompatible initialization handshakes.
+
+The smallest useful plugin has a manifest, one handler, and a runtime entrypoint:
 
 ```rust
 use mesh_llm_plugin::{
-    capability, plugin_server_info, PluginMetadata,
-    http::{get, post},
-    inference::openai_http,
-    mcp::{external_stdio, prompt, resource, tool},
-    PluginStartupPolicy,
+    mcp, plugin, plugin_server_info, PluginMetadata, PluginRuntime,
 };
 
-let plugin = mesh_llm_plugin::plugin! {
-    metadata: PluginMetadata::new(
-        "notes",
-        "1.0.0",
-        plugin_server_info(
-            "notes",
-            "1.0.0",
-            "Notes",
-            "Shared notes services",
-            None::<String>,
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let plugin = plugin! {
+        metadata: PluginMetadata::new(
+            "hello-plugin",
+            "0.1.0",
+            plugin_server_info(
+                "hello-plugin",
+                "0.1.0",
+                "Hello plugin",
+                "A small example plugin",
+                None::<String>,
+            ),
         ),
-    ),
 
-    startup_policy: PluginStartupPolicy::PrivateMeshOnly,
+        mcp: [
+            mcp::tool("ping")
+                .description("Return a health response")
+                .handle(|_args, _context| Box::pin(async {
+                    Ok(serde_json::json!({ "status": "ok" }))
+                })),
+        ],
+    };
+
+    PluginRuntime::run(plugin).await?;
+    Ok(())
+}
+```
+
+`PluginRuntime::run` connects to the endpoint that mesh-llm provides through the plugin environment. Do not invent a socket path or start a second listener in the plugin process.
+
+For typed input, define a serializable schema and pass it to `.input::<T>()`:
+
+```rust
+#[derive(serde::Deserialize, schemars::JsonSchema)]
+struct SearchArgs {
+    query: String,
+}
+
+// ...
+mcp::tool("search")
+    .description("Search notes")
+    .input::<SearchArgs>()
+    .handle(|args, _context| Box::pin(async move {
+        Ok(serde_json::json!({ "query": args.query, "matches": [] }))
+    }))
+```
+
+The same typed-handler pattern is used by HTTP routes. Add `.output::<T>()` when clients benefit from an explicit response schema.
+
+## Build the manifest
+
+The `plugin!` macro keeps the manifest close to the handlers:
+
+```rust
+let plugin = plugin! {
+    metadata: metadata,
 
     provides: [
-        capability("notes.v1"),
-        capability("search.v1"),
-    ],
-
-    mesh: [
-        mesh_llm_plugin::mesh::channel("notes.v1"),
-    ],
-
-    events: [
-        mesh_llm_plugin::events::peer_up(),
+        mesh_llm_plugin::capability("notes.v1"),
     ],
 
     mcp: [
-        tool("search")
+        mcp::tool("search")
             .description("Search notes")
             .input::<SearchArgs>()
             .handle(search),
-
-        resource("notes://latest")
-            .name("Latest Notes")
+        mcp::resource("notes://latest")
+            .name("Latest notes")
             .handle(read_latest),
-
-        prompt("summarize_notes")
-            .description("Summarize recent notes")
-            .handle(summarize_notes),
-
-        external_stdio("filesystem", "npx")
+        mcp::external_stdio("filesystem", "npx")
             .arg("-y")
             .arg("@modelcontextprotocol/server-filesystem"),
     ],
 
     http: [
-        get("/search")
-            .description("Search notes")
-            .input::<SearchArgs>()
-            .handle(search),
-
-        post("/notes")
+        mesh_llm_plugin::http::post("/notes")
             .description("Create a note")
             .input::<PostArgs>()
             .handle(post_note),
     ],
 
     inference: [
-        openai_http("local-llm", "http://127.0.0.1:8080/v1")
-            .managed_by_plugin(false),
+        mesh_llm_plugin::inference::openai_http(
+            "local-llm",
+            "http://127.0.0.1:8080/v1",
+        ),
     ],
-
-    health: |_context| {
-        Box::pin(async move { Ok("ok".to_string()) })
-    },
-
-    on_initialized: |context| {
-        Box::pin(async move {
-            context
-                .send_json_channel(
-                    "notes.v1",
-                    String::new(),
-                    "notes",
-                    &NotesMessage::SyncRequest,
-                )
-                .await
-        })
-    },
-
-    on_channel_message: |message, context| {
-        Box::pin(async move {
-            handle_notes_channel(message, context).await
-        })
-    },
-
-    on_mesh_event: |event, context| {
-        Box::pin(async move {
-            handle_notes_mesh_event(event, context).await
-        })
-    },
 };
 ```
 
-### Key Design Points
+Keep declarations narrow. A plugin receives mesh channels and events only when it explicitly declares them. Use capabilities for stable contracts, not as a second name for the plugin itself.
 
-- `mcp` contains both local MCP contributions and attached external MCP servers
-- `http` contains local HTTP contributions
-- `inference` contains both attached external inference endpoints and plugin-hosted inference providers
-- `provides` declares stable capability contracts that core product routes can depend on
-- `mesh` declares which mesh channels the plugin is allowed to receive and send
-- `events` declares which mesh events the host may deliver to the plugin
+## Lifecycle and host context
 
-Event delivery is allowlist-based: no `mesh` declaration means no channel delivery, no `events` declaration means no mesh events. Plugins only receive the event kinds they explicitly declare.
+The host launches the plugin as a child process and supplies:
 
-The runtime and `stapler` handle schema exposure, MCP projection, HTTP projection, request validation, stream negotiation, transport details, and host-side routing and aggregation.
+| Variable | Meaning |
+| --- | --- |
+| `MESH_LLM_PLUGIN_ENDPOINT` | Local control endpoint to connect to |
+| `MESH_LLM_PLUGIN_TRANSPORT` | Transport kind, such as `unix` or `pipe` |
+| `MESH_LLM_PLUGIN_NAME` | Configured plugin name |
+| `MESH_LLM_PLUGIN_URL` | Optional `[[plugin]].url` value |
 
-Plugin authors should not manually implement MCP `tools/list`, MCP `tools/call`, MCP `resources/read`, HTTP routing, or control-plane socket negotiation.
+Use lifecycle hooks only when the plugin needs them:
 
-## Internal RPC Plugins
+- `health` reports plugin liveness.
+- `on_initialized` runs after the host accepts the manifest.
+- `on_channel_message` handles declared plugin mesh channels.
+- `on_mesh_event` handles declared host events.
 
-Most plugins should use `plugin!`. Host-private plumbing services that need raw RPC methods rather than surfaced MCP, HTTP, or inference declarations should use `InternalRpcPluginBuilder`.
+Keep health fast and independent from long-running operations. Plugin health and the health of a registered inference endpoint are separate: an endpoint may restart while the plugin remains healthy.
 
-This is the escape hatch for internal-only services such as blobstore. It keeps raw host RPC separate from the normal manifest-driven plugin surface.
+For large request bodies, downloads, or streaming responses, declare the mode on the HTTP binding with `.stream_request()`, `.stream_response()`, or `.sse()`. The host then negotiates a side stream so control messages and health checks remain responsive.
 
-## Streaming In The DSL
+## Configuration schemas
 
-Streaming is explicit. For HTTP bindings, the preferred modifiers are:
+If your plugin has user-facing settings, expose a schema in its manifest and document the corresponding TOML. Settings belong under the plugin table:
 
-- `.stream_request()`
-- `.stream_response()`
-- `.sse()`
+```toml
+[[plugin]]
+name = "notes"
 
-These declare whether the request body, response body, or response format requires side-stream transport.
+[plugin.settings]
+storage_path = "/var/lib/mesh-notes"
+retention_days = 14
+```
+
+Prefer typed settings with useful descriptions, defaults, constraints, and explicit restart scope. Do not make users put plugin settings at the top level of `config.toml`.
+
+## Package and release a plugin
+
+The installer expects a native GitHub Release archive. Each archive should contain one directory named after the plugin:
+
+```text
+hello-plugin/
+  plugin.toml
+  hello-plugin
+  README.md
+  LICENSE
+  skills/
+    hello-workflow/
+      SKILL.md
+```
+
+On Windows, the executable is `hello-plugin.exe`. The required files are `plugin.toml` and the executable; documentation, license files, and skills are recommended.
+
+Publish archives using the target triple in the filename:
+
+```text
+hello-plugin-0.1.0-aarch64-apple-darwin.tar.gz
+hello-plugin-0.1.0-x86_64-unknown-linux-gnu.tar.gz
+hello-plugin-0.1.0-x86_64-pc-windows-msvc.zip
+```
+
+The current installer targets macOS Apple Silicon and Intel, Linux ARM64 and x86_64, and Windows ARM64 and x86_64. Release automation should build and test every archive it publishes.
+
+## Ship Agent Skills
+
+A plugin can bundle skills for agent clients under `skills/<skill-name>/SKILL.md`. Use portable lowercase names with single hyphens, include `name` and `description` frontmatter, and keep supporting files relative to the skill directory.
+
+After installation, users can copy plugin skills into detected clients with:
+
+```bash
+mesh-llm skills install
+```
+
+Do not overwrite an existing user-owned skill unless the user explicitly asks for a forced install. Avoid hard-coded home directories and platform-specific paths in the skill.
+
+## Test before publishing
+
+At minimum, test the plugin with a running mesh-llm node and verify:
+
+1. The plugin connects and completes initialization.
+2. The manifest exposes the expected MCP, HTTP, inference, capability, channel, and event entries.
+3. Invalid input returns a useful error without taking down the control session.
+4. Health still responds while a handler is running.
+5. Streaming and cancellation do not leak side streams.
+6. A stopped endpoint becomes unavailable without incorrectly disabling the plugin.
+7. The release archive extracts to the expected directory and runs on each target.
+8. A mixed-version host rejects incompatible protocol versions clearly and accepts the versions you support.
+
+For plugin-specific runtime tests, use the repository's normal Rust test workflow. For a full host check, use the [testing playbook](/docs/pages/testing/).
+
+## Design and security checklist
+
+- Keep the plugin process independent of mesh-llm internals; depend on the author API and protocol contract.
+- Treat all plugin configuration and endpoint URLs as untrusted input.
+- Do not put secrets in manifests, release archives, logs, or MCP tool descriptions.
+- Prefer host-owned HTTP and MCP projections over opening an untracked listener.
+- Use namespaced MCP identifiers to avoid collisions.
+- Keep the control connection for lifecycle and small RPCs; use side streams for bulk data.
+- Declare the smallest possible set of mesh channels and events.
+- Document required network access, files, subprocesses, and permissions.
+- Pin or verify third-party dependencies in release builds.
+
+## Next topics worth documenting
+
+The plugin section would benefit from a compatibility matrix by mesh-llm release, a configuration-schema cookbook, a third-party plugin security model, a release workflow template, and a troubleshooting page with sample `plugins info` and startup diagnostics.

--- a/website/src/docs/pages/developing-plugins.md
+++ b/website/src/docs/pages/developing-plugins.md
@@ -162,6 +162,34 @@ storage_path = "/var/lib/mesh-notes"
 retention_days = 14
 ```
 
+Declare the schema in Rust with the manifest helpers. The host receives this manifest during initialization and uses it to validate `[plugin.settings]`:
+
+```rust
+use mesh_llm_plugin::{
+    PluginMetadata, SimplePlugin, config_integer, config_schema, config_setting,
+    plugin_manifest, plugin_server_info,
+};
+
+let manifest = plugin_manifest![
+    config_schema("notes").setting(
+        config_setting("retention_days", config_integer())
+            .default_value(&14)
+            .description("How long to retain entries."),
+    ),
+];
+
+let plugin = SimplePlugin::new(
+    PluginMetadata::new(
+        "notes",
+        "1.0.0",
+        plugin_server_info("notes", "1.0.0", "Notes", "Shared notes services", None::<String>),
+    )
+    .with_manifest(manifest),
+);
+```
+
+The same manifest can be passed to `InternalRpcPluginBuilder::with_manifest` when using the internal-RPC API. See the [`config_schema` and `config_setting` helpers](https://github.com/Mesh-LLM/mesh-llm/blob/main/crates/mesh-llm-plugin/src/manifest.rs) for the complete schema surface.
+
 Prefer typed settings with useful descriptions, defaults, constraints, and explicit restart scope. Do not make users put plugin settings at the top level of `config.toml`.
 
 ## Package and release a plugin

--- a/website/src/docs/pages/plugins.md
+++ b/website/src/docs/pages/plugins.md
@@ -4,87 +4,160 @@ title: Plugins
 
 # Plugins
 
-Plugins extend mesh-llm with features managed as separate processes. The plugin system handles lifecycle, IPC, and exposing plugin capabilities through MCP and HTTP.
+Plugins add capabilities to mesh-llm without putting every integration into the core runtime. A plugin is a native process managed by mesh-llm over a local control connection. The host owns lifecycle, MCP and HTTP exposure, routing, and policy; the plugin owns its feature logic and local state.
 
-## Install from the Catalog
+Use this page to install a plugin. If you are writing one, start with [Developing Plugins](/docs/pages/developing-plugins/).
 
-Search available plugins:
+## Official plugins
+
+The Mesh-LLM organization currently publishes five first-party plugin repositories. They are separate from the main `mesh-llm` repository and release native archives for supported platforms.
+
+| Plugin | Use it for | Install |
+| --- | --- | --- |
+| [`blackboard`](https://github.com/Mesh-LLM/blackboard) | Share short-lived status, findings, questions, and tips across a mesh. The plugin also ships a Blackboard Agent Skill. | `mesh-llm plugins install blackboard` |
+| [`openai-endpoint`](https://github.com/Mesh-LLM/openai-endpoint) | Add an already-running OpenAI-compatible server such as vLLM, TGI, Ollama, or Lemonade Server. | `mesh-llm plugins install openai-endpoint` |
+| [`flash-moe`](https://github.com/Mesh-LLM/flash-moe) | Attach a Flash-MoE inference endpoint, or let the plugin supervise a local Flash-MoE process. | `mesh-llm plugins install flash-moe` |
+| [`metrics`](https://github.com/Mesh-LLM/metrics) | Advertise metrics support for mesh-llm telemetry. Configure the OTLP destination in mesh-llm, not in the plugin. | `mesh-llm plugins install metrics` |
+| [`agents`](https://github.com/Mesh-LLM/agents) | Run mesh-native A2A agents and expose their tools through the mesh MCP endpoint. | `mesh-llm plugins install Mesh-LLM/agents` |
+
+The catalog is intentionally conservative: repositories such as `hf-hub`, `hf-mesh-skippy-splitter`, `iroh-fabric`, `MeshChat`, and `desktop-app` are useful Mesh-LLM projects, but they are not plugin packages.
+
+The catalog can also contain community plugins. Search it before installing an unfamiliar integration:
 
 ```bash
 mesh-llm plugins search
-mesh-llm plugins search blackboard
+mesh-llm plugins search database
 ```
 
-Install by name:
+Treat a catalog entry as a discovery aid: read the linked repository, check its release assets and permissions, and only then install it.
+
+## Install a plugin
+
+Install the latest compatible release for the current machine:
 
 ```bash
-mesh-llm plugins install blackboard
 mesh-llm plugins install openai-endpoint
-mesh-llm plugins install flash-moe
 ```
 
-Available Mesh-LLM organization plugins:
+You can also install directly from a GitHub repository. This is useful when a plugin is not yet in the catalog or when you want to pin a release:
 
-| Plugin | Description |
-|---|---|
-| `blackboard` | Shared mesh notes |
-| `openai-endpoint` | Connect external OpenAI-compatible backends (vLLM, TGI, Ollama, etc.) |
-| `flash-moe` | Flash-MoE SSD backend for MoE model serving |
+```bash
+mesh-llm plugins install Mesh-LLM/openai-endpoint
+mesh-llm plugins install Mesh-LLM/openai-endpoint@0.1.2
+```
 
-## Configure in `config.toml`
+The installer selects a native release archive using the plugin name, version, operating system, and CPU architecture. It does not download GPU-specific plugin variants. If a plugin does not publish an archive for your target, build it from its repository and configure the binary with `command`.
 
-Add a `[[plugin]]` entry to `~/.mesh-llm/config.toml` for each plugin:
+After installing, inspect the recorded source, version, target, and path:
+
+```bash
+mesh-llm plugins list
+mesh-llm plugins info openai-endpoint
+```
+
+## Configure a plugin
+
+Add one `[[plugin]]` table to `~/.mesh-llm/config.toml`:
+
+```toml
+[[plugin]]
+name = "openai-endpoint"
+url = "http://127.0.0.1:8000/v1"
+```
+
+For plugins that do not need an endpoint, the name is usually enough:
 
 ```toml
 [[plugin]]
 name = "blackboard"
 
 [[plugin]]
-name = "openai-endpoint"
-url = "http://gpu-box:8000/v1"
+name = "metrics"
 
-[[plugin]]
-name = "flash-moe"
+[telemetry]
+enabled = true
+endpoint = "https://otel.example.com"
 ```
 
-Available fields:
+For Flash-MoE, see the [Flash-MoE repository](https://github.com/Mesh-LLM/flash-moe) for both existing-endpoint and managed-process examples. For agents, see the [agents repository](https://github.com/Mesh-LLM/agents) for agent definitions and runtime configuration.
 
-- `name` (required): plugin identifier.
-- `enabled` (optional, default `true`): whether the plugin starts on launch.
-- `command` (optional): path to the plugin binary.
-- `args` (optional): command-line arguments (string array).
-- `url` (optional): URL for endpoint-style plugins.
-- `[plugin.startup]` (optional):
-  - `connect_timeout_secs`: max seconds for the initial connection.
-  - `init_timeout_secs`: max seconds for initialization handshake.
-  - `optional`: if `true`, startup failure is non-fatal.
-  - `lazy_start`: if `true`, the plugin starts on first use instead of at launch.
+### Plugin fields
 
-## Manage Installed Plugins
+| Field | Meaning |
+| --- | --- |
+| `name` | Installed plugin identifier. Required. |
+| `enabled` | Start the plugin with mesh-llm. Defaults to `true`. |
+| `command` | Explicit executable path or command. Useful for locally built plugins. |
+| `args` | Arguments passed to the plugin process. |
+| `url` | Optional endpoint passed to the plugin as `MESH_LLM_PLUGIN_URL`. |
+| `settings` | Plugin-specific settings declared by the installed plugin. Use `[plugin.settings]` in TOML. |
+| `[plugin.startup]` | Startup and failure behavior. |
+
+Startup options include `connect_timeout_secs`, `init_timeout_secs`, `optional`, and `lazy_start`. Mark an integration `optional = true` when mesh-llm should continue starting if that plugin is unavailable. Use `lazy_start = true` for plugins that should start only when directly used.
+
+Plugin settings are validated against the schema exposed by the installed plugin. For example:
+
+```toml
+[[plugin]]
+name = "my-plugin"
+
+[plugin.settings]
+mode = "strict"
+retention_days = 14
+```
+
+## Use plugin features
+
+The host aggregates plugin capabilities into the local console and MCP endpoint. Plugin-owned names are namespaced to prevent collisions:
+
+- Blackboard exposes tools such as `blackboard.feed` and `blackboard.post`, plus the `blackboard://snapshot` resource.
+- Agents exposes tools such as `agents.get_agents`, `agents.send_message`, and `agents.get_task`.
+- Endpoint plugins register inference services that mesh-llm can route to when their endpoint is healthy.
+
+Plugins may also ship Agent Skills. After installing a plugin that includes skills, run:
 
 ```bash
-mesh-llm plugins list                 # list installed plugins
-mesh-llm plugins info blackboard      # show plugin details
-mesh-llm plugins enable blackboard    # enable a disabled plugin
-mesh-llm plugins disable blackboard   # disable without deleting
-mesh-llm plugins update blackboard    # update to latest version
-mesh-llm plugins delete blackboard    # remove permanently
+mesh-llm skills install
 ```
 
-## Plugin Usage: Blackboard
+The supported agent launchers (`mesh-llm goose`, `mesh-llm pi`, `mesh-llm opencode`, and `mesh-llm claude`) install available plugin skills for that client before starting it.
 
-After installing the blackboard plugin, it runs as a managed process when mesh-llm starts. Interact through MCP tools and resources (available through the console's MCP endpoint):
+## Manage installed plugins
 
-- tool: `blackboard.feed`
-- tool: `blackboard.post`
-- resource: `blackboard://snapshot`
+```bash
+mesh-llm plugins update openai-endpoint
+mesh-llm plugins enable openai-endpoint
+mesh-llm plugins disable openai-endpoint
+mesh-llm plugins delete openai-endpoint
+```
 
-For detailed blackboard usage, see [github.com/mesh-llm/blackboard](https://github.com/mesh-llm/blackboard).
+Disabling keeps the archive and metadata on disk but prevents startup. Deleting removes the installed archive, extracted files, and local metadata. Restart mesh-llm after changing a plugin's configuration unless the plugin's own documentation says that it can be reloaded dynamically.
 
-## Deep Dives
+## Troubleshoot startup
+
+Start with the plugin state:
+
+```bash
+mesh-llm plugins info <name>
+```
+
+Then check the following:
+
+- `command` points to an executable that exists and can run on this machine.
+- `url` includes the correct `/v1` path for OpenAI-compatible endpoints.
+- The plugin is enabled and has a compatible release for the local target.
+- The endpoint is reachable from the mesh node, not only from your laptop.
+- A plugin with required settings is installed before those settings are added to `config.toml`.
+- An endpoint can be unhealthy while its plugin process is healthy; check the endpoint itself before reinstalling the plugin.
+
+For the protocol and host/plugin boundary, read [Plugin Architecture](/docs/pages/plugin-architecture/). For the author API and release contract, read [Developing Plugins](/docs/pages/developing-plugins/).
+
+## Further plugin documentation
 
 | Page | What it covers |
-|---|---|
-| [Plugin Architecture](/docs/pages/plugin-architecture/) | Design model, core principles, control session, streams, host vs plugin ownership |
-| [Developing Plugins](/docs/pages/developing-plugins/) | DSL guide, author experience, Rust example, internal RPC, streaming |
-| [Plugin Reference](/docs/pages/plugin-reference/) | External endpoints, MCP bindings, HTTP bindings, capabilities, mesh channels, control messages |
+| --- | --- |
+| [Plugin Architecture](/docs/pages/plugin-architecture/) | Control sessions, side streams, host projections, and ownership boundaries |
+| [Developing Plugins](/docs/pages/developing-plugins/) | Rust author API, manifests, packaging, skills, and testing |
+| [Plugin Reference](/docs/pages/plugin-reference/) | MCP, HTTP, inference, capabilities, mesh channels, and control messages |
+
+Useful next topics for this section are a plugin compatibility matrix by mesh-llm release, a configuration-schema guide with examples, a security and permissions guide for third-party binaries, and a release checklist for plugin authors.

--- a/website/src/docs/pages/plugins.md
+++ b/website/src/docs/pages/plugins.md
@@ -18,7 +18,7 @@ The Mesh-LLM organization currently publishes five first-party plugin repositori
 | [`openai-endpoint`](https://github.com/Mesh-LLM/openai-endpoint) | Add an already-running OpenAI-compatible server such as vLLM, TGI, Ollama, or Lemonade Server. | `mesh-llm plugins install openai-endpoint` |
 | [`flash-moe`](https://github.com/Mesh-LLM/flash-moe) | Attach a Flash-MoE inference endpoint, or let the plugin supervise a local Flash-MoE process. | `mesh-llm plugins install flash-moe` |
 | [`metrics`](https://github.com/Mesh-LLM/metrics) | Advertise metrics support for mesh-llm telemetry. Configure the OTLP destination in mesh-llm, not in the plugin. | `mesh-llm plugins install metrics` |
-| [`agents`](https://github.com/Mesh-LLM/agents) | Run mesh-native A2A agents and expose their tools through the mesh MCP endpoint. | `mesh-llm plugins install Mesh-LLM/agents` |
+| [`agents`](https://github.com/Mesh-LLM/agents) | Run mesh-native A2A agents and expose their tools through the mesh MCP endpoint. | `mesh-llm plugins install agents` |
 
 The catalog is intentionally conservative: repositories such as `hf-hub`, `hf-mesh-skippy-splitter`, `iroh-fabric`, `MeshChat`, and `desktop-app` are useful Mesh-LLM projects, but they are not plugin packages.
 
@@ -45,6 +45,8 @@ You can also install directly from a GitHub repository. This is useful when a pl
 mesh-llm plugins install Mesh-LLM/openai-endpoint
 mesh-llm plugins install Mesh-LLM/openai-endpoint@0.1.2
 ```
+
+Use the catalog name, such as `agents`, for catalog installs. Use the fully qualified `owner/repository` form, such as `Mesh-LLM/agents`, only when installing directly from GitHub.
 
 The installer selects a native release archive using the plugin name, version, operating system, and CPU architecture. It does not download GPU-specific plugin variants. If a plugin does not publish an archive for your target, build it from its repository and configure the binary with `command`.
 
@@ -106,6 +108,12 @@ mode = "strict"
 retention_days = 14
 ```
 
+## Plugin storage
+
+By default, mesh-llm stores plugin metadata under `~/.mesh-llm/plugins/` and extracted plugin files under `~/.mesh-llm/plugins/installed/<name>/`. The metadata record at `~/.mesh-llm/plugins/<name>/plugin-install.json` records the source, version, target, install path, enabled state, and packaged settings schema.
+
+Set `MESH_LLM_PLUGIN_DIR` to use a different store root. With that override, the corresponding paths are `<root>/<name>/plugin-install.json` and `<root>/installed/<name>/`. The extracted directory contains the plugin executable, documentation, and any bundled `skills/` directories. Use `mesh-llm plugins info <name>` to confirm the resolved install path before inspecting files manually.
+
 ## Use plugin features
 
 The host aggregates plugin capabilities into the local console and MCP endpoint. Plugin-owned names are namespaced to prevent collisions:
@@ -131,7 +139,7 @@ mesh-llm plugins disable openai-endpoint
 mesh-llm plugins delete openai-endpoint
 ```
 
-Disabling keeps the archive and metadata on disk but prevents startup. Deleting removes the installed archive, extracted files, and local metadata. Restart mesh-llm after changing a plugin's configuration unless the plugin's own documentation says that it can be reloaded dynamically.
+Disabling keeps the extracted files and metadata on disk but prevents startup. Deleting removes the extracted files and local metadata. Restart mesh-llm after changing a plugin's configuration unless the plugin's own documentation says that it can be reloaded dynamically.
 
 ## Troubleshoot startup
 


### PR DESCRIPTION
## What changed

- Expand the website plugin overview with the five first-party Mesh-LLM plugins:
  - blackboard
  - openai-endpoint
  - flash-moe
  - metrics
  - agents
- Add install, discovery, configuration, Agent Skills, management, and troubleshooting guidance.
- Rewrite the plugin development guide with Rust examples, manifest surfaces, lifecycle/environment details, configuration schemas, packaging, release targets, testing, and security guidance.
- Suggest follow-up documentation topics such as compatibility matrices, schema examples, and third-party plugin security.

## Validation

- `just website-build` ✅

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Reworked plugin development documentation into a Rust-first, manifest-driven author guide, covering contribution surfaces, typed handler schemas, lifecycle hooks, streaming negotiation, configuration/validation, packaging requirements, skills distribution, testing checklists, and a design/security checklist.
  * Expanded plugin usage documentation with clearer installation (including version pinning), configuration examples and startup options, capability namespacing, storage location details, richer plugin management behavior, and a guided troubleshooting flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->