### PR TITLE
Document public packaging installation channels

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1453,7 +1453,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - name: Dispatch verified release to mesh-agent-images
+      - name: Dispatch verified release to mesh-packaging
         env:
           GH_TOKEN: ${{ secrets.MESH_AGENT_IMAGES_DISPATCH_TOKEN }}
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
@@ -1481,7 +1481,7 @@ jobs:
             }' |
             gh api \
               --method POST \
-              repos/Mesh-LLM/mesh-agent-images/dispatches \
+              repos/Mesh-LLM/mesh-packaging/dispatches \
               --input -
 
   publish_crates_preflight:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1461,7 +1461,7 @@ jobs:
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN:-}" ]] || {
-            echo "MESH_AGENT_IMAGES_DISPATCH_TOKEN is required for cross-repository packaging" >&2
+            echo "MESH_AGENT_IMAGES_DISPATCH_TOKEN must grant Contents write access to Mesh-LLM/mesh-packaging for cross-repository dispatch" >&2
             exit 1
           }
           jq -n \

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ On Windows, use PowerShell:
 irm https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.ps1 | iex
 ```
 
+Versioned Homebrew formulas, Ubuntu and Arch packages, checksums, SBOMs, and
+OCI images are available from the public
+[`Mesh-LLM/mesh-packaging`](https://github.com/Mesh-LLM/mesh-packaging)
+repository. See the [platform install guides](https://meshllm.cloud/docs/pages/installing-mesh/)
+for the supported package matrix and install commands.
+
 Finish setup:
 
 ```bash

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -8,7 +8,7 @@ Releases are normally cut by running the **Release** workflow
 dispatched workflow bumps versions, generates and patches the SwiftPM
 manifest, packages SDK console assets, creates and pushes the release tag,
 builds all platform bundles, and publishes the GitHub release. After a complete
-non-canary release succeeds, it dispatches `Mesh-LLM/mesh-agent-images` to
+non-canary release succeeds, it dispatches `Mesh-LLM/mesh-packaging` to
 package the verified release archives, publish the native package release
 assets, and publish the supported GHCR image matrix. Dispatch inputs include
 `skip_gpu_bundles` and `canary` (dry-run: build and smoke everything without
@@ -28,8 +28,9 @@ locally.
 - `gh` CLI authenticated if publishing manually
 - `MESH_AGENT_IMAGES_DISPATCH_TOKEN` configured as a fine-grained repository
   token or GitHub App token with Contents write access to
-  `Mesh-LLM/mesh-agent-images`, which is the permission required to create a
-  repository dispatch event
+  `Mesh-LLM/mesh-packaging`, which is the permission required to create a
+  repository dispatch event. The legacy secret name is retained so existing
+  release environments do not require a coordinated secret rename.
 
 ## Release Attestation Signing Keys
 
@@ -177,7 +178,7 @@ Verify:
 
 Push a `v*` tag to run `.github/workflows/release.yml`. The upstream release
 workflow owns release archive production, but it does not publish OCI images.
-`Mesh-LLM/mesh-agent-images` is the canonical GHCR producer and starts only
+`Mesh-LLM/mesh-packaging` is the canonical GHCR producer and starts only
 after the GitHub release and its complete archive set have published
 successfully. The upstream `docker.yml` workflow performs Dockerfile validation
 only and is not a distribution channel.

--- a/website/src/_includes/components/cta-terminal.njk
+++ b/website/src/_includes/components/cta-terminal.njk
@@ -7,7 +7,6 @@
     </div>
     <div class="cta-terminal-tabs" role="tablist" aria-label="Install methods">
       <button class="active" type="button" role="tab" aria-selected="true" data-install-method="curl" data-install-copy="curl -fsSL https://meshllm.cloud/install.sh | bash">curl</button>
-      <button type="button" role="tab" aria-selected="false" hidden aria-hidden="true" data-install-unavailable="true" data-install-method="brew" data-install-copy="brew install mesh-llm/tap/mesh-llm">brew</button>
       <button type="button" role="tab" aria-selected="false" hidden aria-hidden="true" data-install-unavailable="true" data-install-method="cargo" data-install-copy="cargo install mesh-llm">cargo</button>
     </div>
     <div class="cta-terminal-meta">~ &middot; zsh &middot; mesh-llm</div>
@@ -19,7 +18,6 @@
       <p class="comment"># Install the executable (macOS, Linux)</p>
       <p class="cta-install-command" data-install-command-display aria-live="polite"><span class="prompt">$</span> <span class="cmd">curl</span> <span class="flag">-fsSL</span> <span class="value">https://meshllm.cloud/install.sh</span> <span class="pipe">|</span> <span class="cmd">bash</span></p>
       <template data-install-template="curl"><span class="prompt">$</span> <span class="cmd">curl</span> <span class="flag">-fsSL</span> <span class="value">https://meshllm.cloud/install.sh</span> <span class="pipe">|</span> <span class="cmd">bash</span></template>
-      <template data-install-template="brew"><span class="prompt">$</span> <span class="cmd">brew</span> <span class="cmd">install</span> <span class="value">mesh-llm/tap/mesh-llm</span></template>
       <template data-install-template="cargo"><span class="prompt">$</span> <span class="cmd">cargo</span> <span class="cmd">install</span> <span class="value">mesh-llm</span></template>
     </div>
 

--- a/website/src/docs/pages/installing-linux.md
+++ b/website/src/docs/pages/installing-linux.md
@@ -20,6 +20,24 @@ Check the install:
 mesh-llm --version
 ```
 
+## Native packages and containers
+
+Versioned Ubuntu 24.04 `.deb` and Arch Linux `.pkg.tar.zst` files are published
+as [Mesh packaging release assets](https://github.com/Mesh-LLM/mesh-packaging/releases).
+Choose the file whose distro, architecture, and backend suffix matches the host.
+These are directly downloadable release assets, not apt or pacman repositories;
+download the package's matching `.sha256` sidecar and verify it before installing
+with `apt install` or `pacman -U`.
+
+The same CPU, Vulkan, CUDA, and ROCm package variants are available as OCI
+images from [`ghcr.io/mesh-llm/mesh-llm`](https://github.com/orgs/Mesh-LLM/packages/container/package/mesh-llm).
+Immutable tags include the Mesh version, distro, architecture, and backend. See
+the [packaging matrix](https://github.com/Mesh-LLM/mesh-packaging/blob/main/docs/matrix.md)
+for the supported rows and exact tag scheme.
+
+Alpine packages are not published because Mesh release archives currently use
+glibc rather than musl.
+
 ## What the installer does
 
 The installer downloads the `mesh-llm` executable and adds `~/.local/bin` to your user `PATH` when needed. After install, run `mesh-llm setup` to finish runtime configuration and, if you want it, the background service.

--- a/website/src/docs/pages/installing-linux.md
+++ b/website/src/docs/pages/installing-linux.md
@@ -29,6 +29,30 @@ These are directly downloadable release assets, not apt or pacman repositories;
 download the package's matching `.sha256` sidecar and verify it before installing
 with `apt install` or `pacman -U`.
 
+For Ubuntu, replace the placeholders with the version, architecture, and backend
+from the selected release asset. Architecture is `amd64` or `arm64`; copy the
+exact backend suffix, such as `cpu`, `vulkan`, or `cuda12.9.2`, from the release:
+
+```sh
+PACKAGE='mesh-llm-<version>-ubuntu-<architecture>-<backend>.deb'
+RELEASE_URL='https://github.com/Mesh-LLM/mesh-packaging/releases/download/packaging-v<version>'
+curl -fLO "$RELEASE_URL/$PACKAGE"
+curl -fLO "$RELEASE_URL/$PACKAGE.sha256"
+sha256sum --check "$PACKAGE.sha256"
+sudo apt install "./$PACKAGE"
+```
+
+For Arch Linux, use the matching `amd64` package and backend suffix:
+
+```sh
+PACKAGE='mesh-llm-<version>-arch-amd64-<backend>.pkg.tar.zst'
+RELEASE_URL='https://github.com/Mesh-LLM/mesh-packaging/releases/download/packaging-v<version>'
+curl -fLO "$RELEASE_URL/$PACKAGE"
+curl -fLO "$RELEASE_URL/$PACKAGE.sha256"
+sha256sum --check "$PACKAGE.sha256"
+sudo pacman -U "./$PACKAGE"
+```
+
 The same CPU, Vulkan, CUDA, and ROCm package variants are available as OCI
 images from [`ghcr.io/mesh-llm/mesh-llm`](https://github.com/orgs/Mesh-LLM/packages/container/package/mesh-llm).
 Immutable tags include the Mesh version, distro, architecture, and backend. See

--- a/website/src/docs/pages/installing-macos.md
+++ b/website/src/docs/pages/installing-macos.md
@@ -22,11 +22,25 @@ mesh-llm --version
 
 ## Homebrew
 
-If you use Homebrew:
+Mesh publishes a versioned Homebrew formula for Apple Silicon with each
+[packaging release](https://github.com/Mesh-LLM/mesh-packaging/releases). The
+formula is a release asset rather than a tap, so download it before installing:
 
 ```sh
-brew install mesh-llm/tap/mesh-llm
+brew tap-new mesh-llm/release
+curl -fL https://github.com/Mesh-LLM/mesh-packaging/releases/latest/download/mesh-llm.rb \
+  -o "$(brew --repository mesh-llm/release)/Formula/mesh-llm.rb"
+brew install mesh-llm/release/mesh-llm
 ```
+
+Homebrew requires formulae to live in a tap. The first command creates a local
+tap; it does not clone or depend on a public `Mesh-LLM/homebrew-tap` repository.
+To update later, download the latest formula to the same path and run
+`brew upgrade mesh-llm`.
+
+The formula downloads the checksummed Metal release archive from
+`Mesh-LLM/mesh-llm`. Intel macOS is not available through Homebrew because the
+upstream release does not include an x86_64 macOS archive.
 
 ## What the installer does
 

--- a/website/src/docs/pages/installing-mesh.md
+++ b/website/src/docs/pages/installing-mesh.md
@@ -6,6 +6,13 @@ title: Installing Mesh
 
 Mesh runs on macOS, Linux, and Windows. Choose your platform for detailed install instructions.
 
+The shell and PowerShell installers below remain the simplest installation
+path. Versioned Homebrew formulas, Linux native packages, checksums, SBOMs, and
+OCI images are published by the public
+[`Mesh-LLM/mesh-packaging`](https://github.com/Mesh-LLM/mesh-packaging)
+repository. Homebrew is provided as a release formula rather than a tap, and
+Linux packages are release assets rather than apt or pacman repositories.
+
 ## Choose your platform
 
 - [Installing on macOS](/docs/pages/installing-macos/) (Apple Silicon, Homebrew)


### PR DESCRIPTION
Closes #971.

- replaces the nonexistent Homebrew tap with the published release-formula/local-tap flow
- documents public Ubuntu, Arch, checksum, SBOM, and GHCR locations
- links the public mesh-packaging repository from the project README
- dispatches future releases to the canonical mesh-packaging repository

Published availability validated for v0.73.1:
- Homebrew install/test/style on Apple Silicon
- CPU deb install and command smoke on Ubuntu 24.04 arm64 and emulated amd64
- all 47 release assets anonymously reachable with a complete aggregate checksum
- all 11 immutable and 11 moving GHCR tags anonymously inspectable

Local validation:
- just test-all completed repository consistency, formatting, Clippy, Rust tests, lint, and typecheck; its UI stage reported three unrelated 5-second app-tabs timeouts (950 passed), while all affected files passed with one worker (148/148)
- UI production build
- website production build
- Playwright smoke: 2 passed, 1 skipped

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added Linux “Native packages and containers” guidance for Ubuntu `.deb` and Arch `.pkg.tar.zst` downloads with SHA256 verification, plus OCI image usage and tag details.
  * Updated macOS installation instructions with a versioned Homebrew “release asset” flow for Apple Silicon.
  * Refreshed installation/overview content (including README) to direct users to the packaging repository for formulas, assets, checksums, SBOMs, and OCI images.
* **Installation UI**
  * Updated the install-method terminal tabs to default to the **curl** command and removed the **brew** option.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->