### PR TITLE
fix: ROCm GPU enumeration

### DIFF
--- a/crates/mesh-llm-commands/src/gpus.rs
+++ b/crates/mesh-llm-commands/src/gpus.rs
@@ -352,7 +352,7 @@ mod tests {
     fn human_output_formats_rocm_gpu_without_omitting_backend_details() {
         let mut gpu = sample_gpu(0);
         gpu.display_name = "AMD Instinct MI300X".to_string();
-        gpu.backend_device = Some("HIP0".to_string());
+        gpu.backend_device = Some("ROCm0".to_string());
         gpu.stable_id = Some("pci:0000:65:00.0".to_string());
         gpu.pci_bdf = Some("0000:65:00.0".to_string());
         gpu.vendor_uuid = None;
@@ -364,7 +364,7 @@ mod tests {
 
         assert_eq!(
             format_gpus(&hw),
-            "🖥️ GPU 0\n  Name: AMD Instinct MI300X\n  Stable ID: pci:0000:65:00.0\n  Backend device: HIP0\n  VRAM: 24 GB\n  Bandwidth: unavailable\n  Unified memory: no\n  PCI BDF: 0000:65:00.0"
+            "🖥️ GPU 0\n  Name: AMD Instinct MI300X\n  Stable ID: pci:0000:65:00.0\n  Backend device: ROCm0\n  VRAM: 24 GB\n  Bandwidth: unavailable\n  Unified memory: no\n  PCI BDF: 0000:65:00.0"
         );
     }
 
@@ -372,7 +372,7 @@ mod tests {
     fn human_output_keeps_every_rocm_gpu() {
         let mut first = sample_gpu(0);
         first.display_name = "AMD Instinct MI300X".to_string();
-        first.backend_device = Some("HIP0".to_string());
+        first.backend_device = Some("ROCm0".to_string());
         let mut second = sample_gpu(1);
         second.display_name = "AMD Instinct MI300X".to_string();
         second.backend_device = Some("HIP1".to_string());
@@ -384,7 +384,7 @@ mod tests {
         let output = format_gpus(&hw);
 
         assert_eq!(output.matches("🖥️ GPU ").count(), 2);
-        assert!(output.contains("Backend device: HIP0"));
+        assert!(output.contains("Backend device: ROCm0"));
         assert!(output.contains("Backend device: HIP1"));
     }
 

--- a/crates/mesh-llm-commands/src/gpus.rs
+++ b/crates/mesh-llm-commands/src/gpus.rs
@@ -352,7 +352,7 @@ mod tests {
     fn human_output_formats_rocm_gpu_without_omitting_backend_details() {
         let mut gpu = sample_gpu(0);
         gpu.display_name = "AMD Instinct MI300X".to_string();
-        gpu.backend_device = Some("ROCm0".to_string());
+        gpu.backend_device = Some("HIP0".to_string());
         gpu.stable_id = Some("pci:0000:65:00.0".to_string());
         gpu.pci_bdf = Some("0000:65:00.0".to_string());
         gpu.vendor_uuid = None;
@@ -364,7 +364,7 @@ mod tests {
 
         assert_eq!(
             format_gpus(&hw),
-            "🖥️ GPU 0\n  Name: AMD Instinct MI300X\n  Stable ID: pci:0000:65:00.0\n  Backend device: ROCm0\n  VRAM: 24 GB\n  Bandwidth: unavailable\n  Unified memory: no\n  PCI BDF: 0000:65:00.0"
+            "🖥️ GPU 0\n  Name: AMD Instinct MI300X\n  Stable ID: pci:0000:65:00.0\n  Backend device: HIP0\n  VRAM: 24 GB\n  Bandwidth: unavailable\n  Unified memory: no\n  PCI BDF: 0000:65:00.0"
         );
     }
 
@@ -372,10 +372,10 @@ mod tests {
     fn human_output_keeps_every_rocm_gpu() {
         let mut first = sample_gpu(0);
         first.display_name = "AMD Instinct MI300X".to_string();
-        first.backend_device = Some("ROCm0".to_string());
+        first.backend_device = Some("HIP0".to_string());
         let mut second = sample_gpu(1);
         second.display_name = "AMD Instinct MI300X".to_string();
-        second.backend_device = Some("ROCm1".to_string());
+        second.backend_device = Some("HIP1".to_string());
         let hw = HardwareSurvey {
             gpus: vec![first, second],
             ..HardwareSurvey::default()
@@ -384,8 +384,8 @@ mod tests {
         let output = format_gpus(&hw);
 
         assert_eq!(output.matches("🖥️ GPU ").count(), 2);
-        assert!(output.contains("Backend device: ROCm0"));
-        assert!(output.contains("Backend device: ROCm1"));
+        assert!(output.contains("Backend device: HIP0"));
+        assert!(output.contains("Backend device: HIP1"));
     }
 
     #[test]

--- a/crates/mesh-llm-commands/src/gpus.rs
+++ b/crates/mesh-llm-commands/src/gpus.rs
@@ -47,19 +47,7 @@ pub fn run_gpus(json_output: bool) -> Result<()> {
         return print_json(gpus_json(&hw));
     }
 
-    if hw.gpus.is_empty() {
-        println!(
-            "⚠️ No runtime-selectable GPUs reported by the embedded inference backend. This node will run CPU-only until the backend exposes a selectable device."
-        );
-        return Ok(());
-    }
-
-    for (index, gpu) in hw.gpus.iter().enumerate() {
-        if index > 0 {
-            println!();
-        }
-        print_gpu(gpu);
-    }
+    println!("{}", format_gpus(&hw));
 
     Ok(())
 }
@@ -222,45 +210,57 @@ fn attach_cached_bandwidth(hw: &mut HardwareSurvey) {
     }
 }
 
-fn print_gpu(gpu: &GpuFacts) {
-    println!("🖥️ GPU {}", gpu.index);
-    println!("  Name: {}", gpu.display_name);
+fn format_gpus(hw: &HardwareSurvey) -> String {
+    if hw.gpus.is_empty() {
+        return "⚠️ No runtime-selectable GPUs reported by the embedded inference backend. This node will run CPU-only until the backend exposes a selectable device.".to_string();
+    }
+    hw.gpus
+        .iter()
+        .map(format_gpu)
+        .collect::<Vec<_>>()
+        .join("\n\n")
+}
+
+fn format_gpu(gpu: &GpuFacts) -> String {
+    let mut lines = vec![
+        format!("🖥️ GPU {}", gpu.index),
+        format!("  Name: {}", gpu.display_name),
+    ];
     if let Some(stable_id) = gpu.stable_id.as_deref() {
-        println!("  Stable ID: {stable_id}");
+        lines.push(format!("  Stable ID: {stable_id}"));
     }
     if let Some(backend_device) = gpu.backend_device.as_deref() {
-        println!("  Backend device: {backend_device}");
+        lines.push(format!("  Backend device: {backend_device}"));
     } else {
-        println!(
-            "  Backend device: unavailable (hardware-visible only; embedded runtime did not report a selectable device)"
-        );
+        lines.push("  Backend device: unavailable (hardware-visible only; embedded runtime did not report a selectable device)".to_string());
     }
-    println!("  VRAM: {}", format_vram(gpu.vram_bytes));
-    println!(
+    lines.push(format!("  VRAM: {}", format_vram(gpu.vram_bytes)));
+    lines.push(format!(
         "  Bandwidth: {}",
         gpu.mem_bandwidth_gbps
             .map(format_bandwidth)
             .unwrap_or_else(|| "unavailable".to_string())
-    );
-    println!(
+    ));
+    lines.push(format!(
         "  Unified memory: {}",
         if gpu.unified_memory { "yes" } else { "no" }
-    );
+    ));
     if let Some(pci_bdf) = gpu.pci_bdf.as_deref() {
-        println!("  PCI BDF: {pci_bdf}");
+        lines.push(format!("  PCI BDF: {pci_bdf}"));
     }
     if let Some(vendor_uuid) = gpu.vendor_uuid.as_deref() {
-        println!("  Vendor UUID: {vendor_uuid}");
+        lines.push(format!("  Vendor UUID: {vendor_uuid}"));
     }
     if let Some(metal_registry_id) = gpu.metal_registry_id.as_deref() {
-        println!("  Metal registry ID: {metal_registry_id}");
+        lines.push(format!("  Metal registry ID: {metal_registry_id}"));
     }
     if let Some(dxgi_luid) = gpu.dxgi_luid.as_deref() {
-        println!("  DXGI LUID: {dxgi_luid}");
+        lines.push(format!("  DXGI LUID: {dxgi_luid}"));
     }
     if let Some(pnp_instance_id) = gpu.pnp_instance_id.as_deref() {
-        println!("  PnP instance ID: {pnp_instance_id}");
+        lines.push(format!("  PnP instance ID: {pnp_instance_id}"));
     }
+    lines.join("\n")
 }
 
 fn format_vram(bytes: u64) -> String {
@@ -346,6 +346,46 @@ mod tests {
                 "gpus": [],
             })
         );
+    }
+
+    #[test]
+    fn human_output_formats_rocm_gpu_without_omitting_backend_details() {
+        let mut gpu = sample_gpu(0);
+        gpu.display_name = "AMD Instinct MI300X".to_string();
+        gpu.backend_device = Some("ROCm0".to_string());
+        gpu.stable_id = Some("pci:0000:65:00.0".to_string());
+        gpu.pci_bdf = Some("0000:65:00.0".to_string());
+        gpu.vendor_uuid = None;
+        gpu.mem_bandwidth_gbps = None;
+        let hw = HardwareSurvey {
+            gpus: vec![gpu],
+            ..HardwareSurvey::default()
+        };
+
+        assert_eq!(
+            format_gpus(&hw),
+            "🖥️ GPU 0\n  Name: AMD Instinct MI300X\n  Stable ID: pci:0000:65:00.0\n  Backend device: ROCm0\n  VRAM: 24 GB\n  Bandwidth: unavailable\n  Unified memory: no\n  PCI BDF: 0000:65:00.0"
+        );
+    }
+
+    #[test]
+    fn human_output_keeps_every_rocm_gpu() {
+        let mut first = sample_gpu(0);
+        first.display_name = "AMD Instinct MI300X".to_string();
+        first.backend_device = Some("ROCm0".to_string());
+        let mut second = sample_gpu(1);
+        second.display_name = "AMD Instinct MI300X".to_string();
+        second.backend_device = Some("ROCm1".to_string());
+        let hw = HardwareSurvey {
+            gpus: vec![first, second],
+            ..HardwareSurvey::default()
+        };
+
+        let output = format_gpus(&hw);
+
+        assert_eq!(output.matches("🖥️ GPU ").count(), 2);
+        assert!(output.contains("Backend device: ROCm0"));
+        assert!(output.contains("Backend device: ROCm1"));
     }
 
     #[test]

--- a/crates/mesh-llm-commands/src/gpus/tune_hardware/evaluate.rs
+++ b/crates/mesh-llm-commands/src/gpus/tune_hardware/evaluate.rs
@@ -178,7 +178,10 @@ fn resolve_backend_device<'a>(
         .iter()
         .filter(|gpu| {
             gpu.backend_device.as_deref().is_some_and(|backend_device| {
-                backend_device.eq_ignore_ascii_case(&request.requested_value)
+                mesh_llm_system::backend::backend_device_names_match(
+                    backend_device,
+                    &request.requested_value,
+                )
             })
         })
         .collect::<Vec<_>>();

--- a/crates/mesh-llm-commands/src/gpus/tune_hardware/tests/selection.rs
+++ b/crates/mesh-llm-commands/src/gpus/tune_hardware/tests/selection.rs
@@ -238,6 +238,39 @@ fn gpu_tune_falls_back_to_backend_device_for_non_pinnable_hardware_default() {
 }
 
 #[test]
+fn gpu_tune_accepts_hip_alias_for_rocm_backend_device() {
+    let config = config_with_defaults_and_model(
+        HardwareConfig {
+            device: Some("HIP0".to_string()),
+            ..HardwareConfig::default()
+        },
+        ModelConfigEntry::default(),
+    );
+    let target = sample_target(true);
+    let survey = survey_with_gpus(vec![sample_gpu(0, "uuid:AMD-abc123-def456", Some("ROCm0"))]);
+
+    let evaluation = evaluate_with_probe(
+        &config,
+        &target,
+        &survey,
+        TuneMlockProbe::Supported {
+            limit: TuneMlockLimit::Unlimited,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(
+        evaluation.evaluated_device.target,
+        TuneDeviceTarget::Gpu(TuneGpuTarget {
+            index: 0,
+            display_name: "GPU 0".to_string(),
+            stable_id: Some("uuid:AMD-abc123-def456".to_string()),
+            backend_device: Some("ROCm0".to_string()),
+        })
+    );
+}
+
+#[test]
 fn gpu_tune_backend_fallback_failure_merges_diagnostics_for_non_pinnable_hardware_default() {
     let config = config_with_defaults_and_model(
         HardwareConfig {

--- a/crates/mesh-llm-hardware-profile/src/lib.rs
+++ b/crates/mesh-llm-hardware-profile/src/lib.rs
@@ -6,6 +6,8 @@ use mesh_llm_native_runtime::{
 use std::collections::{BTreeMap, BTreeSet};
 use std::process::Command;
 
+mod rocm;
+
 pub fn host_runtime_profile() -> HostRuntimeProfile {
     let mut gpus = detect_gpus();
     apply_gpu_arch_overrides(&mut gpus);
@@ -58,20 +60,34 @@ pub fn detected_native_runtime_flavors(
 }
 
 fn detect_gpus() -> Vec<HostGpuProfile> {
-    merge_nvidia_and_fallback_gpus(detect_nvidia_gpu_profiles(), fallback_gpu_profiles())
+    merge_detected_and_fallback_gpus(
+        detect_nvidia_gpu_profiles(),
+        detect_rocm_gpu_profiles(),
+        fallback_gpu_profiles(),
+    )
 }
 
-fn merge_nvidia_and_fallback_gpus(
+fn merge_detected_and_fallback_gpus(
     mut nvidia_gpus: Vec<HostGpuProfile>,
+    mut rocm_gpus: Vec<HostGpuProfile>,
     mut fallback_gpus: Vec<HostGpuProfile>,
 ) -> Vec<HostGpuProfile> {
-    if nvidia_gpus.is_empty() {
-        return fallback_gpus;
+    if !nvidia_gpus.is_empty() {
+        fallback_gpus.retain(|gpu| !looks_like_nvidia_gpu_label(&gpu.display_name));
+    }
+    if !rocm_gpus.is_empty() {
+        fallback_gpus.retain(|gpu| !looks_like_rocm_gpu_label(&gpu.display_name));
     }
 
-    fallback_gpus.retain(|gpu| !looks_like_nvidia_gpu_label(&gpu.display_name));
+    nvidia_gpus.append(&mut rocm_gpus);
     nvidia_gpus.extend(fallback_gpus);
     nvidia_gpus
+}
+
+fn detect_rocm_gpu_profiles() -> Vec<HostGpuProfile> {
+    command_output("rocminfo", &[])
+        .map(|output| rocm::gpu_profiles_from_rocminfo(&output))
+        .unwrap_or_default()
 }
 
 fn fallback_gpu_profiles() -> Vec<HostGpuProfile> {
@@ -97,6 +113,17 @@ fn fallback_gpu_profile_from_label(label: String) -> HostGpuProfile {
 fn looks_like_nvidia_gpu_label(label: &str) -> bool {
     let label = label.to_ascii_lowercase();
     label.contains("nvidia") || label.contains("cuda")
+}
+
+fn looks_like_rocm_gpu_label(label: &str) -> bool {
+    let label = label.to_ascii_lowercase();
+    label.contains("amd")
+        || label.contains("radeon")
+        || label.contains("instinct")
+        || label.contains("rocm")
+        || label
+            .split_whitespace()
+            .any(|token| token.starts_with("gfx"))
 }
 
 fn detect_nvidia_gpu_profiles() -> Vec<HostGpuProfile> {
@@ -408,7 +435,6 @@ fn leading_major_version(value: &str) -> Option<u32> {
 
 fn gpu_labels() -> Vec<String> {
     let mut labels = Vec::new();
-    append_command_lines(&mut labels, "rocminfo", &[]);
     append_command_lines(&mut labels, "vulkaninfo", &["--summary"]);
     append_platform_gpu_labels(&mut labels);
     labels.sort();
@@ -817,7 +843,7 @@ GPU 0: NVIDIA GeForce RTX 5090 (UUID: GPU-80ded6bd-1a89-2628-3d94-902187dbab1d)
             profile("NVIDIA Corporation GB202 [GeForce RTX 5090]"),
             profile("AMD Radeon PRO W7900"),
         ];
-        let merged = merge_nvidia_and_fallback_gpus(nvidia_gpus, fallback_gpus);
+        let merged = merge_detected_and_fallback_gpus(nvidia_gpus, Vec::new(), fallback_gpus);
 
         let names = merged
             .iter()
@@ -825,6 +851,27 @@ GPU 0: NVIDIA GeForce RTX 5090 (UUID: GPU-80ded6bd-1a89-2628-3d94-902187dbab1d)
             .collect::<Vec<_>>();
         assert_eq!(names, ["NVIDIA GeForce RTX 5090", "AMD Radeon PRO W7900"]);
         assert_eq!(merged[0].cuda_sm.as_deref(), Some("120"));
+    }
+
+    #[test]
+    fn rocm_probe_results_supply_arches_and_replace_fallback_labels() {
+        let rocm_gpus = rocm::gpu_profiles_from_rocminfo(
+            "Agent 1\nName: gfx942\nMarketing Name: AMD Instinct MI300X\nDevice Type: GPU\n",
+        );
+        let fallback_gpus = vec![
+            profile("AMD Corporation Device 74a1"),
+            profile("NVIDIA GeForce RTX 4090"),
+        ];
+
+        let merged = merge_detected_and_fallback_gpus(Vec::new(), rocm_gpus, fallback_gpus);
+
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].display_name, "AMD Instinct MI300X");
+        assert_eq!(merged[0].rocm_gfx.as_deref(), Some("gfx942"));
+        assert_eq!(merged[1].display_name, "NVIDIA GeForce RTX 4090");
+
+        let rocm = detect_rocm_profile(&merged).expect("ROCm profile");
+        assert_eq!(rocm.gpu_arches, BTreeSet::from(["gfx942".to_string()]));
     }
 
     #[test]

--- a/crates/mesh-llm-hardware-profile/src/lib.rs
+++ b/crates/mesh-llm-hardware-profile/src/lib.rs
@@ -60,38 +60,20 @@ pub fn detected_native_runtime_flavors(
 }
 
 fn detect_gpus() -> Vec<HostGpuProfile> {
-    merge_detected_and_fallback_gpus(
-        detect_nvidia_gpu_profiles(),
-        detect_rocm_gpu_profiles(),
-        fallback_gpu_profiles(),
-    )
+    merge_nvidia_and_fallback_gpus(detect_nvidia_gpu_profiles(), fallback_gpu_profiles())
 }
 
-fn merge_detected_and_fallback_gpus(
+fn merge_nvidia_and_fallback_gpus(
     mut nvidia_gpus: Vec<HostGpuProfile>,
-    mut rocm_gpus: Vec<HostGpuProfile>,
     mut fallback_gpus: Vec<HostGpuProfile>,
 ) -> Vec<HostGpuProfile> {
-    if !nvidia_gpus.is_empty() {
-        fallback_gpus.retain(|gpu| !looks_like_nvidia_gpu_label(&gpu.display_name));
-    }
-    if !rocm_gpus.is_empty() {
-        fallback_gpus.retain(|fallback| {
-            !rocm_gpus
-                .iter()
-                .any(|detected| gpu_profiles_share_identity(detected, fallback))
-        });
+    if nvidia_gpus.is_empty() {
+        return fallback_gpus;
     }
 
-    nvidia_gpus.append(&mut rocm_gpus);
+    fallback_gpus.retain(|gpu| !looks_like_nvidia_gpu_label(&gpu.display_name));
     nvidia_gpus.extend(fallback_gpus);
     nvidia_gpus
-}
-
-fn detect_rocm_gpu_profiles() -> Vec<HostGpuProfile> {
-    command_output("rocminfo", &[])
-        .map(|output| rocm::gpu_profiles_from_rocminfo(&output))
-        .unwrap_or_default()
 }
 
 fn fallback_gpu_profiles() -> Vec<HostGpuProfile> {
@@ -117,21 +99,6 @@ fn fallback_gpu_profile_from_label(label: String) -> HostGpuProfile {
 fn looks_like_nvidia_gpu_label(label: &str) -> bool {
     let label = label.to_ascii_lowercase();
     label.contains("nvidia") || label.contains("cuda")
-}
-
-fn gpu_profiles_share_identity(left: &HostGpuProfile, right: &HostGpuProfile) -> bool {
-    if let (Some(left_id), Some(right_id)) = (&left.stable_id, &right.stable_id) {
-        return left_id.eq_ignore_ascii_case(right_id);
-    }
-
-    normalized_gpu_name(&left.display_name) == normalized_gpu_name(&right.display_name)
-}
-
-fn normalized_gpu_name(name: &str) -> String {
-    name.chars()
-        .filter(|ch| ch.is_ascii_alphanumeric())
-        .flat_map(char::to_lowercase)
-        .collect()
 }
 
 fn detect_nvidia_gpu_profiles() -> Vec<HostGpuProfile> {
@@ -356,7 +323,15 @@ fn detect_cuda_profile(gpus: &[HostGpuProfile]) -> Option<HostCudaProfile> {
 }
 
 fn detect_rocm_profile(gpus: &[HostGpuProfile]) -> Option<HostRocmProfile> {
+    detect_rocm_profile_with_arches(gpus, rocm::gpu_arches())
+}
+
+fn detect_rocm_profile_with_arches(
+    gpus: &[HostGpuProfile],
+    detected_arches: BTreeSet<String>,
+) -> Option<HostRocmProfile> {
     let mut gpu_arches = env_string_set("MESH_LLM_ROCM_GPU_ARCHES");
+    gpu_arches.extend(detected_arches);
     gpu_arches.extend(gpus.iter().filter_map(|gpu| gpu.rocm_gfx.clone()));
     let version = std::env::var("MESH_LLM_ROCM_VERSION").ok();
     let has_rocm_label = gpus.iter().any(|gpu| {
@@ -725,6 +700,16 @@ mod tests {
     }
 
     #[test]
+    fn kfd_architecture_evidence_enables_rocm_without_inventory_synthesis() {
+        let _rocm_arches = EnvVarGuard::clear("MESH_LLM_ROCM_GPU_ARCHES");
+
+        let profile = detect_rocm_profile_with_arches(&[], BTreeSet::from(["gfx942".to_string()]))
+            .expect("KFD architecture should enable a ROCm runtime profile");
+
+        assert_eq!(profile.gpu_arches, BTreeSet::from(["gfx942".to_string()]));
+    }
+
+    #[test]
     fn fallback_profiles_do_not_synthesize_backend_ordinals() {
         let gpu = fallback_gpu_profile_from_label("AMD Radeon PRO W7900".to_string());
 
@@ -851,7 +836,7 @@ GPU 0: NVIDIA GeForce RTX 5090 (UUID: GPU-80ded6bd-1a89-2628-3d94-902187dbab1d)
             profile("NVIDIA Corporation GB202 [GeForce RTX 5090]"),
             profile("AMD Radeon PRO W7900"),
         ];
-        let merged = merge_detected_and_fallback_gpus(nvidia_gpus, Vec::new(), fallback_gpus);
+        let merged = merge_nvidia_and_fallback_gpus(nvidia_gpus, fallback_gpus);
 
         let names = merged
             .iter()
@@ -859,29 +844,6 @@ GPU 0: NVIDIA GeForce RTX 5090 (UUID: GPU-80ded6bd-1a89-2628-3d94-902187dbab1d)
             .collect::<Vec<_>>();
         assert_eq!(names, ["NVIDIA GeForce RTX 5090", "AMD Radeon PRO W7900"]);
         assert_eq!(merged[0].cuda_sm.as_deref(), Some("120"));
-    }
-
-    #[test]
-    fn rocm_probe_results_supply_arches_and_replace_fallback_labels() {
-        let rocm_gpus = rocm::gpu_profiles_from_rocminfo(
-            "Agent 1\nName: gfx942\nMarketing Name: AMD Instinct MI300X\nDevice Type: GPU\n",
-        );
-        let fallback_gpus = vec![
-            profile("AMD Instinct MI300X"),
-            profile("AMD Radeon PRO W7900"),
-            profile("NVIDIA GeForce RTX 4090"),
-        ];
-
-        let merged = merge_detected_and_fallback_gpus(Vec::new(), rocm_gpus, fallback_gpus);
-
-        assert_eq!(merged.len(), 3);
-        assert_eq!(merged[0].display_name, "AMD Instinct MI300X");
-        assert_eq!(merged[0].rocm_gfx.as_deref(), Some("gfx942"));
-        assert_eq!(merged[1].display_name, "AMD Radeon PRO W7900");
-        assert_eq!(merged[2].display_name, "NVIDIA GeForce RTX 4090");
-
-        let rocm = detect_rocm_profile(&merged).expect("ROCm profile");
-        assert_eq!(rocm.gpu_arches, BTreeSet::from(["gfx942".to_string()]));
     }
 
     #[test]

--- a/crates/mesh-llm-hardware-profile/src/lib.rs
+++ b/crates/mesh-llm-hardware-profile/src/lib.rs
@@ -76,7 +76,11 @@ fn merge_detected_and_fallback_gpus(
         fallback_gpus.retain(|gpu| !looks_like_nvidia_gpu_label(&gpu.display_name));
     }
     if !rocm_gpus.is_empty() {
-        fallback_gpus.retain(|gpu| !looks_like_rocm_gpu_label(&gpu.display_name));
+        fallback_gpus.retain(|fallback| {
+            !rocm_gpus
+                .iter()
+                .any(|detected| gpu_profiles_share_identity(detected, fallback))
+        });
     }
 
     nvidia_gpus.append(&mut rocm_gpus);
@@ -115,15 +119,19 @@ fn looks_like_nvidia_gpu_label(label: &str) -> bool {
     label.contains("nvidia") || label.contains("cuda")
 }
 
-fn looks_like_rocm_gpu_label(label: &str) -> bool {
-    let label = label.to_ascii_lowercase();
-    label.contains("amd")
-        || label.contains("radeon")
-        || label.contains("instinct")
-        || label.contains("rocm")
-        || label
-            .split_whitespace()
-            .any(|token| token.starts_with("gfx"))
+fn gpu_profiles_share_identity(left: &HostGpuProfile, right: &HostGpuProfile) -> bool {
+    if let (Some(left_id), Some(right_id)) = (&left.stable_id, &right.stable_id) {
+        return left_id.eq_ignore_ascii_case(right_id);
+    }
+
+    normalized_gpu_name(&left.display_name) == normalized_gpu_name(&right.display_name)
+}
+
+fn normalized_gpu_name(name: &str) -> String {
+    name.chars()
+        .filter(|ch| ch.is_ascii_alphanumeric())
+        .flat_map(char::to_lowercase)
+        .collect()
 }
 
 fn detect_nvidia_gpu_profiles() -> Vec<HostGpuProfile> {
@@ -859,16 +867,18 @@ GPU 0: NVIDIA GeForce RTX 5090 (UUID: GPU-80ded6bd-1a89-2628-3d94-902187dbab1d)
             "Agent 1\nName: gfx942\nMarketing Name: AMD Instinct MI300X\nDevice Type: GPU\n",
         );
         let fallback_gpus = vec![
-            profile("AMD Corporation Device 74a1"),
+            profile("AMD Instinct MI300X"),
+            profile("AMD Radeon PRO W7900"),
             profile("NVIDIA GeForce RTX 4090"),
         ];
 
         let merged = merge_detected_and_fallback_gpus(Vec::new(), rocm_gpus, fallback_gpus);
 
-        assert_eq!(merged.len(), 2);
+        assert_eq!(merged.len(), 3);
         assert_eq!(merged[0].display_name, "AMD Instinct MI300X");
         assert_eq!(merged[0].rocm_gfx.as_deref(), Some("gfx942"));
-        assert_eq!(merged[1].display_name, "NVIDIA GeForce RTX 4090");
+        assert_eq!(merged[1].display_name, "AMD Radeon PRO W7900");
+        assert_eq!(merged[2].display_name, "NVIDIA GeForce RTX 4090");
 
         let rocm = detect_rocm_profile(&merged).expect("ROCm profile");
         assert_eq!(rocm.gpu_arches, BTreeSet::from(["gfx942".to_string()]));

--- a/crates/mesh-llm-hardware-profile/src/rocm.rs
+++ b/crates/mesh-llm-hardware-profile/src/rocm.rs
@@ -1,0 +1,135 @@
+use mesh_llm_native_runtime::HostGpuProfile;
+
+#[derive(Default)]
+struct RocmAgent {
+    name: Option<String>,
+    marketing_name: Option<String>,
+    device_type: Option<String>,
+}
+
+pub(super) fn gpu_profiles_from_rocminfo(output: &str) -> Vec<HostGpuProfile> {
+    let mut profiles = Vec::new();
+    let mut agent = RocmAgent::default();
+
+    for line in output.lines().map(str::trim) {
+        if is_agent_header(line) {
+            push_gpu_profile(&mut profiles, &mut agent);
+            continue;
+        }
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        let value = value.trim();
+        if value.is_empty() {
+            continue;
+        }
+        match key.trim().to_ascii_lowercase().as_str() {
+            "name" => agent.name = Some(value.to_string()),
+            "marketing name" => agent.marketing_name = Some(value.to_string()),
+            "device type" => agent.device_type = Some(value.to_string()),
+            _ => {}
+        }
+    }
+    push_gpu_profile(&mut profiles, &mut agent);
+
+    profiles
+}
+
+fn is_agent_header(line: &str) -> bool {
+    line.strip_prefix("Agent ")
+        .is_some_and(|index| index.trim().parse::<usize>().is_ok())
+}
+
+fn push_gpu_profile(profiles: &mut Vec<HostGpuProfile>, agent: &mut RocmAgent) {
+    let Some(gfx_arch) = agent.name.as_deref().and_then(parse_gfx_arch) else {
+        *agent = RocmAgent::default();
+        return;
+    };
+    let is_gpu = agent
+        .device_type
+        .as_deref()
+        .is_none_or(|kind| kind.eq_ignore_ascii_case("GPU"));
+    if is_gpu {
+        profiles.push(HostGpuProfile {
+            display_name: agent
+                .marketing_name
+                .take()
+                .filter(|name| !name.is_empty())
+                .unwrap_or_else(|| gfx_arch.clone()),
+            backend_device: None,
+            stable_id: None,
+            vram_bytes: None,
+            unified_memory: false,
+            probe: None,
+            cuda_sm: None,
+            rocm_gfx: Some(gfx_arch),
+        });
+    }
+    *agent = RocmAgent::default();
+}
+
+fn parse_gfx_arch(value: &str) -> Option<String> {
+    let token = value.split_whitespace().next()?;
+    let arch = token.split(':').next()?.trim().to_ascii_lowercase();
+    let suffix = arch.strip_prefix("gfx")?;
+    (!suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_alphanumeric())).then_some(arch)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_mi300x_agent_and_ignores_cpu_agent() {
+        let output = r#"
+*******
+Agent 1
+*******
+  Name:                    AMD EPYC 9654 96-Core Processor
+  Marketing Name:          AMD EPYC 9654 96-Core Processor
+  Device Type:             CPU
+*******
+Agent 2
+*******
+  Name:                    gfx942
+  Marketing Name:          AMD Instinct MI300X
+  Device Type:             GPU
+"#;
+
+        let profiles = gpu_profiles_from_rocminfo(output);
+
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].display_name, "AMD Instinct MI300X");
+        assert_eq!(profiles[0].rocm_gfx.as_deref(), Some("gfx942"));
+        assert_eq!(profiles[0].backend_device, None);
+    }
+
+    #[test]
+    fn parses_multiple_gpu_agents_and_normalizes_feature_suffixes() {
+        let output = r#"
+Agent 1
+  Name: gfx942:sramecc+:xnack-
+  Marketing Name: AMD Instinct MI300X
+  Device Type: GPU
+Agent 2
+  Name: GFX1100
+  Marketing Name: AMD Radeon RX 7900 XTX
+  Device Type: GPU
+"#;
+
+        let profiles = gpu_profiles_from_rocminfo(output);
+
+        assert_eq!(profiles.len(), 2);
+        assert_eq!(profiles[0].rocm_gfx.as_deref(), Some("gfx942"));
+        assert_eq!(profiles[1].rocm_gfx.as_deref(), Some("gfx1100"));
+    }
+
+    #[test]
+    fn uses_gfx_arch_when_marketing_name_is_unavailable() {
+        let profiles = gpu_profiles_from_rocminfo("Agent 1\n  Name: gfx1201\n");
+
+        assert_eq!(profiles.len(), 1);
+        assert_eq!(profiles[0].display_name, "gfx1201");
+        assert_eq!(profiles[0].rocm_gfx.as_deref(), Some("gfx1201"));
+    }
+}

--- a/crates/mesh-llm-hardware-profile/src/rocm.rs
+++ b/crates/mesh-llm-hardware-profile/src/rocm.rs
@@ -1,135 +1,143 @@
-use mesh_llm_native_runtime::HostGpuProfile;
+use std::collections::BTreeSet;
+#[cfg(any(target_os = "linux", test))]
+use std::path::Path;
 
-#[derive(Default)]
-struct RocmAgent {
-    name: Option<String>,
-    marketing_name: Option<String>,
-    device_type: Option<String>,
+#[cfg(target_os = "linux")]
+const KFD_TOPOLOGY_NODES: &str = "/sys/class/kfd/kfd/topology/nodes";
+
+/// Returns ROCm architecture evidence for native-runtime selection.
+///
+/// This deliberately does not construct GPU inventory. Once the selected
+/// native runtime is loaded, Skippy's backend ABI remains authoritative for
+/// device identity, ordering, memory, and runtime selectability.
+#[cfg(target_os = "linux")]
+pub(super) fn gpu_arches() -> BTreeSet<String> {
+    gpu_arches_from_topology(Path::new(KFD_TOPOLOGY_NODES))
 }
 
-pub(super) fn gpu_profiles_from_rocminfo(output: &str) -> Vec<HostGpuProfile> {
-    let mut profiles = Vec::new();
-    let mut agent = RocmAgent::default();
-
-    for line in output.lines().map(str::trim) {
-        if is_agent_header(line) {
-            push_gpu_profile(&mut profiles, &mut agent);
-            continue;
-        }
-        let Some((key, value)) = line.split_once(':') else {
-            continue;
-        };
-        let value = value.trim();
-        if value.is_empty() {
-            continue;
-        }
-        match key.trim().to_ascii_lowercase().as_str() {
-            "name" => agent.name = Some(value.to_string()),
-            "marketing name" => agent.marketing_name = Some(value.to_string()),
-            "device type" => agent.device_type = Some(value.to_string()),
-            _ => {}
-        }
-    }
-    push_gpu_profile(&mut profiles, &mut agent);
-
-    profiles
+#[cfg(not(target_os = "linux"))]
+pub(super) fn gpu_arches() -> BTreeSet<String> {
+    BTreeSet::new()
 }
 
-fn is_agent_header(line: &str) -> bool {
-    line.strip_prefix("Agent ")
-        .is_some_and(|index| index.trim().parse::<usize>().is_ok())
-}
-
-fn push_gpu_profile(profiles: &mut Vec<HostGpuProfile>, agent: &mut RocmAgent) {
-    let Some(gfx_arch) = agent.name.as_deref().and_then(parse_gfx_arch) else {
-        *agent = RocmAgent::default();
-        return;
+#[cfg(any(target_os = "linux", test))]
+fn gpu_arches_from_topology(root: &Path) -> BTreeSet<String> {
+    let Ok(nodes) = std::fs::read_dir(root) else {
+        return BTreeSet::new();
     };
-    let is_gpu = agent
-        .device_type
-        .as_deref()
-        .is_none_or(|kind| kind.eq_ignore_ascii_case("GPU"));
-    if is_gpu {
-        profiles.push(HostGpuProfile {
-            display_name: agent
-                .marketing_name
-                .take()
-                .filter(|name| !name.is_empty())
-                .unwrap_or_else(|| gfx_arch.clone()),
-            backend_device: None,
-            stable_id: None,
-            vram_bytes: None,
-            unified_memory: false,
-            probe: None,
-            cuda_sm: None,
-            rocm_gfx: Some(gfx_arch),
-        });
-    }
-    *agent = RocmAgent::default();
+
+    nodes
+        .flatten()
+        .filter_map(|entry| gfx_arch_from_kfd_node(&entry.path()))
+        .collect()
 }
 
-fn parse_gfx_arch(value: &str) -> Option<String> {
-    let token = value.split_whitespace().next()?;
-    let arch = token.split(':').next()?.trim().to_ascii_lowercase();
-    let suffix = arch.strip_prefix("gfx")?;
-    (!suffix.is_empty() && suffix.chars().all(|ch| ch.is_ascii_alphanumeric())).then_some(arch)
+#[cfg(any(target_os = "linux", test))]
+fn gfx_arch_from_kfd_node(node: &Path) -> Option<String> {
+    let gpu_id = std::fs::read_to_string(node.join("gpu_id")).ok()?;
+    if gpu_id.trim().parse::<u64>().ok()? == 0 {
+        return None;
+    }
+
+    let properties = std::fs::read_to_string(node.join("properties")).ok()?;
+    let version = property_value(&properties, "gfx_target_version")?
+        .parse()
+        .ok()?;
+    gfx_arch_from_target_version(version)
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn property_value<'a>(properties: &'a str, name: &str) -> Option<&'a str> {
+    properties.lines().find_map(|line| {
+        let mut fields = line.split_whitespace();
+        (fields.next()? == name).then(|| fields.next()).flatten()
+    })
+}
+
+#[cfg(any(target_os = "linux", test))]
+fn gfx_arch_from_target_version(version: u64) -> Option<String> {
+    if version == 0 {
+        return None;
+    }
+
+    let major = version / 10_000;
+    let minor = (version / 100) % 100;
+    let stepping = version % 100;
+    if major == 0 || minor > 0xf || stepping > 0xf {
+        return None;
+    }
+
+    Some(format!("gfx{major}{minor:x}{stepping:x}"))
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::atomic::{AtomicU64, Ordering};
 
-    #[test]
-    fn parses_mi300x_agent_and_ignores_cpu_agent() {
-        let output = r#"
-*******
-Agent 1
-*******
-  Name:                    AMD EPYC 9654 96-Core Processor
-  Marketing Name:          AMD EPYC 9654 96-Core Processor
-  Device Type:             CPU
-*******
-Agent 2
-*******
-  Name:                    gfx942
-  Marketing Name:          AMD Instinct MI300X
-  Device Type:             GPU
-"#;
+    static NEXT_FIXTURE: AtomicU64 = AtomicU64::new(0);
 
-        let profiles = gpu_profiles_from_rocminfo(output);
+    struct TopologyFixture {
+        root: std::path::PathBuf,
+    }
 
-        assert_eq!(profiles.len(), 1);
-        assert_eq!(profiles[0].display_name, "AMD Instinct MI300X");
-        assert_eq!(profiles[0].rocm_gfx.as_deref(), Some("gfx942"));
-        assert_eq!(profiles[0].backend_device, None);
+    impl TopologyFixture {
+        fn new() -> Self {
+            let suffix = NEXT_FIXTURE.fetch_add(1, Ordering::Relaxed);
+            let root = std::env::temp_dir().join(format!(
+                "mesh-llm-kfd-topology-{}-{suffix}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&root).expect("create KFD topology fixture");
+            Self { root }
+        }
+
+        fn add_node(&self, index: usize, gpu_id: u64, gfx_target_version: u64) {
+            let node = self.root.join(index.to_string());
+            std::fs::create_dir_all(&node).expect("create KFD node fixture");
+            std::fs::write(node.join("gpu_id"), format!("{gpu_id}\n"))
+                .expect("write KFD gpu_id fixture");
+            std::fs::write(
+                node.join("properties"),
+                format!(
+                    "vendor_id 4098\ndevice_id 29857\ngfx_target_version {gfx_target_version}\n"
+                ),
+            )
+            .expect("write KFD properties fixture");
+        }
+    }
+
+    impl Drop for TopologyFixture {
+        fn drop(&mut self) {
+            std::fs::remove_dir_all(&self.root).ok();
+        }
     }
 
     #[test]
-    fn parses_multiple_gpu_agents_and_normalizes_feature_suffixes() {
-        let output = r#"
-Agent 1
-  Name: gfx942:sramecc+:xnack-
-  Marketing Name: AMD Instinct MI300X
-  Device Type: GPU
-Agent 2
-  Name: GFX1100
-  Marketing Name: AMD Radeon RX 7900 XTX
-  Device Type: GPU
-"#;
+    fn discovers_gpu_arches_and_ignores_cpu_nodes() {
+        let fixture = TopologyFixture::new();
+        fixture.add_node(0, 0, 0);
+        fixture.add_node(1, 51_844, 90_402);
+        fixture.add_node(2, 74_492, 110_000);
 
-        let profiles = gpu_profiles_from_rocminfo(output);
-
-        assert_eq!(profiles.len(), 2);
-        assert_eq!(profiles[0].rocm_gfx.as_deref(), Some("gfx942"));
-        assert_eq!(profiles[1].rocm_gfx.as_deref(), Some("gfx1100"));
+        assert_eq!(
+            gpu_arches_from_topology(&fixture.root),
+            BTreeSet::from(["gfx942".to_string(), "gfx1100".to_string()])
+        );
     }
 
     #[test]
-    fn uses_gfx_arch_when_marketing_name_is_unavailable() {
-        let profiles = gpu_profiles_from_rocminfo("Agent 1\n  Name: gfx1201\n");
+    fn formats_hexadecimal_kfd_stepping() {
+        assert_eq!(
+            gfx_arch_from_target_version(90_010).as_deref(),
+            Some("gfx90a")
+        );
+    }
 
-        assert_eq!(profiles.len(), 1);
-        assert_eq!(profiles[0].display_name, "gfx1201");
-        assert_eq!(profiles[0].rocm_gfx.as_deref(), Some("gfx1201"));
+    #[test]
+    fn rejects_missing_or_malformed_kfd_versions() {
+        assert_eq!(gfx_arch_from_target_version(0), None);
+        assert_eq!(gfx_arch_from_target_version(91_600), None);
+        assert_eq!(gfx_arch_from_target_version(90_016), None);
     }
 }

--- a/crates/mesh-llm-system/src/backend.rs
+++ b/crates/mesh-llm-system/src/backend.rs
@@ -88,20 +88,11 @@ pub fn resolve_requested_device_from_available(
     requested: &str,
 ) -> Result<String> {
     if !available.is_empty() {
-        if available.iter().any(|candidate| candidate == requested) {
-            return Ok(requested.to_string());
-        }
-
-        let is_amd_requested = requested.starts_with("ROCm") || requested.starts_with("HIP");
-        if is_amd_requested {
-            let alt_device = if requested.starts_with("ROCm") {
-                requested.replace("ROCm", "HIP")
-            } else {
-                requested.replace("HIP", "ROCm")
-            };
-            if available.iter().any(|candidate| candidate == &alt_device) {
-                return Ok(alt_device);
-            }
+        if let Some(candidate) = available
+            .iter()
+            .find(|candidate| backend_device_names_match(candidate, requested))
+        {
+            return Ok(candidate.clone());
         }
 
         anyhow::bail!(
@@ -112,6 +103,60 @@ pub fn resolve_requested_device_from_available(
     }
 
     Ok(requested.to_string())
+}
+
+/// Matches backend device identifiers while treating ROCm and HIP prefixes as
+/// aliases for the same numbered AMD device.
+pub fn backend_device_names_match(left: &str, right: &str) -> bool {
+    left.eq_ignore_ascii_case(right)
+        || amd_backend_ordinal(left)
+            .zip(amd_backend_ordinal(right))
+            .is_some_and(|(left_ordinal, right_ordinal)| left_ordinal == right_ordinal)
+}
+
+fn amd_backend_ordinal(device: &str) -> Option<&str> {
+    let ordinal = if device
+        .get(..4)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("rocm"))
+    {
+        device.get(4..)?
+    } else if device
+        .get(..3)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("hip"))
+    {
+        device.get(3..)?
+    } else {
+        return None;
+    };
+
+    (!ordinal.is_empty() && ordinal.chars().all(|ch| ch.is_ascii_digit())).then_some(ordinal)
+}
+
+#[cfg(test)]
+mod backend_device_tests {
+    use super::*;
+
+    #[test]
+    fn rocm_and_hip_device_names_are_numbered_aliases() {
+        assert!(backend_device_names_match("ROCm0", "HIP0"));
+        assert!(backend_device_names_match("hip12", "rocm12"));
+        assert!(!backend_device_names_match("ROCm0", "HIP1"));
+        assert!(!backend_device_names_match("HIPster", "ROCm0"));
+    }
+
+    #[test]
+    fn requested_amd_alias_resolves_to_runtime_emitted_name() {
+        let binary = Path::new("mesh-llm");
+
+        assert_eq!(
+            resolve_requested_device_from_available(&["ROCm0".into()], binary, "HIP0").unwrap(),
+            "ROCm0"
+        );
+        assert_eq!(
+            resolve_requested_device_from_available(&["HIP1".into()], binary, "ROCm1").unwrap(),
+            "HIP1"
+        );
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]

--- a/crates/mesh-llm-system/src/hardware/skippy_devices.rs
+++ b/crates/mesh-llm-system/src/hardware/skippy_devices.rs
@@ -167,21 +167,25 @@ mod tests {
     }
 
     #[test]
-    fn hip_backend_device_is_runtime_selectable_gpu_fact() {
-        let facts = gpu_facts_from_backend_devices(vec![BackendDevice {
-            name: "HIP0".to_string(),
-            description: Some("AMD Instinct MI300X".to_string()),
-            device_id: Some("0000:65:00.0".to_string()),
-            memory_free: 200_000_000_000,
-            memory_total: 206_158_430_208,
-            device_type: BackendDeviceType::Accelerator,
-            caps: 0,
-        }]);
+    fn rocm_and_hip_backend_devices_are_runtime_selectable_gpu_facts() {
+        let facts = gpu_facts_from_backend_devices(vec![
+            BackendDevice {
+                name: "ROCm0".to_string(),
+                description: Some("AMD Instinct MI300X".to_string()),
+                device_id: Some("0000:65:00.0".to_string()),
+                memory_free: 200_000_000_000,
+                memory_total: 206_158_430_208,
+                device_type: BackendDeviceType::Accelerator,
+                caps: 0,
+            },
+            backend_device("HIP1", BackendDeviceType::Accelerator, 24_000_000_000),
+        ]);
 
-        assert_eq!(facts.len(), 1);
+        assert_eq!(facts.len(), 2);
         assert_eq!(facts[0].display_name, "AMD Instinct MI300X");
-        assert_eq!(facts[0].backend_device.as_deref(), Some("HIP0"));
+        assert_eq!(facts[0].backend_device.as_deref(), Some("ROCm0"));
         assert_eq!(facts[0].vram_bytes, 206_158_430_208);
         assert_eq!(facts[0].stable_id.as_deref(), Some("pci:0000:65:00.0"));
+        assert_eq!(facts[1].backend_device.as_deref(), Some("HIP1"));
     }
 }


### PR DESCRIPTION
## Summary

- read ROCm architecture evidence from Linux KFD topology sysfs without invoking or parsing rocminfo
- use that evidence only to select the compatible native runtime; Skippy backend ABI remains authoritative for device identity, ordering, memory, and selectability
- preserve fallback adapter labels without synthesizing GPU inventory or backend ordinals
- treat numbered `ROCmN` and `HIPN` selectors as aliases while preserving the exact runtime-emitted backend identifier in discovery and CLI output
- add regression coverage for KFD gfx target conversion, runtime selection without inventory synthesis, multi-adapter discovery, and mesh-llm gpus output

## Root cause

ROCm adapters could be present but lack the gfx architecture evidence required before the native runtime is loaded. Native-runtime resolution then rejected the ROCm artifact, loaded a CPU runtime, and the authoritative embedded backend reported no selectable GPUs.

The bootstrap probe now reads gfx_target_version from /sys/class/kfd/kfd/topology/nodes. It does not create advertised GPU records. Once the ROCm runtime is loaded, the same in-process Skippy backend enumeration used by other backends supplies the actual devices. llama.cpp currently emits numbered `ROCmN` identifiers for HIP builds; mesh-llm accepts equivalent `HIPN` selectors for compatibility but does not rename the backend-reported device.

## Validation

- cargo test -p mesh-llm-hardware-profile --lib
- cargo test -p mesh-llm-system --features skippy-devices --lib
- cargo test -p mesh-llm-commands --lib gpus::tests::
- cargo test -p mesh-llm-commands --lib gpu_tune_accepts_hip_alias_for_rocm_backend_device
- cargo check -p mesh-llm-system -p mesh-llm-commands -p mesh-llm
- cargo clippy -p mesh-llm-system -p mesh-llm-commands -p mesh-llm --all-targets -- -D warnings
- just test-all

Fixes #651


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Linux ROCm GFX-architecture discovery from KFD topology sysfs to seed GPU profile detection.
  * GPU profile detection now merges ROCm architecture evidence from environment input, discovered arches, and per-GPU overrides.

* **Bug Fixes**
  * Improved human-readable GPU listing to render consistent output as a single formatted string, including correct multi-GPU blocks and preserved identifiers.
  * Backend device resolution now treats ROCm and HIP aliases as equivalent for matching and selection; GPU tuning honors HIP aliases for ROCm backends.

* **Tests**
  * Added/updated unit tests covering ROCm architecture evidence, multi-GPU rendering output, ROCm+HIP GPU facts, and HIP alias acceptance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->