### PR TITLE
fix: read-only model download caches

### DIFF
--- a/crates/mesh-llm-host-runtime/src/command_support.rs
+++ b/crates/mesh-llm-host-runtime/src/command_support.rs
@@ -45,8 +45,8 @@ pub mod models {
         installed_model_display_name, installed_model_huggingface_ref,
         layered_package_layer_count_for_path, layered_package_total_bytes_for_path,
         load_model_usage_record_for_path, model_usage_cache_dir, plan_model_cleanup,
-        remote_catalog_model_draft_ref, remote_catalog_model_ref, run_update,
-        scan_installed_models, scan_installed_models_in, search_catalog_json_payload,
+        prepare_download_directories, remote_catalog_model_draft_ref, remote_catalog_model_ref,
+        run_update, scan_installed_models, scan_installed_models_in, search_catalog_json_payload,
         search_catalog_models, search_huggingface, search_huggingface_json_payload,
         show_exact_model, show_model_variants_with_progress,
     };

--- a/crates/mesh-llm-host-runtime/src/models/catalog.rs
+++ b/crates/mesh-llm-host-runtime/src/models/catalog.rs
@@ -163,8 +163,11 @@ fn ensure_cached_hf_asset(api: &hf_hub::HFClientSync, asset: &HfAsset) -> Result
         .send()
         .with_context(|| {
             format!(
-                "Cache Hugging Face asset {}/{}@{}",
-                asset.repo, asset.file, asset.revision
+                "Cache Hugging Face asset {}/{}@{}. {}",
+                asset.repo,
+                asset.file,
+                asset.revision,
+                model_hf::download_cache_diagnostic(),
             )
         })
 }
@@ -703,8 +706,11 @@ fn download_hf_assets_sync(
             Err(err) => {
                 return Err(err).with_context(|| {
                     format!(
-                        "Cache Hugging Face asset {}/{}@{}",
-                        asset.repo, asset.file, asset.revision
+                        "Cache Hugging Face asset {}/{}@{}. {}",
+                        asset.repo,
+                        asset.file,
+                        asset.revision,
+                        model_hf::download_cache_diagnostic(),
                     )
                 });
             }

--- a/crates/mesh-llm-host-runtime/src/models/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/models/mod.rs
@@ -56,6 +56,8 @@ pub use usage::{
     model_usage_cache_dir, plan_model_cleanup, track_managed_model_usage, track_model_usage,
 };
 
+pub use model_hf::{PreparedDownloadDirectories, prepare_download_directories};
+
 pub(crate) fn build_hf_api(_progress: bool) -> Result<HFClientSync> {
     let mut builder = HFClientBuilder::new().cache_dir(huggingface_hub_cache_dir());
     if let Ok(endpoint) = std::env::var("HF_ENDPOINT") {

--- a/crates/mesh-llm-node/src/models.rs
+++ b/crates/mesh-llm-node/src/models.rs
@@ -126,21 +126,7 @@ struct CatalogModel {
 }
 
 pub fn default_huggingface_cache_dir() -> PathBuf {
-    if let Some(path) = env_path("HF_HUB_CACHE").or_else(|| env_path("HUGGINGFACE_HUB_CACHE")) {
-        return path;
-    }
-    if let Some(path) = env_path("HF_HOME") {
-        return path.join("hub");
-    }
-    if let Some(path) = env_path("XDG_CACHE_HOME") {
-        return path.join("huggingface").join("hub");
-    }
-    std::env::var_os("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|| PathBuf::from("."))
-        .join(".cache")
-        .join("huggingface")
-        .join("hub")
+    model_hf::huggingface_hub_cache_dir()
 }
 
 pub fn scan_installed_models(cache_dir: impl AsRef<Path>) -> Vec<InstalledModel> {
@@ -156,12 +142,6 @@ pub fn scan_installed_models(cache_dir: impl AsRef<Path>) -> Vec<InstalledModel>
     });
     models.dedup_by(|left, right| left.model_ref == right.model_ref && left.path == right.path);
     models
-}
-
-fn env_path(name: &str) -> Option<PathBuf> {
-    let value = std::env::var_os(name)?;
-    let path = PathBuf::from(value);
-    (!path.as_os_str().is_empty()).then_some(path)
 }
 
 fn scan_dir(root: &Path, dir: &Path, models: &mut Vec<InstalledModel>) {

--- a/crates/mesh-llm/src/main.rs
+++ b/crates/mesh-llm/src/main.rs
@@ -14,6 +14,8 @@
 const DEFAULT_WORKER_STACK_SIZE: usize = 8 * 1024 * 1024;
 
 fn main() {
+    prepare_model_download_directories();
+
     let mut builder = tokio::runtime::Builder::new_multi_thread();
     builder.enable_all();
 
@@ -25,4 +27,23 @@ fn main() {
 
     let runtime = builder.build().expect("build tokio runtime");
     std::process::exit(runtime.block_on(mesh_llm::run_main()));
+}
+
+fn prepare_model_download_directories() {
+    let prepared =
+        match mesh_llm_host_runtime::command_support::models::prepare_download_directories() {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                eprintln!(
+                    "⚠ Unable to prepare model download directories: {error:#}. Model downloads may fail; set MESH_LLM_DATA_DIR to a writable directory."
+                );
+                return;
+            }
+        };
+    for fallback in &prepared.fallbacks {
+        eprintln!("⚠ {fallback}");
+    }
+    // SAFETY: This runs before the Tokio runtime is constructed, while the
+    // process is still single-threaded.
+    unsafe { prepared.apply_to_process_environment() };
 }

--- a/crates/model-hf/README.md
+++ b/crates/model-hf/README.md
@@ -36,8 +36,17 @@ HUGGING_FACE_HUB_TOKEN
 HF_HUB_CACHE
 HUGGINGFACE_HUB_CACHE
 HF_HOME
+HF_XET_CACHE
 XDG_CACHE_HOME
+MESH_LLM_DATA_DIR
 ```
+
+The shipped `mesh-llm` binary validates both the Hub destination and Xet's
+independent working cache before it starts worker threads. If either configured
+path is read-only, it selects a writable directory under the platform-local
+mesh-llm data directory (falling back to `~/.mesh-llm/data` or the system temp
+directory) and prints the rejected path, operating-system error, and selected
+replacement. `MESH_LLM_DATA_DIR` overrides the application-data fallback root.
 
 Use `HfModelRepository::builder()` to override the cache directory, endpoint, or
 token explicitly in tests and embedding applications.

--- a/crates/model-hf/src/cache_paths.rs
+++ b/crates/model-hf/src/cache_paths.rs
@@ -1,0 +1,359 @@
+use anyhow::{Result, bail};
+use std::collections::HashSet;
+use std::ffi::OsString;
+use std::fmt;
+use std::fs::OpenOptions;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+const HUB_CACHE_ENV: &str = "HF_HUB_CACHE";
+const HUB_CACHE_ALIAS_ENV: &str = "HUGGINGFACE_HUB_CACHE";
+const HF_HOME_ENV: &str = "HF_HOME";
+const XET_CACHE_ENV: &str = "HF_XET_CACHE";
+const XDG_CACHE_HOME_ENV: &str = "XDG_CACHE_HOME";
+const MESH_LLM_DATA_DIR_ENV: &str = "MESH_LLM_DATA_DIR";
+const WRITE_PROBE_PREFIX: &str = ".mesh-llm-write-probe";
+
+static WRITE_PROBE_SEQUENCE: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DownloadDirectoryKind {
+    HuggingFaceHub,
+    HuggingFaceXet,
+}
+
+impl fmt::Display for DownloadDirectoryKind {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::HuggingFaceHub => formatter.write_str("Hugging Face Hub cache"),
+            Self::HuggingFaceXet => formatter.write_str("Hugging Face Xet cache"),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DownloadDirectoryFallback {
+    pub kind: DownloadDirectoryKind,
+    pub requested: PathBuf,
+    pub selected: PathBuf,
+    pub error: String,
+    pub raw_os_error: Option<i32>,
+}
+
+impl fmt::Display for DownloadDirectoryFallback {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            formatter,
+            "{} {} is not writable ({}); using {}. Set {} or {} to choose a different writable location.",
+            self.kind,
+            self.requested.display(),
+            self.error,
+            self.selected.display(),
+            match self.kind {
+                DownloadDirectoryKind::HuggingFaceHub => HUB_CACHE_ENV,
+                DownloadDirectoryKind::HuggingFaceXet => XET_CACHE_ENV,
+            },
+            MESH_LLM_DATA_DIR_ENV,
+        )
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct PreparedDownloadDirectories {
+    pub hub_cache: PathBuf,
+    pub xet_cache: PathBuf,
+    pub fallbacks: Vec<DownloadDirectoryFallback>,
+}
+
+impl PreparedDownloadDirectories {
+    /// Apply the validated directories to the process environment.
+    ///
+    /// # Safety
+    ///
+    /// The caller must guarantee that no other threads are reading or writing
+    /// process environment variables. The shipped binary calls this before it
+    /// constructs its Tokio runtime.
+    pub unsafe fn apply_to_process_environment(&self) {
+        // SAFETY: Upheld by the caller as documented above.
+        unsafe {
+            std::env::set_var(HUB_CACHE_ENV, &self.hub_cache);
+            std::env::set_var(XET_CACHE_ENV, &self.xet_cache);
+        }
+    }
+}
+
+pub fn huggingface_hub_cache_dir() -> PathBuf {
+    requested_hub_cache_dir()
+}
+
+pub fn huggingface_xet_cache_dir() -> PathBuf {
+    requested_xet_cache_dir()
+}
+
+pub fn mesh_llm_cache_dir() -> PathBuf {
+    dirs::cache_dir()
+        .or_else(|| dirs::home_dir().map(|home| home.join(".cache")))
+        .unwrap_or_else(|| std::env::temp_dir().join("mesh-llm-cache"))
+        .join("mesh-llm")
+}
+
+pub fn prepare_download_directories() -> Result<PreparedDownloadDirectories> {
+    prepare_download_directories_in(
+        requested_hub_cache_dir(),
+        requested_xet_cache_dir(),
+        fallback_data_roots(),
+    )
+}
+
+pub fn download_cache_diagnostic() -> String {
+    download_cache_diagnostic_for(&huggingface_hub_cache_dir())
+}
+
+pub fn download_cache_diagnostic_for(hub_cache: &Path) -> String {
+    format!(
+        "Hub cache: {}; Xet cache: {}. Ensure both paths are writable, or set {} to a writable application-data directory",
+        hub_cache.display(),
+        huggingface_xet_cache_dir().display(),
+        MESH_LLM_DATA_DIR_ENV,
+    )
+}
+
+fn requested_hub_cache_dir() -> PathBuf {
+    env_path(HUB_CACHE_ENV)
+        .or_else(|| env_path(HUB_CACHE_ALIAS_ENV))
+        .or_else(|| env_path(HF_HOME_ENV).map(|path| path.join("hub")))
+        .or_else(|| env_path(XDG_CACHE_HOME_ENV).map(|path| path.join("huggingface").join("hub")))
+        .or_else(|| dirs::cache_dir().map(|path| path.join("huggingface").join("hub")))
+        .unwrap_or_else(|| default_data_root().join("huggingface").join("hub"))
+}
+
+fn requested_xet_cache_dir() -> PathBuf {
+    env_path(XET_CACHE_ENV)
+        .or_else(|| env_path(HF_HOME_ENV).map(|path| path.join("xet")))
+        .or_else(|| env_path(XDG_CACHE_HOME_ENV).map(|path| path.join("huggingface").join("xet")))
+        .or_else(|| dirs::cache_dir().map(|path| path.join("huggingface").join("xet")))
+        .unwrap_or_else(|| default_data_root().join("huggingface").join("xet"))
+}
+
+fn env_path(key: &str) -> Option<PathBuf> {
+    let value = std::env::var_os(key)?;
+    nonempty_path(value)
+}
+
+fn nonempty_path(value: OsString) -> Option<PathBuf> {
+    if value.to_str().is_some_and(|value| value.trim().is_empty()) {
+        return None;
+    }
+    let path = PathBuf::from(value);
+    (!path.as_os_str().is_empty()).then_some(path)
+}
+
+fn default_data_root() -> PathBuf {
+    env_path(MESH_LLM_DATA_DIR_ENV)
+        .or_else(|| dirs::data_local_dir().map(|path| path.join("mesh-llm")))
+        .or_else(|| dirs::home_dir().map(|path| path.join(".mesh-llm").join("data")))
+        .unwrap_or_else(|| std::env::temp_dir().join("mesh-llm-data"))
+}
+
+fn fallback_data_roots() -> Vec<PathBuf> {
+    let mut roots = Vec::new();
+    if let Some(path) = env_path(MESH_LLM_DATA_DIR_ENV) {
+        roots.push(path);
+    }
+    if let Some(path) = dirs::data_local_dir() {
+        roots.push(path.join("mesh-llm"));
+    }
+    if let Some(path) = dirs::home_dir() {
+        roots.push(path.join(".mesh-llm").join("data"));
+    }
+    roots.push(std::env::temp_dir().join("mesh-llm-data"));
+    deduplicate_paths(roots)
+}
+
+fn deduplicate_paths(paths: Vec<PathBuf>) -> Vec<PathBuf> {
+    let mut seen = HashSet::new();
+    paths
+        .into_iter()
+        .filter(|path| seen.insert(path.clone()))
+        .collect()
+}
+
+fn prepare_download_directories_in(
+    requested_hub: PathBuf,
+    requested_xet: PathBuf,
+    fallback_roots: Vec<PathBuf>,
+) -> Result<PreparedDownloadDirectories> {
+    let (hub_cache, hub_fallback) = prepare_directory(
+        DownloadDirectoryKind::HuggingFaceHub,
+        requested_hub,
+        fallback_roots
+            .iter()
+            .map(|root| root.join("huggingface").join("hub")),
+    )?;
+    let (xet_cache, xet_fallback) = prepare_directory(
+        DownloadDirectoryKind::HuggingFaceXet,
+        requested_xet,
+        fallback_roots
+            .iter()
+            .map(|root| root.join("huggingface").join("xet")),
+    )?;
+    let fallbacks = hub_fallback.into_iter().chain(xet_fallback).collect();
+    Ok(PreparedDownloadDirectories {
+        hub_cache,
+        xet_cache,
+        fallbacks,
+    })
+}
+
+fn prepare_directory(
+    kind: DownloadDirectoryKind,
+    requested: PathBuf,
+    fallbacks: impl IntoIterator<Item = PathBuf>,
+) -> Result<(PathBuf, Option<DownloadDirectoryFallback>)> {
+    let requested_error = match probe_writable_directory(&requested) {
+        Ok(()) => return Ok((requested, None)),
+        Err(error) => error,
+    };
+    let mut attempts = vec![format!("{}: {}", requested.display(), requested_error)];
+    for fallback in deduplicate_paths(fallbacks.into_iter().collect()) {
+        if fallback == requested {
+            continue;
+        }
+        match probe_writable_directory(&fallback) {
+            Ok(()) => {
+                return Ok((
+                    fallback.clone(),
+                    Some(DownloadDirectoryFallback {
+                        kind,
+                        requested,
+                        selected: fallback,
+                        error: requested_error.to_string(),
+                        raw_os_error: requested_error.raw_os_error(),
+                    }),
+                ));
+            }
+            Err(error) => attempts.push(format!("{}: {}", fallback.display(), error)),
+        }
+    }
+    bail!(
+        "no writable {kind} directory was available; tried {}",
+        attempts.join("; ")
+    )
+}
+
+fn probe_writable_directory(path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir_all(path)?;
+    let sequence = WRITE_PROBE_SEQUENCE.fetch_add(1, Ordering::Relaxed);
+    let probe = path.join(format!(
+        "{WRITE_PROBE_PREFIX}-{}-{sequence}",
+        std::process::id()
+    ));
+    let mut file = OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&probe)?;
+    file.write_all(b"mesh-llm")?;
+    drop(file);
+    std::fs::remove_file(&probe)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn writable_requested_directories_are_preserved() {
+        let temp = tempfile::tempdir().unwrap();
+        let hub = temp.path().join("requested-hub");
+        let xet = temp.path().join("requested-xet");
+
+        let prepared = prepare_download_directories_in(
+            hub.clone(),
+            xet.clone(),
+            vec![temp.path().join("fallback")],
+        )
+        .unwrap();
+
+        assert_eq!(prepared.hub_cache, hub);
+        assert_eq!(prepared.xet_cache, xet);
+        assert!(prepared.fallbacks.is_empty());
+    }
+
+    #[test]
+    fn non_directory_cache_path_uses_writable_data_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let blocked_parent = temp.path().join("not-a-directory");
+        std::fs::write(&blocked_parent, b"file").unwrap();
+        let fallback = temp.path().join("data");
+
+        let prepared = prepare_download_directories_in(
+            blocked_parent.join("hub"),
+            blocked_parent.join("xet"),
+            vec![fallback.clone()],
+        )
+        .unwrap();
+
+        assert_eq!(prepared.hub_cache, fallback.join("huggingface").join("hub"));
+        assert_eq!(prepared.xet_cache, fallback.join("huggingface").join("xet"));
+        assert_eq!(prepared.fallbacks.len(), 2);
+        assert!(
+            prepared
+                .fallbacks
+                .iter()
+                .all(|warning| !warning.error.is_empty())
+        );
+    }
+
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    #[test]
+    fn operating_system_read_only_directory_uses_writable_fallback() {
+        let temp = tempfile::tempdir().unwrap();
+        let read_only_root = if cfg!(target_os = "macos") {
+            PathBuf::from("/System")
+        } else {
+            PathBuf::from("/sys")
+        };
+        let requested_hub = read_only_root.join("mesh-llm-issue-980").join("hub");
+        let writable_xet = temp.path().join("xet");
+
+        let prepared = prepare_download_directories_in(
+            requested_hub.clone(),
+            writable_xet.clone(),
+            vec![temp.path().join("data")],
+        )
+        .unwrap();
+
+        assert_ne!(prepared.hub_cache, requested_hub);
+        assert_eq!(prepared.xet_cache, writable_xet);
+        assert_eq!(prepared.fallbacks.len(), 1);
+        let warning = &prepared.fallbacks[0];
+        assert!(matches!(
+            warning.raw_os_error,
+            Some(30) | Some(13) | Some(1)
+        ));
+    }
+
+    #[test]
+    fn empty_environment_path_is_ignored() {
+        assert_eq!(nonempty_path(OsString::new()), None);
+        assert_eq!(nonempty_path(OsString::from("   ")), None);
+    }
+
+    #[test]
+    fn read_only_filesystem_warning_includes_os_error_and_recovery_path() {
+        let warning = DownloadDirectoryFallback {
+            kind: DownloadDirectoryKind::HuggingFaceXet,
+            requested: PathBuf::from("/"),
+            selected: PathBuf::from("/writable/data/huggingface/xet"),
+            error: std::io::Error::from_raw_os_error(30).to_string(),
+            raw_os_error: Some(30),
+        };
+
+        let message = warning.to_string();
+        assert!(message.contains("Read-only file system"));
+        assert!(message.contains("/writable/data/huggingface/xet"));
+        assert!(message.contains("HF_XET_CACHE"));
+        assert!(message.contains("MESH_LLM_DATA_DIR"));
+    }
+}

--- a/crates/model-hf/src/lib.rs
+++ b/crates/model-hf/src/lib.rs
@@ -1,4 +1,11 @@
+mod cache_paths;
 pub mod store;
+
+pub use cache_paths::{
+    DownloadDirectoryFallback, DownloadDirectoryKind, PreparedDownloadDirectories,
+    download_cache_diagnostic, download_cache_diagnostic_for, huggingface_hub_cache_dir,
+    huggingface_xet_cache_dir, mesh_llm_cache_dir, prepare_download_directories,
+};
 
 use std::{
     ffi::OsStr,
@@ -51,7 +58,12 @@ impl HfModelRepository {
             .revision(revision.to_string())
             .send()
             .await
-            .with_context(|| format!("download Hugging Face model file {repo}@{revision}/{file}"))
+            .with_context(|| {
+                format!(
+                    "download Hugging Face model file {repo}@{revision}/{file}. {}",
+                    download_cache_diagnostic_for(&self.cache_dir)
+                )
+            })
     }
 
     pub async fn download_artifact_files(
@@ -215,27 +227,6 @@ impl HfModelIdentity {
             format!("{}@{}/{}", self.repo_id, self.revision, distribution_id)
         })
     }
-}
-
-pub fn huggingface_hub_cache_dir() -> PathBuf {
-    if let Some(path) = env_path("HF_HUB_CACHE") {
-        return path;
-    }
-    if let Some(path) = env_path("HUGGINGFACE_HUB_CACHE") {
-        return path;
-    }
-    if let Some(path) = env_path("HF_HOME") {
-        return path.join("hub");
-    }
-    if let Some(path) = env_path("XDG_CACHE_HOME") {
-        return path.join("huggingface").join("hub");
-    }
-    std::env::var("HOME")
-        .map(PathBuf::from)
-        .unwrap_or_else(|_| PathBuf::from("."))
-        .join(".cache")
-        .join("huggingface")
-        .join("hub")
 }
 
 pub fn hf_token_override() -> Option<String> {
@@ -446,12 +437,6 @@ fn parse_model_repo_folder_name(folder: &str) -> Option<String> {
 
 fn repo_parts(repo: &str) -> (&str, &str) {
     repo.split_once('/').unwrap_or(("", repo))
-}
-
-fn env_path(key: &str) -> Option<PathBuf> {
-    let value = std::env::var(key).ok()?;
-    let trimmed = value.trim();
-    (!trimmed.is_empty()).then(|| PathBuf::from(trimmed))
 }
 
 fn env_usize(key: &str) -> Option<usize> {

--- a/crates/model-hf/src/store/local.rs
+++ b/crates/model-hf/src/store/local.rs
@@ -88,45 +88,12 @@ fn distribution_ref_file(file: &str) -> String {
         .replace('\\', "/")
 }
 
-fn hf_hub_cache_override() -> Option<PathBuf> {
-    let path = std::env::var("HF_HUB_CACHE")
-        .ok()
-        .or_else(|| std::env::var("HUGGINGFACE_HUB_CACHE").ok())?;
-    let trimmed = path.trim();
-    if trimmed.is_empty() {
-        None
-    } else {
-        Some(PathBuf::from(trimmed))
-    }
-}
-
 pub fn huggingface_hub_cache() -> PathBuf {
-    if let Some(path) = hf_hub_cache_override() {
-        path
-    } else {
-        if let Ok(path) = std::env::var("HF_HOME") {
-            let trimmed = path.trim();
-            if !trimmed.is_empty() {
-                return PathBuf::from(trimmed).join("hub");
-            }
-        }
-        if let Ok(path) = std::env::var("XDG_CACHE_HOME") {
-            let trimmed = path.trim();
-            if !trimmed.is_empty() {
-                return PathBuf::from(trimmed).join("huggingface").join("hub");
-            }
-        }
-        std::env::var("HOME")
-            .map(PathBuf::from)
-            .unwrap_or_else(|_| PathBuf::from("."))
-            .join(".cache")
-            .join("huggingface")
-            .join("hub")
-    }
+    crate::huggingface_hub_cache_dir()
 }
 
 pub fn huggingface_hub_cache_dir() -> PathBuf {
-    huggingface_hub_cache()
+    crate::huggingface_hub_cache_dir()
 }
 
 pub fn huggingface_repo_folder_name(repo_id: &str, repo_type: impl RepoType) -> String {
@@ -179,13 +146,7 @@ fn cache_repo_id(repo: &CachedRepoInfo) -> Option<&str> {
 }
 
 pub fn mesh_llm_cache_dir() -> PathBuf {
-    dirs::cache_dir()
-        .unwrap_or_else(|| {
-            dirs::home_dir()
-                .unwrap_or_else(|| PathBuf::from("."))
-                .join(".cache")
-        })
-        .join("mesh-llm")
+    crate::mesh_llm_cache_dir()
 }
 
 pub fn model_metadata_cache_dir() -> PathBuf {

--- a/crates/skippy-bench/src/main.rs
+++ b/crates/skippy-bench/src/main.rs
@@ -26,7 +26,26 @@ use crate::{
     verify_window_local::verify_window_local,
 };
 
+fn prepare_model_download_directories() {
+    let prepared = match model_hf::prepare_download_directories() {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            eprintln!(
+                "⚠ Unable to prepare model download directories: {error:#}. \
+                 Model downloads may fail; set MESH_LLM_DATA_DIR to a writable directory."
+            );
+            return;
+        }
+    };
+    for fallback in &prepared.fallbacks {
+        eprintln!("⚠ {fallback}");
+    }
+    // SAFETY: runs before any Tokio runtime, process is single-threaded.
+    unsafe { prepared.apply_to_process_environment() };
+}
+
 fn main() -> Result<()> {
+    prepare_model_download_directories();
     match Cli::parse().command {
         CommandKind::LocalSingle(args) => local_single(args),
         CommandKind::LocalSplitInprocess(args) => local_split_inprocess(args),

--- a/crates/skippy-correctness/src/main.rs
+++ b/crates/skippy-correctness/src/main.rs
@@ -15,7 +15,26 @@ use crate::{
     runner::{chain, dtype_matrix, single_step, split_scan, state_handoff},
 };
 
+fn prepare_model_download_directories() {
+    let prepared = match model_hf::prepare_download_directories() {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            eprintln!(
+                "⚠ Unable to prepare model download directories: {error:#}. \
+                 Model downloads may fail; set MESH_LLM_DATA_DIR to a writable directory."
+            );
+            return;
+        }
+    };
+    for fallback in &prepared.fallbacks {
+        eprintln!("⚠ {fallback}");
+    }
+    // SAFETY: runs before any Tokio runtime, process is single-threaded.
+    unsafe { prepared.apply_to_process_environment() };
+}
+
 fn main() -> Result<()> {
+    prepare_model_download_directories();
     match Cli::parse().command {
         CommandKind::SingleStep(args) => single_step(args),
         CommandKind::Chain(args) => chain(args),

--- a/crates/skippy-model-package/src/main.rs
+++ b/crates/skippy-model-package/src/main.rs
@@ -20,7 +20,26 @@ mod write;
 use cli::{Args, Command};
 use package::{ArtifactHook, ExplicitSourceIdentity};
 
+fn prepare_model_download_directories() {
+    let prepared = match model_hf::prepare_download_directories() {
+        Ok(prepared) => prepared,
+        Err(error) => {
+            eprintln!(
+                "⚠ Unable to prepare model download directories: {error:#}. \
+                 Model downloads may fail; set MESH_LLM_DATA_DIR to a writable directory."
+            );
+            return;
+        }
+    };
+    for fallback in &prepared.fallbacks {
+        eprintln!("⚠ {fallback}");
+    }
+    // SAFETY: runs before any Tokio runtime, process is single-threaded.
+    unsafe { prepared.apply_to_process_environment() };
+}
+
 fn main() -> Result<()> {
+    prepare_model_download_directories();
     let args = Args::parse();
     match args.command {
         Command::Inspect { model } => inspect::inspect(model),

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -334,6 +334,13 @@ Switches:
 - `--direct`: download the exact Hugging Face GGUF file directly, bypassing catalog layer-package resolution.
 - `--json`: machine-readable output.
 
+Before downloading, mesh-llm checks both the Hugging Face Hub destination and
+the separate Xet working cache. A configured path that is read-only is replaced
+with a writable mesh-llm data directory, and the warning reports the rejected
+path, operating-system error, and selected replacement. Set
+`MESH_LLM_DATA_DIR` to choose the fallback root, or set `HF_HUB_CACHE` and
+`HF_XET_CACHE` independently when both locations should be explicit.
+
 ### `models package`
 
 Use this to plan or submit a Hugging Face Job that splits a source GGUF into a

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -892,6 +892,12 @@ mesh-llm models prune
 - Skippy materialized stage GGUFs are derived cache and can be preview-pruned
   with `mesh-llm models prune`.
 
+Model downloads validate the Hugging Face Hub cache and Xet working cache
+before worker threads start. If either location is read-only, mesh-llm warns
+with the original operating-system error and uses a writable application-data
+directory instead. `MESH_LLM_DATA_DIR` chooses that fallback root;
+`HF_HUB_CACHE` and `HF_XET_CACHE` configure the two caches directly.
+
 ## Inspect local GPUs
 
 ```bash


### PR DESCRIPTION
## Summary

- validate both Hugging Face Hub and Xet cache directories before worker threads start
- fall back to a writable mesh-llm application-data directory with clear diagnostics when configured paths are read-only
- centralize cache selection across download and inventory paths and document the relevant overrides
- add filesystem edge-case coverage, including real OS-protected paths and os error 30 diagnostics

## Testing

- cargo test -p model-hf --lib
- cargo test -p mesh-llm-node --lib
- cargo test -p mesh-llm-host-runtime --lib models::catalog::tests
- cargo check/clippy for model-hf, mesh-llm-node, and mesh-llm
- just build
- read-only Hub/Xet binary smoke test
- just test-all

Closes #980

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Model downloads now pre-resolve and validate Hugging Face Hub and Xet cache paths at startup (before worker threads begin).
  - If a configured cache destination is read-only/unusable, mesh-llm falls back to writable mesh-llm data locations and emits warnings with the rejected path and OS error.
  - Cache locations are configurable via `HF_HUB_CACHE` / `HF_XET_CACHE`, with `MESH_LLM_DATA_DIR` controlling the fallback root.
- **Bug Fixes**
  - Download failures now include more detailed cache-location diagnostics.
- **Documentation**
  - Updated CLI and usage docs to reflect pre-download validation, warning behavior, and cache configuration/fallback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->