### PR TITLE
Keep active split stages through membership updates

### DIFF
--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -677,11 +677,13 @@ fn scan_layer_package_metadata(
     //
     // The package_ref looks like "hf://meshllm/Qwen3-layers@rev" which resolves
     // to a local cache directory.  Try to find shared/metadata.gguf there.
-    let package_ref = &package.package_ref;
-    let local_ref = skippy::resolve_hf_package_to_local(package_ref, 0, 0, false, false).ok()?;
-    let metadata_path = std::path::Path::new(&local_ref).join("shared/metadata.gguf");
-    if metadata_path.is_file() {
-        return models::gguf::scan_gguf_compact_meta(&metadata_path);
+    if let Ok(local_ref) =
+        skippy::resolve_hf_package_to_local(&package.package_ref, 0, 0, false, false)
+    {
+        let metadata_path = std::path::Path::new(&local_ref).join("shared/metadata.gguf");
+        if metadata_path.is_file() {
+            return models::gguf::scan_gguf_compact_meta(&metadata_path);
+        }
     }
     None
 }
@@ -2633,11 +2635,7 @@ fn split_missing_active_stage_nodes(
 ) -> Vec<iroh::EndpointId> {
     let mut missing = Vec::new();
     for stage in &active.stages {
-        if connected_node_ids
-            .iter()
-            .any(|node_id| *node_id == stage.node_id)
-            || missing.contains(&stage.node_id)
-        {
+        if connected_node_ids.contains(&stage.node_id) || missing.contains(&stage.node_id) {
             continue;
         }
         missing.push(stage.node_id);
@@ -4044,21 +4042,16 @@ mod tests {
     }
 
     #[test]
-    fn split_metadata_reads_cached_source_gguf_before_package_lookup() {
-        let temp_dir = tempfile::tempdir().unwrap();
-        let source_model_path = temp_dir.path().join("model.gguf");
-        write_fake_gguf_model(&source_model_path);
-        let package = skippy::SkippyPackageIdentity {
-            package_ref: "gguf:///models/model.gguf".to_string(),
-            source_model_path,
-            ..package(24)
-        };
+    fn split_metadata_reads_a_synthetic_direct_gguf_source() {
+        let temp = tempfile::tempdir().unwrap();
+        let model_path = temp.path().join("model.gguf");
+        write_fake_gguf_model(&model_path);
+        let package = skippy::synthetic_direct_gguf_package("test/model", &model_path).unwrap();
 
-        let compact = scan_layer_package_metadata(&package)
-            .expect("cached direct GGUF should provide split planning metadata");
+        let metadata = scan_layer_package_metadata(&package).expect("direct GGUF metadata");
 
-        assert_eq!(compact.layer_count, 24);
-        assert_eq!(compact.context_length, 8192);
+        assert_eq!(metadata.context_length, 8192);
+        assert_eq!(metadata.embedding_size, 4096);
     }
 
     fn write_test_layer_package(dir: &Path, source_model_bytes: u64) {

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -665,6 +665,12 @@ pub(super) async fn start_runtime_local_model(
 fn scan_layer_package_metadata(
     package: &skippy::SkippyPackageIdentity,
 ) -> Option<models::gguf::GgufCompactMeta> {
+    // Runtime-slice packages point straight at a cached GGUF. Resolve it
+    // before attempting the layer-package-only shared metadata lookup.
+    if package.source_model_path.is_file() {
+        return models::gguf::scan_gguf_compact_meta(&package.source_model_path);
+    }
+
     // The source_model_path in a layer package identity points to the original
     // GGUF.  But for HF layer packages the source model is not downloaded
     // locally.  Instead, look for the shared metadata file in the package dir.
@@ -676,10 +682,6 @@ fn scan_layer_package_metadata(
     let metadata_path = std::path::Path::new(&local_ref).join("shared/metadata.gguf");
     if metadata_path.is_file() {
         return models::gguf::scan_gguf_compact_meta(&metadata_path);
-    }
-    // Fallback: try scanning the source model directly (works for local packages).
-    if package.source_model_path.is_file() {
-        return models::gguf::scan_gguf_compact_meta(&package.source_model_path);
     }
     None
 }
@@ -1972,23 +1974,40 @@ impl SplitTopologyCoordinator {
                 .map(|gpu| gpu.allocatable_vram_bytes()),
         )
         .await;
+        let connected_node_ids = split_connected_node_ids(&self.node).await;
         self.node
             .refresh_stage_runtime_statuses(Duration::from_secs(2))
             .await;
         let runtime_statuses = self.node.stage_runtime_statuses().await;
         let missing_stage_nodes =
-            split_missing_active_stage_nodes(&self.active, &snapshot.participants);
+            split_missing_active_stage_nodes(&self.active, &connected_node_ids);
         let unavailable_stage_nodes = split_unavailable_active_stage_nodes(
             &self.active,
-            &snapshot.participants,
+            &connected_node_ids,
             &runtime_statuses,
         );
-        let candidate = self.replan_candidate(reason, &snapshot, &unavailable_stage_nodes);
+        let pending_eligibility_nodes = split_active_stage_nodes_pending_eligibility(
+            &self.active,
+            &connected_node_ids,
+            &snapshot.participants,
+            &unavailable_stage_nodes,
+        );
+        let candidate = if pending_eligibility_nodes.is_empty() {
+            self.replan_candidate(reason, &snapshot, &unavailable_stage_nodes)
+        } else {
+            tracing::debug!(
+                model_ref = self.model_ref,
+                reason,
+                stage_nodes = ?split_node_labels(&pending_eligibility_nodes),
+                "split topology replan deferred while active stage peer eligibility settles"
+            );
+            None
+        };
 
         if let Some(should_continue) = self
             .handle_loss_recovery(
                 reason,
-                &snapshot.participants,
+                &connected_node_ids,
                 &missing_stage_nodes,
                 &unavailable_stage_nodes,
                 candidate.as_ref(),
@@ -2058,14 +2077,14 @@ impl SplitTopologyCoordinator {
     async fn handle_loss_recovery(
         &mut self,
         reason: &'static str,
-        current_participants: &[SplitParticipant],
+        connected_node_ids: &[iroh::EndpointId],
         missing_stage_nodes: &[iroh::EndpointId],
         unavailable_stage_nodes: &[iroh::EndpointId],
         candidate: Option<&SplitTopologyGeneration>,
     ) -> Option<bool> {
         let decision = split_loss_recovery_decision(
             &self.active,
-            current_participants,
+            connected_node_ids,
             unavailable_stage_nodes,
             candidate,
             self.local_model_fits(),
@@ -2479,7 +2498,7 @@ fn split_replan_decision_with_reason(
     active: &SplitTopologyGeneration,
     candidate: &SplitTopologyGeneration,
 ) -> (SplitReplanDecision, &'static str) {
-    if split_active_stage_participant_missing(active, &candidate.participants) {
+    if split_active_stage_node_missing_from_participants(active, &candidate.participants) {
         return (
             SplitReplanDecision::Candidate,
             "active_stage_participant_missing",
@@ -2506,12 +2525,12 @@ fn split_replan_decision_with_reason(
 
 fn split_loss_recovery_decision(
     active: &SplitTopologyGeneration,
-    current_participants: &[SplitParticipant],
+    connected_node_ids: &[iroh::EndpointId],
     unavailable_stage_nodes: &[iroh::EndpointId],
     candidate: Option<&SplitTopologyGeneration>,
     local_model_fits: bool,
 ) -> SplitLossRecoveryDecision {
-    if !split_active_stage_participant_missing(active, current_participants)
+    if split_missing_active_stage_nodes(active, connected_node_ids).is_empty()
         && unavailable_stage_nodes.is_empty()
     {
         return SplitLossRecoveryDecision::NoActiveStageLoss;
@@ -2597,22 +2616,26 @@ fn split_stages_meet_minimum(stages: &[RuntimeSliceStagePlan]) -> bool {
     stages.len() >= SPLIT_DEFAULT_MIN_PARTICIPANTS
 }
 
-fn split_active_stage_participant_missing(
+fn split_active_stage_node_missing_from_participants(
     active: &SplitTopologyGeneration,
-    current_participants: &[SplitParticipant],
+    participants: &[SplitParticipant],
 ) -> bool {
-    !split_missing_active_stage_nodes(active, current_participants).is_empty()
+    active.stages.iter().any(|stage| {
+        participants
+            .iter()
+            .all(|participant| participant.node_id != stage.node_id)
+    })
 }
 
 fn split_missing_active_stage_nodes(
     active: &SplitTopologyGeneration,
-    current_participants: &[SplitParticipant],
+    connected_node_ids: &[iroh::EndpointId],
 ) -> Vec<iroh::EndpointId> {
     let mut missing = Vec::new();
     for stage in &active.stages {
-        if current_participants
+        if connected_node_ids
             .iter()
-            .any(|participant| participant.node_id == stage.node_id)
+            .any(|node_id| *node_id == stage.node_id)
             || missing.contains(&stage.node_id)
         {
             continue;
@@ -2624,10 +2647,10 @@ fn split_missing_active_stage_nodes(
 
 fn split_unavailable_active_stage_nodes(
     active: &SplitTopologyGeneration,
-    current_participants: &[SplitParticipant],
+    connected_node_ids: &[iroh::EndpointId],
     runtime_statuses: &[mesh::StageRuntimeStatus],
 ) -> Vec<iroh::EndpointId> {
-    let mut unavailable = split_missing_active_stage_nodes(active, current_participants);
+    let mut unavailable = split_missing_active_stage_nodes(active, connected_node_ids);
     for status in runtime_statuses {
         if !matches!(
             status.state,
@@ -2651,6 +2674,34 @@ fn split_unavailable_active_stage_nodes(
         }
     }
     unavailable
+}
+
+fn split_active_stage_nodes_pending_eligibility(
+    active: &SplitTopologyGeneration,
+    connected_node_ids: &[iroh::EndpointId],
+    eligible_participants: &[SplitParticipant],
+    unavailable_stage_nodes: &[iroh::EndpointId],
+) -> Vec<iroh::EndpointId> {
+    active
+        .stages
+        .iter()
+        .filter_map(|stage| {
+            let connected = connected_node_ids.contains(&stage.node_id);
+            let eligible = eligible_participants
+                .iter()
+                .any(|participant| participant.node_id == stage.node_id);
+            let unavailable = unavailable_stage_nodes.contains(&stage.node_id);
+            (connected && !eligible && !unavailable).then_some(stage.node_id)
+        })
+        .collect()
+}
+
+async fn split_connected_node_ids(node: &mesh::Node) -> Vec<iroh::EndpointId> {
+    let mut node_ids = vec![node.id()];
+    node_ids.extend(node.peers().await.into_iter().map(|peer| peer.id));
+    node_ids.sort_by_key(ToString::to_string);
+    node_ids.dedup();
+    node_ids
 }
 
 async fn stop_split_generation(
@@ -3992,6 +4043,24 @@ mod tests {
         fs::write(path, bytes).unwrap();
     }
 
+    #[test]
+    fn split_metadata_reads_cached_source_gguf_before_package_lookup() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let source_model_path = temp_dir.path().join("model.gguf");
+        write_fake_gguf_model(&source_model_path);
+        let package = skippy::SkippyPackageIdentity {
+            package_ref: "gguf:///models/model.gguf".to_string(),
+            source_model_path,
+            ..package(24)
+        };
+
+        let compact = scan_layer_package_metadata(&package)
+            .expect("cached direct GGUF should provide split planning metadata");
+
+        assert_eq!(compact.layer_count, 24);
+        assert_eq!(compact.context_length, 8192);
+    }
+
     fn write_test_layer_package(dir: &Path, source_model_bytes: u64) {
         fs::create_dir_all(dir.join("layers")).unwrap();
         fs::write(dir.join("metadata.gguf"), b"metadata").unwrap();
@@ -5286,7 +5355,7 @@ max_tokens = 222
     }
 
     #[test]
-    fn split_missing_active_stage_nodes_ignores_unused_lost_participants() {
+    fn split_missing_active_stage_nodes_ignores_unused_lost_nodes() {
         let active = SplitTopologyGeneration::new(
             "topology-a".into(),
             "run-a".into(),
@@ -5294,10 +5363,10 @@ max_tokens = 222
             vec![participant(1), participant(2), participant(3)],
             vec![stage(1, 0, 0, 20), stage(2, 1, 20, 40)],
         );
-        let current_participants = vec![participant(1)];
+        let connected_node_ids = vec![make_id(1), make_id(3)];
 
         assert_eq!(
-            split_missing_active_stage_nodes(&active, &current_participants),
+            split_missing_active_stage_nodes(&active, &connected_node_ids),
             vec![make_id(2)]
         );
     }
@@ -5320,7 +5389,7 @@ max_tokens = 222
         assert_eq!(
             split_unavailable_active_stage_nodes(
                 &active,
-                &[participant(1), participant(2), participant(3)],
+                &[make_id(1), make_id(2), make_id(3)],
                 &statuses,
             ),
             vec![make_id(2)]
@@ -5345,8 +5414,29 @@ max_tokens = 222
         assert_eq!(
             split_unavailable_active_stage_nodes(
                 &active,
-                &[participant(1), participant(2), participant(3)],
+                &[make_id(1), make_id(2), make_id(3)],
                 &statuses,
+            ),
+            vec![make_id(2)]
+        );
+    }
+
+    #[test]
+    fn split_active_stage_nodes_pending_eligibility_retains_connected_stage() {
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2)],
+            vec![stage(1, 0, 0, 20), stage(2, 1, 20, 40)],
+        );
+
+        assert_eq!(
+            split_active_stage_nodes_pending_eligibility(
+                &active,
+                &[make_id(1), make_id(2)],
+                &[participant(1)],
+                &[],
             ),
             vec![make_id(2)]
         );
@@ -5683,7 +5773,7 @@ max_tokens = 222
         assert_eq!(
             split_loss_recovery_decision(
                 &active,
-                &[participant(1), participant(3)],
+                &[make_id(1), make_id(3)],
                 &[],
                 Some(&candidate),
                 true,
@@ -5711,7 +5801,7 @@ max_tokens = 222
         assert_eq!(
             split_loss_recovery_decision(
                 &active,
-                &[participant(1), participant(2), participant(3)],
+                &[make_id(1), make_id(2), make_id(3)],
                 &[make_id(2)],
                 Some(&candidate),
                 true,
@@ -5740,7 +5830,7 @@ max_tokens = 222
         assert_eq!(
             split_loss_recovery_decision(
                 &active,
-                &[participant(1), participant(2), participant(3)],
+                &[make_id(1), make_id(2), make_id(3)],
                 &[make_id(2)],
                 Some(&candidate),
                 true,
@@ -5765,7 +5855,7 @@ max_tokens = 222
         );
 
         assert_eq!(
-            split_loss_recovery_decision(&active, &[participant(1)], &[], None, true),
+            split_loss_recovery_decision(&active, &[make_id(1)], &[], None, true),
             SplitLossRecoveryDecision::LocalFallback
         );
     }
@@ -5781,7 +5871,7 @@ max_tokens = 222
         );
 
         assert_eq!(
-            split_loss_recovery_decision(&active, &[participant(1)], &[], None, false),
+            split_loss_recovery_decision(&active, &[make_id(1)], &[], None, false),
             SplitLossRecoveryDecision::Withdraw
         );
     }
@@ -5804,7 +5894,7 @@ max_tokens = 222
         );
 
         assert_eq!(
-            split_loss_recovery_decision(&active, &[participant(1)], &[], Some(&candidate), true),
+            split_loss_recovery_decision(&active, &[make_id(1)], &[], Some(&candidate), true),
             SplitLossRecoveryDecision::LocalFallback
         );
         assert!(!split_candidate_is_valid_replacement_split(&candidate));
@@ -5831,11 +5921,27 @@ max_tokens = 222
         assert_eq!(
             split_loss_recovery_decision(
                 &active,
-                &[participant(1), participant(2)],
+                &[make_id(1), make_id(2)],
                 &[],
                 Some(&candidate),
                 false,
             ),
+            SplitLossRecoveryDecision::NoActiveStageLoss
+        );
+    }
+
+    #[test]
+    fn split_loss_recovery_ignores_connected_but_temporarily_ineligible_stage_peer() {
+        let active = SplitTopologyGeneration::new(
+            "topology-a".into(),
+            "run-a".into(),
+            1,
+            vec![participant(1), participant(2)],
+            vec![stage(1, 0, 0, 20), stage(2, 1, 20, 40)],
+        );
+
+        assert_eq!(
+            split_loss_recovery_decision(&active, &[make_id(1), make_id(2)], &[], None, true,),
             SplitLossRecoveryDecision::NoActiveStageLoss
         );
     }

--- a/crates/openai-frontend/src/chat.rs
+++ b/crates/openai-frontend/src/chat.rs
@@ -174,6 +174,8 @@ pub struct ChatCompletionResponse {
     pub model: String,
     pub choices: Vec<ChatCompletionChoice>,
     pub usage: Usage,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timings: Option<BTreeMap<String, Value>>,
 }
 
 impl ChatCompletionResponse {
@@ -204,7 +206,13 @@ impl ChatCompletionResponse {
                 finish_reason: Some(finish_reason),
             }],
             usage,
+            timings: None,
         }
+    }
+
+    pub fn with_timings(mut self, timings: Option<BTreeMap<String, Value>>) -> Self {
+        self.timings = timings;
+        self
     }
 }
 

--- a/crates/openai-frontend/src/guardrails/tests.rs
+++ b/crates/openai-frontend/src/guardrails/tests.rs
@@ -1352,6 +1352,7 @@ fn response_with_content_with_usage(
             finish_reason: Some(crate::common::FinishReason::Stop),
         }],
         usage,
+        timings: None,
     }
 }
 
@@ -1386,6 +1387,7 @@ fn response_with_tool_calls_with_usage(
             finish_reason: Some(crate::common::FinishReason::ToolCalls),
         }],
         usage,
+        timings: None,
     }
 }
 

--- a/crates/openai-frontend/src/responses.rs
+++ b/crates/openai-frontend/src/responses.rs
@@ -1227,6 +1227,7 @@ mod tests {
                     finish_reason: Some(FinishReason::ToolCalls),
                 }],
                 usage: Usage::new(6, 3),
+                timings: None,
             })
         }
 

--- a/crates/openai-frontend/src/router.rs
+++ b/crates/openai-frontend/src/router.rs
@@ -644,6 +644,7 @@ mod tests {
                         finish_reason: Some(FinishReason::ToolCalls),
                     }],
                     usage: Usage::new(3, 2),
+                    timings: None,
                 });
             }
             Ok(ChatCompletionResponse::new(

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -1272,6 +1272,7 @@ struct GenerationCacheStats {
     matched_prefix_tokens: u32,
     suffix_prefill_tokens: u32,
     hit_kind: Option<&'static str>,
+    native_mtp_stats: NativeMtpStats,
 }
 
 impl Default for GenerationCacheStats {
@@ -1282,6 +1283,7 @@ impl Default for GenerationCacheStats {
             matched_prefix_tokens: 0,
             suffix_prefill_tokens: 0,
             hit_kind: None,
+            native_mtp_stats: NativeMtpStats::default(),
         }
     }
 }
@@ -1699,6 +1701,7 @@ fn chat_response_from_generated_text(
                 finish_reason: Some(finish_reason),
             }],
             usage: output.usage(),
+            timings: output.timings(),
         };
     }
 
@@ -1708,6 +1711,7 @@ fn chat_response_from_generated_text(
         output.usage(),
         output.finish_reason,
     )
+    .with_timings(output.timings())
 }
 
 fn parsed_chat_message_from_json(
@@ -2309,6 +2313,7 @@ where
             matched_prefix_tokens: cache_stats.matched_prefix_tokens,
             suffix_prefill_tokens: cache_stats.suffix_prefill_tokens,
             cache_hit_kind: cache_stats.hit_kind,
+            native_mtp_stats: cache_stats.native_mtp_stats,
             text: self.text,
             finish_reason: self.finish_reason,
             detokenize_ms: self.metrics.detokenize_ms,
@@ -2326,6 +2331,7 @@ struct GeneratedText {
     matched_prefix_tokens: u32,
     suffix_prefill_tokens: u32,
     cache_hit_kind: Option<&'static str>,
+    native_mtp_stats: NativeMtpStats,
     text: String,
     finish_reason: FinishReason,
     detokenize_ms: f64,
@@ -2337,6 +2343,34 @@ impl GeneratedText {
     fn usage(&self) -> Usage {
         Usage::new(self.prompt_tokens, self.completion_tokens)
             .with_cached_tokens(self.cached_prompt_tokens)
+    }
+
+    fn timings(&self) -> Option<BTreeMap<String, Value>> {
+        if !self.native_mtp_stats.enabled() {
+            return None;
+        }
+
+        let stats = self.native_mtp_stats;
+        Some(BTreeMap::from([
+            ("draft_n".to_string(), json!(stats.drafted_tokens)),
+            ("draft_n_accepted".to_string(), json!(stats.accepted_tokens)),
+            (
+                "native_mtp_rejected".to_string(),
+                json!(stats.rejected_tokens),
+            ),
+            (
+                "native_mtp_verifications".to_string(),
+                json!(stats.verification_count),
+            ),
+            (
+                "native_mtp_proposal_compute_us".to_string(),
+                json!(stats.proposal_compute_us),
+            ),
+            (
+                "native_mtp_verification_compute_us".to_string(),
+                json!(stats.verification_compute_us),
+            ),
+        ]))
     }
 }
 

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -1482,7 +1482,9 @@ impl StageOpenAiBackend {
                 json!(decode_downstream_wait_ms),
             );
             speculative_stats.insert_attrs(&mut decode_attrs);
-            native_mtp.stats().insert_attrs(&mut decode_attrs);
+            let native_mtp_stats = native_mtp.stats();
+            cache_stats.native_mtp_stats = native_mtp_stats;
+            native_mtp_stats.insert_attrs(&mut decode_attrs);
             native_mtp_counters.insert_summary_attrs(&mut decode_attrs, native_mtp_options);
             self.emit_openai_summary("stage.openai_decode", decode_timer, decode_attrs);
             Ok(())

--- a/crates/skippy-server/src/frontend/local_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation.rs
@@ -720,7 +720,9 @@ impl StageOpenAiBackend {
                     stats,
                 );
             }
-            native_mtp.stats().insert_attrs(&mut attrs);
+            let native_mtp_stats = native_mtp.stats();
+            cache_stats.native_mtp_stats = native_mtp_stats;
+            native_mtp_stats.insert_attrs(&mut attrs);
             self.emit_openai_summary("stage.openai_decode", decode_timer, attrs);
             Ok(())
         })();

--- a/crates/skippy-server/src/frontend/tests.rs
+++ b/crates/skippy-server/src/frontend/tests.rs
@@ -707,6 +707,7 @@ impl OpenAiBackend for StructuredGuardrailRecordingBackend {
                 finish_reason: Some(FinishReason::ToolCalls),
             }],
             usage: Usage::new(1, 1),
+            timings: None,
         })
     }
 
@@ -1086,6 +1087,15 @@ fn chat_response_from_parsed_message_separates_reasoning_content() {
         matched_prefix_tokens: 0,
         suffix_prefill_tokens: 0,
         cache_hit_kind: None,
+        native_mtp_stats: NativeMtpStats {
+            drafted_tokens: 7,
+            accepted_tokens: 5,
+            rejected_tokens: 2,
+            verification_count: 7,
+            proposal_compute_us: 100,
+            verification_compute_us: 200,
+            ..NativeMtpStats::default()
+        },
         text: "Checked facts first.</think>Final answer.".to_string(),
         finish_reason: FinishReason::Stop,
         detokenize_ms: 0.0,
@@ -1102,6 +1112,9 @@ fn chat_response_from_parsed_message_separates_reasoning_content() {
 
     let message = &response.choices[0].message;
     assert_eq!(message.content.as_deref(), Some("Final answer."));
+    let timings = response.timings.as_ref().expect("native MTP timings");
+    assert_eq!(timings.get("draft_n"), Some(&json!(7)));
+    assert_eq!(timings.get("draft_n_accepted"), Some(&json!(5)));
     assert_eq!(
         message.reasoning_content.as_deref(),
         Some("Checked facts first.")

--- a/third_party/llama.cpp/patches/0015-Fix-stage-activation-graph-input-allocation.patch
+++ b/third_party/llama.cpp/patches/0015-Fix-stage-activation-graph-input-allocation.patch
@@ -1,0 +1,106 @@
+From b33804b57ebe162aee32c543b7611f4b6ba615cf Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Wed, 15 Jul 2026 07:54:20 +1000
+Subject: [PATCH] Fix stage activation graph input allocation
+
+---
+ src/llama-graph.cpp | 39 +++++++++++++++++++++++++++------------
+ 1 file changed, 27 insertions(+), 12 deletions(-)
+
+diff --git a/src/llama-graph.cpp b/src/llama-graph.cpp
+index a75f0b75..6613747a 100644
+--- a/src/llama-graph.cpp
++++ b/src/llama-graph.cpp
+@@ -135,8 +135,8 @@ void llm_graph_input_embd::set_input(const llama_ubatch * ubatch) {
+ bool llm_graph_input_embd::can_reuse(const llm_graph_params & params) {
+     bool res = true;
+ 
+-    res &= (!params.ubatch.token) || (tokens && tokens->ne[0] == params.ubatch.n_tokens);
+-    res &= (!params.ubatch.embd)  || (embd   &&   embd->ne[1] == params.ubatch.n_tokens);
++    res &= (!params.ubatch.token) || (tokens && tokens->buffer && tokens->ne[0] == params.ubatch.n_tokens);
++    res &= (!params.ubatch.embd)  || (embd   && embd->buffer   && embd->ne[1] == params.ubatch.n_tokens);
+ 
+     return res;
+ }
+@@ -167,9 +167,9 @@ void llm_graph_input_embd_h::set_input(const llama_ubatch * ubatch) {
+ bool llm_graph_input_embd_h::can_reuse(const llm_graph_params & params) {
+     bool res = true;
+ 
+-    res &= (!params.ubatch.token) || (tokens && tokens->ne[0] == params.ubatch.n_tokens);
+-    res &= (!params.ubatch.embd)  || (embd   && embd->ne[1]   == params.ubatch.n_tokens);
+-    res &= (!params.ubatch.embd)  || (h      && h->ne[1]      == params.ubatch.n_tokens);
++    res &= (!params.ubatch.token) || (tokens && tokens->buffer && tokens->ne[0] == params.ubatch.n_tokens);
++    res &= (!params.ubatch.embd)  || (embd   && embd->buffer   && embd->ne[1] == params.ubatch.n_tokens);
++    res &= (!params.ubatch.embd)  || (h      && h->buffer      && h->ne[1] == params.ubatch.n_tokens);
+ 
+     return res;
+ }
+@@ -214,7 +214,9 @@ bool llm_graph_input_gemma3n_altup::can_reuse(const llm_graph_params & params) {
+ }
+ 
+ void llm_graph_input_pos::set_input(const llama_ubatch * ubatch) {
+-    if (ubatch->pos && pos) {
++    // A filtered stage can omit positional work entirely. In that case the
++    // scheduler leaves this otherwise declared graph input unallocated.
++    if (ubatch->pos && pos && pos->buffer) {
+         const int64_t n_tokens = ubatch->n_tokens;
+ 
+         if (ubatch->token && n_pos_per_embd == 4) {
+@@ -238,7 +240,7 @@ void llm_graph_input_pos::set_input(const llama_ubatch * ubatch) {
+ bool llm_graph_input_pos::can_reuse(const llm_graph_params & params) {
+     bool res = true;
+ 
+-    res &= pos->ne[0] == params.ubatch.n_tokens*n_pos_per_embd;
++    res &= pos && pos->buffer && pos->ne[0] == params.ubatch.n_tokens*n_pos_per_embd;
+ 
+     return res;
+ }
+@@ -591,9 +593,15 @@ bool llm_graph_input_attn_kv::can_reuse(const llm_graph_params & params) {
+ }
+ 
+ void llm_graph_input_attn_k::set_input(const llama_ubatch * ubatch) {
+-    mctx->set_input_k_idxs(self_k_idxs, ubatch);
++    // Filtered stages can omit their attention path, leaving these declared
++    // graph inputs unallocated by the scheduler.
++    if (self_k_idxs && self_k_idxs->buffer) {
++        mctx->set_input_k_idxs(self_k_idxs, ubatch);
++    }
+ 
+-    mctx->set_input_kq_mask(self_kq_mask, ubatch, cparams.causal_attn);
++    if (self_kq_mask && self_kq_mask->buffer) {
++        mctx->set_input_kq_mask(self_kq_mask, ubatch, cparams.causal_attn);
++    }
+ }
+ 
+ bool llm_graph_input_attn_k::can_reuse(const llm_graph_params & params) {
+@@ -603,9 +611,10 @@ bool llm_graph_input_attn_k::can_reuse(const llm_graph_params & params) {
+ 
+     bool res = true;
+ 
+-    res &= self_k_idxs->ne[0] == params.ubatch.n_tokens;
++    res &= self_k_idxs && self_k_idxs->buffer && self_k_idxs->ne[0] == params.ubatch.n_tokens;
+ 
+-    res &= can_reuse_kq_mask(self_kq_mask, mctx, params.ubatch, params.cparams);
++    res &= self_kq_mask && self_kq_mask->buffer &&
++        can_reuse_kq_mask(self_kq_mask, mctx, params.ubatch, params.cparams);
+ 
+     return res;
+ }
+@@ -2340,7 +2349,13 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
+     assert(ggml_are_same_shape (inps[0], inps[1]));
+     assert(ggml_are_same_stride(inps[0], inps[1]));
+ 
+-    ggml_tensor * cur = ggml_build_forward_select(gf, inps.data(), inps.size(), ubatch.token ? 0 : 1);
++    // A mid-stage Skippy slice has no token embedding table, so both branches
++    // above refer to `inp->embd`. Feeding the same tensor through
++    // ggml_build_forward_select first visits it as an uncomputed branch and
++    // leaves its input buffer unallocated. It is the only valid input here.
++    ggml_tensor * cur = tok_embd
++        ? ggml_build_forward_select(gf, inps.data(), inps.size(), ubatch.token ? 0 : 1)
++        : inp->embd;
+ 
+     if (n_embd_inp != n_embd) {
+         cur = ggml_view_2d(ctx0, cur, n_embd, n_tokens, cur->nb[1], 0);
+-- 
+2.54.0 (Apple Git-157)
+


### PR DESCRIPTION
## Summary

Split serving now retains an active, connected stage while planner eligibility refreshes. Direct cached GGUFs can supply split-planning metadata through the normal `--model meshllm/GLM-4.7-Flash-MTP-GGUF:Q4_K_M --split` path.

The staged runtime also allocates activation graph inputs correctly for mid-stage slices, preventing the GLM 4.7 Flash MTP prefill assertion. Native MTP responses expose draft and acceptance counters.

## Architecture

Active-stage loss is determined from mesh connectivity and authoritative stage runtime state. Planner eligibility remains prospective; a candidate that would drop a connected, non-failed active stage is deferred.

## Protocol

No mesh wire-protocol, plugin-protocol, or Skippy ABI change.

## Validation

- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `cargo test -p skippy-server --lib` (206 passed)
- `cargo test -p mesh-llm-host-runtime --lib split_` (115 passed)
- Fresh `just release-build` on studio54 and micstudio, including clean application of the new llama.cpp patch
- Two-host direct-LAN GLM 4.7 Flash MTP split smoke using the normal full package reference, with native MTP disabled and enabled
- Real completions completed without the prior `ggml_backend_tensor_set` assertion or topology fallback; native-MTP response reported 65 drafts and 55 accepts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional generation timing details to chat completion responses.
  * Exposed native MTP draft, verification, rejection, and proposal metrics when available.

* **Bug Fixes**
  * Improved split-runtime recovery decisions when node connectivity is changing.
  * Fixed stage activation handling for unallocated graph inputs and mid-stage embedding inputs.
  * Improved metadata extraction for direct GGUF sources.

* **Tests**
  * Expanded coverage for timing data, connected-node recovery behavior, and metadata extraction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->