### PR TITLE
test: validate MI300 runtime selection and placement

### DIFF
--- a/crates/mesh-llm-hardware-profile/src/lib.rs
+++ b/crates/mesh-llm-hardware-profile/src/lib.rs
@@ -323,17 +323,21 @@ fn detect_cuda_profile(gpus: &[HostGpuProfile]) -> Option<HostCudaProfile> {
 }
 
 fn detect_rocm_profile(gpus: &[HostGpuProfile]) -> Option<HostRocmProfile> {
-    detect_rocm_profile_with_arches(gpus, rocm::gpu_arches())
+    let mut gpu_arches = env_string_set("MESH_LLM_ROCM_GPU_ARCHES");
+    gpu_arches.extend(rocm::gpu_arches());
+    detect_rocm_profile_with_arches(
+        gpus,
+        gpu_arches,
+        std::env::var("MESH_LLM_ROCM_VERSION").ok(),
+    )
 }
 
 fn detect_rocm_profile_with_arches(
     gpus: &[HostGpuProfile],
-    detected_arches: BTreeSet<String>,
+    mut gpu_arches: BTreeSet<String>,
+    version: Option<String>,
 ) -> Option<HostRocmProfile> {
-    let mut gpu_arches = env_string_set("MESH_LLM_ROCM_GPU_ARCHES");
-    gpu_arches.extend(detected_arches);
     gpu_arches.extend(gpus.iter().filter_map(|gpu| gpu.rocm_gfx.clone()));
-    let version = std::env::var("MESH_LLM_ROCM_VERSION").ok();
     let has_rocm_label = gpus.iter().any(|gpu| {
         let label = gpu.display_name.to_ascii_lowercase();
         label.contains("amd") || label.contains("radeon") || label.contains("rocm")
@@ -701,10 +705,9 @@ mod tests {
 
     #[test]
     fn kfd_architecture_evidence_enables_rocm_without_inventory_synthesis() {
-        let _rocm_arches = EnvVarGuard::clear("MESH_LLM_ROCM_GPU_ARCHES");
-
-        let profile = detect_rocm_profile_with_arches(&[], BTreeSet::from(["gfx942".to_string()]))
-            .expect("KFD architecture should enable a ROCm runtime profile");
+        let profile =
+            detect_rocm_profile_with_arches(&[], BTreeSet::from(["gfx942".to_string()]), None)
+                .expect("KFD architecture should enable a ROCm runtime profile");
 
         assert_eq!(profile.gpu_arches, BTreeSet::from(["gfx942".to_string()]));
     }
@@ -716,9 +719,9 @@ mod tests {
             select_native_runtime_from_artifacts,
         };
 
-        let _rocm_arches = EnvVarGuard::clear("MESH_LLM_ROCM_GPU_ARCHES");
-        let rocm = detect_rocm_profile_with_arches(&[], BTreeSet::from(["gfx942".to_string()]))
-            .expect("MI300X KFD evidence should produce a ROCm profile");
+        let rocm =
+            detect_rocm_profile_with_arches(&[], BTreeSet::from(["gfx942".to_string()]), None)
+                .expect("MI300X KFD evidence should produce a ROCm profile");
         let runtime_profile = HostRuntimeProfile {
             os: "linux".to_string(),
             arch: "x86_64".to_string(),

--- a/crates/mesh-llm-hardware-profile/src/lib.rs
+++ b/crates/mesh-llm-hardware-profile/src/lib.rs
@@ -710,6 +710,65 @@ mod tests {
     }
 
     #[test]
+    fn mi300x_kfd_evidence_selects_rocm_over_cpu_runtime() {
+        use mesh_llm_native_runtime::{
+            NativeRuntimeArtifact, NativeRuntimeBackend, NativeRuntimePlatform, RuntimeSelection,
+            select_native_runtime_from_artifacts,
+        };
+
+        let _rocm_arches = EnvVarGuard::clear("MESH_LLM_ROCM_GPU_ARCHES");
+        let rocm = detect_rocm_profile_with_arches(&[], BTreeSet::from(["gfx942".to_string()]))
+            .expect("MI300X KFD evidence should produce a ROCm profile");
+        let runtime_profile = HostRuntimeProfile {
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            target_triple: None,
+            available_flavors: detected_native_runtime_flavors(&[], None, Some(&rocm), None),
+            gpus: Vec::new(),
+            cuda: None,
+            rocm: Some(rocm),
+            vulkan: None,
+        };
+        let artifact = |id: &str, backend: NativeRuntimeBackend| NativeRuntimeArtifact {
+            id: id.to_string(),
+            mesh_version: Some("test".to_string()),
+            skippy_abi: "test-abi".to_string(),
+            platform: NativeRuntimePlatform {
+                os: "linux".to_string(),
+                arch: "x86_64".to_string(),
+                target: None,
+            },
+            backend,
+            rank: 0,
+            libraries: vec!["lib/libmeshllm_ffi.so".to_string()],
+            url: None,
+            sha256: None,
+            signature: None,
+        };
+        let artifacts = vec![
+            artifact("runtime-cpu", NativeRuntimeBackend::cpu()),
+            artifact(
+                "runtime-rocm",
+                NativeRuntimeBackend::rocm(vec!["gfx942".to_string()]),
+            ),
+        ];
+
+        let selected = select_native_runtime_from_artifacts(
+            &artifacts,
+            &runtime_profile,
+            "test",
+            Some("test-abi"),
+            &RuntimeSelection::Recommended,
+        )
+        .expect("MI300X should select the compatible ROCm runtime");
+
+        assert_eq!(
+            selected.artifact.backend.kind,
+            NativeRuntimeBackendKind::Rocm
+        );
+    }
+
+    #[test]
     fn fallback_profiles_do_not_synthesize_backend_ordinals() {
         let gpu = fallback_gpu_profile_from_label("AMD Radeon PRO W7900".to_string());
 

--- a/crates/mesh-llm-host-runtime/src/runtime/split_planning.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/split_planning.rs
@@ -734,6 +734,39 @@ mod tests {
     }
 
     #[test]
+    fn resource_planner_assigns_mi300x_a_capacity_weighted_share() {
+        const GIB: u64 = 1024 * 1024 * 1024;
+        let mi300x = participant(1, 192 * GIB);
+        let smaller_accelerator = participant(2, 48 * GIB);
+        let participants = vec![mi300x, smaller_accelerator];
+        let package = package(100, 200 * GIB);
+
+        let plan = plan_runtime_slice_topology_with_resources(
+            "mi300x-topology-test",
+            "unsloth/Qwen3.5-122B-A10B-MTP-GGUF:UD-Q8_K_XL",
+            &package,
+            &participants,
+            &[],
+            SplitTopologyResourceInputs {
+                native_context_length: 1,
+                kv_bytes_per_token: 1,
+                ctx_size_override: Some(1),
+                parallel_override: Some(1),
+            },
+        )
+        .expect("MI300X and smaller accelerator should form a valid topology");
+
+        assert_eq!(plan.stages.len(), 2);
+        assert_eq!(plan.stages[0].node_id, mi300x.node_id);
+        assert_eq!(plan.stages[1].node_id, smaller_accelerator.node_id);
+        assert!(
+            plan.stages[0].parameter_bytes >= plan.stages[1].parameter_bytes * 3,
+            "the 192 GiB MI300X should receive most of the model weight: {:?}",
+            plan.stages
+        );
+    }
+
+    #[test]
     fn resource_planner_prefers_lower_tpot_stage_count_from_participant_rtt() {
         // Node VRAM is sized so the 40GB model fits on two nodes at the minimum
         // context (65536) but needs three at the native context (262144), so


### PR DESCRIPTION
## Summary

- add a regression test proving MI300X `gfx942` KFD evidence selects a compatible ROCm native runtime instead of the CPU fallback
- add a planner regression test proving a 192 GiB MI300X receives the capacity-weighted majority of a large model split
- document through executable coverage that the under-utilization in #653 is fixed by the ROCm bootstrap work in #1039, without adding a device-name-specific scheduling heuristic

## Root cause

The issue logs show every model buffer allocated as `CPU_Mapped`, while the MI300X (`1002:74b5`) remained idle. Runtime artifact selection occurred before authoritative HIP enumeration. Without early ROCm architecture evidence, release builds could select the CPU native runtime, after which no placement decision could use the GPU. #1039 discovers `gfx_target_version` from KFD topology first (`90402` → `gfx942`) so the ROCm runtime is loaded. Once that capability is present, the existing resource planner already weights placement by available accelerator memory.

This PR is intentionally stacked on #1039 and adds the MI300-specific end-to-end decision coverage requested by #653.

## Validation

- `cargo test -p mesh-llm-hardware-profile --lib`
- `cargo test -p mesh-llm-host-runtime runtime::split_planning::tests --lib`
- `cargo check -p mesh-llm-hardware-profile -p mesh-llm-host-runtime -p mesh-llm`
- `cargo clippy -p mesh-llm-hardware-profile -p mesh-llm-host-runtime -p mesh-llm --all-targets -- -D warnings`
- `just test-all`

Depends on #1039. Validates the MI300 path reported in #653.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage confirming ROCm is selected when MI300X hardware evidence is detected and no alternative accelerator runtimes are available.
  * Added coverage verifying resource-aware model splitting assigns proportionally more model data to higher-capacity MI300X hardware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->