### PR TITLE
Fix crates.io release jobs checking out the wrong ref

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1445,6 +1445,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ needs.metadata.outputs.tag }}
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Prepare dispatched release version
@@ -1465,6 +1466,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
         with:
+          ref: ${{ needs.metadata.outputs.tag }}
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
       - name: Prepare dispatched release version


### PR DESCRIPTION
## Summary

Fix the manual release workflow's crates.io preflight and publish jobs to check out the release tag created by the preceding GitHub release job.

## Root cause

Run [29173214598](https://github.com/Mesh-LLM/mesh-llm/actions/runs/29173214598/job/86944153407) checked out the workflow's original `main` SHA in the crates.io publish job. The job then ran `scripts/release-version.sh`, which modified `Cargo.toml`; `scripts/publish-crates.sh` intentionally requires a clean worktree for real publishes, so the first `cargo publish` failed with:

```
error: 1 files in the working directory contain changes that were not yet committed into git:
Cargo.toml
```

The preceding `publish` job has already created and pushed the requested release tag. Both crates.io jobs now use `needs.metadata.outputs.tag`, avoiding the dirty version rewrite and ensuring crates are published from the tagged release source.

## Verification

- `actionlint -oneline .github/workflows/release.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release reliability by ensuring packages are built and published from the intended release tag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->