### PR TITLE
Clarify active split worker status

### DIFF
--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -10,6 +10,7 @@ mod options;
 mod proxy;
 mod release_attestation;
 mod split_planning;
+mod split_status;
 pub(crate) mod survey;
 pub(crate) mod wakeable;
 
@@ -1585,10 +1586,7 @@ where
             Ok(SplitRuntimeStart::Standby { coordinator }) => {
                 drop(startup_load_guard);
                 let _ = emit_event(OutputEvent::Info {
-                    message: format!(
-                        "Split runtime coordinator is {}; standing by for stage assignment",
-                        coordinator.fmt_short()
-                    ),
+                    message: split_status::standby_message(node, model_ref, coordinator).await,
                     context: Some(format!("model={model_ref}")),
                 });
                 startup_reset_model_target(target_tx, model_name, console_state).await;

--- a/crates/mesh-llm-host-runtime/src/runtime/split_status.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/split_status.rs
@@ -1,0 +1,138 @@
+use crate::inference::skippy;
+use crate::mesh;
+
+pub(super) async fn standby_message(
+    node: &mesh::Node,
+    model_ref: &str,
+    coordinator: iroh::EndpointId,
+) -> String {
+    let statuses = node.stage_runtime_statuses().await;
+    let active_stage = active_local_stage(node.id(), model_ref, &statuses);
+    format_standby_message(
+        coordinator,
+        active_stage.map(|stage| (stage.stage_id.as_str(), stage.state)),
+    )
+}
+
+fn active_local_stage<'a>(
+    local_node_id: iroh::EndpointId,
+    model_ref: &str,
+    statuses: &'a [mesh::StageRuntimeStatus],
+) -> Option<&'a mesh::StageRuntimeStatus> {
+    statuses.iter().find(|status| {
+        status.model_id == model_ref
+            && status.node_id == Some(local_node_id)
+            && matches!(
+                status.state,
+                skippy::StageRuntimeState::Starting | skippy::StageRuntimeState::Ready
+            )
+    })
+}
+
+fn format_standby_message(
+    coordinator: iroh::EndpointId,
+    active_stage: Option<(&str, skippy::StageRuntimeState)>,
+) -> String {
+    let Some((stage_id, stage_state)) = active_stage else {
+        return format!(
+            "Split runtime coordinator is {}; waiting for a local stage assignment",
+            coordinator.fmt_short()
+        );
+    };
+    let state = match stage_state {
+        skippy::StageRuntimeState::Starting => "starting",
+        skippy::StageRuntimeState::Ready => "ready",
+        skippy::StageRuntimeState::Stopping
+        | skippy::StageRuntimeState::Stopped
+        | skippy::StageRuntimeState::Failed => "inactive",
+    };
+    format!(
+        "Split stage {stage_id} is {state} under coordinator {}; model requests remain routed through the coordinator",
+        coordinator.fmt_short()
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn coordinator() -> iroh::EndpointId {
+        iroh::SecretKey::from_bytes(&[7; 32]).public()
+    }
+
+    fn stage_status(
+        node_id: iroh::EndpointId,
+        model_id: &str,
+        state: skippy::StageRuntimeState,
+    ) -> mesh::StageRuntimeStatus {
+        mesh::StageRuntimeStatus {
+            topology_id: "topology-a".to_string(),
+            run_id: "run-a".to_string(),
+            model_id: model_id.to_string(),
+            backend: "skippy".to_string(),
+            package_ref: None,
+            manifest_sha256: None,
+            source_model_path: None,
+            source_model_sha256: None,
+            source_model_bytes: None,
+            materialized_path: None,
+            materialized_pinned: false,
+            projector_path: None,
+            stage_id: "stage-1".to_string(),
+            stage_index: 1,
+            node_id: Some(node_id),
+            layer_start: 16,
+            layer_end: 32,
+            state,
+            bind_addr: "127.0.0.1:1234".to_string(),
+            activation_width: 2048,
+            wire_dtype: skippy::StageWireDType::F16,
+            selected_device: None,
+            ctx_size: 4096,
+            lane_count: 4,
+            n_batch: None,
+            n_ubatch: None,
+            flash_attn_type: skippy_protocol::FlashAttentionType::Auto,
+            error: None,
+            shutdown_generation: 1,
+        }
+    }
+
+    #[test]
+    fn reports_pending_assignment() {
+        let message = format_standby_message(coordinator(), None);
+
+        assert!(message.contains("waiting for a local stage assignment"));
+        assert!(!message.contains("stage is ready"));
+    }
+
+    #[test]
+    fn reports_active_worker_stage() {
+        let message = format_standby_message(
+            coordinator(),
+            Some(("stage-1", skippy::StageRuntimeState::Ready)),
+        );
+
+        assert!(message.contains("Split stage stage-1 is ready"));
+        assert!(message.contains("model requests remain routed through the coordinator"));
+        assert!(!message.contains("waiting for a local stage assignment"));
+    }
+
+    #[test]
+    fn selects_only_active_local_stage_for_model() {
+        let local_node = iroh::SecretKey::from_bytes(&[8; 32]).public();
+        let other_node = iroh::SecretKey::from_bytes(&[9; 32]).public();
+        let statuses = vec![
+            stage_status(local_node, "model-a", skippy::StageRuntimeState::Failed),
+            stage_status(other_node, "model-a", skippy::StageRuntimeState::Ready),
+            stage_status(local_node, "model-b", skippy::StageRuntimeState::Ready),
+            stage_status(local_node, "model-a", skippy::StageRuntimeState::Ready),
+        ];
+
+        let selected = active_local_stage(local_node, "model-a", &statuses).unwrap();
+
+        assert_eq!(selected.model_id, "model-a");
+        assert_eq!(selected.node_id, Some(local_node));
+        assert_eq!(selected.state, skippy::StageRuntimeState::Ready);
+    }
+}


### PR DESCRIPTION
## Summary

- replace the ambiguous recurring split-worker "standing by for stage assignment" message with status derived from authoritative local stage state
- report `stage-1` as starting or ready when the coordinator has already assigned it
- clarify that model requests remain routed through the coordinator

## Why

Issue #951 showed that the old message could continue while the same node was already running a ready downstream stage. That made a loaded worker look unassigned and led operators toward the wrong diagnosis.

This PR intentionally changes reporting only. It does not claim to fix the inference hang in #951, change split election or assignment, alter readiness semantics, or add a request timeout.

## Compatibility

No mesh protocol, plugin protocol, Skippy ABI, API schema, routing, or model-load behavior changes.

## Validation

- `cargo fmt --all --check`
- `cargo test -p mesh-llm-host-runtime --lib split_status -- --test-threads=1` (3 passed)
- `cargo test -p mesh-llm-host-runtime --lib -- --test-threads=1` (1575 passed, 8 ignored)
- `cargo check -p mesh-llm-host-runtime`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `git diff --check`

## Notes

The full host-runtime suite initially failed inside the restricted filesystem/socket sandbox because socket binding returned `Operation not permitted`. The required rerun outside that sandbox passed completely.

Related: #951


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer standby status messages for split-runtime coordinators.
  * Status now indicates whether the system is waiting for a local stage assignment or identifies the active stage and its state.

* **Bug Fixes**
  * Improved stage selection so messages reflect the correct active local stage for the requested model.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->