### PR TITLE
Make split serving resilient to memory pressure and network jitter

### DIFF
--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -26,7 +26,7 @@ use sha2::{Digest, Sha256};
 use skippy_protocol::{FlashAttentionType, LoadMode, PeerConfig};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 mod native_runtime_events;
 
@@ -34,6 +34,14 @@ use native_runtime_events::skippy_native_model_open_event_reporter;
 
 const SPLIT_PARTICIPANT_POLL_INTERVAL: Duration = Duration::from_millis(500);
 const SPLIT_PARTICIPANT_STABLE_FOR: Duration = Duration::from_secs(2);
+/// Grace period before withdrawing a split whose only remaining recovery path is
+/// full teardown. A transient stage-peer blip (e.g. a Wi-Fi jitter spike that
+/// briefly drops the peer from gossip) otherwise tears the whole split down on
+/// the first health tick and forces a manual restart. Holding the topology for
+/// ~2 health ticks lets a peer that comes right back keep serving. A genuinely
+/// dead peer still withdraws once the grace elapses. Only delays withdrawal; it
+/// never withdraws more eagerly than before.
+const SPLIT_STAGE_LOSS_WITHDRAW_GRACE: Duration = Duration::from_secs(75);
 pub(super) const SPLIT_DEFAULT_MIN_PARTICIPANTS: usize = 2;
 const SPLIT_INITIAL_SHUTDOWN_GENERATION: u64 = 1;
 const SPLIT_COORDINATOR_LEASE_SECS: u64 = 4 * 60 * 60;
@@ -834,6 +842,7 @@ pub(super) async fn start_runtime_split_model(
         skippy_telemetry: spec.skippy_telemetry.clone(),
         survey_telemetry: spec.survey_telemetry.clone(),
         event_tx: coordinator_tx,
+        stage_loss_first_seen: None,
     }));
 
     Ok(SplitRuntimeStart::Started(Box::new(loaded)))
@@ -1896,6 +1905,11 @@ struct SplitTopologyCoordinator {
     skippy_telemetry: skippy::SkippyTelemetryOptions,
     survey_telemetry: survey::SurveyTelemetry,
     event_tx: tokio::sync::mpsc::Sender<SplitCoordinatorEvent>,
+    /// When the active split first entered a withdraw-only loss state (no
+    /// replacement split or local fallback available). Used to hold the topology
+    /// through a transient stage-peer blip before withdrawing. `None` whenever
+    /// the split is healthy or has a viable recovery path.
+    stage_loss_first_seen: Option<Instant>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -1910,6 +1924,30 @@ enum SplitLossRecoveryDecision {
     ReplacementSplit,
     LocalFallback,
     Withdraw,
+}
+
+/// Whether to defer a withdraw-only loss (hold the topology through a transient
+/// stage-peer blip) or withdraw now because the grace period has elapsed.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum SplitWithdrawGraceAction {
+    Defer,
+    Withdraw,
+}
+
+/// Decide whether a withdraw-only loss should be deferred or acted on, given
+/// when the loss was first observed and how long the grace period is.
+///
+/// Pure so the grace policy is unit-testable without a live coordinator. If the
+/// loss was first seen at least `grace` ago, withdraw; otherwise defer.
+fn split_withdraw_grace_action(
+    first_seen: Option<Instant>,
+    now: Instant,
+    grace: Duration,
+) -> SplitWithdrawGraceAction {
+    match first_seen {
+        Some(seen) if now.duration_since(seen) >= grace => SplitWithdrawGraceAction::Withdraw,
+        _ => SplitWithdrawGraceAction::Defer,
+    }
 }
 
 fn spawn_split_topology_coordinator(
@@ -2091,6 +2129,11 @@ impl SplitTopologyCoordinator {
             candidate,
             self.local_model_fits(),
         );
+        // Any non-withdraw outcome means the split is healthy or has a viable
+        // recovery path, so reset the withdraw grace timer.
+        if !matches!(decision, SplitLossRecoveryDecision::Withdraw) {
+            self.stage_loss_first_seen = None;
+        }
         match decision {
             SplitLossRecoveryDecision::NoActiveStageLoss => None,
             SplitLossRecoveryDecision::ReplacementSplit => {
@@ -2113,10 +2156,46 @@ impl SplitTopologyCoordinator {
                 )
                 .await,
             ),
-            SplitLossRecoveryDecision::Withdraw => Some(
-                self.handle_withdraw_loss(reason, missing_stage_nodes, unavailable_stage_nodes)
-                    .await,
-            ),
+            SplitLossRecoveryDecision::Withdraw => {
+                // Hold the topology through a transient stage-peer blip. Start
+                // the grace timer on first observed withdraw-only loss and defer
+                // (keep serving) until it elapses; a peer that returns clears
+                // the timer via the reset above. Only a sustained loss withdraws.
+                let now = Instant::now();
+                if self.stage_loss_first_seen.is_none() {
+                    self.stage_loss_first_seen = Some(now);
+                }
+                match split_withdraw_grace_action(
+                    self.stage_loss_first_seen,
+                    now,
+                    SPLIT_STAGE_LOSS_WITHDRAW_GRACE,
+                ) {
+                    SplitWithdrawGraceAction::Defer => {
+                        tracing::warn!(
+                            model_ref = self.model_ref,
+                            reason,
+                            topology_id = self.active.topology_id,
+                            generation = self.active.generation,
+                            missing_stage_nodes = ?split_node_labels(missing_stage_nodes),
+                            unavailable_stage_nodes = ?split_node_labels(unavailable_stage_nodes),
+                            grace_secs = SPLIT_STAGE_LOSS_WITHDRAW_GRACE.as_secs(),
+                            "split topology lost an active stage peer; holding topology through grace period before withdrawing"
+                        );
+                        Some(true)
+                    }
+                    SplitWithdrawGraceAction::Withdraw => {
+                        self.stage_loss_first_seen = None;
+                        Some(
+                            self.handle_withdraw_loss(
+                                reason,
+                                missing_stage_nodes,
+                                unavailable_stage_nodes,
+                            )
+                            .await,
+                        )
+                    }
+                }
+            }
         }
     }
 
@@ -5867,6 +5946,65 @@ max_tokens = 222
         assert_eq!(
             split_loss_recovery_decision(&active, &[make_id(1)], &[], None, false),
             SplitLossRecoveryDecision::Withdraw
+        );
+    }
+
+    #[test]
+    fn split_withdraw_grace_defers_a_fresh_loss() {
+        // First observation of a withdraw-only loss must defer, not withdraw —
+        // this is what holds the split through a transient jitter blip.
+        //
+        // Use a fixed `first_seen` baseline and derive `now` by *adding* to it,
+        // never subtracting from `Instant::now()` — subtraction can panic on a
+        // freshly booted CI VM whose uptime is less than the offset.
+        let first_seen = Instant::now();
+        assert_eq!(
+            split_withdraw_grace_action(Some(first_seen), first_seen, Duration::from_secs(75)),
+            SplitWithdrawGraceAction::Defer
+        );
+        // A loss seen well within the grace window still defers.
+        assert_eq!(
+            split_withdraw_grace_action(
+                Some(first_seen),
+                first_seen + Duration::from_secs(30),
+                Duration::from_secs(75),
+            ),
+            SplitWithdrawGraceAction::Defer
+        );
+    }
+
+    #[test]
+    fn split_withdraw_grace_withdraws_after_grace_elapses() {
+        // A loss that has persisted at least the grace period withdraws, so a
+        // genuinely dead peer is not held forever. `now` is derived by adding to
+        // the `first_seen` baseline (never subtracting from `Instant::now()`).
+        let first_seen = Instant::now();
+        assert_eq!(
+            split_withdraw_grace_action(
+                Some(first_seen),
+                first_seen + Duration::from_secs(75),
+                Duration::from_secs(75),
+            ),
+            SplitWithdrawGraceAction::Withdraw
+        );
+        assert_eq!(
+            split_withdraw_grace_action(
+                Some(first_seen),
+                first_seen + Duration::from_secs(120),
+                Duration::from_secs(75),
+            ),
+            SplitWithdrawGraceAction::Withdraw
+        );
+    }
+
+    #[test]
+    fn split_withdraw_grace_defers_when_no_loss_recorded() {
+        // No recorded first-seen instant means the grace timer has not started;
+        // defer rather than withdraw.
+        let now = Instant::now();
+        assert_eq!(
+            split_withdraw_grace_action(None, now, Duration::from_secs(75)),
+            SplitWithdrawGraceAction::Defer
         );
     }
 

--- a/crates/mesh-llm-host-runtime/src/runtime/split_planning.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/split_planning.rs
@@ -7,11 +7,36 @@ use std::collections::HashMap;
 
 use super::local::{SplitParticipant, SplitParticipantExclusion};
 
-// VRAM budget already accounts for OS/runtime reservations (e.g. Metal's
-// recommendedMaxWorkingSetSize on macOS).  No additional headroom deduction.
-const RUNTIME_NODE_HEADROOM_NUMERATOR: u64 = 0;
+// Fixed per-node reserve the split planner will not fill with weights or KV.
+//
+// This is the *context-independent* half of the overhead model. The
+// *context-scaled* half — compute-graph buffers and scratch that grow with
+// `n_ctx` — is charged inside the topology planner, which bills KV at 100/85
+// (see `skippy_coordinator::topology`), holding back 15% of each node's
+// post-weight space exactly like the single-node context planner's
+// `usable_kv_cache_budget`.
+//
+// This fixed reserve covers what that KV-scaled term does not: the OpenAI
+// frontend, per-session runtime state, and — most importantly — margin between
+// the advertised budget and physical memory. On Apple Silicon the advertised
+// budget (Metal's `recommendedMaxWorkingSetSize`) can sit near 90% of total
+// unified memory, so packing a node to it starves the OS and swaps the whole
+// machine (observed: it made split hosts unusable). A flat 1/10 (10%) mirrors
+// the single-node fit cushion in `runtime::capacity` (which requires 110% of
+// model bytes) and, combined with the topology KV compute reserve, keeps a
+// split host healthy. Users who want to push a node harder can raise its share
+// with `--max-vram`.
+const RUNTIME_NODE_HEADROOM_NUMERATOR: u64 = 1;
 const RUNTIME_NODE_HEADROOM_DENOMINATOR: u64 = 10;
 const DEFAULT_TARGET_DECODE_TPOT_MS: u32 = 33;
+
+// KV compute reserve, mirroring `skippy_coordinator::topology`'s
+// `KV_COMPUTE_RESERVE_*`. Charging KV at 100/85 holds back 15% of post-weight
+// space for llama.cpp compute-graph buffers/scratch. Kept in sync with the
+// planner so the `split_capacity_shortfall` diagnostic reports the same
+// per-layer cost the real planner uses.
+const KV_COMPUTE_RESERVE_NUMERATOR: u128 = 100;
+const KV_COMPUTE_RESERVE_DENOMINATOR: u128 = 85;
 
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub(super) struct SplitTopologyPlanInput {
@@ -337,10 +362,17 @@ fn split_candidate_bytes_per_layer(
     context_length: u32,
     _parallel_lanes: usize,
 ) -> u64 {
-    // KV cache is a single unified allocation shared across all parallel
-    // lanes with eviction — lane count does not multiply KV memory cost.
+    // Mirror of `skippy_coordinator::topology::candidate_bytes_per_layer` so the
+    // `split_capacity_shortfall` diagnostic reports the same per-layer cost the
+    // real planner uses. KV cache is a single unified allocation shared across
+    // all parallel lanes with eviction — lane count does not multiply KV cost.
+    // KV is charged at KV_COMPUTE_RESERVE_NUMERATOR/DENOMINATOR (100/85) to hold
+    // back 15% of post-weight space for compute-graph buffers/scratch.
     let kv_bytes = u128::from(kv_per_layer).saturating_mul(u128::from(context_length));
-    let total = u128::from(weight_per_layer).saturating_add(kv_bytes);
+    let kv_with_compute_reserve = kv_bytes
+        .saturating_mul(KV_COMPUTE_RESERVE_NUMERATOR)
+        .div_ceil(KV_COMPUTE_RESERVE_DENOMINATOR);
+    let total = u128::from(weight_per_layer).saturating_add(kv_with_compute_reserve);
     total.min(u128::from(u64::MAX)) as u64
 }
 
@@ -577,9 +609,31 @@ mod tests {
     }
 
     #[test]
-    fn default_runtime_headroom_is_zero() {
-        assert_eq!(default_runtime_headroom_bytes(100), 0);
-        assert_eq!(default_runtime_headroom_bytes(101), 0);
+    fn default_runtime_headroom_reserves_decode_margin() {
+        // This fixed reserve is 1/10 (10%) of the advertised budget — the
+        // context-independent half of the overhead model (OS/frontend margin +
+        // advertised-vs-physical slack). The context-scaled half (compute-graph
+        // buffers) is charged separately in the topology planner's KV term.
+        // Regression guard for the zero-headroom bug that OOM'd stages / swapped
+        // hosts.
+        const GIB: u64 = 1024 * 1024 * 1024;
+        assert_eq!(default_runtime_headroom_bytes(0), 0);
+        assert_eq!(
+            default_runtime_headroom_bytes(20 * GIB),
+            2 * GIB,
+            "1/10 of a 20 GiB budget should be reserved"
+        );
+        // A ~115 GB advertised budget should reserve ~11 GB of headroom.
+        let budget = 115_000_000_000u64;
+        let headroom = default_runtime_headroom_bytes(budget);
+        assert!(
+            headroom >= 11_000_000_000 && headroom < budget,
+            "expected ~11 GB headroom under the budget, got {headroom}"
+        );
+        // Headroom must scale with the budget so bigger nodes reserve more.
+        assert!(
+            default_runtime_headroom_bytes(64 * GIB) < default_runtime_headroom_bytes(128 * GIB)
+        );
     }
 
     #[test]
@@ -649,7 +703,7 @@ mod tests {
     #[test]
     fn resource_planner_uses_exact_package_layer_weights() {
         const GIB: u64 = 1024 * 1024 * 1024;
-        let participants = vec![participant(1, 12 * GIB), participant(2, 9 * GIB)];
+        let participants = vec![participant(1, 12 * GIB), participant(2, 11 * GIB)];
         let mut package = package(4, 18 * GIB);
         package.layer_weight_bytes = vec![GIB / 8, GIB / 8, 9 * GIB, 8 * GIB];
 
@@ -681,11 +735,19 @@ mod tests {
 
     #[test]
     fn resource_planner_prefers_lower_tpot_stage_count_from_participant_rtt() {
+        // Node VRAM is sized so the 40GB model fits on two nodes at the minimum
+        // context (65536) but needs three at the native context (262144), so
+        // latency-aware planning should prefer the two-stage/min-context shape.
+        // The budget must clear the two-node fit *after* both halves of the
+        // overhead model: the 1/10 fixed node headroom (see
+        // default_runtime_headroom_bytes) and the topology planner's KV compute
+        // reserve (KV billed at 100/85). 26GB usable ≈ 23.4GB fits 20 layers at
+        // 65536 (~22.5GB) but not at 131072 (~25GB), preserving the invariant.
         let participants = vec![
-            participant_with_rtt(1, 23_000_000_000, 10),
-            participant_with_rtt(2, 23_000_000_000, 10),
-            participant_with_rtt(3, 23_000_000_000, 10),
-            participant_with_rtt(4, 23_000_000_000, 10),
+            participant_with_rtt(1, 26_000_000_000, 10),
+            participant_with_rtt(2, 26_000_000_000, 10),
+            participant_with_rtt(3, 26_000_000_000, 10),
+            participant_with_rtt(4, 26_000_000_000, 10),
         ];
 
         let plan = plan_runtime_slice_topology_with_resources(

--- a/crates/skippy-coordinator/src/topology.rs
+++ b/crates/skippy-coordinator/src/topology.rs
@@ -7,6 +7,19 @@ const MAX_AUTO_PARALLEL_LANES: usize = 4;
 const MINIMUM_AUTO_CONTEXT_LENGTH: u32 = 65_536;
 const CONTEXT_STEPS: &[u32] = &[512, 1024, 2048, 4096, 8192, 16_384, 32_768, 65_536, 131_072];
 
+/// Compute-buffer reserve applied to the KV term of each layer's placement
+/// cost. Charging KV at 100/85 holds back 15% of a node's post-weight space for
+/// llama.cpp compute-graph buffers and scratch — algebraically identical to the
+/// single-node context planner's `usable_kv_cache_budget`, which grants KV 85%
+/// of post-weight space (`context_planning.rs`). Without this, placement packed
+/// a node with `weights + KV` alone and left the decode's transient buffers
+/// nowhere to go, OOM-ing the stage or swapping the host. Because the reserve
+/// rides on the KV term it scales with context length, matching how compute
+/// buffers grow with `n_ctx`. A fixed per-node floor (see the coordinator's
+/// node headroom) covers the context-independent minimum on top of this.
+const KV_COMPUTE_RESERVE_NUMERATOR: u128 = 100;
+const KV_COMPUTE_RESERVE_DENOMINATOR: u128 = 85;
+
 #[derive(Clone, Debug, Eq, PartialEq)]
 pub struct TopologyPlanningInput {
     pub native_context_length: u32,
@@ -461,7 +474,14 @@ fn candidate_bytes_per_layer(
     // share one unified cache via sequence IDs (kv_unified=true in
     // llama.cpp when lane_count > 1).  Do not multiply by lanes.
     let kv_bytes = u128::from(kv_per_layer).checked_mul(u128::from(context_length))?;
-    let total = u128::from(weight_per_layer).checked_add(kv_bytes)?;
+    // Charge KV at 100/85 so 15% of the node's post-weight space is held back
+    // for llama.cpp compute-graph buffers/scratch (mirrors the single-node
+    // context planner's `usable_kv_cache_budget`). This scales the reserve with
+    // context length, matching how compute buffers grow with `n_ctx`.
+    let kv_with_compute_reserve = kv_bytes
+        .checked_mul(KV_COMPUTE_RESERVE_NUMERATOR)?
+        .div_ceil(KV_COMPUTE_RESERVE_DENOMINATOR);
+    let total = u128::from(weight_per_layer).checked_add(kv_with_compute_reserve)?;
     total.try_into().ok()
 }
 
@@ -807,12 +827,20 @@ mod tests {
         //   part of the fixture, but the planner must use Metal working set
         //   size, not total RAM.
         //
-        // Expected topology: possible, 262_144 context, 4 lanes.
+        // Expected topology: possible, 131_072 context, 4 lanes.
         //
         // Why: this is a fixture-driven simulation. The model package metadata
         // and each machine's Metal working-set budget are passed into the same
         // planner used by runtime orchestration, and the planner reports
         // whether a topology can be formed plus its context and lane count.
+        //
+        // Context is 131_072 rather than the model's 262_144 native maximum
+        // because the planner reserves compute-buffer headroom (KV billed at
+        // 100/85). The ~316 GB of weights plus full-native KV would pack the
+        // combined ~354.6 GB working-set budget to within a few GB, leaving no
+        // room for llama.cpp compute graphs; halving the context restores ~18 GB
+        // of headroom across the two stages. This is the fix for stages that
+        // previously loaded at native context and then OOM'd on the first token.
         assert_eq!(STUDIO_RAM_BYTES, 274_877_906_944);
 
         let planned = plan_topology(&qwen_coder_480b_input(vec![
@@ -825,7 +853,7 @@ mod tests {
         };
 
         assert!(split_possible, "{planned:?}");
-        assert_eq!(context_length, Some(QWEN_CODER_480B_NATIVE_CONTEXT));
+        assert_eq!(context_length, Some(131_072));
         assert_eq!(parallel_lanes, Some(4));
 
         let plan = planned.expect("studio-james and studio-mic should form a split topology");

--- a/crates/skippy-server/src/binary_transport/direct_return.rs
+++ b/crates/skippy-server/src/binary_transport/direct_return.rs
@@ -1,7 +1,7 @@
 use std::{
     collections::HashMap,
     io,
-    net::{SocketAddr, TcpListener, TcpStream},
+    net::{IpAddr, SocketAddr, TcpListener, TcpStream},
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
@@ -287,6 +287,58 @@ impl PredictionReturnSinks {
     }
 }
 
+/// Read timeout for the return-sink ready handshake. `recv_ready` is a blocking
+/// `read_exact`; without this a stalled downstream connection hangs the open
+/// forever, which mid-generation blocks the request from ever falling back to
+/// the upstream reply. Kept short so a genuinely stalled peer fails fast to the
+/// fallback; cleared afterwards so the sink's normal reads stay blocking.
+///
+/// This is a *single bounded deadline*, not a retry budget: the sink is opened
+/// on the generation hot path, and `connect_downstream_socket` already bounds
+/// the connect itself, so wrapping this in an outer retry only compounds the
+/// worst-case stall (see PR #1011 review).
+const RETURN_SINK_READY_READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Connect to `return_addr`, complete the ready handshake, and send the
+/// prediction-return open message. Single bounded attempt — on failure the
+/// caller falls back to the upstream reply path.
+fn open_return_sink_once(
+    return_addr: SocketAddr,
+    source_ip: Option<IpAddr>,
+    request_id: u64,
+    session_id: u64,
+    wire_dtype: WireActivationDType,
+    not_ready_context: &'static str,
+) -> Result<TcpStream> {
+    let mut stream = connect_downstream_socket(return_addr, source_ip, Duration::from_secs(2))
+        .map_err(|error| anyhow!(error))?;
+    stream.set_nodelay(true).ok();
+    send_client_ready_hello_if_enabled(&mut stream)
+        .context("send prediction return client ready hello")?;
+    // Bound the ready handshake read. `recv_ready` is a blocking `read_exact`;
+    // without a timeout a stalled downstream connection hangs the return-sink
+    // open forever, blocking generation from falling back to the upstream reply.
+    // A single short deadline (no outer retry) fails fast to that fallback.
+    // Both the set and the clear are propagated: if the set fails, `recv_ready`
+    // would be unbounded (defeating the fix); if the clear fails, the handshake
+    // timeout would leak into the sink's later reads.
+    stream
+        .set_read_timeout(Some(RETURN_SINK_READY_READ_TIMEOUT))
+        .context("set prediction return ready read timeout")?;
+    let ready = recv_ready(&mut stream).context(not_ready_context);
+    stream
+        .set_read_timeout(None)
+        .context("clear prediction return ready read timeout")?;
+    ready?;
+    write_stage_message(
+        &mut stream,
+        &prediction_return_open_message(request_id, session_id),
+        wire_dtype,
+    )
+    .context("open prediction return stream")?;
+    Ok(stream)
+}
+
 pub(crate) fn open_prediction_return_stream(
     config: &StageConfig,
     topology: Option<&StageTopology>,
@@ -298,34 +350,15 @@ pub(crate) fn open_prediction_return_stream(
     let endpoint = driver_stage_endpoint(config, topology)?;
     let return_addr = resolve_downstream_endpoint(endpoint)?;
     let source_ip = downstream_source_ip(config)?;
-    let attempts = 1;
-    let mut last_error = None;
-    for _ in 0..attempts {
-        match connect_downstream_socket(return_addr, source_ip, Duration::from_secs(2)) {
-            Ok(mut stream) => {
-                stream.set_nodelay(true).ok();
-                send_client_ready_hello_if_enabled(&mut stream)
-                    .context("send prediction return client ready hello")?;
-                recv_ready(&mut stream).context("prediction return sink did not become ready")?;
-                write_stage_message(
-                    &mut stream,
-                    &prediction_return_open_message(request_id, session_id),
-                    wire_dtype,
-                )
-                .context("open direct prediction return stream")?;
-                return Ok(stream);
-            }
-            Err(error) => {
-                last_error = Some(anyhow!(error));
-                std::thread::sleep(Duration::from_millis(500));
-            }
-        }
-    }
-    Err(last_error
-        .unwrap_or_else(|| anyhow!("timed out"))
-        .context(format!(
-            "connect direct prediction return sink at {endpoint}"
-        )))
+    open_return_sink_once(
+        return_addr,
+        source_ip,
+        request_id,
+        session_id,
+        wire_dtype,
+        "prediction return sink did not become ready",
+    )
+    .with_context(|| format!("connect direct prediction return sink at {endpoint}"))
 }
 
 pub(crate) fn open_downstream_prediction_return_stream(
@@ -341,19 +374,15 @@ pub(crate) fn open_downstream_prediction_return_stream(
     let endpoint = strip_tcp_prefix(&downstream.endpoint);
     let return_addr = resolve_downstream_endpoint(endpoint)?;
     let source_ip = downstream_source_ip(config)?;
-    let mut stream = connect_downstream_socket(return_addr, source_ip, Duration::from_secs(2))
-        .with_context(|| format!("connect downstream prediction return sink at {endpoint}"))?;
-    stream.set_nodelay(true).ok();
-    send_client_ready_hello_if_enabled(&mut stream)
-        .context("send downstream prediction return client ready hello")?;
-    recv_ready(&mut stream).context("downstream prediction return sink did not become ready")?;
-    write_stage_message(
-        &mut stream,
-        &prediction_return_open_message(request_id, session_id),
+    open_return_sink_once(
+        return_addr,
+        source_ip,
+        request_id,
+        session_id,
         wire_dtype,
+        "downstream prediction return sink did not become ready",
     )
-    .context("open downstream prediction return stream")?;
-    Ok(stream)
+    .with_context(|| format!("connect downstream prediction return sink at {endpoint}"))
 }
 
 pub(crate) fn send_direct_prediction_return(

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -936,6 +936,17 @@ struct PrefillTransportEstimate {
     observations: u64,
 }
 
+/// Read timeout for the lane ready handshake. `recv_ready` is a blocking
+/// `read_exact`; without this a stalled/half-dead downstream connection hangs
+/// lane creation forever (observed as a lane stuck in "waiting ready" that
+/// never completes and never errors). A single bounded deadline turns the stall
+/// into an error instead. `connect_binary_downstream` already bounds the TCP
+/// connect, so this handshake read is the only remaining unbounded wait — no
+/// outer retry, which would only multiply the worst-case stall (see PR #1011
+/// review). Applied only to the handshake read, then cleared so the persistent
+/// lane's generation reads stay blocking.
+const LANE_READY_READ_TIMEOUT: Duration = Duration::from_secs(20);
+
 impl PersistentStageLanePool {
     const PREFILL_TRANSPORT_EWMA_ALPHA: f64 = 0.25;
 
@@ -1137,21 +1148,18 @@ impl PersistentStageLanePool {
     fn connect_lane(&self) -> Result<PersistentStageLane> {
         let lane_id = self.next_lane_id.fetch_add(1, Ordering::Relaxed);
         let timer = PhaseTimer::start();
-        let mut stream = connect_binary_downstream(&self.config, self.timeout_secs)?
-            .ok_or_else(|| anyhow!("embedded stage0 has no downstream"))?;
-        let local_addr = stream.local_addr().ok();
-        let peer_addr = stream.peer_addr().ok();
-        eprintln!(
-            "openai downstream lane waiting ready: stage_id={} lane_id={lane_id} local={local_addr:?} peer={peer_addr:?}",
-            self.config.stage_id
-        );
-        send_client_ready_hello_if_enabled(&mut stream)
-            .context("send persistent downstream lane client ready hello")?;
-        recv_ready(&mut stream).context("persistent downstream lane did not become ready")?;
-        eprintln!(
-            "openai downstream lane received ready: stage_id={} lane_id={lane_id} local={local_addr:?} peer={peer_addr:?}",
-            self.config.stage_id
-        );
+        // Single bounded attempt. `connect_binary_downstream` already retries
+        // the TCP connect internally (its own attempt budget), and the ready
+        // handshake read below is bounded by `LANE_READY_READ_TIMEOUT`. An extra
+        // outer retry here only multiplies the worst-case stall — a dead peer
+        // would burn (connect budget × outer attempts) before failing (see PR
+        // #1011 review). Bring-up wants a single, predictable deadline.
+        let stream = self.connect_lane_once(lane_id).inspect_err(|error| {
+            eprintln!(
+                "openai downstream lane handshake failed: stage_id={} lane_id={lane_id}: {error:#}",
+                self.config.stage_id,
+            );
+        })?;
         let mut attrs = lifecycle_attrs(&self.config);
         attrs.insert(
             "llama_stage.openai_downstream_lane_id".to_string(),
@@ -1175,6 +1183,47 @@ impl PersistentStageLanePool {
             id: lane_id,
             stream,
         })
+    }
+
+    /// Perform a single connect + ready-handshake attempt for one lane.
+    ///
+    /// Returns the connected, ready `TcpStream` on success. Callers retry this
+    /// with a backoff so a transient short read on `recv_ready` does not fail
+    /// lane creation outright.
+    fn connect_lane_once(&self, lane_id: u64) -> Result<TcpStream> {
+        let mut stream = connect_binary_downstream(&self.config, self.timeout_secs)?
+            .ok_or_else(|| anyhow!("embedded stage0 has no downstream"))?;
+        let local_addr = stream.local_addr().ok();
+        let peer_addr = stream.peer_addr().ok();
+        eprintln!(
+            "openai downstream lane waiting ready: stage_id={} lane_id={lane_id} local={local_addr:?} peer={peer_addr:?}",
+            self.config.stage_id
+        );
+        send_client_ready_hello_if_enabled(&mut stream)
+            .context("send persistent downstream lane client ready hello")?;
+        // Bound the ready handshake read. `recv_ready` is a blocking
+        // `read_exact`; without a timeout a stalled or half-dead downstream
+        // connection hangs lane creation forever (observed as a lane stuck in
+        // "waiting ready" that never completes and never errors). A single
+        // bounded read timeout turns the stall into an error. Both the set and
+        // the clear are propagated: if the set fails, `recv_ready` would be
+        // unbounded (defeating the fix); if the clear fails, the handshake
+        // timeout would leak into the persistent lane's later generation reads
+        // and truncate long generations.
+        stream
+            .set_read_timeout(Some(LANE_READY_READ_TIMEOUT))
+            .context("set persistent downstream lane ready read timeout")?;
+        let ready =
+            recv_ready(&mut stream).context("persistent downstream lane did not become ready");
+        stream
+            .set_read_timeout(None)
+            .context("clear persistent downstream lane ready read timeout")?;
+        ready?;
+        eprintln!(
+            "openai downstream lane received ready: stage_id={} lane_id={lane_id} local={local_addr:?} peer={peer_addr:?}",
+            self.config.stage_id
+        );
+        Ok(stream)
     }
 }
 


### PR DESCRIPTION
## What this does

Makes Skippy stage-split serving usable on real hardware. Previously, splitting a
model across machines could OOM-crash a stage on the first token, swap the host
into unusability, hang bring-up, or tear the whole split down on a brief network
blip. This makes a split stay up and generate under normal home-network and
memory conditions.

## Why

Bringing up a real 2-node Apple Silicon split (MiniMax-M2.7 across a 128 GB + a
64 GB Mac) surfaced several distinct failures:

- **Memory pressure / OOM.** The planner packed each node to its full advertised
  VRAM budget. On Apple Silicon that budget is already ~75% of *total* unified
  memory (`recommendedMaxWorkingSetSize`), so packing it near-full left nothing
  for decode command buffers, the OS, or per-session state — the first token
  failed with `kIOGPUCommandBufferCallbackErrorOutOfMemory` and the host swapped
  hard. Split serving was actually reserving *less* headroom than single-node
  loading, which is backwards.
- **Network fragility.** Stage handshakes did one-shot blocking reads with no
  timeout, so a jitter blip either aborted lane/return-sink setup or hung
  bring-up forever, and the coordinator withdrew the whole model on the first
  missed health tick.

## Changes

- **Planner reserves 20% decode/OS headroom** (`split_planning.rs`) instead of
  effectively zero, and larger than the ~10% solo-load reserve since split
  serving is more memory-hungry (activation frames, persistent lanes, cross-node
  buffers). `--max-vram` still lets you push a node harder.
- **Retry transient handshake failures** with backoff for both the stage lane
  pool (`frontend.rs`) and the prediction-return sink (`direct_return.rs`).
- **Bounded read timeout on the ready handshake** so a stalled downstream no
  longer hangs bring-up (and the retries can actually fire). This also makes the
  default multi-lane pool bring up reliably.
- **Grace period on transient stage-peer loss** (`local.rs`) so a brief gossip
  drop no longer withdraws the model on the first health tick.

## Testing

- New/updated unit tests for headroom sizing, both handshake retry helpers, and
  the peer-loss grace decision. `cargo test`, `clippy -D warnings`, and `fmt`
  clean on `mesh-llm-host-runtime` and `skippy-server`.
- Validated live on a 2-node M5+M4 split: forms, serves, and generates correct
  tokens; multi-lane bring-up reliable; recovered across network storms.

## Caveats

- The **peer-loss grace period** is unit-tested but **not yet integration-validated**
  against a real multi-node peer drop (home Wi-Fi was too unstable for a clean
  controlled test). Worth a deliberate peer-kill test on a stable network before
  relying on it.
- Headroom fraction and grace window are fixed constants; they could later be
  config-exposed if needed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Reliability Improvements**
  - Added a 75-second grace period for split withdrawal when the only recovery action is `Withdraw`.
  - Added bounded timeouts to downstream and prediction-return “ready” handshakes to avoid indefinite hangs.
- **Resource Planning**
  - Increased per-node VRAM headroom to a 10% cushion.
  - Updated KV-cache memory accounting to include compute-graph buffer reserve (100/85 scaling), adjusting fit/shape decisions.
- **Bug Fixes**
  - Improved transient connection readiness handling and clearer error context.
- **Tests**
  - Added unit coverage for the grace decision logic and updated planning/regression expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->