### PR TITLE
Publish the Node SDK to npm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,6 +257,88 @@ jobs:
             dist/native-sdk-crates/*/target/package/*.crate
           if-no-files-found: error
 
+  build_node_sdk_addon:
+    name: Build Node SDK addon ${{ matrix.name }}
+    needs: metadata
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: macOS ARM64
+            os: macos-15
+            backend: metal
+            platform_arch: darwin-arm64
+          - name: macOS x64
+            os: macos-15-intel
+            backend: metal
+            platform_arch: darwin-x64
+          - name: Linux ARM64
+            os: ubuntu-24.04-arm
+            backend: cpu
+            platform_arch: linux-arm64
+          - name: Linux x64
+            os: ubuntu-24.04
+            backend: cpu
+            platform_arch: linux-x64
+          - name: Windows x64
+            os: windows-2022
+            backend: cpu
+            platform_arch: win32-x64
+    env:
+      LLAMA_STAGE_BACKEND: ${{ matrix.backend }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          package-manager-cache: false
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: mozilla-actions/sccache-action@v0.0.9
+
+      - name: Install Linux dependencies
+        if: runner.os == 'Linux'
+        run: sudo apt-get update && sudo apt-get install -y build-essential cmake ninja-build pkg-config libssl-dev libdbus-1-dev curl lld
+
+      - name: Install macOS dependencies
+        if: runner.os == 'macOS'
+        run: brew install cmake ninja lld
+
+      - name: Prepare dispatched release version
+        if: github.event_name == 'workflow_dispatch'
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
+        run: scripts/release-version.sh "$RELEASE_TAG"
+
+      - name: Test Node SDK JavaScript
+        run: npm test --prefix sdk/node
+
+      - name: Build Node SDK addon
+        run: npm run build:native --prefix sdk/node
+
+      - name: Stage Node SDK addon
+        shell: bash
+        run: |
+          set -euo pipefail
+          source="sdk/node/native/${{ matrix.platform_arch }}/mesh_llm_nodejs.node"
+          test -s "$source"
+          destination="dist/node-sdk-addons/${{ matrix.platform_arch }}"
+          mkdir -p "$destination"
+          cp "$source" "$destination/mesh_llm_nodejs.node"
+
+      - name: Upload Node SDK addon
+        uses: actions/upload-artifact@v6
+        with:
+          name: node-sdk-addon-${{ matrix.platform_arch }}
+          path: dist/node-sdk-addons/
+          if-no-files-found: error
+
   build_native_runtime:
     name: Build native runtime ${{ matrix.name }}
     needs: metadata
@@ -1442,3 +1524,121 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
         run: scripts/publish-crates.sh
+
+  publish_node_sdk_preflight:
+    name: Preflight npm Node SDK package
+    needs: [metadata, publish, build_node_sdk_addon]
+    if: ${{ needs.metadata.outputs.canary != 'true' }}
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.metadata.outputs.tag }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install OIDC-capable npm CLI
+        run: npm install --global npm@11.18.0
+
+      - name: Download Node SDK addons
+        uses: actions/download-artifact@v7
+        with:
+          pattern: node-sdk-addon-*
+          path: node-sdk-addons
+          merge-multiple: true
+
+      - name: Verify tagged Node SDK console assets
+        run: scripts/verify-sdk-console-assets.sh --sdk node
+
+      - name: Assemble Node SDK package
+        env:
+          EXPECTED_VERSION: ${{ needs.metadata.outputs.version }}
+        run: |
+          set -euo pipefail
+          scripts/package-node-sdk.mjs node-sdk-addons dist/node-sdk-package
+          actual_version="$(node -p "require('./dist/node-sdk-package/package.json').version")"
+          if [[ "$actual_version" != "$EXPECTED_VERSION" ]]; then
+            echo "Node SDK version mismatch: expected $EXPECTED_VERSION, got $actual_version" >&2
+            exit 1
+          fi
+
+      - name: Test assembled Node SDK package
+        run: |
+          npm test --prefix dist/node-sdk-package
+          node -e "const sdk = require('./dist/node-sdk-package'); console.log(sdk.currentMeshVersion())"
+
+      - name: Pack and dry-run Node SDK package
+        run: |
+          set -euo pipefail
+          mkdir -p dist/npm
+          (
+            cd dist/node-sdk-package
+            npm pack --pack-destination "$GITHUB_WORKSPACE/dist/npm"
+          )
+          tarball="$(find dist/npm -maxdepth 1 -type f -name '*.tgz' -print -quit)"
+          test -n "$tarball"
+          npm publish "./$tarball" --dry-run --access public --provenance=false
+
+      - name: Upload Node SDK npm package
+        uses: actions/upload-artifact@v6
+        with:
+          name: node-sdk-npm-package
+          path: dist/npm/*.tgz
+          if-no-files-found: error
+
+  publish_node_sdk:
+    name: Publish Node SDK to npm
+    needs: [metadata, publish_node_sdk_preflight]
+    if: ${{ needs.metadata.outputs.canary != 'true' }}
+    runs-on: ubuntu-24.04
+    environment: npm
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ needs.metadata.outputs.tag }}
+          persist-credentials: false
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          registry-url: https://registry.npmjs.org
+          package-manager-cache: false
+
+      - name: Install OIDC-capable npm CLI
+        run: npm install --global npm@11.18.0
+
+      - name: Download Node SDK npm package
+        uses: actions/download-artifact@v7
+        with:
+          name: node-sdk-npm-package
+          path: dist/npm
+
+      - name: Publish Node SDK package
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          RELEASE_VERSION: ${{ needs.metadata.outputs.version }}
+          PRERELEASE: ${{ needs.metadata.outputs.prerelease }}
+        run: |
+          set -euo pipefail
+          if npm view "@meshllm/sdk@$RELEASE_VERSION" version >/dev/null 2>&1; then
+            echo "@meshllm/sdk@$RELEASE_VERSION is already published"
+            exit 0
+          fi
+          dist_tag=latest
+          if [[ "$PRERELEASE" == "true" ]]; then
+            dist_tag=next
+          fi
+          tarball="$(find dist/npm -maxdepth 1 -type f -name '*.tgz' -print -quit)"
+          test -n "$tarball"
+          npm publish "./$tarball" \
+            --access public \
+            --tag "$dist_tag" \
+            --provenance

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -245,3 +245,17 @@ script relies on `cargo publish` to report crate versions that were already
 uploaded, continues past those already-uploaded crates, and retries HTTP 429
 new-crate rate-limit responses using the retry time from crates.io when one is
 provided.
+
+The release workflow also builds the Node SDK N-API addon on macOS ARM64 and
+x64, Linux ARM64 and x64, and Windows x64. After the GitHub release is
+published, it assembles those addons with the tagged `sdk/node` sources and
+console assets, validates the package on Linux, and publishes `@meshllm/sdk` to
+npm. Stable versions use the `latest` dist-tag; prerelease versions use `next`.
+
+npm publishing runs from the GitHub-hosted `publish_node_sdk` job in
+`.github/workflows/release.yml`. The job requests an OIDC token and publishes
+with provenance. `NPM_TOKEN` is accepted only to bootstrap the package's first
+version; npm requires the package to exist before a trusted publisher can be
+configured. Remove that repository secret after configuring the npm trusted
+publisher for `Mesh-LLM/mesh-llm`, workflow `release.yml`, and environment
+`npm`.

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -121,7 +121,7 @@ subgraph PRCI["pr_builds.yml · PR Builds"]
         MainCI["ci.yml\npush main / dispatch"]
         WebsiteDeploy["website-pages.yml\nActions Pages deploy\nPublic Website environment"]
         DockerValidate["docker.yml\nmanual client Dockerfile validation"]
-        Release["release.yml\nrelease artifacts + packaging dispatch"]
+        Release["release.yml\nrelease artifacts + npm/crates.io publishing\n+ packaging dispatch"]
         FlyConsole["fly-deploy-console.yml\nmanual Fly console deploy"]
     end
 
@@ -199,9 +199,10 @@ subgraph PRCI["pr_builds.yml · PR Builds"]
   Rust/build/smoke jobs.
 - Docker image validation and publishing are intentionally not part of pull
   request CI. `docker.yml` is a manual, non-publishing client Dockerfile
-  validation workflow. `release.yml` owns release archives and dispatches the
-  completed full release to `Mesh-LLM/mesh-agent-images`, which is the sole
-  GHCR publisher.
+  validation workflow. `release.yml` owns release archives, publishes the Rust
+  crate chain and the prebuilt `@meshllm/sdk` npm package, and dispatches the
+  completed full release to the packaging repository, which is the sole GHCR
+  publisher.
 - `fly-deploy-console.yml` is a manual (`workflow_dispatch`) deploy of the
   `mesh-llm-console` Fly app. It builds the image on Fly's remote builders from
   `fly/Dockerfile` and authenticates with the app-scoped `FLY_API_TOKEN` repo

--- a/scripts/package-node-sdk.mjs
+++ b/scripts/package-node-sdk.mjs
@@ -1,0 +1,80 @@
+#!/usr/bin/env node
+
+import {
+  copyFileSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync
+} from 'node:fs'
+import { basename, dirname, join, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
+const sourceDir = join(repoRoot, 'sdk', 'node')
+const sourceNativeDir = join(sourceDir, 'native')
+const expectedTargets = [
+  'darwin-arm64',
+  'darwin-x64',
+  'linux-arm64',
+  'linux-x64',
+  'win32-x64'
+]
+
+const [addonRootArg, outputDirArg] = process.argv.slice(2)
+if (!addonRootArg || !outputDirArg) {
+  console.error('usage: scripts/package-node-sdk.mjs <addon-root> <output-dir>')
+  process.exit(2)
+}
+
+const addonRoot = resolve(addonRootArg)
+const outputDir = resolve(outputDirArg)
+if (existsSync(outputDir) && readdirSync(outputDir).length > 0) {
+  throw new Error(`output directory must be empty: ${outputDir}`)
+}
+
+const packageJson = JSON.parse(readFileSync(join(sourceDir, 'package.json'), 'utf8'))
+validatePackageMetadata(packageJson)
+
+mkdirSync(outputDir, { recursive: true })
+cpSync(sourceDir, outputDir, {
+  recursive: true,
+  filter: (source) => resolve(source) !== sourceNativeDir
+})
+copyFileSync(join(repoRoot, 'LICENSE'), join(outputDir, 'LICENSE'))
+
+for (const target of expectedTargets) {
+  const source = join(addonRoot, target, 'mesh_llm_nodejs.node')
+  if (!existsSync(source) || statSync(source).size === 0) {
+    throw new Error(`missing non-empty Node SDK addon: ${source}`)
+  }
+  const destination = join(outputDir, 'native', target, basename(source))
+  mkdirSync(dirname(destination), { recursive: true })
+  copyFileSync(source, destination)
+}
+
+console.log(`prepared ${packageJson.name}@${packageJson.version} in ${outputDir}`)
+console.log(`included native addons: ${expectedTargets.join(', ')}`)
+
+function validatePackageMetadata(packageJson) {
+  if (packageJson.name !== '@meshllm/sdk') {
+    throw new Error(`unexpected Node SDK package name: ${packageJson.name}`)
+  }
+  if (!/^\d+\.\d+\.\d+(?:-[0-9A-Za-z.-]+)?$/.test(packageJson.version)) {
+    throw new Error(`invalid Node SDK package version: ${packageJson.version}`)
+  }
+  if (packageJson.repository?.url !== 'git+https://github.com/Mesh-LLM/mesh-llm.git') {
+    throw new Error('Node SDK repository URL must match Mesh-LLM/mesh-llm for npm provenance')
+  }
+  if (packageJson.repository?.directory !== 'sdk/node') {
+    throw new Error('Node SDK repository directory must be sdk/node')
+  }
+  if (packageJson.publishConfig?.access !== 'public') {
+    throw new Error('Node SDK publishConfig.access must be public')
+  }
+  if (packageJson.publishConfig?.registry !== 'https://registry.npmjs.org/') {
+    throw new Error('Node SDK publishConfig.registry must be the public npm registry')
+  }
+}

--- a/scripts/tests/test_package_node_sdk.py
+++ b/scripts/tests/test_package_node_sdk.py
@@ -1,0 +1,88 @@
+import json
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+EXPECTED_TARGETS = (
+    "darwin-arm64",
+    "darwin-x64",
+    "linux-arm64",
+    "linux-x64",
+    "win32-x64",
+)
+
+
+class PackageNodeSdkTests(unittest.TestCase):
+    def test_assembles_all_native_targets_and_npm_tarball(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            addons = temporary_path / "addons"
+            output = temporary_path / "package"
+            for target in EXPECTED_TARGETS:
+                addon = addons / target / "mesh_llm_nodejs.node"
+                addon.parent.mkdir(parents=True)
+                addon.write_bytes(f"fixture:{target}".encode())
+
+            subprocess.run(
+                [
+                    "node",
+                    "scripts/package-node-sdk.mjs",
+                    str(addons),
+                    str(output),
+                ],
+                cwd=ROOT,
+                check=True,
+            )
+
+            for target in EXPECTED_TARGETS:
+                self.assertTrue(
+                    (output / "native" / target / "mesh_llm_nodejs.node").is_file()
+                )
+            self.assertTrue((output / "LICENSE").is_file())
+
+            packed = subprocess.run(
+                ["npm", "pack", "--dry-run", "--json"],
+                cwd=output,
+                check=True,
+                capture_output=True,
+                text=True,
+            )
+            files = {entry["path"] for entry in json.loads(packed.stdout)[0]["files"]}
+            for target in EXPECTED_TARGETS:
+                self.assertIn(
+                    f"native/{target}/mesh_llm_nodejs.node",
+                    files,
+                )
+            self.assertIn("LICENSE", files)
+
+    def test_rejects_a_missing_native_target(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            temporary_path = Path(temporary)
+            addons = temporary_path / "addons"
+            output = temporary_path / "package"
+            for target in EXPECTED_TARGETS[:-1]:
+                addon = addons / target / "mesh_llm_nodejs.node"
+                addon.parent.mkdir(parents=True)
+                addon.write_bytes(b"fixture")
+
+            result = subprocess.run(
+                [
+                    "node",
+                    "scripts/package-node-sdk.mjs",
+                    str(addons),
+                    str(output),
+                ],
+                cwd=ROOT,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("win32-x64", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -7,6 +7,18 @@ The package uses a native N-API addon built from `crates/mesh-llm-nodejs`. It is
 not a mock wrapper around the CLI. Local serving uses the same embedded runtime
 path as the Swift and Kotlin SDKs.
 
+## Install
+
+```bash
+npm install @meshllm/sdk
+```
+
+Release packages include prebuilt addons for:
+
+- macOS on Apple Silicon and Intel
+- Linux on ARM64 and x64
+- Windows on x64
+
 ## Build From Source
 
 ```bash
@@ -117,7 +129,6 @@ Windows is supported through the same N-API addon shape:
   `meshllm-native-windows-x86_64-cuda`, `meshllm-native-windows-x86_64-rocm`,
   or `meshllm-native-windows-x86_64-vulkan`
 
-The Windows release pipeline already builds CPU, CUDA, ROCm, and Vulkan runtime
-bundles. The Node SDK should publish matching prebuilt addon/runtime packages
-for Electron consumers instead of requiring local Visual Studio/CUDA/ROCm/Vulkan
-toolchains.
+The npm package includes the Windows x64 N-API addon. CPU, CUDA, ROCm, and
+Vulkan serving runtimes remain separate release artifacts that the SDK can
+resolve or download for Electron consumers.

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -4,12 +4,22 @@
   "description": "Node.js SDK for MeshLLM client and local serving applications",
   "main": "index.js",
   "types": "index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mesh-LLM/mesh-llm.git",
+    "directory": "sdk/node"
+  },
+  "homepage": "https://github.com/Mesh-LLM/mesh-llm/tree/main/sdk/node",
+  "bugs": {
+    "url": "https://github.com/Mesh-LLM/mesh-llm/issues"
+  },
   "files": [
     "index.js",
     "index.d.ts",
     "native-runtime.js",
     "console/",
     "native/",
+    "LICENSE",
     "README.md"
   ],
   "scripts": {
@@ -28,5 +38,10 @@
     "arm64",
     "x64"
   ],
-  "license": "MIT OR Apache-2.0"
+  "license": "MIT OR Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  }
 }

--- a/sdk/node/scripts/build-native.mjs
+++ b/sdk/node/scripts/build-native.mjs
@@ -7,6 +7,7 @@ const repoRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)))
 const profile = process.env.MESH_NODE_PROFILE || 'release'
 const cargoArgs = [
   'build',
+  '--locked',
   '-p',
   'mesh-llm-nodejs',
   '--no-default-features',
@@ -14,6 +15,12 @@ const cargoArgs = [
   'embedded-runtime'
 ]
 if (profile === 'release') cargoArgs.push('--release')
+if (profile === 'release' && process.platform === 'darwin') {
+  // Cargo's release profile strips debuginfo with llvm-objcopy. On macOS 27,
+  // llvm-objcopy can misalign a large dylib's LINKEDIT string pool and make
+  // dyld reject the addon. Keep the linked Mach-O intact for npm packaging.
+  cargoArgs.push('--config', 'profile.release.strip=false')
+}
 
 const build = spawnSync('cargo', cargoArgs, {
   cwd: repoRoot,


### PR DESCRIPTION
## Summary

- build precompiled Node SDK addons for macOS ARM64/x64, Linux ARM64/x64, and Windows x64 during releases
- assemble and test the exact cross-platform `@meshllm/sdk` tarball before publishing
- publish stable releases under `latest` and prereleases under `next`
- use GitHub Actions OIDC with npm provenance, retaining `NPM_TOKEN` only as a first-publish bootstrap fallback
- document the release path and add package-assembly regression tests

## Why

`@meshllm/sdk` is not currently available from npm, so standalone consumers such as `openclaw-meshllm` must depend on a sibling MeshLLM checkout. This gives the Node SDK a versioned, installable distribution path with prebuilt native addons.

The package must include native binaries: publishing only the JavaScript wrapper would install successfully but fail during `require('@meshllm/sdk')`.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 96 passed, 3 skipped
- `npm test --prefix sdk/node` — 2 passed
- built the macOS ARM64 addon from the clean worktree and loaded it through Node (`currentMeshVersion() === '0.72.1'`)
- `actionlint .github/workflows/*.yml`
- parsed every workflow and composite-action YAML file
- `GIT_MASTER=1 cargo run -p xtask -- repo-consistency release-targets`
- `GIT_MASTER=1 git diff --check`

## npm setup checklist

npm requires a package to exist before a trusted publisher can be attached, so the first release uses a short-lived bootstrap token. After that, publishing is tokenless through OIDC.

- [x] Create or confirm the `meshllm` organization on npm and grant the release maintainer permission to publish public packages under `@meshllm`
- [ ] Enable 2FA on the npm maintainer account
- [ ] In GitHub, create the `npm` environment for `Mesh-LLM/mesh-llm` and add any desired required reviewers
- [ ] Create a granular npm access token scoped to the `meshllm` organization/packages, with publish access and 2FA bypass for automation
- [ ] Add that temporary token as the `NPM_TOKEN` secret on the GitHub `npm` environment
- [ ] Merge this PR and run the next normal MeshLLM release; confirm the first `@meshllm/sdk` version appears publicly on npm with provenance
- [ ] On npm, configure the package's GitHub Actions trusted publisher with organization `Mesh-LLM`, repository `mesh-llm`, workflow filename `release.yml`, environment `npm`, and permission to run `npm publish`
- [ ] Run a subsequent release and confirm `publish_node_sdk` authenticates through OIDC
- [ ] Delete the GitHub `NPM_TOKEN` secret and revoke the bootstrap token on npm
- [ ] Set npm package publishing access to require 2FA and disallow traditional tokens
- [ ] Verify `npm install @meshllm/sdk` and addon loading on each supported platform

## Follow-up

Once the first npm version is live, `openclaw-meshllm` can replace its sibling `file:` dependency with a normal semver dependency on `@meshllm/sdk`.