### PR TITLE
Remove non-plugin catalog note

### DIFF
--- a/website/src/docs/pages/plugins.md
+++ b/website/src/docs/pages/plugins.md
@@ -20,8 +20,6 @@ The Mesh-LLM organization currently publishes five first-party plugin repositori
 | [`metrics`](https://github.com/Mesh-LLM/metrics) | Advertise metrics support for mesh-llm telemetry. Configure the OTLP destination in mesh-llm, not in the plugin. | `mesh-llm plugins install metrics` |
 | [`agents`](https://github.com/Mesh-LLM/agents) | Run mesh-native A2A agents and expose their tools through the mesh MCP endpoint. | `mesh-llm plugins install agents` |
 
-The catalog is intentionally conservative: repositories such as `hf-hub`, `hf-mesh-skippy-splitter`, `iroh-fabric`, `MeshChat`, and `desktop-app` are useful Mesh-LLM projects, but they are not plugin packages.
-
 The catalog can also contain community plugins. Search it before installing an unfamiliar integration:
 
 ```bash


### PR DESCRIPTION
## Summary

- Remove the note listing non-plugin Mesh-LLM repositories from the plugin documentation.

## Validation

- `just website-build`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Simplified the plugin catalog guidance by removing outdated explanatory text.
  * Improved the flow into the section covering community plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->