### PR TITLE
Enable adaptive verify window for ngram/draft speculation

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
@@ -816,6 +816,43 @@ draft_max_tokens = 8
 }
 
 #[test]
+fn ngram_speculation_enables_adaptive_verify_window() {
+    // When N-gram speculation is active the adaptive verify window must be on so
+    // the window shrinks after early rejects instead of staying fixed at its max
+    // and paying the full recovery cost per token (regression guard for the
+    // measured WAN split -40% throughput loss when the window never shrank).
+    let mesh_config = parse_config(
+        r#"
+[defaults.speculative]
+ngram_proposer = "cache"
+ngram_min = 2
+ngram_max = 4
+"#,
+    );
+    let model_file = temp_model_file();
+
+    let resolved = resolve_skippy_config(SkippyConfigResolveRequest {
+        mesh_config: &mesh_config,
+        model_id: "Qwen/Qwen3-0.6B:Q4_K_M",
+        model_path: model_file.path(),
+        model_bytes: 4 * 1024 * 1024 * 1024,
+        allocatable_memory_bytes: None,
+        request_defaults: None,
+        package_generation: None,
+    })
+    .expect("config should resolve");
+
+    let openai = resolved
+        .to_embedded_openai_args(4096, true)
+        .expect("embedded args should build");
+
+    assert!(
+        openai.adaptive_speculative_window,
+        "ngram speculation must enable the adaptive verify window"
+    );
+}
+
+#[test]
 fn layer_package_translation_does_not_treat_hf_ref_as_direct_gguf() {
     let config = MeshConfig::default();
     let package_ref = "hf://meshllm/Qwen3-8B-Q4_K_M-layers";

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/translation.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/translation.rs
@@ -241,7 +241,14 @@ impl ResolvedSkippyConfig {
                 None
             },
             speculative_window: self.speculative_window_for_embedded(mode),
-            adaptive_speculative_window: false,
+            // Enable the adaptive verify window whenever speculation actually
+            // proposes a window (ngram or draft mode). Without this the window
+            // is fixed at its max and never shrinks after an early reject, so a
+            // sustained reject storm keeps proposing deep and keeps paying the
+            // full recovery cost per token (measured ~40% throughput loss on a
+            // WAN split). A reject-responsive window narrows toward the observed
+            // accept depth, cutting recovery frequency.
+            adaptive_speculative_window: mode == "ngram" || mode == "draft",
             draft_n_gpu_layers: if mode == "draft" || self.speculative.native_mtp_enabled {
                 self.speculative.draft_n_gpu_layers
             } else {


### PR DESCRIPTION
## What this fixes

N-gram speculation on a split runtime could be **slower than no speculation**
despite high per-token acceptance. On a 2-node WAN split (Sydney↔Melbourne,
~20ms RTT, MiniMax-M2.7) N-gram ON measured ~40% slower than OFF, with an 0.89
token accept rate but 231 early-reject windows each paying a 2-round-trip
recovery.

## Root cause

The adaptive verify window was never enabled on the split-serving path:
`to_embedded_openai_args` hardcoded `adaptive_speculative_window = false`. With
a fixed window the window never shrank after an early reject
(`window_shrinks = 0` in telemetry), so a sustained reject storm kept proposing
at full depth and kept paying the full recovery cost per committed token. Over
WAN those extra round-trips dominate.

## Change

Enable the adaptive window whenever speculation actually proposes a window
(`ngram` or `draft` mode). The existing `shrink_adaptive_window` logic then
narrows the window toward the observed accept depth after an early reject,
cutting recovery frequency. Native-MTP-only decode is unaffected.

Adds a regression test asserting N-gram speculation turns the adaptive window
on.

## Validation

- `cargo test -p mesh-llm-host-runtime --lib` (new test + existing pass)
- `cargo clippy -p mesh-llm-host-runtime --lib -- -D warnings`
- `cargo fmt --all --check`
- Live A/B on a 2-node split with metrics-server pending (will confirm
  `window_shrinks > 0` and throughput recovery).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled adaptive speculative verification windows for N-gram and draft speculation modes, allowing verification behavior to respond dynamically.

* **Bug Fixes**
  * Corrected embedded inference configuration so adaptive verification is enabled when supported speculation modes are selected.

* **Tests**
  * Added regression coverage to verify adaptive windows are enabled for N-gram speculation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->