### PR TITLE
Make mmap the default for Skippy layer packages

### DIFF
--- a/crates/skippy-server/README.md
+++ b/crates/skippy-server/README.md
@@ -163,6 +163,9 @@ unload or replan.
 - `layer-package` loads a local `model-package.json` directory, validates the
   manifest and selected part files, then opens those GGUF parts directly through
   the stage ABI.
+- `layer-package` explicitly enables mmap-backed loading by default so selected
+  GGUF parts remain file-backed instead of being eagerly copied into a second
+  weight buffer. Set `mmap` to `false` in the stage config to opt out.
 - Package selection validates manifest schema, ABI version, selected part sizes,
   duplicate layers, and required layer presence before runtime load.
 - If a layer package declares `projectors` with `kind: "mmproj"`, package-backed

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -1256,6 +1256,14 @@ fn should_attach_package_projector(config: &StageConfig) -> bool {
     config.stage_index == 0 && config.layer_start == 0
 }
 
+fn effective_model_mmap(load_mode: &LoadMode, mmap: Option<bool>) -> Option<bool> {
+    if load_mode == &LoadMode::LayerPackage {
+        Some(mmap.unwrap_or(true))
+    } else {
+        mmap
+    }
+}
+
 fn runtime_config_from_stage_config(
     config: &StageConfig,
     overrides: &RuntimeLaunchOverrides,
@@ -1285,7 +1293,7 @@ fn runtime_config_from_stage_config(
         n_threads,
         n_threads_batch,
         n_gpu_layers: config.n_gpu_layers,
-        mmap: config.mmap,
+        mmap: effective_model_mmap(&config.load_mode, config.mmap),
         mlock: config.mlock,
         selected_backend_device: config
             .selected_device
@@ -1352,8 +1360,8 @@ mod tests {
     use skippy_runtime::FlashAttentionType as RuntimeFlashAttentionType;
 
     use super::{
-        RuntimeLaunchOverrides, create_indexed_lane_resource, runtime_config_from_stage_config,
-        should_attach_package_projector,
+        RuntimeLaunchOverrides, create_indexed_lane_resource, effective_model_mmap,
+        runtime_config_from_stage_config, should_attach_package_projector,
     };
 
     #[test]
@@ -1638,6 +1646,28 @@ mod tests {
         assert_eq!(runtime_config.n_threads_batch, None);
         assert_eq!(runtime_config.n_batch, None);
         assert_eq!(runtime_config.n_ubatch, None);
+    }
+
+    #[test]
+    fn layer_package_mmap_is_enabled_by_default_and_can_be_disabled() {
+        assert_eq!(
+            effective_model_mmap(&LoadMode::LayerPackage, None),
+            Some(true)
+        );
+        assert_eq!(
+            effective_model_mmap(&LoadMode::LayerPackage, Some(false)),
+            Some(false)
+        );
+        assert_eq!(
+            effective_model_mmap(&LoadMode::LayerPackage, Some(true)),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn non_package_loads_preserve_llama_mmap_auto_mode() {
+        assert_eq!(effective_model_mmap(&LoadMode::RuntimeSlice, None), None);
+        assert_eq!(effective_model_mmap(&LoadMode::ArtifactSlice, None), None);
     }
 
     #[test]


### PR DESCRIPTION
## Title

Make mmap the default for Skippy layer packages

## Original problem

Layer-package loads left `mmap=auto` for llama.cpp to interpret. llama.cpp currently defaults that to enabled, but Skippy did not own the behavior as part of the layer-package contract. That made package-backed loading vulnerable to runtime-specific divergence and allowed experimental branches to silently fall back to eagerly copying every selected weight into a second backend buffer.

## Diagnostics

A 387 MiB Qwen3-0.6B GGUF was split into a 28-layer package and loaded through the real ordered-part ABI on Metal.

- With `mmap` omitted, llama.cpp reported `mmap = true` and the package parts appeared as `MTL0_Mapped model buffer` allocations.
- With `mmap: false`, llama.cpp reported `mmap = false` and allocated one eager `MTL0 model buffer size = 380.92 MiB`.
- Both modes completed an OpenAI-compatible prompt correctly (`The capital of France is` -> `Paris.`).

## Fix

Resolve layer-package `mmap=auto` to an explicit `mmap=true` before crossing the Skippy ABI. Explicit `mmap=false` remains authoritative, while runtime-slice and artifact-slice loads continue to preserve llama.cpp's automatic behavior.

This changes no mesh wire format or Skippy ABI.

## Validation

- [x] `cargo fmt --all --check`
- [x] `just build`
- [x] `cargo test -p skippy-server --lib` (206 passed)
- [x] `cargo check -p skippy-server`
- [x] `cargo clippy -p skippy-server --all-targets -- -D warnings`
- [x] `cargo check -p mesh-llm`
- [x] `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- [x] Real Qwen3-0.6B layer-package Metal smoke with mmap enabled and explicitly disabled
- [x] No UI change; visual evidence does not apply.
