### PR TITLE
Fix GLM 5.2 native MTP execution

### DIFF
--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -1273,7 +1273,8 @@ fn runtime_config_from_stage_config(
             LoadMode::ArtifactSlice => RuntimeLoadMode::ArtifactSlice,
         },
         projector_path: config.projector_path.clone(),
-        include_embeddings: config.layer_start == 0,
+        include_embeddings: config.layer_start == 0
+            || (config.load_mode == LoadMode::LayerPackage && config.downstream.is_none()),
         include_output: config.downstream.is_none(),
         filter_tensors_on_load: config.filter_tensors_on_load,
     })
@@ -1318,11 +1319,14 @@ fn open_stage_model_from_parts_with_events(
 mod tests {
     use anyhow::{Result, bail};
     use skippy_protocol::{FlashAttentionType, LoadMode, PeerConfig, StageConfig, StageDevice};
-    use skippy_runtime::FlashAttentionType as RuntimeFlashAttentionType;
+    use skippy_runtime::{
+        ActivationDesc, ActivationFrame, FlashAttentionType as RuntimeFlashAttentionType,
+        RuntimeActivationDType, RuntimeActivationLayout, SamplingConfig,
+    };
 
     use super::{
-        RuntimeLaunchOverrides, create_indexed_lane_resource, runtime_config_from_stage_config,
-        should_attach_package_projector,
+        RuntimeLaunchOverrides, create_indexed_lane_resource, load_runtime_with_overrides,
+        runtime_config_from_stage_config, should_attach_package_projector,
     };
 
     #[test]
@@ -1512,7 +1516,7 @@ mod tests {
     }
 
     #[test]
-    fn runtime_config_omits_input_embeddings_for_final_non_first_stage() {
+    fn runtime_config_keeps_package_embeddings_for_final_non_first_stage() {
         let config = StageConfig {
             run_id: "run-a".to_string(),
             topology_id: "topology-a".to_string(),
@@ -1541,7 +1545,12 @@ mod tests {
             cache_type_v: "f16".to_string(),
             flash_attn_type: FlashAttentionType::Auto,
             filter_tensors_on_load: true,
-            selected_device: None,
+            selected_device: Some(StageDevice {
+                backend_device: "CPU".into(),
+                stable_id: None,
+                index: None,
+                vram_bytes: None,
+            }),
             kv_cache: None,
             native_mtp_enabled: true,
             load_mode: LoadMode::LayerPackage,
@@ -1557,8 +1566,102 @@ mod tests {
         let runtime_config =
             runtime_config_from_stage_config(&config, &RuntimeLaunchOverrides::default()).unwrap();
 
-        assert!(!runtime_config.include_embeddings);
+        assert!(runtime_config.include_embeddings);
         assert!(runtime_config.include_output);
+    }
+
+    #[test]
+    fn glm52_final_stage_package_executes_native_mtp_when_fixture_is_set() -> anyhow::Result<()> {
+        let Some(package_path) = std::env::var_os("SKIPPY_GLM52_MTP_PACKAGE") else {
+            eprintln!("skipping: SKIPPY_GLM52_MTP_PACKAGE is not set");
+            return Ok(());
+        };
+        let package_path = std::path::PathBuf::from(package_path);
+        if !package_path.join("model-package.json").is_file() {
+            eprintln!(
+                "skipping: {} does not look like a layer package",
+                package_path.display()
+            );
+            return Ok(());
+        }
+
+        let config = StageConfig {
+            run_id: "glm52-mtp-smoke".to_string(),
+            topology_id: "glm52-mtp-smoke-topology".to_string(),
+            model_id: "meshllm/GLM-5.2-Q2_K-MTP-Q8-layers".to_string(),
+            package_ref: Some(package_path.to_string_lossy().to_string()),
+            manifest_sha256: None,
+            source_model_path: None,
+            source_model_sha256: None,
+            source_model_bytes: None,
+            materialized_path: None,
+            materialized_pinned: false,
+            model_path: Some(package_path.to_string_lossy().to_string()),
+            projector_path: None,
+            stage_id: "stage-final".to_string(),
+            stage_index: 1,
+            layer_start: 78,
+            layer_end: 79,
+            ctx_size: 128,
+            lane_count: 1,
+            n_batch: Some(1),
+            n_ubatch: Some(1),
+            n_gpu_layers: 0,
+            mmap: Some(true),
+            mlock: false,
+            cache_type_k: "f16".to_string(),
+            cache_type_v: "f16".to_string(),
+            flash_attn_type: FlashAttentionType::Disabled,
+            filter_tensors_on_load: true,
+            selected_device: Some(StageDevice {
+                backend_device: "CPU".into(),
+                stable_id: None,
+                index: None,
+                vram_bytes: None,
+            }),
+            kv_cache: None,
+            native_mtp_enabled: true,
+            load_mode: LoadMode::LayerPackage,
+            bind_addr: "127.0.0.1:0".to_string(),
+            upstream: Some(PeerConfig {
+                stage_id: "stage-prev".to_string(),
+                stage_index: 0,
+                endpoint: "tcp://127.0.0.1:19000".to_string(),
+            }),
+            downstream: None,
+        };
+
+        let runtime = load_runtime_with_overrides(&config, &RuntimeLaunchOverrides::default())?
+            .expect("GLM final stage should load from the package");
+        let mut runtime = runtime.lock().expect("runtime mutex poisoned");
+        let hidden_bytes = 6144 * std::mem::size_of::<f32>();
+        let input = ActivationFrame {
+            desc: ActivationDesc {
+                version: 1,
+                dtype: RuntimeActivationDType::F32,
+                layout: RuntimeActivationLayout::TokenMajor,
+                producer_stage_index: 0,
+                layer_start: 0,
+                layer_end: 78,
+                token_count: 1,
+                sequence_count: 1,
+                payload_bytes: hidden_bytes as u64,
+                flags: 0,
+            },
+            payload: vec![0; hidden_bytes],
+        };
+        let sampling = SamplingConfig {
+            temperature: 0.0,
+            ..SamplingConfig::default()
+        };
+        let (predicted, draft, _output) =
+            runtime.decode_frame_sampled_mtp("smoke", 1, Some(&sampling), Some(&input), 0, 1)?;
+        let draft = draft.expect("GLM final stage should return a native MTP draft");
+
+        assert!(predicted >= 0);
+        assert_eq!(draft.token_ids.len(), 1);
+        assert!(draft.token_ids[0] >= 0);
+        Ok(())
     }
 
     #[test]

--- a/third_party/llama.cpp/patches/0042-Fix-GLM-DSA-native-MTP-execution.patch
+++ b/third_party/llama.cpp/patches/0042-Fix-GLM-DSA-native-MTP-execution.patch
@@ -1,0 +1,424 @@
+From 0489d807735c3eb284cd072934bc94f0b6919f95 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Wed, 22 Jul 2026 08:41:09 +1000
+Subject: [PATCH] Fix GLM DSA native MTP execution
+
+---
+ src/llama-context.cpp  |  16 ++
+ src/llama-graph.cpp    |  20 ++-
+ src/models/glm-dsa.cpp | 321 +++++++++++++++++++++++++++++++++++++++++
+ src/models/models.h    |   4 +-
+ 4 files changed, 355 insertions(+), 6 deletions(-)
+
+diff --git a/src/llama-context.cpp b/src/llama-context.cpp
+index 9ab7be4b..4342e96e 100644
+--- a/src/llama-context.cpp
++++ b/src/llama-context.cpp
+@@ -495,6 +495,22 @@ llama_context::~llama_context() {
+ 
+ void llama_context::resolve_fused_ops(const llama_memory_context_i * mctx, uint32_t n_seqs) {
+     const char * func = __func__;
++
++    if (model.arch == LLM_ARCH_GLM_DSA) {
++        cparams.fused_gdn_ar = false;
++        cparams.fused_gdn_ch = false;
++        cparams.auto_fgdn = false;
++
++        cparams.fused_dsv4_hc_pre = false;
++        cparams.fused_dsv4_hc_comb = false;
++        cparams.fused_dsv4_hc_post = false;
++        cparams.auto_fhc = false;
++
++        if (cparams.ctx_type == LLAMA_CONTEXT_TYPE_MTP) {
++            cparams.auto_flid = false;
++        }
++    }
++
+     auto resolve = [&](const llm_fused_op_probe & probe, bool & enabled) {
+         if (!enabled) {
+             return;
+diff --git a/src/llama-graph.cpp b/src/llama-graph.cpp
+index 244a400a..6cef391d 100644
+--- a/src/llama-graph.cpp
++++ b/src/llama-graph.cpp
+@@ -661,15 +661,25 @@ bool llm_graph_input_attn_k::can_reuse(const llm_graph_params & params) {
+ }
+ 
+ void llm_graph_input_attn_k_dsa::set_input(const llama_ubatch * ubatch) {
+-    mctx->get_mla()->set_input_k_idxs(self_k_idxs_mla, ubatch);
++    if (self_k_idxs_mla && self_k_idxs_mla->buffer) {
++        mctx->get_mla()->set_input_k_idxs(self_k_idxs_mla, ubatch);
++    }
+ 
+-    mctx->get_mla()->set_input_kq_mask(self_kq_mask_mla, ubatch, cparams.causal_attn);
++    if (self_kq_mask_mla && self_kq_mask_mla->buffer) {
++        mctx->get_mla()->set_input_kq_mask(self_kq_mask_mla, ubatch, cparams.causal_attn);
++    }
+ 
+-    mctx->get_lid()->set_input_k_idxs(self_k_idxs_lid, ubatch);
++    if (self_k_idxs_lid && self_k_idxs_lid->buffer) {
++        mctx->get_lid()->set_input_k_idxs(self_k_idxs_lid, ubatch);
++    }
+ 
+-    mctx->get_lid()->set_input_kq_mask(self_kq_mask_lid, ubatch, cparams.causal_attn);
++    if (self_kq_mask_lid && self_kq_mask_lid->buffer) {
++        mctx->get_lid()->set_input_kq_mask(self_kq_mask_lid, ubatch, cparams.causal_attn);
++    }
+ 
+-    mctx->get_lid()->set_input_k_rot(self_k_rot_lid);
++    if (self_k_rot_lid && self_k_rot_lid->buffer) {
++        mctx->get_lid()->set_input_k_rot(self_k_rot_lid);
++    }
+ }
+ 
+ bool llm_graph_input_attn_k_dsa::can_reuse(const llm_graph_params & params) {
+diff --git a/src/models/glm-dsa.cpp b/src/models/glm-dsa.cpp
+index adde84fd..16d605c4 100644
+--- a/src/models/glm-dsa.cpp
++++ b/src/models/glm-dsa.cpp
+@@ -147,6 +147,327 @@ void llama_model_glm_dsa::load_arch_tensors(llama_model_loader &) {
+     }
+ }
+ 
++llama_model_glm_dsa::graph_mtp::graph_mtp(const llama_model & model, const llm_graph_params & params) :
++    llm_graph_context(params) {
++    GGML_ASSERT(hparams.n_layer_nextn > 0 && "GLM_DSA MTP requires n_layer_nextn > 0");
++    GGML_ASSERT(hparams.n_layer_nextn == 1 && "GLM_DSA MTP currently only supports a single MTP block");
++    GGML_ASSERT(hparams.is_mla() && "GLM_DSA MTP requires MLA attention");
++
++    const int il = hparams.n_layer() + cparams.nextn_layer_offset;
++    GGML_ASSERT(cparams.nextn_layer_offset >= 0 &&
++                cparams.nextn_layer_offset < (int) hparams.n_layer_nextn &&
++                "nextn_layer_offset out of range [0, n_layer_nextn)");
++
++    const auto & layer = model.layers[il];
++
++    GGML_ASSERT(layer.nextn.eh_proj && "GLM_DSA MTP block missing nextn.eh_proj");
++    GGML_ASSERT(layer.nextn.enorm   && "GLM_DSA MTP block missing nextn.enorm");
++    GGML_ASSERT(layer.nextn.hnorm   && "GLM_DSA MTP block missing nextn.hnorm");
++    GGML_ASSERT(layer.wk_b && layer.wv_b && "GLM_DSA MTP sparse attention requires split K_B and V_B tensors");
++
++    const int64_t n_embd_head_k = hparams.n_embd_head_k_mla();
++    const int64_t n_embd_head_qk_rope = hparams.n_rot();
++    const int64_t n_embd_head_qk_nope = n_embd_head_k - n_embd_head_qk_rope;
++
++    const int64_t n_indexer_head = hparams.indexer_n_head;
++    const int64_t n_embd_indexer_head = hparams.indexer_head_size;
++    const int64_t n_embd_indexer_head_rope = hparams.n_rot();
++    const int64_t n_embd_indexer_head_nope = n_embd_indexer_head - n_embd_indexer_head_rope;
++    const uint32_t n_indexer_top_k = hparams.indexer_top_k;
++    const uint32_t kv_lora_rank = hparams.n_lora_kv;
++
++    GGML_ASSERT(n_embd_head_qk_nope >= 1);
++    GGML_ASSERT(n_embd_indexer_head_nope >= 1);
++    GGML_ASSERT(ext_factor >= 0.0f);
++
++    const float attn_factor_org = attn_factor * (1.0f + 0.1f * logf(1.0f / freq_scale));
++    const float mscale = attn_factor_org * (1.0f + 0.1f * hparams.rope_yarn_log_mul * logf(1.0f / freq_scale));
++    const float kq_scale = 1.0f * mscale * mscale / sqrtf(float(n_embd_head_k));
++
++    auto inp = std::make_unique<llm_graph_input_embd>(hparams.n_embd);
++
++    inp->tokens = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, n_tokens);
++    ggml_set_input(inp->tokens);
++
++    inp->embd = ggml_new_tensor_2d(ctx0, GGML_TYPE_F32, hparams.n_embd, n_tokens);
++    ggml_set_input(inp->embd);
++    ggml_set_name(inp->embd, "mtp_h_input");
++
++    ggml_tensor * tok_embd_w = layer.nextn.embed_tokens ? layer.nextn.embed_tokens : model.tok_embd;
++    GGML_ASSERT(tok_embd_w && "GLM_DSA MTP: missing token embedding fallback");
++
++    ggml_tensor * h_input = inp->embd;
++    ggml_tensor * tok_embd = ggml_get_rows(ctx0, tok_embd_w, inp->tokens);
++    cb(tok_embd, "mtp_tok_embd", il);
++
++    res->add_input(std::move(inp));
++
++    ggml_tensor * inp_pos = build_inp_pos();
++    llm_graph_input_attn_k_dsa * inp_attn_dsa = build_attn_inp_k_dsa();
++
++    ggml_tensor * h_norm = build_norm(h_input, layer.nextn.hnorm, nullptr, LLM_NORM_RMS, il);
++    cb(h_norm, "mtp_hnorm", il);
++
++    ggml_tensor * e_norm = build_norm(tok_embd, layer.nextn.enorm, nullptr, LLM_NORM_RMS, il);
++    cb(e_norm, "mtp_enorm", il);
++
++    ggml_tensor * concat = ggml_concat(ctx0, e_norm, h_norm, 0);
++    cb(concat, "mtp_concat", il);
++
++    ggml_tensor * cur = build_lora_mm(layer.nextn.eh_proj, concat, layer.nextn.eh_proj_s);
++    cb(cur, "mtp_eh_proj", il);
++
++    ggml_tensor * inpSA = cur;
++
++    cur = build_norm(cur, layer.attn_norm, nullptr, LLM_NORM_RMS, il);
++    cb(cur, "mtp_attn_norm", il);
++
++    ggml_tensor * qr = ggml_mul_mat(ctx0, layer.wq_a, cur);
++    cb(qr, "mtp_qr", il);
++
++    qr = build_norm(qr, layer.attn_q_a_norm, nullptr, LLM_NORM_RMS, il);
++    cb(qr, "mtp_qr_norm", il);
++
++    ggml_tensor * top_k = nullptr;
++
++    {
++        ggml_tensor * indexer_q = ggml_mul_mat(ctx0, layer.indexer_attn_q_b, qr);
++        cb(indexer_q, "mtp_indexer_q", il);
++
++        ggml_tensor * indexer_q_pe =
++            ggml_view_3d(ctx0, indexer_q, n_embd_indexer_head_rope, n_indexer_head, n_tokens,
++                         ggml_row_size(indexer_q->type, n_embd_indexer_head),
++                         ggml_row_size(indexer_q->type, n_embd_indexer_head) * n_indexer_head, 0);
++        cb(indexer_q_pe, "mtp_indexer_q_pe", il);
++
++        ggml_tensor * indexer_q_nope =
++            ggml_view_3d(ctx0, indexer_q, n_embd_indexer_head_nope, n_indexer_head, n_tokens,
++                         ggml_row_size(indexer_q->type, n_embd_indexer_head),
++                         ggml_row_size(indexer_q->type, n_embd_indexer_head) * n_indexer_head,
++                         ggml_row_size(indexer_q->type, n_embd_indexer_head_nope));
++        cb(indexer_q_nope, "mtp_indexer_q_nope", il);
++
++        indexer_q_pe = ggml_rope_ext(ctx0, indexer_q_pe, inp_pos, nullptr, n_rot,
++                             LLAMA_ROPE_TYPE_NEOX, n_ctx_orig, freq_base, freq_scale,
++                             ext_factor, attn_factor, beta_fast, beta_slow);
++        cb(indexer_q_pe, "mtp_indexer_q_pe", il);
++
++        indexer_q = ggml_concat(ctx0, indexer_q_pe, indexer_q_nope, 0);
++        cb(indexer_q, "mtp_indexer_q", il);
++
++        ggml_tensor * indexer_k = ggml_mul_mat(ctx0, layer.indexer_attn_k, cur);
++        cb(indexer_k, "mtp_indexer_k", il);
++
++        indexer_k = build_norm(indexer_k, layer.indexer_k_norm, layer.indexer_k_norm_b, LLM_NORM, il);
++        cb(indexer_k, "mtp_indexer_k", il);
++
++        ggml_tensor * indexer_k_pe =
++            ggml_view_3d(ctx0, indexer_k, n_embd_indexer_head_rope, 1, n_tokens,
++                         ggml_row_size(indexer_k->type, n_embd_indexer_head),
++                         ggml_row_size(indexer_k->type, n_embd_indexer_head), 0);
++        cb(indexer_k_pe, "mtp_indexer_k_pe", il);
++
++        ggml_tensor * indexer_k_nope =
++            ggml_view_3d(ctx0, indexer_k, n_embd_indexer_head_nope, 1, n_tokens,
++                         ggml_row_size(indexer_k->type, n_embd_indexer_head),
++                         ggml_row_size(indexer_k->type, n_embd_indexer_head),
++                         ggml_row_size(indexer_k->type, n_embd_indexer_head_nope));
++        cb(indexer_k_nope, "mtp_indexer_k_nope", il);
++
++        indexer_k_pe = ggml_rope_ext(ctx0, indexer_k_pe, inp_pos, nullptr, n_rot,
++                             LLAMA_ROPE_TYPE_NEOX, n_ctx_orig, freq_base, freq_scale,
++                             ext_factor, attn_factor, beta_fast, beta_slow);
++        cb(indexer_k_pe, "mtp_indexer_k_pe", il);
++
++        indexer_k = ggml_concat(ctx0, indexer_k_pe, indexer_k_nope, 0);
++        cb(indexer_k, "mtp_indexer_k", il);
++
++        if (inp_attn_dsa->self_k_rot_lid) {
++            indexer_q = ggml_mul_mat(ctx0, inp_attn_dsa->self_k_rot_lid, indexer_q);
++            cb(indexer_q, "mtp_indexer_q", il);
++            indexer_k = ggml_mul_mat(ctx0, inp_attn_dsa->self_k_rot_lid, indexer_k);
++            cb(indexer_k, "mtp_indexer_k", il);
++        }
++
++        const auto * mctx_lid = inp_attn_dsa->mctx->get_lid();
++        const auto & k_idxs_lid = inp_attn_dsa->get_k_idxs_lid();
++        ggml_build_forward_expand(gf, mctx_lid->cpy_k(ctx0, indexer_k, k_idxs_lid, il));
++
++        ggml_tensor * indexer_weights = ggml_mul_mat(ctx0, layer.indexer_proj, cur);
++        cb(indexer_weights, "mtp_indexer_weights", il);
++
++        indexer_k = mctx_lid->get_k(ctx0, il);
++
++        const auto n_stream = indexer_k->ne[3];
++        indexer_q = ggml_view_4d(ctx0, indexer_q, indexer_q->ne[0], indexer_q->ne[1], indexer_q->ne[2] / n_stream, n_stream,
++                                 indexer_q->nb[1], indexer_q->nb[2], indexer_q->nb[3] / n_stream, 0);
++        indexer_weights = ggml_view_4d(ctx0, indexer_weights, indexer_weights->ne[0], indexer_weights->ne[1] / n_stream, indexer_weights->ne[2], n_stream,
++                                       indexer_weights->nb[1], indexer_weights->nb[2] / n_stream, indexer_weights->nb[3] / n_stream, 0);
++
++        indexer_weights = ggml_scale(ctx0, indexer_weights, 1.0f / sqrtf(float(n_embd_indexer_head * n_indexer_head)));
++        cb(indexer_weights, "mtp_indexer_weights", il);
++
++        ggml_tensor * indexer_score = nullptr;
++        if (cparams.fused_lid) {
++            indexer_score = ggml_lightning_indexer(ctx0, indexer_q, indexer_k, indexer_weights, inp_attn_dsa->get_kq_mask_lid());
++            cb(indexer_score, "mtp_indexer_score", il);
++            res->add_fused_node({LLM_FUSED_OP_LIGHTNING_INDEXER, indexer_score, il});
++        } else {
++            indexer_q = ggml_permute(ctx0, indexer_q, 0, 2, 1, 3);
++            cb(indexer_q, "mtp_indexer_q", il);
++            indexer_k = ggml_permute(ctx0, indexer_k, 0, 2, 1, 3);
++            cb(indexer_k, "mtp_indexer_k", il);
++
++            ggml_tensor * indexer_kq = ggml_mul_mat(ctx0, indexer_k, indexer_q);
++            cb(indexer_kq, "mtp_indexer_kq", il);
++
++            indexer_kq = ggml_cont(ctx0, ggml_permute(ctx0, indexer_kq, 2, 1, 0, 3));
++            cb(indexer_kq, "mtp_indexer_kq", il);
++
++            indexer_score = ggml_relu(ctx0, indexer_kq);
++            cb(indexer_score, "mtp_indexer_score", il);
++
++            indexer_score = ggml_mul(ctx0, indexer_score, indexer_weights);
++            cb(indexer_score, "mtp_indexer_score", il);
++
++            indexer_score = ggml_sum_rows(ctx0, indexer_score);
++            cb(indexer_score, "mtp_indexer_score", il);
++
++            indexer_score = ggml_cont(ctx0, ggml_permute(ctx0, indexer_score, 2, 1, 0, 3));
++            cb(indexer_score, "mtp_indexer_score", il);
++
++            ggml_tensor * indexer_kq_mask = inp_attn_dsa->get_kq_mask_lid();
++            indexer_score = ggml_add(ctx0, indexer_score, indexer_kq_mask);
++            cb(indexer_score, "mtp_indexer_score", il);
++        }
++
++        uint32_t n_top_k = indexer_score->ne[0] < n_indexer_top_k ? indexer_score->ne[0] : n_indexer_top_k;
++        top_k = ggml_cont(ctx0, ggml_top_k(ctx0, indexer_score, n_top_k));
++        cb(top_k, "mtp_top_k", il);
++    }
++
++    ggml_tensor * q = ggml_mul_mat(ctx0, layer.wq_b, qr);
++    cb(q, "mtp_q", il);
++
++    ggml_tensor * q_nope =
++        ggml_view_3d(ctx0, q, n_embd_head_qk_nope, n_head, n_tokens, ggml_row_size(q->type, n_embd_head_k),
++                     ggml_row_size(q->type, n_embd_head_k) * n_head, 0);
++    cb(q_nope, "mtp_q_nope", il);
++
++    ggml_tensor * q_pe = ggml_view_3d(
++        ctx0, q, n_embd_head_qk_rope, n_head, n_tokens, ggml_row_size(q->type, n_embd_head_k),
++        ggml_row_size(q->type, n_embd_head_k) * n_head, ggml_row_size(q->type, n_embd_head_qk_nope));
++    cb(q_pe, "mtp_q_pe", il);
++
++    ggml_tensor * kv_cmpr_pe = ggml_mul_mat(ctx0, layer.wkv_a_mqa, cur);
++    cb(kv_cmpr_pe, "mtp_kv_cmpr_pe", il);
++
++    ggml_tensor * kv_cmpr =
++        ggml_view_2d(ctx0, kv_cmpr_pe, kv_lora_rank, n_tokens,
++                     ggml_row_size(kv_cmpr_pe->type, kv_lora_rank + n_embd_head_qk_rope), 0);
++    cb(kv_cmpr, "mtp_kv_cmpr", il);
++
++    ggml_tensor * k_pe = ggml_view_3d(ctx0, kv_cmpr_pe, n_embd_head_qk_rope, 1, n_tokens,
++                                      ggml_row_size(kv_cmpr_pe->type, kv_lora_rank + n_embd_head_qk_rope),
++                                      ggml_row_size(kv_cmpr_pe->type, kv_lora_rank + n_embd_head_qk_rope),
++                                      ggml_row_size(kv_cmpr_pe->type, kv_lora_rank));
++    cb(k_pe, "mtp_k_pe", il);
++
++    q_pe = ggml_rope_ext(ctx0, q_pe, inp_pos, nullptr, n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
++                         ext_factor, attn_factor, beta_fast, beta_slow);
++    cb(q_pe, "mtp_q_pe", il);
++
++    k_pe = ggml_rope_ext(ctx0, k_pe, inp_pos, nullptr, n_rot, rope_type, n_ctx_orig, freq_base, freq_scale,
++                         ext_factor, attn_factor, beta_fast, beta_slow);
++    cb(k_pe, "mtp_k_pe", il);
++
++    kv_cmpr = build_norm(kv_cmpr, layer.attn_kv_a_norm, nullptr, LLM_NORM_RMS, il);
++    cb(kv_cmpr, "mtp_kv_cmpr", il);
++
++    q_nope = ggml_permute(ctx0, q_nope, 0, 2, 1, 3);
++    cb(q_nope, "mtp_q_nope_perm", il);
++
++    ggml_tensor * q_nope_absorbed = ggml_mul_mat(ctx0, layer.wk_b, q_nope);
++    cb(q_nope_absorbed, "mtp_q_nope_absorbed", il);
++
++    q_nope_absorbed = ggml_permute(ctx0, q_nope_absorbed, 0, 2, 1, 3);
++    cb(q_nope_absorbed, "mtp_q_nope_absorbed_perm", il);
++
++    ggml_tensor * Qcur = ggml_concat(ctx0, q_nope_absorbed, q_pe, 0);
++    cb(Qcur, "mtp_Qcur", il);
++
++    kv_cmpr = ggml_reshape_3d(ctx0, kv_cmpr, kv_lora_rank, 1, n_tokens);
++    cb(kv_cmpr, "mtp_kv_cmpr_reshape", il);
++
++    ggml_tensor * Kcur = ggml_concat(ctx0, kv_cmpr, k_pe, 0);
++    cb(Kcur, "mtp_Kcur", il);
++    Kcur = ggml_repeat(ctx0, Kcur, Qcur);
++    cb(Kcur, "mtp_Kcur_repeat", il);
++
++    ggml_tensor * Vcur = kv_cmpr;
++    cb(Vcur, "mtp_Vcur", il);
++
++    cur = build_attn(inp_attn_dsa,
++            layer.wo, nullptr, layer.wo_s,
++            Qcur, Kcur, Vcur, nullptr, nullptr, layer.wv_b, top_k, kq_scale, il);
++    cb(cur, "mtp_attn_out", il);
++
++    ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpSA);
++    cb(ffn_inp, "mtp_ffn_inp", il);
++
++    cur = build_norm(ffn_inp, layer.ffn_norm, nullptr, LLM_NORM_RMS, il);
++    cb(cur, "mtp_ffn_norm", il);
++
++    ggml_tensor * moe_out = build_moe_ffn(cur,
++        layer.ffn_gate_inp,
++        layer.ffn_up_exps,
++        layer.ffn_gate_exps,
++        layer.ffn_down_exps,
++        layer.ffn_exp_probs_b,
++        n_expert, n_expert_used,
++        LLM_FFN_SILU, hparams.expert_weights_norm,
++        hparams.expert_weights_scale,
++        (llama_expert_gating_func_type) hparams.expert_gating_func,
++        il,
++        nullptr,
++        layer.ffn_gate_up_exps,
++        layer.ffn_up_exps_s,
++        layer.ffn_gate_exps_s,
++        layer.ffn_down_exps_s);
++    cb(moe_out, "mtp_ffn_moe_out", il);
++
++    ggml_tensor * ffn_shexp =
++        build_ffn(cur,
++            layer.ffn_up_shexp, nullptr, layer.ffn_up_shexp_s,
++            layer.ffn_gate_shexp, nullptr, layer.ffn_gate_shexp_s,
++            layer.ffn_down_shexp, nullptr, layer.ffn_down_shexp_s,
++            nullptr, LLM_FFN_SILU, LLM_FFN_PAR, il);
++    cb(ffn_shexp, "mtp_ffn_shexp", il);
++
++    cur = ggml_add(ctx0, moe_out, ffn_shexp);
++    cb(cur, "mtp_ffn_out", il);
++
++    cur = ggml_add(ctx0, cur, ffn_inp);
++    cb(cur, "mtp_post_ffn", il);
++
++    cb(cur, "h_nextn", -1);
++    res->t_h_nextn = cur;
++
++    ggml_tensor * head_norm_w = layer.nextn.shared_head_norm ? layer.nextn.shared_head_norm : model.output_norm;
++    GGML_ASSERT(head_norm_w && "GLM_DSA MTP: missing both nextn.shared_head_norm and output_norm");
++    cur = build_norm(cur, head_norm_w, nullptr, LLM_NORM_RMS, -1);
++    cb(cur, "mtp_head_norm", -1);
++
++    ggml_tensor * head_w = layer.nextn.shared_head_head ? layer.nextn.shared_head_head : model.output;
++    ggml_tensor * head_s = layer.nextn.shared_head_head ? layer.nextn.shared_head_head_s : model.output_s;
++    GGML_ASSERT(head_w && "GLM_DSA MTP: missing LM head (nextn.shared_head_head or model.output)");
++    cur = build_lora_mm(head_w, cur, head_s);
++    cb(cur, "result_output", -1);
++
++    res->t_logits = cur;
++    ggml_build_forward_expand(gf, cur);
++}
++
+ llama_model_glm_dsa::graph::graph(const llama_model & model, const llm_graph_params & params) :
+     llm_graph_context(params) {
+     const bool is_mla = hparams.is_mla();
+diff --git a/src/models/models.h b/src/models/models.h
+index d8120d9d..fa1e36c1 100644
+--- a/src/models/models.h
++++ b/src/models/models.h
+@@ -1221,7 +1221,9 @@ struct llama_model_glm_dsa : public llama_model_base {
+     void load_arch_hparams(llama_model_loader & ml) override;
+     void load_arch_tensors(llama_model_loader & ml) override;
+ 
+-    using graph_mtp = llama_model_deepseek2::graph_mtp;
++    struct graph_mtp : public llm_graph_context {
++        graph_mtp(const llama_model & model, const llm_graph_params & params);
++    };
+ 
+     struct graph : public llm_graph_context {
+         graph(const llama_model & model, const llm_graph_params & params);
+-- 
+2.54.0 (Apple Git-157)
+


### PR DESCRIPTION
## What changed

- Adds a dedicated GLM-DSA MTP graph in the llama.cpp patch queue instead of reusing the DeepSeek2 MTP graph.
- Runs GLM-DSA MTP through the GLM sparse-attention/indexer path, including DSA KV cache setup, optional LID rotation input handling, and GLM-specific top-k attention.
- Keeps embeddings available for final layer-package stages so GLM MTP can fall back to token embeddings when the package does not carry `nextn.embed_tokens`.
- Adds an opt-in package-backed smoke test for GLM 5.2 native MTP execution via `SKIPPY_GLM52_MTP_PACKAGE`.

## Why

GLM-5.2's final MTP block is GLM-DSA shaped. Reusing the DeepSeek2 MTP graph and loading the final package stage without embeddings caused native MTP execution to fail for the published GLM 5.2 layer package.

## Validation

- `LLAMA_BUILD_DIR=.deps/llama-build/build-stage-abi-static-cpu SKIPPY_FORCE_LLAMA_BUILD=1 scripts/build-llama.sh`
- `cargo fmt --all --check`
- `cargo test -p skippy-server runtime_config_keeps_package_embeddings_for_final_non_first_stage -- --nocapture`
- `LLAMA_STAGE_BUILD_DIR=.deps/llama-build/build-stage-abi-static-cpu SKIPPY_GLM52_MTP_PACKAGE=/Users/jdumay/.cache/huggingface/hub/models--meshllm--GLM-5.2-Q2_K-MTP-Q8-layers/snapshots/main GGML_METAL_DEVICES=0 cargo test -p skippy-server glm52_final_stage_package_executes_native_mtp_when_fixture_is_set -- --nocapture`
- Fresh patch queue apply: `LLAMA_WORKDIR=$(mktemp -d /tmp/mesh-llm-llama.XXXXXX) scripts/prepare-llama.sh pinned`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed GLM-DSA model execution for multi-token prediction (MTP), improving compatibility and reliability.
  * Preserved embeddings when loading final-stage layer packages, including stages beyond the first.

* **Testing**
  * Added validation for native MTP execution on supported GLM-DSA packages.
  * Expanded coverage for final-stage package loading and generated token outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->