### PR TITLE
chore: dispatch completed releases to packaging

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,49 +1,20 @@
-name: docker
+name: Docker client Dockerfile validation
 
 on:
   workflow_dispatch:
-  push:
-    tags: ['v*']
 
 concurrency:
   group: docker-${{ github.ref }}
   cancel-in-progress: false
 
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ vars.IMAGE_NAME || 'mesh-llm/mesh-llm' }}
-
 permissions:
   contents: read
-  packages: write
 
 jobs:
   docker-client:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
-      - name: Setup Blacksmith Builder
-        uses: useblacksmith/setup-docker-builder@v1
-      - uses: docker/login-action@v3
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - id: meta
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=semver,pattern={{version}}
-            type=sha,prefix=sha-,format=short
-            type=raw,value=latest,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=client,enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
-      - uses: useblacksmith/build-push-action@v2
-        with:
-          context: .
-          file: docker/Dockerfile.client
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+      - uses: docker/setup-buildx-action@v4
+      - name: Validate client Dockerfile
+        run: docker buildx build --check --file docker/Dockerfile.client .

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,6 +15,8 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
       - uses: docker/setup-buildx-action@v4
       - name: Validate client Dockerfile
         run: docker buildx build --check --file docker/Dockerfile.client .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1445,6 +1445,45 @@ jobs:
           overwrite_files: true
           files: release-artifacts/*
 
+  dispatch_packaging_release:
+    name: Dispatch package and image publishing
+    needs: [metadata, publish]
+    if: ${{ needs.publish.result == 'success' && needs.metadata.outputs.skip_gpu_bundles != 'true' }}
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch verified release to mesh-agent-images
+        env:
+          GH_TOKEN: ${{ secrets.MESH_AGENT_IMAGES_DISPATCH_TOKEN }}
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+          RELEASE_VERSION: ${{ needs.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          [[ -n "${GH_TOKEN:-}" ]] || {
+            echo "MESH_AGENT_IMAGES_DISPATCH_TOKEN is required for cross-repository packaging" >&2
+            exit 1
+          }
+          jq -n \
+            --arg repository "$GITHUB_REPOSITORY" \
+            --arg ref "$RELEASE_TAG" \
+            --arg version "$RELEASE_VERSION" \
+            '{
+              event_type: "mesh-llm-release",
+              client_payload: {
+                repository: $repository,
+                ref: $ref,
+                version: $version,
+                dry_run: false,
+                publish_images: true,
+                publish_release_assets: true
+              }
+            }' |
+            gh api \
+              --method POST \
+              repos/Mesh-LLM/mesh-agent-images/dispatches \
+              --input -
+
   publish_crates_preflight:
     name: Preflight crates.io packages
     needs: [metadata, publish]

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -7,9 +7,13 @@ Releases are normally cut by running the **Release** workflow
 `workflow_dispatch` with the version input (for example `v0.31.0`). The
 dispatched workflow bumps versions, generates and patches the SwiftPM
 manifest, packages SDK console assets, creates and pushes the release tag,
-builds all platform bundles, and publishes the GitHub release. Dispatch inputs
-include `skip_gpu_bundles` and `canary` (dry-run: build and smoke everything
-without publishing).
+builds all platform bundles, and publishes the GitHub release. After a complete
+non-canary release succeeds, it dispatches `Mesh-LLM/mesh-agent-images` to
+package the verified release archives, publish the native package release
+assets, and publish the supported GHCR image matrix. Dispatch inputs include
+`skip_gpu_bundles` and `canary` (dry-run: build and smoke everything without
+publishing). Releases that intentionally skip GPU bundles do not dispatch the
+full packaging matrix.
 
 The sections below document the underlying steps. They matter when releasing
 manually via a tag push, debugging the workflow, or validating bundles
@@ -22,6 +26,10 @@ locally.
 - `cmake` and a native compiler installed
 - Node/npm installed for the UI build
 - `gh` CLI authenticated if publishing manually
+- `MESH_AGENT_IMAGES_DISPATCH_TOKEN` configured as a fine-grained repository
+  token or GitHub App token with Contents write access to
+  `Mesh-LLM/mesh-agent-images`, which is the permission required to create a
+  repository dispatch event
 
 ## Release Attestation Signing Keys
 
@@ -167,7 +175,12 @@ Verify:
 
 ## Publish
 
-Push a `v*` tag to run `.github/workflows/release.yml`.
+Push a `v*` tag to run `.github/workflows/release.yml`. The upstream release
+workflow owns release archive production, but it does not publish OCI images.
+`Mesh-LLM/mesh-agent-images` is the canonical GHCR producer and starts only
+after the GitHub release and its complete archive set have published
+successfully. The upstream `docker.yml` workflow performs Dockerfile validation
+only and is not a distribution channel.
 
 On non-prerelease tags, the release workflow also publishes the Rust SDK crate
 chain to crates.io in dependency order:

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -116,8 +116,8 @@ subgraph PRCI["pr_builds.yml · PR Builds"]
     subgraph MainRelease["non-PR workflows"]
         MainCI["ci.yml\npush main / dispatch"]
         WebsiteDeploy["website-pages.yml\nActions Pages deploy\nPublic Website environment"]
-        DockerPublish["docker.yml\ntag / dispatch publish"]
-        Release["release.yml\nrelease artifacts + publish gates"]
+        DockerValidate["docker.yml\nmanual client Dockerfile validation"]
+        Release["release.yml\nrelease artifacts + packaging dispatch"]
         FlyConsole["fly-deploy-console.yml\nmanual Fly console deploy"]
     end
 
@@ -190,9 +190,10 @@ subgraph PRCI["pr_builds.yml · PR Builds"]
   artifact cleanup. Cleanup-only workflow edits do not fan out into
   Rust/build/smoke jobs.
 - Docker image validation and publishing are intentionally not part of pull
-  request CI; non-PR workflows (`ci.yml`, `website-pages.yml`, `docker.yml`,
-  `release.yml`) own main, dispatch, tag, website deployment, and release-grade
-  publishing behavior.
+  request CI. `docker.yml` is a manual, non-publishing client Dockerfile
+  validation workflow. `release.yml` owns release archives and dispatches the
+  completed full release to `Mesh-LLM/mesh-agent-images`, which is the sole
+  GHCR publisher.
 - `fly-deploy-console.yml` is a manual (`workflow_dispatch`) deploy of the
   `mesh-llm-console` Fly app. It builds the image on Fly's remote builders from
   `fly/Dockerfile` and authenticates with the app-scoped `FLY_API_TOKEN` repo


### PR DESCRIPTION
## Summary
- dispatch successful complete non-canary releases to Mesh-LLM/mesh-agent-images after GitHub Release publication
- enable package assets and GHCR image publication in the production payload
- retire upstream tag-based GHCR publishing and retain only manual Dockerfile validation
- document the release ownership boundary

## Validation
- actionlint
- workflow YAML and duplicate-step-ID checks
- just check-release
- receiver repository_dispatch dry run: https://github.com/Mesh-LLM/mesh-packaging/actions/runs/29512465086

## Before merge
- provision MESH_AGENT_IMAGES_DISPATCH_TOKEN as a fine-grained token or GitHub App token scoped to Mesh-LLM/mesh-agent-images with Contents write access
- merge with the coordinated Mesh-LLM/mesh-agent-images ownership PR

No package, image, or release asset was published.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Completed non-canary releases can now automatically dispatch post-release packaging and publish native release assets and the supported container image set.
* **Bug Fixes**
  * Updated the client container workflow to validate the client Dockerfile via build checks without publishing images.
* **Documentation**
  * Refreshed release and CI docs to clarify dispatch-driven packaging/publishing behavior, required dispatch token permissions, and that Docker workflow performs validation only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->