### PR TITLE
fix: Qwen thinking in nightly stability probes

### DIFF
--- a/scripts/qa-agent-tool-call-reliability.py
+++ b/scripts/qa-agent-tool-call-reliability.py
@@ -143,6 +143,7 @@ def build_tool_probe_request(model: str, attempt: int) -> dict[str, Any]:
         "stream": False,
         "max_tokens": 96,
         "temperature": 0,
+        "chat_template_kwargs": {"enable_thinking": False},
     }
 
 
@@ -244,6 +245,7 @@ def build_tool_result_request(
         "stream": False,
         "max_tokens": 64,
         "temperature": 0,
+        "chat_template_kwargs": {"enable_thinking": False},
     }
 
 

--- a/scripts/qa-nightly-stability.py
+++ b/scripts/qa-nightly-stability.py
@@ -483,6 +483,7 @@ def build_chat_request(model: str, attempt: int, stream: bool) -> dict[str, Any]
         "stream": stream,
         "max_tokens": 32,
         "temperature": 0,
+        "chat_template_kwargs": {"enable_thinking": False},
     }
     if stream:
         body["stream_options"] = {"include_usage": True}

--- a/scripts/tests/test_qa_agent_tool_call_reliability.py
+++ b/scripts/tests/test_qa_agent_tool_call_reliability.py
@@ -150,6 +150,34 @@ class AgentToolCallReliabilityTests(unittest.TestCase):
         with self.assertRaisesRegex(ValueError, "missing expected fixture value"):
             self.harness.validate_final_answer(bad_response, "signal-7429")
 
+    def test_requests_explicitly_disable_thinking(self) -> None:
+        call = self.harness.ToolCall(call_id="call_1", key="codeword")
+        assistant_message = {
+            "role": "assistant",
+            "tool_calls": [
+                {
+                    "id": call.call_id,
+                    "type": "function",
+                    "function": {
+                        "name": self.harness.TOOL_NAME,
+                        "arguments": json.dumps({"key": call.key}),
+                    },
+                }
+            ],
+        }
+        requests = [
+            self.harness.build_tool_probe_request("auto", 1),
+            self.harness.build_stream_tool_probe_request("auto", 1),
+            self.harness.build_tool_result_request("auto", 1, assistant_message, call),
+            self.harness.build_stream_tool_result_request("auto", 1, assistant_message, call),
+        ]
+
+        for request in requests:
+            self.assertEqual(
+                request["chat_template_kwargs"],
+                {"enable_thinking": False},
+            )
+
     def test_writes_jsonl_probe_results(self) -> None:
         result = self.harness.ProbeResult(
             model="auto",

--- a/scripts/tests/test_qa_nightly_stability.py
+++ b/scripts/tests/test_qa_nightly_stability.py
@@ -227,6 +227,14 @@ class NightlyStabilityHarnessTests(unittest.TestCase):
         self.assertIsNotNone(result.tok_per_sec)
         self.assertIn("expected exactly STREAM_OK", result.detail)
 
+    def test_chat_requests_explicitly_disable_thinking(self) -> None:
+        for stream in (False, True):
+            request = self.harness.build_chat_request("auto", 1, stream)
+            self.assertEqual(
+                request["chat_template_kwargs"],
+                {"enable_thinking": False},
+            )
+
     def test_write_evidence_outputs_machine_readable_files(self) -> None:
         rows = [
             self.harness.CommandResult(


### PR DESCRIPTION
## Summary

- explicitly disable thinking in nightly chat-completion probes
- apply the same control to tool-call and tool-result request variants
- cover plain, streaming, tool-call, and continuation payloads with regression tests

## Root cause

The `auto` route in nightly run 29826026015 selected Qwen3.6, which emitted its thinking process before the required `STABILITY_OK` sentinel. The stability harness did not explicitly set `chat_template_kwargs.enable_thinking`.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_qa*.py'`
- `git diff --check`
- live exact-model probe attempted against the public Qwen3.6 route; it reached the existing 180-second execution timeout without returning a response


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automated chat and tool-call checks by explicitly disabling hidden “thinking” output, producing more consistent response validation.

* **Tests**
  * Added coverage confirming that streaming and non-streaming chat, tool-call, and tool-result checks consistently use the expected response configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->