### PR TITLE
fix: Windows Vulkan runtime dependencies

### DIFF
--- a/.github/actions/compute-changes/action.yml
+++ b/.github/actions/compute-changes/action.yml
@@ -288,7 +288,7 @@ runs:
         WINDOWS_GPU_BUILD_REQUIRED="false"
         if [[ -n "$CHANGED_FILES" ]]; then
           WINDOWS_CPU_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^crates/mesh-llm-nodejs/|^crates/skippy-ffi/|^scripts/build-windows\.ps1$|^third_party/llama\.cpp/|^Cargo\.toml$|^Cargo\.lock$|^\.github/cache-version\.txt$)' || true)
-          WINDOWS_GPU_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^crates/skippy-ffi/|^scripts/(build-windows|install-windows-sdk)\.ps1$|^scripts/(package-native-runtime|verify-native-runtime-package)\.sh$|^scripts/windows-native-runtime-deps\.py$|^scripts/tests/test_windows_native_runtime_deps\.py$|^third_party/llama\.cpp/|^\.github/cache-version\.txt$|^\.github/actions/setup-windows-rocm-sdk/)' || true)
+          WINDOWS_GPU_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^crates/skippy-ffi/|^scripts/(build-windows|install-windows-sdk)\.ps1$|^scripts/(package-native-runtime|verify-native-runtime-package)\.sh$|^scripts/windows-native-runtime-deps\.py$|^scripts/tests/test_windows_native_runtime_deps\.py$|^third_party/llama\.cpp/|^\.github/cache-version\.txt$|^\.github/actions/(compute-changes/action\.yml$|setup-windows-rocm-sdk/))' || true)
           if [[ -n "$WINDOWS_CPU_INPUTS" ]] || [[ "$BACKEND_RECIPE_CHANGED" == "true" ]]; then
             WINDOWS_CPU_BUILD_REQUIRED="true"
           fi

--- a/.github/actions/compute-changes/action.yml
+++ b/.github/actions/compute-changes/action.yml
@@ -288,7 +288,7 @@ runs:
         WINDOWS_GPU_BUILD_REQUIRED="false"
         if [[ -n "$CHANGED_FILES" ]]; then
           WINDOWS_CPU_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^crates/mesh-llm-nodejs/|^crates/skippy-ffi/|^scripts/build-windows\.ps1$|^third_party/llama\.cpp/|^Cargo\.toml$|^Cargo\.lock$|^\.github/cache-version\.txt$)' || true)
-          WINDOWS_GPU_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^crates/skippy-ffi/|^scripts/build-windows\.ps1$|^scripts/install-windows-sdk\.ps1$|^third_party/llama\.cpp/|^\.github/cache-version\.txt$|^\.github/actions/setup-windows-rocm-sdk/)' || true)
+          WINDOWS_GPU_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^crates/skippy-ffi/|^scripts/(build-windows|install-windows-sdk)\.ps1$|^scripts/(package-native-runtime|verify-native-runtime-package)\.sh$|^scripts/windows-native-runtime-deps\.py$|^scripts/tests/test_windows_native_runtime_deps\.py$|^third_party/llama\.cpp/|^\.github/cache-version\.txt$|^\.github/actions/setup-windows-rocm-sdk/)' || true)
           if [[ -n "$WINDOWS_CPU_INPUTS" ]] || [[ "$BACKEND_RECIPE_CHANGED" == "true" ]]; then
             WINDOWS_CPU_BUILD_REQUIRED="true"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,7 @@ jobs:
               - '.github/cache-version.txt'
               - '.github/workflows/ci.yml'
               - '.github/workflows/smoke.yml'
+              - '.github/actions/compute-changes/action.yml'
 
             ui:
               - 'crates/mesh-llm-ui/**'
@@ -148,6 +149,7 @@ jobs:
               - 'Justfile'
               - '.github/cache-version.txt'
               - '.github/actions/setup-windows-rocm-sdk/**'
+              - '.github/actions/compute-changes/action.yml'
               - '.github/workflows/ci.yml'
               - '.github/workflows/windows-warm-caches.yml'
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,6 +140,10 @@ jobs:
               - 'crates/skippy-ffi/**'
               - 'scripts/build-windows.ps1'
               - 'scripts/install-windows-sdk.ps1'
+              - 'scripts/package-native-runtime.sh'
+              - 'scripts/verify-native-runtime-package.sh'
+              - 'scripts/windows-native-runtime-deps.py'
+              - 'scripts/tests/test_windows_native_runtime_deps.py'
               - 'third_party/llama.cpp/**'
               - 'Justfile'
               - '.github/cache-version.txt'
@@ -1092,6 +1096,14 @@ jobs:
         if: ${{ env.RUN_WINDOWS_GPU == 'true' }}
         with:
           persist-credentials: false
+      - uses: actions/setup-python@v6
+        if: ${{ env.RUN_WINDOWS_GPU == 'true' && matrix.backend == 'vulkan' }}
+        with:
+          python-version: '3.x'
+      - name: Test Windows native-runtime dependency resolver
+        if: ${{ env.RUN_WINDOWS_GPU == 'true' && matrix.backend == 'vulkan' }}
+        shell: pwsh
+        run: python -m unittest scripts.tests.test_windows_native_runtime_deps -v
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ env.RUN_WINDOWS_GPU == 'true' }}
       - uses: taiki-e/install-action@just

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -123,6 +123,10 @@ jobs:
               - 'crates/skippy-ffi/**'
               - 'scripts/build-windows.ps1'
               - 'scripts/install-windows-sdk.ps1'
+              - 'scripts/package-native-runtime.sh'
+              - 'scripts/verify-native-runtime-package.sh'
+              - 'scripts/windows-native-runtime-deps.py'
+              - 'scripts/tests/test_windows_native_runtime_deps.py'
               - 'third_party/llama.cpp/**'
               - '.github/cache-version.txt'
               - '.github/actions/setup-windows-rocm-sdk/**'
@@ -1026,6 +1030,14 @@ jobs:
         run: Write-Host "Skipping Windows ${{ matrix.name }} because this change does not touch Windows GPU build inputs."
       - uses: actions/checkout@v5
         if: ${{ matrix.backend == 'cpu' || env.RUN_WINDOWS_GPU == 'true' }}
+      - uses: actions/setup-python@v6
+        if: ${{ env.RUN_WINDOWS_GPU == 'true' && matrix.backend == 'vulkan' }}
+        with:
+          python-version: '3.x'
+      - name: Test Windows native-runtime dependency resolver
+        if: ${{ env.RUN_WINDOWS_GPU == 'true' && matrix.backend == 'vulkan' }}
+        shell: pwsh
+        run: python -m unittest scripts.tests.test_windows_native_runtime_deps -v
       - uses: dtolnay/rust-toolchain@stable
         if: ${{ matrix.backend == 'cpu' || env.RUN_WINDOWS_GPU == 'true' }}
       - uses: taiki-e/install-action@just

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -119,18 +119,6 @@ jobs:
               - 'Cargo.toml'
               - 'Cargo.lock'
               - '.github/cache-version.txt'
-            windows_gpu:
-              - 'crates/skippy-ffi/**'
-              - 'scripts/build-windows.ps1'
-              - 'scripts/install-windows-sdk.ps1'
-              - 'scripts/package-native-runtime.sh'
-              - 'scripts/verify-native-runtime-package.sh'
-              - 'scripts/windows-native-runtime-deps.py'
-              - 'scripts/tests/test_windows_native_runtime_deps.py'
-              - 'third_party/llama.cpp/**'
-              - '.github/cache-version.txt'
-              - '.github/actions/setup-windows-rocm-sdk/**'
-
             docs:
               - 'docs/**'
               - '**.md'

--- a/crates/mesh-llm-system/src/hardware/skippy_devices.rs
+++ b/crates/mesh-llm-system/src/hardware/skippy_devices.rs
@@ -188,4 +188,23 @@ mod tests {
         assert_eq!(facts[0].stable_id.as_deref(), Some("pci:0000:65:00.0"));
         assert_eq!(facts[1].backend_device.as_deref(), Some("HIP1"));
     }
+
+    #[test]
+    fn vulkan_backend_device_is_runtime_selectable_gpu_fact() {
+        let facts = gpu_facts_from_backend_devices(vec![BackendDevice {
+            name: "Vulkan0".to_string(),
+            description: Some("AMD Radeon RX 9070 XT".to_string()),
+            device_id: Some("0000:03:00.0".to_string()),
+            memory_free: 15_000_000_000,
+            memory_total: 17_179_869_184,
+            device_type: BackendDeviceType::Gpu,
+            caps: 0,
+        }]);
+
+        assert_eq!(facts.len(), 1);
+        assert_eq!(facts[0].display_name, "AMD Radeon RX 9070 XT");
+        assert_eq!(facts[0].backend_device.as_deref(), Some("Vulkan0"));
+        assert_eq!(facts[0].vram_bytes, 17_179_869_184);
+        assert_eq!(facts[0].stable_id.as_deref(), Some("pci:0000:03:00.0"));
+    }
 }

--- a/crates/skippy-ffi/src/dynamic_library.rs
+++ b/crates/skippy-ffi/src/dynamic_library.rs
@@ -1,0 +1,18 @@
+use libloading::Library;
+use std::path::Path;
+
+#[cfg(target_os = "windows")]
+pub(crate) unsafe fn load(path: &Path) -> Result<Library, libloading::Error> {
+    use libloading::os::windows::{LOAD_WITH_ALTERED_SEARCH_PATH, Library as WindowsLibrary};
+
+    // LoadLibraryExW normally searches the application directory for a
+    // dependent DLL, even when the requested DLL has an absolute path. Native
+    // runtimes are installed elsewhere, so make the loaded DLL's directory the
+    // first dependency search location.
+    unsafe { WindowsLibrary::load_with_flags(path, LOAD_WITH_ALTERED_SEARCH_PATH) }.map(Into::into)
+}
+
+#[cfg(not(target_os = "windows"))]
+pub(crate) unsafe fn load(path: &Path) -> Result<Library, libloading::Error> {
+    unsafe { Library::new(path) }
+}

--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -7,6 +7,9 @@ pub const FEATURE_NATIVE_MTP_N1: u64 = 1 << 25;
 pub const FEATURE_NGRAM_SIMPLE_DRAFT: u64 = 1 << 26;
 pub const FEATURE_NGRAM_CACHE_DRAFT: u64 = 1 << 27;
 
+#[cfg(feature = "dynamic-runtime")]
+mod dynamic_library;
+
 #[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct AbiVersion {
@@ -752,7 +755,7 @@ mod dynamic {
                     let mut libraries = Vec::with_capacity(paths.len());
                     for path in paths {
                         libraries.push(
-                            unsafe { Library::new(path.as_ref()) }
+                            unsafe { crate::dynamic_library::load(path.as_ref()) }
                                 .map_err(|err| NativeRuntimeLoadError::Load(err.to_string()))?,
                         );
                     }

--- a/scripts/package-native-runtime.sh
+++ b/scripts/package-native-runtime.sh
@@ -376,6 +376,25 @@ for library in "${runtime_libraries[@]}"; do
     library_paths+=("lib/$name")
 done
 
+if [[ "$runtime_os" == "windows" && "$BACKEND" == "vulkan" ]]; then
+    dependency_args=()
+    for library in "${runtime_libraries[@]}"; do
+        dependency_args+=(--search-dir "$(dirname "$library")")
+    done
+    "$(python_bin)" "$SCRIPT_DIR/windows-native-runtime-deps.py" collect \
+        --lib-dir "$stage_dir/lib" \
+        "${dependency_args[@]}"
+
+    library_paths=()
+    while IFS= read -r library; do
+        name="$(basename "$library")"
+        if [[ "$name" != "$primary_name" ]]; then
+            library_paths+=("lib/$name")
+        fi
+    done < <(find "$stage_dir/lib" -maxdepth 1 -type f -name '*.dll' | sort)
+    library_paths+=("lib/$primary_name")
+fi
+
 rewrite_macos_runtime_paths
 rewrite_linux_runtime_paths
 

--- a/scripts/tests/test_windows_native_runtime_deps.py
+++ b/scripts/tests/test_windows_native_runtime_deps.py
@@ -1,0 +1,121 @@
+import importlib.util
+import json
+import pathlib
+import struct
+import subprocess
+import tempfile
+import unittest
+
+
+SCRIPT = pathlib.Path(__file__).parents[1] / "windows-native-runtime-deps.py"
+VERIFY_SCRIPT = pathlib.Path(__file__).parents[1] / "verify-native-runtime-package.sh"
+SPEC = importlib.util.spec_from_file_location("windows_native_runtime_deps", SCRIPT)
+DEPS = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader is not None
+SPEC.loader.exec_module(DEPS)
+
+
+def write_pe(path: pathlib.Path, imports: list[str]) -> None:
+    data = bytearray(0x800)
+    data[:2] = b"MZ"
+    struct.pack_into("<I", data, 0x3C, 0x80)
+    data[0x80:0x84] = b"PE\0\0"
+    struct.pack_into("<HHIIIHH", data, 0x84, 0x8664, 1, 0, 0, 0, 0xF0, 0)
+    optional = 0x98
+    struct.pack_into("<H", data, optional, 0x20B)
+    struct.pack_into("<II", data, optional + 120, 0x1000, (len(imports) + 1) * 20)
+    section = optional + 0xF0
+    data[section : section + 8] = b".rdata\0\0"
+    struct.pack_into("<IIII", data, section + 8, 0x500, 0x1000, 0x500, 0x200)
+    name_offset = 0x300
+    for index, name in enumerate(imports):
+        descriptor = 0x200 + index * 20
+        name_rva = 0x1000 + name_offset - 0x200
+        struct.pack_into("<IIIII", data, descriptor, 0, 0, 0, name_rva, 0)
+        encoded = name.encode("ascii") + b"\0"
+        data[name_offset : name_offset + len(encoded)] = encoded
+        name_offset += len(encoded)
+    path.write_bytes(data)
+
+
+class WindowsNativeRuntimeDepsTests(unittest.TestCase):
+    def test_reads_pe_import_table(self):
+        with tempfile.TemporaryDirectory() as directory:
+            library = pathlib.Path(directory) / "ggml-vulkan.dll"
+            write_pe(library, ["KERNEL32.dll", "libstdc++-6.dll"])
+
+            self.assertEqual(
+                DEPS.imported_dlls(library), ["KERNEL32.dll", "libstdc++-6.dll"]
+            )
+
+    def test_collects_mingw_dependency_closure(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = pathlib.Path(directory)
+            lib_dir = root / "artifact" / "lib"
+            search_dir = root / "sdk" / "Bin"
+            lib_dir.mkdir(parents=True)
+            search_dir.mkdir(parents=True)
+            write_pe(
+                lib_dir / "ggml-vulkan.dll",
+                ["vulkan-1.dll", "libstdc++-6.dll", "libwinpthread-1.dll"],
+            )
+            write_pe(
+                search_dir / "libstdc++-6.dll",
+                ["KERNEL32.dll", "libgcc_s_seh-1.dll"],
+            )
+            write_pe(search_dir / "libwinpthread-1.dll", ["KERNEL32.dll"])
+            write_pe(search_dir / "libgcc_s_seh-1.dll", ["KERNEL32.dll"])
+
+            copied = DEPS.collect_dependencies(lib_dir, [search_dir])
+
+            self.assertEqual(
+                {path.name for path in copied},
+                {"libgcc_s_seh-1.dll", "libstdc++-6.dll", "libwinpthread-1.dll"},
+            )
+            DEPS.verify_dependencies(lib_dir)
+
+    def test_verification_rejects_missing_non_system_dependency(self):
+        with tempfile.TemporaryDirectory() as directory:
+            lib_dir = pathlib.Path(directory)
+            write_pe(lib_dir / "ggml-vulkan.dll", ["libstdc++-6.dll"])
+
+            with self.assertRaisesRegex(RuntimeError, "libstdc\\+\\+-6.dll"):
+                DEPS.verify_dependencies(lib_dir)
+
+    def test_package_verifier_accepts_closed_windows_dependency_graph(self):
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = pathlib.Path(directory) / "meshllm-native-runtime-windows-x86_64-vulkan"
+            lib_dir = artifact / "lib"
+            lib_dir.mkdir(parents=True)
+            write_pe(lib_dir / "ggml-vulkan.dll", ["vulkan-1.dll", "libstdc++-6.dll"])
+            write_pe(lib_dir / "libstdc++-6.dll", ["KERNEL32.dll"])
+            write_pe(lib_dir / "llama.dll", ["ggml-vulkan.dll"])
+            manifest = {
+                "runtime": {
+                    "id": artifact.name,
+                    "mesh_version": "0.72.1",
+                    "skippy_abi": "0.1.32",
+                    "platform": {"os": "windows", "arch": "x86_64"},
+                    "backend": {"kind": "vulkan"},
+                    "libraries": [
+                        "lib/ggml-vulkan.dll",
+                        "lib/libstdc++-6.dll",
+                        "lib/llama.dll",
+                    ],
+                }
+            }
+            (artifact / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+
+            result = subprocess.run(
+                ["bash", str(VERIFY_SCRIPT), str(artifact)],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("verified native runtime artifact", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_windows_native_runtime_deps.py
+++ b/scripts/tests/test_windows_native_runtime_deps.py
@@ -107,7 +107,7 @@ class WindowsNativeRuntimeDepsTests(unittest.TestCase):
             (artifact / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
             result = subprocess.run(
-                ["bash", str(VERIFY_SCRIPT), str(artifact)],
+                ["bash", str(VERIFY_SCRIPT), artifact.as_posix()],
                 check=False,
                 capture_output=True,
                 text=True,

--- a/scripts/tests/test_windows_native_runtime_deps.py
+++ b/scripts/tests/test_windows_native_runtime_deps.py
@@ -1,6 +1,8 @@
 import importlib.util
 import json
+import os
 import pathlib
+import shutil
 import struct
 import subprocess
 import tempfile
@@ -13,6 +15,17 @@ SPEC = importlib.util.spec_from_file_location("windows_native_runtime_deps", SCR
 DEPS = importlib.util.module_from_spec(SPEC)
 assert SPEC.loader is not None
 SPEC.loader.exec_module(DEPS)
+
+
+def bash_executable() -> str:
+    if os.name != "nt":
+        return shutil.which("bash") or "bash"
+    git = shutil.which("git")
+    if git:
+        candidate = pathlib.Path(git).parent.parent / "bin" / "bash.exe"
+        if candidate.is_file():
+            return str(candidate)
+    raise RuntimeError("Git Bash is required for native-runtime verifier tests")
 
 
 def write_pe(path: pathlib.Path, imports: list[str]) -> None:
@@ -107,7 +120,7 @@ class WindowsNativeRuntimeDepsTests(unittest.TestCase):
             (artifact / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
             result = subprocess.run(
-                ["bash", VERIFY_SCRIPT.as_posix(), artifact.as_posix()],
+                [bash_executable(), VERIFY_SCRIPT.as_posix(), artifact.as_posix()],
                 check=False,
                 capture_output=True,
                 text=True,

--- a/scripts/tests/test_windows_native_runtime_deps.py
+++ b/scripts/tests/test_windows_native_runtime_deps.py
@@ -107,13 +107,13 @@ class WindowsNativeRuntimeDepsTests(unittest.TestCase):
             (artifact / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
 
             result = subprocess.run(
-                ["bash", str(VERIFY_SCRIPT), artifact.as_posix()],
+                ["bash", VERIFY_SCRIPT.as_posix(), artifact.as_posix()],
                 check=False,
                 capture_output=True,
                 text=True,
             )
 
-            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(result.returncode, 0, result.stdout + result.stderr)
             self.assertIn("verified native runtime artifact", result.stdout)
 
 

--- a/scripts/verify-native-runtime-package.sh
+++ b/scripts/verify-native-runtime-package.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TMP_ROOT=""
 trap 'rm -rf "$TMP_ROOT"' EXIT
 
@@ -14,6 +15,7 @@ Verifies MeshLLM native runtime artifacts:
   - all runtime.libraries exist
   - library_sha256 matches the primary library
   - Linux shared-library RUNPATH/RPATH is relocatable and resolves packaged deps
+  - Windows non-system DLL imports are present in the artifact
   - archive checksum sidecar when present
 EOF
 }
@@ -152,7 +154,30 @@ if library_sha256:
 PY
     verify_macos_runtime_paths "$artifact_dir" "$manifest"
     verify_linux_runtime_paths "$artifact_dir" "$manifest"
+    verify_windows_runtime_dependencies "$artifact_dir" "$manifest"
     echo "verified native runtime artifact: $artifact_dir"
+}
+
+verify_windows_runtime_dependencies() {
+    local artifact_dir="$1"
+    local manifest="$2"
+    if ! "$(python_bin)" - "$manifest" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as fh:
+    runtime = json.load(fh)["runtime"]
+is_windows_vulkan = (
+    runtime["platform"].get("os") == "windows"
+    and runtime["backend"].get("kind") == "vulkan"
+)
+raise SystemExit(0 if is_windows_vulkan else 1)
+PY
+    then
+        return 0
+    fi
+    "$(python_bin)" "$SCRIPT_DIR/windows-native-runtime-deps.py" verify \
+        --lib-dir "$artifact_dir/lib"
 }
 
 verify_macos_runtime_paths() {

--- a/scripts/windows-native-runtime-deps.py
+++ b/scripts/windows-native-runtime-deps.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Collect and verify non-system DLL dependencies in Windows native runtimes."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import shutil
+import struct
+import sys
+
+
+HOST_DLLS = {
+    "advapi32.dll",
+    "bcrypt.dll",
+    "cfgmgr32.dll",
+    "comdlg32.dll",
+    "crypt32.dll",
+    "d3d12.dll",
+    "dbghelp.dll",
+    "dxgi.dll",
+    "gdi32.dll",
+    "kernel32.dll",
+    "msvcp140.dll",
+    "msvcrt.dll",
+    "ntdll.dll",
+    "ole32.dll",
+    "oleaut32.dll",
+    "psapi.dll",
+    "rpcrt4.dll",
+    "secur32.dll",
+    "setupapi.dll",
+    "shell32.dll",
+    "shlwapi.dll",
+    "ucrtbase.dll",
+    "user32.dll",
+    "version.dll",
+    "vcruntime140.dll",
+    "vcruntime140_1.dll",
+    "vulkan-1.dll",
+    "winmm.dll",
+    "ws2_32.dll",
+}
+
+
+class PeFormatError(ValueError):
+    """Raised when a file is not a supported PE image."""
+
+
+def _unpack(data: bytes, fmt: str, offset: int) -> tuple[int, ...]:
+    size = struct.calcsize(fmt)
+    if offset < 0 or offset + size > len(data):
+        raise PeFormatError("truncated PE image")
+    return struct.unpack_from(fmt, data, offset)
+
+
+def _cstring(data: bytes, offset: int) -> str:
+    if offset < 0 or offset >= len(data):
+        raise PeFormatError("PE import name points outside the image")
+    end = data.find(b"\0", offset)
+    if end < 0:
+        raise PeFormatError("unterminated PE import name")
+    return data[offset:end].decode("ascii")
+
+
+def imported_dlls(path: pathlib.Path) -> list[str]:
+    data = path.read_bytes()
+    if data[:2] != b"MZ":
+        raise PeFormatError(f"not a PE image: {path}")
+    (pe_offset,) = _unpack(data, "<I", 0x3C)
+    if data[pe_offset : pe_offset + 4] != b"PE\0\0":
+        raise PeFormatError(f"invalid PE signature: {path}")
+
+    file_header = pe_offset + 4
+    (_, section_count, _, _, _, optional_size, _) = _unpack(
+        data, "<HHIIIHH", file_header
+    )
+    optional_header = file_header + 20
+    (magic,) = _unpack(data, "<H", optional_header)
+    if magic == 0x20B:
+        data_directories = optional_header + 112
+    elif magic == 0x10B:
+        data_directories = optional_header + 96
+    else:
+        raise PeFormatError(f"unsupported PE optional-header magic 0x{magic:x}: {path}")
+
+    (import_rva, _) = _unpack(data, "<II", data_directories + 8)
+    section_table = optional_header + optional_size
+    sections: list[tuple[int, int, int]] = []
+    for index in range(section_count):
+        section = section_table + index * 40
+        (virtual_size, virtual_address, raw_size, raw_offset) = _unpack(
+            data, "<IIII", section + 8
+        )
+        sections.append((virtual_address, max(virtual_size, raw_size), raw_offset))
+
+    def rva_offset(rva: int) -> int:
+        for virtual_address, size, raw_offset in sections:
+            if virtual_address <= rva < virtual_address + size:
+                return raw_offset + rva - virtual_address
+        if rva < len(data):
+            return rva
+        raise PeFormatError(f"PE RVA 0x{rva:x} is outside every section: {path}")
+
+    if import_rva == 0:
+        return []
+    descriptor = rva_offset(import_rva)
+    imports: list[str] = []
+    while True:
+        fields = _unpack(data, "<IIIII", descriptor)
+        if not any(fields):
+            break
+        name_rva = fields[3]
+        if name_rva == 0:
+            raise PeFormatError(f"PE import descriptor has no DLL name: {path}")
+        imports.append(_cstring(data, rva_offset(name_rva)))
+        descriptor += 20
+    return imports
+
+
+def is_host_dll(name: str) -> bool:
+    normalized = name.casefold()
+    return (
+        normalized in HOST_DLLS
+        or normalized.startswith("api-ms-win-")
+        or normalized.startswith("ext-ms-win-")
+    )
+
+
+def default_search_dirs() -> list[pathlib.Path]:
+    candidates: list[pathlib.Path] = []
+    vulkan_sdk = os.environ.get("VULKAN_SDK")
+    if vulkan_sdk:
+        candidates.extend(
+            [pathlib.Path(vulkan_sdk) / "Bin", pathlib.Path(vulkan_sdk) / "Bin32"]
+        )
+    candidates.extend(
+        pathlib.Path(entry)
+        for entry in os.environ.get("PATH", "").split(os.pathsep)
+        if entry
+    )
+    return candidates
+
+
+def _dll_index(directories: list[pathlib.Path]) -> dict[str, pathlib.Path]:
+    result: dict[str, pathlib.Path] = {}
+    for directory in directories:
+        if not directory.is_dir():
+            continue
+        try:
+            entries = directory.iterdir()
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.is_file() and entry.suffix.casefold() == ".dll":
+                result.setdefault(entry.name.casefold(), entry)
+    return result
+
+
+def _packaged_dlls(lib_dir: pathlib.Path) -> dict[str, pathlib.Path]:
+    return {
+        path.name.casefold(): path
+        for path in lib_dir.iterdir()
+        if path.is_file() and path.suffix.casefold() == ".dll"
+    }
+
+
+def dependency_gaps(lib_dir: pathlib.Path) -> dict[str, set[str]]:
+    packaged = _packaged_dlls(lib_dir)
+    gaps: dict[str, set[str]] = {}
+    for name, library in sorted(packaged.items()):
+        missing = {
+            dependency
+            for dependency in imported_dlls(library)
+            if not is_host_dll(dependency) and dependency.casefold() not in packaged
+        }
+        if missing:
+            gaps[name] = missing
+    return gaps
+
+
+def collect_dependencies(
+    lib_dir: pathlib.Path, search_dirs: list[pathlib.Path]
+) -> list[pathlib.Path]:
+    search_index = _dll_index([lib_dir, *search_dirs, *default_search_dirs()])
+    copied: list[pathlib.Path] = []
+    while True:
+        gaps = dependency_gaps(lib_dir)
+        if not gaps:
+            return copied
+        unresolved: dict[str, set[str]] = {}
+        for importer, dependencies in gaps.items():
+            for dependency in sorted(dependencies):
+                source = search_index.get(dependency.casefold())
+                if source is None:
+                    unresolved.setdefault(importer, set()).add(dependency)
+                    continue
+                destination = lib_dir / source.name
+                if not destination.exists():
+                    shutil.copy2(source, destination)
+                    copied.append(destination)
+        if unresolved:
+            details = "; ".join(
+                f"{importer}: {', '.join(sorted(dependencies))}"
+                for importer, dependencies in sorted(unresolved.items())
+            )
+            raise RuntimeError(f"unresolved Windows runtime DLL dependencies: {details}")
+
+
+def verify_dependencies(lib_dir: pathlib.Path) -> None:
+    gaps = dependency_gaps(lib_dir)
+    if not gaps:
+        return
+    details = "; ".join(
+        f"{importer}: {', '.join(sorted(dependencies))}"
+        for importer, dependencies in sorted(gaps.items())
+    )
+    raise RuntimeError(f"unpackaged Windows runtime DLL dependencies: {details}")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    collect = subparsers.add_parser("collect")
+    collect.add_argument("--lib-dir", type=pathlib.Path, required=True)
+    collect.add_argument("--search-dir", type=pathlib.Path, action="append", default=[])
+    verify = subparsers.add_parser("verify")
+    verify.add_argument("--lib-dir", type=pathlib.Path, required=True)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    try:
+        if args.command == "collect":
+            copied = collect_dependencies(args.lib_dir, args.search_dir)
+            for path in copied:
+                print(f"bundled Windows runtime dependency: {path.name}")
+        else:
+            verify_dependencies(args.lib_dir)
+    except (OSError, PeFormatError, RuntimeError) as error:
+        print(error, file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

- resolve the full non-system PE DLL dependency closure when packaging Windows Vulkan native runtimes
- load installed Windows runtime DLLs with sibling dependency lookup enabled
- verify packaged Vulkan dependency closure and exercise RX 9070 XT GPU enumeration
- run the resolver in Windows Vulkan CI when packaging inputs change

## Root cause

The Windows Vulkan artifact manifest listed llama.cpp runtime DLLs but omitted transitive MinGW dependencies imported by ggml-vulkan.dll. Windows also loaded the primary DLL without searching its installed runtime directory for sibling dependencies, so startup failed before Vulkan device enumeration and the system reported zero GPUs.

## Validation

- Python dependency resolver unit/integration suite
- Windows MSVC cross-target check for skippy-ffi dynamic loading
- focused skippy-ffi and mesh-llm-system checks, Clippy, and tests
- just test-all

Stacked on #1039 as requested.

Closes #1022

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Windows Vulkan native-runtime packaging by collecting and ordering required DLL dependencies.
  * Added Windows-native runtime dependency verification during artifact checks.
* **Bug Fixes**
  * CI change detection for Windows GPU builds now covers additional native-runtime packaging inputs and runs Vulkan-only dependency validation.
* **Improvements**
  * Enhanced dynamic runtime library loading on Windows for absolute-path DLLs.
* **Tests**
  * Added unit tests for Vulkan runtime-selectable GPU facts and comprehensive Windows native-runtime dependency discovery/verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->