### PR TITLE
Refresh general documentation

### DIFF
--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -167,7 +167,7 @@ Switches:
 
 - `--json`: machine-readable output.
 
-Runtime switches:
+### Common runtime options
 
 - `--join <TOKEN>`: join a specific mesh using an invite token (repeatable).
 - `--discover [NAME]`: discover a mesh and join it. With a name, joins the mesh matching that name. Without a name, behaves like `--auto`.
@@ -331,6 +331,7 @@ mesh-llm models download mlx-community/SmolLM-135M-8bit
 Switches:
 
 - `--draft`: also download the recommended draft model (if available).
+- `--direct`: download the exact Hugging Face GGUF file directly, bypassing catalog layer-package resolution.
 - `--json`: machine-readable output.
 
 ### `models package`
@@ -443,6 +444,9 @@ Switches:
 Use this to update mesh-llm and exit.
 
 Switches:
+- `--version <VERSION>`: install a specific release tag or version, for example `v0.60.0`.
+- `--flavor <FLAVOR>`: install or switch to a specific release bundle flavor (`cpu`, `cuda`, `rocm`, `vulkan`, or `metal`).
+- `--detect-flavor`: re-detect the best host backend flavor before selecting the release bundle. Cannot be combined with `--flavor`.
 - `--auto-update`: available on most commands; when set, mesh-llm checks for a newer bundled release before proceeding.
 
 

--- a/docs/skippy/speculative_decoding.md
+++ b/docs/skippy/speculative_decoding.md
@@ -1,7 +1,8 @@
 # Speculative Decoding Outstanding Work
 
 This note tracks open work for n-gram speculative decoding. The broader usage
-guide and latest benchmark tables live in [`../SPECULATIVE_DECODING.md`](../SPECULATIVE_DECODING.md).
+guide lives in [`../USAGE.md`](../USAGE.md); benchmark evidence is maintained
+in the family result documents under this directory.
 
 ## Current State
 

--- a/website/src/docs/pages/CLI.md
+++ b/website/src/docs/pages/CLI.md
@@ -183,10 +183,11 @@ Switches:
 
 - `--json`: machine-readable output.
 
-Runtime switches:
+### Common runtime options
 
 - `--join <TOKEN>`: join a specific mesh using an invite token (repeatable).
 - `--discover [NAME]`: discover a mesh via Nostr and join it. With a name, joins the mesh matching that name. Without a name, behaves like `--auto`.
+- `--mesh-discovery-mode <nostr|mdns>`: choose public Nostr or LAN mDNS discovery. mDNS is LAN-scoped and still requires an invite token for joining.
 - `--auto`: auto-join the best discovered mesh.
 - `--model <MODEL>`: model to serve (catalog id from `models recommended`, HF ref/URL, or path).
 - `--gguf <GGUF>`: serve a specific local GGUF file directly (repeatable).
@@ -217,11 +218,15 @@ Subcommands:
 
 - `recommended`
 - `installed`
+- `cleanup`
+- `prune`
 - `search`
 - `show`
 - `download`
+- `package`
 - `certify`
 - `updates`
+- `delete`
 
 ### `models recommended`
 
@@ -238,6 +243,29 @@ Run this when you want to see what’s already on your machine.
 Switches:
 
 - `--json`: machine-readable output.
+
+### `models cleanup`
+
+Preview or remove stale managed model-cache entries:
+
+```bash
+mesh-llm models cleanup
+mesh-llm models cleanup --unused-since 30d --yes
+```
+
+Use `--json` for machine-readable output. The default is a preview; `--yes`
+applies the removal.
+
+### `models prune`
+
+Preview or remove stale derived Skippy stage artifacts:
+
+```bash
+mesh-llm models prune
+mesh-llm models prune --yes
+```
+
+The default is a preview and active or pinned stage artifacts are preserved.
 
 ### `models search`
 
@@ -291,6 +319,21 @@ Switches:
 - `--direct`: download the exact HuggingFace GGUF file directly, bypassing catalog layer-package resolution.
 - `--json`: machine-readable output.
 
+### `models package`
+
+Plan or submit a Hugging Face Job that splits a source GGUF into a Skippy
+layer-package repository. The default is a dry run; `--confirm` is required to
+submit a spend-bearing job.
+
+```bash
+mesh-llm models package unsloth/Qwen3-8B-GGUF:Q4_K_M --dry-run
+mesh-llm models package unsloth/Qwen3-8B-GGUF:Q4_K_M --confirm --follow
+mesh-llm models package --status <JOB_ID>
+```
+
+Use `--help` for the full planning, status, logs, cancel, and publishing
+options.
+
 ### `models certify`
 
 Use this when you want a repeatable Skippy layer-package confidence report
@@ -336,6 +379,11 @@ Switches:
 - `--check`: check only; do not refresh cache.
 - `--json`: machine-readable output.
 
+### `models delete`
+
+Remove a managed model entry. Run `mesh-llm models delete --help` first to
+review the current confirmation and selection options.
+
 ### `download`
 
 Use this to quickly download by built-in catalog ID or shorthand.
@@ -361,6 +409,21 @@ Switches:
 - `--flavor <FLAVOR>`: install or switch to a specific release bundle flavor (`cpu`, `cuda`, `rocm`, `vulkan`, or `metal`).
 - `--detect-flavor`: re-detect the best host backend flavor before selecting the release bundle. Cannot be combined with `--flavor`.
 - `--auto-update`: available on most commands; when set, mesh-llm checks for a newer bundled release before proceeding.
+
+### `runtime`
+
+Inspect and manage installed native runtimes:
+
+```bash
+mesh-llm runtime list
+mesh-llm runtime install
+mesh-llm runtime install cuda13
+mesh-llm runtime remove <RUNTIME_ID>
+mesh-llm runtime prune --active-only
+```
+
+Use `--json` for machine-readable output. Runtime selection is constrained by
+the running Mesh version, platform, backend, and Skippy ABI.
 
 
 ### `gpus`

--- a/website/src/docs/pages/config-defaults.md
+++ b/website/src/docs/pages/config-defaults.md
@@ -16,48 +16,41 @@ batch                   = 0              # Batch size (0 = auto)
 ubatch                  = 0              # Micro-batch size (0 = auto)
 cache_type_k            = "f16"          # Key cache dtype
 cache_type_v            = "f16"          # Value cache dtype
-kv_offload              = true           # Offload KV cache to GPU
-no_kv_offload           = false          # Keep KV cache on CPU
-no_mmap                 = false          # Disable memory-mapped model loading
-mlock                   = false          # Lock model in RAM
-num_experts_per_token   = 0              # MoE: experts per token (0 = all)
-expert_count            = 0              # MoE: total expert count
-no_cont_batching        = false          # Disable continuous batching
-max_batched_tokens      = 0              # Max tokens per batch
-pooling_type            = ""             # Pooling type for embedding models
+kv_offload              = "auto"        # KV-cache offload policy
+prompt_cache            = "auto"        # Prompt-cache policy
+flash_attention         = "auto"        # Flash-attention policy
 
 [defaults.hardware]
-model_runtime = "cpu"                    # "cpu", "cuda", "vulkan", "metal", "sycl", etc.
+model_runtime = "auto"                   # "auto", "cpu", "cuda", "rocm", "vulkan", or "metal"
 device        = ""                       # Device ID (empty = auto)
-gpu_layers    = 0                        # Layers to offload to GPU (0 = auto)
+gpu_layers    = "auto"                   # Layers to offload (or an integer)
 main_gpu      = 0                        # Primary GPU index
 tensor_split  = ""                       # Comma-separated tensor split ratios
-no_mul_mat_q  = false                    # Disable mulmat quantization
-decode_only_q = false                    # Quantize only decode path
-check_tensors = ""                       # Tensor check mode
-temp_file     = ""                       # Temporary file path for offloading
+mmap          = "auto"                   # Memory-map model loading
+mlock         = false                    # Lock model pages in RAM
+warmup        = "auto"                   # Run model warmup when supported
 
 [defaults.throughput]
 parallel              = 1                # Parallel sequence count
-continuous_batching   = true             # Enable continuous batching
+continuous_batching   = "auto"          # Enable continuous batching
 threads               = 0                # Thread count (0 = auto)
-cpu_threads           = 0                # CPU thread count
-flash_attn            = false            # Enable flash attention
-no_flash_attn         = false            # Disable flash attention
-tensor_cores          = false            # Use tensor cores on NVIDIA GPUs
-no_kv_reuse           = false            # Disable KV cache reuse across requests
+threads_batch         = 0                # Batch thread count (0 = auto)
+tuning_profile        = "balanced"      # "throughput", "balanced", or "saver"
 
 [defaults.skippy]
-stage_model_package  = ""                # Path or repo for skippy stage model
-enable               = false             # Enable skippy stage serving
-activation_dtype     = "q8_0"            # Activation wire dtype
-num_stages           = 0                 # Number of stages (0 = auto)
-stage_plan           = ""                # Explicit stage plan path
+stage_model_path      = ""               # Path or repo for a stage model
+stage_role            = ""               # Stage role override
+stage_topology        = ""               # Stage topology override
+activation_wire_dtype = "auto"           # "auto", "f16", "f32", or "q8"
+binary_stage_transport = ""              # Binary stage transport override
+prefill_chunking      = "auto"           # Prefill chunking policy
+prefill_chunk_size    = 0                 # Fixed prefill chunk size (0 = auto)
 
 [defaults.speculative]
-draft_model          = ""                # Path or repo for draft model
-enable               = false             # Enable speculative decoding
-draft_parallel       = 1                 # Draft parallel sequences
+mode                 = "auto"            # "auto", "disabled", "draft", or "ngram"
+draft_model          = ""                # Path or repo for a draft model
+draft_max_tokens     = 0                 # Maximum draft-token window
+draft_min_tokens     = 0                 # Minimum draft-token window
 draft_gpu_layers     = 0                 # Draft GPU layers (0 = auto)
 draft_device         = ""                # Draft device override
 
@@ -74,13 +67,13 @@ stop          = []                       # Stop sequences
 typical_p     = 0.0                      # Typical sampling
 
 [defaults.multimodal]
-clip_model_path   = ""                   # Path to CLIP model for multimodal
-mmproj_path       = ""                   # Path to multimodal projection
-image_main_gpu    = 0                    # GPU for image processing
+mmproj            = ""                   # Path or reference to a multimodal projector
+mmproj_offload    = "auto"               # Projector offload policy
+image_min_tokens  = 0                     # Minimum image token budget
+image_max_tokens  = 0                     # Maximum image token budget
 
-[defaults.advanced]
-cont_batching_init_slots = 0             # Initial slot count for continuous batching
-hierarchical_slots        = false        # Enable hierarchical KV slot management
+[defaults.advanced.server]
+alias = ""                               # Optional model alias
 ```
 
 ## Sub-config reference

--- a/website/src/docs/pages/config-models.md
+++ b/website/src/docs/pages/config-models.md
@@ -7,16 +7,14 @@ description: Configuring models and plugins in ~/.mesh-llm/config.toml
 
 ## Models
 
-The `[[models]]` array configures which models mesh-llm serves. Each entry can set the same sub-configs as `[defaults]` plus a `name` and `source`.
+The `[[models]]` array configures which models mesh-llm serves. Each entry requires a `model` reference and can override the same sub-configs as `[defaults]`.
 
 ```toml
 [[models]]
-name          = "llama-3.1-8b"
-source        = "hf:meta-llama/Llama-3.1-8B-Instruct-GGUF"
+model         = "meta-llama/Llama-3.1-8B-Instruct-GGUF"
 
 [models.model_fit]
 ctx_size      = 8192
-gpu_layers    = -1           # -1 = all layers on GPU
 
 [models.throughput]
 parallel      = 4
@@ -26,21 +24,15 @@ max_tokens    = 2048
 temperature   = 0.7
 ```
 
-The `source` field supports:
-- `hf:org/model` — Hugging Face model ID
-- A local GGUF file path
-- A model reference or alias
-
-The optional `runtime` field sets a preferred runtime backend (`auto`, `cpu`, `cuda`, `vulkan`, `metal`, `sycl`, etc.).
+The `model` field accepts a catalog id, Hugging Face reference, URL, or local model path.
 
 ```toml
 [[models]]
-name    = "codellama-7b"
-source  = "hf:codellama/CodeLlama-7b-Instruct-GGUF"
-runtime = "cuda"
+model = "codellama/CodeLlama-7b-Instruct-GGUF"
 
 [models.hardware]
-gpu_layers = -1
+model_runtime = "cuda"
+gpu_layers = "auto"
 ```
 
 ## Plugins

--- a/website/src/docs/pages/config-reference.md
+++ b/website/src/docs/pages/config-reference.md
@@ -10,27 +10,30 @@ description: Environment variables, rejected fields, and CLI commands for mesh-l
 | Variable | Override |
 |---|---|
 | `MESH_LLM_CONFIG` | Full path to config file (instead of `~/.mesh-llm/config.toml`) |
-| `MESH_LLM_PORT` | Inference API port (overrides `owner_control.bind`) |
-| `MESH_LLM_CONSOLE_PORT` | Console/management API port |
-| `MESH_LLM_DATA_DIR` | Data directory for models and runtime state |
 
 ## Managing Config via CLI
 
 ```bash
-mesh-llm config show           # Show the loaded config
-mesh-llm config show-effective # Show the effective (merged) config
+mesh-llm config validate
+mesh-llm config validate --config-path ./mesh.toml
+mesh-llm config validate --config-path ./mesh.toml --json
 ```
 
-## Documented Rejected Fields
+`config validate` checks the TOML file without starting a node. If
+`--config-path` is omitted, it uses the global `--config` path, then
+`MESH_LLM_CONFIG`, then `~/.mesh-llm/config.toml`.
+
+## Rejected Fields
 
 The following fields are recognized by the parser but explicitly rejected. Setting them will cause a validation error:
 
 | Section | Rejected fields |
 |---|---|
-| `model_fit` | `rpc_backend`, `threads_http`, `sleep_idle_seconds` |
-| `hardware` | `backend_sampling` |
-| `request_defaults` | `grammar`, `json_schema`, `logprobs` |
+| `hardware` | `rpc_backend` |
+| `throughput` | `threads_http`, `sleep_idle_seconds` |
+| `skippy` | `openai_frontend_mode` |
+| `request_defaults` | `backend_sampling`, `grammar`, `json_schema`, `logprobs` |
 | `advanced.server` | `host`, `port`, `reuse_port`, `timeout`, `metrics`, `slots`, `props`, `api_prefix` |
-| Top-level | `embeddings`, `reranking`, `pooling`, `vocoder` |
+| `multimodal` | `embeddings`, `reranking`, `pooling`, `vocoder` |
 
 These fields existed in the predecessor system (llama-server) and are not valid in mesh-llm config.

--- a/website/src/docs/pages/config-toml.md
+++ b/website/src/docs/pages/config-toml.md
@@ -24,11 +24,11 @@ Controls GPU assignment and parallelism.
 ```toml
 [gpu]
 assignment = "auto"       # "auto" (default) or "pinned"
-parallel  = {}            # Optional GPU parallel config map
+parallel  = 2              # Optional total parallel inference slots
 ```
 
 - `assignment` — `"auto"` lets mesh-llm assign GPUs dynamically; `"pinned"` locks models to specific GPUs.
-- `parallel` — map of device type to parallel config (rarely needed; `auto` handles most cases).
+- `parallel` — optional total parallel inference-slot count. Omit it to let the runtime choose.
 
 ## Owner Control
 
@@ -36,12 +36,12 @@ Network identity and binding.
 
 ```toml
 [owner_control]
-bind           = "[::]:9337"   # Listen address for inference API
-advertise_addr = ""             # Override advertised address (auto-detected if empty)
+bind           = "[::]:7447"   # Mesh owner-control listen address
+advertise_addr = ""             # Override the address advertised to peers
 ```
 
-- `bind` — address and port for the inference HTTP server. Default `[::]:9337`.
-- `advertise_addr` — advertised address for mesh discovery. Auto-detected when empty. Set this explicitly for NAT or Docker setups.
+- `bind` — address and port for the owner-control endpoint. The inference API remains on `9337` unless changed by the runtime surface.
+- `advertise_addr` — address and port announced to peers. Auto-detected when empty; set it explicitly for NAT or Docker setups.
 
 ## Telemetry
 
@@ -68,15 +68,17 @@ Peer compatibility constraints.
 
 ```toml
 [mesh_requirements]
-min_node_protocol         = 0    # Minimum acceptable peer protocol version
-max_node_protocol         = 0    # Maximum acceptable peer protocol version
-min_release_version       = ""   # Minimum release version string
+# Optional node/release bounds. Omit these unless the mesh needs an admission gate.
+# min_node_version         = "0.72.0"
+# max_node_version         = "0.72.1"
+min_protocol_version      = 0    # Minimum acceptable peer protocol version
+max_protocol_version      = 0    # Maximum acceptable peer protocol version
 require_release_attestation = false
-release_signer_keys       = []   # List of allowed release signer public keys
+release_signer_keys       = []   # Allowed release signer public keys
 ```
 
-- `min_node_protocol` / `max_node_protocol` — constrain which protocol versions to accept. `0` means no constraint.
-- `min_release_version` — reject peers running older release versions. Empty means no constraint.
+- `min_node_version` / `max_node_version` — optional semantic-version bounds for peers.
+- `min_protocol_version` / `max_protocol_version` — constrain peer protocol versions. `0` means no constraint.
 - `release_signer_keys` — if set, only accept peers whose release binary is signed by one of these keys.
 
 ## Runtime
@@ -85,14 +87,13 @@ Runtime behavior and model reconciliation.
 
 ```toml
 [runtime]
-reconcile_model_targets              = true
+reconcile_model_targets                = false
 reconcile_model_target_demand_upgrades = false
-model_target_demand_upgrade_interval_secs = 300
-model_target_demand_upgrade_threshold = 0
-model_target_demand_upgrade_min_wait_secs = 0
+model_target_demand_upgrade_min_requests = 2
+model_target_demand_upgrade_max_age_secs = 3600
 ```
 
-Model target reconciliation automatically adjusts running models to match configured targets. Demand upgrades allow the runtime to upgrade model quality (e.g., larger quantizations) when demand metrics cross the threshold.
+Model target reconciliation keeps running models aligned with configured targets. Demand upgrades use the minimum request count and maximum request age above when deciding whether a higher-quality target is warranted.
 
 ## Deep Dives
 

--- a/website/src/docs/pages/testing.md
+++ b/website/src/docs/pages/testing.md
@@ -94,7 +94,7 @@ Run these manual checks after changes to `runtime/interactive.rs` or `cli/output
 
 For terminal restoration QA:
 
-- Resize during startup, after llama-server readiness, and while the dashboard has focus on different panels.
+- Resize during startup, after model/runtime readiness, and while the dashboard has focus on different panels.
 - Detach and reattach tmux/screen while the dashboard is active.
 - Click dashboard panels and use the mouse wheel in terminal, tmux, and screen.
 - Press `q` and `Ctrl+C`; the cursor should be visible and the shell prompt should not remain in raw mode.
@@ -105,12 +105,12 @@ For terminal restoration QA:
 ### 1. Solo (single node)
 
 ```bash
-mesh-llm serve --model Qwen2.5-3B --console
+mesh-llm serve --model Qwen2.5-3B --console 3131
 ```
 
 - API on `:9337`, console on `:3131`
 - Console: `host=true, peers=0`
-- llama-server has 1 RPC entry (self)
+- The local embedded runtime is the only serving entry.
 
 ### 1a. Headless mode (API-only, no embedded UI)
 
@@ -148,7 +148,7 @@ mesh-llm serve --model Qwen2.5-32B --join <TOKEN>
 ```
 
 - `--split` forces tensor split even when model fits on host
-- llama-server has 2 RPC entries
+- Both nodes participate in the distributed serving path.
 - Tensor split proportional to VRAM (e.g. `0.67,0.33`)
 - Draft model auto-detected and used
 
@@ -173,7 +173,7 @@ mesh-llm client --join <TOKEN> --port 9555
 
 ```bash
 # node A: seeds mesh with two models, serves 3B
-mesh-llm serve --model Qwen2.5-3B --model GLM-4.7-Flash --console
+mesh-llm serve --model Qwen2.5-3B --model GLM-4.7-Flash --console 3131
 # node B: joins, auto-assigned to GLM (needed, on disk)
 mesh-llm serve --join <TOKEN>
 ```
@@ -228,7 +228,7 @@ mesh-llm unload GLM-4.7-Flash-Q4_K_M
 
 ```bash
 # Running node
-mesh-llm serve --model Qwen2.5-0.5B-Instruct-Q4_K_M --console
+mesh-llm serve --model Qwen2.5-0.5B-Instruct-Q4_K_M --console 3131
 
 # Operator surface
 mesh-llm load Llama-3.2-1B-Instruct-Q4_K_M
@@ -312,7 +312,7 @@ mesh-llm serve --model Qwen2.5-3B --join <TOKEN> --port 8091
 ```
 
 - Joiner log: `⚡ API ready (bootstrap): http://localhost:8091`
-- BEFORE `rpc-server` or `llama-server` starts on joiner:
+- Before the full local model runtime becomes ready on the joiner:
   - `curl localhost:8091/v1/models` → lists mesh models
   - `curl localhost:8091/v1/chat/completions` → inference via tunnel to originator
 - Log: `⚡ Bootstrap proxy handing off to full API proxy`
@@ -408,7 +408,7 @@ curl localhost:3131/api/discover # Nostr meshes (current mesh marked by mesh_id)
 
 - Regossip after becoming host should NOT cause restart loops
 - Log should show "still host, no restart needed" on re-check
-- llama-server starts exactly once per election (not 5-9 times)
+- The local model runtime starts exactly once per election (not 5-9 times)
 - Heartbeat gossip doesn't re-discover dead peers (discover_peers=false)
 
 ## Control-Plane Protocol (Protobuf v1)
@@ -471,7 +471,7 @@ Two processes under the same user share `~/.mesh-llm/key` and appear as the same
 ### 14. Forced split on one machine
 
 ```bash
-mesh-llm serve --model Qwen2.5-3B --port 9337 --split --console
+mesh-llm serve --model Qwen2.5-3B --port 9337 --split --console 3131
 ```
 
 ```bash
@@ -479,7 +479,7 @@ mesh-llm serve --model Qwen2.5-3B --join <TOKEN> --port 9338 --split --max-vram 
 ```
 
 - Host starts solo, then re-elects with split when worker joins
-- Worker becomes rpc-server, proxies API to host
+- Worker joins the mesh and proxies assigned inference traffic to the serving path
 - Tensor split proportional to VRAM (e.g. `0.98,0.02`)
 - Kill worker → host detects via heartbeat (~60s), reverts to solo mode
 
@@ -503,8 +503,8 @@ mesh-llm client --join <TOKEN> --port 9338
 ```bash
 just bundle
 # scp, then on remote:
-codesign -s - ~/mesh-bundle/mesh-llm ~/mesh-bundle/rpc-server ~/mesh-bundle/llama-server
-xattr -cr ~/mesh-bundle/mesh-llm ~/mesh-bundle/rpc-server ~/mesh-bundle/llama-server
+codesign -s - ~/mesh-bundle/mesh-llm
+xattr -cr ~/mesh-bundle/mesh-llm
 ```
 
 Must codesign + xattr after every scp or macOS kills the binary (exit 137).
@@ -512,9 +512,9 @@ Must codesign + xattr after every scp or macOS kills the binary (exit 137).
 ## Cleanup
 
 ```bash
-pkill -f mesh-llm; pkill -f rpc-server; pkill -f llama-server
+pkill -f mesh-llm
 ```
 
 Prefer `mesh-llm stop` for tracked local instances. If the runtime is wedged,
-kill any remaining mesh-llm process and then verify no stale backend process is
-still bound to the test ports.
+kill any remaining mesh-llm process and then verify no stale process is still
+bound to the test ports.


### PR DESCRIPTION
## Summary

- refresh the public and root CLI references with current commands and options
- update the public config guides to the current TOML schema and validation command
- modernize the testing guide for the embedded runtime and remove obsolete backend instructions
- repair the broken speculative-decoding documentation link

## Why

Several public documentation pages had drifted from the current CLI, config structs, and embedded serving architecture. The changes make the documented examples parseable and keep operator guidance aligned with the current implementation.

Plugin documentation and plugin-specific sections are intentionally excluded because they are being rewritten separately in PR #972.

## Validation

- `just website-build`
- Python TOML parsing of changed config examples
- local Markdown-link scan
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded CLI guidance for model cleanup, pruning, packaging, deletion, runtime management, discovery modes, and update options.
  * Documented direct GGUF downloads and additional release selection controls.
  * Updated configuration examples and reference details for model selection, hardware, runtime, networking, mesh compatibility, and inference policies.
  * Clarified configuration validation, rejected fields, and path resolution behavior.
  * Refined speculative decoding links and refreshed testing procedures, console usage, runtime expectations, and macOS cleanup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->