### PR TITLE
Fix Windows autoupdate import

### DIFF
--- a/crates/mesh-llm-system/src/autoupdate.rs
+++ b/crates/mesh-llm-system/src/autoupdate.rs
@@ -10,8 +10,10 @@ mod release_fetch;
 pub use release_fetch::{latest_release_version, version_newer};
 
 use platform_probe::{installed_bundle_flavor, preferred_bundle_flavor_for_current_host};
+#[cfg(not(windows))]
+use release_fetch::INSTALL_SCRIPT_URL;
 use release_fetch::{
-    INSTALL_SCRIPT_URL, InstallOutcome, PostInstallAction, RELEASES_URL, ReleaseAssetPreference,
+    InstallOutcome, PostInstallAction, RELEASES_URL, ReleaseAssetPreference,
     current_release_target, describe_requested_update, exec_current_binary, install_latest_bundle,
     latest_release_info, mesh_binary_name, path_is_writable, platform_has_release_assets,
     release_asset_candidates, release_has_any_platform_asset, resolve_release_asset_name,


### PR DESCRIPTION
## Summary
- gate the `INSTALL_SCRIPT_URL` import behind `cfg(not(windows))`
- match the existing non-Windows-only usage of the reinstall guidance

## Why
Windows release builds import `INSTALL_SCRIPT_URL` unconditionally even though the constant is compiled out on Windows. This breaks Windows CI before unrelated PR checks can complete.

## Validation
- cargo check -p mesh-llm-system
- cargo check -p mesh-llm-system --target x86_64-pc-windows-msvc attempted locally, but this macOS toolchain could not resolve the Windows `core/std` target despite rustup reporting it installed
