### PR TITLE
fix: record activation cache prefix identities

### DIFF
--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -1,3 +1,4 @@
+mod activation_cache;
 mod binary_kv;
 mod binary_messaging;
 mod decode_batcher;

--- a/crates/skippy-server/src/binary_transport/activation_cache.rs
+++ b/crates/skippy-server/src/binary_transport/activation_cache.rs
@@ -1,0 +1,82 @@
+use serde_json::json;
+use skippy_protocol::{StageConfig, binary::StageWireMessage};
+
+use crate::{
+    kv_integration::{KvStageIntegration, ResidentActivationRecord},
+    telemetry::Telemetry,
+};
+
+use super::binary_kv::{BinaryKvRecordResult, binary_message_kv_attrs};
+
+pub(super) fn add_binary_activation_records(
+    result: &mut BinaryKvRecordResult,
+    config: &StageConfig,
+    kv: &KvStageIntegration,
+    telemetry: &Telemetry,
+    session_id: &str,
+    message: &StageWireMessage,
+    records: &[ResidentActivationRecord],
+) {
+    for record in records {
+        accumulate_record(result, record);
+        let mut attrs =
+            binary_message_kv_attrs(config, kv, session_id, message, record.token_count);
+        attrs.insert("skippy.kv.decision".to_string(), json!("activation_record"));
+        attrs.insert(
+            "skippy.activation_cache.payload_bytes".to_string(),
+            json!(record.payload_bytes),
+        );
+        attrs.insert(
+            "skippy.activation_cache.entries".to_string(),
+            json!(record.entries),
+        );
+        attrs.insert(
+            "skippy.activation_cache.resident_bytes".to_string(),
+            json!(record.resident_bytes),
+        );
+        telemetry.emit("stage.binary_kv_record_decision", attrs);
+    }
+}
+
+fn accumulate_record(result: &mut BinaryKvRecordResult, record: &ResidentActivationRecord) {
+    result.recorded_activations = result.recorded_activations.saturating_add(1);
+    result.recorded_activation_bytes = result
+        .recorded_activation_bytes
+        .saturating_add(record.payload_bytes as u64);
+    result.evicted_activation_entries = result
+        .evicted_activation_entries
+        .saturating_add(record.evicted_entries);
+    result.evicted_activation_bytes = result
+        .evicted_activation_bytes
+        .saturating_add(record.evicted_bytes);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn activation_record(token_count: usize, payload_bytes: usize) -> ResidentActivationRecord {
+        ResidentActivationRecord {
+            page_id: format!("page-{token_count}"),
+            token_count,
+            payload_bytes,
+            evicted_entries: 1,
+            evicted_bytes: 4,
+            entries: 2,
+            resident_bytes: 16,
+        }
+    }
+
+    #[test]
+    fn binary_activation_stats_include_each_record_identity() {
+        let mut result = BinaryKvRecordResult::default();
+
+        accumulate_record(&mut result, &activation_record(2214, 8_856));
+        accumulate_record(&mut result, &activation_record(2176, 8_704));
+
+        assert_eq!(result.recorded_activations, 2);
+        assert_eq!(result.recorded_activation_bytes, 17_560);
+        assert_eq!(result.evicted_activation_entries, 2);
+        assert_eq!(result.evicted_activation_bytes, 8);
+    }
+}

--- a/crates/skippy-server/src/binary_transport/binary_kv.rs
+++ b/crates/skippy-server/src/binary_transport/binary_kv.rs
@@ -119,7 +119,7 @@ fn binary_kv_attrs(config: &StageConfig, kv: &KvStageIntegration) -> BTreeMap<St
     attrs
 }
 
-fn binary_message_kv_attrs(
+pub(super) fn binary_message_kv_attrs(
     config: &StageConfig,
     kv: &KvStageIntegration,
     session_id: &str,
@@ -671,36 +671,23 @@ pub(in crate::binary_transport) fn maybe_record_binary_prefill(
     }
     if config.downstream.is_some()
         && let Some(output) = output
-        && let Some(record) = kv.record_resident_activation(
+    {
+        let records = kv.record_resident_activation(
             config,
             &base,
             token_start,
             token_ids,
             activation_width,
             output,
-        )
-    {
-        result.recorded_activations = result.recorded_activations.saturating_add(1);
-        result.recorded_activation_bytes = result
-            .recorded_activation_bytes
-            .saturating_add(record.payload_bytes as u64);
-        result.evicted_activation_entries = result
-            .evicted_activation_entries
-            .saturating_add(record.evicted_entries);
-        result.evicted_activation_bytes = result
-            .evicted_activation_bytes
-            .saturating_add(record.evicted_bytes);
-        attrs.insert(
-            "skippy.activation_cache.recorded_page_id".to_string(),
-            json!(record.page_id),
         );
-        attrs.insert(
-            "skippy.activation_cache.entries".to_string(),
-            json!(record.entries),
-        );
-        attrs.insert(
-            "skippy.activation_cache.resident_bytes".to_string(),
-            json!(record.resident_bytes),
+        super::activation_cache::add_binary_activation_records(
+            &mut result,
+            config,
+            kv,
+            telemetry,
+            session_id,
+            message,
+            &records,
         );
     }
     attrs.insert(

--- a/crates/skippy-server/src/binary_transport/binary_messaging.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging.rs
@@ -34,6 +34,7 @@ use skippy_protocol::binary::{WireMessageKind, read_stage_message, send_ready};
 
 pub(in crate::binary_transport) mod async_forwarder;
 mod connection;
+mod prefill_recording;
 pub(in crate::binary_transport) mod reply;
 mod summary;
 mod telemetry;

--- a/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
@@ -18,7 +18,6 @@ use crate::binary_transport::binary_kv::emit_binary_proactive_eviction;
 use crate::binary_transport::binary_kv::maybe_lookup_binary_prefill;
 use crate::binary_transport::binary_kv::maybe_prefix_cache_control;
 use crate::binary_transport::binary_kv::maybe_record_binary_full_prefill;
-use crate::binary_transport::binary_kv::maybe_record_binary_prefill;
 use crate::binary_transport::direct_return;
 use crate::binary_transport::direct_return::PredictionReturnSinks;
 use crate::binary_transport::forwarded_stage_message_timed;
@@ -28,7 +27,6 @@ use crate::binary_transport::restore_prefill_decode::handle_binary_restore_prefi
 use crate::binary_transport::run_binary_stage_message;
 use crate::binary_transport::send_client_ready_hello_if_enabled;
 use crate::binary_transport::stage_execution::binary_message_attrs;
-use crate::binary_transport::stage_execution::binary_message_base;
 use crate::binary_transport::stage_execution::binary_message_session_id;
 use crate::binary_transport::stage_execution::decode_record_tokens_sideband;
 use crate::binary_transport::stage_execution::elapsed_ms;
@@ -740,56 +738,21 @@ pub(super) fn handle_binary_connection(
         }
 
         if message.kind.is_prefill() && !restored_prefill {
-            let record = if let Some(tokens) = accumulated_prefill_tokens.get(&session_key).cloned()
-            {
-                let mut runtime = runtime.lock().expect("runtime lock poisoned");
-                let mut record = maybe_record_binary_full_prefill(
-                    config,
-                    &mut runtime,
-                    kv,
-                    telemetry,
-                    &session_key,
-                    &message,
-                    &tokens,
-                );
-                drop(runtime);
-                if let Some(kv) = kv
-                    && config.downstream.is_some()
-                {
-                    let base = binary_message_base(config, &session_key, &message);
-                    let activations = kv.record_resident_activation(
-                        config,
-                        &base,
-                        0,
-                        &tokens,
-                        activation_width,
-                        &output,
-                    );
-                    crate::binary_transport::activation_cache::add_binary_activation_records(
-                        &mut record,
-                        config,
-                        kv,
-                        telemetry,
-                        &session_key,
-                        &message,
-                        &activations,
-                    );
-                }
-                record
-            } else {
-                maybe_record_binary_prefill(
-                    config,
-                    runtime,
-                    kv,
-                    telemetry,
-                    &session_key,
-                    &message,
-                    &token_ids,
-                    lookup_result.restored_tokens as u64,
-                    activation_width,
-                    Some(&output),
-                )
-            };
+            let record = super::prefill_recording::record_completed_prefill(
+                config,
+                runtime,
+                kv,
+                telemetry,
+                &session_key,
+                &message,
+                accumulated_prefill_tokens
+                    .get(&session_key)
+                    .map(Vec::as_slice),
+                &token_ids,
+                lookup_result.restored_tokens as u64,
+                activation_width,
+                &output,
+            );
             if record.recorded_pages > 0 {
                 message_reply_stats.kv_recorded_pages += record.recorded_pages as i64;
                 message_reply_stats.kv_record_stage_mask |= stage_mask(config.stage_index);

--- a/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
@@ -757,25 +757,23 @@ pub(super) fn handle_binary_connection(
                     && config.downstream.is_some()
                 {
                     let base = binary_message_base(config, &session_key, &message);
-                    if let Some(activation) = kv.record_resident_activation(
+                    let activations = kv.record_resident_activation(
                         config,
                         &base,
                         0,
                         &tokens,
                         activation_width,
                         &output,
-                    ) {
-                        record.recorded_activations = record.recorded_activations.saturating_add(1);
-                        record.recorded_activation_bytes = record
-                            .recorded_activation_bytes
-                            .saturating_add(activation.payload_bytes as u64);
-                        record.evicted_activation_entries = record
-                            .evicted_activation_entries
-                            .saturating_add(activation.evicted_entries);
-                        record.evicted_activation_bytes = record
-                            .evicted_activation_bytes
-                            .saturating_add(activation.evicted_bytes);
-                    }
+                    );
+                    crate::binary_transport::activation_cache::add_binary_activation_records(
+                        &mut record,
+                        config,
+                        kv,
+                        telemetry,
+                        &session_key,
+                        &message,
+                        &activations,
+                    );
                 }
                 record
             } else {

--- a/crates/skippy-server/src/binary_transport/binary_messaging/prefill_recording.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/prefill_recording.rs
@@ -1,0 +1,158 @@
+use std::sync::{Arc, Mutex};
+
+use skippy_protocol::{StageConfig, binary::StageWireMessage};
+use skippy_runtime::ActivationFrame;
+
+use crate::{
+    binary_transport::{
+        activation_cache::add_binary_activation_records,
+        binary_kv::{
+            BinaryKvRecordResult, maybe_record_binary_full_prefill, maybe_record_binary_prefill,
+        },
+        stage_execution::binary_message_base,
+    },
+    kv_integration::KvStageIntegration,
+    runtime_state::RuntimeState,
+    telemetry::Telemetry,
+};
+
+enum PrefillRecordPlan<'a> {
+    Full(&'a [i32]),
+    Incremental {
+        token_ids: &'a [i32],
+        restored_tokens: u64,
+    },
+}
+
+fn prefill_record_plan<'a>(
+    accumulated_tokens: Option<&'a [i32]>,
+    token_ids: &'a [i32],
+    restored_tokens: u64,
+) -> PrefillRecordPlan<'a> {
+    accumulated_tokens.map_or(
+        PrefillRecordPlan::Incremental {
+            token_ids,
+            restored_tokens,
+        },
+        PrefillRecordPlan::Full,
+    )
+}
+
+#[allow(clippy::too_many_arguments)]
+pub(super) fn record_completed_prefill(
+    config: &StageConfig,
+    runtime: &Arc<Mutex<RuntimeState>>,
+    kv: Option<&Arc<KvStageIntegration>>,
+    telemetry: &Telemetry,
+    session_id: &str,
+    message: &StageWireMessage,
+    accumulated_tokens: Option<&[i32]>,
+    token_ids: &[i32],
+    restored_tokens: u64,
+    activation_width: i32,
+    output: &ActivationFrame,
+) -> BinaryKvRecordResult {
+    match prefill_record_plan(accumulated_tokens, token_ids, restored_tokens) {
+        PrefillRecordPlan::Full(tokens) => record_full_prefill_with_activations(
+            config,
+            runtime,
+            kv,
+            telemetry,
+            session_id,
+            message,
+            tokens,
+            activation_width,
+            output,
+        ),
+        PrefillRecordPlan::Incremental {
+            token_ids,
+            restored_tokens,
+        } => maybe_record_binary_prefill(
+            config,
+            runtime,
+            kv,
+            telemetry,
+            session_id,
+            message,
+            token_ids,
+            restored_tokens,
+            activation_width,
+            Some(output),
+        ),
+    }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn record_full_prefill_with_activations(
+    config: &StageConfig,
+    runtime: &Arc<Mutex<RuntimeState>>,
+    kv: Option<&Arc<KvStageIntegration>>,
+    telemetry: &Telemetry,
+    session_id: &str,
+    message: &StageWireMessage,
+    tokens: &[i32],
+    activation_width: i32,
+    output: &ActivationFrame,
+) -> BinaryKvRecordResult {
+    let mut runtime = runtime.lock().expect("runtime lock poisoned");
+    let mut record = maybe_record_binary_full_prefill(
+        config,
+        &mut runtime,
+        kv,
+        telemetry,
+        session_id,
+        message,
+        tokens,
+    );
+    drop(runtime);
+    if let Some(kv) = kv
+        && config.downstream.is_some()
+    {
+        let base = binary_message_base(config, session_id, message);
+        let activations =
+            kv.record_resident_activation(config, &base, 0, tokens, activation_width, output);
+        add_binary_activation_records(
+            &mut record,
+            config,
+            kv,
+            telemetry,
+            session_id,
+            message,
+            &activations,
+        );
+    }
+    record
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn accumulated_prompt_takes_full_prefill_recording_path() {
+        let accumulated = [1, 2, 3, 4];
+        let message = [3, 4];
+
+        let plan = prefill_record_plan(Some(&accumulated), &message, 2);
+
+        assert!(matches!(
+            plan,
+            PrefillRecordPlan::Full(tokens) if tokens == accumulated
+        ));
+    }
+
+    #[test]
+    fn message_tokens_take_incremental_recording_path_without_accumulation() {
+        let message = [3, 4];
+
+        let plan = prefill_record_plan(None, &message, 2);
+
+        assert!(matches!(
+            plan,
+            PrefillRecordPlan::Incremental {
+                token_ids,
+                restored_tokens: 2,
+            } if token_ids == message
+        ));
+    }
+}

--- a/crates/skippy-server/src/frontend/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/prefix_cache.rs
@@ -406,7 +406,7 @@ impl StageOpenAiBackend {
                 })
                 .collect::<OpenAiResult<Vec<_>>>()?
         };
-        let activation_record = kv.record_resident_activation(
+        let activation_records = kv.record_resident_activation(
             &self.config,
             &base,
             token_start,
@@ -440,7 +440,7 @@ impl StageOpenAiBackend {
             self.telemetry
                 .emit("stage.openai_kv_record_decision", attrs);
         }
-        if let Some(record) = activation_record {
+        for record in &activation_records {
             let mut attrs = self.openai_attrs(ids);
             attrs.insert(
                 "skippy.kv.decision".to_string(),
@@ -451,10 +451,9 @@ impl StageOpenAiBackend {
                 json!(record_candidate_count),
             );
             attrs.insert("skippy.kv.token_start".to_string(), json!(token_start));
-            attrs.insert("skippy.kv.token_count".to_string(), json!(token_ids.len()));
             attrs.insert(
-                "skippy.activation_cache.recorded_page_id".to_string(),
-                json!(record.page_id),
+                "skippy.kv.token_count".to_string(),
+                json!(record.token_count),
             );
             attrs.insert(
                 "skippy.activation_cache.payload_bytes".to_string(),
@@ -462,7 +461,8 @@ impl StageOpenAiBackend {
             );
             self.telemetry
                 .emit("stage.openai_kv_record_decision", attrs);
-        } else if !recorded_any {
+        }
+        if activation_records.is_empty() && !recorded_any {
             let mut attrs = self.openai_attrs(ids);
             attrs.insert("skippy.kv.decision".to_string(), json!("stage0_record"));
             attrs.insert(

--- a/crates/skippy-server/src/kv_integration/activation.rs
+++ b/crates/skippy-server/src/kv_integration/activation.rs
@@ -16,29 +16,36 @@ impl KvStageIntegration {
         if !self.should_lookup() || token_ids.is_empty() {
             return None;
         }
-        let identity = self.prefill_identity(config, base, token_start, token_ids);
-        let page_id = activation_page_id(&identity.page_id, activation_width);
-        let lookup = self
-            .activations
-            .lock()
-            .expect("resident activation cache lock poisoned")
-            .lookup(&page_id)?;
-        let identity_token_count = identity.identity.token_count;
-        if lookup.token_count != identity_token_count
-            || u64::from(lookup.frame.desc.token_count) != identity_token_count
-            || lookup.frame.desc.payload_bytes != lookup.byte_size
-            || lookup.frame.payload.len() as u64 != lookup.byte_size
-        {
-            return None;
+        // Walk lookup candidates longest-prefix-first; the first validated
+        // cache hit is the longest activation frame reachable from this prompt.
+        for identity in self.lookup_identities(config, base, token_start, token_ids) {
+            let page_id = activation_page_id(&identity.page_id, activation_width);
+            let Some(lookup) = self
+                .activations
+                .lock()
+                .expect("resident activation cache lock poisoned")
+                .lookup(&page_id)
+            else {
+                continue;
+            };
+            let identity_token_count = identity.identity.token_count;
+            if lookup.token_count != identity_token_count
+                || u64::from(lookup.frame.desc.token_count) != identity_token_count
+                || lookup.frame.desc.payload_bytes != lookup.byte_size
+                || lookup.frame.payload.len() as u64 != lookup.byte_size
+            {
+                continue;
+            }
+            return Some(ResidentActivationRestore {
+                identity,
+                page_id,
+                token_count: lookup.token_count as usize,
+                payload_bytes: lookup.byte_size as usize,
+                entries: lookup.entries,
+                frame: lookup.frame,
+            });
         }
-        Some(ResidentActivationRestore {
-            identity,
-            page_id,
-            token_count: lookup.token_count as usize,
-            payload_bytes: lookup.byte_size as usize,
-            entries: lookup.entries,
-            frame: lookup.frame,
-        })
+        None
     }
 
     pub fn record_resident_activation(
@@ -273,10 +280,33 @@ mod tests {
                 .collect::<Vec<_>>(),
             vec![2214, 2176]
         );
-        let shared_tokens = &lookup_tokens[..2176];
         let restored = kv
-            .restore_resident_activation(&config, &test_base(), 0, shared_tokens, 4096)
-            .expect("grid-floor activation should restore by the same identity");
+            .restore_resident_activation(&config, &test_base(), 0, &lookup_tokens, 4096)
+            .expect("grid-floor activation should restore via a lookup candidate");
+        assert_eq!(restored.identity.identity.token_count, 2176);
+        assert_eq!(restored.token_count, 2176);
+        assert_eq!(restored.frame.desc.token_count, 2176);
+        assert_eq!(restored.frame.payload.len(), 2176 * 4);
+    }
+
+    #[test]
+    fn restore_hits_shared_prefix_activation_for_extended_prompt() {
+        let config = test_config();
+        let kv = KvStageIntegration::from_config(&config)
+            .unwrap()
+            .expect("resident cache enabled");
+        let recorded_tokens = (0..2214).collect::<Vec<i32>>();
+        let mut extended_lookup_tokens = recorded_tokens.clone();
+        extended_lookup_tokens.extend(100_000..100_017);
+        let frame = activation_frame(recorded_tokens.len() as u32, recorded_tokens.len() * 4);
+
+        let records =
+            kv.record_resident_activation(&config, &test_base(), 0, &recorded_tokens, 4096, &frame);
+        assert_eq!(records.len(), 2);
+
+        let restored = kv
+            .restore_resident_activation(&config, &test_base(), 0, &extended_lookup_tokens, 4096)
+            .expect("extended prompt should restore the shared grid-floor activation");
         assert_eq!(restored.identity.identity.token_count, 2176);
         assert_eq!(restored.token_count, 2176);
         assert_eq!(restored.frame.desc.token_count, 2176);

--- a/crates/skippy-server/src/kv_integration/activation.rs
+++ b/crates/skippy-server/src/kv_integration/activation.rs
@@ -1,6 +1,6 @@
 use skippy_cache::activation_page_id;
 use skippy_protocol::{MessageBase, StageConfig};
-use skippy_runtime::ActivationFrame;
+use skippy_runtime::{ActivationFrame, RuntimeActivationLayout};
 
 use super::{KvStageIntegration, ResidentActivationRecord, ResidentActivationRestore};
 
@@ -23,6 +23,14 @@ impl KvStageIntegration {
             .lock()
             .expect("resident activation cache lock poisoned")
             .lookup(&page_id)?;
+        let identity_token_count = identity.identity.token_count;
+        if lookup.token_count != identity_token_count
+            || u64::from(lookup.frame.desc.token_count) != identity_token_count
+            || lookup.frame.desc.payload_bytes != lookup.byte_size
+            || lookup.frame.payload.len() as u64 != lookup.byte_size
+        {
+            return None;
+        }
         Some(ResidentActivationRestore {
             identity,
             page_id,
@@ -41,42 +49,78 @@ impl KvStageIntegration {
         token_ids: &[i32],
         activation_width: i32,
         frame: &ActivationFrame,
-    ) -> Option<ResidentActivationRecord> {
+    ) -> Vec<ResidentActivationRecord> {
         if !self.should_record() || token_ids.is_empty() {
-            return None;
+            return Vec::new();
         }
         let token_count = token_ids.len() as u64;
         if token_count < self.candidate_policy.min_tokens || frame.payload.is_empty() {
-            return None;
+            return Vec::new();
         }
         if u64::from(frame.desc.token_count) != token_count
             || frame.desc.payload_bytes != frame.payload.len() as u64
         {
-            return None;
+            return Vec::new();
         }
-        let identity = self.prefill_identity(config, base, token_start, token_ids);
-        let page_id = activation_page_id(&identity.page_id, activation_width);
+        let identities = self.record_identities(config, base, token_start, token_ids);
         let mut cache = self
             .activations
             .lock()
             .expect("resident activation cache lock poisoned");
-        let stored = cache.record(
-            page_id.clone(),
-            token_count,
-            frame.payload.len() as u64,
-            frame.clone(),
-        );
-        let stats = cache.stats();
-        Some(ResidentActivationRecord {
-            page_id,
-            token_count: token_count as usize,
-            payload_bytes: frame.payload.len(),
-            evicted_entries: stored.evicted_entries,
-            evicted_bytes: stored.evicted_bytes,
-            entries: stats.entries,
-            resident_bytes: stats.resident_bytes,
-        })
+        identities
+            .into_iter()
+            .filter_map(|identity| {
+                let candidate_token_count = usize::try_from(identity.identity.token_count).ok()?;
+                let candidate_frame = activation_prefix_frame(frame, candidate_token_count)?;
+                let page_id = activation_page_id(&identity.page_id, activation_width);
+                let payload_bytes = candidate_frame.payload.len();
+                let stored = cache.record(
+                    page_id.clone(),
+                    identity.identity.token_count,
+                    payload_bytes as u64,
+                    candidate_frame,
+                );
+                let stats = cache.stats();
+                Some(ResidentActivationRecord {
+                    page_id,
+                    token_count: candidate_token_count,
+                    payload_bytes,
+                    evicted_entries: stored.evicted_entries,
+                    evicted_bytes: stored.evicted_bytes,
+                    entries: stats.entries,
+                    resident_bytes: stats.resident_bytes,
+                })
+            })
+            .collect()
     }
+}
+
+fn activation_prefix_frame(
+    frame: &ActivationFrame,
+    candidate_token_count: usize,
+) -> Option<ActivationFrame> {
+    let frame_token_count = usize::try_from(frame.desc.token_count).ok()?;
+    if candidate_token_count == frame_token_count {
+        return Some(frame.clone());
+    }
+    if candidate_token_count == 0
+        || candidate_token_count > frame_token_count
+        || frame.desc.layout != RuntimeActivationLayout::TokenMajor
+        || frame.desc.flags != 0
+        || !frame.payload.len().is_multiple_of(frame_token_count)
+    {
+        return None;
+    }
+    let payload_bytes = frame
+        .payload
+        .len()
+        .checked_div(frame_token_count)?
+        .checked_mul(candidate_token_count)?;
+    let mut prefix = frame.clone();
+    prefix.desc.token_count = u32::try_from(candidate_token_count).ok()?;
+    prefix.desc.payload_bytes = payload_bytes as u64;
+    prefix.payload.truncate(payload_bytes);
+    Some(prefix)
 }
 
 #[cfg(test)]
@@ -179,11 +223,11 @@ mod tests {
             .unwrap()
             .expect("resident cache enabled");
         let tokens = (0..300).collect::<Vec<_>>();
-        let frame = activation_frame(tokens.len() as u32, 64);
+        let frame = activation_frame(tokens.len() as u32, tokens.len() * 4);
 
         let record = kv.record_resident_activation(&config, &test_base(), 0, &tokens, 4096, &frame);
 
-        assert!(record.is_some());
+        assert_eq!(record.len(), 2);
         let restored = kv
             .restore_resident_activation(&config, &test_base(), 0, &tokens, 4096)
             .expect("activation frame should restore by exact identity");
@@ -201,7 +245,7 @@ mod tests {
 
         let record = kv.record_resident_activation(&config, &test_base(), 0, &tokens, 4096, &frame);
 
-        assert!(record.is_none());
+        assert!(record.is_empty());
         assert!(
             kv.restore_resident_activation(&config, &test_base(), 0, &tokens, 4096)
                 .is_none()
@@ -209,7 +253,7 @@ mod tests {
     }
 
     #[test]
-    fn resident_activation_stays_exact_for_shared_prefix_candidates() {
+    fn resident_activation_records_identity_matched_shared_prefix_frame() {
         let config = test_config();
         let kv = KvStageIntegration::from_config(&config)
             .unwrap()
@@ -217,16 +261,26 @@ mod tests {
         let recorded_tokens = (0..2214).collect::<Vec<_>>();
         let mut lookup_tokens = recorded_tokens.clone();
         lookup_tokens.extend(100_000..100_017);
-        let frame = activation_frame(recorded_tokens.len() as u32, 64);
+        let frame = activation_frame(recorded_tokens.len() as u32, recorded_tokens.len() * 4);
 
         let record =
             kv.record_resident_activation(&config, &test_base(), 0, &recorded_tokens, 4096, &frame);
 
-        assert!(record.is_some());
-        assert!(
-            kv.restore_resident_activation(&config, &test_base(), 0, &lookup_tokens, 4096)
-                .is_none()
+        assert_eq!(
+            record
+                .iter()
+                .map(|record| record.token_count)
+                .collect::<Vec<_>>(),
+            vec![2214, 2176]
         );
+        let shared_tokens = &lookup_tokens[..2176];
+        let restored = kv
+            .restore_resident_activation(&config, &test_base(), 0, shared_tokens, 4096)
+            .expect("grid-floor activation should restore by the same identity");
+        assert_eq!(restored.identity.identity.token_count, 2176);
+        assert_eq!(restored.token_count, 2176);
+        assert_eq!(restored.frame.desc.token_count, 2176);
+        assert_eq!(restored.frame.payload.len(), 2176 * 4);
     }
 
     #[test]
@@ -236,14 +290,51 @@ mod tests {
             .unwrap()
             .expect("resident cache enabled");
         let tokens = (0..300).collect::<Vec<_>>();
-        let frame = activation_frame(tokens.len() as u32, 64);
+        let frame = activation_frame(tokens.len() as u32, tokens.len() * 4);
 
         let record = kv.record_resident_activation(&config, &test_base(), 0, &tokens, 4096, &frame);
 
-        assert!(record.is_some());
+        assert_eq!(record.len(), 2);
         assert!(
             kv.restore_resident_activation(&config, &test_base(), 0, &tokens, 8192)
                 .is_none()
         );
+    }
+
+    #[test]
+    fn resident_activation_rejects_ambiguous_cached_token_count() {
+        let config = test_config();
+        let kv = KvStageIntegration::from_config(&config)
+            .unwrap()
+            .expect("resident cache enabled");
+        let tokens = (0..300).collect::<Vec<_>>();
+        let identity = kv.prefill_identity(&config, &test_base(), 0, &tokens);
+        let page_id = activation_page_id(&identity.page_id, 4096);
+        kv.activations
+            .lock()
+            .expect("resident activation cache lock poisoned")
+            .record(page_id, 256, 64, activation_frame(256, 64));
+
+        assert!(
+            kv.restore_resident_activation(&config, &test_base(), 0, &tokens, 4096)
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn resident_activation_does_not_alias_flagged_frame_to_shorter_identity() {
+        let config = test_config();
+        let kv = KvStageIntegration::from_config(&config)
+            .unwrap()
+            .expect("resident cache enabled");
+        let tokens = (0..300).collect::<Vec<_>>();
+        let mut frame = activation_frame(tokens.len() as u32, 600);
+        frame.desc.flags = 1;
+
+        let records =
+            kv.record_resident_activation(&config, &test_base(), 0, &tokens, 4096, &frame);
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].token_count, tokens.len());
     }
 }


### PR DESCRIPTION
Closes #683.

## Summary
- record every eligible prefix identity for resident activation frames
- preserve identity/frame token-count continuity and reject ambiguous cached records
- apply per-identity accounting and telemetry to chunked/full binary and OpenAI prefill paths
- extract binary activation-cache accounting into its owning module

## Validation
- `cargo test -p skippy-server --lib` (277 passed)
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `cargo test -p skippy-protocol --lib`
- `just test-all`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded activation-cache support to record/restore multiple matching activation entries.
  * Added per-entry activation-cache telemetry for binary KV decisions (including recorded and evicted metrics).
  * Centralized “completed prefill” binary KV recording for more consistent accounting.
* **Bug Fixes**
  * Strengthened activation-cache identity validation to avoid incorrect restores when token counts or payload/descriptor sizes differ.
  * Improved eligibility and shape checks to reduce ambiguous or mismatched restorations.
* **Tests**
  * Updated and expanded coverage for multi-record activation flows, restoration correctness, and rejection scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->