### PR TITLE
fix: partial layer packages in models installed list

### DIFF
--- a/crates/mesh-llm-host-runtime/src/command_support.rs
+++ b/crates/mesh-llm-host-runtime/src/command_support.rs
@@ -46,9 +46,9 @@ pub mod models {
         layered_package_layer_count_for_path, layered_package_total_bytes_for_path,
         load_model_usage_record_for_path, model_usage_cache_dir, plan_model_cleanup,
         remote_catalog_model_draft_ref, remote_catalog_model_ref, run_update,
-        scan_installed_models, search_catalog_json_payload, search_catalog_models,
-        search_huggingface, search_huggingface_json_payload, show_exact_model,
-        show_model_variants_with_progress,
+        scan_installed_models, scan_installed_models_in, search_catalog_json_payload,
+        search_catalog_models, search_huggingface, search_huggingface_json_payload,
+        show_exact_model, show_model_variants_with_progress,
     };
     pub use crate::models::{capabilities, catalog};
 }

--- a/crates/mesh-llm-host-runtime/src/models/local.rs
+++ b/crates/mesh-llm-host-runtime/src/models/local.rs
@@ -6,7 +6,7 @@ pub use model_hf::store::local::{
     huggingface_identity_for_path, huggingface_repo_folder_name,
     layered_package_layer_count_for_path, layered_package_total_bytes_for_path, mesh_llm_cache_dir,
     model_ref_for_path, scan_hf_cache_fast, scan_hf_cache_info, scan_installed_models,
-    scan_local_models,
+    scan_installed_models_in, scan_local_models,
 };
 
 #[cfg(test)]

--- a/crates/mesh-llm-host-runtime/src/models/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/models/mod.rs
@@ -33,7 +33,7 @@ pub use inventory::{LocalModelInventorySnapshot, scan_local_inventory_snapshot_w
 pub use local::{
     find_mmproj_path, find_model_path, huggingface_hub_cache_dir, huggingface_identity_for_path,
     layered_package_layer_count_for_path, layered_package_total_bytes_for_path, mesh_llm_cache_dir,
-    model_ref_for_path, scan_installed_models, scan_local_models,
+    model_ref_for_path, scan_installed_models, scan_installed_models_in, scan_local_models,
 };
 pub use maintenance::{run_update, warn_about_updates_for_paths};
 pub(crate) use profile::{served_model_metadata_for_model, served_model_metadata_for_path};

--- a/crates/mesh-llm/src/commands/models/installed.rs
+++ b/crates/mesh-llm/src/commands/models/installed.rs
@@ -1,10 +1,12 @@
 use anyhow::Result;
 use mesh_llm_host_runtime::command_support::models::{
-    find_model_path, find_remote_catalog_model_exact, huggingface_identity_for_path,
-    installed_model_capabilities, installed_model_display_name, installed_model_huggingface_ref,
-    layered_package_layer_count_for_path, layered_package_total_bytes_for_path,
-    load_model_usage_record_for_path, remote_catalog_model_ref, scan_installed_models,
+    find_model_path, find_remote_catalog_model_exact, huggingface_hub_cache_dir,
+    huggingface_identity_for_path, installed_model_capabilities, installed_model_display_name,
+    installed_model_huggingface_ref, layered_package_layer_count_for_path,
+    layered_package_total_bytes_for_path, load_model_usage_record_for_path,
+    remote_catalog_model_ref, scan_installed_models_in,
 };
+use std::path::Path;
 
 use super::formatters::{InstalledRow, models_formatter};
 
@@ -12,8 +14,8 @@ fn installed_layer_package_count(name: &str, detected_count: Option<usize>) -> O
     detected_count.or_else(|| name.ends_with("-layers").then_some(0))
 }
 
-fn build_installed_rows() -> Vec<InstalledRow> {
-    scan_installed_models()
+fn build_installed_rows(cache_root: &Path) -> Vec<InstalledRow> {
+    scan_installed_models_in(cache_root)
         .into_iter()
         .map(|name| {
             let path = find_model_path(&name);
@@ -74,15 +76,13 @@ fn build_installed_rows() -> Vec<InstalledRow> {
 
 pub(super) fn run_model_installed(json_output: bool) -> Result<()> {
     let formatter = models_formatter(json_output);
-    let rows = build_installed_rows();
+    let rows = build_installed_rows(&huggingface_hub_cache_dir());
     formatter.render_installed(&rows)
 }
 
 #[cfg(test)]
 mod tests {
     use super::build_installed_rows;
-    use serial_test::serial;
-    use std::ffi::OsString;
     use std::path::{Path, PathBuf};
 
     fn unique_temp_dir(prefix: &str) -> PathBuf {
@@ -91,16 +91,6 @@ mod tests {
             .unwrap()
             .as_nanos();
         std::env::temp_dir().join(format!("mesh-llm-{prefix}-{stamp}"))
-    }
-
-    fn restore_env(key: &str, previous: Option<OsString>) {
-        if let Some(value) = previous {
-            // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe { std::env::set_var(key, value) };
-        } else {
-            // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe { std::env::remove_var(key) };
-        }
     }
 
     fn create_cache_repo_file(
@@ -126,12 +116,7 @@ mod tests {
     }
 
     #[test]
-    #[serial]
     fn installed_rows_keep_layered_package_ref_and_safe_commands() {
-        let prev_hub_cache = std::env::var_os("HF_HUB_CACHE");
-        let prev_hf_home = std::env::var_os("HF_HOME");
-        let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
-
         let temp = unique_temp_dir("installed-layered-row");
         create_cache_repo_file(
             &temp,
@@ -155,14 +140,7 @@ mod tests {
             9,
         );
 
-        // TODO: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::set_var("HF_HUB_CACHE", &temp) };
-        // TODO: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::remove_var("HF_HOME") };
-        // TODO: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::remove_var("XDG_CACHE_HOME") };
-
-        let rows = build_installed_rows();
+        let rows = build_installed_rows(&temp);
         assert_eq!(rows.len(), 1);
         let row = &rows[0];
         assert_eq!(row.model_ref, "meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers");
@@ -175,18 +153,10 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&temp);
-        restore_env("HF_HUB_CACHE", prev_hub_cache);
-        restore_env("HF_HOME", prev_hf_home);
-        restore_env("XDG_CACHE_HOME", prev_xdg);
     }
 
     #[test]
-    #[serial]
     fn installed_rows_keep_partial_layered_package_grouped() {
-        let prev_hub_cache = std::env::var_os("HF_HUB_CACHE");
-        let prev_hf_home = std::env::var_os("HF_HOME");
-        let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
-
         let temp = unique_temp_dir("installed-partial-layered-row");
         let metadata = create_cache_repo_file(
             &temp,
@@ -196,14 +166,7 @@ mod tests {
             6,
         );
 
-        // TODO: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::set_var("HF_HUB_CACHE", &temp) };
-        // TODO: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::remove_var("HF_HOME") };
-        // TODO: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::remove_var("XDG_CACHE_HOME") };
-
-        let rows = build_installed_rows();
+        let rows = build_installed_rows(&temp);
         assert_eq!(rows.len(), 1);
         let row = &rows[0];
         assert_eq!(row.path, metadata);
@@ -217,8 +180,5 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&temp);
-        restore_env("HF_HUB_CACHE", prev_hub_cache);
-        restore_env("HF_HOME", prev_hf_home);
-        restore_env("XDG_CACHE_HOME", prev_xdg);
     }
 }

--- a/crates/mesh-llm/src/commands/models/installed.rs
+++ b/crates/mesh-llm/src/commands/models/installed.rs
@@ -1,0 +1,224 @@
+use anyhow::Result;
+use mesh_llm_host_runtime::command_support::models::{
+    find_model_path, find_remote_catalog_model_exact, huggingface_identity_for_path,
+    installed_model_capabilities, installed_model_display_name, installed_model_huggingface_ref,
+    layered_package_layer_count_for_path, layered_package_total_bytes_for_path,
+    load_model_usage_record_for_path, remote_catalog_model_ref, scan_installed_models,
+};
+
+use super::formatters::{InstalledRow, models_formatter};
+
+fn installed_layer_package_count(name: &str, detected_count: Option<usize>) -> Option<usize> {
+    detected_count.or_else(|| name.ends_with("-layers").then_some(0))
+}
+
+fn build_installed_rows() -> Vec<InstalledRow> {
+    scan_installed_models()
+        .into_iter()
+        .map(|name| {
+            let path = find_model_path(&name);
+            let display_name = installed_model_display_name(&name);
+            let catalog_model = find_remote_catalog_model_exact(&name);
+            let layer_count =
+                installed_layer_package_count(&name, layered_package_layer_count_for_path(&path));
+            let model_ref = if layer_count.is_some() {
+                name.clone()
+            } else if let Some(model) = catalog_model.as_ref() {
+                remote_catalog_model_ref(model)
+            } else if let Some(identity) = huggingface_identity_for_path(&path) {
+                installed_model_huggingface_ref(&identity)
+            } else {
+                name.clone()
+            };
+            let show_command = layer_count
+                .is_none()
+                .then(|| format!("mesh-llm models show {model_ref}"));
+            let download_command = layer_count
+                .is_none()
+                .then(|| format!("mesh-llm models download {model_ref}"));
+            let delete_command = format!("mesh-llm models delete {model_ref}");
+            let size = if let Some(bytes) = layered_package_total_bytes_for_path(&path) {
+                Some(bytes)
+            } else if path
+                .extension()
+                .and_then(|ext| ext.to_str())
+                .is_some_and(|ext| ext.eq_ignore_ascii_case("gguf"))
+            {
+                Some(
+                    mesh_llm_host_runtime::command_support::models::election::total_model_bytes(
+                        &path,
+                    ),
+                )
+            } else {
+                std::fs::metadata(&path).map(|meta| meta.len()).ok()
+            };
+            let capabilities = installed_model_capabilities(&name);
+            let usage = load_model_usage_record_for_path(&path);
+            InstalledRow {
+                name: display_name,
+                model_ref,
+                show_command,
+                download_command,
+                delete_command,
+                path,
+                size,
+                layer_count,
+                catalog_model,
+                capabilities,
+                managed_by_mesh: usage.as_ref().is_some_and(|record| record.mesh_managed),
+                last_used_at: usage.map(|record| record.last_used_at),
+            }
+        })
+        .collect()
+}
+
+pub(super) fn run_model_installed(json_output: bool) -> Result<()> {
+    let formatter = models_formatter(json_output);
+    let rows = build_installed_rows();
+    formatter.render_installed(&rows)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::build_installed_rows;
+    use serial_test::serial;
+    use std::ffi::OsString;
+    use std::path::{Path, PathBuf};
+
+    fn unique_temp_dir(prefix: &str) -> PathBuf {
+        let stamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        std::env::temp_dir().join(format!("mesh-llm-{prefix}-{stamp}"))
+    }
+
+    fn restore_env(key: &str, previous: Option<OsString>) {
+        if let Some(value) = previous {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::set_var(key, value) };
+        } else {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::remove_var(key) };
+        }
+    }
+
+    fn create_cache_repo_file(
+        root: &Path,
+        repo_id: &str,
+        revision: &str,
+        relative_file: &str,
+        size_bytes: usize,
+    ) -> PathBuf {
+        let repo_dir = root.join(format!("models--{}", repo_id.replace('/', "--")));
+        let refs_dir = repo_dir.join("refs");
+        let snapshot_dir = repo_dir.join("snapshots").join(revision);
+        std::fs::create_dir_all(&refs_dir).unwrap();
+        std::fs::create_dir_all(
+            snapshot_dir.join(Path::new(relative_file).parent().unwrap_or(Path::new(""))),
+        )
+        .unwrap();
+        std::fs::write(refs_dir.join("main"), revision).unwrap();
+
+        let path = snapshot_dir.join(relative_file);
+        std::fs::write(&path, vec![0u8; size_bytes]).unwrap();
+        path
+    }
+
+    #[test]
+    #[serial]
+    fn installed_rows_keep_layered_package_ref_and_safe_commands() {
+        let prev_hub_cache = std::env::var_os("HF_HUB_CACHE");
+        let prev_hf_home = std::env::var_os("HF_HOME");
+        let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
+
+        let temp = unique_temp_dir("installed-layered-row");
+        create_cache_repo_file(
+            &temp,
+            "meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers",
+            "abcdef1234567890",
+            "shared/embeddings.gguf",
+            6,
+        );
+        create_cache_repo_file(
+            &temp,
+            "meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers",
+            "abcdef1234567890",
+            "layers/layer-000.gguf",
+            9,
+        );
+        create_cache_repo_file(
+            &temp,
+            "meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers",
+            "abcdef1234567890",
+            "layers/layer-001.gguf",
+            9,
+        );
+
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("HF_HUB_CACHE", &temp) };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("HF_HOME") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("XDG_CACHE_HOME") };
+
+        let rows = build_installed_rows();
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.model_ref, "meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers");
+        assert_eq!(row.layer_count, Some(2));
+        assert_eq!(row.show_command, None);
+        assert_eq!(row.download_command, None);
+        assert_eq!(
+            row.delete_command,
+            "mesh-llm models delete meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers"
+        );
+
+        let _ = std::fs::remove_dir_all(&temp);
+        restore_env("HF_HUB_CACHE", prev_hub_cache);
+        restore_env("HF_HOME", prev_hf_home);
+        restore_env("XDG_CACHE_HOME", prev_xdg);
+    }
+
+    #[test]
+    #[serial]
+    fn installed_rows_keep_partial_layered_package_grouped() {
+        let prev_hub_cache = std::env::var_os("HF_HUB_CACHE");
+        let prev_hf_home = std::env::var_os("HF_HOME");
+        let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
+
+        let temp = unique_temp_dir("installed-partial-layered-row");
+        let metadata = create_cache_repo_file(
+            &temp,
+            "meshllm/Qwen3-8B-Q4_K_M-layers",
+            "abcdef1234567890",
+            "shared/metadata.gguf",
+            6,
+        );
+
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("HF_HUB_CACHE", &temp) };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("HF_HOME") };
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::remove_var("XDG_CACHE_HOME") };
+
+        let rows = build_installed_rows();
+        assert_eq!(rows.len(), 1);
+        let row = &rows[0];
+        assert_eq!(row.path, metadata);
+        assert_eq!(row.model_ref, "meshllm/Qwen3-8B-Q4_K_M-layers");
+        assert_eq!(row.layer_count, Some(0));
+        assert_eq!(row.show_command, None);
+        assert_eq!(row.download_command, None);
+        assert_eq!(
+            row.delete_command,
+            "mesh-llm models delete meshllm/Qwen3-8B-Q4_K_M-layers"
+        );
+
+        let _ = std::fs::remove_dir_all(&temp);
+        restore_env("HF_HUB_CACHE", prev_hub_cache);
+        restore_env("HF_HOME", prev_hf_home);
+        restore_env("XDG_CACHE_HOME", prev_xdg);
+    }
+}

--- a/crates/mesh-llm/src/commands/models/mod.rs
+++ b/crates/mesh-llm/src/commands/models/mod.rs
@@ -1,6 +1,7 @@
 mod formatters;
 mod formatters_console;
 mod formatters_json;
+mod installed;
 
 use anyhow::{Result, anyhow, bail};
 use formatters::DownloadStats;
@@ -14,10 +15,9 @@ use mesh_llm_host_runtime::command_support::models::{
     DownloadTransferStats, ModelCleanupPlan, ModelCleanupResult, SearchArtifactFilter,
     SearchProgress, SearchSort, ShowVariantsProgress, delete,
     download_model_ref_with_progress_details, download_model_ref_with_progress_details_direct,
-    find_remote_catalog_model_exact, installed_model_capabilities,
-    load_model_usage_record_for_path, model_usage_cache_dir, plan_model_cleanup, remote_catalog,
-    remote_catalog_model_ref, scan_installed_models, search_catalog_models, search_huggingface,
-    show_exact_model, show_model_variants_with_progress,
+    find_remote_catalog_model_exact, model_usage_cache_dir, plan_model_cleanup, remote_catalog,
+    remote_catalog_model_ref, search_catalog_models, search_huggingface, show_exact_model,
+    show_model_variants_with_progress,
 };
 use mesh_llm_tui::terminal_progress::{DeterminateProgressLine, clear_stderr_line, start_spinner};
 use serde_json::json;
@@ -26,9 +26,10 @@ use std::time::Duration;
 use std::time::Instant;
 
 use formatters::{
-    DownloadRenderInput, InstalledRow, catalog_model_is_mlx, format_installed_size,
-    format_relative_timestamp, model_kind_code, models_formatter, search_formatter,
+    DownloadRenderInput, catalog_model_is_mlx, format_installed_size, format_relative_timestamp,
+    model_kind_code, models_formatter, search_formatter,
 };
+use installed::run_model_installed;
 
 pub async fn run_model_search(
     query: &[String],
@@ -139,68 +140,6 @@ pub fn run_model_recommended(json_output: bool) -> Result<()> {
     remote_catalog::ensure_catalog()?;
     let models = remote_catalog::loaded_models()?;
     formatter.render_recommended(&models)
-}
-
-fn build_installed_rows() -> Vec<InstalledRow> {
-    scan_installed_models()
-        .into_iter()
-        .map(|name| {
-            let path = mesh_llm_host_runtime::command_support::models::find_model_path(&name);
-            let display_name = mesh_llm_host_runtime::command_support::models::installed_model_display_name(&name);
-            let catalog_model = find_remote_catalog_model_exact(&name);
-            let layer_count = mesh_llm_host_runtime::command_support::models::layered_package_layer_count_for_path(&path);
-            let model_ref = if layer_count.is_some() {
-                name.clone()
-            } else if let Some(model) = catalog_model.as_ref() {
-                remote_catalog_model_ref(model)
-            } else if let Some(identity) = mesh_llm_host_runtime::command_support::models::huggingface_identity_for_path(&path) {
-                mesh_llm_host_runtime::command_support::models::installed_model_huggingface_ref(&identity)
-            } else {
-                name.clone()
-            };
-            let show_command = layer_count
-                .is_none()
-                .then(|| format!("mesh-llm models show {model_ref}"));
-            let download_command = layer_count
-                .is_none()
-                .then(|| format!("mesh-llm models download {model_ref}"));
-            let delete_command = format!("mesh-llm models delete {model_ref}");
-            let size =
-                if let Some(bytes) = mesh_llm_host_runtime::command_support::models::layered_package_total_bytes_for_path(&path) {
-                    Some(bytes)
-                } else if path
-                    .extension()
-                    .and_then(|ext| ext.to_str())
-                    .is_some_and(|ext| ext.eq_ignore_ascii_case("gguf"))
-                {
-                    Some(mesh_llm_host_runtime::command_support::models::election::total_model_bytes(&path))
-                } else {
-                    std::fs::metadata(&path).map(|meta| meta.len()).ok()
-                };
-            let capabilities = installed_model_capabilities(&name);
-            let usage = load_model_usage_record_for_path(&path);
-            InstalledRow {
-                name: display_name,
-                model_ref,
-                show_command,
-                download_command,
-                delete_command,
-                path,
-                size,
-                layer_count,
-                catalog_model,
-                capabilities,
-                managed_by_mesh: usage.as_ref().is_some_and(|record| record.mesh_managed),
-                last_used_at: usage.map(|record| record.last_used_at),
-            }
-        })
-        .collect()
-}
-
-pub fn run_model_installed(json_output: bool) -> Result<()> {
-    let formatter = models_formatter(json_output);
-    let rows = build_installed_rows();
-    formatter.render_installed(&rows)
 }
 
 pub async fn run_model_certify(
@@ -867,52 +806,11 @@ fn map_search_sort(sort: ModelSearchSort) -> SearchSort {
 #[cfg(test)]
 mod tests {
     use super::{
-        build_delete_preview_model, build_installed_rows, parse_cleanup_age,
-        resolve_download_layer_package_ref, validate_model_certify_options,
+        build_delete_preview_model, parse_cleanup_age, resolve_download_layer_package_ref,
+        validate_model_certify_options,
     };
     use serial_test::serial;
-    use std::ffi::OsString;
-    use std::path::{Path, PathBuf};
-
-    fn unique_temp_dir(prefix: &str) -> PathBuf {
-        let stamp = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos();
-        std::env::temp_dir().join(format!("mesh-llm-{prefix}-{stamp}"))
-    }
-
-    fn restore_env(key: &str, previous: Option<OsString>) {
-        if let Some(value) = previous {
-            // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe { std::env::set_var(key, value) };
-        } else {
-            // TODO: Audit that the environment access only happens in single-threaded code.
-            unsafe { std::env::remove_var(key) };
-        }
-    }
-
-    fn create_cache_repo_file(
-        root: &Path,
-        repo_id: &str,
-        revision: &str,
-        relative_file: &str,
-        size_bytes: usize,
-    ) -> PathBuf {
-        let repo_dir = root.join(format!("models--{}", repo_id.replace('/', "--")));
-        let refs_dir = repo_dir.join("refs");
-        let snapshot_dir = repo_dir.join("snapshots").join(revision);
-        std::fs::create_dir_all(&refs_dir).unwrap();
-        std::fs::create_dir_all(
-            snapshot_dir.join(Path::new(relative_file).parent().unwrap_or(Path::new(""))),
-        )
-        .unwrap();
-        std::fs::write(refs_dir.join("main"), revision).unwrap();
-
-        let path = snapshot_dir.join(relative_file);
-        std::fs::write(&path, vec![0u8; size_bytes]).unwrap();
-        path
-    }
+    use std::path::PathBuf;
 
     #[test]
     fn cleanup_age_parser_accepts_common_units() {
@@ -1002,61 +900,6 @@ mod tests {
             resolve_download_layer_package_ref("plain-local-model"),
             None
         );
-    }
-
-    #[test]
-    #[serial]
-    fn installed_rows_keep_layered_package_ref_and_safe_commands() {
-        let prev_hub_cache = std::env::var_os("HF_HUB_CACHE");
-        let prev_hf_home = std::env::var_os("HF_HOME");
-        let prev_xdg = std::env::var_os("XDG_CACHE_HOME");
-
-        let temp = unique_temp_dir("installed-layered-row");
-        create_cache_repo_file(
-            &temp,
-            "meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers",
-            "abcdef1234567890",
-            "shared/embeddings.gguf",
-            6,
-        );
-        create_cache_repo_file(
-            &temp,
-            "meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers",
-            "abcdef1234567890",
-            "layers/layer-000.gguf",
-            9,
-        );
-        create_cache_repo_file(
-            &temp,
-            "meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers",
-            "abcdef1234567890",
-            "layers/layer-001.gguf",
-            9,
-        );
-
-        // TODO: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::set_var("HF_HUB_CACHE", &temp) };
-        // TODO: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::remove_var("HF_HOME") };
-        // TODO: Audit that the environment access only happens in single-threaded code.
-        unsafe { std::env::remove_var("XDG_CACHE_HOME") };
-
-        let rows = build_installed_rows();
-        assert_eq!(rows.len(), 1);
-        let row = &rows[0];
-        assert_eq!(row.model_ref, "meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers");
-        assert_eq!(row.layer_count, Some(2));
-        assert_eq!(row.show_command, None);
-        assert_eq!(row.download_command, None);
-        assert_eq!(
-            row.delete_command,
-            "mesh-llm models delete meshllm/DeepSeek-V3.2-UD-Q4_K_XL-layers"
-        );
-
-        let _ = std::fs::remove_dir_all(&temp);
-        restore_env("HF_HUB_CACHE", prev_hub_cache);
-        restore_env("HF_HOME", prev_hf_home);
-        restore_env("XDG_CACHE_HOME", prev_xdg);
     }
 
     #[test]

--- a/crates/model-hf/src/store/local.rs
+++ b/crates/model-hf/src/store/local.rs
@@ -484,15 +484,18 @@ fn push_model_name(
     }
 }
 
-fn scan_hf_cache_models(names: &mut Vec<String>, seen: &mut HashSet<String>, min_size_bytes: u64) {
-    let cache_root = huggingface_hub_cache_dir();
-
-    for path in direct_hf_cache_root_gguf_paths(&cache_root) {
+fn scan_hf_cache_models(
+    cache_root: &Path,
+    names: &mut Vec<String>,
+    seen: &mut HashSet<String>,
+    min_size_bytes: u64,
+) {
+    for path in direct_hf_cache_root_gguf_paths(cache_root) {
         push_model_name(&path, names, seen, min_size_bytes);
     }
 
     if std::env::var("MESH_LLM_ALLOW_FULL_HF_CACHE_SCAN").unwrap_or_default() == "1" {
-        let Some(cache_info) = scan_hf_cache_info(&cache_root) else {
+        let Some(cache_info) = scan_hf_cache_info(cache_root) else {
             return;
         };
         for repo in &cache_info.repos {
@@ -512,24 +515,23 @@ fn scan_hf_cache_models(names: &mut Vec<String>, seen: &mut HashSet<String>, min
                     if !file.file_name.ends_with(".gguf") {
                         continue;
                     }
-                    let path = cache_scanned_file_path(&cache_root, repo, revision, file);
+                    let path = cache_scanned_file_path(cache_root, repo, revision, file);
                     push_model_name(&path, names, seen, min_size_bytes);
                 }
             }
         }
     } else {
-        for path in scan_hf_cache_fast(&cache_root) {
+        for path in scan_hf_cache_fast(cache_root) {
             push_model_name(&path, names, seen, min_size_bytes);
         }
     }
 }
 
-fn scan_models_with_min_size(min_size_bytes: u64) -> Vec<String> {
+fn scan_models_with_min_size(cache_root: &Path, min_size_bytes: u64) -> Vec<String> {
     let mut names = Vec::new();
     let mut seen = HashSet::new();
-    let canonical_dir = huggingface_hub_cache_dir();
-    if canonical_dir.exists() {
-        scan_hf_cache_models(&mut names, &mut seen, min_size_bytes);
+    if cache_root.exists() {
+        scan_hf_cache_models(cache_root, &mut names, &mut seen, min_size_bytes);
     }
     names.sort();
     names
@@ -537,12 +539,17 @@ fn scan_models_with_min_size(min_size_bytes: u64) -> Vec<String> {
 
 /// Scan model directories for GGUF files and return canonical model refs.
 pub fn scan_local_models() -> Vec<String> {
-    scan_models_with_min_size(500_000_000)
+    scan_models_with_min_size(&huggingface_hub_cache_dir(), 500_000_000)
 }
 
 /// Scan installed GGUF models, including small draft models, and return canonical model refs.
 pub fn scan_installed_models() -> Vec<String> {
-    scan_models_with_min_size(0)
+    scan_installed_models_in(&huggingface_hub_cache_dir())
+}
+
+/// Scan an explicit Hugging Face cache for installed GGUF models.
+pub fn scan_installed_models_in(cache_root: &Path) -> Vec<String> {
+    scan_models_with_min_size(cache_root, 0)
 }
 
 fn hf_identity_model_ref(identity: &HuggingFaceModelIdentity) -> String {

--- a/crates/model-hf/src/store/mod.rs
+++ b/crates/model-hf/src/store/mod.rs
@@ -13,7 +13,7 @@ pub use local::{
     huggingface_identity_for_path, huggingface_repo_folder_name, huggingface_snapshot_path,
     layered_package_layer_count_for_path, layered_package_total_bytes_for_path, mesh_llm_cache_dir,
     model_metadata_cache_dir, model_ref_for_path, scan_hf_cache_fast, scan_hf_cache_info,
-    scan_installed_models, scan_local_models,
+    scan_installed_models, scan_installed_models_in, scan_local_models,
 };
 pub use usage::{
     ModelCleanupPlan, ModelCleanupResult, ModelUsageRecord, execute_model_cleanup,


### PR DESCRIPTION
## Summary

- keep partially downloaded Skippy layer packages grouped under their logical `*-layers` model reference
- avoid exposing internal files such as `shared/metadata.gguf` as top-level installed models
- suppress invalid show/download commands for layer package rows while retaining package-level deletion
- extract installed-model row assembly into its own module

## Root cause

`scan_installed_models` already returned the logical layer package name, but installed-row assembly only treated it as a package when at least one layer shard was detected. A partial package containing shared metadata but no layer shards therefore fell back to reconstructing a Hugging Face reference from the internal metadata path.

## Test coverage

Added a regression test that creates a partial cached `*-layers` repository containing only `shared/metadata.gguf`. The test verifies that the result:

- uses the logical package reference
- reports zero currently detected layers
- does not offer show or download commands for the internal artifact
- deletes using the package reference

## Validation

- `cargo test -p mesh-llm --lib` (42 passed)
- `just build`
- `cargo fmt --all --check`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- verified against the local Hugging Face cache: leaked internal references decreased from 1 to 0

Fixes #1004


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an installed-models listing command with human-readable and JSON output.
  - Displays model references, available sizes, capabilities, usage history, layer counts, and management timestamps.
  - Prevents unsafe actions for layered packages (show/download only when not layered) and still provides deletion.
- **Bug Fixes**
  - Improved installed-model discovery/scanning to respect the configured Hugging Face cache root and enhance reference/size detection across layered, catalog, Hugging Face, and filesystem sources.
- **Tests**
  - Added unit coverage for fully- and partially-layered installed model layouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->