### PR TITLE
Add direct quant layer package tooling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7488,6 +7488,7 @@ dependencies = [
  "clap",
  "libc",
  "llama-quant-ffi",
+ "regex-lite",
  "serde",
  "serde_json",
  "skippy-ffi",

--- a/crates/skippy-quantize/Cargo.toml
+++ b/crates/skippy-quantize/Cargo.toml
@@ -21,3 +21,6 @@ llama-quant-ffi = { path = "../llama-quant-ffi" }
 serde.workspace = true
 serde_json.workspace = true
 skippy-ffi = { path = "../skippy-ffi" }
+
+[dev-dependencies]
+regex-lite = "0.1"

--- a/crates/skippy-quantize/README.md
+++ b/crates/skippy-quantize/README.md
@@ -414,10 +414,24 @@ per-tensor policy with `--tensor-type-file` or repeated `--tensor-type`.
 The tensor recipe format is one override per line:
 
 ```text
-blk.*.ffn_gate_exps.weight=Q2_K
-blk.*.ffn_down_exps.weight=Q3_K
-mtp.*=Q8_0
+attn_q_a\.weight$=Q8_0
+ffn_down_shexp\.weight$=Q4_K
+(^|\.)nextn\.=Q8_0
 ```
+
+Recipe files are whitespace-tokenized, so keep comments in a sidecar README
+rather than inside the recipe itself. `PATTERN` is passed to llama.cpp as a
+regular expression and matched with `std::regex_search`; first match wins.
+Use raw GGML tensor types such as `Q2_K`, `Q3_K`, `Q4_K`, `Q8_0`, `F16`, and
+`BF16`, not artifact profile names such as `Q2_K-MTP-Q8`.
+
+Repository-maintained GLM-5.2 recipes live under
+`recipes/quantization/`. The baseline
+`glm-5.2-q2-k-mtp-q8.tensor-types.txt` recreates the lab comfort-fit profile
+from base `--quant Q2_K`. The experimental
+`glm-5.2-q2-k-routed-down-mtp-q8.tensor-types.txt` lowers only decoder-layer
+`blk.0..77.ffn_down_exps.weight` tensors to `Q2_K`, deliberately excluding
+`blk.78`, the native NextN/MTP block.
 
 Inspect supported modes and raw tensor override types:
 

--- a/crates/skippy-quantize/src/float_convert.rs
+++ b/crates/skippy-quantize/src/float_convert.rs
@@ -82,7 +82,7 @@ pub(crate) fn convert_float_chunk<W: Write>(
     Ok(output.len() as u64)
 }
 
-fn read_float_element(input: &[u8], dtype: FloatDType, index: usize) -> f32 {
+pub(crate) fn read_float_element(input: &[u8], dtype: FloatDType, index: usize) -> f32 {
     match dtype {
         FloatDType::F32 => {
             let start = index * 4;
@@ -105,7 +105,7 @@ fn read_float_element(input: &[u8], dtype: FloatDType, index: usize) -> f32 {
     }
 }
 
-fn write_float_element(output: &mut Vec<u8>, dtype: FloatDType, value: f32) {
+pub(crate) fn write_float_element(output: &mut Vec<u8>, dtype: FloatDType, value: f32) {
     match dtype {
         FloatDType::F32 => output.extend_from_slice(&value.to_le_bytes()),
         FloatDType::F16 => output.extend_from_slice(&f32_to_f16_bits(value).to_le_bytes()),

--- a/crates/skippy-quantize/src/gguf_template.rs
+++ b/crates/skippy-quantize/src/gguf_template.rs
@@ -51,7 +51,7 @@ pub(crate) fn metadata_from_hf_config_with_options(
     push_common_llm_metadata(&mut metadata, arch, &config, options)?;
     push_attention_metadata(&mut metadata, arch, &config)?;
     push_glm_dsa_indexer_metadata(&mut metadata, arch, &config)?;
-    push_moe_metadata(&mut metadata, arch, &config);
+    push_moe_metadata(&mut metadata, arch, &config)?;
     push_tokenizer_metadata(&mut metadata, source, &config)?;
     if options.include_mtp {
         push_if_u32(
@@ -152,7 +152,15 @@ fn push_common_llm_metadata(
         config,
         "intermediate_size",
     );
-    if let Some(eps) = optional_f32(config, "rms_norm_eps") {
+    if arch == "glm-dsa" {
+        push_required_f32(
+            metadata,
+            arch,
+            "attention.layer_norm_rms_epsilon",
+            config,
+            "rms_norm_eps",
+        )?;
+    } else if let Some(eps) = optional_f32(config, "rms_norm_eps") {
         metadata.push(GgufKv::f32(
             &format!("{arch}.attention.layer_norm_rms_epsilon"),
             eps,
@@ -171,53 +179,110 @@ fn push_attention_metadata(metadata: &mut Vec<GgufKv>, arch: &str, config: &Valu
         &format!("{arch}.attention.head_count_kv"),
         optional_u32(config, "num_key_value_heads").unwrap_or(head_count),
     ));
-    if let Some((nope, rope)) =
+    let mut key_len_mla = None;
+    let (key_len, rope_dim) = if let Some((nope, rope)) =
         optional_u32(config, "qk_nope_head_dim").zip(optional_u32(config, "qk_rope_head_dim"))
     {
-        metadata.push(GgufKv::u32(
-            &format!("{arch}.attention.key_length"),
-            nope + rope,
-        ));
-        metadata.push(GgufKv::u32(&format!("{arch}.rope.dimension_count"), rope));
+        let dense_key_len = nope + rope;
+        if arch == "glm-dsa" {
+            ensure!(
+                rope > 0,
+                "GLM-DSA qk_rope_head_dim must be greater than zero"
+            );
+            ensure!(
+                rope % 2 == 0,
+                "GLM-DSA qk_rope_head_dim must be even for native llama.cpp RoPE"
+            );
+            ensure!(
+                nope > 0,
+                "GLM-DSA qk_nope_head_dim must be greater than zero for native MLA split"
+            );
+            let kv_lora_rank = required_u32(config, "kv_lora_rank")?;
+            ensure!(
+                kv_lora_rank > 0,
+                "GLM-DSA kv_lora_rank must be greater than zero"
+            );
+            key_len_mla = Some(dense_key_len);
+            (kv_lora_rank + rope, rope)
+        } else {
+            (dense_key_len, rope)
+        }
     } else {
         let head_dim = optional_u32(config, "head_dim").unwrap_or(
             required_u32(config, "hidden_size")? / required_u32(config, "num_attention_heads")?,
         );
-        metadata.push(GgufKv::u32(
-            &format!("{arch}.attention.key_length"),
-            head_dim,
-        ));
-        metadata.push(GgufKv::u32(
-            &format!("{arch}.rope.dimension_count"),
-            head_dim,
-        ));
-    }
+        (head_dim, head_dim)
+    };
+    metadata.push(GgufKv::u32(
+        &format!("{arch}.attention.key_length"),
+        key_len,
+    ));
+    metadata.push(GgufKv::u32(
+        &format!("{arch}.rope.dimension_count"),
+        rope_dim,
+    ));
     let value_len = optional_u32(config, "v_head_dim")
         .or_else(|| optional_u32(config, "head_dim"))
         .unwrap_or(
             required_u32(config, "hidden_size")? / required_u32(config, "num_attention_heads")?,
         );
+    if arch == "glm-dsa" {
+        ensure!(
+            value_len > 0,
+            "GLM-DSA v_head_dim must be greater than zero"
+        );
+    }
     metadata.push(GgufKv::u32(
         &format!("{arch}.attention.value_length"),
         value_len,
     ));
+    if arch == "glm-dsa" {
+        let key_len_mla = key_len_mla.context(
+            "GLM-DSA metadata requires qk_nope_head_dim and qk_rope_head_dim for MLA key length",
+        )?;
+        metadata.push(GgufKv::u32(
+            &format!("{arch}.attention.key_length_mla"),
+            key_len_mla,
+        ));
+        metadata.push(GgufKv::u32(
+            &format!("{arch}.attention.value_length_mla"),
+            value_len,
+        ));
+    }
     if let Some(theta) = optional_f32(config, "rope_theta") {
         metadata.push(GgufKv::f32(&format!("{arch}.rope.freq_base"), theta));
     }
-    push_if_u32(
-        metadata,
-        arch,
-        "attention.q_lora_rank",
-        config,
-        "q_lora_rank",
-    );
-    push_if_u32(
-        metadata,
-        arch,
-        "attention.kv_lora_rank",
-        config,
-        "kv_lora_rank",
-    );
+    if arch == "glm-dsa" {
+        push_required_u32(
+            metadata,
+            arch,
+            "attention.q_lora_rank",
+            config,
+            "q_lora_rank",
+        )?;
+        push_required_u32(
+            metadata,
+            arch,
+            "attention.kv_lora_rank",
+            config,
+            "kv_lora_rank",
+        )?;
+    } else {
+        push_if_u32(
+            metadata,
+            arch,
+            "attention.q_lora_rank",
+            config,
+            "q_lora_rank",
+        );
+        push_if_u32(
+            metadata,
+            arch,
+            "attention.kv_lora_rank",
+            config,
+            "kv_lora_rank",
+        );
+    }
     Ok(())
 }
 
@@ -250,10 +315,183 @@ fn push_glm_dsa_indexer_metadata(
         config,
         &["index_topk", "indexer_top_k"],
     )?;
+    push_first_u32(
+        metadata,
+        arch,
+        "attention.indexer.top_k_frequency",
+        config,
+        &["index_topk_freq", "indexer_top_k_freq"],
+    );
+    push_first_u32(
+        metadata,
+        arch,
+        "attention.indexer.skip_top_k_offset",
+        config,
+        &["index_skip_topk_offset", "indexer_skip_top_k_offset"],
+    );
+    push_glm_dsa_indexer_types(metadata, arch, config)?;
+    validate_glm_dsa_indexer_contract(config)?;
     Ok(())
 }
 
-fn push_moe_metadata(metadata: &mut Vec<GgufKv>, arch: &str, config: &Value) {
+fn validate_glm_dsa_indexer_contract(config: &Value) -> Result<()> {
+    let index_head_dim = optional_u32(config, "index_head_dim")
+        .or_else(|| optional_u32(config, "indexer_head_size"))
+        .context("GLM-DSA config missing index_head_dim/indexer_head_size")?;
+    let rope_dim = required_u32(config, "qk_rope_head_dim")?;
+    ensure!(
+        index_head_dim > rope_dim,
+        "GLM-DSA index_head_dim must be greater than qk_rope_head_dim"
+    );
+
+    let freq = optional_u32(config, "index_topk_freq")
+        .or_else(|| optional_u32(config, "indexer_top_k_freq"));
+    let offset = optional_u32(config, "index_skip_topk_offset")
+        .or_else(|| optional_u32(config, "indexer_skip_top_k_offset"));
+    if let Some(freq) = freq {
+        ensure!(
+            freq > 0,
+            "GLM-DSA index_topk_freq must be greater than zero when present"
+        );
+        let offset = offset.context(
+            "GLM-DSA index_skip_topk_offset/indexer_skip_top_k_offset is required when index_topk_freq is present",
+        )?;
+        validate_glm_dsa_indexer_types_match_frequency(config, freq, offset)?;
+    }
+    Ok(())
+}
+
+fn validate_glm_dsa_indexer_types_match_frequency(
+    config: &Value,
+    freq: u32,
+    offset: u32,
+) -> Result<()> {
+    let Some(types) = config.get("indexer_types") else {
+        return Ok(());
+    };
+    let types = types
+        .as_array()
+        .context("config value \"indexer_types\" must be an array")?;
+    for (layer, value) in types.iter().enumerate() {
+        let role = value
+            .as_str()
+            .context("config value \"indexer_types\" must contain strings")?
+            .to_ascii_lowercase();
+        let role_full = role == "full";
+        let freq_full = glm_dsa_frequency_layer_is_full(layer as u32, offset, freq);
+        ensure!(
+            role_full == freq_full,
+            "GLM-DSA indexer_types conflicts with index_topk_freq at layer {layer}"
+        );
+    }
+    Ok(())
+}
+
+fn glm_dsa_frequency_layer_is_full(layer: u32, offset: u32, freq: u32) -> bool {
+    layer < offset || (layer - offset + 1).is_multiple_of(freq)
+}
+
+fn push_glm_dsa_indexer_types(
+    metadata: &mut Vec<GgufKv>,
+    arch: &str,
+    config: &Value,
+) -> Result<()> {
+    let Some(types) = config.get("indexer_types") else {
+        return Ok(());
+    };
+
+    let types = types
+        .as_array()
+        .context("config value \"indexer_types\" must be an array")?;
+    let n_layers = required_u32(config, "num_hidden_layers")? as usize;
+    ensure!(
+        types.len() == n_layers,
+        "config value \"indexer_types\" length {} must match num_hidden_layers {n_layers}",
+        types.len()
+    );
+
+    let mut normalized = Vec::with_capacity(types.len());
+    for value in types {
+        let role = value
+            .as_str()
+            .context("config value \"indexer_types\" must contain strings")?
+            .to_ascii_lowercase();
+        ensure!(
+            role == "full" || role == "shared",
+            "config value \"indexer_types\" must contain only \"full\" or \"shared\""
+        );
+        normalized.push(role);
+    }
+
+    metadata.push(GgufKv::array_string(
+        &format!("{arch}.attention.indexer.types"),
+        normalized,
+    ));
+    Ok(())
+}
+
+fn push_moe_metadata(metadata: &mut Vec<GgufKv>, arch: &str, config: &Value) -> Result<()> {
+    if arch == "glm-dsa" {
+        validate_glm_dsa_moe_contract(config)?;
+        push_required_first_u32(
+            metadata,
+            arch,
+            "expert_count",
+            config,
+            &["n_routed_experts", "num_experts"],
+        )?;
+        push_required_first_u32(
+            metadata,
+            arch,
+            "expert_used_count",
+            config,
+            &["num_experts_per_tok"],
+        )?;
+        push_required_first_u32(
+            metadata,
+            arch,
+            "expert_shared_count",
+            config,
+            &["n_shared_experts"],
+        )?;
+        push_required_first_u32(
+            metadata,
+            arch,
+            "expert_feed_forward_length",
+            config,
+            &["moe_intermediate_size"],
+        )?;
+        push_required_first_u32(
+            metadata,
+            arch,
+            "leading_dense_block_count",
+            config,
+            &["first_k_dense_replace"],
+        )?;
+        push_required_f32(
+            metadata,
+            arch,
+            "expert_weights_scale",
+            config,
+            "routed_scaling_factor",
+        )?;
+        push_required_bool(
+            metadata,
+            arch,
+            "expert_weights_norm",
+            config,
+            "norm_topk_prob",
+        )?;
+        push_first_u32(
+            metadata,
+            arch,
+            "expert_shared_feed_forward_length",
+            config,
+            &["shared_expert_intermediate_size"],
+        );
+        return Ok(());
+    }
+
     push_first_u32(
         metadata,
         arch,
@@ -302,6 +540,29 @@ fn push_moe_metadata(metadata: &mut Vec<GgufKv>, arch: &str, config: &Value) {
     if let Some(norm) = optional_bool(config, "norm_topk_prob") {
         metadata.push(GgufKv::bool(&format!("{arch}.expert_weights_norm"), norm));
     }
+    Ok(())
+}
+
+fn validate_glm_dsa_moe_contract(config: &Value) -> Result<()> {
+    let target_layers = required_u32(config, "num_hidden_layers")?;
+    ensure!(
+        target_layers > 0,
+        "GLM-DSA num_hidden_layers must be greater than zero"
+    );
+    let expert_count = optional_u32(config, "n_routed_experts")
+        .or_else(|| optional_u32(config, "num_experts"))
+        .context("GLM-DSA config missing n_routed_experts/num_experts")?;
+    let expert_used = required_u32(config, "num_experts_per_tok")?;
+    ensure!(
+        expert_used <= expert_count,
+        "GLM-DSA num_experts_per_tok must be less than or equal to expert count"
+    );
+    let dense_lead = optional_u32(config, "first_k_dense_replace").unwrap_or(0);
+    ensure!(
+        dense_lead < target_layers,
+        "GLM-DSA first_k_dense_replace must be less than num_hidden_layers"
+    );
+    Ok(())
 }
 
 fn push_required_first_u32(
@@ -350,6 +611,32 @@ fn push_required_u32(
         &format!("{arch}.{gguf_suffix}"),
         required_u32(config, config_key)?,
     ));
+    Ok(())
+}
+
+fn push_required_f32(
+    metadata: &mut Vec<GgufKv>,
+    arch: &str,
+    gguf_suffix: &str,
+    config: &Value,
+    config_key: &str,
+) -> Result<()> {
+    let value = optional_f32(config, config_key)
+        .with_context(|| format!("config missing {config_key:?}"))?;
+    metadata.push(GgufKv::f32(&format!("{arch}.{gguf_suffix}"), value));
+    Ok(())
+}
+
+fn push_required_bool(
+    metadata: &mut Vec<GgufKv>,
+    arch: &str,
+    gguf_suffix: &str,
+    config: &Value,
+    config_key: &str,
+) -> Result<()> {
+    let value = optional_bool(config, config_key)
+        .with_context(|| format!("config missing {config_key:?}"))?;
+    metadata.push(GgufKv::bool(&format!("{arch}.{gguf_suffix}"), value));
     Ok(())
 }
 
@@ -516,6 +803,23 @@ mod tests {
               "index_n_heads": 32,
               "index_head_dim": 128,
               "index_topk": 2048,
+              "index_topk_freq": 4,
+              "index_skip_topk_offset": 3,
+              "indexer_types": [
+                "full", "full", "full", "shared", "shared", "shared", "full",
+                "shared", "shared", "shared", "full", "shared", "shared",
+                "shared", "full", "shared", "shared", "shared", "full",
+                "shared", "shared", "shared", "full", "shared", "shared",
+                "shared", "full", "shared", "shared", "shared", "full",
+                "shared", "shared", "shared", "full", "shared", "shared",
+                "shared", "full", "shared", "shared", "shared", "full",
+                "shared", "shared", "shared", "full", "shared", "shared",
+                "shared", "full", "shared", "shared", "shared", "full",
+                "shared", "shared", "shared", "full", "shared", "shared",
+                "shared", "full", "shared", "shared", "shared", "full",
+                "shared", "shared", "shared", "full", "shared", "shared",
+                "shared", "full", "shared", "shared", "shared"
+              ],
               "n_routed_experts": 256,
               "num_experts_per_tok": 8,
               "n_shared_experts": 1,
@@ -530,6 +834,27 @@ mod tests {
 
         let metadata = metadata_from_hf_config(&root, 3).unwrap();
 
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.attention.key_length" && *value == 576
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.attention.key_length_mla" && *value == 256
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.attention.value_length_mla" && *value == 256
+            )
+        }));
         assert!(metadata.iter().any(|kv| {
             matches!(
                 kv,
@@ -551,6 +876,123 @@ mod tests {
                     if key == "glm-dsa.attention.indexer.top_k" && *value == 2048
             )
         }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.attention.indexer.top_k_frequency" && *value == 4
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.attention.indexer.skip_top_k_offset" && *value == 3
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::ArrayString { key, value }
+                    if key == "glm-dsa.attention.indexer.types"
+                        && value.len() == 78
+                        && value[0] == "full"
+                        && value[3] == "shared"
+                        && value[6] == "full"
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.expert_count" && *value == 256
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.expert_used_count" && *value == 8
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.expert_shared_count" && *value == 1
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.expert_feed_forward_length" && *value == 2048
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::U32 { key, value }
+                    if key == "glm-dsa.leading_dense_block_count" && *value == 3
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::F32 { key, value }
+                    if key == "glm-dsa.expert_weights_scale" && (*value - 2.5).abs() < f32::EPSILON
+            )
+        }));
+        assert!(metadata.iter().any(|kv| {
+            matches!(
+                kv,
+                GgufKv::Bool { key, value }
+                    if key == "glm-dsa.expert_weights_norm" && *value
+            )
+        }));
+        fs::remove_dir_all(root).unwrap();
+    }
+
+    #[test]
+    fn rejects_glm_dsa_config_missing_runtime_contract_metadata() {
+        let root = unique_temp_dir();
+        fs::create_dir_all(&root).unwrap();
+        fs::write(
+            root.join("config.json"),
+            r#"{
+              "model_type": "glm_moe_dsa",
+              "vocab_size": 154880,
+              "max_position_embeddings": 1048576,
+              "hidden_size": 6144,
+              "intermediate_size": 12288,
+              "num_hidden_layers": 78,
+              "num_attention_heads": 64,
+              "num_key_value_heads": 64,
+              "qk_nope_head_dim": 192,
+              "qk_rope_head_dim": 64,
+              "v_head_dim": 256,
+              "q_lora_rank": 2048,
+              "kv_lora_rank": 512,
+              "index_n_heads": 32,
+              "index_head_dim": 128,
+              "index_topk": 2048,
+              "n_routed_experts": 256,
+              "n_shared_experts": 1,
+              "moe_intermediate_size": 2048,
+              "first_k_dense_replace": 3,
+              "routed_scaling_factor": 2.5,
+              "norm_topk_prob": true,
+              "rms_norm_eps": 1e-5
+            }"#,
+        )
+        .unwrap();
+
+        let err = metadata_from_hf_config(&root, 3).unwrap_err();
+
+        assert!(
+            err.to_string().contains("num_experts_per_tok"),
+            "unexpected error: {err:#}"
+        );
         fs::remove_dir_all(root).unwrap();
     }
 

--- a/crates/skippy-quantize/src/gguf_writer.rs
+++ b/crates/skippy-quantize/src/gguf_writer.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, btree_map::Entry};
+use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
 use std::fs::{self, File};
 use std::io::{Seek, Write};
 use std::path::Path;
@@ -6,7 +6,10 @@ use std::path::Path;
 use anyhow::{Context, Result, ensure};
 use serde::Serialize;
 
-use crate::float_convert::{FloatDType, convert_float_chunk, target_dtype_for_tensor};
+use crate::float_convert::{
+    FloatDType, convert_float_chunk, read_float_element, target_dtype_for_tensor,
+    write_float_element,
+};
 use crate::hf_checkpoint::{SafetensorFile, SafetensorTensorInfo, open_safetensor_files};
 use crate::tensor_map::{
     TensorNameMap, hf_layer_id, is_mtp_source_tensor, is_shared_mtp_context_tensor,
@@ -27,6 +30,13 @@ const GGUF_TYPE_UINT64: u32 = 10;
 const GGML_TYPE_F32: u32 = 0;
 const GGML_TYPE_F16: u32 = 1;
 const GGML_TYPE_BF16: u32 = 30;
+const GLM_DSA_INDEXER_TENSORS: &[&str] = &[
+    "indexer.k_norm.weight",
+    "indexer.k_norm.bias",
+    "indexer.proj.weight",
+    "indexer.attn_k.weight",
+    "indexer.attn_q_b.weight",
+];
 
 #[derive(Debug, Clone)]
 pub(crate) struct RawGgufWriteOptions {
@@ -119,11 +129,22 @@ fn prepare_raw_safetensors_gguf(
         "no safetensors files found under {}",
         source.display()
     );
+    let metadata_seed = options.metadata.clone();
+    let glm_dsa_kv_b_split = match metadata_seed.as_ref() {
+        Some(metadata) if is_glm_dsa_metadata(metadata) => {
+            match glm_dsa_kv_b_split_config(metadata)? {
+                Some(config) => GlmDsaKvBSplitMode::Config(config),
+                None => GlmDsaKvBSplitMode::MissingMetadata,
+            }
+        }
+        _ => GlmDsaKvBSplitMode::Disabled,
+    };
     let tensors = collect_tensor_sources(
         &files,
         options.tensor_name_map,
         options.output_type,
         options.tensor_selection,
+        glm_dsa_kv_b_split,
     )?;
     ensure!(
         !tensors.is_empty(),
@@ -131,18 +152,142 @@ fn prepare_raw_safetensors_gguf(
         source.display()
     );
     let total_tensor_count = tensors.len();
+    let mut metadata = metadata_seed.unwrap_or_else(|| raw_metadata(source, total_tensor_count));
+    enrich_glm_dsa_indexshare_metadata(&mut metadata, &tensors)?;
     let mut tensors = select_split_tensors(tensors, options.split)?;
     assign_gguf_offsets(&mut tensors)?;
-    let metadata = options
-        .metadata
-        .clone()
-        .unwrap_or_else(|| raw_metadata(source, total_tensor_count));
     let metadata = split_metadata(metadata, options.split, total_tensor_count)?;
     Ok(PreparedGgufWrite {
         files,
         tensors,
         metadata,
     })
+}
+
+fn enrich_glm_dsa_indexshare_metadata(
+    metadata: &mut Vec<GgufKv>,
+    tensors: &[TensorSource],
+) -> Result<()> {
+    if metadata_string(metadata, "general.architecture").as_deref() != Some("glm-dsa") {
+        return Ok(());
+    }
+    if metadata_has_key(metadata, "glm-dsa.attention.indexer.types")
+        || metadata_has_key(metadata, "glm-dsa.attention.indexer.top_k_frequency")
+    {
+        return Ok(());
+    }
+
+    let block_count = metadata_u32(metadata, "glm-dsa.block_count")
+        .context("GLM-DSA metadata missing glm-dsa.block_count")?;
+    let nextn_layers = metadata_u32(metadata, "glm-dsa.nextn_predict_layers").unwrap_or(0);
+    ensure!(
+        nextn_layers < block_count,
+        "GLM-DSA nextn_predict_layers {nextn_layers} must be less than block_count {block_count}"
+    );
+    let decoder_layers = block_count - nextn_layers;
+    let tensor_names = tensors
+        .iter()
+        .map(|tensor| tensor.name.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut roles = Vec::with_capacity(decoder_layers as usize);
+    for layer in 0..decoder_layers {
+        let indexer_count = GLM_DSA_INDEXER_TENSORS
+            .iter()
+            .filter(|suffix| tensor_names.contains(format!("blk.{layer}.{suffix}").as_str()))
+            .count();
+        ensure!(
+            indexer_count == 0 || indexer_count == GLM_DSA_INDEXER_TENSORS.len(),
+            "GLM-DSA layer {layer} has partial indexer tensor group ({indexer_count}/{})",
+            GLM_DSA_INDEXER_TENSORS.len()
+        );
+        roles.push(if indexer_count == GLM_DSA_INDEXER_TENSORS.len() {
+            "full".to_string()
+        } else {
+            "shared".to_string()
+        });
+    }
+    metadata.push(GgufKv::array_string(
+        "glm-dsa.attention.indexer.types",
+        roles,
+    ));
+    Ok(())
+}
+
+fn metadata_has_key(metadata: &[GgufKv], key: &str) -> bool {
+    metadata.iter().any(|kv| kv.key() == key)
+}
+
+fn metadata_string(metadata: &[GgufKv], key: &str) -> Option<String> {
+    metadata.iter().find_map(|kv| match kv {
+        GgufKv::String {
+            key: item_key,
+            value,
+        } if item_key == key => Some(value.clone()),
+        _ => None,
+    })
+}
+
+fn is_glm_dsa_metadata(metadata: &[GgufKv]) -> bool {
+    metadata_string(metadata, "general.architecture").as_deref() == Some("glm-dsa")
+}
+
+fn metadata_u32(metadata: &[GgufKv], key: &str) -> Option<u32> {
+    metadata.iter().find_map(|kv| match kv {
+        GgufKv::U32 {
+            key: item_key,
+            value,
+        } if item_key == key => Some(*value),
+        _ => None,
+    })
+}
+
+fn glm_dsa_kv_b_split_config(metadata: &[GgufKv]) -> Result<Option<GlmDsaKvBSplitConfig>> {
+    if !is_glm_dsa_metadata(metadata) {
+        return Ok(None);
+    }
+    let Some(head_count) = metadata_u32(metadata, "glm-dsa.attention.head_count") else {
+        return Ok(None);
+    };
+    let Some(key_length) = metadata_u32(metadata, "glm-dsa.attention.key_length_mla")
+        .or_else(|| metadata_u32(metadata, "glm-dsa.attention.key_length"))
+    else {
+        return Ok(None);
+    };
+    let Some(rope_dim) = metadata_u32(metadata, "glm-dsa.rope.dimension_count") else {
+        return Ok(None);
+    };
+    let Some(value_head_dim) = metadata_u32(metadata, "glm-dsa.attention.value_length") else {
+        return Ok(None);
+    };
+    let Some(kv_lora_rank) = metadata_u32(metadata, "glm-dsa.attention.kv_lora_rank") else {
+        return Ok(None);
+    };
+    ensure!(
+        key_length > rope_dim,
+        "glm-dsa.attention.key_length_mla must be greater than rope.dimension_count for kv_b split"
+    );
+    Ok(Some(GlmDsaKvBSplitConfig {
+        head_count: u64::from(head_count),
+        qk_nope_head_dim: u64::from(key_length - rope_dim),
+        value_head_dim: u64::from(value_head_dim),
+        kv_lora_rank: u64::from(kv_lora_rank),
+    }))
+}
+
+fn glm_dsa_kv_b_layer(name: &str) -> Result<Option<u32>> {
+    let Some(rest) = name.strip_prefix("model.layers.") else {
+        return Ok(None);
+    };
+    let Some((layer, suffix)) = rest.split_once('.') else {
+        return Ok(None);
+    };
+    if suffix != "self_attn.kv_b_proj.weight" {
+        return Ok(None);
+    }
+    layer
+        .parse::<u32>()
+        .map(Some)
+        .with_context(|| format!("parse GLM-DSA kv_b layer id in {name}"))
 }
 
 fn select_split_tensors(
@@ -289,6 +434,7 @@ fn collect_tensor_sources(
     tensor_name_map: TensorNameMap,
     output_type: Option<ConvertOutputType>,
     tensor_selection: TensorSelection,
+    glm_dsa_kv_b_split: GlmDsaKvBSplitMode,
 ) -> Result<Vec<TensorSource>> {
     let mut tensors = Vec::new();
     let mut expert_groups = BTreeMap::<ExpertGroupKey, ExpertGroup>::new();
@@ -313,6 +459,27 @@ fn collect_tensor_sources(
                     }
                 }
                 continue;
+            }
+            if let Some(layer) = glm_dsa_kv_b_layer(tensor.name())? {
+                match glm_dsa_kv_b_split {
+                    GlmDsaKvBSplitMode::Config(split) => {
+                        tensors.extend(TensorSource::from_glm_dsa_kv_b_split(
+                            file_index,
+                            tensor,
+                            layer,
+                            split,
+                            output_type,
+                        )?);
+                        continue;
+                    }
+                    GlmDsaKvBSplitMode::MissingMetadata => {
+                        anyhow::bail!(
+                            "GLM-DSA tensor {} requires attention head/value/rope/kv_lora metadata for kv_b split",
+                            tensor.name()
+                        );
+                    }
+                    GlmDsaKvBSplitMode::Disabled => {}
+                }
             }
             tensors.push(TensorSource::from_safetensor(
                 file_index,
@@ -377,6 +544,7 @@ impl TensorSource {
                 element_count,
                 source_byte_len: tensor.byte_len(),
                 target_byte_len: tensor_byte_len(element_count, target_dtype)?,
+                transform: TensorTransform::Identity,
             }],
             name,
             dims: tensor.shape().iter().rev().copied().collect(),
@@ -384,6 +552,89 @@ impl TensorSource {
             byte_len: tensor_byte_len(element_count, target_dtype)?,
             gguf_offset: 0,
         })
+    }
+
+    fn from_glm_dsa_kv_b_split(
+        file_index: usize,
+        tensor: &SafetensorTensorInfo,
+        layer: u32,
+        split: GlmDsaKvBSplitConfig,
+        output_type: Option<ConvertOutputType>,
+    ) -> Result<Vec<Self>> {
+        ensure!(
+            tensor.shape().len() == 2,
+            "GLM-DSA tensor {} must be rank-2 for kv_b split, got shape {:?}",
+            tensor.name(),
+            tensor.shape()
+        );
+        let expected_rows = split
+            .head_count
+            .checked_mul(split.qk_nope_head_dim + split.value_head_dim)
+            .context("GLM-DSA kv_b expected row count overflow")?;
+        ensure!(
+            tensor.shape()[0] == expected_rows && tensor.shape()[1] == split.kv_lora_rank,
+            "GLM-DSA tensor {} shape {:?} does not match expected [{expected_rows}, {}]",
+            tensor.name(),
+            tensor.shape(),
+            split.kv_lora_rank
+        );
+        let source_dtype = FloatDType::from_safetensor(tensor.dtype()).with_context(|| {
+            format!("unsupported dtype {} for {}", tensor.dtype(), tensor.name())
+        })?;
+        let target_dtype = target_dtype_for_tensor(source_dtype, output_type, tensor.shape())?;
+        let source_element_count = tensor_element_count(tensor)?;
+        let k_element_count = split
+            .head_count
+            .checked_mul(split.qk_nope_head_dim)
+            .and_then(|value| value.checked_mul(split.kv_lora_rank))
+            .context("GLM-DSA attn_k_b element count overflow")?;
+        let v_element_count = split
+            .head_count
+            .checked_mul(split.value_head_dim)
+            .and_then(|value| value.checked_mul(split.kv_lora_rank))
+            .context("GLM-DSA attn_v_b element count overflow")?;
+        Ok(vec![
+            Self {
+                segments: vec![TensorSegment {
+                    file_index,
+                    source_name: tensor.name().to_string(),
+                    source_dtype,
+                    target_dtype,
+                    element_count: source_element_count,
+                    source_byte_len: tensor.byte_len(),
+                    target_byte_len: tensor_byte_len(k_element_count, target_dtype)?,
+                    transform: TensorTransform::GlmDsaKvB {
+                        split,
+                        part: GlmDsaKvBPart::K,
+                    },
+                }],
+                name: format!("blk.{layer}.attn_k_b.weight"),
+                dims: vec![split.qk_nope_head_dim, split.kv_lora_rank, split.head_count],
+                ggml_type: ggml_type_for_dtype(target_dtype),
+                byte_len: tensor_byte_len(k_element_count, target_dtype)?,
+                gguf_offset: 0,
+            },
+            Self {
+                segments: vec![TensorSegment {
+                    file_index,
+                    source_name: tensor.name().to_string(),
+                    source_dtype,
+                    target_dtype,
+                    element_count: source_element_count,
+                    source_byte_len: tensor.byte_len(),
+                    target_byte_len: tensor_byte_len(v_element_count, target_dtype)?,
+                    transform: TensorTransform::GlmDsaKvB {
+                        split,
+                        part: GlmDsaKvBPart::V,
+                    },
+                }],
+                name: format!("blk.{layer}.attn_v_b.weight"),
+                dims: vec![split.kv_lora_rank, split.value_head_dim, split.head_count],
+                ggml_type: ggml_type_for_dtype(target_dtype),
+                byte_len: tensor_byte_len(v_element_count, target_dtype)?,
+                gguf_offset: 0,
+            },
+        ])
     }
 }
 
@@ -395,6 +646,37 @@ struct TensorSegment {
     element_count: u64,
     source_byte_len: u64,
     target_byte_len: u64,
+    transform: TensorTransform,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum TensorTransform {
+    Identity,
+    GlmDsaKvB {
+        split: GlmDsaKvBSplitConfig,
+        part: GlmDsaKvBPart,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+enum GlmDsaKvBPart {
+    K,
+    V,
+}
+
+#[derive(Debug, Clone, Copy)]
+enum GlmDsaKvBSplitMode {
+    Disabled,
+    MissingMetadata,
+    Config(GlmDsaKvBSplitConfig),
+}
+
+#[derive(Debug, Clone, Copy)]
+struct GlmDsaKvBSplitConfig {
+    head_count: u64,
+    qk_nope_head_dim: u64,
+    value_head_dim: u64,
+    kv_lora_rank: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -538,6 +820,7 @@ impl ExpertGroup {
                 element_count,
                 source_byte_len: tensor.byte_len(),
                 target_byte_len: tensor_byte_len(element_count, self.target_dtype)?,
+                transform: TensorTransform::Identity,
             },
         );
         ensure!(
@@ -636,6 +919,21 @@ pub(crate) enum GgufKv {
 }
 
 impl GgufKv {
+    fn key(&self) -> &str {
+        match self {
+            Self::ArrayF32 { key, .. }
+            | Self::ArrayI32 { key, .. }
+            | Self::ArrayString { key, .. }
+            | Self::Bool { key, .. }
+            | Self::F32 { key, .. }
+            | Self::I32 { key, .. }
+            | Self::String { key, .. }
+            | Self::U16 { key, .. }
+            | Self::U32 { key, .. }
+            | Self::U64 { key, .. } => key,
+        }
+    }
+
     pub(crate) fn array_f32(key: &str, value: Vec<f32>) -> Self {
         Self::ArrayF32 {
             key: key.to_string(),
@@ -848,6 +1146,10 @@ fn stream_segment(
     segment: &TensorSegment,
     buffer_size: usize,
 ) -> Result<u64> {
+    if let TensorTransform::GlmDsaKvB { split, part } = segment.transform {
+        return stream_glm_dsa_kv_b_split(writer, file, segment, buffer_size, split, part);
+    }
+
     if segment.source_dtype == segment.target_dtype {
         let copied = file.stream_tensor(&segment.source_name, writer, buffer_size)?;
         ensure!(
@@ -889,6 +1191,116 @@ fn stream_segment(
         segment.source_name
     );
     Ok(output_bytes)
+}
+
+fn stream_glm_dsa_kv_b_split(
+    writer: &mut File,
+    file: &SafetensorFile,
+    segment: &TensorSegment,
+    buffer_size: usize,
+    split: GlmDsaKvBSplitConfig,
+    part: GlmDsaKvBPart,
+) -> Result<u64> {
+    let mut source = Vec::with_capacity(
+        usize::try_from(segment.source_byte_len)
+            .context("GLM-DSA kv_b source byte length does not fit usize")?,
+    );
+    let mut source_bytes = 0_u64;
+    file.stream_tensor_chunks(&segment.source_name, buffer_size, |chunk| {
+        source.extend_from_slice(chunk);
+        source_bytes += chunk.len() as u64;
+        Ok(())
+    })?;
+    ensure!(
+        source_bytes == segment.source_byte_len,
+        "read {} bytes for {}, expected {}",
+        source_bytes,
+        segment.source_name,
+        segment.source_byte_len
+    );
+    ensure!(
+        source.len() % segment.source_dtype.byte_size() as usize == 0,
+        "GLM-DSA kv_b source split an element boundary"
+    );
+
+    let combined_head_dim = split.qk_nope_head_dim + split.value_head_dim;
+    let mut output_bytes = 0_u64;
+    let flush_limit = buffer_size.max(segment.target_dtype.byte_size() as usize);
+    let mut output = Vec::with_capacity(flush_limit);
+    for head in 0..split.head_count {
+        match part {
+            GlmDsaKvBPart::K => {
+                for lora in 0..split.kv_lora_rank {
+                    for qk in 0..split.qk_nope_head_dim {
+                        output_bytes += push_transformed_float(
+                            writer,
+                            &source,
+                            segment.source_dtype,
+                            segment.target_dtype,
+                            &mut output,
+                            flush_limit,
+                            (head * combined_head_dim + qk) * split.kv_lora_rank + lora,
+                        )?;
+                    }
+                }
+            }
+            GlmDsaKvBPart::V => {
+                for value in 0..split.value_head_dim {
+                    for lora in 0..split.kv_lora_rank {
+                        output_bytes += push_transformed_float(
+                            writer,
+                            &source,
+                            segment.source_dtype,
+                            segment.target_dtype,
+                            &mut output,
+                            flush_limit,
+                            (head * combined_head_dim + split.qk_nope_head_dim + value)
+                                * split.kv_lora_rank
+                                + lora,
+                        )?;
+                    }
+                }
+            }
+        }
+    }
+    writer.write_all(&output)?;
+    ensure!(
+        output_bytes == segment.target_byte_len,
+        "wrote {} bytes for transformed {}, expected {}",
+        output_bytes,
+        segment.source_name,
+        segment.target_byte_len
+    );
+    Ok(output_bytes)
+}
+
+fn push_transformed_float(
+    writer: &mut File,
+    source: &[u8],
+    source_dtype: FloatDType,
+    target_dtype: FloatDType,
+    output: &mut Vec<u8>,
+    flush_limit: usize,
+    source_index: u64,
+) -> Result<u64> {
+    let source_index =
+        usize::try_from(source_index).context("GLM-DSA kv_b source index does not fit usize")?;
+    let source_width = source_dtype.byte_size() as usize;
+    ensure!(
+        source_index
+            .checked_add(1)
+            .and_then(|count| count.checked_mul(source_width))
+            .is_some_and(|end| end <= source.len()),
+        "GLM-DSA kv_b source index {source_index} is outside source tensor"
+    );
+    let value = read_float_element(source, source_dtype, source_index);
+    write_float_element(output, target_dtype, value);
+    let written = target_dtype.byte_size();
+    if output.len() >= flush_limit {
+        writer.write_all(output)?;
+        output.clear();
+    }
+    Ok(written)
 }
 
 fn aligned_chunk_size(buffer_size: usize, element_size: usize) -> usize {

--- a/crates/skippy-quantize/src/gguf_writer.rs
+++ b/crates/skippy-quantize/src/gguf_writer.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet, btree_map::Entry};
+use std::collections::{BTreeMap, btree_map::Entry};
 use std::fs::{self, File};
 use std::io::{Seek, Write};
 use std::path::Path;
@@ -6,15 +6,19 @@ use std::path::Path;
 use anyhow::{Context, Result, ensure};
 use serde::Serialize;
 
-use crate::float_convert::{
-    FloatDType, convert_float_chunk, read_float_element, target_dtype_for_tensor,
-    write_float_element,
-};
+use crate::float_convert::{FloatDType, convert_float_chunk, target_dtype_for_tensor};
 use crate::hf_checkpoint::{SafetensorFile, SafetensorTensorInfo, open_safetensor_files};
 use crate::tensor_map::{
     TensorNameMap, hf_layer_id, is_mtp_source_tensor, is_shared_mtp_context_tensor,
 };
 use crate::types::ConvertOutputType;
+
+mod glm_dsa;
+
+use glm_dsa::{
+    GlmDsaKvBSplitMode, TensorTransform, enrich_glm_dsa_indexshare_metadata, glm_dsa_kv_b_layer,
+    glm_dsa_kv_b_split_mode, stream_transformed_segment,
+};
 
 const GGUF_MAGIC: &[u8; 4] = b"GGUF";
 const GGUF_VERSION: u32 = 3;
@@ -30,14 +34,6 @@ const GGUF_TYPE_UINT64: u32 = 10;
 const GGML_TYPE_F32: u32 = 0;
 const GGML_TYPE_F16: u32 = 1;
 const GGML_TYPE_BF16: u32 = 30;
-const GLM_DSA_INDEXER_TENSORS: &[&str] = &[
-    "indexer.k_norm.weight",
-    "indexer.k_norm.bias",
-    "indexer.proj.weight",
-    "indexer.attn_k.weight",
-    "indexer.attn_q_b.weight",
-];
-
 #[derive(Debug, Clone)]
 pub(crate) struct RawGgufWriteOptions {
     pub(crate) buffer_size: usize,
@@ -130,15 +126,7 @@ fn prepare_raw_safetensors_gguf(
         source.display()
     );
     let metadata_seed = options.metadata.clone();
-    let glm_dsa_kv_b_split = match metadata_seed.as_ref() {
-        Some(metadata) if is_glm_dsa_metadata(metadata) => {
-            match glm_dsa_kv_b_split_config(metadata)? {
-                Some(config) => GlmDsaKvBSplitMode::Config(config),
-                None => GlmDsaKvBSplitMode::MissingMetadata,
-            }
-        }
-        _ => GlmDsaKvBSplitMode::Disabled,
-    };
+    let glm_dsa_kv_b_split = glm_dsa_kv_b_split_mode(metadata_seed.as_deref())?;
     let tensors = collect_tensor_sources(
         &files,
         options.tensor_name_map,
@@ -162,132 +150,6 @@ fn prepare_raw_safetensors_gguf(
         tensors,
         metadata,
     })
-}
-
-fn enrich_glm_dsa_indexshare_metadata(
-    metadata: &mut Vec<GgufKv>,
-    tensors: &[TensorSource],
-) -> Result<()> {
-    if metadata_string(metadata, "general.architecture").as_deref() != Some("glm-dsa") {
-        return Ok(());
-    }
-    if metadata_has_key(metadata, "glm-dsa.attention.indexer.types")
-        || metadata_has_key(metadata, "glm-dsa.attention.indexer.top_k_frequency")
-    {
-        return Ok(());
-    }
-
-    let block_count = metadata_u32(metadata, "glm-dsa.block_count")
-        .context("GLM-DSA metadata missing glm-dsa.block_count")?;
-    let nextn_layers = metadata_u32(metadata, "glm-dsa.nextn_predict_layers").unwrap_or(0);
-    ensure!(
-        nextn_layers < block_count,
-        "GLM-DSA nextn_predict_layers {nextn_layers} must be less than block_count {block_count}"
-    );
-    let decoder_layers = block_count - nextn_layers;
-    let tensor_names = tensors
-        .iter()
-        .map(|tensor| tensor.name.as_str())
-        .collect::<BTreeSet<_>>();
-    let mut roles = Vec::with_capacity(decoder_layers as usize);
-    for layer in 0..decoder_layers {
-        let indexer_count = GLM_DSA_INDEXER_TENSORS
-            .iter()
-            .filter(|suffix| tensor_names.contains(format!("blk.{layer}.{suffix}").as_str()))
-            .count();
-        ensure!(
-            indexer_count == 0 || indexer_count == GLM_DSA_INDEXER_TENSORS.len(),
-            "GLM-DSA layer {layer} has partial indexer tensor group ({indexer_count}/{})",
-            GLM_DSA_INDEXER_TENSORS.len()
-        );
-        roles.push(if indexer_count == GLM_DSA_INDEXER_TENSORS.len() {
-            "full".to_string()
-        } else {
-            "shared".to_string()
-        });
-    }
-    metadata.push(GgufKv::array_string(
-        "glm-dsa.attention.indexer.types",
-        roles,
-    ));
-    Ok(())
-}
-
-fn metadata_has_key(metadata: &[GgufKv], key: &str) -> bool {
-    metadata.iter().any(|kv| kv.key() == key)
-}
-
-fn metadata_string(metadata: &[GgufKv], key: &str) -> Option<String> {
-    metadata.iter().find_map(|kv| match kv {
-        GgufKv::String {
-            key: item_key,
-            value,
-        } if item_key == key => Some(value.clone()),
-        _ => None,
-    })
-}
-
-fn is_glm_dsa_metadata(metadata: &[GgufKv]) -> bool {
-    metadata_string(metadata, "general.architecture").as_deref() == Some("glm-dsa")
-}
-
-fn metadata_u32(metadata: &[GgufKv], key: &str) -> Option<u32> {
-    metadata.iter().find_map(|kv| match kv {
-        GgufKv::U32 {
-            key: item_key,
-            value,
-        } if item_key == key => Some(*value),
-        _ => None,
-    })
-}
-
-fn glm_dsa_kv_b_split_config(metadata: &[GgufKv]) -> Result<Option<GlmDsaKvBSplitConfig>> {
-    if !is_glm_dsa_metadata(metadata) {
-        return Ok(None);
-    }
-    let Some(head_count) = metadata_u32(metadata, "glm-dsa.attention.head_count") else {
-        return Ok(None);
-    };
-    let Some(key_length) = metadata_u32(metadata, "glm-dsa.attention.key_length_mla")
-        .or_else(|| metadata_u32(metadata, "glm-dsa.attention.key_length"))
-    else {
-        return Ok(None);
-    };
-    let Some(rope_dim) = metadata_u32(metadata, "glm-dsa.rope.dimension_count") else {
-        return Ok(None);
-    };
-    let Some(value_head_dim) = metadata_u32(metadata, "glm-dsa.attention.value_length") else {
-        return Ok(None);
-    };
-    let Some(kv_lora_rank) = metadata_u32(metadata, "glm-dsa.attention.kv_lora_rank") else {
-        return Ok(None);
-    };
-    ensure!(
-        key_length > rope_dim,
-        "glm-dsa.attention.key_length_mla must be greater than rope.dimension_count for kv_b split"
-    );
-    Ok(Some(GlmDsaKvBSplitConfig {
-        head_count: u64::from(head_count),
-        qk_nope_head_dim: u64::from(key_length - rope_dim),
-        value_head_dim: u64::from(value_head_dim),
-        kv_lora_rank: u64::from(kv_lora_rank),
-    }))
-}
-
-fn glm_dsa_kv_b_layer(name: &str) -> Result<Option<u32>> {
-    let Some(rest) = name.strip_prefix("model.layers.") else {
-        return Ok(None);
-    };
-    let Some((layer, suffix)) = rest.split_once('.') else {
-        return Ok(None);
-    };
-    if suffix != "self_attn.kv_b_proj.weight" {
-        return Ok(None);
-    }
-    layer
-        .parse::<u32>()
-        .map(Some)
-        .with_context(|| format!("parse GLM-DSA kv_b layer id in {name}"))
 }
 
 fn select_split_tensors(
@@ -553,89 +415,6 @@ impl TensorSource {
             gguf_offset: 0,
         })
     }
-
-    fn from_glm_dsa_kv_b_split(
-        file_index: usize,
-        tensor: &SafetensorTensorInfo,
-        layer: u32,
-        split: GlmDsaKvBSplitConfig,
-        output_type: Option<ConvertOutputType>,
-    ) -> Result<Vec<Self>> {
-        ensure!(
-            tensor.shape().len() == 2,
-            "GLM-DSA tensor {} must be rank-2 for kv_b split, got shape {:?}",
-            tensor.name(),
-            tensor.shape()
-        );
-        let expected_rows = split
-            .head_count
-            .checked_mul(split.qk_nope_head_dim + split.value_head_dim)
-            .context("GLM-DSA kv_b expected row count overflow")?;
-        ensure!(
-            tensor.shape()[0] == expected_rows && tensor.shape()[1] == split.kv_lora_rank,
-            "GLM-DSA tensor {} shape {:?} does not match expected [{expected_rows}, {}]",
-            tensor.name(),
-            tensor.shape(),
-            split.kv_lora_rank
-        );
-        let source_dtype = FloatDType::from_safetensor(tensor.dtype()).with_context(|| {
-            format!("unsupported dtype {} for {}", tensor.dtype(), tensor.name())
-        })?;
-        let target_dtype = target_dtype_for_tensor(source_dtype, output_type, tensor.shape())?;
-        let source_element_count = tensor_element_count(tensor)?;
-        let k_element_count = split
-            .head_count
-            .checked_mul(split.qk_nope_head_dim)
-            .and_then(|value| value.checked_mul(split.kv_lora_rank))
-            .context("GLM-DSA attn_k_b element count overflow")?;
-        let v_element_count = split
-            .head_count
-            .checked_mul(split.value_head_dim)
-            .and_then(|value| value.checked_mul(split.kv_lora_rank))
-            .context("GLM-DSA attn_v_b element count overflow")?;
-        Ok(vec![
-            Self {
-                segments: vec![TensorSegment {
-                    file_index,
-                    source_name: tensor.name().to_string(),
-                    source_dtype,
-                    target_dtype,
-                    element_count: source_element_count,
-                    source_byte_len: tensor.byte_len(),
-                    target_byte_len: tensor_byte_len(k_element_count, target_dtype)?,
-                    transform: TensorTransform::GlmDsaKvB {
-                        split,
-                        part: GlmDsaKvBPart::K,
-                    },
-                }],
-                name: format!("blk.{layer}.attn_k_b.weight"),
-                dims: vec![split.qk_nope_head_dim, split.kv_lora_rank, split.head_count],
-                ggml_type: ggml_type_for_dtype(target_dtype),
-                byte_len: tensor_byte_len(k_element_count, target_dtype)?,
-                gguf_offset: 0,
-            },
-            Self {
-                segments: vec![TensorSegment {
-                    file_index,
-                    source_name: tensor.name().to_string(),
-                    source_dtype,
-                    target_dtype,
-                    element_count: source_element_count,
-                    source_byte_len: tensor.byte_len(),
-                    target_byte_len: tensor_byte_len(v_element_count, target_dtype)?,
-                    transform: TensorTransform::GlmDsaKvB {
-                        split,
-                        part: GlmDsaKvBPart::V,
-                    },
-                }],
-                name: format!("blk.{layer}.attn_v_b.weight"),
-                dims: vec![split.kv_lora_rank, split.value_head_dim, split.head_count],
-                ggml_type: ggml_type_for_dtype(target_dtype),
-                byte_len: tensor_byte_len(v_element_count, target_dtype)?,
-                gguf_offset: 0,
-            },
-        ])
-    }
 }
 
 struct TensorSegment {
@@ -647,36 +426,6 @@ struct TensorSegment {
     source_byte_len: u64,
     target_byte_len: u64,
     transform: TensorTransform,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum TensorTransform {
-    Identity,
-    GlmDsaKvB {
-        split: GlmDsaKvBSplitConfig,
-        part: GlmDsaKvBPart,
-    },
-}
-
-#[derive(Debug, Clone, Copy)]
-enum GlmDsaKvBPart {
-    K,
-    V,
-}
-
-#[derive(Debug, Clone, Copy)]
-enum GlmDsaKvBSplitMode {
-    Disabled,
-    MissingMetadata,
-    Config(GlmDsaKvBSplitConfig),
-}
-
-#[derive(Debug, Clone, Copy)]
-struct GlmDsaKvBSplitConfig {
-    head_count: u64,
-    qk_nope_head_dim: u64,
-    value_head_dim: u64,
-    kv_lora_rank: u64,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
@@ -919,21 +668,6 @@ pub(crate) enum GgufKv {
 }
 
 impl GgufKv {
-    fn key(&self) -> &str {
-        match self {
-            Self::ArrayF32 { key, .. }
-            | Self::ArrayI32 { key, .. }
-            | Self::ArrayString { key, .. }
-            | Self::Bool { key, .. }
-            | Self::F32 { key, .. }
-            | Self::I32 { key, .. }
-            | Self::String { key, .. }
-            | Self::U16 { key, .. }
-            | Self::U32 { key, .. }
-            | Self::U64 { key, .. } => key,
-        }
-    }
-
     pub(crate) fn array_f32(key: &str, value: Vec<f32>) -> Self {
         Self::ArrayF32 {
             key: key.to_string(),
@@ -1146,8 +880,8 @@ fn stream_segment(
     segment: &TensorSegment,
     buffer_size: usize,
 ) -> Result<u64> {
-    if let TensorTransform::GlmDsaKvB { split, part } = segment.transform {
-        return stream_glm_dsa_kv_b_split(writer, file, segment, buffer_size, split, part);
+    if let Some(written) = stream_transformed_segment(writer, file, segment, buffer_size)? {
+        return Ok(written);
     }
 
     if segment.source_dtype == segment.target_dtype {
@@ -1191,116 +925,6 @@ fn stream_segment(
         segment.source_name
     );
     Ok(output_bytes)
-}
-
-fn stream_glm_dsa_kv_b_split(
-    writer: &mut File,
-    file: &SafetensorFile,
-    segment: &TensorSegment,
-    buffer_size: usize,
-    split: GlmDsaKvBSplitConfig,
-    part: GlmDsaKvBPart,
-) -> Result<u64> {
-    let mut source = Vec::with_capacity(
-        usize::try_from(segment.source_byte_len)
-            .context("GLM-DSA kv_b source byte length does not fit usize")?,
-    );
-    let mut source_bytes = 0_u64;
-    file.stream_tensor_chunks(&segment.source_name, buffer_size, |chunk| {
-        source.extend_from_slice(chunk);
-        source_bytes += chunk.len() as u64;
-        Ok(())
-    })?;
-    ensure!(
-        source_bytes == segment.source_byte_len,
-        "read {} bytes for {}, expected {}",
-        source_bytes,
-        segment.source_name,
-        segment.source_byte_len
-    );
-    ensure!(
-        source.len() % segment.source_dtype.byte_size() as usize == 0,
-        "GLM-DSA kv_b source split an element boundary"
-    );
-
-    let combined_head_dim = split.qk_nope_head_dim + split.value_head_dim;
-    let mut output_bytes = 0_u64;
-    let flush_limit = buffer_size.max(segment.target_dtype.byte_size() as usize);
-    let mut output = Vec::with_capacity(flush_limit);
-    for head in 0..split.head_count {
-        match part {
-            GlmDsaKvBPart::K => {
-                for lora in 0..split.kv_lora_rank {
-                    for qk in 0..split.qk_nope_head_dim {
-                        output_bytes += push_transformed_float(
-                            writer,
-                            &source,
-                            segment.source_dtype,
-                            segment.target_dtype,
-                            &mut output,
-                            flush_limit,
-                            (head * combined_head_dim + qk) * split.kv_lora_rank + lora,
-                        )?;
-                    }
-                }
-            }
-            GlmDsaKvBPart::V => {
-                for value in 0..split.value_head_dim {
-                    for lora in 0..split.kv_lora_rank {
-                        output_bytes += push_transformed_float(
-                            writer,
-                            &source,
-                            segment.source_dtype,
-                            segment.target_dtype,
-                            &mut output,
-                            flush_limit,
-                            (head * combined_head_dim + split.qk_nope_head_dim + value)
-                                * split.kv_lora_rank
-                                + lora,
-                        )?;
-                    }
-                }
-            }
-        }
-    }
-    writer.write_all(&output)?;
-    ensure!(
-        output_bytes == segment.target_byte_len,
-        "wrote {} bytes for transformed {}, expected {}",
-        output_bytes,
-        segment.source_name,
-        segment.target_byte_len
-    );
-    Ok(output_bytes)
-}
-
-fn push_transformed_float(
-    writer: &mut File,
-    source: &[u8],
-    source_dtype: FloatDType,
-    target_dtype: FloatDType,
-    output: &mut Vec<u8>,
-    flush_limit: usize,
-    source_index: u64,
-) -> Result<u64> {
-    let source_index =
-        usize::try_from(source_index).context("GLM-DSA kv_b source index does not fit usize")?;
-    let source_width = source_dtype.byte_size() as usize;
-    ensure!(
-        source_index
-            .checked_add(1)
-            .and_then(|count| count.checked_mul(source_width))
-            .is_some_and(|end| end <= source.len()),
-        "GLM-DSA kv_b source index {source_index} is outside source tensor"
-    );
-    let value = read_float_element(source, source_dtype, source_index);
-    write_float_element(output, target_dtype, value);
-    let written = target_dtype.byte_size();
-    if output.len() >= flush_limit {
-        writer.write_all(output)?;
-        output.clear();
-    }
-    Ok(written)
 }
 
 fn aligned_chunk_size(buffer_size: usize, element_size: usize) -> usize {

--- a/crates/skippy-quantize/src/gguf_writer/glm_dsa.rs
+++ b/crates/skippy-quantize/src/gguf_writer/glm_dsa.rs
@@ -1,0 +1,491 @@
+use std::collections::BTreeSet;
+use std::fs::File;
+use std::io::Write;
+
+use anyhow::{Context, Result, ensure};
+
+use crate::float_convert::{
+    FloatDType, read_float_element, target_dtype_for_tensor, write_float_element,
+};
+use crate::hf_checkpoint::{SafetensorFile, SafetensorTensorInfo};
+use crate::types::ConvertOutputType;
+
+use super::{
+    GgufKv, TensorSegment, TensorSource, ggml_type_for_dtype, tensor_byte_len, tensor_element_count,
+};
+
+const INDEXER_TENSORS: &[&str] = &[
+    "indexer.k_norm.weight",
+    "indexer.k_norm.bias",
+    "indexer.proj.weight",
+    "indexer.attn_k.weight",
+    "indexer.attn_q_b.weight",
+];
+
+pub(super) fn enrich_glm_dsa_indexshare_metadata(
+    metadata: &mut Vec<GgufKv>,
+    tensors: &[TensorSource],
+) -> Result<()> {
+    if !is_glm_dsa_metadata(metadata) {
+        return Ok(());
+    }
+    if metadata_has_key(metadata, "glm-dsa.attention.indexer.types")
+        || metadata_has_key(metadata, "glm-dsa.attention.indexer.top_k_frequency")
+    {
+        return Ok(());
+    }
+
+    let block_count = metadata_u32(metadata, "glm-dsa.block_count")
+        .context("GLM-DSA metadata missing glm-dsa.block_count")?;
+    let nextn_layers = metadata_u32(metadata, "glm-dsa.nextn_predict_layers").unwrap_or(0);
+    ensure!(
+        nextn_layers < block_count,
+        "GLM-DSA nextn_predict_layers {nextn_layers} must be less than block_count {block_count}"
+    );
+    let decoder_layers = block_count - nextn_layers;
+    let tensor_names = tensors
+        .iter()
+        .map(|tensor| tensor.name.as_str())
+        .collect::<BTreeSet<_>>();
+    let mut roles = Vec::with_capacity(decoder_layers as usize);
+    for layer in 0..decoder_layers {
+        let indexer_count = INDEXER_TENSORS
+            .iter()
+            .filter(|suffix| tensor_names.contains(format!("blk.{layer}.{suffix}").as_str()))
+            .count();
+        ensure!(
+            indexer_count == 0 || indexer_count == INDEXER_TENSORS.len(),
+            "GLM-DSA layer {layer} has partial indexer tensor group ({indexer_count}/{})",
+            INDEXER_TENSORS.len()
+        );
+        roles.push(if indexer_count == INDEXER_TENSORS.len() {
+            "full".to_string()
+        } else {
+            "shared".to_string()
+        });
+    }
+    metadata.push(GgufKv::array_string(
+        "glm-dsa.attention.indexer.types",
+        roles,
+    ));
+    Ok(())
+}
+
+pub(super) fn glm_dsa_kv_b_split_mode(metadata: Option<&[GgufKv]>) -> Result<GlmDsaKvBSplitMode> {
+    let Some(metadata) = metadata.filter(|metadata| is_glm_dsa_metadata(metadata)) else {
+        return Ok(GlmDsaKvBSplitMode::Disabled);
+    };
+    Ok(match glm_dsa_kv_b_split_config(metadata)? {
+        Some(config) => GlmDsaKvBSplitMode::Config(config),
+        None => GlmDsaKvBSplitMode::MissingMetadata,
+    })
+}
+
+fn glm_dsa_kv_b_split_config(metadata: &[GgufKv]) -> Result<Option<GlmDsaKvBSplitConfig>> {
+    if !is_glm_dsa_metadata(metadata) {
+        return Ok(None);
+    }
+    let Some(head_count) = metadata_u32(metadata, "glm-dsa.attention.head_count") else {
+        return Ok(None);
+    };
+    let Some(key_length) = metadata_u32(metadata, "glm-dsa.attention.key_length_mla")
+        .or_else(|| metadata_u32(metadata, "glm-dsa.attention.key_length"))
+    else {
+        return Ok(None);
+    };
+    let Some(rope_dim) = metadata_u32(metadata, "glm-dsa.rope.dimension_count") else {
+        return Ok(None);
+    };
+    let Some(value_head_dim) = metadata_u32(metadata, "glm-dsa.attention.value_length") else {
+        return Ok(None);
+    };
+    let Some(kv_lora_rank) = metadata_u32(metadata, "glm-dsa.attention.kv_lora_rank") else {
+        return Ok(None);
+    };
+    ensure!(
+        key_length > rope_dim,
+        "glm-dsa.attention.key_length_mla must be greater than rope.dimension_count for kv_b split"
+    );
+    Ok(Some(GlmDsaKvBSplitConfig {
+        head_count: u64::from(head_count),
+        qk_nope_head_dim: u64::from(key_length - rope_dim),
+        value_head_dim: u64::from(value_head_dim),
+        kv_lora_rank: u64::from(kv_lora_rank),
+    }))
+}
+
+pub(super) fn glm_dsa_kv_b_layer(name: &str) -> Result<Option<u32>> {
+    let Some(rest) = name.strip_prefix("model.layers.") else {
+        return Ok(None);
+    };
+    let Some((layer, suffix)) = rest.split_once('.') else {
+        return Ok(None);
+    };
+    if suffix != "self_attn.kv_b_proj.weight" {
+        return Ok(None);
+    }
+    layer
+        .parse::<u32>()
+        .map(Some)
+        .with_context(|| format!("parse GLM-DSA kv_b layer id in {name}"))
+}
+
+impl TensorSource {
+    pub(super) fn from_glm_dsa_kv_b_split(
+        file_index: usize,
+        tensor: &SafetensorTensorInfo,
+        layer: u32,
+        split: GlmDsaKvBSplitConfig,
+        output_type: Option<ConvertOutputType>,
+    ) -> Result<Vec<Self>> {
+        ensure!(
+            tensor.shape().len() == 2,
+            "GLM-DSA tensor {} must be rank-2 for kv_b split, got shape {:?}",
+            tensor.name(),
+            tensor.shape()
+        );
+        let expected_rows = split
+            .head_count
+            .checked_mul(split.qk_nope_head_dim + split.value_head_dim)
+            .context("GLM-DSA kv_b expected row count overflow")?;
+        ensure!(
+            tensor.shape()[0] == expected_rows && tensor.shape()[1] == split.kv_lora_rank,
+            "GLM-DSA tensor {} shape {:?} does not match expected [{expected_rows}, {}]",
+            tensor.name(),
+            tensor.shape(),
+            split.kv_lora_rank
+        );
+        let source_dtype = FloatDType::from_safetensor(tensor.dtype()).with_context(|| {
+            format!("unsupported dtype {} for {}", tensor.dtype(), tensor.name())
+        })?;
+        let target_dtype = target_dtype_for_tensor(source_dtype, output_type, tensor.shape())?;
+        let source_element_count = tensor_element_count(tensor)?;
+        let k_element_count = split
+            .head_count
+            .checked_mul(split.qk_nope_head_dim)
+            .and_then(|value| value.checked_mul(split.kv_lora_rank))
+            .context("GLM-DSA attn_k_b element count overflow")?;
+        let v_element_count = split
+            .head_count
+            .checked_mul(split.value_head_dim)
+            .and_then(|value| value.checked_mul(split.kv_lora_rank))
+            .context("GLM-DSA attn_v_b element count overflow")?;
+        Ok(vec![
+            Self {
+                segments: vec![TensorSegment {
+                    file_index,
+                    source_name: tensor.name().to_string(),
+                    source_dtype,
+                    target_dtype,
+                    element_count: source_element_count,
+                    source_byte_len: tensor.byte_len(),
+                    target_byte_len: tensor_byte_len(k_element_count, target_dtype)?,
+                    transform: TensorTransform::GlmDsaKvB {
+                        split,
+                        part: GlmDsaKvBPart::K,
+                    },
+                }],
+                name: format!("blk.{layer}.attn_k_b.weight"),
+                dims: vec![split.qk_nope_head_dim, split.kv_lora_rank, split.head_count],
+                ggml_type: ggml_type_for_dtype(target_dtype),
+                byte_len: tensor_byte_len(k_element_count, target_dtype)?,
+                gguf_offset: 0,
+            },
+            Self {
+                segments: vec![TensorSegment {
+                    file_index,
+                    source_name: tensor.name().to_string(),
+                    source_dtype,
+                    target_dtype,
+                    element_count: source_element_count,
+                    source_byte_len: tensor.byte_len(),
+                    target_byte_len: tensor_byte_len(v_element_count, target_dtype)?,
+                    transform: TensorTransform::GlmDsaKvB {
+                        split,
+                        part: GlmDsaKvBPart::V,
+                    },
+                }],
+                name: format!("blk.{layer}.attn_v_b.weight"),
+                dims: vec![split.kv_lora_rank, split.value_head_dim, split.head_count],
+                ggml_type: ggml_type_for_dtype(target_dtype),
+                byte_len: tensor_byte_len(v_element_count, target_dtype)?,
+                gguf_offset: 0,
+            },
+        ])
+    }
+}
+
+pub(super) fn stream_transformed_segment(
+    writer: &mut File,
+    file: &SafetensorFile,
+    segment: &TensorSegment,
+    buffer_size: usize,
+) -> Result<Option<u64>> {
+    let TensorTransform::GlmDsaKvB { split, part } = segment.transform else {
+        return Ok(None);
+    };
+    stream_glm_dsa_kv_b_split(writer, file, segment, buffer_size, split, part).map(Some)
+}
+
+fn stream_glm_dsa_kv_b_split(
+    writer: &mut File,
+    file: &SafetensorFile,
+    segment: &TensorSegment,
+    buffer_size: usize,
+    split: GlmDsaKvBSplitConfig,
+    part: GlmDsaKvBPart,
+) -> Result<u64> {
+    let mut source = Vec::with_capacity(
+        usize::try_from(segment.source_byte_len)
+            .context("GLM-DSA kv_b source byte length does not fit usize")?,
+    );
+    let mut source_bytes = 0_u64;
+    file.stream_tensor_chunks(&segment.source_name, buffer_size, |chunk| {
+        source.extend_from_slice(chunk);
+        source_bytes += chunk.len() as u64;
+        Ok(())
+    })?;
+    ensure!(
+        source_bytes == segment.source_byte_len,
+        "read {} bytes for {}, expected {}",
+        source_bytes,
+        segment.source_name,
+        segment.source_byte_len
+    );
+    ensure!(
+        source.len() % segment.source_dtype.byte_size() as usize == 0,
+        "GLM-DSA kv_b source split an element boundary"
+    );
+
+    let combined_head_dim = split.qk_nope_head_dim + split.value_head_dim;
+    let mut output_bytes = 0_u64;
+    let flush_limit = buffer_size.max(segment.target_dtype.byte_size() as usize);
+    let mut output = Vec::with_capacity(flush_limit);
+    for head in 0..split.head_count {
+        match part {
+            GlmDsaKvBPart::K => {
+                for lora in 0..split.kv_lora_rank {
+                    for qk in 0..split.qk_nope_head_dim {
+                        output_bytes += push_transformed_float(
+                            writer,
+                            &source,
+                            segment.source_dtype,
+                            segment.target_dtype,
+                            &mut output,
+                            flush_limit,
+                            (head * combined_head_dim + qk) * split.kv_lora_rank + lora,
+                        )?;
+                    }
+                }
+            }
+            GlmDsaKvBPart::V => {
+                for value in 0..split.value_head_dim {
+                    for lora in 0..split.kv_lora_rank {
+                        output_bytes += push_transformed_float(
+                            writer,
+                            &source,
+                            segment.source_dtype,
+                            segment.target_dtype,
+                            &mut output,
+                            flush_limit,
+                            (head * combined_head_dim + split.qk_nope_head_dim + value)
+                                * split.kv_lora_rank
+                                + lora,
+                        )?;
+                    }
+                }
+            }
+        }
+    }
+    writer.write_all(&output)?;
+    ensure!(
+        output_bytes == segment.target_byte_len,
+        "wrote {} bytes for transformed {}, expected {}",
+        output_bytes,
+        segment.source_name,
+        segment.target_byte_len
+    );
+    Ok(output_bytes)
+}
+
+fn push_transformed_float(
+    writer: &mut File,
+    source: &[u8],
+    source_dtype: FloatDType,
+    target_dtype: FloatDType,
+    output: &mut Vec<u8>,
+    flush_limit: usize,
+    source_index: u64,
+) -> Result<u64> {
+    let source_index =
+        usize::try_from(source_index).context("GLM-DSA kv_b source index does not fit usize")?;
+    let source_width = source_dtype.byte_size() as usize;
+    ensure!(
+        source_index
+            .checked_add(1)
+            .and_then(|count| count.checked_mul(source_width))
+            .is_some_and(|end| end <= source.len()),
+        "GLM-DSA kv_b source index {source_index} is outside source tensor"
+    );
+    let value = read_float_element(source, source_dtype, source_index);
+    write_float_element(output, target_dtype, value);
+    let written = target_dtype.byte_size();
+    if output.len() >= flush_limit {
+        writer.write_all(output)?;
+        output.clear();
+    }
+    Ok(written)
+}
+
+fn metadata_has_key(metadata: &[GgufKv], key: &str) -> bool {
+    metadata.iter().any(|kv| kv.key() == key)
+}
+
+fn metadata_string<'a>(metadata: &'a [GgufKv], key: &str) -> Option<&'a str> {
+    metadata.iter().find_map(|kv| match kv {
+        GgufKv::String {
+            key: item_key,
+            value,
+        } if item_key == key => Some(value.as_str()),
+        _ => None,
+    })
+}
+
+fn is_glm_dsa_metadata(metadata: &[GgufKv]) -> bool {
+    metadata_string(metadata, "general.architecture") == Some("glm-dsa")
+}
+
+fn metadata_u32(metadata: &[GgufKv], key: &str) -> Option<u32> {
+    metadata.iter().find_map(|kv| match kv {
+        GgufKv::U32 {
+            key: item_key,
+            value,
+        } if item_key == key => Some(*value),
+        _ => None,
+    })
+}
+
+impl GgufKv {
+    fn key(&self) -> &str {
+        match self {
+            Self::ArrayF32 { key, .. }
+            | Self::ArrayI32 { key, .. }
+            | Self::ArrayString { key, .. }
+            | Self::Bool { key, .. }
+            | Self::F32 { key, .. }
+            | Self::I32 { key, .. }
+            | Self::String { key, .. }
+            | Self::U16 { key, .. }
+            | Self::U32 { key, .. }
+            | Self::U64 { key, .. } => key,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum TensorTransform {
+    Identity,
+    GlmDsaKvB {
+        split: GlmDsaKvBSplitConfig,
+        part: GlmDsaKvBPart,
+    },
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum GlmDsaKvBSplitMode {
+    Disabled,
+    MissingMetadata,
+    Config(GlmDsaKvBSplitConfig),
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) struct GlmDsaKvBSplitConfig {
+    head_count: u64,
+    qk_nope_head_dim: u64,
+    value_head_dim: u64,
+    kv_lora_rank: u64,
+}
+
+#[derive(Debug, Clone, Copy)]
+pub(super) enum GlmDsaKvBPart {
+    K,
+    V,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn infers_indexshare_types_from_mapped_tensor_names() {
+        let mut metadata = minimal_metadata(3);
+        let tensors = [0_u32, 2]
+            .into_iter()
+            .flat_map(|layer| {
+                INDEXER_TENSORS
+                    .iter()
+                    .map(move |suffix| mock_tensor_source(&format!("blk.{layer}.{suffix}")))
+            })
+            .collect::<Vec<_>>();
+
+        enrich_glm_dsa_indexshare_metadata(&mut metadata, &tensors).unwrap();
+
+        assert_eq!(
+            string_array(&metadata, "glm-dsa.attention.indexer.types"),
+            Some(vec!["full", "shared", "full"])
+        );
+    }
+
+    #[test]
+    fn rejects_partial_indexshare_group() {
+        let mut metadata = minimal_metadata(2);
+        let tensors = vec![mock_tensor_source("blk.0.indexer.k_norm.weight")];
+
+        let err = enrich_glm_dsa_indexshare_metadata(&mut metadata, &tensors).unwrap_err();
+
+        assert!(
+            err.to_string().contains("partial indexer tensor group"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn detects_kv_b_projection_layer() {
+        assert_eq!(
+            glm_dsa_kv_b_layer("model.layers.12.self_attn.kv_b_proj.weight").unwrap(),
+            Some(12)
+        );
+        assert_eq!(
+            glm_dsa_kv_b_layer("model.layers.12.self_attn.q_b_proj.weight").unwrap(),
+            None
+        );
+    }
+
+    fn minimal_metadata(block_count: u32) -> Vec<GgufKv> {
+        vec![
+            GgufKv::string("general.architecture", "glm-dsa"),
+            GgufKv::u32("glm-dsa.block_count", block_count),
+        ]
+    }
+
+    fn mock_tensor_source(name: &str) -> TensorSource {
+        TensorSource {
+            segments: Vec::new(),
+            name: name.to_string(),
+            dims: vec![1],
+            ggml_type: 0,
+            byte_len: 4,
+            gguf_offset: 0,
+        }
+    }
+
+    fn string_array<'a>(metadata: &'a [GgufKv], key: &str) -> Option<Vec<&'a str>> {
+        metadata.iter().find_map(|kv| match kv {
+            GgufKv::ArrayString {
+                key: item_key,
+                value,
+            } if item_key == key => Some(value.iter().map(String::as_str).collect()),
+            _ => None,
+        })
+    }
+}

--- a/crates/skippy-quantize/src/gguf_writer_tests.rs
+++ b/crates/skippy-quantize/src/gguf_writer_tests.rs
@@ -1,3 +1,4 @@
+use std::collections::BTreeMap;
 use std::io::Read;
 use std::path::PathBuf;
 
@@ -376,6 +377,262 @@ fn validates_qwen_dense_native_conversion_fixture() {
 }
 
 #[test]
+fn writes_glm_dsa_indexer_tensors_with_hf_name_mapping() {
+    let root = unique_temp_dir();
+    fs::create_dir_all(&root).unwrap();
+    write_safetensor(
+        &root.join("model.safetensors"),
+        &[
+            (
+                "model.layers.0.self_attn.indexer.k_norm.weight",
+                "F32",
+                &[1],
+                &[1, 0, 0, 0],
+            ),
+            (
+                "model.layers.0.self_attn.indexer.k_norm.bias",
+                "F32",
+                &[1],
+                &[2, 0, 0, 0],
+            ),
+            (
+                "model.layers.0.self_attn.indexer.weights_proj.weight",
+                "F32",
+                &[1],
+                &[3, 0, 0, 0],
+            ),
+            (
+                "model.layers.0.self_attn.indexer.wk.weight",
+                "F32",
+                &[1],
+                &[4, 0, 0, 0],
+            ),
+            (
+                "model.layers.0.self_attn.indexer.wq_b.weight",
+                "F32",
+                &[1],
+                &[5, 0, 0, 0],
+            ),
+        ],
+    );
+
+    let output = root.join("glm-dsa-indexer.gguf");
+    write_raw_safetensors_gguf(
+        &root,
+        &output,
+        RawGgufWriteOptions {
+            buffer_size: 4,
+            metadata: None,
+            tensor_name_map: TensorNameMap::HfToGguf,
+            split: None,
+            output_type: Some(ConvertOutputType::Bf16),
+            tensor_selection: TensorSelection::All,
+        },
+    )
+    .unwrap();
+
+    let bytes = fs::read(&output).unwrap();
+    let parsed = parse_test_gguf(&bytes);
+    assert_eq!(parsed.tensor_count, 5);
+    parsed.tensor("blk.0.indexer.k_norm.weight");
+    parsed.tensor("blk.0.indexer.k_norm.bias");
+    parsed.tensor("blk.0.indexer.proj.weight");
+    parsed.tensor("blk.0.indexer.attn_k.weight");
+    parsed.tensor("blk.0.indexer.attn_q_b.weight");
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn splits_glm_dsa_kv_b_projection_for_native_layout() {
+    let root = unique_temp_dir();
+    fs::create_dir_all(&root).unwrap();
+    write_safetensor(
+        &root.join("model.safetensors"),
+        &[(
+            "model.layers.0.self_attn.kv_b_proj.weight",
+            "F32",
+            &[6, 2],
+            &f32_bytes(&[
+                1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0, 11.0, 12.0,
+            ]),
+        )],
+    );
+    let output = root.join("glm-dsa-kv-b.gguf");
+
+    write_raw_safetensors_gguf(
+        &root,
+        &output,
+        RawGgufWriteOptions {
+            buffer_size: 8,
+            metadata: Some(glm_dsa_kv_b_split_metadata()),
+            tensor_name_map: TensorNameMap::HfToGguf,
+            split: None,
+            output_type: Some(ConvertOutputType::F32),
+            tensor_selection: TensorSelection::All,
+        },
+    )
+    .unwrap();
+
+    let bytes = fs::read(&output).unwrap();
+    let parsed = parse_test_gguf(&bytes);
+    assert_eq!(parsed.tensor_count, 2);
+    let k_b = parsed.tensor("blk.0.attn_k_b.weight");
+    let v_b = parsed.tensor("blk.0.attn_v_b.weight");
+    assert_eq!(k_b.dims, vec![3, 2, 1]);
+    assert_eq!(v_b.dims, vec![2, 3, 1]);
+    assert_eq!(
+        &bytes[k_b.absolute_offset..k_b.absolute_offset + 24],
+        f32_bytes(&[1.0, 3.0, 5.0, 2.0, 4.0, 6.0]).as_slice()
+    );
+    assert_eq!(
+        &bytes[v_b.absolute_offset..v_b.absolute_offset + 24],
+        f32_bytes(&[7.0, 8.0, 9.0, 10.0, 11.0, 12.0]).as_slice()
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn infers_glm_dsa_indexshare_types_from_mapped_tensor_names() {
+    let mut metadata = minimal_glm_dsa_metadata(3, 0);
+    let tensors = vec![
+        mock_tensor_source("blk.0.indexer.k_norm.weight"),
+        mock_tensor_source("blk.0.indexer.k_norm.bias"),
+        mock_tensor_source("blk.0.indexer.proj.weight"),
+        mock_tensor_source("blk.0.indexer.attn_k.weight"),
+        mock_tensor_source("blk.0.indexer.attn_q_b.weight"),
+        mock_tensor_source("blk.2.indexer.k_norm.weight"),
+        mock_tensor_source("blk.2.indexer.k_norm.bias"),
+        mock_tensor_source("blk.2.indexer.proj.weight"),
+        mock_tensor_source("blk.2.indexer.attn_k.weight"),
+        mock_tensor_source("blk.2.indexer.attn_q_b.weight"),
+    ];
+
+    enrich_glm_dsa_indexshare_metadata(&mut metadata, &tensors).unwrap();
+
+    assert_eq!(
+        array_string_metadata(&metadata, "glm-dsa.attention.indexer.types"),
+        Some(vec![
+            "full".to_string(),
+            "shared".to_string(),
+            "full".to_string(),
+        ])
+    );
+}
+
+#[test]
+fn writes_inferred_glm_dsa_indexshare_types_to_gguf_metadata() {
+    let root = unique_temp_dir();
+    fs::create_dir_all(&root).unwrap();
+    write_safetensor(
+        &root.join("model.safetensors"),
+        &[
+            (
+                "model.layers.0.self_attn.indexer.k_norm.weight",
+                "F32",
+                &[1],
+                &[1, 0, 0, 0],
+            ),
+            (
+                "model.layers.0.self_attn.indexer.k_norm.bias",
+                "F32",
+                &[1],
+                &[2, 0, 0, 0],
+            ),
+            (
+                "model.layers.0.self_attn.indexer.weights_proj.weight",
+                "F32",
+                &[1],
+                &[3, 0, 0, 0],
+            ),
+            (
+                "model.layers.0.self_attn.indexer.wk.weight",
+                "F32",
+                &[1],
+                &[4, 0, 0, 0],
+            ),
+            (
+                "model.layers.0.self_attn.indexer.wq_b.weight",
+                "F32",
+                &[1],
+                &[5, 0, 0, 0],
+            ),
+            (
+                "model.layers.2.self_attn.indexer.k_norm.weight",
+                "F32",
+                &[1],
+                &[6, 0, 0, 0],
+            ),
+            (
+                "model.layers.2.self_attn.indexer.k_norm.bias",
+                "F32",
+                &[1],
+                &[7, 0, 0, 0],
+            ),
+            (
+                "model.layers.2.self_attn.indexer.weights_proj.weight",
+                "F32",
+                &[1],
+                &[8, 0, 0, 0],
+            ),
+            (
+                "model.layers.2.self_attn.indexer.wk.weight",
+                "F32",
+                &[1],
+                &[9, 0, 0, 0],
+            ),
+            (
+                "model.layers.2.self_attn.indexer.wq_b.weight",
+                "F32",
+                &[1],
+                &[10, 0, 0, 0],
+            ),
+        ],
+    );
+    let output = root.join("glm-dsa-indexshare-types.gguf");
+
+    write_raw_safetensors_gguf(
+        &root,
+        &output,
+        RawGgufWriteOptions {
+            buffer_size: 4,
+            metadata: Some(minimal_glm_dsa_metadata(3, 0)),
+            tensor_name_map: TensorNameMap::HfToGguf,
+            split: None,
+            output_type: Some(ConvertOutputType::Bf16),
+            tensor_selection: TensorSelection::All,
+        },
+    )
+    .unwrap();
+
+    let parsed = parse_test_gguf(&fs::read(&output).unwrap());
+
+    assert_eq!(
+        parsed
+            .metadata_string_arrays
+            .get("glm-dsa.attention.indexer.types"),
+        Some(&vec![
+            "full".to_string(),
+            "shared".to_string(),
+            "full".to_string(),
+        ])
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn rejects_glm_dsa_partial_indexshare_group_during_metadata_enrichment() {
+    let mut metadata = minimal_glm_dsa_metadata(2, 0);
+    let tensors = vec![mock_tensor_source("blk.0.indexer.k_norm.weight")];
+
+    let err = enrich_glm_dsa_indexshare_metadata(&mut metadata, &tensors).unwrap_err();
+
+    assert!(
+        err.to_string().contains("partial indexer tensor group"),
+        "unexpected error: {err:#}"
+    );
+}
+
+#[test]
 fn validates_qwen2_moe_native_conversion_fixture() {
     let root = unique_temp_dir();
     fs::create_dir_all(&root).unwrap();
@@ -553,6 +810,102 @@ fn validates_qwen3_moe_native_conversion_fixture() {
 }
 
 #[test]
+fn validates_glm_dsa_native_conversion_fixture() {
+    let root = unique_temp_dir();
+    fs::create_dir_all(&root).unwrap();
+    write_glm_dsa_config_and_tokenizer(&root);
+    let tensor_count = write_tiny_glm_dsa_safetensor(&root);
+    let metadata = metadata_from_hf_config(&root, tensor_count).unwrap();
+    let validation = validate_raw_safetensors_gguf(
+        &root,
+        RawGgufWriteOptions {
+            buffer_size: 8,
+            metadata: Some(metadata.clone()),
+            tensor_name_map: TensorNameMap::HfToGgufWithMtp { layer_start: 3 },
+            split: None,
+            output_type: None,
+            tensor_selection: TensorSelection::All,
+        },
+    )
+    .unwrap();
+    assert!(validation.selected_tensor_count > 0);
+
+    let output = root.join("glm-dsa-native.gguf");
+    write_raw_safetensors_gguf(
+        &root,
+        &output,
+        RawGgufWriteOptions {
+            buffer_size: 8,
+            metadata: Some(metadata),
+            tensor_name_map: TensorNameMap::HfToGgufWithMtp { layer_start: 3 },
+            split: None,
+            output_type: None,
+            tensor_selection: TensorSelection::All,
+        },
+    )
+    .unwrap();
+    let parsed = parse_test_gguf(&fs::read(&output).unwrap());
+
+    assert_eq!(
+        parsed
+            .metadata_string_arrays
+            .get("glm-dsa.attention.indexer.types"),
+        Some(&vec![
+            "full".to_string(),
+            "shared".to_string(),
+            "full".to_string(),
+        ])
+    );
+    assert_eq!(parsed.tensor("blk.0.attn_k_b.weight").dims, vec![3, 2, 1]);
+    assert_eq!(parsed.tensor("blk.0.attn_v_b.weight").dims, vec![2, 2, 1]);
+    parsed.tensor("blk.0.indexer.proj.weight");
+    parsed.tensor("blk.2.indexer.proj.weight");
+    parsed.tensor("blk.3.attn_norm.weight");
+    parsed.tensor("blk.3.ffn_gate_inp.weight");
+    parsed.tensor("blk.3.indexer.proj.weight");
+    parsed.tensor("blk.3.nextn.eh_proj.weight");
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn rejects_glm_dsa_indexer_type_frequency_conflict_from_config() {
+    let root = unique_temp_dir();
+    fs::create_dir_all(&root).unwrap();
+    write_glm_dsa_config_and_tokenizer(&root);
+    rewrite_config(
+        &root,
+        &[("\"index_topk_freq\": 2", "\"index_topk_freq\": 1")],
+    );
+
+    let err = metadata_from_hf_config(&root, 1).unwrap_err();
+
+    assert!(
+        err.to_string()
+            .contains("GLM-DSA indexer_types conflicts with index_topk_freq at layer 1"),
+        "unexpected error: {err:#}"
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
+fn rejects_glm_dsa_indexer_frequency_without_offset_from_config() {
+    let root = unique_temp_dir();
+    fs::create_dir_all(&root).unwrap();
+    write_glm_dsa_config_and_tokenizer(&root);
+    rewrite_config(&root, &[("          \"index_skip_topk_offset\": 1,\n", "")]);
+
+    let err = metadata_from_hf_config(&root, 1).unwrap_err();
+
+    assert!(
+        err.to_string().contains(
+            "GLM-DSA index_skip_topk_offset/indexer_skip_top_k_offset is required when index_topk_freq is present"
+        ),
+        "unexpected error: {err:#}"
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn validates_llama_dense_native_conversion_fixture() {
     let root = unique_temp_dir();
     fs::create_dir_all(&root).unwrap();
@@ -700,6 +1053,59 @@ fn writes_only_selected_split_with_split_metadata() {
 }
 
 #[test]
+fn infers_glm_dsa_indexshare_types_before_split_selection() {
+    let root = unique_temp_dir();
+    fs::create_dir_all(&root).unwrap();
+    write_safetensor(
+        &root.join("model.safetensors"),
+        &[
+            ("blk.0.indexer.attn_k.weight", "F32", &[1], &[1, 0, 0, 0]),
+            ("blk.0.indexer.attn_q_b.weight", "F32", &[1], &[1, 0, 0, 0]),
+            ("blk.0.indexer.k_norm.bias", "F32", &[1], &[1, 0, 0, 0]),
+            ("blk.0.indexer.k_norm.weight", "F32", &[1], &[1, 0, 0, 0]),
+            ("blk.0.indexer.proj.weight", "F32", &[1], &[1, 0, 0, 0]),
+            ("blk.2.indexer.attn_k.weight", "F32", &[1], &[2, 0, 0, 0]),
+            ("blk.2.indexer.attn_q_b.weight", "F32", &[1], &[2, 0, 0, 0]),
+            ("blk.2.indexer.k_norm.bias", "F32", &[1], &[2, 0, 0, 0]),
+            ("blk.2.indexer.k_norm.weight", "F32", &[1], &[2, 0, 0, 0]),
+            ("blk.2.indexer.proj.weight", "F32", &[1], &[2, 0, 0, 0]),
+        ],
+    );
+    let output = root.join("split.gguf");
+
+    write_raw_safetensors_gguf(
+        &root,
+        &output,
+        RawGgufWriteOptions {
+            buffer_size: 4,
+            metadata: Some(minimal_glm_dsa_metadata(3, 0)),
+            tensor_name_map: TensorNameMap::Raw,
+            split: Some(GgufSplit {
+                split_index: 2,
+                split_count: 2,
+            }),
+            output_type: None,
+            tensor_selection: TensorSelection::All,
+        },
+    )
+    .unwrap();
+
+    let bytes = fs::read(&output).unwrap();
+    let parsed = parse_test_gguf(&bytes);
+    assert_eq!(
+        parsed
+            .metadata_string_arrays
+            .get("glm-dsa.attention.indexer.types"),
+        Some(&vec![
+            "full".to_string(),
+            "shared".to_string(),
+            "full".to_string(),
+        ])
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn native_splits_are_byte_balanced_not_tensor_count_balanced() {
     let root = unique_temp_dir();
     fs::create_dir_all(&root).unwrap();
@@ -776,6 +1182,7 @@ fn keeps_rank_one_f32_tensor_as_f32_for_bf16_output() {
 struct ParsedGguf {
     tensor_count: u64,
     metadata_count: u64,
+    metadata_string_arrays: BTreeMap<String, Vec<String>>,
     data_start: usize,
     tensors: Vec<ParsedTensor>,
 }
@@ -804,8 +1211,9 @@ fn parse_test_gguf(bytes: &[u8]) -> ParsedGguf {
     assert_eq!(read_u32(&mut cursor), GGUF_VERSION);
     let tensor_count = read_u64(&mut cursor);
     let metadata_count = read_u64(&mut cursor);
+    let mut metadata_string_arrays = BTreeMap::new();
     for _ in 0..metadata_count {
-        let _key = read_string(&mut cursor);
+        let key = read_string(&mut cursor);
         let value_type = read_u32(&mut cursor);
         match value_type {
             GGUF_TYPE_BOOL => {
@@ -831,7 +1239,11 @@ fn parse_test_gguf(bytes: &[u8]) -> ParsedGguf {
             GGUF_TYPE_UINT64 => {
                 let _ = read_u64(&mut cursor);
             }
-            GGUF_TYPE_ARRAY => skip_array(&mut cursor),
+            GGUF_TYPE_ARRAY => {
+                if let Some(value) = read_string_array_or_skip(&mut cursor) {
+                    metadata_string_arrays.insert(key, value);
+                }
+            }
             other => panic!("unexpected metadata type {other}"),
         }
     }
@@ -850,6 +1262,7 @@ fn parse_test_gguf(bytes: &[u8]) -> ParsedGguf {
     ParsedGguf {
         tensor_count,
         metadata_count,
+        metadata_string_arrays,
         data_start,
         tensors: tensors
             .into_iter()
@@ -882,14 +1295,19 @@ fn read_u64(cursor: &mut std::io::Cursor<&[u8]>) -> u64 {
     u64::from_le_bytes(bytes)
 }
 
-fn skip_array(cursor: &mut std::io::Cursor<&[u8]>) {
+fn read_string_array_or_skip(cursor: &mut std::io::Cursor<&[u8]>) -> Option<Vec<String>> {
     let element_type = read_u32(cursor);
     let len = read_u64(cursor);
+    if element_type == GGUF_TYPE_STRING {
+        return Some((0..len).map(|_| read_string(cursor)).collect());
+    }
+    skip_array_items(cursor, element_type, len);
+    None
+}
+
+fn skip_array_items(cursor: &mut std::io::Cursor<&[u8]>, element_type: u32, len: u64) {
     for _ in 0..len {
         match element_type {
-            GGUF_TYPE_STRING => {
-                let _ = read_string(cursor);
-            }
             GGUF_TYPE_INT32 | GGUF_TYPE_FLOAT32 | GGUF_TYPE_UINT32 => {
                 let _ = read_u32(cursor);
             }
@@ -906,6 +1324,58 @@ fn unique_temp_dir() -> PathBuf {
         .as_nanos();
     let id = NEXT_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     std::env::temp_dir().join(format!("skippy-gguf-writer-{nanos}-{id}"))
+}
+
+fn minimal_glm_dsa_metadata(block_count: u32, nextn_layers: u32) -> Vec<GgufKv> {
+    let mut metadata = vec![
+        GgufKv::string("general.architecture", "glm-dsa"),
+        GgufKv::u32("glm-dsa.block_count", block_count),
+    ];
+    if nextn_layers > 0 {
+        metadata.push(GgufKv::u32("glm-dsa.nextn_predict_layers", nextn_layers));
+    }
+    metadata
+}
+
+fn glm_dsa_kv_b_split_metadata() -> Vec<GgufKv> {
+    vec![
+        GgufKv::string("general.architecture", "glm-dsa"),
+        GgufKv::u32("glm-dsa.block_count", 1),
+        GgufKv::u32("glm-dsa.attention.head_count", 1),
+        GgufKv::u32("glm-dsa.attention.key_length", 3),
+        GgufKv::u32("glm-dsa.attention.key_length_mla", 4),
+        GgufKv::u32("glm-dsa.rope.dimension_count", 1),
+        GgufKv::u32("glm-dsa.attention.value_length", 3),
+        GgufKv::u32("glm-dsa.attention.kv_lora_rank", 2),
+    ]
+}
+
+fn mock_tensor_source(name: &str) -> TensorSource {
+    TensorSource {
+        segments: Vec::new(),
+        name: name.to_string(),
+        dims: vec![1],
+        ggml_type: GGML_TYPE_F32,
+        byte_len: 4,
+        gguf_offset: 0,
+    }
+}
+
+fn f32_bytes(values: &[f32]) -> Vec<u8> {
+    values
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect()
+}
+
+fn array_string_metadata(metadata: &[GgufKv], key: &str) -> Option<Vec<String>> {
+    metadata.iter().find_map(|kv| match kv {
+        GgufKv::ArrayString {
+            key: item_key,
+            value,
+        } if item_key == key => Some(value.clone()),
+        _ => None,
+    })
 }
 
 fn write_safetensor(path: &Path, tensors: &[(&str, &str, &[u64], &[u8])]) {
@@ -1021,6 +1491,87 @@ fn write_qwen3_moe_config_and_tokenizer(root: &Path) {
         }"#,
     )
     .unwrap();
+}
+
+fn write_glm_dsa_config_and_tokenizer(root: &Path) {
+    fs::write(
+        root.join("config.json"),
+        r#"{
+          "model_type": "glm_moe_dsa",
+          "vocab_size": 8,
+          "max_position_embeddings": 128,
+          "hidden_size": 4,
+          "intermediate_size": 8,
+          "num_hidden_layers": 3,
+          "num_nextn_predict_layers": 1,
+          "num_attention_heads": 1,
+          "num_key_value_heads": 1,
+          "qk_nope_head_dim": 3,
+          "qk_rope_head_dim": 2,
+          "v_head_dim": 2,
+          "q_lora_rank": 2,
+          "kv_lora_rank": 2,
+          "index_n_heads": 1,
+          "index_head_dim": 4,
+          "index_topk": 2,
+          "index_topk_freq": 2,
+          "index_skip_topk_offset": 1,
+          "indexer_types": ["full", "shared", "full"],
+          "n_routed_experts": 2,
+          "num_experts_per_tok": 1,
+          "n_shared_experts": 1,
+          "moe_intermediate_size": 2,
+          "first_k_dense_replace": 1,
+          "routed_scaling_factor": 2.5,
+          "norm_topk_prob": true,
+          "rms_norm_eps": 1e-5
+        }"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("tokenizer.json"),
+        r#"{
+          "model": {
+            "type": "BPE",
+            "vocab": {
+              "a": 0,
+              "b": 1,
+              "[gMASK]": 2,
+              "<|user|>": 3,
+              "<|observation|>": 4,
+              "<|endoftext|>": 5,
+              "<|assistant|>": 6,
+              "<|system|>": 7
+            },
+            "merges": ["a b"]
+          },
+          "decoder": {"type": "ByteLevel"},
+          "added_tokens": [
+            {"id": 2, "content": "[gMASK]", "special": true},
+            {"id": 3, "content": "<|user|>", "special": true},
+            {"id": 4, "content": "<|observation|>", "special": true},
+            {"id": 5, "content": "<|endoftext|>", "special": true},
+            {"id": 6, "content": "<|assistant|>", "special": true},
+            {"id": 7, "content": "<|system|>", "special": true}
+          ]
+        }"#,
+    )
+    .unwrap();
+    fs::write(
+        root.join("tokenizer_config.json"),
+        r#"{"eos_token": "<|assistant|>", "pad_token": "<|endoftext|>", "mask_token": "[gMASK]", "add_bos_token": false}"#,
+    )
+    .unwrap();
+}
+
+fn rewrite_config(root: &Path, replacements: &[(&str, &str)]) {
+    let path = root.join("config.json");
+    let mut config = fs::read_to_string(&path).unwrap();
+    for (from, to) in replacements {
+        assert!(config.contains(from), "config did not contain {from:?}");
+        config = config.replace(from, to);
+    }
+    fs::write(path, config).unwrap();
 }
 
 fn write_llama_config_and_tokenizer(root: &Path) {
@@ -1139,4 +1690,153 @@ fn write_dense_hf_safetensor(root: &Path) {
             ("lm_head.weight", "F32", &[1], &[14, 0, 0, 0]),
         ],
     );
+}
+
+struct OwnedSafetensorTensor {
+    name: String,
+    dtype: &'static str,
+    shape: Vec<u64>,
+    bytes: Vec<u8>,
+}
+
+fn write_tiny_glm_dsa_safetensor(root: &Path) -> usize {
+    let mut tensors = Vec::new();
+    push_f32_tensor(&mut tensors, "model.embed_tokens.weight");
+    push_f32_tensor(&mut tensors, "model.norm.weight");
+    for layer in 0..3 {
+        add_glm_dsa_attention_tensors(&mut tensors, layer);
+    }
+    add_glm_dsa_attention_tensors(&mut tensors, 3);
+    add_glm_dsa_dense_ffn_tensors(&mut tensors, 0);
+    for layer in [1, 2] {
+        add_glm_dsa_moe_tensors(&mut tensors, layer);
+    }
+    add_glm_dsa_moe_tensors(&mut tensors, 3);
+    add_glm_dsa_indexer_tensors(&mut tensors, 0);
+    add_glm_dsa_indexer_tensors(&mut tensors, 2);
+    add_glm_dsa_indexer_tensors(&mut tensors, 3);
+    for suffix in ["eh_proj.weight", "enorm.weight", "hnorm.weight"] {
+        push_f32_tensor(&mut tensors, format!("model.layers.3.{suffix}"));
+    }
+    let tensor_count = tensors.len();
+    write_owned_safetensor(&root.join("model.safetensors"), &tensors);
+    tensor_count
+}
+
+fn add_glm_dsa_attention_tensors(tensors: &mut Vec<OwnedSafetensorTensor>, layer: u32) {
+    for suffix in [
+        "input_layernorm.weight",
+        "self_attn.q_a_layernorm.weight",
+        "self_attn.kv_a_layernorm.weight",
+        "self_attn.q_a_proj.weight",
+        "self_attn.q_b_proj.weight",
+        "self_attn.kv_a_proj_with_mqa.weight",
+        "self_attn.o_proj.weight",
+        "post_attention_layernorm.weight",
+    ] {
+        push_layer_f32_tensor(tensors, layer, suffix);
+    }
+    push_bf16_tensor(
+        tensors,
+        format!("model.layers.{layer}.self_attn.kv_b_proj.weight"),
+        &[5, 2],
+    );
+}
+
+fn add_glm_dsa_dense_ffn_tensors(tensors: &mut Vec<OwnedSafetensorTensor>, layer: u32) {
+    for suffix in [
+        "mlp.gate_proj.weight",
+        "mlp.down_proj.weight",
+        "mlp.up_proj.weight",
+    ] {
+        push_layer_f32_tensor(tensors, layer, suffix);
+    }
+}
+
+fn add_glm_dsa_moe_tensors(tensors: &mut Vec<OwnedSafetensorTensor>, layer: u32) {
+    for suffix in [
+        "mlp.gate.weight",
+        "mlp.shared_experts.gate_proj.weight",
+        "mlp.shared_experts.down_proj.weight",
+        "mlp.shared_experts.up_proj.weight",
+    ] {
+        push_layer_f32_tensor(tensors, layer, suffix);
+    }
+    for expert in 0..2 {
+        for projection in ["gate_proj", "down_proj", "up_proj"] {
+            push_layer_f32_tensor(
+                tensors,
+                layer,
+                format!("mlp.experts.{expert}.{projection}.weight"),
+            );
+        }
+    }
+}
+
+fn add_glm_dsa_indexer_tensors(tensors: &mut Vec<OwnedSafetensorTensor>, layer: u32) {
+    for suffix in [
+        "self_attn.indexer.k_norm.weight",
+        "self_attn.indexer.k_norm.bias",
+        "self_attn.indexer.weights_proj.weight",
+        "self_attn.indexer.wk.weight",
+        "self_attn.indexer.wq_b.weight",
+    ] {
+        push_layer_f32_tensor(tensors, layer, suffix);
+    }
+}
+
+fn push_layer_f32_tensor(
+    tensors: &mut Vec<OwnedSafetensorTensor>,
+    layer: u32,
+    suffix: impl AsRef<str>,
+) {
+    push_f32_tensor(tensors, format!("model.layers.{layer}.{}", suffix.as_ref()));
+}
+
+fn push_f32_tensor(tensors: &mut Vec<OwnedSafetensorTensor>, name: impl Into<String>) {
+    tensors.push(OwnedSafetensorTensor {
+        name: name.into(),
+        dtype: "F32",
+        shape: vec![1],
+        bytes: vec![0, 0, 0x80, 0x3f],
+    });
+}
+
+fn push_bf16_tensor(
+    tensors: &mut Vec<OwnedSafetensorTensor>,
+    name: impl Into<String>,
+    shape: &[u64],
+) {
+    let elements = shape.iter().product::<u64>() as usize;
+    tensors.push(OwnedSafetensorTensor {
+        name: name.into(),
+        dtype: "BF16",
+        shape: shape.to_vec(),
+        bytes: vec![0; elements * 2],
+    });
+}
+
+fn write_owned_safetensor(path: &Path, tensors: &[OwnedSafetensorTensor]) {
+    let mut offset = 0_u64;
+    let mut entries = serde_json::Map::new();
+    for tensor in tensors {
+        let end = offset + tensor.bytes.len() as u64;
+        entries.insert(
+            tensor.name.clone(),
+            serde_json::json!({
+                "dtype": tensor.dtype,
+                "shape": tensor.shape,
+                "data_offsets": [offset, end],
+            }),
+        );
+        offset = end;
+    }
+    let header = serde_json::Value::Object(entries).to_string();
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(&(header.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(header.as_bytes());
+    for tensor in tensors {
+        bytes.extend_from_slice(&tensor.bytes);
+    }
+    fs::write(path, bytes).unwrap();
 }

--- a/crates/skippy-quantize/src/gguf_writer_tests.rs
+++ b/crates/skippy-quantize/src/gguf_writer_tests.rs
@@ -492,34 +492,6 @@ fn splits_glm_dsa_kv_b_projection_for_native_layout() {
 }
 
 #[test]
-fn infers_glm_dsa_indexshare_types_from_mapped_tensor_names() {
-    let mut metadata = minimal_glm_dsa_metadata(3, 0);
-    let tensors = vec![
-        mock_tensor_source("blk.0.indexer.k_norm.weight"),
-        mock_tensor_source("blk.0.indexer.k_norm.bias"),
-        mock_tensor_source("blk.0.indexer.proj.weight"),
-        mock_tensor_source("blk.0.indexer.attn_k.weight"),
-        mock_tensor_source("blk.0.indexer.attn_q_b.weight"),
-        mock_tensor_source("blk.2.indexer.k_norm.weight"),
-        mock_tensor_source("blk.2.indexer.k_norm.bias"),
-        mock_tensor_source("blk.2.indexer.proj.weight"),
-        mock_tensor_source("blk.2.indexer.attn_k.weight"),
-        mock_tensor_source("blk.2.indexer.attn_q_b.weight"),
-    ];
-
-    enrich_glm_dsa_indexshare_metadata(&mut metadata, &tensors).unwrap();
-
-    assert_eq!(
-        array_string_metadata(&metadata, "glm-dsa.attention.indexer.types"),
-        Some(vec![
-            "full".to_string(),
-            "shared".to_string(),
-            "full".to_string(),
-        ])
-    );
-}
-
-#[test]
 fn writes_inferred_glm_dsa_indexshare_types_to_gguf_metadata() {
     let root = unique_temp_dir();
     fs::create_dir_all(&root).unwrap();
@@ -617,19 +589,6 @@ fn writes_inferred_glm_dsa_indexshare_types_to_gguf_metadata() {
         ])
     );
     fs::remove_dir_all(root).unwrap();
-}
-
-#[test]
-fn rejects_glm_dsa_partial_indexshare_group_during_metadata_enrichment() {
-    let mut metadata = minimal_glm_dsa_metadata(2, 0);
-    let tensors = vec![mock_tensor_source("blk.0.indexer.k_norm.weight")];
-
-    let err = enrich_glm_dsa_indexshare_metadata(&mut metadata, &tensors).unwrap_err();
-
-    assert!(
-        err.to_string().contains("partial indexer tensor group"),
-        "unexpected error: {err:#}"
-    );
 }
 
 #[test]
@@ -1350,32 +1309,11 @@ fn glm_dsa_kv_b_split_metadata() -> Vec<GgufKv> {
     ]
 }
 
-fn mock_tensor_source(name: &str) -> TensorSource {
-    TensorSource {
-        segments: Vec::new(),
-        name: name.to_string(),
-        dims: vec![1],
-        ggml_type: GGML_TYPE_F32,
-        byte_len: 4,
-        gguf_offset: 0,
-    }
-}
-
 fn f32_bytes(values: &[f32]) -> Vec<u8> {
     values
         .iter()
         .flat_map(|value| value.to_le_bytes())
         .collect()
-}
-
-fn array_string_metadata(metadata: &[GgufKv], key: &str) -> Option<Vec<String>> {
-    metadata.iter().find_map(|kv| match kv {
-        GgufKv::ArrayString {
-            key: item_key,
-            value,
-        } if item_key == key => Some(value.clone()),
-        _ => None,
-    })
 }
 
 fn write_safetensor(path: &Path, tensors: &[(&str, &str, &[u64], &[u8])]) {

--- a/crates/skippy-quantize/src/main.rs
+++ b/crates/skippy-quantize/src/main.rs
@@ -979,6 +979,7 @@ fn quant_manifest_from_args(args: &InitQuantArgs) -> Result<Manifest> {
         quant: Some(args.quant.base_quant().as_llama_name().to_string()),
         output_type: None,
         tensor_type_file: args.tensor_type_file.clone(),
+        tensor_type_recipe: None,
     };
     Ok(manifest)
 }
@@ -1051,6 +1052,7 @@ fn convert_manifest_from_args(args: &InitConvertArgs) -> Result<Manifest> {
         quant: None,
         output_type: Some(args.output_type),
         tensor_type_file: None,
+        tensor_type_recipe: None,
     };
     Ok(manifest)
 }

--- a/crates/skippy-quantize/src/manifest.rs
+++ b/crates/skippy-quantize/src/manifest.rs
@@ -24,6 +24,8 @@ pub struct Manifest {
     pub quant: Option<String>,
     pub output_type: Option<ConvertOutputType>,
     pub tensor_type_file: Option<PathBuf>,
+    #[serde(default)]
+    pub tensor_type_recipe: Option<String>,
 }
 
 pub fn ensure_manifest(path: &Path, manifest: &Manifest) -> Result<()> {

--- a/crates/skippy-quantize/src/native_quantize.rs
+++ b/crates/skippy-quantize/src/native_quantize.rs
@@ -736,6 +736,7 @@ mod tests {
             quant: Some("Q2_K".to_string()),
             output_type: None,
             tensor_type_file,
+            tensor_type_recipe: None,
         }
     }
 

--- a/crates/skippy-quantize/src/tensor_map.rs
+++ b/crates/skippy-quantize/src/tensor_map.rs
@@ -182,6 +182,11 @@ impl<'a> HfLayerTensor<'a> {
             "self_attn.kv_a_proj_with_mqa.weight" => Ok(format!("blk.{bid}.attn_kv_a_mqa.weight")),
             "self_attn.kv_b_proj.weight" => Ok(format!("blk.{bid}.attn_kv_b.weight")),
             "self_attn.kv_a_layernorm.weight" => Ok(format!("blk.{bid}.attn_kv_a_norm.weight")),
+            "self_attn.indexer.k_norm.weight" => Ok(format!("blk.{bid}.indexer.k_norm.weight")),
+            "self_attn.indexer.k_norm.bias" => Ok(format!("blk.{bid}.indexer.k_norm.bias")),
+            "self_attn.indexer.weights_proj.weight" => Ok(format!("blk.{bid}.indexer.proj.weight")),
+            "self_attn.indexer.wk.weight" => Ok(format!("blk.{bid}.indexer.attn_k.weight")),
+            "self_attn.indexer.wq_b.weight" => Ok(format!("blk.{bid}.indexer.attn_q_b.weight")),
             "mlp.down_proj.weight" => Ok(format!("blk.{bid}.ffn_down.weight")),
             "mlp.gate_proj.weight" => Ok(format!("blk.{bid}.ffn_gate.weight")),
             "mlp.up_proj.weight" => Ok(format!("blk.{bid}.ffn_up.weight")),
@@ -227,6 +232,40 @@ mod tests {
                 .map_tensor_name("model.layers.7.mlp.shared_experts.gate_proj.weight")
                 .unwrap(),
             "blk.7.ffn_gate_shexp.weight"
+        );
+    }
+
+    #[test]
+    fn maps_glm_dsa_indexer_tensor_names() {
+        assert_eq!(
+            TensorNameMap::HfToGguf
+                .map_tensor_name("model.layers.7.self_attn.indexer.k_norm.weight")
+                .unwrap(),
+            "blk.7.indexer.k_norm.weight"
+        );
+        assert_eq!(
+            TensorNameMap::HfToGguf
+                .map_tensor_name("model.layers.7.self_attn.indexer.k_norm.bias")
+                .unwrap(),
+            "blk.7.indexer.k_norm.bias"
+        );
+        assert_eq!(
+            TensorNameMap::HfToGguf
+                .map_tensor_name("model.layers.7.self_attn.indexer.weights_proj.weight")
+                .unwrap(),
+            "blk.7.indexer.proj.weight"
+        );
+        assert_eq!(
+            TensorNameMap::HfToGguf
+                .map_tensor_name("model.layers.7.self_attn.indexer.wk.weight")
+                .unwrap(),
+            "blk.7.indexer.attn_k.weight"
+        );
+        assert_eq!(
+            TensorNameMap::HfToGguf
+                .map_tensor_name("model.layers.7.self_attn.indexer.wq_b.weight")
+                .unwrap(),
+            "blk.7.indexer.attn_q_b.weight"
         );
     }
 

--- a/crates/skippy-quantize/src/types.rs
+++ b/crates/skippy-quantize/src/types.rs
@@ -729,6 +729,7 @@ mod tests {
     }
 
     fn pinned_llama_quant_option_names() -> Vec<String> {
+        const UNSUPPORTED_FFI_QUANT_MODES: &[&str] = &["Q2_0"];
         let quantize_cpp = repo_root().join(".deps/llama.cpp/tools/quantize/quantize.cpp");
         let source = fs::read_to_string(&quantize_cpp)
             .unwrap_or_else(|err| panic!("read {}: {err}", quantize_cpp.display()));
@@ -744,6 +745,7 @@ mod tests {
                 line.strip_prefix("{ \"")
                     .and_then(|rest| rest.split_once('"').map(|(name, _)| name.to_string()))
             })
+            .filter(|name| !UNSUPPORTED_FFI_QUANT_MODES.contains(&name.as_str()))
             .collect()
     }
 

--- a/crates/skippy-quantize/src/validation_commands.rs
+++ b/crates/skippy-quantize/src/validation_commands.rs
@@ -134,3 +134,65 @@ fn print_progress(progress: &Progress) {
         None => print_success("Next window: complete"),
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use regex_lite::Regex;
+
+    use super::*;
+
+    #[test]
+    fn glm52_q2_routed_down_recipe_targets_decoder_down_only() {
+        let recipe = include_str!(
+            "../../../recipes/quantization/glm-5.2-q2-k-routed-down-mtp-q8.tensor-types.txt"
+        );
+        let routed_down = recipe
+            .split_whitespace()
+            .next()
+            .expect("recipe should start with routed-down override");
+        let (pattern, tensor_type) = routed_down
+            .split_once('=')
+            .expect("recipe entry should be PATTERN=TYPE");
+
+        assert_eq!(tensor_type, "Q2_K");
+        let regex = Regex::new(pattern).expect("routed-down pattern should compile");
+
+        for layer in [0, 8, 45, 77] {
+            let name = format!("blk.{layer}.ffn_down_exps.weight");
+            assert!(regex.is_match(&name), "expected {name} to match");
+        }
+
+        for name in [
+            "blk.78.ffn_down_exps.weight",
+            "blk.8.ffn_gate_exps.weight",
+            "blk.8.ffn_up_exps.weight",
+            "blk.8.ffn_down_shexp.weight",
+            "blk.78.nextn.ffn_down_exps.weight",
+        ] {
+            assert!(!regex.is_match(name), "did not expect {name} to match");
+        }
+    }
+
+    #[test]
+    fn checked_in_glm52_quant_recipes_validate() {
+        for (name, recipe) in [
+            (
+                "glm-5.2-q2-k-mtp-q8",
+                include_str!("../../../recipes/quantization/glm-5.2-q2-k-mtp-q8.tensor-types.txt"),
+            ),
+            (
+                "glm-5.2-q2-k-routed-down-mtp-q8",
+                include_str!(
+                    "../../../recipes/quantization/glm-5.2-q2-k-routed-down-mtp-q8.tensor-types.txt"
+                ),
+            ),
+        ] {
+            let mut entry_count = 0;
+            for token in recipe.split_whitespace() {
+                ensure_tensor_type_entry(token).expect("checked-in tensor recipe should validate");
+                entry_count += 1;
+            }
+            assert!(entry_count > 0, "{name} recipe must not be empty");
+        }
+    }
+}

--- a/crates/skippy-quantize/src/verify.rs
+++ b/crates/skippy-quantize/src/verify.rs
@@ -159,6 +159,7 @@ mod tests {
             quant: Some("Q2_K".to_string()),
             output_type: None,
             tensor_type_file: None,
+            tensor_type_recipe: None,
         };
 
         let report = verify_manifest(&manifest).unwrap();

--- a/recipes/quantization/README.md
+++ b/recipes/quantization/README.md
@@ -1,0 +1,42 @@
+# Quantization Recipes
+
+This directory contains tensor-type override recipes for `skippy-quantize`.
+Recipe files are intentionally comment-free because `skippy-quantize
+validate-tensor-types` parses each whitespace-separated token as a
+`PATTERN=TYPE` entry.
+
+`PATTERN` is passed to llama.cpp as a regular expression and matched with
+`std::regex_search`. First match wins, so put narrow overrides before broad
+ones.
+
+## GLM-5.2
+
+Use `glm-5.2-q2-k-mtp-q8.tensor-types.txt` with base `--quant Q2_K` to
+recreate the lab's comfort-fit GLM-5.2 profile:
+
+- GLM attention projection tensors that were sensitive in local testing stay
+  at `Q8_0`.
+- Shared expert tensors stay at `Q4_K`.
+- Native NextN/MTP tensors containing `.nextn.` stay at `Q8_0`.
+- Routed expert gate/up tensors follow the `Q2_K` default.
+- Routed expert down tensors follow llama.cpp's `Q2_K` profile fallback, which
+  currently keeps them at `Q3_K` where required.
+
+Use `glm-5.2-q2-k-routed-down-mtp-q8.tensor-types.txt` for the Phase E
+routed-down experiment. It changes only decoder-layer routed down projections
+to `Q2_K`:
+
+```text
+^blk\.([0-9]|[1-6][0-9]|7[0-7])\.ffn_down_exps\.weight$=Q2_K
+```
+
+The range deliberately excludes `blk.78`, the GLM-5.2 native NextN/MTP block.
+That lets us test the measured decode throughput win from q2_K routed-down
+without lowering the MTP block's sparse MLP down projection.
+
+Validate recipes before launching an expensive quantization job:
+
+```bash
+skippy-quantize validate-tensor-types recipes/quantization/glm-5.2-q2-k-mtp-q8.tensor-types.txt
+skippy-quantize validate-tensor-types recipes/quantization/glm-5.2-q2-k-routed-down-mtp-q8.tensor-types.txt
+```

--- a/recipes/quantization/glm-5.2-q2-k-mtp-q8.tensor-types.txt
+++ b/recipes/quantization/glm-5.2-q2-k-mtp-q8.tensor-types.txt
@@ -1,0 +1,7 @@
+attn_kv_a_mqa\.weight$=Q8_0
+attn_q_a\.weight$=Q8_0
+attn_q_b\.weight$=Q8_0
+ffn_down_shexp\.weight$=Q4_K
+ffn_gate_shexp\.weight$=Q4_K
+ffn_up_shexp\.weight$=Q4_K
+(^|\.)nextn\.=Q8_0

--- a/recipes/quantization/glm-5.2-q2-k-routed-down-mtp-q8.tensor-types.txt
+++ b/recipes/quantization/glm-5.2-q2-k-routed-down-mtp-q8.tensor-types.txt
@@ -1,0 +1,8 @@
+^blk\.([0-9]|[1-6][0-9]|7[0-7])\.ffn_down_exps\.weight$=Q2_K
+attn_kv_a_mqa\.weight$=Q8_0
+attn_q_a\.weight$=Q8_0
+attn_q_b\.weight$=Q8_0
+ffn_down_shexp\.weight$=Q4_K
+ffn_gate_shexp\.weight$=Q4_K
+ffn_up_shexp\.weight$=Q4_K
+(^|\.)nextn\.=Q8_0

--- a/scripts/glm52-q2-routed-down-hf-job.sh
+++ b/scripts/glm52-q2-routed-down-hf-job.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cat >&2 <<'EOF'
+GLM-5.2 routed-down quantization must run locally for this experiment.
+
+Use the local BF16 GGUF shards on micstudio:
+
+  SOURCE_ROOT=/Users/lab/glm52-work/bf16-gguf \
+  SOURCE_PREFIX=BF16 \
+  scripts/glm52-q2-routed-down-layer-package.sh
+
+Hugging Face can be used later for publishing artifacts, but not for
+quantization execution.
+EOF
+
+exit 2

--- a/scripts/glm52-q2-routed-down-layer-package.sh
+++ b/scripts/glm52-q2-routed-down-layer-package.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+skippy_quantize_bin="${SKIPPY_QUANTIZE_BIN:-$repo_root/target/release/skippy-quantize}"
+skippy_model_package_bin="${SKIPPY_MODEL_PACKAGE_BIN:-$repo_root/target/release/skippy-model-package}"
+
+work_base="${WORK_BASE:-/Users/lab/glm52-work/q2-routed-down}"
+source_root="${SOURCE_ROOT:-/Users/lab/glm52-work/bf16-gguf}"
+source_prefix="${SOURCE_PREFIX:-BF16}"
+target_root="${TARGET_ROOT:-$work_base/quant-scratch}"
+target_prefix="${TARGET_PREFIX:-Q2_K-RoutedDown-MTP-Q8}"
+output_basename="${OUTPUT_BASENAME:-GLM-5.2-Q2_K-RoutedDown-MTP-Q8}"
+manifest="${MANIFEST:-$work_base/quant-manifest.json}"
+package_dir="${PACKAGE_DIR:-$work_base/package/GLM-5.2-Q2_K-RoutedDown-MTP-Q8-layers}"
+package_model_id="${PACKAGE_MODEL_ID:-meshllm/GLM-5.2-Q2_K-RoutedDown-MTP-Q8-GGUF:Q2_K-RoutedDown-MTP-Q8}"
+package_source_repo="${PACKAGE_SOURCE_REPO:-meshllm/GLM-5.2-Q2_K-RoutedDown-MTP-Q8-GGUF}"
+package_source_revision="${PACKAGE_SOURCE_REVISION:-local}"
+recipe="${TENSOR_TYPE_FILE:-$repo_root/recipes/quantization/glm-5.2-q2-k-routed-down-mtp-q8.tensor-types.txt}"
+work_dir="${WORK_DIR:-$work_base/native-work}"
+spool_dir="${SPOOL_DIR:-$work_base/spool}"
+record_dir="${RECORD_DIR:-$work_base/records}"
+status_file="${JSON_EVENT_FILE:-$work_base/status.json}"
+shard_scratch_dir="${SHARD_SCRATCH_DIR:-$work_dir/shard-scratch}"
+stages="${STAGES:-2}"
+nthreads="${NTHREADS:-}"
+dry_run="${DRY_RUN:-0}"
+
+if [[ ! -x "$skippy_quantize_bin" ]]; then
+  echo "missing executable: $skippy_quantize_bin" >&2
+  echo "build it with: just skippy-quantize-standalone-release-build" >&2
+  exit 1
+fi
+
+if [[ "$dry_run" != "1" && ! -x "$skippy_model_package_bin" ]]; then
+  echo "missing executable: $skippy_model_package_bin" >&2
+  echo "build it with: cargo build --release --locked -p skippy-model-package" >&2
+  exit 1
+fi
+
+if [[ ! -f "$recipe" ]]; then
+  echo "missing tensor-type recipe: $recipe" >&2
+  exit 1
+fi
+
+if [[ ! -d "$source_root/$source_prefix" ]]; then
+  echo "missing BF16 source prefix: $source_root/$source_prefix" >&2
+  echo "point SOURCE_ROOT/SOURCE_PREFIX at the local BF16 GGUF shards before running" >&2
+  exit 1
+fi
+
+common_args=(
+  --source "$source_root"
+  --source-prefix "$source_prefix"
+  --target "$target_root"
+  --target-prefix "$target_prefix"
+  --output-basename "$output_basename"
+  --quant Q2_K
+  --tensor-type-file "$recipe"
+  --window-size 1
+  --manifest "$manifest"
+  --backend llama-api
+  --work-dir "$work_dir"
+  --spool-dir "$spool_dir"
+  --record-dir "$record_dir"
+  --json-event-file "$status_file"
+  --json-event-interval-seconds 120
+  --json-event-window 8
+  --watchdog-seconds 120
+)
+
+if [[ -n "$nthreads" ]]; then
+  common_args+=(--nthreads "$nthreads")
+fi
+
+if [[ "$dry_run" == "1" ]]; then
+  exec "$skippy_quantize_bin" quant-job "${common_args[@]}" --preflight-only
+fi
+
+export SKIPPY_MODEL_PACKAGE_SHARD_SCRATCH_DIR="$shard_scratch_dir"
+
+exec "$skippy_quantize_bin" quantize-layer-package \
+  "${common_args[@]}" \
+  --package-dir "$package_dir" \
+  --package-model-id "$package_model_id" \
+  --package-source-repo "$package_source_repo" \
+  --package-source-revision "$package_source_revision" \
+  --skippy-model-package-bin "$skippy_model_package_bin" \
+  --stages "$stages" \
+  --replace-package

--- a/scripts/skippy-bf16-to-quant-layer-package.sh
+++ b/scripts/skippy-bf16-to-quant-layer-package.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+skippy_quantize_bin="${SKIPPY_QUANTIZE_BIN:-target/release/skippy-quantize}"
+if [[ ! -x "$skippy_quantize_bin" ]]; then
+  echo "missing executable: $skippy_quantize_bin" >&2
+  echo "build it with: just skippy-quantize-standalone-release-build" >&2
+  exit 1
+fi
+
+exec "$skippy_quantize_bin" quantize-layer-package "$@"

--- a/scripts/skippy-bf16-to-quant-layer-package.sh
+++ b/scripts/skippy-bf16-to-quant-layer-package.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-skippy_quantize_bin="${SKIPPY_QUANTIZE_BIN:-target/release/skippy-quantize}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+skippy_quantize_bin="${SKIPPY_QUANTIZE_BIN:-$repo_root/target/release/skippy-quantize}"
 if [[ ! -x "$skippy_quantize_bin" ]]; then
   echo "missing executable: $skippy_quantize_bin" >&2
   echo "build it with: just skippy-quantize-standalone-release-build" >&2


### PR DESCRIPTION
## Summary

- add direct BF16/FP16 GGUF to quantized layer-package tooling in `skippy-quantize`
- support explicit tensor-type recipes and metadata overrides for custom quant profiles
- add GLM-5.2 quant recipes plus helper scripts for local/HF quant layer-package workflows

## Why

Large-model experiments need to reuse BF16 GGUF artifacts and produce quantized Skippy layer packages without round-tripping through ad hoc intermediate scripts. This makes the quant path reproducible and keeps custom tensor decisions explicit in checked-in recipes.

## Validation

- `bash -n scripts/skippy-bf16-to-quant-layer-package.sh scripts/glm52-q2-routed-down-layer-package.sh scripts/glm52-q2-routed-down-hf-job.sh`
- `cargo check -p skippy-quantize`
- `cargo test -p skippy-quantize`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added GLM-DSA model conversion support, including indexer metadata and KV projection splitting.
  - Added tensor-name mapping and quantization recipes for GLM 5.2, including routed-down variants.
  - Added scripts for local routed-down model packaging and BF16-to-layer-package conversion.
  - Existing manifests can now omit tensor recipe settings.

- **Documentation**
  - Documented recipe syntax, regex matching, precedence, validation, and GLM-5.2 usage.

- **Bug Fixes**
  - Improved validation and error reporting for incomplete or conflicting GLM-DSA configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->