### PR TITLE
Compact public-mesh consultation progress in chat

### DIFF
--- a/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.test.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.test.ts
@@ -193,6 +193,52 @@ describe('createMeshConnectionAdapter', () => {
     expect(contentDeltas).toEqual([' Final answer.'])
   })
 
+  it('keeps each distinct mesh progress phase once for expandable details', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(
+          createSSEStream([
+            'data: {"type":"response.reasoning_text.delta","delta":"Routing through mesh…\\n"}\n',
+            'data: {"type":"response.reasoning_text.delta","delta":"Routing through mesh…\\n"}\n',
+            'data: {"type":"response.reasoning_text.delta","delta":"Querying peer models…\\n"}\n',
+            'data: {"type":"response.reasoning_text.delta","delta":"Verifier found conflicting dates.\\n"}\n',
+            'data: {"type":"response.reasoning_text.delta","delta":"Waiting on a slow peer…\\n"}\n',
+            'data: {"type":"response.reasoning_text.delta","delta":"Waiting on a slow peer…\\n"}\n',
+            'data: {"type":"response.reasoning_text.delta","delta":"Still gathering responses…\\n"}\n',
+            'data: {"type":"response.reasoning_text.delta","delta":"Hold on, this is taking a moment…\\n"}\n',
+            'data: {"type":"response.output_text.delta","delta":"Corroborated answer."}\n',
+            'data: [DONE]\n'
+          ]),
+          { status: 200 }
+        )
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const adapter = createMeshConnectionAdapter('mesh')
+    const chunks: StreamChunk[] = []
+    for await (const chunk of adapter.connect(createMessages(), undefined, undefined)) {
+      chunks.push(chunk)
+    }
+
+    const progressDeltas = chunks
+      .filter((chunk) => chunk.type === EventType.REASONING_MESSAGE_CONTENT)
+      .map((chunk) => (chunk.type === EventType.REASONING_MESSAGE_CONTENT ? chunk.delta : ''))
+    const answerDeltas = chunks
+      .filter((chunk) => chunk.type === EventType.TEXT_MESSAGE_CONTENT)
+      .map((chunk) => (chunk.type === EventType.TEXT_MESSAGE_CONTENT ? chunk.delta : ''))
+
+    expect(progressDeltas).toEqual([
+      'Routing through mesh…\n',
+      'Querying peer models…\n',
+      'Verifier found conflicting dates.\n',
+      'Waiting on a slow peer…\n',
+      'Still gathering responses…\n',
+      'Hold on, this is taking a moment…\n'
+    ])
+    expect(answerDeltas).toEqual(['Corroborated answer.'])
+  })
+
   it('includes the latest system prompt in responses requests', async () => {
     let currentSystemPrompt = 'Be concise about mesh routing.'
     const fetchMock = vi.fn().mockResolvedValue(new Response(createSSEStream(['data: [DONE]\n']), { status: 200 }))

--- a/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.ts
@@ -9,6 +9,7 @@ import { generateRequestId } from '@/lib/api/request-id'
 import type { ChatSSEEvent } from '@/lib/api/types'
 import { buildResponsesInput } from '@/features/chat/api/build-input'
 import type { ChatResponseMetadata } from '@/features/chat/api/response-metadata'
+import { isMeshVirtualModel, syntheticMoaProgressKey } from '@/features/chat/lib/moa-progress'
 
 function nowMs() {
   return performance.now()
@@ -175,6 +176,7 @@ async function* runConnect(
   const requestId = generateRequestId()
   const messageId = generateRequestId()
   const requestStartedAt = nowMs()
+  const meshVirtualModel = isMeshVirtualModel(model)
 
   yield { type: EventType.RUN_STARTED, threadId: requestId, runId: requestId }
 
@@ -203,12 +205,17 @@ async function* runConnect(
 
   let messageStarted = false
   let reasoningOpen = false
+  const seenMeshProgress = new Set<string>()
   let firstDeltaAt: number | undefined
 
   for await (const event of parseSSEStream(response.body, abortSignal)) {
     if (abortSignal?.aborted) break
 
     if (event.type === 'response.reasoning_text.delta') {
+      const progressKey = meshVirtualModel ? syntheticMoaProgressKey(event.delta) : undefined
+      if (progressKey && seenMeshProgress.has(progressKey)) continue
+
+      if (progressKey) seenMeshProgress.add(progressKey)
       firstDeltaAt ??= nowMs()
       if (!messageStarted) {
         messageStarted = true

--- a/crates/mesh-llm-ui/src/features/chat/components/MessageRow.test.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/components/MessageRow.test.tsx
@@ -409,6 +409,74 @@ describe('MessageRow', () => {
     expect(screen.getByText('Streaming response...')).toBeInTheDocument()
   })
 
+  it('keeps a noisy mesh consultation in one compact expandable row', async () => {
+    const user = userEvent.setup()
+    render(
+      <MessageRow
+        messageRole="assistant"
+        body={
+          '<think>Routing through mesh…\nQuerying peer models…\nWaiting on a slow peer…\nHold on, this is taking a moment…</think>'
+        }
+        timestamp="12:11"
+        model="mesh"
+        state="streaming"
+      />
+    )
+
+    const disclosure = screen.getByRole('button', {
+      name: 'Consulting peers and corroborating responses… Show details'
+    })
+    const rawTrace = screen.getByText(/Routing through mesh/)
+
+    expect(disclosure.closest('[data-thinking-state="active"]')).toBeInTheDocument()
+    expect(rawTrace).not.toBeVisible()
+    expect(screen.getByText('Streaming response...')).toBeVisible()
+
+    await user.click(disclosure)
+
+    const details = screen.getByRole('region', {
+      name: 'Consulting peers and corroborating responses… details'
+    })
+    expect(rawTrace).toBeVisible()
+    expect(disclosure).toHaveAttribute('aria-expanded', 'true')
+    expect(details).toHaveAttribute('tabindex', '0')
+    details.focus()
+    expect(details).toHaveFocus()
+    expect(rawTrace).toHaveTextContent('Waiting on a slow peer…')
+    expect(rawTrace).toHaveTextContent('Hold on, this is taking a moment…')
+  })
+
+  it('keeps a fast mesh answer visible before any consultation progress arrives', () => {
+    render(
+      <MessageRow
+        messageRole="assistant"
+        body="Fast mesh answer is already streaming."
+        timestamp="12:11"
+        model="mesh"
+        state="streaming"
+      />
+    )
+
+    expect(screen.getByText('Fast mesh answer is already streaming.')).toBeVisible()
+    expect(screen.queryByText('Consulting peers and corroborating responses…')).not.toBeInTheDocument()
+    expect(screen.queryByText('Thinking…')).not.toBeInTheDocument()
+  })
+
+  it('labels completed mesh work as a folded peer consultation', () => {
+    render(
+      <MessageRow
+        messageRole="assistant"
+        body="<think>Routing through mesh…</think>Corroborated answer."
+        timestamp="12:11"
+        model="mesh"
+      />
+    )
+
+    expect(screen.getByRole('button', { name: 'Peer consultation Show details' })).toBeVisible()
+    expect(screen.getByText('Routing through mesh…')).not.toBeVisible()
+    expect(screen.getByText('Corroborated answer.')).toBeVisible()
+  })
+
   it('only opts the message body back into text selection', () => {
     const { container } = render(
       <MessageRow

--- a/crates/mesh-llm-ui/src/features/chat/components/MessageRow.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/components/MessageRow.tsx
@@ -17,6 +17,8 @@ import remarkGfm from 'remark-gfm'
 import type { MessageRole } from '@/features/app-tabs/types'
 import { cn } from '@/lib/cn'
 import { ResponseStatsBar } from '@/features/chat/components/ResponseStatsBar'
+import { ThinkingDisclosure } from '@/features/chat/components/ThinkingDisclosure'
+import { isMeshVirtualModel } from '@/features/chat/lib/moa-progress'
 import { splitAssistantThinking } from '@/features/chat/components/thinking-segments'
 
 export type MessageAttachmentAction = {
@@ -239,13 +241,16 @@ function AssistantMarkdown({
 function AssistantMessageContent({
   body,
   linksEnabled,
+  model,
   streaming
 }: {
   body: string
   linksEnabled: boolean
+  model?: string
   streaming: boolean
 }) {
-  const segments = splitAssistantThinking(body, { streaming })
+  const meshVirtualModel = isMeshVirtualModel(model)
+  const segments = splitAssistantThinking(body, { streaming: streaming && !meshVirtualModel })
 
   if (segments.length === 0) return null
 
@@ -255,7 +260,18 @@ function AssistantMessageContent({
         const key = `${segment.kind}-${index}`
 
         if (segment.kind === 'thinking') {
-          const active = streaming && segment.open
+          const hasResponseAfter = segments
+            .slice(index + 1)
+            .some((candidate) => candidate.kind === 'response' && candidate.text.length > 0)
+          const active = streaming && (segment.open || (meshVirtualModel && !hasResponseAfter))
+
+          if (meshVirtualModel) {
+            return (
+              <ThinkingDisclosure active={active} key={key}>
+                <AssistantMarkdown text={segment.text} linksEnabled={linksEnabled} variant="thinking" />
+              </ThinkingDisclosure>
+            )
+          }
 
           return (
             <div
@@ -431,7 +447,7 @@ export function MessageRow({
             </span>
           </div>
         ) : isResponse ? (
-          <AssistantMessageContent body={body} linksEnabled={true} streaming={isStreamingPlaceholder} />
+          <AssistantMessageContent body={body} linksEnabled={true} model={model} streaming={isStreamingPlaceholder} />
         ) : (
           body
         )}

--- a/crates/mesh-llm-ui/src/features/chat/components/ThinkingDisclosure.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/components/ThinkingDisclosure.tsx
@@ -1,0 +1,62 @@
+import * as Collapsible from '@radix-ui/react-collapsible'
+import { ChevronRight, Loader2, Network } from 'lucide-react'
+import { useState, type ReactNode } from 'react'
+import { cn } from '@/lib/cn'
+import { MOA_PROGRESS_LABEL } from '@/features/chat/lib/moa-progress'
+
+type ThinkingDisclosureProps = {
+  active: boolean
+  children: ReactNode
+}
+
+export function ThinkingDisclosure({ active, children }: ThinkingDisclosureProps) {
+  const [open, setOpen] = useState(false)
+  const label = active ? MOA_PROGRESS_LABEL : 'Peer consultation'
+
+  return (
+    <Collapsible.Root
+      className="block overflow-hidden rounded-[var(--radius)] border text-[length:var(--density-type-body)] leading-[1.5] text-fg-dim"
+      data-thinking-state={active ? 'active' : 'complete'}
+      onOpenChange={setOpen}
+      open={open}
+      style={{
+        background: 'color-mix(in oklab, var(--color-accent) 5%, var(--color-panel))',
+        borderColor: 'color-mix(in oklab, var(--color-accent) 22%, var(--color-border-soft))'
+      }}
+    >
+      <Collapsible.Trigger asChild>
+        <button
+          aria-label={`${label} ${open ? 'Hide' : 'Show'} details`}
+          className="flex w-full select-none items-center gap-2 px-3 py-2.5 text-left font-mono text-[length:var(--density-type-label)] uppercase tracking-[0.07em] text-fg-faint outline-none transition-colors hover:text-fg-dim focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent"
+          type="button"
+        >
+          {active ? (
+            <Loader2 className="size-3 shrink-0 animate-spin" aria-hidden={true} />
+          ) : (
+            <Network className="size-3 shrink-0" aria-hidden={true} strokeWidth={1.7} />
+          )}
+          <span aria-live="polite" className="min-w-0 flex-1 truncate">
+            {label}
+          </span>
+          <span className="hidden normal-case tracking-normal text-fg-faint sm:inline">
+            {open ? 'Hide details' : 'Show details'}
+          </span>
+          <ChevronRight
+            aria-hidden={true}
+            className={cn('size-3 shrink-0 transition-transform', open && 'rotate-90')}
+          />
+        </button>
+      </Collapsible.Trigger>
+      <Collapsible.Content
+        aria-label={`${label} details`}
+        className="max-h-64 overflow-y-auto border-t border-border-soft px-3 py-2.5 outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-accent"
+        forceMount
+        hidden={!open}
+        role="region"
+        tabIndex={open ? 0 : -1}
+      >
+        {children}
+      </Collapsible.Content>
+    </Collapsible.Root>
+  )
+}

--- a/crates/mesh-llm-ui/src/features/chat/lib/live-chat-models.test.ts
+++ b/crates/mesh-llm-ui/src/features/chat/lib/live-chat-models.test.ts
@@ -31,6 +31,10 @@ describe('statusBackedChatModels', () => {
             serving_models: ['legacy-routable']
           },
           {
+            hosted_models: [],
+            serving_models: ['legacy-status-api-routable']
+          },
+          {
             hosted_models: ['hosted-routable'],
             hosted_models_known: true,
             serving_models: ['assigned-copy']
@@ -39,7 +43,11 @@ describe('statusBackedChatModels', () => {
       })
     )
 
-    expect(models.map((model) => model.name)).toEqual(['hosted-routable', 'legacy-routable'])
+    expect(models.map((model) => model.name)).toEqual([
+      'hosted-routable',
+      'legacy-routable',
+      'legacy-status-api-routable'
+    ])
   })
 
   it('includes only warm local model entries while retaining legacy strings', () => {

--- a/crates/mesh-llm-ui/src/features/chat/lib/live-chat-models.test.ts
+++ b/crates/mesh-llm-ui/src/features/chat/lib/live-chat-models.test.ts
@@ -1,0 +1,61 @@
+import { statusBackedChatModels } from '@/features/chat/lib/live-chat-models'
+import type { StatusPayload } from '@/lib/api/types'
+
+function status(overrides: Partial<StatusPayload>): StatusPayload {
+  return {
+    node_id: 'local-node',
+    node_state: 'client',
+    model_name: '',
+    peers: [],
+    models: [],
+    my_vram_gb: 0,
+    gpus: [],
+    serving_models: [],
+    ...overrides
+  }
+}
+
+describe('statusBackedChatModels', () => {
+  it('uses peer-hosted models and only falls back to assigned models for legacy peers', () => {
+    const models = statusBackedChatModels(
+      status({
+        peers: [
+          {
+            hosted_models: [],
+            hosted_models_known: true,
+            serving_models: ['assigned-but-not-hosted']
+          },
+          {
+            hosted_models: [],
+            hosted_models_known: false,
+            serving_models: ['legacy-routable']
+          },
+          {
+            hosted_models: ['hosted-routable'],
+            hosted_models_known: true,
+            serving_models: ['assigned-copy']
+          }
+        ]
+      })
+    )
+
+    expect(models.map((model) => model.name)).toEqual(['hosted-routable', 'legacy-routable'])
+  })
+
+  it('includes only warm local model entries while retaining legacy strings', () => {
+    const models = statusBackedChatModels(
+      status({
+        node_state: 'serving',
+        serving_models: [
+          { name: 'warm-local', node_id: 'local-node', status: 'warm' },
+          { name: 'loading-local', node_id: 'local-node', status: 'loading' },
+          { name: 'unloading-local', node_id: 'local-node', status: 'unloading' },
+          'legacy-local',
+          'mesh'
+        ]
+      })
+    )
+
+    expect(models.map((model) => model.name)).toEqual(['legacy-local', 'warm-local'])
+  })
+})

--- a/crates/mesh-llm-ui/src/features/chat/lib/live-chat-models.ts
+++ b/crates/mesh-llm-ui/src/features/chat/lib/live-chat-models.ts
@@ -19,7 +19,7 @@ function localRoutableModelNames(status: StatusPayload): string[] {
 
 function peerRoutableModelNames(peer: PeerInfo): string[] {
   const hosted = peer.hosted_models?.filter(Boolean) ?? []
-  if (hosted.length > 0 || peer.hosted_models_known !== false) return hosted
+  if (hosted.length > 0 || peer.hosted_models_known === true) return hosted
   return peer.serving_models?.filter(Boolean) ?? []
 }
 

--- a/crates/mesh-llm-ui/src/features/chat/lib/live-chat-models.ts
+++ b/crates/mesh-llm-ui/src/features/chat/lib/live-chat-models.ts
@@ -1,0 +1,43 @@
+import type { ModelSummary } from '@/features/app-tabs/types'
+import type { PeerInfo, ServingModelEntry, StatusPayload } from '@/lib/api/types'
+
+const VIRTUAL_MESH_MODEL = 'mesh'
+
+function addModelName(names: Set<string>, name: string | undefined) {
+  const normalized = name?.trim()
+  if (normalized && normalized !== VIRTUAL_MESH_MODEL) names.add(normalized)
+}
+
+function localRoutableModelNames(status: StatusPayload): string[] {
+  if (status.node_state === 'client') return []
+
+  return (status.serving_models ?? []).flatMap((model: ServingModelEntry) => {
+    if (typeof model === 'string') return [model]
+    return model.status === 'warm' ? [model.name] : []
+  })
+}
+
+function peerRoutableModelNames(peer: PeerInfo): string[] {
+  const hosted = peer.hosted_models?.filter(Boolean) ?? []
+  if (hosted.length > 0 || peer.hosted_models_known !== false) return hosted
+  return peer.serving_models?.filter(Boolean) ?? []
+}
+
+export function statusBackedChatModels(status: StatusPayload | undefined): ModelSummary[] {
+  if (!status) return []
+
+  const names = new Set<string>()
+  for (const model of localRoutableModelNames(status)) addModelName(names, model)
+  for (const peer of status.peers ?? []) {
+    for (const model of peerRoutableModelNames(peer)) addModelName(names, model)
+  }
+
+  return [...names].sort().map((name) => ({
+    name,
+    family: name.split('/')[0] ?? name,
+    size: 'Unknown',
+    context: 'Unknown',
+    status: 'warm',
+    tags: []
+  }))
+}

--- a/crates/mesh-llm-ui/src/features/chat/lib/moa-progress.ts
+++ b/crates/mesh-llm-ui/src/features/chat/lib/moa-progress.ts
@@ -1,0 +1,20 @@
+export const MOA_PROGRESS_LABEL = 'Consulting peers and corroborating responses…'
+
+const SYNTHETIC_MOA_PROGRESS = new Set([
+  'routing through mesh…',
+  'querying peer models…',
+  'comparing responses…',
+  'waiting on a slow peer…',
+  'still gathering responses…',
+  "hold on, this one's taking a moment…",
+  'hold on, this is taking a moment…'
+])
+
+export function isMeshVirtualModel(model?: string) {
+  return model?.trim().toLowerCase() === 'mesh'
+}
+
+export function syntheticMoaProgressKey(delta: string) {
+  const normalized = delta.trim().replace(/\s+/g, ' ').toLowerCase()
+  return SYNTHETIC_MOA_PROGRESS.has(normalized) ? normalized : undefined
+}

--- a/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.test.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.test.tsx
@@ -10,6 +10,8 @@ import { loadChatState, saveChatState, trimThreadMessages } from '@/features/cha
 import { ChatLayout } from '@/features/chat/layouts/ChatLayout'
 import { ChatPage, ChatPageContent } from '@/features/chat/pages/ChatPage'
 import { adaptModelsToSummary } from '@/features/network/api/models-adapter'
+import { useModelsQuery } from '@/features/network/api/use-models-query'
+import { useStatusQuery } from '@/features/network/api/use-status-query'
 import { DataModeProvider } from '@/lib/data-mode/DataModeContext'
 import { FeatureFlagProvider } from '@/lib/feature-flags'
 
@@ -98,7 +100,7 @@ const chatMock = vi.hoisted(() => {
     sendOptimisticUserMessageBeforeError: false,
     sendOptimisticAssistantPlaceholderBeforeError: false,
     reloadAssistantText: 'Retried assistant reply',
-    reloadStatus: 'ready' as const,
+    reloadStatus: 'ready' as 'ready' | 'submitted' | 'streaming' | 'error',
     reloadErrorMessage: undefined as string | undefined,
     stopCalls: [] as string[],
     sendCalls: [] as Array<{
@@ -176,11 +178,11 @@ vi.mock('@/features/chat/api/chat-storage', () => ({
 }))
 
 vi.mock('@/features/network/api/use-models-query', () => ({
-  useModelsQuery: vi.fn(() => ({ data: { mesh_models: [] }, isFetching: false, isError: false, refetch: vi.fn() }))
+  useModelsQuery: vi.fn()
 }))
 
 vi.mock('@/features/network/api/use-status-query', () => ({
-  useStatusQuery: vi.fn(() => ({ data: undefined }))
+  useStatusQuery: vi.fn()
 }))
 
 vi.mock('@/features/network/api/models-adapter', () => ({
@@ -471,6 +473,18 @@ describe('ChatPage', () => {
     vi.mocked(saveChatState).mockResolvedValue(undefined)
     vi.mocked(trimThreadMessages).mockImplementation((messages) => messages)
     vi.mocked(adaptModelsToSummary).mockReturnValue(CHAT_HARNESS.models)
+    vi.mocked(useModelsQuery).mockReturnValue({
+      data: { mesh_models: [] },
+      isFetching: false,
+      isError: false,
+      refetch: vi.fn()
+    } as unknown as ReturnType<typeof useModelsQuery>)
+    vi.mocked(useStatusQuery).mockReturnValue({
+      data: undefined,
+      isFetching: false,
+      isError: false,
+      refetch: vi.fn()
+    } as unknown as ReturnType<typeof useStatusQuery>)
     attachmentPreprocessingMock.describeImageForPrompt.mockReset()
     attachmentPreprocessingMock.extractPdfTextFromFile.mockReset()
     attachmentPreprocessingMock.describeScannedPdf.mockReset()
@@ -569,6 +583,104 @@ describe('ChatPage', () => {
 
     const options = await screen.findAllByRole('option')
     expect(options[0]).toHaveTextContent('Auto')
+  })
+
+  it('renders usable live chat with status-backed models while catalog enrichment is loading', async () => {
+    const user = userEvent.setup()
+    vi.mocked(useModelsQuery).mockReturnValue({
+      data: undefined,
+      isFetching: true,
+      isError: false,
+      refetch: vi.fn()
+    } as unknown as ReturnType<typeof useModelsQuery>)
+    vi.mocked(useStatusQuery).mockReturnValue({
+      data: {
+        llama_ready: false,
+        node_state: 'client',
+        serving_models: [],
+        peers: [{ hosted_models_known: false, serving_models: ['peer-model'] }]
+      },
+      isFetching: false,
+      isError: false,
+      refetch: vi.fn()
+    } as unknown as ReturnType<typeof useStatusQuery>)
+
+    renderChatPage({ mode: 'live' })
+
+    expect(screen.getByText('Start Chatting')).toBeVisible()
+    expect(screen.getByLabelText('Prompt')).toBeEnabled()
+    const modelSelect = screen.getByRole('combobox', { name: 'Select model' })
+    expect(modelSelect).toHaveTextContent('Mesh — automatic')
+
+    await user.click(modelSelect)
+
+    expect(screen.getByRole('option', { name: /peer-model/ })).toBeVisible()
+  })
+
+  it('keeps live chat usable when catalog enrichment fails but runtime status is ready', () => {
+    vi.mocked(useModelsQuery).mockReturnValue({
+      data: undefined,
+      isFetching: false,
+      isError: true,
+      refetch: vi.fn()
+    } as unknown as ReturnType<typeof useModelsQuery>)
+    vi.mocked(useStatusQuery).mockReturnValue({
+      data: { llama_ready: true, serving_models: ['local-model'], peers: [] },
+      isFetching: false,
+      isError: false,
+      refetch: vi.fn()
+    } as unknown as ReturnType<typeof useStatusQuery>)
+
+    renderChatPage({ mode: 'live' })
+
+    expect(screen.getByText('Start Chatting')).toBeVisible()
+    expect(screen.getByLabelText('Prompt')).toBeEnabled()
+  })
+
+  it('uses a warm catalog without waiting for runtime status', () => {
+    vi.mocked(adaptModelsToSummary).mockReturnValue([
+      { ...CHAT_HARNESS.models[0], name: 'catalog-model', status: 'warm' }
+    ])
+    vi.mocked(useModelsQuery).mockReturnValue({
+      data: { mesh_models: [{}] },
+      isFetching: false,
+      isError: false,
+      refetch: vi.fn()
+    } as unknown as ReturnType<typeof useModelsQuery>)
+    vi.mocked(useStatusQuery).mockReturnValue({
+      data: undefined,
+      isFetching: true,
+      isError: false,
+      refetch: vi.fn()
+    } as unknown as ReturnType<typeof useStatusQuery>)
+
+    renderChatPage({ mode: 'live' })
+
+    expect(screen.getByText('Start Chatting')).toBeVisible()
+    expect(screen.getByLabelText('Prompt')).toBeEnabled()
+  })
+
+  it('keeps warm catalog chat usable if runtime status fails', () => {
+    vi.mocked(adaptModelsToSummary).mockReturnValue([
+      { ...CHAT_HARNESS.models[0], name: 'catalog-model', status: 'warm' }
+    ])
+    vi.mocked(useModelsQuery).mockReturnValue({
+      data: { mesh_models: [{}] },
+      isFetching: false,
+      isError: false,
+      refetch: vi.fn()
+    } as unknown as ReturnType<typeof useModelsQuery>)
+    vi.mocked(useStatusQuery).mockReturnValue({
+      data: undefined,
+      isFetching: false,
+      isError: true,
+      refetch: vi.fn()
+    } as unknown as ReturnType<typeof useStatusQuery>)
+
+    renderChatPage({ mode: 'live' })
+
+    expect(screen.getByText('Start Chatting')).toBeVisible()
+    expect(screen.getByLabelText('Prompt')).toBeEnabled()
   })
 
   it('excludes cold live models from the chat model selector', async () => {
@@ -935,6 +1047,27 @@ describe('ChatPage', () => {
     })
   })
 
+  it('keeps retried mesh progress folded before response metadata arrives', async () => {
+    const user = userEvent.setup()
+
+    renderChatPage({ mode: 'live' })
+
+    await user.type(screen.getByLabelText('Prompt'), 'Check this with the mesh')
+    await user.click(screen.getByRole('button', { name: 'Send' }))
+    await user.click(screen.getByRole('button', { name: 'Stop streaming' }))
+
+    chatMock.reloadAssistantText = 'Routing through mesh…</think>'
+    chatMock.reloadStatus = 'streaming'
+    await user.click(screen.getByRole('button', { name: 'Retry last' }))
+
+    const disclosure = await screen.findByRole('button', {
+      name: 'Consulting peers and corroborating responses… Show details'
+    })
+    expect(disclosure.closest('[data-thinking-state="active"]')).toBeInTheDocument()
+    expect(screen.getByText('Routing through mesh…')).not.toBeVisible()
+    expect(screen.queryByText('Thinking')).not.toBeInTheDocument()
+  })
+
   it('renders streamed thinking separately, formats final markdown, and persists the raw assistant body', async () => {
     const user = userEvent.setup()
     const streamedBody = 'Reasoning text.</think> The capital of France is **Paris**.'
@@ -945,8 +1078,12 @@ describe('ChatPage', () => {
     await user.type(screen.getByLabelText('Prompt'), 'Show final answer formatting')
     await user.click(screen.getByRole('button', { name: 'Send' }))
 
-    expect(await screen.findByText('Thinking')).toBeInTheDocument()
-    expect(screen.getByText('Reasoning text.')).toBeInTheDocument()
+    const reasoningDisclosure = await screen.findByRole('button', { name: 'Peer consultation Show details' })
+    expect(screen.getByText('Reasoning text.')).not.toBeVisible()
+
+    await user.click(reasoningDisclosure)
+
+    expect(screen.getByText('Reasoning text.')).toBeVisible()
 
     const paris = screen.getByText('Paris')
     expect(paris.tagName.toLowerCase()).toBe('strong')

--- a/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.tsx
@@ -45,6 +45,7 @@ import { cn } from '@/lib/utils'
 import { useDataMode } from '@/lib/data-mode'
 import { useBooleanFeatureFlag } from '@/lib/feature-flags'
 import { CHAT_HARNESS } from '@/features/app-tabs/data'
+import { statusBackedChatModels } from '@/features/chat/lib/live-chat-models'
 import type {
   ChatActionMetric,
   ChatHarnessData,
@@ -469,18 +470,17 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
   const modelsQuery = useModelsQuery({ enabled: mode === 'live' })
   const statusQuery = useStatusQuery({ enabled: liveMode })
   const liveStatus = statusQuery.data
-  const liveModels = modelsQuery.data ? adaptModelsToSummary(modelsQuery.data.mesh_models) : undefined
-  const resolvedModels = liveMode ? liveModels : data.models
-  const displayModels = resolvedModels ?? data.models
+  const catalogModels = modelsQuery.data ? adaptModelsToSummary(modelsQuery.data.mesh_models) : undefined
+  const statusModels = useMemo(() => statusBackedChatModels(liveStatus), [liveStatus])
+  const liveModels = catalogModels && catalogModels.length > 0 ? catalogModels : statusModels
+  const displayModels = liveMode ? liveModels : data.models
   const selectableModels = useMemo(() => displayModels.filter(isChatSelectableModel), [displayModels])
-  const showLiveError = liveMode && !liveModels && !modelsQuery.isFetching && modelsQuery.isError
-  const showLiveLoading = liveMode && !liveModels && !showLiveError
-  const warmModelCount = liveModels?.filter(isChatSelectableModel).length ?? 0
-  const canChat =
-    !liveMode ||
-    (liveStatus?.llama_ready ?? false) ||
-    warmModelCount > 0 ||
-    (liveStatus?.serving_models?.length ?? 0) > 0
+  const warmModelCount = catalogModels?.filter(isChatSelectableModel).length ?? 0
+  const hasLiveReadiness = liveStatus != null || warmModelCount > 0
+  const liveReadinessFetching = statusQuery.isFetching || modelsQuery.isFetching
+  const showLiveError = liveMode && !hasLiveReadiness && !liveReadinessFetching && statusQuery.isError
+  const showLiveLoading = liveMode && !hasLiveReadiness && liveReadinessFetching
+  const canChat = !liveMode || (liveStatus?.llama_ready ?? false) || warmModelCount > 0 || statusModels.length > 0
   const transparencyTabEnabled = useBooleanFeatureFlag('chat/transparencyTab')
   const systemPromptButtonEnabled = useBooleanFeatureFlag('chat/systemPromptButton')
   const [sidebarTab, setSidebarTab] = useState<'conversations' | 'transparency'>('conversations')
@@ -544,7 +544,11 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
     submittedModel: string
     submittedAttachmentMessageId?: string
   } | null>(null)
-  const pendingRetryRef = useRef<{ conversationId: string; model: string } | null>(null)
+  const pendingRetryRef = useRef<{
+    conversationId: string
+    model: string
+    previousAssistantMessageIds: Set<string>
+  } | null>(null)
   const handledChatErrorRef = useRef<{ conversationId: string; message: string } | null>(null)
   const revokeSubmittedAttachmentPreviews = useCallback((previews: SubmittedAttachmentPreview[]) => {
     for (const preview of previews) {
@@ -773,8 +777,8 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
     removeSubmittedAttachmentPreviewsForConversation
   ])
   const retryLiveData = useCallback(() => {
-    void modelsQuery.refetch()
-  }, [modelsQuery])
+    void statusQuery.refetch()
+  }, [statusQuery])
   const switchToTestData = useCallback(() => setMode('harness'), [setMode])
 
   useEffect(() => {
@@ -871,6 +875,23 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
     submittedAttachmentsByMessageId,
     updateThread
   ])
+
+  useEffect(() => {
+    const pendingRetry = pendingRetryRef.current
+    if (!pendingRetry || pendingRetry.conversationId !== chatConversationId) return
+
+    const retryAssistant = chat.messages.find(
+      (message) => message.role === 'assistant' && !pendingRetry.previousAssistantMessageIds.has(message.id)
+    )
+    if (!retryAssistant) return
+
+    setMessageModels((current) =>
+      current[retryAssistant.id] === pendingRetry.model
+        ? current
+        : { ...current, [retryAssistant.id]: pendingRetry.model }
+    )
+    if (chat.status === 'ready' && !chat.error) pendingRetryRef.current = null
+  }, [chat.error, chat.messages, chat.status, chatConversationId, setMessageModels])
 
   useEffect(() => {
     const pendingRetry = pendingRetryRef.current
@@ -1066,7 +1087,13 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
     clearStoppedConversation(ensuredConversationId)
     setFailedSubmission(null)
     handledChatErrorRef.current = null
-    pendingRetryRef.current = { conversationId: ensuredConversationId, model: activeModelName }
+    pendingRetryRef.current = {
+      conversationId: ensuredConversationId,
+      model: activeModelName,
+      previousAssistantMessageIds: new Set(
+        chat.messages.filter((message) => message.role === 'assistant').map((message) => message.id)
+      )
+    }
     await chat.reload()
   }, [activeModelName, canRetry, chat, clearStoppedConversation, ensureConversation])
 
@@ -1168,10 +1195,10 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
   if (showLiveError) {
     return (
       <LiveDataUnavailableOverlay
-        debugTitle="Could not reach the local model catalog"
-        title="Live chat models are unavailable"
-        debugDescription="Chat could not fetch the initial model catalog from the configured API target. Start the backend, verify the endpoint, or switch Data source back to Harness in Tweaks while debugging."
-        productionDescription="Chat is waiting for the live model catalog before starting a conversation. Keep the page open while the service recovers, or switch Data source back to Harness in Tweaks to inspect sample conversations."
+        debugTitle="Could not reach local runtime status"
+        title="Live chat is unavailable"
+        debugDescription="Chat could not fetch runtime status from the configured API target. Start the backend, verify the endpoint, or switch Data source back to Harness in Tweaks while debugging."
+        productionDescription="Chat is waiting for the local runtime to become reachable. Keep the page open while the service recovers, or switch Data source back to Harness in Tweaks to inspect sample conversations."
         onRetry={retryLiveData}
         onSwitchToTestData={switchToTestData}
       >

--- a/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.tsx
@@ -470,7 +470,10 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
   const modelsQuery = useModelsQuery({ enabled: mode === 'live' })
   const statusQuery = useStatusQuery({ enabled: liveMode })
   const liveStatus = statusQuery.data
-  const catalogModels = modelsQuery.data ? adaptModelsToSummary(modelsQuery.data.mesh_models) : undefined
+  const catalogModels = useMemo(
+    () => (modelsQuery.data ? adaptModelsToSummary(modelsQuery.data.mesh_models) : undefined),
+    [modelsQuery.data]
+  )
   const statusModels = useMemo(() => statusBackedChatModels(liveStatus), [liveStatus])
   const liveModels = catalogModels && catalogModels.length > 0 ? catalogModels : statusModels
   const displayModels = liveMode ? liveModels : data.models

--- a/crates/mesh-llm-ui/src/features/developer/playground/areas/ChatComponentsArea.tsx
+++ b/crates/mesh-llm-ui/src/features/developer/playground/areas/ChatComponentsArea.tsx
@@ -45,6 +45,8 @@ Use the [local status endpoint](http://localhost:3131/api/status) before changin
 
 const STREAMING_THINKING_RESPONSE = `<think>Inspecting peer load, model warmth, and route latency.`
 
+const MESH_CONSULTATION_RESPONSE = `<think>Routing through mesh…</think>`
+
 export function ChatComponentsArea({ state }: { state: DeveloperPlaygroundState }) {
   const transparencyTabEnabled = useBooleanFeatureFlag('chat/transparencyTab')
   const [transparencyPreview, setTransparencyPreview] = useState<TransparencyPreview>('empty')
@@ -325,6 +327,15 @@ export function ChatComponentsArea({ state }: { state: DeveloperPlaygroundState 
                     tokens="42 tok"
                     tokPerSec="18.4 tok/s"
                     ttft="181ms"
+                  />
+                  <MessageRow
+                    body={MESH_CONSULTATION_RESPONSE}
+                    messageRole="assistant"
+                    model="mesh"
+                    onStopStreaming={() => undefined}
+                    route="public mesh"
+                    state="streaming"
+                    timestamp="14:33"
                   />
                   <MessageRow
                     body={MARKDOWN_THINKING_RESPONSE}

--- a/crates/mesh-llm-ui/src/lib/api/types.ts
+++ b/crates/mesh-llm-ui/src/lib/api/types.ts
@@ -97,6 +97,7 @@ export interface PeerInfo {
   role?: string
   serving_models?: string[]
   hosted_models?: string[]
+  hosted_models_known?: boolean
   models?: string[]
   my_vram_gb?: number
   vram_gb?: number


### PR DESCRIPTION
## Original problem

The web chat rendered every repeated MoA progress event as visible reasoning. With slow or unreliable public peers, status such as slow-peer waits and hold-on messages could fill the screen even though the useful answer was good. Chat startup also waited for the full model catalog when runtime status already exposed routable models.

## Diagnostics

Reproduced against the public mesh. The same synthetic progress cycle repeated during a request, while the model catalog could arrive materially later than runtime status. The inference, corroboration, routing, and tool paths themselves remained healthy.

## Fix

- Fold consultation output only for the virtual mesh model into a compact, closed-by-default disclosure.
- Keep every distinct progress phase once in the expanded detail, suppress repeated cycles, and preserve all unrecognized or genuine reasoning.
- Keep fast plain mesh answers visible immediately and leave direct-model thinking unchanged.
- Associate retried mesh responses with their model before response metadata arrives.
- Let runtime status provide initial routable chat models while the richer catalog continues loading in the background.

This is UI-only. It does not change MoA arbitration, tool behavior, request routing, gossip, or wire protocols.

## Validation

- [x] Focused chat tests passed.
- [x] Full UI suite passed: 953 passed, 3 skipped.
- [x] UI typecheck, lint, and format checks passed.
- [x] VITE_MESH_LLM_DEBUG_UI=false just build passed.
- [x] Live public-mesh client smoke passed: collapsed and expanded consultation states, distinct phases, fast answer streaming, and status-backed startup.
- [x] UI behavior is also represented in the chat-components playground. No static screenshot is attached because the important behavior is the active-to-complete stream transition; the deterministic component tests and playground cover both states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added expandable/collapsible “Peer consultation” thinking details for mesh-routed responses.
  - Improved live model selection by combining catalog and runtime status (including warm models).
- **Bug Fixes**
  - De-duplicated repeated mesh progress events so progress phases show once while the final answer still streams normally.
  - Refined “Retry last” so the selected model applies only to newly generated assistant messages.
  - Updated live-mode readiness and runtime-unavailable messaging for clarity.
- **Tests**
  - Expanded UI and streaming coverage around mesh thinking/disclosure and live-model readiness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->