### PR TITLE
Pipeline the standalone N-gram verify-window path

### DIFF
--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -914,10 +914,18 @@ impl StageOpenAiBackend {
             );
             let composite_sidecar_enabled =
                 native_mtp_options.ngram_hybrid && draft_guard.is_none();
+            // A standalone N-gram plan (no native MTP, no draft model) can drive
+            // the same verify-window pipeline; the single-window native-MTP path
+            // stays composite-only, so standalone drafting still falls back to the
+            // serial block at depth 1.
+            let standalone_ngram_pipelining = !request.native_mtp_enabled
+                && request.speculative.ngram.is_some()
+                && draft_guard.is_none();
             let native_mtp_verify_windows_enabled =
                 (request.native_mtp_enabled || composite_sidecar_enabled) && draft_guard.is_none();
-            let pipelined_decode_enabled =
-                composite_sidecar_enabled && verify_window_scheduler.depth() > 1;
+            let pipelined_decode_enabled = (composite_sidecar_enabled
+                || standalone_ngram_pipelining)
+                && verify_window_scheduler.depth() > 1;
             let mut verify_window_forwarder = None;
             if let Some(direct_return_path) = direct_prediction_return_path(
                 native_mtp_verify_windows_enabled,
@@ -1442,7 +1450,9 @@ impl StageOpenAiBackend {
                         continue;
                     }
                 }
-                if draft_guard.is_some() || request.speculative.ngram.is_some() {
+                if draft_guard.is_some()
+                    || (request.speculative.ngram.is_some() && !pipelined_decode_enabled)
+                {
                     let remaining = (request.max_tokens as usize).saturating_sub(decoded_tokens);
                     if remaining == 0 {
                         break;

--- a/crates/skippy-server/src/frontend/native_mtp/decode.rs
+++ b/crates/skippy-server/src/frontend/native_mtp/decode.rs
@@ -13,6 +13,9 @@ pub(in crate::frontend) struct NativeMtpDecodeOptions {
     pub(in crate::frontend) suppress_cooldown_drafts: bool,
     pub(in crate::frontend) suppress_cooldown_draft_limit: usize,
     pub(in crate::frontend) ngram_hybrid: bool,
+    /// The composite provider should generate N-gram proposals — true for both
+    /// the MTP+extension composite and a standalone (no-MTP) N-gram plan.
+    pub(in crate::frontend) ngram_proposals_enabled: bool,
     pub(in crate::frontend) ngram_proposer: &'static str,
     pub(in crate::frontend) ngram_size: usize,
     pub(in crate::frontend) ngram_max_proposal_tokens: usize,
@@ -32,15 +35,24 @@ impl NativeMtpDecodeOptions {
             suppress_cooldown_drafts: config.native_mtp.suppress_cooldown_drafts,
             suppress_cooldown_draft_limit: config.native_mtp.suppress_cooldown_draft_limit,
             ngram_hybrid: config.extension.is_some() && config.ngram.is_some(),
+            ngram_proposals_enabled: config.ngram.is_some()
+                && (config.extension.is_some() || !config.native_mtp.enabled),
             ngram_proposer: config
                 .ngram
                 .as_ref()
                 .map_or("none", |ngram| ngram.kind.as_str()),
             ngram_size: config.ngram.as_ref().map_or(0, |ngram| ngram.min_ngram),
-            ngram_max_proposal_tokens: config
-                .extension
-                .as_ref()
-                .map_or(0, |extension| extension.max_tokens),
+            // The composite path takes its horizon from the extension policy; a
+            // standalone N-gram plan (no extension) uses the proposer's own limit.
+            ngram_max_proposal_tokens: config.extension.as_ref().map_or_else(
+                || {
+                    config
+                        .ngram
+                        .as_ref()
+                        .map_or(0, |ngram| ngram.max_proposal_tokens)
+                },
+                |extension| extension.max_tokens,
+            ),
             verify_window_min_tokens: config.verify_window.min_tokens.max(1),
             verify_window_max_tokens: config.verify_window.max_tokens.max(1),
         }
@@ -623,6 +635,7 @@ mod tests {
             suppress_cooldown_drafts: false,
             suppress_cooldown_draft_limit: 0,
             ngram_hybrid: true,
+            ngram_proposals_enabled: true,
             ngram_proposer: "cache",
             ngram_size: 2,
             ngram_max_proposal_tokens: 4,
@@ -659,6 +672,29 @@ mod tests {
     }
 
     #[test]
+    fn standalone_ngram_enables_proposals_without_extension() {
+        // A standalone plan has no native MTP and no extension policy. It must
+        // still enable the composite provider (so the verify-window pipeline can
+        // seed) and source its horizon from the proposer's own limit.
+        let config = SpeculativeDecodeConfig {
+            ngram: Some(crate::frontend::NgramProposalConfig {
+                kind: crate::frontend::NgramProposerKind::Suffix,
+                min_ngram: 5,
+                max_ngram: 32,
+                max_proposal_tokens: 48,
+            }),
+            ..SpeculativeDecodeConfig::default()
+        };
+
+        let options = NativeMtpDecodeOptions::from_config(&config);
+
+        assert!(options.ngram_proposals_enabled);
+        assert!(!options.ngram_hybrid, "standalone is not an MTP composite");
+        assert_eq!(options.ngram_max_proposal_tokens, 48);
+        assert_eq!(options.ngram_proposer, "suffix");
+    }
+
+    #[test]
     fn counters_track_verify_window_verification_by_origin() {
         let mut counters = NativeMtpDecodeCounters::default();
         counters.observe_verify_window_verification(NativeMtpDraftOrigin::InitialSerial, true);
@@ -681,6 +717,7 @@ mod tests {
                 suppress_cooldown_drafts: false,
                 suppress_cooldown_draft_limit: 2,
                 ngram_hybrid: true,
+                ngram_proposals_enabled: true,
                 ngram_proposer: "cache",
                 ngram_size: 8,
                 ngram_max_proposal_tokens: 4,
@@ -800,6 +837,7 @@ mod tests {
                 suppress_cooldown_drafts: false,
                 suppress_cooldown_draft_limit: 0,
                 ngram_hybrid: true,
+                ngram_proposals_enabled: true,
                 ngram_proposer: "cache",
                 ngram_size: 8,
                 ngram_max_proposal_tokens: 4,

--- a/crates/skippy-server/src/frontend/native_mtp/hybrid.rs
+++ b/crates/skippy-server/src/frontend/native_mtp/hybrid.rs
@@ -19,7 +19,7 @@ pub(in crate::frontend) struct CompositeProposalProvider {
 impl CompositeProposalProvider {
     pub(in crate::frontend) fn from_options(options: NativeMtpDecodeOptions) -> Self {
         Self {
-            enabled: options.ngram_hybrid,
+            enabled: options.ngram_proposals_enabled,
             max_proposal_tokens: options.ngram_max_proposal_tokens,
         }
     }
@@ -392,6 +392,7 @@ mod tests {
             suppress_cooldown_drafts: false,
             suppress_cooldown_draft_limit: 0,
             ngram_hybrid: true,
+            ngram_proposals_enabled: true,
             ngram_proposer: "cache",
             ngram_size: 2,
             ngram_max_proposal_tokens: 4,

--- a/crates/skippy-server/src/frontend/tests/prompting.rs
+++ b/crates/skippy-server/src/frontend/tests/prompting.rs
@@ -252,6 +252,7 @@ fn generated_text_timings_prefer_composite_proposal_totals() {
         suppress_cooldown_drafts: false,
         suppress_cooldown_draft_limit: 0,
         ngram_hybrid: true,
+        ngram_proposals_enabled: true,
         ngram_proposer: "cache",
         ngram_size: 2,
         ngram_max_proposal_tokens: 4,


### PR DESCRIPTION
# Standalone N-gram verify-window pipelining

**TL;DR:** Lets a standalone N-gram plan (`cache`/`suffix`, no MTP) reuse the composite verify-window pipeline instead of drafting one window per round trip. Opt-in via `verify_window_pipeline_depth > 1`. Default is unchanged. Mechanism is correct and tested; throughput win is not yet demonstrated and needs a two-machine split.

## What

- Standalone plans drafted serially regardless of `verify_window_pipeline_depth`, because the pipeline enablement (`ngram_hybrid`) required an extension policy that standalone plans do not have.
- New `ngram_proposals_enabled` flag turns the composite provider on for standalone too; `ngram_max_proposal_tokens` falls back to the proposer's own limit when there is no extension.
- `embedded_generation` enables the pipeline for standalone at depth greater than 1; the serial path stays as the depth-1 fallback; the single native-MTP window path stays composite only.

## Safety

- Opt-in. Default depth 1, so existing configs are unchanged.
- Composite (MTP) behavior identical: the new flag equals the old `ngram_hybrid` for every composite plan.
- Pure N-gram is a no-op for all MTP-specific calls (already guarded).

## Validation

- Tests green: skippy-server 298, host-runtime 1709, config 98, clippy clean.
- Local 8B split at depth 3: `verify_window_max_in_flight` 0 to 3, `parallel_fraction` 0 to 0.81, accept 0.92, output correct.

## Performance

Local two-stage 8B split, one M1 GPU (pessimistic: shared compute, blocking-sleep
latency model), standalone suffix re-emit, verify_window_max_tokens sized to the
proposal limit:

| one-way RTT | serial | pipelined | ratio |
| --- | --- | --- | --- |
| 0ms | 69.6 | 58.0 | 0.83 |
| 50ms | 53.3 | 49.8 | 0.93 |
| 100ms | 42.8 | 42.7 | 1.00 |
| 150ms | 36.4 | 38.0 | 1.04 |

Pipelining crosses over at about 100ms one-way RTT and leads above it. This is a
floor: separate GPUs and a real network (two-machine split) let compute and
propagation overlap, which this single-machine test cannot, so the crossover should
move lower and the lead should grow. Below the crossover, keep depth at 1.

Chunk size matters: set verify_window_max_tokens to the proposal limit, otherwise
the pipeline runs many small round trips and loses.

## Try it

Set `verify_window_pipeline_depth = 3` on a standalone `ngram-suffix` config, run a two-stage split, check `verify_window_max_in_flight > 1` in the response `timings`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled standalone N-gram proposals to support speculative decoding and verification at deeper pipeline stages.
  * Improved proposal handling when native MTP or a draft model is unavailable.
  * Standalone N-gram configurations now honor their configured proposal-token limit.

* **Bug Fixes**
  * Prevented duplicate proposal execution paths during pipelined decoding.

* **Tests**
  * Added coverage for standalone N-gram proposal enablement and token horizons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->