### PR TITLE
Fix publish preflight consistency check

### DIFF
--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -2321,6 +2321,7 @@ fn check_publish_workflow_invariants(repo_root: &Path) -> DynResult<()> {
           steps:
             - uses: actions/checkout@v5
               with:
+                ref: ${{ needs.metadata.outputs.tag }}
                 persist-credentials: false
             - uses: dtolnay/rust-toolchain@stable
             - name: Prepare dispatched release version


### PR DESCRIPTION
## Summary

Update the publish workflow invariant to expect the tag checkout added by #981. The preflight job exists, but the exact-string consistency check still expected its previous checkout block and caused main and unrelated PR CI runs to fail.

## Validation

- `cargo run -p xtask -- repo-consistency publish-crates`
- `cargo check -p xtask`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo fmt --all --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated release workflow validation to ensure publishing uses the intended version reference during checkout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->