### PR TITLE
Plan split topology with exact layer weights

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
@@ -1207,6 +1207,7 @@ mod tests {
                 .to_string(),
             source_model_bytes: 1234,
             source_files: Vec::new(),
+            layer_weight_bytes: Vec::new(),
             layer_count,
             activation_width: 4096,
             tensor_count: 100,

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/package.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/package.rs
@@ -17,6 +17,7 @@ pub struct SkippyPackageIdentity {
     pub source_model_sha256: String,
     pub source_model_bytes: u64,
     pub source_files: Vec<SkippyPackageSourceFile>,
+    pub layer_weight_bytes: Vec<u64>,
     pub layer_count: u32,
     pub activation_width: u32,
     pub tensor_count: u64,
@@ -108,6 +109,7 @@ pub fn synthetic_direct_gguf_package(
         source_model_sha256,
         source_model_bytes,
         source_files,
+        layer_weight_bytes: Vec::new(),
         layer_count: compact.layer_count,
         activation_width: compact.embedding_size,
         tensor_count,
@@ -315,6 +317,7 @@ pub fn identity_from_layer_package(package_ref: &str) -> Result<SkippyPackageIde
     let source_model_bytes = info
         .source_model_bytes
         .unwrap_or_else(|| info.layers.iter().map(|l| l.artifact_bytes).sum::<u64>());
+    let layer_weight_bytes = layer_weight_bytes_from_info(&info);
 
     // For local paths inside an HF cache, convert to an exact hf:// ref so all
     // nodes resolve the same snapshot independently. HF cache dirs look like:
@@ -328,11 +331,43 @@ pub fn identity_from_layer_package(package_ref: &str) -> Result<SkippyPackageIde
         source_model_sha256: info.source_model_sha256,
         source_model_bytes,
         source_files: Vec::new(),
+        layer_weight_bytes,
         layer_count: info.layer_count,
         activation_width,
         tensor_count: info.layers.iter().map(|l| l.tensor_count as u64).sum(),
         generation: info.generation,
     })
+}
+
+fn layer_weight_bytes_from_info(info: &skippy_runtime::package::LayerPackageInfo) -> Vec<u64> {
+    let mut layers = info.layers.clone();
+    layers.sort_by_key(|layer| layer.layer_index);
+    if layers.len() != info.layer_count as usize
+        || layers
+            .iter()
+            .enumerate()
+            .any(|(index, layer)| layer.layer_index as usize != index)
+    {
+        return Vec::new();
+    }
+    let mut weights = layers
+        .into_iter()
+        .map(|layer| layer.tensor_bytes.max(layer.artifact_bytes))
+        .collect::<Vec<_>>();
+    let accounted = weights.iter().copied().sum::<u64>();
+    let unaccounted = info
+        .source_model_bytes
+        .unwrap_or_default()
+        .saturating_sub(accounted);
+    if let Some((first, rest)) = weights.split_first_mut() {
+        *first = first.saturating_add(unaccounted.div_ceil(2));
+        if let Some(last) = rest.last_mut() {
+            *last = last.saturating_add(unaccounted / 2);
+        } else {
+            *first = first.saturating_add(unaccounted / 2);
+        }
+    }
+    weights
 }
 
 /// Detect if a local path is inside an HF cache directory and convert to `hf://` ref.
@@ -520,5 +555,71 @@ mod tests {
 
         assert!(error.contains("missing activation_width"));
         assert!(error.contains("rebuild the package manifest"));
+    }
+
+    #[test]
+    fn package_layer_weights_include_shared_model_bytes_at_endpoints() {
+        let info = skippy_runtime::package::LayerPackageInfo {
+            package_dir: PathBuf::from("/models/package"),
+            manifest_sha256: "manifest".to_string(),
+            model_id: "org/model".to_string(),
+            source_model_path: "model.gguf".to_string(),
+            source_model_sha256: "source".to_string(),
+            source_model_bytes: Some(120),
+            layer_count: 2,
+            activation_width: Some(1024),
+            generation: None,
+            projectors: Vec::new(),
+            layers: vec![
+                skippy_runtime::package::LayerPackageLayerInfo {
+                    layer_index: 0,
+                    tensor_count: 1,
+                    tensor_bytes: 30,
+                    artifact_bytes: 30,
+                },
+                skippy_runtime::package::LayerPackageLayerInfo {
+                    layer_index: 1,
+                    tensor_count: 1,
+                    tensor_bytes: 40,
+                    artifact_bytes: 40,
+                },
+            ],
+        };
+
+        assert_eq!(layer_weight_bytes_from_info(&info), vec![55, 65]);
+    }
+
+    #[test]
+    fn package_layer_weights_require_contiguous_indices() {
+        let mut info = skippy_runtime::package::LayerPackageInfo {
+            package_dir: PathBuf::from("/models/package"),
+            manifest_sha256: "manifest".to_string(),
+            model_id: "org/model".to_string(),
+            source_model_path: "model.gguf".to_string(),
+            source_model_sha256: "source".to_string(),
+            source_model_bytes: Some(70),
+            layer_count: 2,
+            activation_width: Some(1024),
+            generation: None,
+            projectors: Vec::new(),
+            layers: vec![
+                skippy_runtime::package::LayerPackageLayerInfo {
+                    layer_index: 0,
+                    tensor_count: 1,
+                    tensor_bytes: 30,
+                    artifact_bytes: 30,
+                },
+                skippy_runtime::package::LayerPackageLayerInfo {
+                    layer_index: 2,
+                    tensor_count: 1,
+                    tensor_bytes: 40,
+                    artifact_bytes: 40,
+                },
+            ],
+        };
+
+        assert!(layer_weight_bytes_from_info(&info).is_empty());
+        info.layers[1].layer_index = 1;
+        assert_eq!(layer_weight_bytes_from_info(&info), vec![30, 40]);
     }
 }

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/test_support.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/test_support.rs
@@ -73,6 +73,7 @@ pub(super) fn fake_package_identity(layer_count: u32) -> SkippyPackageIdentity {
             .to_string(),
         source_model_bytes: 1234,
         source_files: Vec::new(),
+        layer_weight_bytes: Vec::new(),
         layer_count,
         activation_width: 4096,
         tensor_count: 100,

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -3844,6 +3844,7 @@ mod tests {
             source_model_sha256: "source".to_string(),
             source_model_bytes: u64::from(layer_count) * 1_000_000,
             source_files: Vec::new(),
+            layer_weight_bytes: Vec::new(),
             layer_count,
             activation_width: 2048,
             tensor_count: 100,

--- a/crates/mesh-llm-host-runtime/src/runtime/split_planning.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/split_planning.rs
@@ -18,6 +18,7 @@ pub(super) struct SplitTopologyPlanInput {
     pub(super) native_context_length: u32,
     pub(super) layer_count: u32,
     pub(super) model_weight_bytes: u64,
+    pub(super) layer_weight_bytes: Vec<u64>,
     pub(super) kv_bytes_per_token: u64,
     pub(super) context_length_override: Option<u32>,
     pub(super) parallel_lanes_override: Option<usize>,
@@ -74,6 +75,7 @@ pub(super) fn plan_split_topology(input: SplitTopologyPlanInput) -> Result<Split
         native_context_length: input.native_context_length,
         layer_count: input.layer_count,
         model_weight_bytes: input.model_weight_bytes,
+        layer_weight_bytes: input.layer_weight_bytes,
         kv_bytes_per_token: input.kv_bytes_per_token,
         minimum_nodes: input.minimum_nodes,
         nodes: input
@@ -222,6 +224,7 @@ fn runtime_slice_plan_input(
         native_context_length: resources.native_context_length,
         layer_count: package.layer_count,
         model_weight_bytes: package.source_model_bytes,
+        layer_weight_bytes: package_layer_weight_bytes(package),
         kv_bytes_per_token: resources.kv_bytes_per_token,
         context_length_override: resources.ctx_size_override,
         parallel_lanes_override: resources.parallel_override,
@@ -238,6 +241,13 @@ fn runtime_slice_plan_input(
             })
             .collect(),
     }
+}
+
+fn package_layer_weight_bytes(package: &skippy::SkippyPackageIdentity) -> Vec<u64> {
+    if package.layer_weight_bytes.len() == package.layer_count as usize {
+        return package.layer_weight_bytes.clone();
+    }
+    Vec::new()
 }
 
 fn map_runtime_slice_stages(
@@ -548,6 +558,7 @@ mod tests {
             source_model_sha256: "source".to_string(),
             source_model_bytes,
             source_files: Vec::new(),
+            layer_weight_bytes: Vec::new(),
             layer_count,
             activation_width: 896,
             tensor_count: 100,
@@ -633,6 +644,39 @@ mod tests {
         assert!(plan.slots > 0);
         assert_eq!(plan.stages.first().unwrap().layer_start, 0);
         assert_eq!(plan.stages.last().unwrap().layer_end, 30);
+    }
+
+    #[test]
+    fn resource_planner_uses_exact_package_layer_weights() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        let participants = vec![participant(1, 12 * GIB), participant(2, 9 * GIB)];
+        let mut package = package(4, 18 * GIB);
+        package.layer_weight_bytes = vec![GIB / 8, GIB / 8, 9 * GIB, 8 * GIB];
+
+        let plan = plan_runtime_slice_topology_with_resources(
+            "topology-test",
+            "model-a",
+            &package,
+            &participants,
+            &[],
+            SplitTopologyResourceInputs {
+                native_context_length: 1,
+                kv_bytes_per_token: 1,
+                ctx_size_override: Some(1),
+                parallel_override: Some(1),
+            },
+        )
+        .expect("resource-aware topology with exact layer weights");
+
+        assert_eq!(
+            plan.stages
+                .iter()
+                .map(|stage| (stage.layer_start, stage.layer_end))
+                .collect::<Vec<_>>(),
+            vec![(0, 3), (3, 4)]
+        );
+        assert_eq!(plan.stages[0].parameter_bytes, 9 * GIB + GIB / 4);
+        assert_eq!(plan.stages[1].parameter_bytes, 8 * GIB);
     }
 
     #[test]

--- a/crates/skippy-coordinator/src/topology.rs
+++ b/crates/skippy-coordinator/src/topology.rs
@@ -12,6 +12,7 @@ pub struct TopologyPlanningInput {
     pub native_context_length: u32,
     pub layer_count: u32,
     pub model_weight_bytes: u64,
+    pub layer_weight_bytes: Vec<u64>,
     pub kv_bytes_per_token: u64,
     pub minimum_nodes: usize,
     pub nodes: Vec<TopologyNode>,
@@ -155,12 +156,6 @@ fn context_candidates(
                 native: native_context,
             });
         }
-        if requested < minimum_context {
-            return Err(TopologyPlanError::ContextBelowMinimum {
-                requested,
-                minimum: minimum_context,
-            });
-        }
         return Ok(vec![requested]);
     }
 
@@ -297,71 +292,46 @@ fn fit_candidate(
         return None;
     }
 
-    let weight_per_layer = input
-        .model_weight_bytes
-        .div_ceil(u64::from(input.layer_count));
+    let layer_weights = layer_weight_bytes(input);
     let kv_per_layer = input
         .kv_bytes_per_token
         .div_ceil(u64::from(input.layer_count));
-    let bytes_per_layer = candidate_bytes_per_layer(
-        weight_per_layer,
-        kv_per_layer,
-        context_length,
-        parallel_lanes,
-    )?;
+    let layer_required_bytes =
+        layer_required_bytes(&layer_weights, kv_per_layer, context_length, parallel_lanes)?;
 
-    let mut capacities = nodes
-        .iter()
-        .map(|node| {
-            let max_layers = node.usable_vram_bytes / bytes_per_layer;
-            (
-                node.clone(),
-                max_layers.min(u64::from(input.layer_count)) as usize,
-            )
-        })
-        .collect::<Vec<_>>();
-    capacities.sort_by(|(left_node, left_layers), (right_node, right_layers)| {
-        right_layers
-            .cmp(left_layers)
-            .then_with(|| {
-                right_node
-                    .usable_vram_bytes
-                    .cmp(&left_node.usable_vram_bytes)
-            })
-            .then_with(|| left_node.node_id.cmp(&right_node.node_id))
+    let mut capacities = nodes.to_vec();
+    capacities.sort_by(|left, right| {
+        right
+            .usable_vram_bytes
+            .cmp(&left.usable_vram_bytes)
+            .then_with(|| left.node_id.cmp(&right.node_id))
     });
-
-    if capacities.iter().any(|(_, max_layers)| *max_layers == 0) {
-        return None;
-    }
-    if capacities
-        .iter()
-        .map(|(_, max_layers)| *max_layers)
-        .sum::<usize>()
-        < layer_count
-    {
-        return None;
-    }
 
     let mut next_layer = 0u32;
     let mut stages = Vec::with_capacity(capacities.len());
     let mut minimum_remaining_vram = u64::MAX;
     let mut total_remaining_vram = 0u128;
 
-    for (stage_index, (node, max_layers)) in capacities.iter().enumerate() {
+    for (stage_index, node) in capacities.iter().enumerate() {
         let remaining_layers = input.layer_count - next_layer;
         let remaining_nodes = capacities.len() - stage_index;
         let min_for_later = remaining_nodes.saturating_sub(1) as u32;
         let assignable = remaining_layers.saturating_sub(min_for_later);
-        let layer_span = assignable.min(*max_layers as u32);
+        let layer_span = assignable.min(max_contiguous_layers_from(
+            &layer_required_bytes,
+            next_layer as usize,
+            assignable as usize,
+            node.usable_vram_bytes,
+        ) as u32);
         if layer_span == 0 {
             return None;
         }
 
         let layer_start = next_layer;
         let layer_end = layer_start + layer_span;
-        let parameter_bytes = u64::from(layer_span).saturating_mul(weight_per_layer);
-        let required_bytes = u64::from(layer_span).saturating_mul(bytes_per_layer);
+        let range = layer_start as usize..layer_end as usize;
+        let parameter_bytes = sum_u64(&layer_weights[range.clone()]);
+        let required_bytes = sum_u64(&layer_required_bytes[range]);
         if required_bytes > node.usable_vram_bytes {
             return None;
         }
@@ -471,6 +441,16 @@ fn decode_tpot_target_met(estimate: Option<u32>, target: Option<u32>) -> Option<
     Some(estimate? <= target?)
 }
 
+fn layer_weight_bytes(input: &TopologyPlanningInput) -> Vec<u64> {
+    if input.layer_weight_bytes.len() == input.layer_count as usize {
+        return input.layer_weight_bytes.clone();
+    }
+    let weight_per_layer = input
+        .model_weight_bytes
+        .div_ceil(u64::from(input.layer_count));
+    vec![weight_per_layer; input.layer_count as usize]
+}
+
 fn candidate_bytes_per_layer(
     weight_per_layer: u64,
     kv_per_layer: u64,
@@ -483,6 +463,45 @@ fn candidate_bytes_per_layer(
     let kv_bytes = u128::from(kv_per_layer).checked_mul(u128::from(context_length))?;
     let total = u128::from(weight_per_layer).checked_add(kv_bytes)?;
     total.try_into().ok()
+}
+
+fn layer_required_bytes(
+    layer_weights: &[u64],
+    kv_per_layer: u64,
+    context_length: u32,
+    parallel_lanes: usize,
+) -> Option<Vec<u64>> {
+    layer_weights
+        .iter()
+        .map(|weight| {
+            candidate_bytes_per_layer(*weight, kv_per_layer, context_length, parallel_lanes)
+        })
+        .collect()
+}
+
+fn max_contiguous_layers_from(
+    layer_required_bytes: &[u64],
+    start: usize,
+    limit: usize,
+    capacity: u64,
+) -> u64 {
+    let mut total = 0u64;
+    let mut count = 0u64;
+    for bytes in layer_required_bytes.iter().skip(start).take(limit) {
+        let next = total.saturating_add(*bytes);
+        if next > capacity {
+            break;
+        }
+        total = next;
+        count += 1;
+    }
+    count
+}
+
+fn sum_u64(values: &[u64]) -> u64 {
+    values
+        .iter()
+        .fold(0u64, |total, value| total.saturating_add(*value))
 }
 
 #[cfg(test)]
@@ -520,6 +539,7 @@ mod tests {
             native_context_length: 65_536,
             layer_count: 40,
             model_weight_bytes: 40 * GIB,
+            layer_weight_bytes: Vec::new(),
             kv_bytes_per_token: 64 * 1024,
             minimum_nodes: 1,
             nodes,
@@ -534,6 +554,7 @@ mod tests {
             native_context_length: QWEN_CODER_480B_NATIVE_CONTEXT,
             layer_count: QWEN_CODER_480B_LAYERS,
             model_weight_bytes: QWEN_CODER_480B_WEIGHT_BYTES,
+            layer_weight_bytes: Vec::new(),
             kv_bytes_per_token: QWEN_CODER_480B_Q8_KV_BYTES_PER_TOKEN,
             minimum_nodes: 2,
             nodes,
@@ -607,6 +628,49 @@ mod tests {
             .find(|stage| stage.node_id == "large")
             .unwrap();
         assert!(small.layer_end - small.layer_start < large.layer_end - large.layer_start);
+    }
+
+    #[test]
+    fn exact_layer_weights_allow_uneven_package_fit() {
+        let mut request = input(vec![node("large", 12), node("small", 9)]);
+        request.layer_count = 4;
+        request.model_weight_bytes = 18 * GIB;
+        request.layer_weight_bytes = vec![GIB / 8, GIB / 8, 9 * GIB, 8 * GIB];
+        request.kv_bytes_per_token = 1;
+        request.minimum_nodes = 2;
+
+        let plan = plan_topology(&request).unwrap();
+
+        assert_eq!(plan.stages.len(), 2);
+        assert_eq!(
+            plan.stages
+                .iter()
+                .map(|stage| (stage.node_id.as_str(), stage.layer_start, stage.layer_end))
+                .collect::<Vec<_>>(),
+            vec![("large", 0, 3), ("small", 3, 4)]
+        );
+        assert_eq!(plan.stages[0].parameter_bytes, 9 * GIB + GIB / 4);
+        assert_eq!(plan.stages[1].parameter_bytes, 8 * GIB);
+    }
+
+    #[test]
+    fn exact_layer_capacity_is_evaluated_at_each_stage_boundary() {
+        let mut request = input(vec![node("large", 11), node("small", 3)]);
+        request.layer_count = 4;
+        request.model_weight_bytes = 12 * GIB;
+        request.layer_weight_bytes = vec![9 * GIB, GIB, GIB, GIB];
+        request.kv_bytes_per_token = 1;
+        request.minimum_nodes = 2;
+
+        let plan = plan_topology(&request).unwrap();
+
+        assert_eq!(
+            plan.stages
+                .iter()
+                .map(|stage| (stage.layer_start, stage.layer_end))
+                .collect::<Vec<_>>(),
+            vec![(0, 2), (2, 4)]
+        );
     }
 
     #[test]
@@ -684,18 +748,14 @@ mod tests {
     }
 
     #[test]
-    fn rejects_context_override_below_minimum_floor() {
+    fn accepts_explicit_context_override_below_auto_floor() {
         let mut request = input(vec![node("a", 80), node("b", 80)]);
         request.native_context_length = 262_144;
         request.context_length_override = Some(32_768);
 
-        assert_eq!(
-            plan_topology(&request),
-            Err(TopologyPlanError::ContextBelowMinimum {
-                requested: 32_768,
-                minimum: 65_536,
-            })
-        );
+        let plan = plan_topology(&request).unwrap();
+
+        assert_eq!(plan.context_length, 32_768);
     }
 
     #[test]


### PR DESCRIPTION
## Title
Plan split topology with exact layer weights

## Original problem
Resource-aware split planning treated transformer layers as uniformly sized. That produces poor boundaries for models with uneven dense, routed-expert, shared-expert, or auxiliary layers, and could undercount shared endpoint tensors and KV cost across parallel lanes.

## Diagnostics
Synthetic uneven-layer fixtures showed that average-layer planning can reject valid placements or choose boundaries that overload a later node. Package inspection also showed that embeddings, output tensors, and other shared bytes were not represented in a per-layer vector.

## Fix
Carry ordered per-layer weight bytes from layer-package metadata into topology planning and choose contiguous boundaries from cumulative exact weights.

Account for shared model bytes at the first/final endpoints, multiply KV requirements by actual parallel lanes, and evaluate each later stage from its current boundary. Fall back to existing average-layer behavior when package indices are incomplete or non-contiguous.

The planner also accepts explicit context overrides below the automatic 64K planning floor while continuing to reject values above native context.

## Validation
- [x] `cargo check -p skippy-coordinator -p mesh-llm-host-runtime -p mesh-llm`
- [x] `cargo test -p skippy-coordinator` (29 passed)
- [x] `cargo test -p mesh-llm-host-runtime inference::skippy::package::tests --lib` (9 passed)
- [x] `cargo test -p mesh-llm-host-runtime runtime::split_planning::tests --lib` (7 passed)
- [x] `cargo clippy -p skippy-coordinator -p mesh-llm-host-runtime -p mesh-llm --all-targets --no-deps -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `git diff --check`
- [x] No UI changes; screenshots do not apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved model topology planning by accounting for the actual weight size of each layer.
  - Better supports uneven layer distribution across nodes based on available memory.
  - Added per-layer weight information to package and planning data.

- **Bug Fixes**
  - Corrected handling of shared model weight data when calculating layer sizes.
  - Context-length overrides below the planner’s minimum are now accepted when otherwise valid.

- **Tests**
  - Added coverage for uneven layer weights, stage boundaries, and invalid layer ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->