### PR TITLE
Reliable WAN split serving + speculative pipelining over the internet

### DIFF
--- a/SKIPPY_PROTOCOL_TODO.md
+++ b/SKIPPY_PROTOCOL_TODO.md
@@ -16,6 +16,14 @@ chunk and every normal decode token.
 > predicted-token / span returns exist (`binary_transport/direct_return.rs`).
 > Checkboxes that remain `[ ]` are still open or unverified.
 
+> **See also:** [docs/skippy/WAN_SPLIT_TRANSPORT_STATUS.md](docs/skippy/WAN_SPLIT_TRANSPORT_STATUS.md)
+> for the WAN split transport status/handoff (branch
+> `wip/wan-direct-prediction-return`, PR #1028): what is proven over WAN, the
+> landed transport keep-set, why fixed pipeline depth is diagnostic-only, the
+> go-forward suffix-ngram + adaptive-depth direction (PR #1037), and the 2-node
+> bringup config trap. Draft-model speculation is deferred on branch
+> `wip/wan-draft-ahead`.
+
 ## Current Observations
 
 - Prefill and decode use the same neighbor-chain shape:

--- a/crates/mesh-llm-cli/src/parser/commands.rs
+++ b/crates/mesh-llm-cli/src/parser/commands.rs
@@ -604,6 +604,11 @@ pub struct Cli {
     #[arg(long, hide = true)]
     pub speculative_verify_window_pipeline_depth: Option<u32>,
 
+    /// Force pipelined verify windows whenever depth > 1, bypassing the adaptive
+    /// profitability gate (shard-style "bet on the pipeline" mode for WAN splits).
+    #[arg(long, hide = true)]
+    pub speculative_verify_window_pipeline_force: Option<bool>,
+
     /// Draft model for speculative decoding.
     #[arg(long, hide = true)]
     pub draft: Option<PathBuf>,

--- a/crates/mesh-llm-config/src/model.rs
+++ b/crates/mesh-llm-config/src/model.rs
@@ -570,6 +570,7 @@ pub struct SpeculativeConfig {
     pub verify_window_min_tokens: Option<u32>,
     pub verify_window_max_tokens: Option<u32>,
     pub verify_window_pipeline_depth: Option<u32>,
+    pub verify_window_pipeline_force: Option<bool>,
     pub spec_default: Option<BoolOrAuto>,
     pub(crate) legacy_draft_model_path_used: bool,
 }
@@ -623,6 +624,7 @@ impl SpeculativeConfig {
             verify_window_min_tokens: pick!(verify_window_min_tokens),
             verify_window_max_tokens: pick!(verify_window_max_tokens),
             verify_window_pipeline_depth: pick!(verify_window_pipeline_depth),
+            verify_window_pipeline_force: pick!(verify_window_pipeline_force),
             spec_default: pick!(spec_default),
             legacy_draft_model_path_used: overrides
                 .filter(|config| config.draft_model.is_some())
@@ -700,6 +702,8 @@ struct SpeculativeConfigRaw {
     #[serde(default)]
     verify_window_pipeline_depth: Option<u32>,
     #[serde(default)]
+    verify_window_pipeline_force: Option<bool>,
+    #[serde(default)]
     spec_default: Option<BoolOrAuto>,
 }
 
@@ -746,6 +750,7 @@ impl<'de> Deserialize<'de> for SpeculativeConfig {
             verify_window_min_tokens: raw.verify_window_min_tokens,
             verify_window_max_tokens: raw.verify_window_max_tokens,
             verify_window_pipeline_depth: raw.verify_window_pipeline_depth,
+            verify_window_pipeline_force: raw.verify_window_pipeline_force,
             spec_default: raw.spec_default,
             legacy_draft_model_path_used: legacy_used,
         })
@@ -812,6 +817,10 @@ impl Serialize for SpeculativeConfig {
         map.serialize_entry(
             "verify_window_pipeline_depth",
             &self.verify_window_pipeline_depth,
+        )?;
+        map.serialize_entry(
+            "verify_window_pipeline_force",
+            &self.verify_window_pipeline_force,
         )?;
         map.serialize_entry("spec_default", &self.spec_default)?;
         map.end()

--- a/crates/mesh-llm-config/src/model/built_in_schema.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema.rs
@@ -710,6 +710,10 @@ fn speculative_settings(prefix: &str) -> Vec<ConfigSettingSchema> {
             &format!("{prefix}.verify_window_pipeline_depth"),
             ConfigValueSchema::Integer,
         ),
+        basic_setting(
+            &format!("{prefix}.verify_window_pipeline_force"),
+            ConfigValueSchema::Boolean,
+        ),
         basic_setting(&format!("{prefix}.spec_default"), bool_or_auto_schema()),
     ]
 }

--- a/crates/mesh-llm-config/src/model/built_in_schema/control_behavior/speculative.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema/control_behavior/speculative.rs
@@ -79,7 +79,8 @@ pub(super) fn apply_speculative_behavior(
         | "native_mtp_suppress_cooldown_draft_limit"
         | "verify_window_min_tokens"
         | "verify_window_max_tokens"
-        | "verify_window_pipeline_depth" => {}
+        | "verify_window_pipeline_depth"
+        | "verify_window_pipeline_force" => {}
         _ => {}
     }
 }

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/speculative.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/speculative.rs
@@ -404,6 +404,15 @@ fn resolve_decode_config(input: DecodeResolutionInput<'_>) -> Result<Speculative
             .and_then(|config| config.verify_window_pipeline_depth),
     )
     .map_or(config.verify_window.pipeline_depth, |value| value as usize);
+    config.verify_window.pipeline_force = pick_owned(
+        input
+            .model_config
+            .and_then(|config| config.verify_window_pipeline_force),
+        input
+            .global_config
+            .and_then(|config| config.verify_window_pipeline_force),
+    )
+    .unwrap_or(config.verify_window.pipeline_force);
     if config.verify_window.min_tokens > config.verify_window.max_tokens {
         bail!("skippy speculative verify window requires min_tokens <= max_tokens");
     }
@@ -481,6 +490,7 @@ fn package_decode_config(
             min_tokens: 1,
             max_tokens: 4,
             pipeline_depth: 1,
+            pipeline_force: false,
         });
     let effective_strategy = match (native_mtp.is_some(), ngram.as_ref().map(|value| value.kind)) {
         (true, Some(NgramProposerKind::Simple)) => "native-mtp+ngram-simple",
@@ -579,6 +589,7 @@ fn verify_window_config(policy: &PackageWindowPolicyInfo) -> VerifyWindowConfig 
         min_tokens: policy.min_window as usize,
         max_tokens: policy.max_window as usize,
         pipeline_depth: 1,
+        pipeline_force: false,
     }
 }
 

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/speculative.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/speculative.rs
@@ -377,47 +377,58 @@ fn resolve_decode_config(input: DecodeResolutionInput<'_>) -> Result<Speculative
     .map_or(config.native_mtp.suppress_cooldown_draft_limit, |value| {
         value as usize
     });
-    config.verify_window.min_tokens = pick_optional_u32(
-        input
-            .model_config
-            .and_then(|config| config.verify_window_min_tokens),
-        input
-            .global_config
-            .and_then(|config| config.verify_window_min_tokens),
-    )
-    .map_or(config.verify_window.min_tokens, |value| value as usize);
-    config.verify_window.max_tokens = pick_optional_u32(
-        input
-            .model_config
-            .and_then(|config| config.verify_window_max_tokens),
-        input
-            .global_config
-            .and_then(|config| config.verify_window_max_tokens),
-    )
-    .map_or(config.verify_window.max_tokens, |value| value as usize);
-    config.verify_window.pipeline_depth = pick_optional_u32(
-        input
-            .model_config
-            .and_then(|config| config.verify_window_pipeline_depth),
-        input
-            .global_config
-            .and_then(|config| config.verify_window_pipeline_depth),
-    )
-    .map_or(config.verify_window.pipeline_depth, |value| value as usize);
-    config.verify_window.pipeline_force = pick_owned(
-        input
-            .model_config
-            .and_then(|config| config.verify_window_pipeline_force),
-        input
-            .global_config
-            .and_then(|config| config.verify_window_pipeline_force),
-    )
-    .unwrap_or(config.verify_window.pipeline_force);
+    resolve_verify_window_config(&mut config.verify_window, &input);
     if config.verify_window.min_tokens > config.verify_window.max_tokens {
         bail!("skippy speculative verify window requires min_tokens <= max_tokens");
     }
     config.validate()?;
     Ok(config)
+}
+
+/// Apply model/global config overrides onto the resolved verify-window config.
+/// Extracted from `resolve_decode_config` to keep that function within the
+/// clippy line limit; each field prefers model config, then global, then the
+/// already-resolved default.
+fn resolve_verify_window_config(
+    verify_window: &mut VerifyWindowConfig,
+    input: &DecodeResolutionInput<'_>,
+) {
+    verify_window.min_tokens = pick_optional_u32(
+        input
+            .model_config
+            .and_then(|config| config.verify_window_min_tokens),
+        input
+            .global_config
+            .and_then(|config| config.verify_window_min_tokens),
+    )
+    .map_or(verify_window.min_tokens, |value| value as usize);
+    verify_window.max_tokens = pick_optional_u32(
+        input
+            .model_config
+            .and_then(|config| config.verify_window_max_tokens),
+        input
+            .global_config
+            .and_then(|config| config.verify_window_max_tokens),
+    )
+    .map_or(verify_window.max_tokens, |value| value as usize);
+    verify_window.pipeline_depth = pick_optional_u32(
+        input
+            .model_config
+            .and_then(|config| config.verify_window_pipeline_depth),
+        input
+            .global_config
+            .and_then(|config| config.verify_window_pipeline_depth),
+    )
+    .map_or(verify_window.pipeline_depth, |value| value as usize);
+    verify_window.pipeline_force = pick_owned(
+        input
+            .model_config
+            .and_then(|config| config.verify_window_pipeline_force),
+        input
+            .global_config
+            .and_then(|config| config.verify_window_pipeline_force),
+    )
+    .unwrap_or(verify_window.pipeline_force);
 }
 
 fn package_decode_config(

--- a/crates/mesh-llm-host-runtime/src/mesh/stage_transport.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/stage_transport.rs
@@ -1045,11 +1045,29 @@ impl Node {
         skippy_protocol::validate_stage_transport_open(&open)
             .map_err(|e| anyhow::anyhow!("StageTransportOpen validation error: {e}"))?;
         let conn = self.stage_connection_to_peer(peer_id).await?;
-        let snapshot = split_stage_path_snapshot_from_connection(&conn)
-            .with_peer_path_fallback(self.peer_stage_path_fallback(peer_id).await);
-        if let Some(rejection) = snapshot.stage_path_rejection() {
-            anyhow::bail!(
-                "stage transport path to {} is not eligible for split serving: {}",
+        // Do NOT re-apply the formation-time RTT/path eligibility ceiling
+        // (MAX_SPLIT_RTT_MS) to operational streams here. This function only runs
+        // from the post-formation stage-transport bridge, and split admission
+        // already gates path eligibility using gossiped, hysteresis-smoothed peer
+        // RTT plus re-election (see api/split_readiness.rs and node RTT handling).
+        //
+        // Re-checking the *instantaneous* per-connection RTT snapshot on every
+        // fresh stream caused transient failures under normal WAN jitter: pooled
+        // forward lanes (opened once at low RTT and reused) kept working, while
+        // per-request direct-prediction-return sinks — which open a fresh bridge
+        // stream each request — were rejected whenever the snapshot briefly read
+        // above the ceiling. That aborted the bridge task, dropped the accepted
+        // return-sink TCP connection, and surfaced as a ready-handshake timeout on
+        // stage 0, degrading/​502-ing an already-admitted split. A transiently slow
+        // or relay path still *works* (just slower); sustained degradation is
+        // handled by re-election, not by killing individual operational streams.
+        if let Some(rejection) = split_stage_path_snapshot_from_connection(&conn)
+            .with_peer_path_fallback(self.peer_stage_path_fallback(peer_id).await)
+            .stage_path_rejection()
+        {
+            tracing::warn!(
+                "stage transport path to {} reports {} on a formed split; proceeding \
+                 (operational streams tolerate transient path degradation)",
                 peer_id.fmt_short(),
                 rejection.as_str()
             );

--- a/crates/mesh-llm-host-runtime/tests/fixtures/config_schema_defaults_ui_reference.json
+++ b/crates/mesh-llm-host-runtime/tests/fixtures/config_schema_defaults_ui_reference.json
@@ -939,6 +939,13 @@
       }
     },
     {
+      "canonical_path": "defaults.speculative.verify_window_pipeline_force",
+      "support": "supported",
+      "source": {
+        "kind": "built_in"
+      }
+    },
+    {
       "canonical_path": "defaults.throughput.continuous_batching",
       "support": "supported",
       "source": {

--- a/crates/mesh-llm/src/lib.rs
+++ b/crates/mesh-llm/src/lib.rs
@@ -225,6 +225,7 @@ fn speculative_overrides_from_cli(
     overrides.verify_window_min_tokens = cli.speculative_verify_window_min_tokens;
     overrides.verify_window_max_tokens = cli.speculative_verify_window_max_tokens;
     overrides.verify_window_pipeline_depth = cli.speculative_verify_window_pipeline_depth;
+    overrides.verify_window_pipeline_force = cli.speculative_verify_window_pipeline_force;
     (overrides != Default::default()).then_some(overrides)
 }
 

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -18,6 +18,7 @@ pub(crate) use self::decode_batcher::DecodeFrameBatcher;
 pub use self::direct_return::PredictionReturnHub;
 pub use self::direct_return::PredictionReturnListener;
 pub(crate) use self::direct_return::PredictionReturnReceiver;
+pub(crate) use self::direct_return::classify_return_failure_phase;
 pub(crate) use self::forwarding::{forwarded_stage_message, forwarded_stage_message_timed};
 pub use self::options::{BinaryStageOptions, EmbeddedOpenAiStageOptions, parse_wire_dtype};
 pub(crate) use self::stage_execution::{

--- a/crates/skippy-server/src/binary_transport/direct_return.rs
+++ b/crates/skippy-server/src/binary_transport/direct_return.rs
@@ -302,14 +302,24 @@ impl PredictionReturnSinks {
 /// Read timeout for the return-sink ready handshake. `recv_ready` is a blocking
 /// `read_exact`; without this a stalled downstream connection hangs the open
 /// forever, which mid-generation blocks the request from ever falling back to
-/// the upstream reply. Kept short so a genuinely stalled peer fails fast to the
-/// fallback; cleared afterwards so the sink's normal reads stay blocking.
+/// the upstream reply. Cleared afterwards so the sink's normal reads stay
+/// blocking.
+///
+/// Budget sizing (20s): over a WAN mesh the return sink connects to a LOCAL
+/// bridge alias, but the remote `ready` byte only arrives after the bridge
+/// COLD-establishes a fresh stage QUIC connection (up to ~10s) and the remote
+/// inbound handler then dials its local binary server. A 5s budget timed out
+/// during that cold setup (observed EAGAIN on a healthy ~26ms WAN split), even
+/// though the pooled forward lanes — which get a 20s initial connect budget and
+/// are then reused — succeeded on the same bridge. Matching the forward-lane
+/// budget lets the cold return path complete instead of failing to the slower
+/// upstream-reply fallback.
 ///
 /// This is a *single bounded deadline*, not a retry budget: the sink is opened
 /// on the generation hot path, and `connect_downstream_socket` already bounds
 /// the connect itself, so wrapping this in an outer retry only compounds the
 /// worst-case stall (see PR #1011 review).
-const RETURN_SINK_READY_READ_TIMEOUT: Duration = Duration::from_secs(5);
+const RETURN_SINK_READY_READ_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Connect to `return_addr`, complete the ready handshake, and send the
 /// prediction-return open message. Single bounded attempt — on failure the

--- a/crates/skippy-server/src/binary_transport/direct_return.rs
+++ b/crates/skippy-server/src/binary_transport/direct_return.rs
@@ -152,6 +152,7 @@ impl PredictionReturnHub {
             key,
             hub: self.clone(),
             receiver,
+            direct_reply_seen: Arc::new(AtomicBool::new(false)),
         })
     }
 
@@ -202,6 +203,15 @@ pub(crate) struct PredictionReturnReceiver {
     key: PredictionReturnKey,
     hub: Arc<PredictionReturnHub>,
     receiver: mpsc::Receiver<Result<StageReply, String>>,
+    /// Trips the first time a reply is actually delivered over the direct route.
+    ///
+    /// This is the implicit "selection confirmation": the tail sends replies on
+    /// this socket ONLY if it selected it as the return route for this request.
+    /// A successful `PredictionReturnOpen` write does not prove selection (the
+    /// tail may still reply on the forward lane), but an actual delivered direct
+    /// reply does. Pipelining (depth > 1, direct-only completion) must gate on
+    /// this to avoid a 300s hang waiting on a route the tail never chose.
+    direct_reply_seen: Arc<AtomicBool>,
 }
 
 impl PredictionReturnReceiver {
@@ -213,6 +223,27 @@ impl PredictionReturnReceiver {
                 eprintln!("direct prediction return reader failed: {error:#}");
             }
         });
+    }
+
+    /// Whether a reply has been observed on the direct return route. Once true,
+    /// the tail has committed to replying directly for this request (route
+    /// selection is stable after generation configuration), so dependent
+    /// (pipelined) direct-only windows are safe to dispatch.
+    pub(crate) fn direct_confirmed(&self) -> bool {
+        self.direct_reply_seen.load(Ordering::Acquire)
+    }
+
+    /// Clear the confirmation flag. Called once right after the generation-config
+    /// ACK so that only POST-config direct replies count as route confirmation.
+    ///
+    /// Pre-config phases (prefix-cache restore, prefill) can send one-off direct
+    /// replies over sockets that are NOT the persistent generation return route;
+    /// counting those would falsely confirm the route and seed a direct-only
+    /// pipeline that then hangs waiting on a route the tail did not actually
+    /// select. Resetting here is safe because those pre-config replies are
+    /// consumed synchronously before generation config completes.
+    pub(crate) fn reset_direct_confirmation(&self) {
+        self.direct_reply_seen.store(false, Ordering::Release);
     }
 
     pub(crate) fn try_recv_expected(&self, expected: WireReplyKind) -> Result<Option<StageReply>> {
@@ -234,7 +265,11 @@ impl PredictionReturnReceiver {
 
     fn try_recv(&self) -> Result<Option<StageReply>> {
         match self.receiver.try_recv() {
-            Ok(Ok(reply)) => Ok(Some(reply)),
+            Ok(Ok(reply)) => {
+                // A delivered direct reply confirms the tail selected this route.
+                self.direct_reply_seen.store(true, Ordering::Release);
+                Ok(Some(reply))
+            }
             Ok(Err(error)) => Err(anyhow!(error)),
             Err(TryRecvError::Empty) => Ok(None),
             Err(TryRecvError::Disconnected) => {
@@ -321,15 +356,20 @@ impl PredictionReturnSinks {
 /// worst-case stall (see PR #1011 review).
 const RETURN_SINK_READY_READ_TIMEOUT: Duration = Duration::from_secs(20);
 
-/// Connect to `return_addr`, complete the ready handshake, and send the
-/// prediction-return open message. Single bounded attempt — on failure the
-/// caller falls back to the upstream reply path.
-fn open_return_sink_once(
+/// Connect to `return_addr` and complete the ready handshake, WITHOUT sending a
+/// `PredictionReturnOpen` message. This is the expensive, WAN-flaky half of
+/// opening a return sink (fresh TCP connect through the local bridge alias +
+/// QUIC bi-stream setup + blocking `recv_ready`). Splitting it out lets a pool
+/// pre-warm return sockets off the generation hot path, exactly like the
+/// forward `PersistentStageLanePool`.
+///
+/// A prepared-but-unbound socket is safe to park: the remote binary stage
+/// server's first-message read is an untimed blocking read, so it simply waits
+/// until we later send `PredictionReturnOpen` to bind the socket to a specific
+/// `(request_id, session_id)`.
+fn prepare_return_sink_socket(
     return_addr: SocketAddr,
     source_ip: Option<IpAddr>,
-    request_id: u64,
-    session_id: u64,
-    wire_dtype: WireActivationDType,
     not_ready_context: &'static str,
 ) -> Result<TcpStream> {
     let mut stream = connect_downstream_socket(return_addr, source_ip, Duration::from_secs(2))
@@ -352,12 +392,40 @@ fn open_return_sink_once(
         .set_read_timeout(None)
         .context("clear prediction return ready read timeout")?;
     ready?;
+    Ok(stream)
+}
+
+/// Bind a prepared (connected + ready) return socket to a specific request by
+/// writing the `PredictionReturnOpen` message. Cheap: a single write, safe to
+/// run on the generation hot path.
+fn bind_prepared_return_sink(
+    stream: &mut TcpStream,
+    request_id: u64,
+    session_id: u64,
+    wire_dtype: WireActivationDType,
+) -> Result<()> {
     write_stage_message(
-        &mut stream,
+        stream,
         &prediction_return_open_message(request_id, session_id),
         wire_dtype,
     )
-    .context("open prediction return stream")?;
+    .context("open prediction return stream")
+}
+
+/// Connect to `return_addr`, complete the ready handshake, and send the
+/// prediction-return open message. Single bounded attempt — on failure the
+/// caller falls back to the upstream reply path. This is the cold path used
+/// when no pre-warmed socket is available.
+fn open_return_sink_once(
+    return_addr: SocketAddr,
+    source_ip: Option<IpAddr>,
+    request_id: u64,
+    session_id: u64,
+    wire_dtype: WireActivationDType,
+    not_ready_context: &'static str,
+) -> Result<TcpStream> {
+    let mut stream = prepare_return_sink_socket(return_addr, source_ip, not_ready_context)?;
+    bind_prepared_return_sink(&mut stream, request_id, session_id, wire_dtype)?;
     Ok(stream)
 }
 
@@ -405,6 +473,41 @@ pub(crate) fn open_downstream_prediction_return_stream(
         "downstream prediction return sink did not become ready",
     )
     .with_context(|| format!("connect downstream prediction return sink at {endpoint}"))
+}
+
+/// Pre-warm a downstream return sink: perform the WAN-flaky connect + ready
+/// handshake WITHOUT binding it to a request. The returned socket is parked and
+/// can later be bound cheaply on the generation hot path via
+/// [`bind_downstream_prediction_return_socket`]. Used by the prepared-return
+/// pool so the cold, unreliable half of opening a return sink happens off the
+/// request path (mirrors the forward `PersistentStageLanePool` pre-warm).
+pub(crate) fn prepare_downstream_prediction_return_socket(
+    config: &StageConfig,
+) -> Result<TcpStream> {
+    let downstream = config
+        .downstream
+        .as_ref()
+        .ok_or_else(|| anyhow!("direct prediction return requires downstream stage"))?;
+    let endpoint = strip_tcp_prefix(&downstream.endpoint);
+    let return_addr = resolve_downstream_endpoint(endpoint)?;
+    let source_ip = downstream_source_ip(config)?;
+    prepare_return_sink_socket(
+        return_addr,
+        source_ip,
+        "downstream prediction return sink did not become ready",
+    )
+    .with_context(|| format!("prewarm downstream prediction return sink at {endpoint}"))
+}
+
+/// Bind a pre-warmed downstream return socket to a specific request by writing
+/// the `PredictionReturnOpen` message. Cheap; safe on the generation hot path.
+pub(crate) fn bind_downstream_prediction_return_socket(
+    stream: &mut TcpStream,
+    request_id: u64,
+    session_id: u64,
+    wire_dtype: WireActivationDType,
+) -> Result<()> {
+    bind_prepared_return_sink(stream, request_id, session_id, wire_dtype)
 }
 
 pub(crate) fn send_direct_prediction_return(
@@ -461,6 +564,94 @@ fn prediction_return_open_message(request_id: u64, session_id: u64) -> StageWire
         positions: Vec::new(),
         activation: Vec::new(),
         raw_bytes: Vec::new(),
+    }
+}
+
+/// Classify a return-sink open/bind failure into a bounded, privacy-safe phase
+/// label for telemetry. Raw endpoints and full error chains stay in local
+/// stderr logs only; OTLP attributes must not carry them.
+///
+/// Phase meanings (see the return-sink open sequence in `open_return_sink_once`
+/// and `prepare_return_sink_socket`):
+/// - `connect_refused` — local bridge listener gone/wrong (no one accepted).
+/// - `connect_timeout` — TCP connect to the (local bridge) endpoint timed out.
+/// - `ready_timeout` — local connect ok; no `ready` handshake byte in time
+///   (bridge/QUIC/remote-accept problem — the WAN leg).
+/// - `remote_eof` — remote/bridge accepted then closed before handshake.
+/// - `open_write_failed` — handshake ok but the open message write failed.
+/// - `other` — anything else; inspect local logs.
+pub(crate) fn classify_return_failure_phase(error_detail: &str) -> &'static str {
+    let lower = error_detail.to_ascii_lowercase();
+    if lower.contains("did not become ready") || lower.contains("ready read timeout") {
+        "ready_timeout"
+    } else if lower.contains("connection refused") {
+        "connect_refused"
+    } else if lower.contains("timed out") || lower.contains("timeout") {
+        "connect_timeout"
+    } else if lower.contains("unexpectedeof")
+        || lower.contains("unexpected eof")
+        || lower.contains("connection reset")
+    {
+        "remote_eof"
+    } else if lower.contains("open prediction return stream") || lower.contains("broken pipe") {
+        "open_write_failed"
+    } else {
+        "other"
+    }
+}
+
+#[cfg(test)]
+mod failure_phase_tests {
+    use super::classify_return_failure_phase;
+
+    #[test]
+    fn maps_ready_timeout_the_wan_leg() {
+        assert_eq!(
+            classify_return_failure_phase("downstream prediction return sink did not become ready"),
+            "ready_timeout"
+        );
+    }
+
+    #[test]
+    fn maps_connect_refused_local_bridge_gone() {
+        assert_eq!(
+            classify_return_failure_phase(
+                "connect downstream prediction return sink at 127.0.0.1:54321: Connection refused (os error 61)"
+            ),
+            "connect_refused"
+        );
+    }
+
+    #[test]
+    fn maps_remote_eof() {
+        assert_eq!(
+            classify_return_failure_phase("read direct prediction return: UnexpectedEof"),
+            "remote_eof"
+        );
+    }
+
+    #[test]
+    fn maps_open_write_failed() {
+        assert_eq!(
+            classify_return_failure_phase("open prediction return stream: broken pipe"),
+            "open_write_failed"
+        );
+    }
+
+    #[test]
+    fn unknown_is_other() {
+        assert_eq!(
+            classify_return_failure_phase("some unexpected condition"),
+            "other"
+        );
+    }
+
+    #[test]
+    fn connect_timeout_distinct_from_ready_timeout() {
+        assert_eq!(
+            classify_return_failure_phase("connect ...: operation timed out"),
+            "connect_timeout"
+        );
     }
 }
 

--- a/crates/skippy-server/src/binary_transport/options.rs
+++ b/crates/skippy-server/src/binary_transport/options.rs
@@ -228,6 +228,7 @@ mod tests {
                 min_tokens: 1,
                 max_tokens: 6,
                 pipeline_depth: 2,
+                pipeline_force: false,
             },
         }
     }

--- a/crates/skippy-server/src/frontend/decode_scheduler.rs
+++ b/crates/skippy-server/src/frontend/decode_scheduler.rs
@@ -9,23 +9,41 @@ const PIPELINE_PROFIT_MARGIN: f64 = 1.15;
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct VerifyWindowPipelineConfig {
     depth: usize,
+    force: bool,
 }
 
 impl VerifyWindowPipelineConfig {
     pub(super) fn new(depth: usize) -> Self {
         Self {
             depth: depth.max(1),
+            force: false,
         }
+    }
+
+    /// Force pipelining whenever `depth > 1`, bypassing the adaptive profitability
+    /// gate. This is the shard-style "bet on the pipeline" mode: keep `depth` verify
+    /// windows in flight from the first eligible proposal instead of waiting for the
+    /// profiler to prove profitability first (which, on a low-continuation WAN split,
+    /// it may never do — see `is_profitable`). Mistakes are absorbed by the existing
+    /// FIFO completion + stale-drain + reject-cooldown machinery.
+    pub(super) fn with_force(mut self, force: bool) -> Self {
+        self.force = force;
+        self
     }
 
     pub(super) fn depth(self) -> usize {
         self.depth
+    }
+
+    pub(super) fn force(self) -> bool {
+        self.force
     }
 }
 
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub(super) struct VerifyWindowPipelineStats {
     depth: usize,
+    force: bool,
     direct_prediction_return: bool,
     opened_windows: usize,
     max_in_flight: usize,
@@ -43,6 +61,10 @@ impl VerifyWindowPipelineStats {
         timings.insert(
             "verify_window_depth".to_string(),
             serde_json::json!(self.depth),
+        );
+        timings.insert(
+            "verify_window_force".to_string(),
+            serde_json::json!(self.force),
         );
         timings.insert(
             "verify_window_direct_prediction_return".to_string(),
@@ -167,6 +189,7 @@ impl VerifyWindowScheduler {
             in_flight: VecDeque::new(),
             stats: VerifyWindowPipelineStats {
                 depth: config.depth(),
+                force: config.force(),
                 ..VerifyWindowPipelineStats::default()
             },
             width_profiles: BTreeMap::new(),
@@ -207,7 +230,13 @@ impl VerifyWindowScheduler {
         );
     }
 
+    /// True when the pipeline may be seeded this step. In forced mode (`depth > 1`
+    /// and `force`), this is unconditional — the profiler is bypassed. Otherwise it
+    /// falls back to the adaptive gate: some observed width must be profitable.
     pub(super) fn has_profitable_pipeline_width(&self) -> bool {
+        if self.forced() {
+            return true;
+        }
         self.config.depth() > 1
             && self
                 .width_profiles
@@ -215,13 +244,20 @@ impl VerifyWindowScheduler {
                 .any(VerifyWindowWidthProfile::is_profitable)
     }
 
+    /// Whether pipelining is forced on: `depth > 1` and the operator opted into the
+    /// bet-on-the-pipeline mode.
+    pub(super) fn forced(&self) -> bool {
+        self.config.depth() > 1 && self.config.force()
+    }
+
     pub(super) fn permit_pipeline_width(&mut self, width: usize) -> bool {
         self.stats.policy_permit_checks = self.stats.policy_permit_checks.saturating_add(1);
         let permitted = self.config.depth() > 1
-            && self
-                .width_profiles
-                .get(&width)
-                .is_some_and(VerifyWindowWidthProfile::is_profitable);
+            && (self.config.force()
+                || self
+                    .width_profiles
+                    .get(&width)
+                    .is_some_and(VerifyWindowWidthProfile::is_profitable));
         if permitted {
             self.stats.policy_permits = self.stats.policy_permits.saturating_add(1);
         } else {
@@ -338,7 +374,7 @@ mod tests {
 
     #[test]
     fn bounds_depth_and_requires_fifo_reply_ids() {
-        let config = VerifyWindowPipelineConfig { depth: 2 };
+        let config = VerifyWindowPipelineConfig::new(2);
         let mut scheduler = VerifyWindowScheduler::new(config);
         let first = scheduler.open(10, 0).unwrap();
         let second = scheduler.open(11, 1).unwrap();
@@ -357,7 +393,7 @@ mod tests {
 
     #[test]
     fn discards_stale_windows_after_divergence() {
-        let config = VerifyWindowPipelineConfig { depth: 3 };
+        let config = VerifyWindowPipelineConfig::new(3);
         let mut scheduler = VerifyWindowScheduler::new(config);
         scheduler.open(10, 0).unwrap();
         scheduler.open(11, 1).unwrap();
@@ -371,7 +407,7 @@ mod tests {
 
     #[test]
     fn pipeline_policy_waits_for_enough_width_specific_evidence() {
-        let mut scheduler = VerifyWindowScheduler::new(VerifyWindowPipelineConfig { depth: 2 });
+        let mut scheduler = VerifyWindowScheduler::new(VerifyWindowPipelineConfig::new(2));
         for _ in 0..PIPELINE_PROFILE_MIN_OBSERVATIONS - 1 {
             scheduler.observe_pipeline_profile(2, true, 20.0, 80.0);
         }
@@ -385,7 +421,7 @@ mod tests {
 
     #[test]
     fn pipeline_policy_suppresses_low_acceptance_local_work() {
-        let mut scheduler = VerifyWindowScheduler::new(VerifyWindowPipelineConfig { depth: 2 });
+        let mut scheduler = VerifyWindowScheduler::new(VerifyWindowPipelineConfig::new(2));
         for index in 0..PIPELINE_PROFILE_MIN_OBSERVATIONS {
             scheduler.observe_pipeline_profile(2, index < 2, 31.0, 24.0);
         }
@@ -399,7 +435,7 @@ mod tests {
 
     #[test]
     fn pipeline_policy_profiles_each_verify_width_independently() {
-        let mut scheduler = VerifyWindowScheduler::new(VerifyWindowPipelineConfig { depth: 2 });
+        let mut scheduler = VerifyWindowScheduler::new(VerifyWindowPipelineConfig::new(2));
         for index in 0..PIPELINE_PROFILE_MIN_OBSERVATIONS {
             scheduler.observe_pipeline_profile(1, index < 7, 20.0, 80.0);
             scheduler.observe_pipeline_profile(2, index < 2, 31.0, 24.0);
@@ -411,8 +447,34 @@ mod tests {
     }
 
     #[test]
+    fn forced_mode_pipelines_without_any_profitability_evidence() {
+        let mut scheduler =
+            VerifyWindowScheduler::new(VerifyWindowPipelineConfig::new(4).with_force(true));
+
+        // No observations at all — the adaptive gate would refuse. Forced mode admits.
+        assert!(scheduler.forced());
+        assert!(scheduler.has_profitable_pipeline_width());
+        assert!(scheduler.permit_pipeline_width(2));
+        assert!(scheduler.permit_pipeline_width(4));
+        assert_eq!(scheduler.stats().policy_permits, 2);
+        assert_eq!(scheduler.stats().policy_suppressed, 0);
+        assert!(scheduler.stats().force);
+    }
+
+    #[test]
+    fn forced_mode_is_inert_at_depth_one() {
+        let mut scheduler =
+            VerifyWindowScheduler::new(VerifyWindowPipelineConfig::new(1).with_force(true));
+
+        // depth == 1 can never pipeline dependent work, even when forced.
+        assert!(!scheduler.forced());
+        assert!(!scheduler.has_profitable_pipeline_width());
+        assert!(!scheduler.permit_pipeline_width(2));
+    }
+
+    #[test]
     fn pipeline_depth_one_never_admits_dependent_work() {
-        let mut scheduler = VerifyWindowScheduler::new(VerifyWindowPipelineConfig { depth: 1 });
+        let mut scheduler = VerifyWindowScheduler::new(VerifyWindowPipelineConfig::new(1));
         for _ in 0..PIPELINE_PROFILE_MIN_OBSERVATIONS {
             scheduler.observe_pipeline_profile(2, true, 20.0, 80.0);
         }
@@ -423,7 +485,7 @@ mod tests {
 
     #[test]
     fn pipeline_policy_adapts_when_recent_acceptance_changes() {
-        let mut scheduler = VerifyWindowScheduler::new(VerifyWindowPipelineConfig { depth: 2 });
+        let mut scheduler = VerifyWindowScheduler::new(VerifyWindowPipelineConfig::new(2));
         for _ in 0..PIPELINE_PROFILE_MAX_OBSERVATIONS {
             scheduler.observe_pipeline_profile(2, true, 20.0, 80.0);
         }
@@ -437,7 +499,7 @@ mod tests {
 
     #[test]
     fn pipeline_policy_counters_are_exposed_in_response_timings() {
-        let mut scheduler = VerifyWindowScheduler::new(VerifyWindowPipelineConfig { depth: 2 });
+        let mut scheduler = VerifyWindowScheduler::new(VerifyWindowPipelineConfig::new(2));
         for _ in 0..PIPELINE_PROFILE_MIN_OBSERVATIONS {
             scheduler.observe_pipeline_profile(2, true, 20.0, 80.0);
         }

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -73,6 +73,7 @@ impl StageOpenAiBackend {
             .ok_or_else(|| OpenAiError::backend("embedded stage 0 has no downstream lane pool"))?;
         let mut lane = lane_pool.checkout(request.ids)?;
         let mut direct_prediction_return_opened = false;
+        let mut direct_prediction_return_error: Option<String> = None;
         if let Some(prediction_return) = request.prediction_return.as_ref() {
             match crate::binary_transport::direct_return::open_downstream_prediction_return_stream(
                 request.config,
@@ -85,9 +86,28 @@ impl StageOpenAiBackend {
                     direct_prediction_return_opened = true;
                 }
                 Err(error) => {
+                    let detail = format!("{error:#}");
+                    // Raw endpoints + full error chain: local stderr only (never OTLP/502).
                     eprintln!(
-                        "direct prediction return upstream-opened sink unavailable: {error:#}"
+                        "direct prediction return upstream-opened sink unavailable \
+                         (stage_bind_addr={}, downstream={:?}): {detail}",
+                        request.config.bind_addr,
+                        request.config.downstream.as_ref().map(|d| &d.endpoint),
                     );
+                    // OTLP: bounded, privacy-safe fields only.
+                    let failure_phase = classify_direct_return_failure_phase(&detail);
+                    let mut attrs = self.openai_attrs(request.ids);
+                    attrs.insert(
+                        "llama_stage.direct_prediction_return.opened".to_string(),
+                        json!(false),
+                    );
+                    attrs.insert(
+                        "llama_stage.direct_prediction_return.failure_phase".to_string(),
+                        json!(failure_phase),
+                    );
+                    self.telemetry
+                        .emit("stage.direct_prediction_return_unavailable", attrs);
+                    direct_prediction_return_error = Some(failure_phase.to_string());
                 }
             }
         }
@@ -895,14 +915,42 @@ impl StageOpenAiBackend {
                 native_mtp_options.ngram_hybrid && draft_guard.is_none();
             let native_mtp_verify_windows_enabled =
                 (request.native_mtp_enabled || composite_sidecar_enabled) && draft_guard.is_none();
-            let pipelined_decode_enabled =
-                composite_sidecar_enabled && verify_window_scheduler.depth() > 1;
+            // Availability/performance separation (per docs/skippy/PIPELINED_VERIFY_WINDOW.md and
+            // expert review): the forward lane makes the split *servable*; direct prediction return
+            // makes it *pipeline-capable*. Serial VerifyWindow completion polls BOTH the direct
+            // return receiver and the forward lane (see embedded_execution.rs
+            // `poll_direct_or_downstream_reply`), so it serves correctly without a direct sink —
+            // only slower. The pipelined path's completion is direct-only and would block up to
+            // DIRECT_RETURN_FALLBACK_TIMEOUT (300s) waiting for a reply that never comes, so
+            // pipelining MUST stay gated on a confirmed direct-return sink.
+            let pipelined_decode_enabled = direct_prediction_return_opened
+                && composite_sidecar_enabled
+                && verify_window_scheduler.depth() > 1;
             if native_mtp_verify_windows_enabled && !direct_prediction_return_opened {
-                return Err(OpenAiError::backend(
-                    "native MTP verify windows require direct prediction return",
-                ));
+                // Not fatal: fall back to serial VerifyWindow over the forward lane. Record why the
+                // pipeline is unavailable so a WAN run can see it in one response, without failing
+                // the request.
+                let mut attrs = self.openai_attrs(request.ids);
+                attrs.insert(
+                    "llama_stage.direct_prediction_return.opened".to_string(),
+                    json!(false),
+                );
+                attrs.insert(
+                    "llama_stage.verify_window.pipeline_available".to_string(),
+                    json!(false),
+                );
+                attrs.insert(
+                    "llama_stage.direct_prediction_return.failure_phase".to_string(),
+                    json!(
+                        direct_prediction_return_error
+                            .as_deref()
+                            .unwrap_or("not_configured")
+                    ),
+                );
+                self.telemetry
+                    .emit("stage.verify_window_serial_fallback", attrs);
             }
-            if native_mtp_verify_windows_enabled {
+            if native_mtp_verify_windows_enabled && direct_prediction_return_opened {
                 verify_window_scheduler.mark_direct_prediction_return();
             }
             let mut pipelined_windows = VecDeque::new();
@@ -1996,5 +2044,96 @@ impl StageOpenAiBackend {
         self.finish_embedded_generation_session(&request, lane_pool, lane, &result, &session_key)?;
         result?;
         Ok(cache_stats)
+    }
+}
+
+/// Classify a direct-prediction-return sink-open failure into a bounded,
+/// privacy-safe phase label for telemetry. Raw endpoints and full error chains
+/// stay in local stderr logs only; OTLP attributes must not carry them.
+///
+/// Phase meanings (see docs/skippy/PIPELINED_VERIFY_WINDOW.md and the return-sink
+/// open sequence in `binary_transport::direct_return::open_return_sink_once`):
+/// - `connect_refused` — local bridge listener gone/wrong (no one accepted).
+/// - `connect_timeout` — TCP connect to the (local bridge) endpoint timed out.
+/// - `ready_timeout` — local connect ok; no `ready` handshake byte in time
+///   (bridge/QUIC/remote-accept problem — the WAN leg).
+/// - `remote_eof` — remote/bridge accepted then closed before handshake.
+/// - `open_write_failed` — handshake ok but the open message write failed.
+/// - `other` — anything else; inspect local logs.
+fn classify_direct_return_failure_phase(error_detail: &str) -> &'static str {
+    let lower = error_detail.to_ascii_lowercase();
+    if lower.contains("did not become ready") || lower.contains("ready read timeout") {
+        "ready_timeout"
+    } else if lower.contains("connection refused") {
+        "connect_refused"
+    } else if lower.contains("timed out") || lower.contains("timeout") {
+        "connect_timeout"
+    } else if lower.contains("unexpectedeof")
+        || lower.contains("unexpected eof")
+        || lower.contains("connection reset")
+    {
+        "remote_eof"
+    } else if lower.contains("open prediction return stream") || lower.contains("broken pipe") {
+        "open_write_failed"
+    } else {
+        "other"
+    }
+}
+
+#[cfg(test)]
+mod direct_return_failure_phase_tests {
+    use super::classify_direct_return_failure_phase;
+
+    #[test]
+    fn maps_ready_timeout_the_wan_leg() {
+        assert_eq!(
+            classify_direct_return_failure_phase(
+                "downstream prediction return sink did not become ready"
+            ),
+            "ready_timeout"
+        );
+    }
+
+    #[test]
+    fn maps_connect_refused_local_bridge_gone() {
+        assert_eq!(
+            classify_direct_return_failure_phase(
+                "connect downstream prediction return sink at 127.0.0.1:54321: Connection refused (os error 61)"
+            ),
+            "connect_refused"
+        );
+    }
+
+    #[test]
+    fn maps_remote_eof() {
+        assert_eq!(
+            classify_direct_return_failure_phase("read direct prediction return: UnexpectedEof"),
+            "remote_eof"
+        );
+    }
+
+    #[test]
+    fn maps_open_write_failed() {
+        assert_eq!(
+            classify_direct_return_failure_phase("open prediction return stream: broken pipe"),
+            "open_write_failed"
+        );
+    }
+
+    #[test]
+    fn unknown_is_other() {
+        assert_eq!(
+            classify_direct_return_failure_phase("some unexpected condition"),
+            "other"
+        );
+    }
+
+    #[test]
+    fn connect_timeout_distinct_from_ready_timeout() {
+        // A bare connect timeout (no "did not become ready") is the connect phase.
+        assert_eq!(
+            classify_direct_return_failure_phase("connect ...: operation timed out"),
+            "connect_timeout"
+        );
     }
 }

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -75,7 +75,32 @@ impl StageOpenAiBackend {
         let mut direct_prediction_return_opened = false;
         let mut direct_prediction_return_error: Option<String> = None;
         if let Some(prediction_return) = request.prediction_return.as_ref() {
-            match crate::binary_transport::direct_return::open_downstream_prediction_return_stream(
+            // Prefer a pre-warmed return socket (connect + ready handshake already
+            // done off the hot path). Binding it is a cheap write. Only if the pool
+            // is empty/stale do we fall back to the cold open, which does the
+            // WAN-flaky connect+handshake inline.
+            // `checkout_bound` signals the pool's own maintenance worker to
+            // refill the consumed slot; no per-request thread is spawned here.
+            let pooled = request
+                .prepared_return_pool
+                .as_ref()
+                .and_then(|pool| pool.checkout_bound(request_id, session_id));
+            if let Some(stream) = pooled {
+                prediction_return.attach_opened_stream(stream);
+                direct_prediction_return_opened = true;
+                let mut attrs = self.openai_attrs(request.ids);
+                attrs.insert(
+                    "llama_stage.direct_prediction_return.opened".to_string(),
+                    json!(true),
+                );
+                attrs.insert(
+                    "llama_stage.direct_prediction_return.source".to_string(),
+                    json!("prewarmed_pool"),
+                );
+                self.telemetry
+                    .emit("stage.direct_prediction_return_opened", attrs);
+            } else {
+                match crate::binary_transport::direct_return::open_downstream_prediction_return_stream(
                 request.config,
                 request_id,
                 session_id,
@@ -95,7 +120,8 @@ impl StageOpenAiBackend {
                         request.config.downstream.as_ref().map(|d| &d.endpoint),
                     );
                     // OTLP: bounded, privacy-safe fields only.
-                    let failure_phase = classify_direct_return_failure_phase(&detail);
+                    let failure_phase =
+                        crate::binary_transport::classify_return_failure_phase(&detail);
                     let mut attrs = self.openai_attrs(request.ids);
                     attrs.insert(
                         "llama_stage.direct_prediction_return.opened".to_string(),
@@ -108,6 +134,7 @@ impl StageOpenAiBackend {
                     self.telemetry
                         .emit("stage.direct_prediction_return_unavailable", attrs);
                     direct_prediction_return_error = Some(failure_phase.to_string());
+                }
                 }
             }
         }
@@ -674,6 +701,14 @@ impl StageOpenAiBackend {
                     reply.kind
                 )));
             }
+            // Phase-scope direct-return confirmation: only replies observed AFTER
+            // generation config count as proof the tail selected the direct route
+            // for decode. Pre-config phases (prefix-cache restore, prefill) can
+            // send one-off direct replies over non-generation sockets, which would
+            // otherwise falsely confirm and seed a direct-only pipeline that hangs.
+            if let Some(prediction_return) = request.prediction_return.as_ref() {
+                prediction_return.reset_direct_confirmation();
+            }
 
             let decode_timer = PhaseTimer::start();
             let mut decoded_tokens = 0usize;
@@ -974,8 +1009,22 @@ impl StageOpenAiBackend {
                 let token_timer = PhaseTimer::start();
                 let native_mtp_remaining =
                     (request.max_tokens as usize).saturating_sub(decoded_tokens);
+                // Implicit selection confirmation (expert-reviewed safety
+                // invariant): more than one VerifyWindow may be in flight only
+                // after a reply has actually been observed on this request's
+                // direct return route. A successful `PredictionReturnOpen` write
+                // does not prove the tail chose the direct route — it may still
+                // reply on the forward lane — so seeding the direct-only pipeline
+                // on bind success risks a 300s hang. While unconfirmed we stay
+                // serial (depth 1), whose completion polls BOTH the direct
+                // receiver and the forward lane; the first direct reply trips
+                // confirmation and unlocks pipelining for the rest of the request.
+                let direct_return_confirmed = request.prediction_return.as_ref().is_some_and(
+                    crate::binary_transport::PredictionReturnReceiver::direct_confirmed,
+                );
                 let mut pipeline_seed = None;
                 if pipelined_decode_enabled
+                    && direct_return_confirmed
                     && pipelined.is_none()
                     && pipelined_windows.is_empty()
                     && native_mtp_reject_cooldown_remaining == 0
@@ -2044,96 +2093,5 @@ impl StageOpenAiBackend {
         self.finish_embedded_generation_session(&request, lane_pool, lane, &result, &session_key)?;
         result?;
         Ok(cache_stats)
-    }
-}
-
-/// Classify a direct-prediction-return sink-open failure into a bounded,
-/// privacy-safe phase label for telemetry. Raw endpoints and full error chains
-/// stay in local stderr logs only; OTLP attributes must not carry them.
-///
-/// Phase meanings (see docs/skippy/PIPELINED_VERIFY_WINDOW.md and the return-sink
-/// open sequence in `binary_transport::direct_return::open_return_sink_once`):
-/// - `connect_refused` — local bridge listener gone/wrong (no one accepted).
-/// - `connect_timeout` — TCP connect to the (local bridge) endpoint timed out.
-/// - `ready_timeout` — local connect ok; no `ready` handshake byte in time
-///   (bridge/QUIC/remote-accept problem — the WAN leg).
-/// - `remote_eof` — remote/bridge accepted then closed before handshake.
-/// - `open_write_failed` — handshake ok but the open message write failed.
-/// - `other` — anything else; inspect local logs.
-fn classify_direct_return_failure_phase(error_detail: &str) -> &'static str {
-    let lower = error_detail.to_ascii_lowercase();
-    if lower.contains("did not become ready") || lower.contains("ready read timeout") {
-        "ready_timeout"
-    } else if lower.contains("connection refused") {
-        "connect_refused"
-    } else if lower.contains("timed out") || lower.contains("timeout") {
-        "connect_timeout"
-    } else if lower.contains("unexpectedeof")
-        || lower.contains("unexpected eof")
-        || lower.contains("connection reset")
-    {
-        "remote_eof"
-    } else if lower.contains("open prediction return stream") || lower.contains("broken pipe") {
-        "open_write_failed"
-    } else {
-        "other"
-    }
-}
-
-#[cfg(test)]
-mod direct_return_failure_phase_tests {
-    use super::classify_direct_return_failure_phase;
-
-    #[test]
-    fn maps_ready_timeout_the_wan_leg() {
-        assert_eq!(
-            classify_direct_return_failure_phase(
-                "downstream prediction return sink did not become ready"
-            ),
-            "ready_timeout"
-        );
-    }
-
-    #[test]
-    fn maps_connect_refused_local_bridge_gone() {
-        assert_eq!(
-            classify_direct_return_failure_phase(
-                "connect downstream prediction return sink at 127.0.0.1:54321: Connection refused (os error 61)"
-            ),
-            "connect_refused"
-        );
-    }
-
-    #[test]
-    fn maps_remote_eof() {
-        assert_eq!(
-            classify_direct_return_failure_phase("read direct prediction return: UnexpectedEof"),
-            "remote_eof"
-        );
-    }
-
-    #[test]
-    fn maps_open_write_failed() {
-        assert_eq!(
-            classify_direct_return_failure_phase("open prediction return stream: broken pipe"),
-            "open_write_failed"
-        );
-    }
-
-    #[test]
-    fn unknown_is_other() {
-        assert_eq!(
-            classify_direct_return_failure_phase("some unexpected condition"),
-            "other"
-        );
-    }
-
-    #[test]
-    fn connect_timeout_distinct_from_ready_timeout() {
-        // A bare connect timeout (no "did not become ready") is the connect phase.
-        assert_eq!(
-            classify_direct_return_failure_phase("connect ...: operation timed out"),
-            "connect_timeout"
-        );
     }
 }

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -888,7 +888,8 @@ impl StageOpenAiBackend {
                 _ => None,
             };
             let mut verify_window_scheduler = VerifyWindowScheduler::new(
-                VerifyWindowPipelineConfig::new(request.speculative.verify_window.pipeline_depth),
+                VerifyWindowPipelineConfig::new(request.speculative.verify_window.pipeline_depth)
+                    .with_force(request.speculative.verify_window.pipeline_force),
             );
             let composite_sidecar_enabled =
                 native_mtp_options.ngram_hybrid && draft_guard.is_none();

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -45,7 +45,10 @@ use crate::frontend::wire_messages::embedded_prefill_message;
 use crate::frontend::wire_messages::embedded_verify_window_message;
 use crate::frontend::wire_messages::generation_config_message;
 use crate::telemetry::now_unix_nanos;
-use lifecycle::{EmbeddedDecodeSummary, PipelinedCompositeWindow, decode_uses_context_sideband};
+use lifecycle::{
+    EmbeddedDecodeSummary, PipelinedCompositeWindow, decode_uses_context_sideband,
+    refill_pipeline_ngram_candidates,
+};
 use openai_frontend::OpenAiError;
 use openai_frontend::OpenAiResult;
 use serde_json::json;
@@ -1161,6 +1164,28 @@ impl StageOpenAiBackend {
                                     .sum::<usize>()
                                 < request.max_tokens as usize
                         {
+                            // Continuous refill (Phase 1): before planning the
+                            // next window, top up n-gram candidates so depth stays
+                            // full across proposal boundaries instead of draining
+                            // and rebuilding. Reads the n-gram cache over committed
+                            // history + the optimistic suffix (read-only); the
+                            // sealed-tail guard prevents splicing behind an
+                            // unbridged window. No-op once sealed or on cache miss.
+                            let verify_width =
+                                adaptive_verify_window.width(pipeline.candidate_len());
+                            if pipeline.candidate_len() < verify_width.saturating_add(1) {
+                                let refill_budget =
+                                    native_mtp_options.ngram_max_proposal_tokens.min(
+                                        native_mtp_remaining
+                                            .saturating_sub(pipeline.optimistic_suffix().len()),
+                                    );
+                                refill_pipeline_ngram_candidates(
+                                    pipeline,
+                                    &context_tokens,
+                                    &mut cached_ngram_proposer,
+                                    refill_budget,
+                                )?;
+                            }
                             let Some(planned) = pipeline.next_window(
                                 adaptive_verify_window.width(pipeline.candidate_len()),
                             ) else {

--- a/crates/skippy-server/src/frontend/embedded_generation/lifecycle.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation/lifecycle.rs
@@ -246,3 +246,33 @@ pub(super) fn decode_uses_context_sideband(
     context_token_ids.len() <= sideband_capacity
         && context_token_ids.last().copied() == Some(current)
 }
+
+/// Continuous refill (Phase 1, Option A): top up the pipeline's dispatchable
+/// candidates with fresh n-gram tail tokens so pipeline depth stays full across
+/// what would otherwise be a proposal boundary, instead of draining and
+/// rebuilding.
+///
+/// The n-gram cache is synced to committed history ONLY; the pipeline's
+/// optimistic (unverified) suffix is passed purely as read-only lookup context.
+/// Any refilled candidate that turns out wrong is discarded by the existing
+/// FIFO stale-drain + KV rewind, so this can only waste target work, never
+/// corrupt committed state. `append_ngram_candidates` refuses to append once the
+/// tail is sealed, preserving the sealed-tail invariant.
+///
+/// Returns the number of candidates appended (0 if disabled, sealed, budget 0,
+/// or no n-gram match).
+pub(super) fn refill_pipeline_ngram_candidates(
+    pipeline: &mut crate::frontend::CompositeProposalPipeline,
+    committed_tokens: &[i32],
+    cached_ngram_proposer: &mut Option<crate::frontend::speculative::CachedNgramProposer>,
+    max_tokens: usize,
+) -> OpenAiResult<usize> {
+    if max_tokens == 0 || !pipeline.can_refill() {
+        return Ok(0);
+    }
+    let Some(cache) = cached_ngram_proposer.as_mut() else {
+        return Ok(0);
+    };
+    let tokens = cache.propose(committed_tokens, pipeline.optimistic_suffix(), max_tokens)?;
+    Ok(pipeline.append_ngram_candidates(&tokens))
+}

--- a/crates/skippy-server/src/frontend/generation.rs
+++ b/crates/skippy-server/src/frontend/generation.rs
@@ -2,6 +2,7 @@ mod cache_hints;
 mod draft_runner;
 mod parsing;
 mod persistent_lanes;
+mod prepared_return_pool;
 mod queue;
 mod server;
 mod streaming;
@@ -24,6 +25,7 @@ pub(in crate::frontend) use cache_hints::{
 pub(in crate::frontend) use draft_runner::*;
 pub(in crate::frontend) use parsing::*;
 pub(in crate::frontend) use persistent_lanes::*;
+pub(in crate::frontend) use prepared_return_pool::PreparedPredictionReturnPool;
 pub(in crate::frontend) use queue::*;
 pub(in crate::frontend) use streaming::*;
 pub(in crate::frontend) use types::*;

--- a/crates/skippy-server/src/frontend/generation/prepared_return_pool.rs
+++ b/crates/skippy-server/src/frontend/generation/prepared_return_pool.rs
@@ -1,0 +1,399 @@
+//! Pre-warmed pool of direct-prediction-return sockets for stage 0.
+//!
+//! Opening a return sink over a WAN mesh split is unreliable when done cold on
+//! the generation hot path: each request opens a fresh TCP connection through
+//! the local bridge alias, which spins up a fresh QUIC bi-stream and blocks on a
+//! ready handshake. Under normal WAN jitter that intermittently fails
+//! (`failed to fill whole buffer`, EAGAIN), which drops the request to the
+//! slower serial upstream-reply path and prevents speculative pipelining.
+//!
+//! The forward path never has this problem because `PersistentStageLanePool`
+//! pre-warms and reuses its lanes. This pool applies the same idea to the return
+//! channel: a single long-lived maintenance worker keeps `capacity` return
+//! sockets pre-warmed (connect + ready handshake done, NOT bound to a request).
+//! A request binds one cheaply by writing `PredictionReturnOpen`.
+//!
+//! Design notes (from expert review):
+//! - One maintenance worker owns all prepares: serialized refill (no capacity
+//!   overshoot), no per-request thread stampede, and proactive rotation so the
+//!   pool stays warm even while idle (a parked socket cannot be liveness-probed
+//!   reliably, so it is rotated out on age before it can silently rot).
+//! - `checkout` is FIFO (`pop_front`) and purges expired sockets, so a burst
+//!   after idle does not hand out stale sockets.
+//! - This pool removes the cold-handshake intermittency (the "prepared" state).
+//!   It does NOT by itself prove the tail selected the socket end-to-end; that
+//!   is the selection-ACK layer on the receiver. Direct-only pipelining must
+//!   gate on that confirmation, not merely on a successful bind here.
+//! - Scope: targets stage 0's immediate downstream, which is the real tail only
+//!   in a two-stage topology. Longer chains fall back to the cold open.
+
+use std::collections::VecDeque;
+use std::sync::Arc;
+use std::sync::Condvar;
+use std::sync::Mutex;
+use std::sync::atomic::AtomicBool;
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering;
+use std::thread::JoinHandle;
+use std::time::Duration;
+use std::time::Instant;
+
+use serde_json::json;
+use skippy_protocol::StageConfig;
+use skippy_protocol::binary::WireActivationDType;
+
+use crate::binary_transport::direct_return;
+use crate::telemetry::Telemetry;
+use crate::telemetry::lifecycle_attrs;
+
+/// A pre-warmed return socket: connected + ready-handshaked, not yet bound to a
+/// request. `prepared_at` drives age-based rotation.
+struct PreparedReturnSink {
+    id: u64,
+    stream: std::net::TcpStream,
+    prepared_at: Instant,
+}
+
+/// Rotate a parked socket out this long after preparation. Chosen below
+/// [`PREPARED_SINK_MAX_AGE`] so the maintenance worker replaces a socket
+/// *before* it would be rejected at checkout, keeping the pool continuously warm
+/// even under idle/sporadic traffic.
+const PREPARED_SINK_REFRESH_AGE: Duration = Duration::from_secs(15);
+
+/// Hard cutoff: a socket older than this is never handed out (safety net if the
+/// maintenance worker is briefly starved). A parked socket's TCP half is the
+/// loopback bridge, so a dead remote QUIC leg can leave it looking healthy
+/// indefinitely; age bounds how long a silently-dead socket can be used.
+const PREPARED_SINK_MAX_AGE: Duration = Duration::from_secs(30);
+
+/// Maintenance worker wake interval. Bounds how quickly the pool refills after a
+/// checkout and how promptly it rotates aging sockets. Checkout also signals the
+/// worker so refill is prompt under load rather than waiting a full interval.
+const MAINTENANCE_INTERVAL: Duration = Duration::from_secs(2);
+
+/// Whether a prepared socket parked since `prepared_at` is still fresh enough to
+/// hand out at checkout. Pure so the age policy can be tested directly.
+fn prepared_sink_is_fresh(prepared_at: Instant, now: Instant, max_age: Duration) -> bool {
+    now.saturating_duration_since(prepared_at) <= max_age
+}
+
+/// Whether the maintenance worker should proactively rotate a socket out
+/// (replace before it can expire at checkout). Pure for testability.
+fn prepared_sink_should_rotate(prepared_at: Instant, now: Instant, refresh_age: Duration) -> bool {
+    now.saturating_duration_since(prepared_at) >= refresh_age
+}
+
+struct PoolState {
+    sinks: VecDeque<PreparedReturnSink>,
+    shutdown: bool,
+}
+
+pub(in crate::frontend) struct PreparedPredictionReturnPool {
+    config: StageConfig,
+    wire_dtype: WireActivationDType,
+    telemetry: Telemetry,
+    state: Mutex<PoolState>,
+    /// Signals the maintenance worker to run a refill/rotate pass promptly
+    /// (e.g. right after a checkout) instead of waiting for the next interval.
+    wake: Condvar,
+    next_sink_id: AtomicU64,
+    capacity: usize,
+    worker: Mutex<Option<JoinHandle<()>>>,
+    worker_started: AtomicBool,
+}
+
+impl PreparedPredictionReturnPool {
+    /// Build the pool and start its maintenance worker. Returns `None` when
+    /// there is no downstream (single-stage: no return channel needed).
+    pub(in crate::frontend) fn new(
+        config: &StageConfig,
+        capacity: usize,
+        wire_dtype: WireActivationDType,
+        telemetry: Telemetry,
+    ) -> Option<Arc<Self>> {
+        config.downstream.as_ref()?;
+        let capacity = capacity.max(1);
+        let pool = Arc::new(Self {
+            config: config.clone(),
+            wire_dtype,
+            telemetry,
+            state: Mutex::new(PoolState {
+                sinks: VecDeque::with_capacity(capacity),
+                shutdown: false,
+            }),
+            wake: Condvar::new(),
+            next_sink_id: AtomicU64::new(0),
+            capacity,
+            worker: Mutex::new(None),
+            worker_started: AtomicBool::new(false),
+        });
+        pool.start_worker();
+        Some(pool)
+    }
+
+    fn start_worker(self: &Arc<Self>) {
+        if self.worker_started.swap(true, Ordering::SeqCst) {
+            return;
+        }
+        let worker_pool = Arc::clone(self);
+        let handle = std::thread::Builder::new()
+            .name("prediction-return-pool".to_string())
+            .spawn(move || worker_pool.maintenance_loop())
+            .ok();
+        if let Ok(mut slot) = self.worker.lock() {
+            *slot = handle;
+        }
+    }
+
+    /// Take a pre-warmed socket and bind it to `(request_id, session_id)` by
+    /// writing `PredictionReturnOpen`. Returns `None` when the pool is empty or
+    /// every pooled socket is stale/failed to bind — callers then fall back to
+    /// the cold open. Never blocks on a network connect; signals the maintenance
+    /// worker to replenish the consumed slot.
+    pub(in crate::frontend) fn checkout_bound(
+        &self,
+        request_id: u64,
+        session_id: u64,
+    ) -> Option<std::net::TcpStream> {
+        let result = loop {
+            let Some(mut sink) = self.pop_fresh_sink() else {
+                break None;
+            };
+            match direct_return::bind_downstream_prediction_return_socket(
+                &mut sink.stream,
+                request_id,
+                session_id,
+                self.wire_dtype,
+            ) {
+                Ok(()) => {
+                    self.emit_checkout(sink.id, true, None);
+                    break Some(sink.stream);
+                }
+                Err(error) => {
+                    // A prepared socket that fails to bind was silently dead;
+                    // drop it and try the next pooled socket. `bind` is a local
+                    // write, so this only catches already-broken sockets — true
+                    // end-to-end confirmation is the receiver's selection ACK.
+                    self.emit_checkout(
+                        sink.id,
+                        false,
+                        Some(direct_return::classify_return_failure_phase(&format!(
+                            "{error:#}"
+                        ))),
+                    );
+                    continue;
+                }
+            }
+        };
+        // Wake the maintenance worker to refill the consumed slot promptly,
+        // whether or not we got a socket (empty pool should refill fast too).
+        self.wake.notify_one();
+        result
+    }
+
+    fn pop_fresh_sink(&self) -> Option<PreparedReturnSink> {
+        let now = Instant::now();
+        let mut state = self.state.lock().ok()?;
+        while let Some(sink) = state.sinks.pop_front() {
+            if prepared_sink_is_fresh(sink.prepared_at, now, PREPARED_SINK_MAX_AGE) {
+                return Some(sink);
+            }
+            // aged out; drop and continue
+        }
+        None
+    }
+
+    fn maintenance_loop(self: Arc<Self>) {
+        loop {
+            if self.is_shutdown() {
+                return;
+            }
+            self.purge_and_refill();
+            // Wait for a checkout signal or the maintenance interval, whichever
+            // comes first. Timeout drives idle rotation; the signal drives
+            // prompt refill under load.
+            let Ok(state) = self.state.lock() else {
+                return;
+            };
+            let (_guard, _timeout) = match self.wake.wait_timeout(state, MAINTENANCE_INTERVAL) {
+                Ok(pair) => pair,
+                Err(_) => return,
+            };
+        }
+    }
+
+    /// Purge expired/near-expiry sockets and prepare new ones up to capacity.
+    /// Network prepares happen OUTSIDE the state lock; the lock is only held for
+    /// bookkeeping, so a slow WAN handshake never blocks checkout.
+    fn purge_and_refill(&self) {
+        // Phase 1 (locked): drop sockets due for rotation, count the deficit.
+        let deficit = {
+            let now = Instant::now();
+            let Ok(mut state) = self.state.lock() else {
+                return;
+            };
+            if state.shutdown {
+                return;
+            }
+            state.sinks.retain(|s| {
+                !prepared_sink_should_rotate(s.prepared_at, now, PREPARED_SINK_REFRESH_AGE)
+            });
+            self.capacity.saturating_sub(state.sinks.len())
+        };
+        // Phase 2 (unlocked): prepare up to `deficit` sockets. Serialized here
+        // because only this worker prepares, so capacity cannot be overshot.
+        for _ in 0..deficit {
+            if self.is_shutdown() {
+                return;
+            }
+            match self.prepare_one() {
+                Ok(sink) => {
+                    let Ok(mut state) = self.state.lock() else {
+                        return;
+                    };
+                    if state.shutdown {
+                        return;
+                    }
+                    // Re-check capacity under lock in case checkout added nothing
+                    // but rotation math changed; never exceed capacity.
+                    if state.sinks.len() < self.capacity {
+                        state.sinks.push_back(sink);
+                    }
+                }
+                Err(error) => {
+                    let mut attrs = lifecycle_attrs(&self.config);
+                    attrs.insert(
+                        "llama_stage.prediction_return.failure_phase".to_string(),
+                        json!(direct_return::classify_return_failure_phase(&format!(
+                            "{error:#}"
+                        ))),
+                    );
+                    self.telemetry
+                        .emit("stage.prediction_return_prepare_failed", attrs);
+                    // Downstream transiently unreachable; stop this pass and try
+                    // again next interval rather than hammering.
+                    return;
+                }
+            }
+        }
+    }
+
+    fn prepare_one(&self) -> anyhow::Result<PreparedReturnSink> {
+        let stream = direct_return::prepare_downstream_prediction_return_socket(&self.config)?;
+        Ok(PreparedReturnSink {
+            id: self.next_sink_id.fetch_add(1, Ordering::Relaxed),
+            stream,
+            prepared_at: Instant::now(),
+        })
+    }
+
+    fn is_shutdown(&self) -> bool {
+        self.state.lock().map(|s| s.shutdown).unwrap_or(true)
+    }
+
+    fn emit_checkout(&self, sink_id: u64, bound: bool, failure_phase: Option<&'static str>) {
+        let mut attrs = lifecycle_attrs(&self.config);
+        attrs.insert(
+            "llama_stage.prediction_return_prepared_sink_id".to_string(),
+            json!(sink_id),
+        );
+        attrs.insert(
+            "llama_stage.prediction_return_prepared_bound".to_string(),
+            json!(bound),
+        );
+        if let Some(phase) = failure_phase {
+            attrs.insert(
+                "llama_stage.prediction_return.failure_phase".to_string(),
+                json!(phase),
+            );
+        }
+        self.telemetry
+            .emit("stage.prediction_return_prepared_checkout", attrs);
+    }
+}
+
+impl Drop for PreparedPredictionReturnPool {
+    fn drop(&mut self) {
+        // Signal shutdown, wake the worker, and join it so parked sockets are
+        // dropped (closed) deterministically before teardown.
+        if let Ok(mut state) = self.state.lock() {
+            state.shutdown = true;
+            state.sinks.clear();
+        }
+        self.wake.notify_all();
+        if let Ok(mut slot) = self.worker.lock()
+            && let Some(handle) = slot.take()
+        {
+            let _ = handle.join();
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fresh_within_max_age() {
+        let now = Instant::now();
+        let prepared = now - Duration::from_secs(10);
+        assert!(prepared_sink_is_fresh(prepared, now, PREPARED_SINK_MAX_AGE));
+    }
+
+    #[test]
+    fn stale_past_max_age() {
+        let now = Instant::now();
+        let prepared = now - Duration::from_secs(31);
+        assert!(!prepared_sink_is_fresh(
+            prepared,
+            now,
+            PREPARED_SINK_MAX_AGE
+        ));
+    }
+
+    #[test]
+    fn exactly_at_max_age_is_fresh() {
+        let now = Instant::now();
+        let prepared = now - PREPARED_SINK_MAX_AGE;
+        assert!(prepared_sink_is_fresh(prepared, now, PREPARED_SINK_MAX_AGE));
+    }
+
+    #[test]
+    fn future_prepared_at_is_fresh_not_panic() {
+        let now = Instant::now();
+        let prepared = now + Duration::from_secs(5);
+        assert!(prepared_sink_is_fresh(prepared, now, PREPARED_SINK_MAX_AGE));
+    }
+
+    #[test]
+    fn rotates_at_refresh_age_before_max_age() {
+        let now = Instant::now();
+        // A socket past the refresh age but before max age should rotate (worker
+        // replaces it) yet still be handable if reached at checkout — proving
+        // refresh < max keeps the pool warm ahead of expiry.
+        let prepared = now - Duration::from_secs(20);
+        assert!(prepared_sink_should_rotate(
+            prepared,
+            now,
+            PREPARED_SINK_REFRESH_AGE
+        ));
+        assert!(prepared_sink_is_fresh(prepared, now, PREPARED_SINK_MAX_AGE));
+    }
+
+    #[test]
+    fn does_not_rotate_before_refresh_age() {
+        let now = Instant::now();
+        let prepared = now - Duration::from_secs(5);
+        assert!(!prepared_sink_should_rotate(
+            prepared,
+            now,
+            PREPARED_SINK_REFRESH_AGE
+        ));
+    }
+
+    #[test]
+    fn refresh_age_is_below_max_age() {
+        // Invariant that keeps the pool warm: rotate before expiry.
+        assert!(PREPARED_SINK_REFRESH_AGE < PREPARED_SINK_MAX_AGE);
+    }
+}

--- a/crates/skippy-server/src/frontend/generation/server.rs
+++ b/crates/skippy-server/src/frontend/generation/server.rs
@@ -11,6 +11,7 @@ use crate::frontend::decode_batcher::DecodeBatcher;
 use crate::frontend::generation::OpenAiBackendMode;
 use crate::frontend::generation::PersistentStageLanePool;
 use crate::frontend::generation::PhaseTimer;
+use crate::frontend::generation::PreparedPredictionReturnPool;
 use crate::frontend::generation::StageOpenAiBackend;
 use crate::frontend::generation::attach_native_mtp_draft_model;
 use crate::frontend::generation::ensure_generation_concurrency_fits_lanes;
@@ -332,6 +333,16 @@ pub fn embedded_openai_backend(args: EmbeddedOpenAiArgs) -> Result<EmbeddedOpenA
         args.telemetry.clone(),
     )
     .context("create embedded OpenAI persistent downstream lanes")?;
+    // Pre-warm a pool of direct-prediction-return sockets alongside the forward
+    // lanes so the WAN-flaky connect+ready handshake happens off the generation
+    // hot path. `capacity = generation_concurrency` (per expert review): a single
+    // global pool sized to the number of concurrent requests, not per request.
+    let prepared_return_pool = PreparedPredictionReturnPool::new(
+        &args.config,
+        args.generation_concurrency,
+        args.wire_dtype,
+        args.telemetry.clone(),
+    );
     let prefill_reply_credit_limit = args.reply_credit_limit.unwrap_or(3);
     let mode = OpenAiBackendMode::EmbeddedStageZero {
         config: args.config.clone(),
@@ -351,6 +362,7 @@ pub fn embedded_openai_backend(args: EmbeddedOpenAiArgs) -> Result<EmbeddedOpenA
         prefill_reply_credit_limit,
         lane_pool,
         prediction_returns: args.prediction_returns.clone(),
+        prepared_return_pool,
     };
     args.telemetry
         .emit("stage.openai_server_start", lifecycle_attrs(&args.config));

--- a/crates/skippy-server/src/frontend/generation/types.rs
+++ b/crates/skippy-server/src/frontend/generation/types.rs
@@ -14,6 +14,7 @@ use crate::frontend::generation::GenerationTokenLimit;
 use crate::frontend::generation::OpenAiGenerationIds;
 use crate::frontend::generation::PersistentStageLanePool;
 use crate::frontend::generation::PreparedGenerationPrompt;
+use crate::frontend::generation::PreparedPredictionReturnPool;
 use crate::frontend::native_mtp::NativeMtpDecodeTelemetry;
 use crate::frontend::prefill::PrefillChunkPolicy;
 use crate::frontend::speculative::OpenAiSpeculativeStats;
@@ -78,6 +79,7 @@ pub(in crate::frontend) enum OpenAiBackendMode {
         prefill_reply_credit_limit: usize,
         lane_pool: Option<Arc<PersistentStageLanePool>>,
         prediction_returns: Option<Arc<PredictionReturnHub>>,
+        prepared_return_pool: Option<Arc<PreparedPredictionReturnPool>>,
     },
 }
 
@@ -149,6 +151,7 @@ pub(in crate::frontend) struct EmbeddedStageZeroGeneration<'a> {
     pub(in crate::frontend) prefill_reply_credit_limit: usize,
     pub(in crate::frontend) lane_pool: Option<Arc<PersistentStageLanePool>>,
     pub(in crate::frontend) prediction_return: Option<PredictionReturnReceiver>,
+    pub(in crate::frontend) prepared_return_pool: Option<Arc<PreparedPredictionReturnPool>>,
     pub(in crate::frontend) draft: Option<Arc<Mutex<DraftRunner>>>,
     pub(in crate::frontend) speculative_window: usize,
     pub(in crate::frontend) adaptive_speculative_window: bool,

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -158,6 +158,7 @@ impl StageOpenAiBackend {
                 prefill_reply_credit_limit,
                 lane_pool,
                 prediction_returns,
+                prepared_return_pool,
             } => self.generate_embedded_stage_zero_tokens(
                 EmbeddedStageZeroGeneration {
                     config: &config,
@@ -172,6 +173,7 @@ impl StageOpenAiBackend {
                         .map(|hub| hub.register(ids.request_id, ids.session_id))
                         .transpose()
                         .map_err(openai_backend_error)?,
+                    prepared_return_pool,
                     draft: self.draft.clone(),
                     speculative_window: self.speculative_window,
                     adaptive_speculative_window: self.adaptive_speculative_window,

--- a/crates/skippy-server/src/frontend/native_mtp/decode.rs
+++ b/crates/skippy-server/src/frontend/native_mtp/decode.rs
@@ -141,7 +141,21 @@ pub(in crate::frontend) struct NativeMtpDecodeCounters {
     adaptive_verify_window_width_max: usize,
     adaptive_verify_window_grow_count: usize,
     adaptive_verify_window_shrink_count: usize,
+    // Phase 0 survival curve: per logical composite proposal, how far the draft
+    // stayed correct, split by source. `eligible_ge[k]` counts proposals that
+    // actually offered depth k+1 (index 0 = depth 1); `survived_ge[k]` counts
+    // those accepted through depth k+1. P(A>=k) = survived_ge[k-1]/eligible_ge[k-1].
+    // Lets us measure acceptance depth `g` per source x workload (benchmark-side)
+    // to decide whether pipelining depth pays. Stale-drained proposals excluded.
+    logical_proposal_count: usize,
+    native_eligible_ge: [usize; SURVIVAL_DEPTHS],
+    native_survived_ge: [usize; SURVIVAL_DEPTHS],
+    ngram_eligible_ge: [usize; SURVIVAL_DEPTHS],
+    ngram_survived_ge: [usize; SURVIVAL_DEPTHS],
 }
+
+/// Survival curve tracks depths 1..=8 (native MTP max draft depth is 8).
+pub(in crate::frontend) const SURVIVAL_DEPTHS: usize = 8;
 
 impl NativeMtpDecodeCounters {
     pub(in crate::frontend) fn verify_window_verification_count(&self) -> usize {
@@ -215,6 +229,50 @@ impl NativeMtpDecodeCounters {
         self.hybrid_native_mtp_token_count += proposal.native_mtp_token_count();
         self.hybrid_ngram_token_count += proposal.ngram_token_count();
         self.hybrid_pure_ngram_proposal_count += usize::from(proposal.is_pure_ngram());
+        self.observe_survival(
+            proposal.native_mtp_token_count(),
+            proposal.ngram_token_count(),
+            accepted_token_count,
+        );
+    }
+
+    /// Feed the per-source survival curve for one retired logical proposal.
+    ///
+    /// The proposal is a single linear candidate stream: `native` MTP tokens
+    /// first, then `ngram` tail tokens. `accepted` is how many led tokens the
+    /// target actually confirmed (including the free-target token when it
+    /// matched the next buffered candidate — the caller already folds that in).
+    ///
+    /// Decomposition (expert-reviewed): native survival is `min(accepted, N)`;
+    /// ngram survival only counts once the native prefix fully survived, so a
+    /// native failure never contaminates ngram quality. `eligible_ge[k]` is
+    /// only incremented when the source actually offered depth `k+1`.
+    fn observe_survival(&mut self, native: usize, ngram: usize, accepted: usize) {
+        self.logical_proposal_count += 1;
+        let native_survived = accepted.min(native);
+        // Tail is only eligible/measured after the whole native prefix survived.
+        let ngram_survived = if accepted >= native {
+            (accepted - native).min(ngram)
+        } else {
+            0
+        };
+        for depth in 1..=SURVIVAL_DEPTHS {
+            let idx = depth - 1;
+            if native >= depth {
+                self.native_eligible_ge[idx] += 1;
+                if native_survived >= depth {
+                    self.native_survived_ge[idx] += 1;
+                }
+            }
+            // Ngram tail depth is only meaningful when the native prefix fully
+            // survived (else the tail was never actually reached/verified).
+            if ngram >= depth && accepted >= native {
+                self.ngram_eligible_ge[idx] += 1;
+                if ngram_survived >= depth {
+                    self.ngram_survived_ge[idx] += 1;
+                }
+            }
+        }
     }
 
     pub(in crate::frontend) fn observe_ngram_tail_rejection(&mut self) {
@@ -492,6 +550,28 @@ impl NativeMtpDecodeCounters {
             "native_mtp_adaptive_verify_window_shrinks".to_string(),
             json!(self.adaptive_verify_window_shrink_count),
         );
+        // Phase 0 survival curve (arrays indexed by depth-1, i.e. [0]=depth 1).
+        // P(A>=k) per source = survived_ge[k-1] / eligible_ge[k-1].
+        timings.insert(
+            "native_mtp_survival_logical_proposals".to_string(),
+            json!(self.logical_proposal_count),
+        );
+        timings.insert(
+            "native_mtp_survival_native_eligible_ge".to_string(),
+            json!(self.native_eligible_ge),
+        );
+        timings.insert(
+            "native_mtp_survival_native_survived_ge".to_string(),
+            json!(self.native_survived_ge),
+        );
+        timings.insert(
+            "native_mtp_survival_ngram_eligible_ge".to_string(),
+            json!(self.ngram_eligible_ge),
+        );
+        timings.insert(
+            "native_mtp_survival_ngram_survived_ge".to_string(),
+            json!(self.ngram_survived_ge),
+        );
     }
 }
 
@@ -556,6 +636,55 @@ impl NativeMtpDecodeTelemetry {
 mod tests {
     use super::super::CompositeProposalProvider;
     use super::*;
+
+    // Survival decomposition: native=3, ngram=4, all 7 accepted (+ free target
+    // folded in by caller => accepted can exceed proposal len; min() caps it).
+    #[test]
+    fn survival_full_accept_counts_both_sources_to_their_depth() {
+        let mut c = NativeMtpDecodeCounters::default();
+        c.observe_survival(3, 4, 7);
+        assert_eq!(c.logical_proposal_count, 1);
+        // native eligible+survived at depths 1..=3
+        assert_eq!(&c.native_eligible_ge[0..3], &[1, 1, 1]);
+        assert_eq!(&c.native_survived_ge[0..3], &[1, 1, 1]);
+        assert_eq!(c.native_eligible_ge[3], 0);
+        // ngram eligible+survived at depths 1..=4
+        assert_eq!(&c.ngram_eligible_ge[0..4], &[1, 1, 1, 1]);
+        assert_eq!(&c.ngram_survived_ge[0..4], &[1, 1, 1, 1]);
+    }
+
+    // Native fails partway: ngram tail must NOT be counted eligible (it was
+    // never reached), so native failure can't contaminate ngram quality.
+    #[test]
+    fn survival_native_partial_reject_excludes_ngram_tail() {
+        let mut c = NativeMtpDecodeCounters::default();
+        c.observe_survival(3, 4, 2); // only 2 of 3 native accepted
+        assert_eq!(&c.native_eligible_ge[0..3], &[1, 1, 1]);
+        assert_eq!(&c.native_survived_ge[0..3], &[1, 1, 0]); // survived depth 1,2 not 3
+        // ngram never reached -> not eligible at any depth
+        assert_eq!(c.ngram_eligible_ge.iter().sum::<usize>(), 0);
+        assert_eq!(c.ngram_survived_ge.iter().sum::<usize>(), 0);
+    }
+
+    // Ngram partial: native fully survived, ngram accepted 2 of 4.
+    #[test]
+    fn survival_ngram_partial_accept() {
+        let mut c = NativeMtpDecodeCounters::default();
+        c.observe_survival(3, 4, 5); // 3 native + 2 ngram
+        assert_eq!(&c.native_survived_ge[0..3], &[1, 1, 1]);
+        assert_eq!(&c.ngram_eligible_ge[0..4], &[1, 1, 1, 1]);
+        assert_eq!(&c.ngram_survived_ge[0..4], &[1, 1, 0, 0]);
+    }
+
+    // Pure-ngram proposal (native=0): everything is tail from depth 1.
+    #[test]
+    fn survival_pure_ngram_proposal() {
+        let mut c = NativeMtpDecodeCounters::default();
+        c.observe_survival(0, 5, 3); // 0 native, 3 of 5 ngram accepted
+        assert_eq!(c.native_eligible_ge.iter().sum::<usize>(), 0);
+        assert_eq!(&c.ngram_eligible_ge[0..5], &[1, 1, 1, 1, 1]);
+        assert_eq!(&c.ngram_survived_ge[0..5], &[1, 1, 1, 0, 0]);
+    }
 
     fn options() -> NativeMtpDecodeOptions {
         NativeMtpDecodeOptions {

--- a/crates/skippy-server/src/frontend/native_mtp/hybrid.rs
+++ b/crates/skippy-server/src/frontend/native_mtp/hybrid.rs
@@ -160,6 +160,19 @@ impl NativeMtpHybridProposal {
         &self.tokens
     }
 
+    /// Extend the proposal with additional n-gram tail tokens (continuous
+    /// refill). These are n-gram-sourced by construction, so only the n-gram
+    /// count grows; the native-MTP prefix length is unchanged.
+    pub(in crate::frontend) fn append_ngram_tokens(&mut self, tokens: &[i32]) {
+        self.tokens.extend_from_slice(tokens);
+        self.ngram_token_count = self.ngram_token_count.saturating_add(tokens.len());
+        if tokens.is_empty() {
+            return;
+        }
+        // A refilled tail means an n-gram continuation was available.
+        self.ngram_span_available = true;
+    }
+
     pub(in crate::frontend) fn native_mtp_token_count(&self) -> usize {
         self.native_mtp_token_count
     }

--- a/crates/skippy-server/src/frontend/native_mtp/pipeline.rs
+++ b/crates/skippy-server/src/frontend/native_mtp/pipeline.rs
@@ -36,6 +36,14 @@ pub(in crate::frontend) struct CompositeProposalPipeline {
     dispatched_native_mtp_token_count: usize,
     accepted_tokens: usize,
     next_draft: Option<NativeMtpDraft>,
+    /// Sealed-tail invariant (expert-reviewed): once a dispatched window had no
+    /// reserved free-target candidate (`expected_free_target == None`), the
+    /// pipeline's optimistic frontier is no longer represented by a buffered
+    /// bridge token, so appending more candidates behind it would splice onto a
+    /// stale `pipelined_current`. Once sealed, refill is refused and the pipeline
+    /// must retire/reseed. This is the flag the ledger-free continuous refill
+    /// relies on for correctness.
+    sealed: bool,
 }
 
 impl CompositeProposalPipeline {
@@ -52,6 +60,7 @@ impl CompositeProposalPipeline {
             dispatched_native_mtp_token_count: 0,
             accepted_tokens: 0,
             next_draft: None,
+            sealed: false,
         }
     }
 
@@ -72,11 +81,46 @@ impl CompositeProposalPipeline {
             .min(verify_width);
         let proposal_tokens = self.candidates.drain(..verify_width).collect();
         self.dispatched_native_mtp_token_count += native_mtp_token_count;
+        let expected_free_target = self.candidates.pop_front();
+        if expected_free_target.is_none() {
+            // No reserved bridge token: the optimistic frontier is no longer
+            // represented by a buffered candidate. Seal the tail so refill can
+            // never splice behind this window (sealed-tail invariant).
+            self.sealed = true;
+        }
         Some(PipelinedCandidateWindow {
             proposal_tokens,
-            expected_free_target: self.candidates.pop_front(),
+            expected_free_target,
             native_mtp_token_count,
         })
+    }
+
+    /// The uncommitted optimistic suffix (proposal tokens past what the target
+    /// has committed). Safe to use ONLY as read-only lookup context for the
+    /// n-gram cache; it must never be indexed into the cache as committed
+    /// history.
+    pub(in crate::frontend) fn optimistic_suffix(&self) -> &[i32] {
+        let tokens = self.proposal.tokens();
+        &tokens[self.accepted_tokens.min(tokens.len())..]
+    }
+
+    /// Whether the pipeline may still accept refilled candidates. False once the
+    /// tail is sealed (a window was dispatched without a reserved free target).
+    pub(in crate::frontend) fn can_refill(&self) -> bool {
+        !self.sealed
+    }
+
+    /// Append n-gram tail candidates for continuous refill. Extends both the
+    /// proposal (for accounting/telemetry) and the dispatchable candidate deque.
+    /// Refuses to append when the tail is sealed (returns 0), preserving the
+    /// sealed-tail invariant. Returns the number of candidates appended.
+    pub(in crate::frontend) fn append_ngram_candidates(&mut self, tokens: &[i32]) -> usize {
+        if self.sealed || tokens.is_empty() {
+            return 0;
+        }
+        self.proposal.append_ngram_tokens(tokens);
+        self.candidates.extend(tokens.iter().copied());
+        tokens.len()
     }
 
     pub(in crate::frontend) fn proposal(&self) -> &NativeMtpHybridProposal {
@@ -230,5 +274,71 @@ mod tests {
                 .proposal()
                 .ngram_tail_rejected(pipeline.accepted_tokens())
         );
+    }
+
+    #[test]
+    fn optimistic_suffix_tracks_accepted_tokens() {
+        let mut pipeline = CompositeProposalPipeline::new(
+            proposal(vec![9, 1, 2, 3], 1),
+            Some(NativeMtpDraftOrigin::InitialSerial),
+            2,
+        );
+        assert_eq!(pipeline.optimistic_suffix(), &[9, 1, 2, 3]);
+        pipeline.observe_accepted(2);
+        assert_eq!(pipeline.optimistic_suffix(), &[2, 3]);
+        // accepted beyond len saturates, no panic
+        pipeline.observe_accepted(10);
+        assert_eq!(pipeline.optimistic_suffix(), &[] as &[i32]);
+    }
+
+    #[test]
+    fn append_ngram_candidates_extends_proposal_and_deque() {
+        let mut pipeline = CompositeProposalPipeline::new(
+            proposal(vec![9, 1, 2, 3], 1),
+            Some(NativeMtpDraftOrigin::InitialSerial),
+            2,
+        );
+        // consume the first window (width 2), leaving candidates [2,3] then
+        // reserving 2 as free target -> candidates [3]
+        let first = pipeline.next_window(2).unwrap();
+        assert_eq!(first.proposal_tokens(), &[9, 1]);
+        assert_eq!(first.expected_free_target(), Some(2));
+        assert!(pipeline.can_refill());
+        assert_eq!(pipeline.append_ngram_candidates(&[4, 5]), 2);
+        assert_eq!(pipeline.proposal().tokens(), &[9, 1, 2, 3, 4, 5]);
+        assert_eq!(pipeline.proposal().ngram_token_count(), 5);
+        // next window can now draw the refilled candidates
+        let second = pipeline.next_window(2).unwrap();
+        assert_eq!(second.proposal_tokens(), &[3, 4]);
+        assert_eq!(second.expected_free_target(), Some(5));
+    }
+
+    #[test]
+    fn sealed_tail_refuses_refill_after_window_without_free_target() {
+        let mut pipeline = CompositeProposalPipeline::new(
+            proposal(vec![9, 1], 1),
+            Some(NativeMtpDraftOrigin::InitialSerial),
+            2,
+        );
+        // width-2 window drains both candidates, leaving none to reserve as the
+        // free target -> tail seals.
+        let first = pipeline.next_window(2).unwrap();
+        assert_eq!(first.proposal_tokens(), &[9, 1]);
+        assert_eq!(first.expected_free_target(), None);
+        assert!(!pipeline.can_refill());
+        // refill is refused once sealed (sealed-tail invariant)
+        assert_eq!(pipeline.append_ngram_candidates(&[4, 5]), 0);
+        assert_eq!(pipeline.proposal().tokens(), &[9, 1]);
+    }
+
+    #[test]
+    fn append_empty_is_noop() {
+        let mut pipeline = CompositeProposalPipeline::new(
+            proposal(vec![9, 1, 2], 1),
+            Some(NativeMtpDraftOrigin::InitialSerial),
+            2,
+        );
+        assert_eq!(pipeline.append_ngram_candidates(&[]), 0);
+        assert_eq!(pipeline.proposal().tokens(), &[9, 1, 2]);
     }
 }

--- a/crates/skippy-server/src/frontend/speculative.rs
+++ b/crates/skippy-server/src/frontend/speculative.rs
@@ -62,6 +62,10 @@ pub struct VerifyWindowConfig {
     pub min_tokens: usize,
     pub max_tokens: usize,
     pub pipeline_depth: usize,
+    /// Bet-on-the-pipeline mode: when `pipeline_depth > 1`, keep windows in flight
+    /// unconditionally instead of waiting for the adaptive profitability gate. See
+    /// `VerifyWindowPipelineConfig::with_force`.
+    pub pipeline_force: bool,
 }
 
 impl Default for SpeculativeDecodeConfig {
@@ -83,6 +87,7 @@ impl Default for SpeculativeDecodeConfig {
                 min_tokens: 1,
                 max_tokens: 4,
                 pipeline_depth: 1,
+                pipeline_force: false,
             },
         }
     }

--- a/crates/skippy-server/src/frontend/tests/multimodal.rs
+++ b/crates/skippy-server/src/frontend/tests/multimodal.rs
@@ -388,6 +388,7 @@ async fn real_multimodal_split_smoke_when_fixture_is_set() -> Result<()> {
             prefill_reply_credit_limit: 0,
             lane_pool: Some(lane_pool),
             prediction_returns: None,
+            prepared_return_pool: None,
         },
         draft: None,
         speculative_window: 0,

--- a/docs/skippy/WAN_SPLIT_TRANSPORT_STATUS.md
+++ b/docs/skippy/WAN_SPLIT_TRANSPORT_STATUS.md
@@ -1,0 +1,109 @@
+# WAN Split Transport - Status and Handoff
+
+Status notes for the WAN split-serving transport work on branch
+`wip/wan-direct-prediction-return` (PR #1028). This branch lands the **transport
+core** only: it is proposer-agnostic and carries no draft-model code. Companion
+to [WAN_SPLIT_PERF.md](WAN_SPLIT_PERF.md) (the throughput/latency model) and
+[PIPELINED_VERIFY_WINDOW.md](PIPELINED_VERIFY_WINDOW.md) (the verify-window
+pipeline).
+
+## Goal
+
+Make a 2-stage split serve reliably over a WAN link, and give the verify-window
+pipeline the transport primitives it needs to hide inter-stage latency. The
+throughput lever (committed tokens per ring traversal / traversal time) is left
+to the proposer; this branch only makes the traversal correct, fast to warm, and
+pipeline-capable.
+
+## What is proven (on this branch)
+
+Validated live on a 2-node WAN split (Apple Silicon coordinator <-> remote
+GPU worker, ~24 ms RTT):
+
+- The split **serves** end-to-end. A per-stream RTT gate mismatch previously
+  turned every request into a 502; the split now serves correctly, and when a
+  direct-return sink is unavailable it falls back to the serial VerifyWindow
+  path over the forward lane (slower, not broken).
+- **Direct prediction return works over WAN** after raising the return-sink
+  ready-handshake timeout (5s -> 20s) to cover cold WAN bridge setup, and
+  pre-warming a pool of return-sink sockets. Warm setup dropped from ~12.7s to
+  ~0.6s.
+- **Pipelining engages**: with a confirmed direct-return route, verify-window
+  `max_in_flight` reached depth 4 over the WAN split.
+
+## Landed pieces (keep set)
+
+- `c340f741` - serve without direct-return + per-stream RTT operational-stream
+  gate fix. Root-cause fix; turns hard 502s into served requests.
+  Note: the warn-and-proceed behavior also changes failure semantics for LAN
+  splits - a degraded stream now resolves via re-election rather than a fast
+  stream failure.
+- `46108cfc` - 20s return-sink ready timeout (matches the forward-lane budget).
+- `2b76ba4e` - pre-warmed return-sink pool + implicit pipeline confirmation
+  gated on a real direct reply (closes a 300s-hang hazard). Best-tested code on
+  the branch. Known limit: the pool covers stage-0 -> immediate-downstream only,
+  so 3+-stage chains still cold-open the deeper links.
+- `73766d27` - refactor: extract verify-window resolution (clippy line-count).
+- `ced1812a` - test fixture: `verify_window_pipeline_force` in the defaults UI
+  schema reference.
+- `86ff55eb` - per-source accepted-prefix **survival telemetry** (native MTP and
+  n-gram). This is the instrument for judging *any* proposer's depth behavior.
+- `44d31e3b` - continuous n-gram refill of the speculative horizon (Phase 1).
+  Sound mechanism (sealed-tail invariant). It only pays with a proposer that can
+  keep the horizon full; expect little from it with the current 4-token n-gram
+  window until PR #1037's suffix proposer lands.
+- `e48d4583` - forced-pipeline mode (`verify_window_pipeline_force`). This is a
+  **benchmark/CI lever only** to bypass the adaptive profitability gate; it is
+  not a production default.
+
+Protocol: no wire change in this set. Older peers stay on the serial path;
+mixed-version meshes remain safe.
+
+## Key finding: fixed depth is diagnostic, not the win
+
+The one controlled A/B on this branch showed that forcing deeper fixed-depth
+speculation *lost* throughput (about 45 -> 37 tok/s) because stale/divergent
+windows exploded (2 -> 16). Depth only helps when accepted-prefix survival stays
+high at that depth. So `verify_window_pipeline_force` + fixed depth is a
+measurement tool, not a serving policy.
+
+The go-forward payoff plan is therefore:
+
+- **Proposer:** ride PR #1037's suffix-ngram (prompt-lookup) proposer, which
+  matches verbatim spans up to 64 tokens and holds high acceptance on the
+  re-emissive text that dominates agent/coding workloads (file edits, tool-output
+  echo). The 4-token llama.cpp n-gram window is too short for this.
+- **Depth:** make it **adaptive**, gated on the Phase 0 survival curve per
+  source - deep while suffix matches hold, dropping to a single serial traversal
+  on a miss. Fixed depth is what lost throughput here.
+- Fix PR #1037's two blockers before benchmarking it over WAN: the
+  prefix-cache + speculative-checkpoint 502 (`chain_restore_hit`), and
+  greedy-equivalence (verified speculative decode must be byte-identical to
+  baseline decode).
+
+## Deferred: draft-model speculation
+
+Draft-*model* speculation was explored on this branch and **cut** per reviewer
+triage. Once the WAN is hidden, the draft model becomes the loop's cost center
+(shard's numbers put it at ~94% of the loop), so a synchronous draft on the
+critical path cannot win. That work is parked on branch `wip/wan-draft-ahead`
+(not merge-ready). If ever revived, it must be **async draft-ahead** that hides
+draft compute inside the WAN RTT, and only for novel-prose workloads where
+n-gram survival is near zero - the MTP + suffix composite likely covers the gap
+without an external draft.
+
+## Bringup config trap (read before a 2-node split)
+
+The most common failure bringing up a 2-node split is the split silently never
+forming: the coordinator sits in `standby`, `peers=1`, forever. Causes seen:
+
+- **Worker `--max-vram` >= model size.** The worker reports it can hold the
+  whole model alone, so placement correctly decides no split is needed. Cap
+  **both** nodes below model size (e.g. two nodes at 12 GB each for an ~18 GB
+  model). If you see `Split waiting for peers ... found 1 eligible
+  [worker:>=model-size]`, fix `--max-vram` instead of waiting out the timeout.
+- **Same-machine loopback shares one identity.** Two `mesh-llm serve` processes
+  on one host load the same `~/.mesh-llm/key` and appear as a single node, so the
+  split cannot form. Give the second process a distinct identity with
+  `MESH_LLM_EPHEMERAL_KEY=1` (see `docs/design/TESTING.md`, "Forced split on one
+  machine"). For a genuine WAN test, use two real machines.


### PR DESCRIPTION
## What this enables

Split serving now works reliably over a **WAN** link, and speculative "verify-window" pipelining can actually engage across it. Before this change, a 2-node split across the internet (e.g. a coordinator in one region and a GPU box in another) would **502 every request** — the direct-prediction-return channel that pipelining depends on could not be established, and even when it could, normal WAN latency jitter tore it down mid-request.

After this change:
- A cross-WAN split **serves inference** (previously impossible — it 502'd or hung).
- Speculative pipelining **engages over WAN** (`verify_window_max_in_flight > 1`), the mechanism that hides remote round-trip latency.
- When the direct channel genuinely isn't available, requests **fall back to serial serving instead of failing** — a request is never dropped.

Validated live on a Sydney↔AU 4090 split (~26ms RTT): direct-return confirmed working, warm requests dropped from ~12.7s to ~0.6s once the channel was reliable.

## Architecture

Four changes, smallest-first:

1. **Serve without direct-return, and stop killing operational streams on RTT jitter.** The native-MTP verify path used to hard-require a direct-return sink and 502 without it. It now falls back to serial completion over the forward lane (which polls both routes), so the split serves regardless. Separately, `open_stage_transport_stream` no longer re-applies the formation-time `MAX_SPLIT_RTT_MS` ceiling to every fresh operational stream — split *admission* already gates path eligibility with gossiped, hysteresis-smoothed RTT plus re-election. Re-checking instantaneous per-stream RTT was rejecting per-request return sinks under normal jitter while pooled forward lanes stayed healthy.

2. **Return-sink ready-handshake timeout 5s → 20s.** Over WAN the return sink connects to a local bridge alias, but the remote `ready` byte only arrives after the bridge cold-establishes a fresh stage QUIC connection (~10s budget) and the remote handler dials its local server. 5s timed out during that cold setup; forward lanes already used a 20s budget. Matching it lets the cold return path complete.

3. **Pre-warmed return-sink pool.** A single long-lived maintenance worker keeps `capacity = generation_concurrency` return sockets pre-warmed off the hot path (connect + ready handshake done, not yet bound), age-rotated before they can silently rot, and refilled FIFO on checkout. The hot path binds a pooled socket with a cheap write and falls back to a cold open, then to serial. This removes the cold-handshake intermittency that made direct-return work only sporadically.

4. **Implicit pipeline confirmation.** A successful `PredictionReturnOpen` write does not prove the tail selected the direct route (it may still reply on the forward lane), and the pipelined completion path is direct-only — so a false positive could hang up to 300s. Pipelining now gates on an *actual* direct reply observed **after** generation config, not on bind success. While unconfirmed, serial completion polls both routes (serving promptly) and trips confirmation on the first real direct reply. The flag is reset right after the generation-config ACK so pre-config restore/prefill replies can't falsely confirm.

## Protocol

No wire-format change. All behavior is additive and compatible with mixed-version meshes:
- The return-sink open/bind and confirmation are frontend-local (stage 0 ↔ tail over the existing binary transport); no new message kinds or fields.
- Older peers that reply on the forward lane simply keep the request on the serial path — correct, just not pipelined.
- The per-stream RTT gate change relaxes an operational check only; split *admission* eligibility is unchanged.

## Validation

- New unit tests: prepared-return-pool age/rotation policy, shared return-failure classifier; existing `direct_return`, `split_stage_path`, `split_readiness`, `stage_transport` suites pass.
- Full `skippy-server` lib suite green; `cargo clippy -D warnings` clean on `skippy-server` and `mesh-llm-host-runtime`; `cargo fmt --all --check` clean.
- Live: 2-node WAN split (Sydney M5 ↔ AU 4090, ~26ms) serves HTTP 200; `verify_window_direct_prediction_return=true`; pipelining reached `max_in_flight` up to 4 under forced mode.

## Notes / follow-up (not in this PR)

Depth tuning is intentionally out of scope. A separate A/B on this branch showed that pushing proposal depth from 2→4 on GLM-4.7-Flash over WAN *did* fill the pipeline and hide latency (downstream-wait ~700ms→~335ms) but **reduced** net throughput (~45→~37 tok/s) because divergence discarded far more speculative windows. The throughput lever for that model/workload is speculative **acceptance rate** and **keeping the pipeline full without wasting work on divergence**, not raw depth — tracked separately. This PR is the reliability foundation that makes any of that measurable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a hidden CLI/config option to force speculative verify-window pipelining when depth is greater than one.
  * Added pre-warmed pooling for direct prediction-return connections to speed up embedded generation.
* **Bug Fixes**
  * Operational traffic no longer aborts on transient split-path rejection; it now warns and continues.
  * Verify-window pipelining is now gated on confirmed direct-return delivery; when unavailable, it falls back to serial behavior.
* **Monitoring**
  * Improved telemetry for direct-return open/bind phase classification, confirmation gating, verify-window force/fallback, and native vs ngram survival accounting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->