### PR TITLE
Avoid stale embedded Metal shaders in llama builds

### DIFF
--- a/scripts/build-llama.sh
+++ b/scripts/build-llama.sh
@@ -206,10 +206,14 @@ if [[ "$USE_SCCACHE" != "0" && -n "$SCCACHE_BIN" ]] &&
 fi
 
 if [[ "$USE_SCCACHE" != "0" && -n "$SCCACHE_BIN" ]]; then
-  CMAKE_ARGS+=(
-    -DCMAKE_C_COMPILER_LAUNCHER="$SCCACHE_BIN"
-    -DCMAKE_CXX_COMPILER_LAUNCHER="$SCCACHE_BIN"
-  )
+  if [[ "$(uname -s)" == "Darwin" && "$LLAMA_BACKEND" == "metal" ]]; then
+    # The embedded Metal source is pulled into an assembly object with .incbin.
+    # sccache does not include that payload in the assembly cache key.
+    CMAKE_ARGS+=(-DCMAKE_C_COMPILER_LAUNCHER=)
+  else
+    CMAKE_ARGS+=(-DCMAKE_C_COMPILER_LAUNCHER="$SCCACHE_BIN")
+  fi
+  CMAKE_ARGS+=(-DCMAKE_CXX_COMPILER_LAUNCHER="$SCCACHE_BIN")
   case "$LLAMA_BACKEND" in
     cuda)
       CMAKE_ARGS+=(-DCMAKE_CUDA_COMPILER_LAUNCHER="$SCCACHE_BIN")
@@ -218,11 +222,23 @@ if [[ "$USE_SCCACHE" != "0" && -n "$SCCACHE_BIN" ]]; then
       CMAKE_ARGS+=(-DCMAKE_HIP_COMPILER_LAUNCHER="$SCCACHE_BIN")
       ;;
   esac
-  echo "using sccache for llama.cpp C/C++ compilation: $SCCACHE_BIN"
+  echo "using sccache for llama.cpp compilation where safe: $SCCACHE_BIN"
 elif [[ "$USE_SCCACHE" != "0" ]]; then
   echo "sccache not found; llama.cpp build will run without compiler caching" >&2
+  CMAKE_ARGS+=(
+    -DCMAKE_C_COMPILER_LAUNCHER=
+    -DCMAKE_CXX_COMPILER_LAUNCHER=
+    -DCMAKE_CUDA_COMPILER_LAUNCHER=
+    -DCMAKE_HIP_COMPILER_LAUNCHER=
+  )
 else
-  CMAKE_ARGS+=(-DGGML_CCACHE=OFF)
+  CMAKE_ARGS+=(
+    -DGGML_CCACHE=OFF
+    -DCMAKE_C_COMPILER_LAUNCHER=
+    -DCMAKE_CXX_COMPILER_LAUNCHER=
+    -DCMAKE_CUDA_COMPILER_LAUNCHER=
+    -DCMAKE_HIP_COMPILER_LAUNCHER=
+  )
 fi
 
 if [[ "$#" -gt 0 ]]; then


### PR DESCRIPTION
## Summary

- avoid using `sccache` for the C compiler launcher on Darwin Metal llama.cpp builds
- keep C++/CUDA/HIP compiler launchers cached where they are safe
- explicitly clear CMake compiler launcher settings when caching is unavailable or disabled

## Why

The embedded Metal shader library is included through an assembly `.incbin` object. `sccache` does not include that embedded payload in the assembly cache key, which can leave a llama.cpp build using stale Metal shader contents after shader source changes.

## Validation

- `bash -n scripts/build-llama.sh`
- `just build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compiler caching configuration for Apple Metal builds.
  * Prevented unsupported or unavailable caching settings from affecting C, C++, CUDA, and HIP compilation.
  * Updated build status messages to accurately reflect when caching is enabled only where safe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->