### PR TITLE
Fix release version staging

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1419,8 +1419,16 @@ jobs:
           scripts/verify-sdk-console-assets.sh --sdk all
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add Cargo.toml Cargo.lock crates/*/Cargo.toml tools/*/Cargo.toml sdk/kotlin/build.gradle.kts Package.swift
+          # release-version.sh owns the complete tracked version surface. Stage
+          # all tracked release-preparation changes so this list cannot drift
+          # when another version-bearing file is added to the script.
+          git add --update
           git add -f sdk/node/console sdk/swift/Sources/MeshLLM/Resources/Console sdk/kotlin/src/main/resources/mesh-llm/console
+          if ! git diff --quiet; then
+            echo "Release preparation left unstaged tracked changes:" >&2
+            git status --short >&2
+            exit 1
+          fi
           if git diff --cached --quiet; then
             echo "Release source files already match $RELEASE_TAG"
           else

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -211,32 +211,15 @@ push_release_source_commit() {
 
     scripts/release-version.sh "$version"
 
-    if git diff --quiet; then
+    git add --update
+    if ! git diff --quiet; then
+        git status --short >&2
+        die "release preparation left unstaged tracked changes"
+    fi
+
+    if git diff --cached --quiet; then
         echo "Release source files already match $version; no commit needed."
     else
-        git add \
-            Cargo.toml \
-            Cargo.lock \
-            crates/*/Cargo.toml \
-            tools/*/Cargo.toml \
-            crates/mesh-llm-config/src/model/built_in_schema.rs \
-            crates/mesh-llm-config/src/model/built_in_schema/presentation.rs \
-            crates/mesh-llm-native-runtime/README.md \
-            crates/mesh-llm-sdk/README.md \
-            crates/mesh-llm-ui/package.json \
-            crates/mesh-llm-ui/package-lock.json \
-            docs/SDK.md \
-            docs/design/NATIVE_RUNTIMES.md \
-            docs/sdk/node.md \
-            docs/sdk/rust.md \
-            docs/sdk/swift.md \
-            sdk/kotlin/README.md \
-            sdk/kotlin/build.gradle.kts \
-            sdk/kotlin/example/example-jvm/build.gradle.kts \
-            sdk/node/package.json \
-            sdk/swift/README.md \
-            sdk/swift/scripts/generate-swift-bindings.sh \
-            website/src/docs/pages/CLI.md
         git commit -m "$tag: prepare release source"
     fi
 

--- a/tools/xtask/src/main.rs
+++ b/tools/xtask/src/main.rs
@@ -2287,6 +2287,7 @@ fn check_publish_catalog_sync(repo_root: &Path) -> DynResult<()> {
 
 fn check_publish_workflow_invariants(repo_root: &Path) -> DynResult<()> {
     let release = fs::read_to_string(repo_root.join("RELEASE.md"))?;
+    let release_script = fs::read_to_string(repo_root.join("scripts/release.sh"))?;
     let release_workflow = fs::read_to_string(repo_root.join(".github/workflows/release.yml"))?;
     let pr_quality_workflow =
         fs::read_to_string(repo_root.join(".github/workflows/pr_quality.yml"))?;
@@ -2310,6 +2311,35 @@ fn check_publish_workflow_invariants(repo_root: &Path) -> DynResult<()> {
         &release_workflow,
         "scripts/publish-crates.sh --dry-run --allow-dirty --sleep-seconds 0",
         "release workflow publish-chain dry-run",
+    )?;
+    let publish_job = workflow_job_section(&release_workflow, "publish")
+        .ok_or("release workflow: missing `publish` job for release tag staging check")?;
+    ensure_contains(
+        publish_job,
+        "git add --update",
+        "release workflow complete tracked release version staging",
+    )?;
+    ensure_contains_normalized(
+        publish_job,
+        "if ! git diff --quiet; then
+            echo \"Release preparation left unstaged tracked changes:\" >&2
+            git status --short >&2
+            exit 1
+          fi",
+        "release workflow unstaged tracked release change guard",
+    )?;
+    ensure_contains(
+        &release_script,
+        "git add --update",
+        "local release complete tracked release version staging",
+    )?;
+    ensure_contains_normalized(
+        &release_script,
+        "if ! git diff --quiet; then
+        git status --short >&2
+        die \"release preparation left unstaged tracked changes\"
+    fi",
+        "local release unstaged tracked release change guard",
     )?;
     ensure_contains_normalized(
         &release_workflow,


### PR DESCRIPTION
## Summary

- keep `scripts/release-version.sh` as the single owner of the complete version surface
- stage every tracked release-preparation change in both workflow-dispatched and local releases
- add repository-consistency guards that prevent a partial staging list from returning

## Root cause

The `v0.73.1` release workflow ran `scripts/release-version.sh`, which correctly updated Cargo, npm, Kotlin, docs, and version allowlists in the checkout. The tag-creation step then staged a hard-coded subset containing Cargo manifests, `Cargo.lock`, Kotlin metadata, and `Package.swift`.

That omitted `crates/mesh-llm-ui/package.json`, its lockfile, `sdk/node/package.json`, and other tracked version-bearing files. The resulting tag contained Cargo version `0.73.1` but npm package version `0.72.1`. The crates.io preflight reran the shared updater and failed on that mismatch.

## Impact

Future release tags commit the complete tracked output from the shared version updater. Generated SDK console assets remain explicitly force-added.

This PR does not rewrite the already-published `v0.73.1` tag. That tag needs deliberate recreation or replacement with a patch release after this change merges.

## Validation

- `bash -n scripts/release.sh scripts/release-version.sh`
- `actionlint .github/workflows/release.yml`
- `cargo fmt --all --check`
- `cargo check -p xtask`
- `cargo test -p xtask`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo run -p xtask -- repo-consistency publish-crates`
- isolated `scripts/release-version.sh 0.72.2` integration test confirming Cargo, both npm manifests, the UI lockfile, and Kotlin metadata all update, all 46 tracked changes stage, and a second run is idempotent


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release preparation to reliably include all tracked changes.
  * Added safeguards that detect incomplete staging and stop the release process with a clear error.

* **Chores**
  * Updated release automation to handle release-source changes more consistently.
  * Added validation checks to ensure release workflows maintain the required staging safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->