### PR TITLE
Fix broken website documentation links

### DIFF
--- a/website/src/_data/docs.js
+++ b/website/src/_data/docs.js
@@ -24,7 +24,7 @@ export default [
     title: "Running Models",
     description: "Serve local models, use Hugging Face GGUFs, and scale across machines.",
     links: [
-      ["Run your first model", "/docs/pages/quickstart/#serve-a-model"],
+      ["Run your first model", "/docs/pages/quickstart/#3-start-one-private-node"],
       ["Choose a model", "/docs/pages/choose-a-model/"],
       ["Running large models", "/docs/pages/running-large-models/"],
       ["Console chat", "/docs/pages/console-chat/"],

--- a/website/src/docs/pages/CLI.md
+++ b/website/src/docs/pages/CLI.md
@@ -637,13 +637,13 @@ Use this to stop local `mesh-llm` instances tracked in the runtime root.
 
 ### `blackboard` (plugin)
 
-Shared mesh notes — post, search, and read notes across the mesh. Blackboard was moved from a built-in command to an [installable plugin](plugins.md#using-plugins):
+Shared mesh notes — post, search, and read notes across the mesh. Blackboard was moved from a built-in command to an [installable plugin](/docs/pages/plugins/#use-plugin-features):
 
 ```bash
 mesh-llm plugins install blackboard
 ```
 
-Once installed, it runs as a managed plugin process when mesh-llm starts. See the [plugins documentation](plugins.md#using-plugins) for configuration and usage.
+Once installed, it runs as a managed plugin process when mesh-llm starts. See the [plugins documentation](/docs/pages/plugins/#use-plugin-features) for configuration and usage.
 
 ### `plugins` / `plugin`
 
@@ -662,7 +662,7 @@ Subcommands:
 - `plugins search [query]`: search the plugin catalog.
 - `plugins list`: list installed/configured plugins.
 
-See [plugins documentation](plugins.md#using-plugins) for more detail.
+See [plugins documentation](/docs/pages/plugins/#use-plugin-features) for more detail.
 
 
 ### `auth`


### PR DESCRIPTION
## Summary

- fix CLI links to the Plugins documentation route and its actual `use-plugin-features` anchor
- fix the shared docs navigation link to the Quickstart model-serving section

## Root cause

The website emits documentation pages as directory routes (`/docs/pages/<slug>/index.html`), while the affected links used a source Markdown filename and stale heading IDs.

## Validation

- `just website-build`
- static audit of all 41 generated HTML files: 0 missing links, 0 missing fragments, 0 duplicate IDs, 0 malformed documents
- local browser smoke test of homepage, CLI docs, Plugins anchor, and Catalog with no console errors

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Run your first model” link to point to the latest quickstart instructions.
  * Updated CLI plugin references to use the current plugin documentation location.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->