### PR TITLE
chore: harden management access and release integrity

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4153,6 +4153,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "sha2 0.10.9",
  "tar",
  "tempfile",
  "zip",

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -104,7 +104,7 @@ urlencoding = "2"
 libc = "0.2.183"
 mdns-sd = "0.19"
 regex-lite = "0.1"
-rmcp = { version = "1.2", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-client-reqwest", "transport-streamable-http-server"] }
+rmcp = { version = "1.8", features = ["client", "server", "transport-child-process", "transport-io", "transport-streamable-http-client-reqwest", "transport-streamable-http-server"] }
 axum = "0.8"
 schemars = "1"
 prost = "0.14"

--- a/crates/mesh-llm-host-runtime/src/api/access.rs
+++ b/crates/mesh-llm-host-runtime/src/api/access.rs
@@ -44,25 +44,27 @@ pub(crate) fn is_trusted_local_request(
     host.is_none_or(is_trusted_local_authority) && origin.is_none_or(is_trusted_local_origin)
 }
 
-pub(crate) fn request_origin(raw_request: &[u8]) -> Option<&str> {
+pub(crate) fn request_origin(raw_request: &[u8]) -> Result<Option<&str>, ()> {
     request_header(raw_request, "origin")
 }
 
-pub(crate) fn request_host(raw_request: &[u8]) -> Option<&str> {
+pub(crate) fn request_host(raw_request: &[u8]) -> Result<Option<&str>, ()> {
     request_header(raw_request, "host")
 }
 
-fn request_header<'a>(raw_request: &'a [u8], name: &str) -> Option<&'a str> {
+fn request_header<'a>(raw_request: &'a [u8], name: &str) -> Result<Option<&'a str>, ()> {
     let mut headers = [httparse::EMPTY_HEADER; 64];
     let mut request = httparse::Request::new(&mut headers);
-    request.parse(raw_request).ok()?;
-    request.headers.iter().find_map(|header| {
-        header
-            .name
-            .eq_ignore_ascii_case(name)
-            .then(|| std::str::from_utf8(header.value).ok())
-            .flatten()
-    })
+    match request.parse(raw_request).map_err(|_| ())? {
+        httparse::Status::Complete(_) => {}
+        httparse::Status::Partial => return Err(()),
+    }
+    request
+        .headers
+        .iter()
+        .find(|header| header.name.eq_ignore_ascii_case(name))
+        .map(|header| std::str::from_utf8(header.value).map_err(|_| ()))
+        .transpose()
 }
 
 fn is_loopback_ip(ip: IpAddr) -> bool {
@@ -177,7 +179,16 @@ mod tests {
     #[test]
     fn origin_header_is_extracted_case_insensitively() {
         let request = b"POST /mcp HTTP/1.1\r\nHost: localhost\r\noRiGiN: https://attacker.example\r\nContent-Length: 0\r\n\r\n";
-        assert_eq!(request_origin(request), Some("https://attacker.example"));
+        assert_eq!(
+            request_origin(request),
+            Ok(Some("https://attacker.example"))
+        );
+    }
+
+    #[test]
+    fn malformed_security_header_is_rejected() {
+        let request = b"POST /mcp HTTP/1.1\r\nHost: localhost\r\nOrigin: https://local\xff\r\n\r\n";
+        assert_eq!(request_origin(request), Err(()));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/api/access.rs
+++ b/crates/mesh-llm-host-runtime/src/api/access.rs
@@ -1,0 +1,203 @@
+use std::net::{IpAddr, SocketAddr};
+
+pub(crate) fn requires_trusted_local_access(method: &str, path: &str) -> bool {
+    if path == "/mcp"
+        || path.starts_with("/api/plugins")
+        || (method == "POST"
+            && (path == "/mesh/hook"
+                || path == "/api/objects"
+                || path.starts_with("/api/objects/")))
+    {
+        return true;
+    }
+
+    matches!(
+        (method, path),
+        ("GET", "/api/runtime/config-schema")
+            | ("GET", "/api/runtime/config-control-state")
+            | ("GET", "/api/runtime/control-bootstrap")
+            | ("POST", "/api/runtime/control/get-config")
+            | ("POST", "/api/runtime/control/refresh-inventory")
+            | ("POST", "/api/runtime/control/apply-config")
+            | ("POST", "/api/runtime/config/validate")
+            | ("POST", "/api/runtime/mesh-guardrails")
+            | ("POST", "/api/runtime/models")
+            | ("POST", "/api/model-interests")
+    ) || (method == "DELETE"
+        && (path.starts_with("/api/runtime/models/")
+            || path.starts_with("/api/runtime/instances/")
+            || path.starts_with("/api/model-interests/")))
+}
+
+pub(crate) fn is_trusted_local_request(
+    peer_addr: Option<SocketAddr>,
+    origin: Option<&str>,
+    host: Option<&str>,
+) -> bool {
+    let Some(peer_addr) = peer_addr else {
+        return false;
+    };
+    if !is_loopback_ip(peer_addr.ip()) {
+        return false;
+    }
+
+    host.is_none_or(is_trusted_local_authority) && origin.is_none_or(is_trusted_local_origin)
+}
+
+pub(crate) fn request_origin(raw_request: &[u8]) -> Option<&str> {
+    request_header(raw_request, "origin")
+}
+
+pub(crate) fn request_host(raw_request: &[u8]) -> Option<&str> {
+    request_header(raw_request, "host")
+}
+
+fn request_header<'a>(raw_request: &'a [u8], name: &str) -> Option<&'a str> {
+    let mut headers = [httparse::EMPTY_HEADER; 64];
+    let mut request = httparse::Request::new(&mut headers);
+    request.parse(raw_request).ok()?;
+    request.headers.iter().find_map(|header| {
+        header
+            .name
+            .eq_ignore_ascii_case(name)
+            .then(|| std::str::from_utf8(header.value).ok())
+            .flatten()
+    })
+}
+
+fn is_loopback_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => ip.is_loopback(),
+        IpAddr::V6(ip) => {
+            ip.is_loopback()
+                || ip
+                    .to_ipv4_mapped()
+                    .is_some_and(|mapped| mapped.is_loopback())
+        }
+    }
+}
+
+fn is_trusted_local_origin(origin: &str) -> bool {
+    let Ok(origin) = url::Url::parse(origin.trim()) else {
+        return false;
+    };
+    if !matches!(origin.scheme(), "http" | "https") {
+        return false;
+    }
+    origin
+        .host_str()
+        .is_some_and(|host| host.eq_ignore_ascii_case("localhost") || is_loopback_host(host))
+}
+
+fn is_trusted_local_authority(authority: &str) -> bool {
+    let Ok(authority) = authority.trim().parse::<http::uri::Authority>() else {
+        return false;
+    };
+    let host = authority.host();
+    host.eq_ignore_ascii_case("localhost") || is_loopback_host(host)
+}
+
+fn is_loopback_host(host: &str) -> bool {
+    host.trim_matches(['[', ']'])
+        .parse::<IpAddr>()
+        .is_ok_and(is_loopback_ip)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sensitive_management_routes_require_trusted_local_access() {
+        for (method, path) in [
+            ("POST", "/mcp"),
+            ("GET", "/api/plugins"),
+            ("POST", "/api/plugins/agents/tools/run"),
+            ("POST", "/api/objects"),
+            ("POST", "/api/objects/complete"),
+            ("POST", "/mesh/hook"),
+            ("POST", "/api/runtime/models"),
+            ("DELETE", "/api/runtime/models/qwen"),
+            ("DELETE", "/api/runtime/instances/instance-1"),
+            ("POST", "/api/runtime/mesh-guardrails"),
+            ("POST", "/api/model-interests"),
+            ("DELETE", "/api/model-interests/qwen"),
+        ] {
+            assert!(
+                requires_trusted_local_access(method, path),
+                "{method} {path} must be local-only"
+            );
+        }
+    }
+
+    #[test]
+    fn read_only_status_routes_remain_network_accessible() {
+        for path in [
+            "/api/status",
+            "/api/models",
+            "/api/runtime",
+            "/api/events",
+            "/api/discover",
+        ] {
+            assert!(
+                !requires_trusted_local_access("GET", path),
+                "GET {path} should remain readable"
+            );
+        }
+    }
+
+    #[test]
+    fn non_loopback_callers_are_rejected() {
+        assert!(!is_trusted_local_request(
+            Some(SocketAddr::from(([192, 0, 2, 10], 40123))),
+            None,
+            Some("localhost:3131")
+        ));
+    }
+
+    #[test]
+    fn browser_requests_from_untrusted_origins_are_rejected() {
+        assert!(!is_trusted_local_request(
+            Some(SocketAddr::from(([127, 0, 0, 1], 40123))),
+            Some("https://attacker.example"),
+            Some("localhost:3131")
+        ));
+        assert!(!is_trusted_local_request(
+            Some(SocketAddr::from(([127, 0, 0, 1], 40123))),
+            Some("null"),
+            Some("localhost:3131")
+        ));
+        assert!(!is_trusted_local_request(
+            Some(SocketAddr::from(([127, 0, 0, 1], 40123))),
+            None,
+            Some("attacker.example")
+        ));
+    }
+
+    #[test]
+    fn origin_header_is_extracted_case_insensitively() {
+        let request = b"POST /mcp HTTP/1.1\r\nHost: localhost\r\noRiGiN: https://attacker.example\r\nContent-Length: 0\r\n\r\n";
+        assert_eq!(request_origin(request), Some("https://attacker.example"));
+    }
+
+    #[test]
+    fn trusted_local_callers_are_allowed() {
+        let peer = Some(SocketAddr::from(([127, 0, 0, 1], 40123)));
+        assert!(is_trusted_local_request(peer, None, Some("localhost:3131")));
+        assert!(is_trusted_local_request(
+            peer,
+            Some("http://localhost:3131"),
+            Some("localhost:3131")
+        ));
+        assert!(is_trusted_local_request(
+            peer,
+            Some("http://127.0.0.1:3131"),
+            Some("127.0.0.1:3131")
+        ));
+        assert!(is_trusted_local_request(
+            Some(SocketAddr::from(([0, 0, 0, 0, 0, 0, 0, 1], 40123))),
+            Some("http://[::1]:3131"),
+            Some("[::1]:3131")
+        ));
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/api/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/mod.rs
@@ -43,6 +43,7 @@
 //! and `/api/models` per-model `routing_metrics.targets` are measured on the
 //! current node only; not mesh-wide aggregates.
 
+mod access;
 mod assets;
 mod http;
 mod model_target_capacity;

--- a/crates/mesh-llm-host-runtime/src/api/server.rs
+++ b/crates/mesh-llm-host-runtime/src/api/server.rs
@@ -221,20 +221,21 @@ pub(crate) async fn handle_request(mut stream: TcpStream, state: &MeshApi) -> an
         return Ok(());
     }
 
-    if requires_trusted_local_access(method, path_only)
-        && !is_trusted_local_request(
-            source_addr,
-            request_origin(&request.raw),
-            request_host(&request.raw),
-        )
-    {
-        respond_error(
-            &mut stream,
-            403,
-            "This management route requires a trusted local caller",
-        )
-        .await?;
-        return Ok(());
+    if requires_trusted_local_access(method, path_only) {
+        let trusted_local_request = match (request_origin(&request.raw), request_host(&request.raw))
+        {
+            (Ok(origin), Ok(host)) => is_trusted_local_request(source_addr, origin, host),
+            _ => false,
+        };
+        if !trusted_local_request {
+            respond_error(
+                &mut stream,
+                403,
+                "This management route requires a trusted local caller",
+            )
+            .await?;
+            return Ok(());
+        }
     }
 
     match (method, path_only) {

--- a/crates/mesh-llm-host-runtime/src/api/server.rs
+++ b/crates/mesh-llm-host-runtime/src/api/server.rs
@@ -1,5 +1,8 @@
 use super::{
     MeshApi,
+    access::{
+        is_trusted_local_request, request_host, request_origin, requires_trusted_local_access,
+    },
     assets::{respond_console_asset, respond_console_index},
     http::{http_body_text, respond_error},
     routes::dispatch_request,
@@ -215,6 +218,22 @@ pub(crate) async fn handle_request(mut stream: TcpStream, state: &MeshApi) -> an
 
     if method == "GET" && state.is_headless().await && is_ui_only_route(path_only) {
         respond_error(&mut stream, 404, "Not found").await?;
+        return Ok(());
+    }
+
+    if requires_trusted_local_access(method, path_only)
+        && !is_trusted_local_request(
+            source_addr,
+            request_origin(&request.raw),
+            request_host(&request.raw),
+        )
+    {
+        respond_error(
+            &mut stream,
+            403,
+            "This management route requires a trusted local caller",
+        )
+        .await?;
         return Ok(());
     }
 

--- a/crates/mesh-llm-host-runtime/src/api/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests.rs
@@ -2709,6 +2709,43 @@ async fn management_mcp_endpoint_initializes_streamable_http_session() {
 }
 
 #[tokio::test]
+async fn management_mcp_endpoint_rejects_cross_origin_browser_requests() {
+    let state = build_test_mesh_api().await;
+    let (addr, handle) = spawn_management_test_server(state).await;
+    let response = send_management_request(
+        addr,
+        "POST /mcp HTTP/1.1\r\n\
+         Host: localhost\r\n\
+         Origin: https://attacker.example\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: 2\r\n\r\n{}"
+            .to_string(),
+    )
+    .await;
+
+    assert!(response.starts_with("HTTP/1.1 403"), "{response}");
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
+async fn management_mcp_endpoint_rejects_dns_rebinding_host_headers() {
+    let state = build_test_mesh_api().await;
+    let (addr, handle) = spawn_management_test_server(state).await;
+    let response = send_management_request(
+        addr,
+        "POST /mcp HTTP/1.1\r\n\
+         Host: attacker.example\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: 2\r\n\r\n{}"
+            .to_string(),
+    )
+    .await;
+
+    assert!(response.starts_with("HTTP/1.1 403"), "{response}");
+    handle.await.unwrap().unwrap();
+}
+
+#[tokio::test]
 async fn runtime_data_sse_bridge_delivers_initial_and_incremental_updates() {
     let state = build_test_mesh_api().await;
     let (addr, handle) = spawn_management_test_server(state.clone()).await;

--- a/crates/mesh-llm-plugin-manager/Cargo.toml
+++ b/crates/mesh-llm-plugin-manager/Cargo.toml
@@ -20,6 +20,7 @@ mesh-llm-skills.workspace = true
 reqwest = { version = "0.12", features = ["json", "stream"] }
 serde.workspace = true
 serde_json.workspace = true
+sha2.workspace = true
 tar = "0.4"
 tempfile = "3"
 zip = { version = "2", default-features = false, features = ["deflate"] }

--- a/crates/mesh-llm-plugin-manager/src/github.rs
+++ b/crates/mesh-llm-plugin-manager/src/github.rs
@@ -123,4 +123,6 @@ pub struct GitHubReleaseAsset {
     pub browser_download_url: String,
     #[serde(default)]
     pub size: Option<u64>,
+    #[serde(default)]
+    pub digest: Option<String>,
 }

--- a/crates/mesh-llm-plugin-manager/src/install.rs
+++ b/crates/mesh-llm-plugin-manager/src/install.rs
@@ -3,6 +3,7 @@ use std::{fs, io::Write, path::PathBuf};
 use anyhow::{Context, Result, bail};
 use futures_util::StreamExt;
 use reqwest::Client;
+use sha2::Digest;
 
 use crate::{
     archive::{ExtractedPluginArchive, extract_plugin_archive},
@@ -340,6 +341,7 @@ async fn download_asset(
     asset: &GitHubReleaseAsset,
     progress: &mut impl PluginProgressReporter,
 ) -> Result<PathBuf> {
+    required_plugin_asset_sha256(asset)?;
     progress.report(PluginProgressEvent::DownloadStarted {
         asset: asset.name.clone(),
         total_bytes: asset.size,
@@ -355,29 +357,61 @@ async fn download_asset(
         bail!("plugin asset download failed: {status} {}", asset.name);
     }
 
-    let temp = tempfile::Builder::new()
+    let mut temp = tempfile::Builder::new()
         .prefix("mesh-plugin-asset-")
         .suffix(&format!("-{}", asset.name))
         .tempfile()
         .context("create plugin asset temp file")?;
-    let (mut file, path) = temp.keep().context("persist plugin asset temp path")?;
 
     let mut downloaded = 0u64;
+    let mut hasher = sha2::Sha256::new();
     let mut stream = response.bytes_stream();
     while let Some(chunk) = stream.next().await {
         let chunk = chunk.with_context(|| format!("read plugin asset {}", asset.name))?;
         downloaded += chunk.len() as u64;
-        file.write_all(&chunk)
-            .with_context(|| format!("write plugin asset temp file {}", path.display()))?;
+        temp.write_all(&chunk)
+            .with_context(|| format!("write plugin asset temp file {}", temp.path().display()))?;
+        hasher.update(&chunk);
         progress.report(PluginProgressEvent::DownloadProgress {
             downloaded_bytes: downloaded,
             total_bytes: asset.size,
         });
     }
+    temp.flush()
+        .with_context(|| format!("flush plugin asset temp file {}", temp.path().display()))?;
+    verify_plugin_asset_checksum(asset, hasher)?;
+    let (_file, path) = temp.keep().context("persist plugin asset temp path")?;
     progress.report(PluginProgressEvent::DownloadFinished {
         asset: asset.name.clone(),
     });
     Ok(path)
+}
+
+fn verify_plugin_asset_checksum(asset: &GitHubReleaseAsset, hasher: sha2::Sha256) -> Result<()> {
+    let expected = required_plugin_asset_sha256(asset)?;
+    let actual = format!("{:x}", hasher.finalize());
+    if actual != expected {
+        bail!(
+            "plugin asset checksum mismatch for {}: expected {expected}, got {actual}",
+            asset.name
+        );
+    }
+    Ok(())
+}
+
+fn required_plugin_asset_sha256(asset: &GitHubReleaseAsset) -> Result<String> {
+    let digest = asset
+        .digest
+        .as_deref()
+        .with_context(|| format!("plugin asset {} is missing a GitHub digest", asset.name))?;
+    let Some(sha256) = digest.trim().strip_prefix("sha256:") else {
+        bail!("plugin asset {} digest must use sha256", asset.name);
+    };
+    let sha256 = sha256.to_ascii_lowercase();
+    if sha256.len() != 64 || !sha256.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        bail!("plugin asset {} has an invalid sha256 digest", asset.name);
+    }
+    Ok(sha256)
 }
 
 #[cfg(test)]
@@ -616,6 +650,7 @@ mod tests {
             name: "demo-v1.0.0-aarch64-apple-darwin.tar.gz".to_string(),
             browser_download_url: "https://example.invalid/demo.tar.gz".to_string(),
             size: Some(123),
+            digest: None,
         };
 
         let metadata = build_installed_metadata(
@@ -741,5 +776,42 @@ mod tests {
             Some(PluginProgressEvent::Installed { name, version })
                 if name == "demo" && version == "0.1.0-dev"
         ));
+    }
+
+    #[test]
+    fn modified_plugin_asset_is_rejected_before_extraction() {
+        let expected = format!("{:x}", sha2::Sha256::digest(b"expected plugin archive"));
+        let asset = GitHubReleaseAsset {
+            name: "demo.tar.gz".to_string(),
+            browser_download_url: "https://example.invalid/demo.tar.gz".to_string(),
+            size: None,
+            digest: Some(format!("sha256:{expected}")),
+        };
+        let mut hasher = sha2::Sha256::new();
+        hasher.update(b"modified plugin archive");
+
+        let error = verify_plugin_asset_checksum(&asset, hasher)
+            .expect_err("modified plugin asset must fail verification");
+        assert!(error.to_string().contains("checksum mismatch"), "{error:?}");
+    }
+
+    #[test]
+    fn plugin_assets_without_valid_github_digests_are_rejected() {
+        let mut asset = GitHubReleaseAsset {
+            name: "demo.tar.gz".to_string(),
+            browser_download_url: "https://example.invalid/demo.tar.gz".to_string(),
+            size: None,
+            digest: None,
+        };
+        let missing = required_plugin_asset_sha256(&asset).unwrap_err();
+        assert!(missing.to_string().contains("missing a GitHub digest"));
+
+        asset.digest = Some("sha512:abc".to_string());
+        let wrong_algorithm = required_plugin_asset_sha256(&asset).unwrap_err();
+        assert!(wrong_algorithm.to_string().contains("must use sha256"));
+
+        asset.digest = Some("sha256:not-a-digest".to_string());
+        let malformed = required_plugin_asset_sha256(&asset).unwrap_err();
+        assert!(malformed.to_string().contains("invalid sha256"));
     }
 }

--- a/crates/mesh-llm-plugin/Cargo.toml
+++ b/crates/mesh-llm-plugin/Cargo.toml
@@ -14,7 +14,7 @@ workspace = true
 anyhow = "1"
 async-trait = "0.1"
 prost = "0.14"
-rmcp = { version = "1.2", features = ["server"] }
+rmcp = { version = "1.8", features = ["server"] }
 schemars = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/mesh-llm-runtime-install/src/lib.rs
+++ b/crates/mesh-llm-runtime-install/src/lib.rs
@@ -280,6 +280,7 @@ fn installed_outcome(
 }
 
 async fn download_release_manifest(url: &str) -> Result<NativeRuntimeReleaseManifest> {
+    let diagnostic_url = url_without_query(url);
     let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(60))
         .build()
@@ -289,32 +290,39 @@ async fn download_release_manifest(url: &str) -> Result<NativeRuntimeReleaseMani
         .header("User-Agent", "mesh-llm")
         .send()
         .await
-        .with_context(|| format!("download native runtime release manifest {url}"))?
+        .with_context(|| format!("download native runtime release manifest {diagnostic_url}"))?
         .error_for_status()
-        .with_context(|| format!("native runtime release manifest request failed for {url}"))?
+        .with_context(|| {
+            format!("native runtime release manifest request failed for {diagnostic_url}")
+        })?
         .bytes()
         .await
-        .with_context(|| format!("read native runtime release manifest {url}"))?;
+        .with_context(|| format!("read native runtime release manifest {diagnostic_url}"))?;
     let checksum_url = release_manifest_checksum_url(url);
+    let diagnostic_checksum_url = url_without_query(&checksum_url);
     let checksum = client
         .get(&checksum_url)
         .header("User-Agent", "mesh-llm")
         .send()
         .await
-        .with_context(|| format!("download native runtime manifest checksum {checksum_url}"))?
+        .with_context(|| {
+            format!("download native runtime manifest checksum {diagnostic_checksum_url}")
+        })?
         .error_for_status()
         .with_context(|| {
-            format!("native runtime manifest checksum request failed for {checksum_url}")
+            format!("native runtime manifest checksum request failed for {diagnostic_checksum_url}")
         })?
         .text()
         .await
-        .with_context(|| format!("read native runtime manifest checksum {checksum_url}"))?;
+        .with_context(|| {
+            format!("read native runtime manifest checksum {diagnostic_checksum_url}")
+        })?;
     verify_release_manifest_checksum(&bytes, &checksum)
-        .with_context(|| format!("verify native runtime release manifest {url}"))?;
+        .with_context(|| format!("verify native runtime release manifest {diagnostic_url}"))?;
     let text = std::str::from_utf8(&bytes)
-        .with_context(|| format!("decode native runtime release manifest {url}"))?;
+        .with_context(|| format!("decode native runtime release manifest {diagnostic_url}"))?;
     NativeRuntimeReleaseManifest::from_json_str(text)
-        .with_context(|| format!("parse native runtime release manifest {url}"))
+        .with_context(|| format!("parse native runtime release manifest {diagnostic_url}"))
 }
 
 fn verify_release_manifest_checksum(manifest_bytes: &[u8], checksum_text: &str) -> Result<()> {
@@ -331,6 +339,10 @@ fn release_manifest_checksum_url(url: &str) -> String {
         Some((base, query)) => format!("{base}.sha256?{query}"),
         None => format!("{url}.sha256"),
     }
+}
+
+fn url_without_query(url: &str) -> &str {
+    url.split_once('?').map_or(url, |(base, _)| base)
 }
 
 async fn download_and_install_runtime(
@@ -607,6 +619,18 @@ mod tests {
                 "https://example.invalid/native-runtimes.json?token=secret"
             ),
             "https://example.invalid/native-runtimes.json.sha256?token=secret"
+        );
+    }
+
+    #[test]
+    fn manifest_diagnostic_urls_redact_query_parameters() {
+        assert_eq!(
+            url_without_query("https://example.invalid/native-runtimes.json?token=secret"),
+            "https://example.invalid/native-runtimes.json"
+        );
+        assert_eq!(
+            url_without_query("https://example.invalid/native-runtimes.json"),
+            "https://example.invalid/native-runtimes.json"
         );
     }
 

--- a/crates/mesh-llm-runtime-install/src/lib.rs
+++ b/crates/mesh-llm-runtime-install/src/lib.rs
@@ -290,13 +290,16 @@ async fn download_release_manifest(url: &str) -> Result<NativeRuntimeReleaseMani
         .header("User-Agent", "mesh-llm")
         .send()
         .await
+        .map_err(reqwest::Error::without_url)
         .with_context(|| format!("download native runtime release manifest {diagnostic_url}"))?
         .error_for_status()
+        .map_err(reqwest::Error::without_url)
         .with_context(|| {
             format!("native runtime release manifest request failed for {diagnostic_url}")
         })?
         .bytes()
         .await
+        .map_err(reqwest::Error::without_url)
         .with_context(|| format!("read native runtime release manifest {diagnostic_url}"))?;
     let checksum_url = release_manifest_checksum_url(url);
     let diagnostic_checksum_url = url_without_query(&checksum_url);
@@ -305,15 +308,18 @@ async fn download_release_manifest(url: &str) -> Result<NativeRuntimeReleaseMani
         .header("User-Agent", "mesh-llm")
         .send()
         .await
+        .map_err(reqwest::Error::without_url)
         .with_context(|| {
             format!("download native runtime manifest checksum {diagnostic_checksum_url}")
         })?
         .error_for_status()
+        .map_err(reqwest::Error::without_url)
         .with_context(|| {
             format!("native runtime manifest checksum request failed for {diagnostic_checksum_url}")
         })?
         .text()
         .await
+        .map_err(reqwest::Error::without_url)
         .with_context(|| {
             format!("read native runtime manifest checksum {diagnostic_checksum_url}")
         })?;

--- a/crates/mesh-llm-runtime-install/src/lib.rs
+++ b/crates/mesh-llm-runtime-install/src/lib.rs
@@ -280,10 +280,11 @@ fn installed_outcome(
 }
 
 async fn download_release_manifest(url: &str) -> Result<NativeRuntimeReleaseManifest> {
-    let text = reqwest::Client::builder()
+    let client = reqwest::Client::builder()
         .timeout(Duration::from_secs(60))
         .build()
-        .context("build native runtime manifest HTTP client")?
+        .context("build native runtime manifest HTTP client")?;
+    let bytes = client
         .get(url)
         .header("User-Agent", "mesh-llm")
         .send()
@@ -291,11 +292,45 @@ async fn download_release_manifest(url: &str) -> Result<NativeRuntimeReleaseMani
         .with_context(|| format!("download native runtime release manifest {url}"))?
         .error_for_status()
         .with_context(|| format!("native runtime release manifest request failed for {url}"))?
-        .text()
+        .bytes()
         .await
         .with_context(|| format!("read native runtime release manifest {url}"))?;
-    NativeRuntimeReleaseManifest::from_json_str(&text)
+    let checksum_url = release_manifest_checksum_url(url);
+    let checksum = client
+        .get(&checksum_url)
+        .header("User-Agent", "mesh-llm")
+        .send()
+        .await
+        .with_context(|| format!("download native runtime manifest checksum {checksum_url}"))?
+        .error_for_status()
+        .with_context(|| {
+            format!("native runtime manifest checksum request failed for {checksum_url}")
+        })?
+        .text()
+        .await
+        .with_context(|| format!("read native runtime manifest checksum {checksum_url}"))?;
+    verify_release_manifest_checksum(&bytes, &checksum)
+        .with_context(|| format!("verify native runtime release manifest {url}"))?;
+    let text = std::str::from_utf8(&bytes)
+        .with_context(|| format!("decode native runtime release manifest {url}"))?;
+    NativeRuntimeReleaseManifest::from_json_str(text)
         .with_context(|| format!("parse native runtime release manifest {url}"))
+}
+
+fn verify_release_manifest_checksum(manifest_bytes: &[u8], checksum_text: &str) -> Result<()> {
+    let expected = normalize_sha256(checksum_text)?;
+    let actual = hex::encode(sha2::Sha256::digest(manifest_bytes));
+    if actual != expected {
+        bail!("native runtime manifest checksum mismatch: expected {expected}, got {actual}");
+    }
+    Ok(())
+}
+
+fn release_manifest_checksum_url(url: &str) -> String {
+    match url.split_once('?') {
+        Some((base, query)) => format!("{base}.sha256?{query}"),
+        None => format!("{url}.sha256"),
+    }
 }
 
 async fn download_and_install_runtime(
@@ -552,6 +587,35 @@ mod tests {
             err.to_string().contains("missing required sha256"),
             "{err:?}"
         );
+    }
+
+    #[test]
+    fn modified_release_manifest_is_rejected_before_parsing() {
+        let expected = hex::encode(sha2::Sha256::digest(b"expected manifest"));
+        let error = verify_release_manifest_checksum(
+            b"modified manifest",
+            &format!("{expected}  native-runtimes.json"),
+        )
+        .expect_err("modified release manifest must fail verification");
+        assert!(error.to_string().contains("checksum mismatch"), "{error:?}");
+    }
+
+    #[test]
+    fn release_manifest_checksum_url_preserves_query_parameters() {
+        assert_eq!(
+            release_manifest_checksum_url(
+                "https://example.invalid/native-runtimes.json?token=secret"
+            ),
+            "https://example.invalid/native-runtimes.json.sha256?token=secret"
+        );
+    }
+
+    #[test]
+    fn matching_release_manifest_checksum_is_accepted() {
+        let manifest = b"{\"mesh_version\":\"0.73.1\"}";
+        let expected = hex::encode(sha2::Sha256::digest(manifest));
+        verify_release_manifest_checksum(manifest, &format!("{expected}  native-runtimes.json"))
+            .unwrap();
     }
 
     #[test]

--- a/crates/mesh-llm-system/src/autoupdate.rs
+++ b/crates/mesh-llm-system/src/autoupdate.rs
@@ -32,10 +32,16 @@ enum PostInstallAction {
     ExitAfterInstall,
 }
 
+#[derive(Clone, Debug)]
+struct ReleaseAsset {
+    name: String,
+    sha256: String,
+}
+
 struct ReleaseInfo {
     tag: String,
     version: String,
-    assets: Vec<String>,
+    assets: Vec<ReleaseAsset>,
 }
 
 struct UpdateTarget {
@@ -93,7 +99,7 @@ pub async fn check_for_update(current_version: &str) {
             })
         });
         match bundle_asset {
-            Some(ref asset) if release.assets.iter().any(|a| a == asset) => {
+            Some(ref asset) if release.assets.iter().any(|a| &a.name == asset) => {
                 eprintln!(
                     "✨ New version: v{current_version} -> v{}. Run 'mesh-llm update'.",
                     release.version
@@ -460,7 +466,7 @@ fn resolve_release_asset_name(
             release
                 .assets
                 .iter()
-                .any(|candidate| candidate == asset_name)
+                .any(|candidate| candidate.name == *asset_name)
         })
 }
 
@@ -769,7 +775,11 @@ fn release_info_from_json(body: &serde_json::Value) -> Option<ReleaseInfo> {
         .map(|items| {
             items
                 .iter()
-                .filter_map(|item| item["name"].as_str().map(str::to_string))
+                .filter_map(|item| {
+                    let name = item["name"].as_str()?.to_string();
+                    let sha256 = github_release_asset_sha256(item)?;
+                    Some(ReleaseAsset { name, sha256 })
+                })
                 .collect::<Vec<_>>()
         })
         .unwrap_or_default();
@@ -779,6 +789,36 @@ fn release_info_from_json(body: &serde_json::Value) -> Option<ReleaseInfo> {
         version: version.to_string(),
         assets,
     })
+}
+
+fn github_release_asset_sha256(asset: &serde_json::Value) -> Option<String> {
+    normalize_github_sha256(asset["digest"].as_str()?).ok()
+}
+
+fn normalize_github_sha256(value: &str) -> Result<String> {
+    let Some(digest) = value.trim().strip_prefix("sha256:") else {
+        bail!("GitHub release asset digest must use sha256");
+    };
+    let digest = digest.to_ascii_lowercase();
+    if digest.len() != 64 || !digest.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        bail!("GitHub release asset has an invalid sha256 digest");
+    }
+    Ok(digest)
+}
+
+fn verify_release_asset_bytes(bytes: &[u8], expected_sha256: &str) -> Result<()> {
+    use sha2::Digest;
+
+    let expected = normalize_github_sha256(&format!("sha256:{expected_sha256}"))?;
+    let actual = hex::encode(sha2::Sha256::digest(bytes));
+    if actual != expected {
+        bail!("release asset checksum mismatch: expected {expected}, got {actual}");
+    }
+    Ok(())
+}
+
+fn release_asset<'a>(release: &'a ReleaseInfo, name: &str) -> Option<&'a ReleaseAsset> {
+    release.assets.iter().find(|asset| asset.name == name)
 }
 
 async fn resolve_release_info(requested_version: Option<&str>) -> Result<Option<ReleaseInfo>> {
@@ -880,7 +920,14 @@ async fn install_latest_bundle(
         .with_context(|| format!("Failed to create update workspace {}", workspace.display()))?;
 
     let result = async {
-        download_url(&release_asset_url(&release.tag, asset_name), &archive).await?;
+        let asset = release_asset(release, asset_name)
+            .with_context(|| format!("Release asset metadata missing for {asset_name}"))?;
+        download_url(
+            &release_asset_url(&release.tag, asset_name),
+            &archive,
+            &asset.sha256,
+        )
+        .await?;
         extract_bundle_archive(&archive, &extracted)?;
         let staged_files = collect_bundle_files(&extracted, expected_flavor)?;
         verify_staged_mesh_binary_version(&extracted, &release.version)?;
@@ -910,10 +957,14 @@ async fn install_native_runtime_after_update(
     release: &ReleaseInfo,
     workspace: &Path,
 ) {
+    let Some(asset) = release_asset(release, "native-runtimes.json") else {
+        return;
+    };
     let manifest_path = workspace.join("native-runtimes.json");
     match download_optional_url(
         &release_asset_url(&release.tag, "native-runtimes.json"),
         &manifest_path,
+        &asset.sha256,
     )
     .await
     {
@@ -960,7 +1011,7 @@ async fn install_native_runtime_after_update(
 ) {
 }
 
-async fn download_optional_url(url: &str, path: &Path) -> Result<bool> {
+async fn download_optional_url(url: &str, path: &Path, expected_sha256: &str) -> Result<bool> {
     let response = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(60))
         .build()
@@ -979,12 +1030,14 @@ async fn download_optional_url(url: &str, path: &Path) -> Result<bool> {
         .bytes()
         .await
         .with_context(|| format!("Read optional release asset body from {url}"))?;
+    verify_release_asset_bytes(&bytes, expected_sha256)
+        .with_context(|| format!("Verify optional release asset {url}"))?;
     std::fs::write(path, &bytes)
         .with_context(|| format!("Write optional release asset {}", path.display()))?;
     Ok(true)
 }
 
-async fn download_url(url: &str, path: &Path) -> Result<()> {
+async fn download_url(url: &str, path: &Path, expected_sha256: &str) -> Result<()> {
     let response = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(300))
         .build()
@@ -1000,6 +1053,8 @@ async fn download_url(url: &str, path: &Path) -> Result<()> {
         .bytes()
         .await
         .with_context(|| format!("Read release asset body from {url}"))?;
+    verify_release_asset_bytes(&bytes, expected_sha256)
+        .with_context(|| format!("Verify release asset {url}"))?;
     std::fs::write(path, &bytes)
         .with_context(|| format!("Write release asset {}", path.display()))?;
     Ok(())
@@ -1517,6 +1572,13 @@ mod tests {
         path
     }
 
+    fn test_release_asset(name: impl Into<String>) -> ReleaseAsset {
+        ReleaseAsset {
+            name: name.into(),
+            sha256: "a".repeat(64),
+        }
+    }
+
     #[test]
     fn test_version_newer() {
         assert!(version_newer("0.33.1", "0.33.0"));
@@ -1657,7 +1719,9 @@ mod tests {
         let release = ReleaseInfo {
             tag: "v0.60.0".to_string(),
             version: "0.60.0".to_string(),
-            assets: vec!["mesh-llm-v0.60.0-x86_64-pc-windows-msvc.zip".to_string()],
+            assets: vec![test_release_asset(
+                "mesh-llm-v0.60.0-x86_64-pc-windows-msvc.zip",
+            )],
         };
         assert!(release_has_any_platform_asset(
             &release, "windows", "x86_64"
@@ -1686,7 +1750,7 @@ mod tests {
         let published_release = ReleaseInfo {
             tag: "v0.60.0".to_string(),
             version: "0.60.0".to_string(),
-            assets: vec![stable_asset],
+            assets: vec![test_release_asset(stable_asset)],
         };
         assert!(release_has_any_platform_asset(
             &published_release,
@@ -1725,8 +1789,8 @@ mod tests {
             tag: "v0.60.0".to_string(),
             version: "0.60.0".to_string(),
             assets: vec![
-                "mesh-llm-aarch64-unknown-linux-gnu.tar.gz".to_string(),
-                "mesh-llm-v0.60.0-aarch64-unknown-linux-gnu.tar.gz".to_string(),
+                test_release_asset("mesh-llm-aarch64-unknown-linux-gnu.tar.gz"),
+                test_release_asset("mesh-llm-v0.60.0-aarch64-unknown-linux-gnu.tar.gz"),
             ],
         };
 
@@ -1745,7 +1809,9 @@ mod tests {
         let release = ReleaseInfo {
             tag: "v0.60.0".to_string(),
             version: "0.60.0".to_string(),
-            assets: vec!["mesh-llm-v0.60.0-aarch64-unknown-linux-gnu.tar.gz".to_string()],
+            assets: vec![test_release_asset(
+                "mesh-llm-v0.60.0-aarch64-unknown-linux-gnu.tar.gz",
+            )],
         };
 
         assert_eq!(
@@ -1764,8 +1830,8 @@ mod tests {
             tag: "v0.60.0".to_string(),
             version: "0.60.0".to_string(),
             assets: vec![
-                "mesh-llm-aarch64-unknown-linux-gnu.tar.gz".to_string(),
-                "mesh-llm-v0.60.0-aarch64-unknown-linux-gnu.tar.gz".to_string(),
+                test_release_asset("mesh-llm-aarch64-unknown-linux-gnu.tar.gz"),
+                test_release_asset("mesh-llm-v0.60.0-aarch64-unknown-linux-gnu.tar.gz"),
             ],
         };
 
@@ -1784,7 +1850,9 @@ mod tests {
         let release = ReleaseInfo {
             tag: "v0.60.0".to_string(),
             version: "0.60.0".to_string(),
-            assets: vec!["mesh-llm-aarch64-unknown-linux-gnu.tar.gz".to_string()],
+            assets: vec![test_release_asset(
+                "mesh-llm-aarch64-unknown-linux-gnu.tar.gz",
+            )],
         };
 
         assert_eq!(
@@ -1825,6 +1893,57 @@ mod tests {
                 .contains("contains mesh-llm v0.68.0; refusing to install")
         );
         let _ = std::fs::remove_dir_all(dir);
+    }
+
+    #[test]
+    fn github_release_asset_digest_is_required_and_validated() {
+        let digest = "a".repeat(64);
+        let asset = serde_json::json!({
+            "name": "mesh-llm-aarch64-apple-darwin.tar.gz",
+            "digest": format!("sha256:{digest}")
+        });
+        assert_eq!(github_release_asset_sha256(&asset), Some(digest));
+
+        let missing = serde_json::json!({
+            "name": "mesh-llm-aarch64-apple-darwin.tar.gz"
+        });
+        assert_eq!(github_release_asset_sha256(&missing), None);
+    }
+
+    #[test]
+    fn release_metadata_excludes_assets_without_valid_github_digests() {
+        let valid_digest = "b".repeat(64);
+        let release = release_info_from_json(&serde_json::json!({
+            "tag_name": "v0.73.1",
+            "assets": [
+                {
+                    "name": "verified.tar.gz",
+                    "digest": format!("sha256:{valid_digest}")
+                },
+                {
+                    "name": "missing.tar.gz"
+                },
+                {
+                    "name": "invalid.tar.gz",
+                    "digest": "sha256:not-a-digest"
+                }
+            ]
+        }))
+        .unwrap();
+
+        assert_eq!(release.assets.len(), 1);
+        assert_eq!(release.assets[0].name, "verified.tar.gz");
+        assert_eq!(release.assets[0].sha256, valid_digest);
+    }
+
+    #[test]
+    fn modified_release_asset_is_rejected_before_execution() {
+        use sha2::Digest;
+
+        let expected = hex::encode(sha2::Sha256::digest(b"expected release archive"));
+        let error = verify_release_asset_bytes(b"modified release archive", &expected)
+            .expect_err("modified release asset must fail verification");
+        assert!(error.to_string().contains("checksum mismatch"), "{error:?}");
     }
 
     #[test]

--- a/crates/mesh-llm-system/src/autoupdate.rs
+++ b/crates/mesh-llm-system/src/autoupdate.rs
@@ -9,6 +9,12 @@ use std::path::{Path, PathBuf};
 use crate::backend;
 use crate::release_target::ReleaseTarget;
 
+mod release_integrity;
+
+use release_integrity::{
+    ReleaseAsset, github_release_asset_sha256, release_asset, verify_release_asset_bytes,
+};
+
 const DEFAULT_RELEASE_REPO: &str = "Mesh-LLM/mesh-llm";
 #[cfg(not(windows))]
 const INSTALL_SCRIPT_URL: &str =
@@ -30,12 +36,6 @@ enum InstallOutcome {
 enum PostInstallAction {
     RestartCurrentProcess,
     ExitAfterInstall,
-}
-
-#[derive(Clone, Debug)]
-struct ReleaseAsset {
-    name: String,
-    sha256: String,
 }
 
 struct ReleaseInfo {
@@ -789,36 +789,6 @@ fn release_info_from_json(body: &serde_json::Value) -> Option<ReleaseInfo> {
         version: version.to_string(),
         assets,
     })
-}
-
-fn github_release_asset_sha256(asset: &serde_json::Value) -> Option<String> {
-    normalize_github_sha256(asset["digest"].as_str()?).ok()
-}
-
-fn normalize_github_sha256(value: &str) -> Result<String> {
-    let Some(digest) = value.trim().strip_prefix("sha256:") else {
-        bail!("GitHub release asset digest must use sha256");
-    };
-    let digest = digest.to_ascii_lowercase();
-    if digest.len() != 64 || !digest.chars().all(|ch| ch.is_ascii_hexdigit()) {
-        bail!("GitHub release asset has an invalid sha256 digest");
-    }
-    Ok(digest)
-}
-
-fn verify_release_asset_bytes(bytes: &[u8], expected_sha256: &str) -> Result<()> {
-    use sha2::Digest;
-
-    let expected = normalize_github_sha256(&format!("sha256:{expected_sha256}"))?;
-    let actual = hex::encode(sha2::Sha256::digest(bytes));
-    if actual != expected {
-        bail!("release asset checksum mismatch: expected {expected}, got {actual}");
-    }
-    Ok(())
-}
-
-fn release_asset<'a>(release: &'a ReleaseInfo, name: &str) -> Option<&'a ReleaseAsset> {
-    release.assets.iter().find(|asset| asset.name == name)
 }
 
 async fn resolve_release_info(requested_version: Option<&str>) -> Result<Option<ReleaseInfo>> {
@@ -1893,57 +1863,6 @@ mod tests {
                 .contains("contains mesh-llm v0.68.0; refusing to install")
         );
         let _ = std::fs::remove_dir_all(dir);
-    }
-
-    #[test]
-    fn github_release_asset_digest_is_required_and_validated() {
-        let digest = "a".repeat(64);
-        let asset = serde_json::json!({
-            "name": "mesh-llm-aarch64-apple-darwin.tar.gz",
-            "digest": format!("sha256:{digest}")
-        });
-        assert_eq!(github_release_asset_sha256(&asset), Some(digest));
-
-        let missing = serde_json::json!({
-            "name": "mesh-llm-aarch64-apple-darwin.tar.gz"
-        });
-        assert_eq!(github_release_asset_sha256(&missing), None);
-    }
-
-    #[test]
-    fn release_metadata_excludes_assets_without_valid_github_digests() {
-        let valid_digest = "b".repeat(64);
-        let release = release_info_from_json(&serde_json::json!({
-            "tag_name": "v0.73.1",
-            "assets": [
-                {
-                    "name": "verified.tar.gz",
-                    "digest": format!("sha256:{valid_digest}")
-                },
-                {
-                    "name": "missing.tar.gz"
-                },
-                {
-                    "name": "invalid.tar.gz",
-                    "digest": "sha256:not-a-digest"
-                }
-            ]
-        }))
-        .unwrap();
-
-        assert_eq!(release.assets.len(), 1);
-        assert_eq!(release.assets[0].name, "verified.tar.gz");
-        assert_eq!(release.assets[0].sha256, valid_digest);
-    }
-
-    #[test]
-    fn modified_release_asset_is_rejected_before_execution() {
-        use sha2::Digest;
-
-        let expected = hex::encode(sha2::Sha256::digest(b"expected release archive"));
-        let error = verify_release_asset_bytes(b"modified release archive", &expected)
-            .expect_err("modified release asset must fail verification");
-        assert!(error.to_string().contains("checksum mismatch"), "{error:?}");
     }
 
     #[test]

--- a/crates/mesh-llm-system/src/autoupdate/release_integrity.rs
+++ b/crates/mesh-llm-system/src/autoupdate/release_integrity.rs
@@ -1,0 +1,93 @@
+use anyhow::{Result, bail};
+use sha2::Digest;
+
+#[derive(Clone, Debug)]
+pub(super) struct ReleaseAsset {
+    pub(super) name: String,
+    pub(super) sha256: String,
+}
+
+pub(super) fn github_release_asset_sha256(asset: &serde_json::Value) -> Option<String> {
+    normalize_github_sha256(asset["digest"].as_str()?).ok()
+}
+
+fn normalize_github_sha256(value: &str) -> Result<String> {
+    let Some(digest) = value.trim().strip_prefix("sha256:") else {
+        bail!("GitHub release asset digest must use sha256");
+    };
+    let digest = digest.to_ascii_lowercase();
+    if digest.len() != 64 || !digest.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        bail!("GitHub release asset has an invalid sha256 digest");
+    }
+    Ok(digest)
+}
+
+pub(super) fn verify_release_asset_bytes(bytes: &[u8], expected_sha256: &str) -> Result<()> {
+    let expected = normalize_github_sha256(&format!("sha256:{expected_sha256}"))?;
+    let actual = hex::encode(sha2::Sha256::digest(bytes));
+    if actual != expected {
+        bail!("release asset checksum mismatch: expected {expected}, got {actual}");
+    }
+    Ok(())
+}
+
+pub(super) fn release_asset<'a>(
+    release: &'a super::ReleaseInfo,
+    name: &str,
+) -> Option<&'a ReleaseAsset> {
+    release.assets.iter().find(|asset| asset.name == name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn github_release_asset_digest_is_required_and_validated() {
+        let digest = "a".repeat(64);
+        let asset = serde_json::json!({
+            "name": "mesh-llm-aarch64-apple-darwin.tar.gz",
+            "digest": format!("sha256:{digest}")
+        });
+        assert_eq!(github_release_asset_sha256(&asset), Some(digest));
+
+        let missing = serde_json::json!({
+            "name": "mesh-llm-aarch64-apple-darwin.tar.gz"
+        });
+        assert_eq!(github_release_asset_sha256(&missing), None);
+    }
+
+    #[test]
+    fn release_metadata_excludes_assets_without_valid_github_digests() {
+        let valid_digest = "b".repeat(64);
+        let release = super::super::release_info_from_json(&serde_json::json!({
+            "tag_name": "v0.73.1",
+            "assets": [
+                {
+                    "name": "verified.tar.gz",
+                    "digest": format!("sha256:{valid_digest}")
+                },
+                {
+                    "name": "missing.tar.gz"
+                },
+                {
+                    "name": "invalid.tar.gz",
+                    "digest": "sha256:not-a-digest"
+                }
+            ]
+        }))
+        .unwrap();
+
+        assert_eq!(release.assets.len(), 1);
+        assert_eq!(release.assets[0].name, "verified.tar.gz");
+        assert_eq!(release.assets[0].sha256, valid_digest);
+    }
+
+    #[test]
+    fn modified_release_asset_is_rejected_before_execution() {
+        let expected = hex::encode(sha2::Sha256::digest(b"expected release archive"));
+        let error = verify_release_asset_bytes(b"modified release archive", &expected)
+            .expect_err("modified release asset must fail verification");
+        assert!(error.to_string().contains("checksum mismatch"), "{error:?}");
+    }
+}


### PR DESCRIPTION
## Summary

- restrict MCP, plugin execution, configuration, upload, and mutation routes to trusted loopback callers
- reject cross-origin browser requests and DNS-rebinding Host headers on sensitive management routes
- require and verify GitHub SHA-256 digests before installing update and plugin assets
- verify the native runtime release manifest before parsing it
- raise the explicit `rmcp` dependency floor to 1.8

## Why

The management listener combines read-only status endpoints with privileged MCP, plugin, and runtime-control operations. When exposed beyond loopback, those privileged routes did not have an equivalent caller boundary. Downloaded updates and plugin assets also reached extraction or execution without validating GitHub-provided asset digests, while the native runtime manifest was trusted before its artifact checksums were consumed.

Read-only status and discovery routes remain remotely accessible. Sensitive management routes now return `403` unless the TCP peer, Host header, and any Origin header all identify a trusted local caller.

Related to #1005.

## Validation

- `cargo test -p mesh-llm-host-runtime --lib` — 1,601 passed, 8 ignored
- `cargo test -p mesh-llm-system --lib` — 167 passed
- `cargo test -p mesh-llm-plugin-manager --lib` — 25 passed
- `cargo test -p mesh-llm-runtime-install --lib` — 13 passed
- focused MCP cross-origin and DNS-rebinding regression tests
- `cargo check` and warning-denying Clippy for affected crates and `mesh-llm`
- `cargo fmt --all --check`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Restricted sensitive management endpoints to trusted local callers only, returning HTTP 403 otherwise.
  * Added protections against cross-origin requests and DNS rebinding via strict `Origin`/`Host` validation.
* **Reliability**
  * Added SHA-256 integrity checks for plugin downloads, release manifests, and update assets.
  * Downloads now fail when expected digests are missing, malformed, or don’t match.
* **Maintenance**
  * Updated MCP-related components/dependencies and enhanced GitHub release asset digest handling for safer update flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->