### PR TITLE
Improve Skippy downstream readiness and decode batching

### DIFF
--- a/crates/skippy-server/README.md
+++ b/crates/skippy-server/README.md
@@ -132,6 +132,12 @@ unload or replan.
   downstream streams open for the lifetime of that lane. `Stop` resets the
   logical session on a lane and leaves the TCP stream open. A failed lane is
   retired and replaced.
+- Set `SKIPPY_BINARY_WARM_PRECONNECT=1` to establish one downstream binary
+  connection while a stage runtime loads and replenish it after use. This is
+  opt-in and leaves the normal on-demand connection path unchanged.
+- Set `SKIPPY_DECODE_BATCH_COLLECTION_US` to an opt-in collection window for
+  cross-request decode batching. The default is zero added wait; configured
+  values are capped at 10,000 microseconds and ignored for single-lane runtimes.
 - `--openai-prefill-chunk-policy` selects fixed, scheduled, or adaptive stage0
   prefill chunking without changing the default fixed
   `--openai-prefill-chunk-size`. Passing `--openai-prefill-chunk-schedule`

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -428,10 +428,38 @@ fn take_warm_or_connect_downstream(
         .lock()
         .map_err(|_| anyhow!("warm downstream lock poisoned"))?
         .take();
-    warm.map_or_else(
-        || connect_binary_downstream(config, timeout_secs),
-        |stream| Ok(Some(stream)),
-    )
+    match warm {
+        Some(stream) if warm_downstream_is_healthy(&stream)? => Ok(Some(stream)),
+        Some(_) | None => connect_binary_downstream(config, timeout_secs),
+    }
+}
+
+fn warm_downstream_is_healthy(stream: &TcpStream) -> Result<bool> {
+    let previous_timeout = stream
+        .read_timeout()
+        .context("read warm downstream timeout")?;
+    stream
+        .set_read_timeout(Some(Duration::from_millis(1)))
+        .context("set warm downstream health-check timeout")?;
+    let mut byte = [0_u8; 1];
+    let peek_result = stream.peek(&mut byte);
+    stream
+        .set_read_timeout(previous_timeout)
+        .context("restore warm downstream timeout")?;
+
+    Ok(match peek_result {
+        Ok(0) => false,
+        Ok(_) => true,
+        Err(error)
+            if matches!(
+                error.kind(),
+                io::ErrorKind::WouldBlock | io::ErrorKind::TimedOut
+            ) =>
+        {
+            true
+        }
+        Err(_) => false,
+    })
 }
 
 fn prepare_binary_stage_connection(stream: &TcpStream) -> Result<()> {

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -47,6 +47,7 @@ pub(crate) mod direct_return;
 pub(crate) mod forwarding;
 mod kv_eviction;
 mod options;
+mod preconnect;
 mod socket;
 mod wire;
 
@@ -61,6 +62,7 @@ use self::kv_eviction::{
     evict_binary_resident_prefix_for_decode,
 };
 pub use self::options::{BinaryStageOptions, EmbeddedOpenAiStageOptions, parse_wire_dtype};
+use self::preconnect::spawn_downstream_preconnector;
 use self::socket::*;
 pub use self::wire::WireCondition;
 pub(crate) use self::wire::write_stage_message_conditioned;
@@ -211,6 +213,10 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
         telemetry_level,
     );
     telemetry.emit("stage.binary_server_start", lifecycle_attrs(&config));
+    let warm_downstream = Arc::new(Mutex::new(None));
+    if warm_downstream_preconnect_enabled() {
+        spawn_downstream_preconnector(config.clone(), warm_downstream.clone(), shutdown.clone());
+    }
     let runtime = load_runtime(&config)?.context("binary stage server requires model_path")?;
     let decode_frame_batcher = DecodeFrameBatcher::new(runtime.clone(), max_inflight);
     if max_inflight > 0 {
@@ -325,6 +331,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
         let decode_frame_batcher = decode_frame_batcher.clone();
         let kv = kv.clone();
         let telemetry = telemetry.clone();
+        let warm_downstream = warm_downstream.clone();
         let prediction_returns = prediction_returns.clone();
         let prediction_return_sinks = prediction_return_sinks.clone();
         thread::spawn(move || {
@@ -353,8 +360,11 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
                     }
                     return prediction_return_sinks.insert_opened_sink(first_message, upstream);
                 }
-                let downstream =
-                    connect_binary_downstream(&config, downstream_connect_timeout_secs)?;
+                let downstream = take_warm_or_connect_downstream(
+                    &config,
+                    &warm_downstream,
+                    downstream_connect_timeout_secs,
+                )?;
                 handle_binary_connection(
                     &config,
                     topology.as_ref(),
@@ -389,6 +399,39 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
         });
     }
     Ok(())
+}
+
+fn warm_downstream_preconnect_enabled() -> bool {
+    warm_downstream_preconnect_enabled_from(
+        env::var("SKIPPY_BINARY_WARM_PRECONNECT").ok().as_deref(),
+    )
+}
+
+fn warm_downstream_preconnect_enabled_from(value: Option<&str>) -> bool {
+    value.is_some_and(|value| {
+        matches!(
+            value.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        )
+    })
+}
+
+fn take_warm_or_connect_downstream(
+    config: &StageConfig,
+    warm_downstream: &Arc<Mutex<Option<TcpStream>>>,
+    timeout_secs: u64,
+) -> Result<Option<TcpStream>> {
+    if config.downstream.is_none() {
+        return Ok(None);
+    }
+    let warm = warm_downstream
+        .lock()
+        .map_err(|_| anyhow!("warm downstream lock poisoned"))?
+        .take();
+    warm.map_or_else(
+        || connect_binary_downstream(config, timeout_secs),
+        |stream| Ok(Some(stream)),
+    )
 }
 
 fn prepare_binary_stage_connection(stream: &TcpStream) -> Result<()> {

--- a/crates/skippy-server/src/binary_transport/decode_batcher.rs
+++ b/crates/skippy-server/src/binary_transport/decode_batcher.rs
@@ -6,7 +6,7 @@ use std::{
         mpsc as std_mpsc,
     },
     thread::{self, JoinHandle},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Result, anyhow};
@@ -23,6 +23,7 @@ struct DecodeFrameBatcherShared {
     state: Mutex<DecodeFrameBatcherState>,
     ready: Condvar,
     max_batch_size: usize,
+    collection_window: Duration,
     owner_count: AtomicUsize,
     worker: Mutex<Option<JoinHandle<()>>>,
 }
@@ -58,6 +59,7 @@ impl DecodeFrameBatcher {
             state: Mutex::new(DecodeFrameBatcherState::default()),
             ready: Condvar::new(),
             max_batch_size: max_batch_size.max(1),
+            collection_window: crate::decode_batch_policy::collection_window(max_batch_size),
             owner_count: AtomicUsize::new(1),
             worker: Mutex::new(None),
         });
@@ -153,8 +155,33 @@ impl DecodeFrameBatcherShared {
         if state.pending.is_empty() && state.stopping {
             return None;
         }
+        state = self.collect_until_deadline(state);
         let batch_size = self.max_batch_size.min(state.pending.len());
         Some(state.pending.drain(..batch_size).collect())
+    }
+
+    fn collect_until_deadline<'a>(
+        &self,
+        mut state: std::sync::MutexGuard<'a, DecodeFrameBatcherState>,
+    ) -> std::sync::MutexGuard<'a, DecodeFrameBatcherState> {
+        if self.collection_window.is_zero() || state.pending.len() >= self.max_batch_size {
+            return state;
+        }
+        let deadline = Instant::now() + self.collection_window;
+        while !state.stopping && state.pending.len() < self.max_batch_size {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                break;
+            };
+            let (next, timeout) = self
+                .ready
+                .wait_timeout(state, remaining)
+                .expect("decode frame batcher lock poisoned");
+            state = next;
+            if timeout.timed_out() {
+                break;
+            }
+        }
+        state
     }
 
     fn run_batch(&self, batch: Vec<PendingDecodeFrame>) {

--- a/crates/skippy-server/src/binary_transport/preconnect.rs
+++ b/crates/skippy-server/src/binary_transport/preconnect.rs
@@ -1,0 +1,79 @@
+use std::{
+    net::TcpStream,
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    },
+    thread,
+    time::Duration,
+};
+
+use skippy_protocol::StageConfig;
+
+use super::connect_binary_downstream;
+
+const WARM_DOWNSTREAM_RETRY_SLEEP: Duration = Duration::from_millis(500);
+const WARM_DOWNSTREAM_SLOT_POLL: Duration = Duration::from_millis(50);
+const WARM_DOWNSTREAM_CONNECT_TIMEOUT_SECS: u64 = 2;
+
+pub(super) fn spawn_downstream_preconnector(
+    config: StageConfig,
+    warm_downstream: Arc<Mutex<Option<TcpStream>>>,
+    shutdown: Arc<AtomicBool>,
+) {
+    if config.downstream.is_none() {
+        return;
+    }
+    let thread_name = format!("skippy-warm-downstream-{}", config.stage_index);
+    let _ = thread::Builder::new().name(thread_name).spawn(move || {
+        run_downstream_preconnector(config, warm_downstream, shutdown);
+    });
+}
+
+fn run_downstream_preconnector(
+    config: StageConfig,
+    warm_downstream: Arc<Mutex<Option<TcpStream>>>,
+    shutdown: Arc<AtomicBool>,
+) {
+    while !shutdown.load(Ordering::SeqCst) {
+        if warm_slot_is_full(&warm_downstream) {
+            thread::sleep(WARM_DOWNSTREAM_SLOT_POLL);
+            continue;
+        }
+        match connect_binary_downstream(&config, WARM_DOWNSTREAM_CONNECT_TIMEOUT_SECS) {
+            Ok(Some(stream)) => {
+                eprintln!(
+                    "downstream warm preconnect ready: stage_id={} local={:?} remote={:?}",
+                    config.stage_id,
+                    stream.local_addr().ok(),
+                    stream.peer_addr().ok(),
+                );
+                store_warm_stream(&warm_downstream, stream);
+            }
+            Ok(None) => return,
+            Err(error) => {
+                eprintln!(
+                    "downstream warm preconnect failed: stage_id={} error={error:#}",
+                    config.stage_id,
+                );
+                thread::sleep(WARM_DOWNSTREAM_RETRY_SLEEP);
+            }
+        }
+    }
+}
+
+fn warm_slot_is_full(warm_downstream: &Arc<Mutex<Option<TcpStream>>>) -> bool {
+    warm_downstream
+        .lock()
+        .map(|guard| guard.is_some())
+        .unwrap_or(true)
+}
+
+fn store_warm_stream(warm_downstream: &Arc<Mutex<Option<TcpStream>>>, stream: TcpStream) {
+    let Ok(mut guard) = warm_downstream.lock() else {
+        return;
+    };
+    if guard.is_none() {
+        *guard = Some(stream);
+    }
+}

--- a/crates/skippy-server/src/binary_transport/tests.rs
+++ b/crates/skippy-server/src/binary_transport/tests.rs
@@ -6,7 +6,7 @@ use super::{
 };
 use std::{
     io,
-    net::{TcpListener, TcpStream},
+    net::{Shutdown, TcpListener, TcpStream},
     os::fd::AsRawFd,
     thread,
     time::Duration,
@@ -84,6 +84,37 @@ fn warm_downstream_connection_is_consumed_before_connecting() {
         .unwrap();
 
     assert_eq!(result.peer_addr().unwrap(), client.local_addr().unwrap());
+    assert!(warm.lock().unwrap().is_none());
+}
+
+#[test]
+fn stale_warm_downstream_connection_is_replaced() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let endpoint = listener.local_addr().unwrap().to_string();
+    let client = TcpStream::connect(&endpoint).unwrap();
+    let (stale_server, _) = listener.accept().unwrap();
+    client.shutdown(Shutdown::Both).unwrap();
+
+    for _ in 0..20 {
+        if !super::warm_downstream_is_healthy(&stale_server).unwrap() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(5));
+    }
+    assert!(!super::warm_downstream_is_healthy(&stale_server).unwrap());
+
+    let mut config = prefix_cache_test_config();
+    config.downstream.as_mut().unwrap().endpoint = endpoint;
+    let warm = std::sync::Arc::new(std::sync::Mutex::new(Some(stale_server)));
+    let replacement = super::take_warm_or_connect_downstream(&config, &warm, 1)
+        .unwrap()
+        .unwrap();
+    let (accepted, _) = listener.accept().unwrap();
+
+    assert_eq!(
+        accepted.peer_addr().unwrap(),
+        replacement.local_addr().unwrap()
+    );
     assert!(warm.lock().unwrap().is_none());
 }
 

--- a/crates/skippy-server/src/binary_transport/tests.rs
+++ b/crates/skippy-server/src/binary_transport/tests.rs
@@ -2,6 +2,7 @@ use super::{
     binary_full_prefill_record_identities, decode_record_tokens_sideband,
     is_decode_frame_batch_candidate, native_mtp_enabled_from, prepare_binary_stage_connection,
     restore_prefill_decode_as_decode_message, token_sideband_or_fill,
+    warm_downstream_preconnect_enabled_from,
 };
 use std::{
     io,
@@ -61,6 +62,29 @@ fn native_mtp_enabled_flag_defaults_on_and_accepts_false_values() {
     assert!(!native_mtp_enabled_from(Some("0")));
     assert!(!native_mtp_enabled_from(Some("false")));
     assert!(!native_mtp_enabled_from(Some(" disabled ")));
+}
+
+#[test]
+fn warm_preconnect_is_opt_in() {
+    assert!(!warm_downstream_preconnect_enabled_from(None));
+    assert!(!warm_downstream_preconnect_enabled_from(Some("0")));
+    assert!(warm_downstream_preconnect_enabled_from(Some("true")));
+    assert!(warm_downstream_preconnect_enabled_from(Some(" ON ")));
+}
+
+#[test]
+fn warm_downstream_connection_is_consumed_before_connecting() {
+    let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+    let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+    let (server, _) = listener.accept().unwrap();
+    let warm = std::sync::Arc::new(std::sync::Mutex::new(Some(server)));
+
+    let result = super::take_warm_or_connect_downstream(&prefix_cache_test_config(), &warm, 1)
+        .unwrap()
+        .unwrap();
+
+    assert_eq!(result.peer_addr().unwrap(), client.local_addr().unwrap());
+    assert!(warm.lock().unwrap().is_none());
 }
 
 #[test]

--- a/crates/skippy-server/src/decode_batch_policy.rs
+++ b/crates/skippy-server/src/decode_batch_policy.rs
@@ -1,0 +1,53 @@
+use std::{env, time::Duration};
+
+const COLLECTION_US_ENV: &str = "SKIPPY_DECODE_BATCH_COLLECTION_US";
+const MAX_COLLECTION_US: u64 = 10_000;
+
+pub(crate) fn collection_window(max_batch_size: usize) -> Duration {
+    collection_window_from_value(max_batch_size, env::var(COLLECTION_US_ENV).ok().as_deref())
+}
+
+fn collection_window_from_value(max_batch_size: usize, value: Option<&str>) -> Duration {
+    if max_batch_size <= 1 {
+        return Duration::ZERO;
+    }
+    let micros = value
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or(0)
+        .min(MAX_COLLECTION_US);
+    Duration::from_micros(micros)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn single_lane_never_waits() {
+        assert_eq!(
+            collection_window_from_value(1, Some("1000")),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn invalid_or_missing_values_disable_collection() {
+        assert_eq!(collection_window_from_value(8, None), Duration::ZERO);
+        assert_eq!(
+            collection_window_from_value(8, Some("invalid")),
+            Duration::ZERO
+        );
+    }
+
+    #[test]
+    fn collection_window_is_bounded() {
+        assert_eq!(
+            collection_window_from_value(8, Some("750")),
+            Duration::from_micros(750)
+        );
+        assert_eq!(
+            collection_window_from_value(8, Some("50000")),
+            Duration::from_micros(MAX_COLLECTION_US)
+        );
+    }
+}

--- a/crates/skippy-server/src/frontend/decode_batcher.rs
+++ b/crates/skippy-server/src/frontend/decode_batcher.rs
@@ -6,7 +6,7 @@ use std::{
         mpsc as std_mpsc,
     },
     thread::{self, JoinHandle},
-    time::Instant,
+    time::{Duration, Instant},
 };
 
 use super::*;
@@ -21,6 +21,7 @@ struct DecodeBatcherShared {
     state: Mutex<DecodeBatcherState>,
     ready: Condvar,
     max_batch_size: usize,
+    collection_window: Duration,
     owner_count: AtomicUsize,
     worker: Mutex<Option<JoinHandle<()>>>,
 }
@@ -55,6 +56,7 @@ impl DecodeBatcher {
             state: Mutex::new(DecodeBatcherState::default()),
             ready: Condvar::new(),
             max_batch_size: max_batch_size.max(1),
+            collection_window: crate::decode_batch_policy::collection_window(max_batch_size),
             owner_count: AtomicUsize::new(1),
             worker: Mutex::new(None),
         });
@@ -145,8 +147,33 @@ impl DecodeBatcherShared {
         if state.pending.is_empty() && state.stopping {
             return None;
         }
+        state = self.collect_until_deadline(state);
         let batch_size = self.max_batch_size.min(state.pending.len());
         Some(state.pending.drain(..batch_size).collect())
+    }
+
+    fn collect_until_deadline<'a>(
+        &self,
+        mut state: std::sync::MutexGuard<'a, DecodeBatcherState>,
+    ) -> std::sync::MutexGuard<'a, DecodeBatcherState> {
+        if self.collection_window.is_zero() || state.pending.len() >= self.max_batch_size {
+            return state;
+        }
+        let deadline = Instant::now() + self.collection_window;
+        while !state.stopping && state.pending.len() < self.max_batch_size {
+            let Some(remaining) = deadline.checked_duration_since(Instant::now()) else {
+                break;
+            };
+            let (next, timeout) = self
+                .ready
+                .wait_timeout(state, remaining)
+                .expect("decode batcher lock poisoned");
+            state = next;
+            if timeout.timed_out() {
+                break;
+            }
+        }
+        state
     }
 
     fn run_batch(&self, batch: Vec<PendingDecode>) {

--- a/crates/skippy-server/src/lib.rs
+++ b/crates/skippy-server/src/lib.rs
@@ -6,6 +6,7 @@
 pub mod binary_transport;
 pub mod cli;
 pub mod config;
+mod decode_batch_policy;
 pub mod embedded;
 pub mod frontend;
 pub mod http;


### PR DESCRIPTION
## Title
Improve Skippy downstream readiness and decode batching

## Original problem
Split-stage forwarding establishes a downstream TCP connection on the request path, and both local and binary decode batchers dispatch as soon as the first request arrives. This leaves avoidable connection latency at startup and gives concurrent decode requests no bounded opportunity to coalesce.

## Diagnostics
Review of the embedded and binary transport paths showed that they use separate batch collectors with immediate dispatch, while downstream connections are created only when forwarding begins.

## Fix
Add one shared, bounded decode collection policy used by both batchers. `SKIPPY_DECODE_BATCH_COLLECTION_US` enables a collection window up to 10,000 microseconds and is ignored when the configured maximum batch size is one.

Add opt-in downstream warm preconnection with `SKIPPY_BINARY_WARM_PRECONNECT=1`. A background worker maintains one spare connection and normal on-demand connection remains the fallback.

Both features default off, so existing transport and latency behavior remains unchanged. This PR contains no model-specific sidebands, speculation, MTP return paths, or lab routing behavior.

## Validation
- [x] `cargo test -p skippy-server --lib` (211 passed)
- [x] `cargo clippy -p skippy-server --all-targets --no-deps -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] No UI changes; screenshots do not apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional downstream connection prewarming to reduce connection setup delays.
  * Added optional cross-request decode batching with a configurable collection window.
  * Added configuration guidance for both features, including supported limits and defaults.

* **Performance**
  * Improved decode batching by collecting requests until the configured window expires or the batch reaches capacity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->