### PR TITLE
fix: support ROCm RDNA APU kernels safely

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -474,8 +474,8 @@ jobs:
       image: rocm/dev-ubuntu-24.04:7.0-complete
     env:
       LLAMA_STAGE_BACKEND: rocm
-      LLAMA_STAGE_AMDGPU_TARGETS: gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201
-      LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-dynamic-rocm-gfx90a_gfx942_gfx1100_gfx1101_gfx1102_gfx1200_gfx1201
+      LLAMA_STAGE_AMDGPU_TARGETS: gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201
+      LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-dynamic-rocm-gfx90a_gfx942_gfx1100_gfx1101_gfx1102_gfx1103_gfx1151_gfx1200_gfx1201
       MESH_NATIVE_RUNTIME_TARGET: x86_64-unknown-linux-gnu
     steps:
       - name: Install base packages
@@ -503,7 +503,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.LLAMA_STAGE_BUILD_DIR }}
-          key: ${{ env.CACHE_NAMESPACE }}-release-llama-linux-x86_64-rocm7.0-dynamic-gfx90a_gfx942_gfx1100_gfx1101_gfx1102_gfx1200_gfx1201-${{ hashFiles('scripts/build-llama.sh', 'scripts/prepare-llama.sh', 'scripts/package-native-runtime.sh', 'third_party/llama.cpp/upstream.txt', 'third_party/llama.cpp/patches/**', '.github/cache-version.txt') }}
+          key: ${{ env.CACHE_NAMESPACE }}-release-llama-linux-x86_64-rocm7.0-dynamic-gfx90a_gfx942_gfx1100_gfx1101_gfx1102_gfx1103_gfx1151_gfx1200_gfx1201-${{ hashFiles('scripts/build-llama.sh', 'scripts/prepare-llama.sh', 'scripts/package-native-runtime.sh', 'third_party/llama.cpp/upstream.txt', 'third_party/llama.cpp/patches/**', '.github/cache-version.txt') }}
       - name: Prepare dispatched release version
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -898,8 +898,8 @@ jobs:
       image: rocm/dev-ubuntu-24.04:7.0-complete
     env:
       LLAMA_STAGE_BACKEND: rocm
-      LLAMA_STAGE_AMDGPU_TARGETS: gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201
-      LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-rocm-gfx90a_gfx942_gfx1100_gfx1101_gfx1102_gfx1200_gfx1201
+      LLAMA_STAGE_AMDGPU_TARGETS: gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201
+      LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-rocm-gfx90a_gfx942_gfx1100_gfx1101_gfx1102_gfx1103_gfx1151_gfx1200_gfx1201
     steps:
       - name: Install base packages
         run: |
@@ -934,7 +934,7 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{ env.LLAMA_STAGE_BUILD_DIR }}
-          key: ${{ env.CACHE_NAMESPACE }}-release-llama-linux-x86_64-rocm7.0-static-gfx90a_gfx942_gfx1100_gfx1101_gfx1102_gfx1200_gfx1201-${{ hashFiles('scripts/build-linux.sh', 'scripts/build-linux-rocm.sh', 'scripts/build-llama.sh', 'scripts/prepare-llama.sh', 'Justfile', 'third_party/llama.cpp/upstream.txt', 'third_party/llama.cpp/patches/**', '.github/cache-version.txt') }}
+          key: ${{ env.CACHE_NAMESPACE }}-release-llama-linux-x86_64-rocm7.0-static-gfx90a_gfx942_gfx1100_gfx1101_gfx1102_gfx1103_gfx1151_gfx1200_gfx1201-${{ hashFiles('scripts/build-linux.sh', 'scripts/build-linux-rocm.sh', 'scripts/build-llama.sh', 'scripts/prepare-llama.sh', 'Justfile', 'third_party/llama.cpp/upstream.txt', 'third_party/llama.cpp/patches/**', '.github/cache-version.txt') }}
       - name: Prepare dispatched release version
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -1224,7 +1224,7 @@ jobs:
             artifact_name: release-native-runtime-windows-x86_64-cuda12
           - name: ROCm
             backend: rocm
-            rocm_architectures: gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201
+            rocm_architectures: gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201
             artifact_name: release-native-runtime-windows-x86_64-rocm
           - name: Vulkan
             backend: vulkan

--- a/Justfile
+++ b/Justfile
@@ -184,10 +184,10 @@ release-build-cuda-windows cuda_arch="75;80;86;87;89;90":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cuda -CudaArch "{{cuda_arch}}" -BuildProfile release
 
 # Build a Linux ROCm ABI release artifact with an explicit architecture list.
-release-build-rocm rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201":
+release-build-rocm rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201":
     @MESH_LLM_BUILD_PROFILE=release scripts/build-linux-rocm.sh "{{ rocm_arch }}"
 
-release-build-rocm-windows rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1200;gfx1201":
+release-build-rocm-windows rocm_arch="gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend rocm -RocmArch "{{rocm_arch}}" -BuildProfile release
 
 # Build a Linux Vulkan ABI release artifact.

--- a/crates/mesh-llm-native-runtime/src/resolver.rs
+++ b/crates/mesh-llm-native-runtime/src/resolver.rs
@@ -433,11 +433,10 @@ fn evaluate_rocm_requirements(
     // HIP release artifacts contain architecture-specific code objects and do
     // not have a portable kernel fallback. Accepting a partial match can leave
     // an enumerated GPU with no launchable kernels, which faults at inference.
-    if !requirements.gpu_arches.is_empty()
-        && rocm
-            .gpu_arches
-            .iter()
-            .any(|arch| !requirements.gpu_arches.contains(arch))
+    if rocm
+        .gpu_arches
+        .iter()
+        .any(|arch| !requirements.gpu_arches.contains(arch))
     {
         reasons.push(CandidateRejection::RocmGpuArchUnsupported {
             supported: requirements.gpu_arches.clone(),
@@ -660,6 +659,34 @@ mod tests {
                     "meshllm-runtime-linux-x86_64-rocm",
                     &["gfx1100", "gfx1101", "gfx1102"],
                 ),
+            ],
+        };
+
+        let selected = select_native_runtime(
+            &manifest,
+            &rocm_profile(&["gfx1103"]),
+            "0.68.0",
+            &RuntimeSelection::Recommended,
+        )
+        .expect("CPU runtime should remain a safe fallback");
+
+        assert_eq!(
+            selected.artifact.backend.kind,
+            NativeRuntimeBackendKind::Cpu
+        );
+    }
+
+    #[test]
+    fn rocm_runtime_without_packaged_arches_falls_back_to_cpu() {
+        let manifest = NativeRuntimeReleaseManifest {
+            mesh_version: "0.68.0".to_string(),
+            skippy_abi: "0.1.25".to_string(),
+            artifacts: vec![
+                artifact(
+                    "meshllm-runtime-linux-x86_64-cpu",
+                    NativeRuntimeBackend::cpu(),
+                ),
+                rocm_runtime("meshllm-runtime-linux-x86_64-rocm", &[]),
             ],
         };
 

--- a/crates/mesh-llm-native-runtime/src/resolver.rs
+++ b/crates/mesh-llm-native-runtime/src/resolver.rs
@@ -430,11 +430,14 @@ fn evaluate_rocm_requirements(
         reasons.push(CandidateRejection::RocmProfileMissing);
         return;
     };
+    // HIP release artifacts contain architecture-specific code objects and do
+    // not have a portable kernel fallback. Accepting a partial match can leave
+    // an enumerated GPU with no launchable kernels, which faults at inference.
     if !requirements.gpu_arches.is_empty()
-        && requirements
+        && rocm
             .gpu_arches
             .iter()
-            .all(|arch| !rocm.gpu_arches.contains(arch))
+            .any(|arch| !requirements.gpu_arches.contains(arch))
     {
         reasons.push(CandidateRejection::RocmGpuArchUnsupported {
             supported: requirements.gpu_arches.clone(),
@@ -492,8 +495,8 @@ fn compare_candidates(left: &&CandidateEvaluation, right: &&CandidateEvaluation)
 mod tests {
     use super::*;
     use crate::{
-        CudaRuntimeRequirements, HostCudaProfile, HostRuntimeProfile, NativeRuntimeBackend,
-        NativeRuntimeManifest, NativeRuntimePlatform,
+        CudaRuntimeRequirements, HostCudaProfile, HostRocmProfile, HostRuntimeProfile,
+        NativeRuntimeBackend, NativeRuntimeManifest, NativeRuntimePlatform,
     };
 
     fn artifact(id: &str, backend: NativeRuntimeBackend) -> NativeRuntimeArtifact {
@@ -548,6 +551,28 @@ mod tests {
                 rocm: None,
                 vulkan: None,
             },
+        )
+    }
+
+    fn rocm_profile(arches: &[&str]) -> HostRuntimeProfile {
+        HostRuntimeProfile {
+            available_flavors: BTreeSet::from([
+                NativeRuntimeBackendKind::Cpu,
+                NativeRuntimeBackendKind::Rocm,
+            ]),
+            cuda: None,
+            rocm: Some(HostRocmProfile {
+                version: Some("7.0".to_string()),
+                gpu_arches: arches.iter().map(|value| value.to_string()).collect(),
+            }),
+            ..profile()
+        }
+    }
+
+    fn rocm_runtime(id: &str, arches: &[&str]) -> NativeRuntimeArtifact {
+        artifact(
+            id,
+            NativeRuntimeBackend::rocm(arches.iter().map(|value| value.to_string()).collect()),
         )
     }
 
@@ -618,6 +643,85 @@ mod tests {
                 &RuntimeSelection::Recommended
             )
             .is_none()
+        );
+    }
+
+    #[test]
+    fn unsupported_rocm_apu_arch_falls_back_to_cpu() {
+        let manifest = NativeRuntimeReleaseManifest {
+            mesh_version: "0.68.0".to_string(),
+            skippy_abi: "0.1.25".to_string(),
+            artifacts: vec![
+                artifact(
+                    "meshllm-runtime-linux-x86_64-cpu",
+                    NativeRuntimeBackend::cpu(),
+                ),
+                rocm_runtime(
+                    "meshllm-runtime-linux-x86_64-rocm",
+                    &["gfx1100", "gfx1101", "gfx1102"],
+                ),
+            ],
+        };
+
+        let selected = select_native_runtime(
+            &manifest,
+            &rocm_profile(&["gfx1103"]),
+            "0.68.0",
+            &RuntimeSelection::Recommended,
+        )
+        .expect("CPU runtime should remain a safe fallback");
+
+        assert_eq!(
+            selected.artifact.backend.kind,
+            NativeRuntimeBackendKind::Cpu
+        );
+    }
+
+    #[test]
+    fn rocm_runtime_requires_complete_detected_arch_coverage() {
+        let manifest = NativeRuntimeReleaseManifest {
+            mesh_version: "0.68.0".to_string(),
+            skippy_abi: "0.1.25".to_string(),
+            artifacts: vec![rocm_runtime(
+                "meshllm-runtime-linux-x86_64-rocm",
+                &["gfx1100"],
+            )],
+        };
+
+        assert!(
+            select_native_runtime(
+                &manifest,
+                &rocm_profile(&["gfx1100", "gfx1151"]),
+                "0.68.0",
+                &RuntimeSelection::Recommended,
+            )
+            .is_none(),
+            "a partial match could expose the unsupported GPU to a kernel launch"
+        );
+    }
+
+    #[test]
+    fn rocm_runtime_accepts_rdna_apu_arches_when_both_are_packaged() {
+        let manifest = NativeRuntimeReleaseManifest {
+            mesh_version: "0.68.0".to_string(),
+            skippy_abi: "0.1.25".to_string(),
+            artifacts: vec![rocm_runtime(
+                "meshllm-runtime-linux-x86_64-rocm",
+                &["gfx1100", "gfx1103", "gfx1151"],
+            )],
+        };
+
+        let selected = select_native_runtime(
+            &manifest,
+            &rocm_profile(&["gfx1103", "gfx1151"]),
+            "0.68.0",
+            &RuntimeSelection::Recommended,
+        )
+        .expect("packaged RDNA APU kernels should make ROCm safe to select");
+
+        assert_eq!(
+            selected.artifact.backend.kind,
+            NativeRuntimeBackendKind::Rocm
         );
     }
 


### PR DESCRIPTION
## Summary

- package ROCm native runtimes with gfx1103 (Phoenix) and gfx1151 (Strix Halo) code objects on Linux and Windows
- reject ROCm artifacts unless they cover every detected host ROCm architecture, allowing recommended selection to fall back safely instead of reaching a missing-kernel launch
- cover unsupported APU fallback, mixed partial architecture sets, and fully supported RDNA APU selection with resolver regression tests

This PR is stacked on #1039 because its KFD topology probing supplies the architecture evidence used by native runtime selection.

## Validation

- cargo test -p mesh-llm-native-runtime --lib
- cargo test -p mesh-llm-hardware-profile --lib
- cargo check/clippy for mesh-llm-native-runtime, mesh-llm-hardware-profile, and mesh-llm
- cargo fmt --all -- --check
- ROCm release recipe dry-runs and release workflow validation
- just test-all

Closes #966

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded ROCm GPU architecture coverage for Linux and Windows release builds, enabling support for a wider range of AMD GPUs.

* **Bug Fixes**
  * Improved ROCm runtime compatibility checks to only select ROCm when the packaged GPU architectures fully cover what the host reports.
  * When ROCm isn’t fully compatible, the system now avoids choosing an incompatible runtime and falls back appropriately (or yields no compatible ROCm candidate).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->