### PR TITLE
fix(mesh): owner-control listener must not share the mesh relay slot

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/node.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node.rs
@@ -258,23 +258,6 @@ pub(crate) fn init_owner_runtime(
     })
 }
 
-pub(crate) fn configure_control_relay(
-    mut builder: iroh::endpoint::Builder,
-    relay: Option<RelayConfig<'_>>,
-) -> Result<iroh::endpoint::Builder> {
-    if let Some(relay) = relay.filter(|relay| relay.policy.uses_relay()) {
-        let urls = effective_relay_urls(relay.policy, relay.urls);
-        tracing::info!("Owner-control relay: {:?}", urls);
-        builder = builder.relay_mode(iroh::endpoint::RelayMode::Custom(relay_map_from_urls(
-            &urls,
-            relay.auths,
-        )?));
-    } else {
-        builder = builder.relay_mode(iroh::endpoint::RelayMode::Disabled);
-    }
-    Ok(builder)
-}
-
 pub(crate) fn default_plugin_event_source(endpoint_id: EndpointId, source_peer_id: &mut String) {
     if source_peer_id.is_empty() {
         *source_peer_id = endpoint_id_hex(endpoint_id);
@@ -1060,7 +1043,6 @@ impl Node {
             owner_config
                 .as_ref()
                 .and_then(|config| config.control_advertise_addr),
-            relay.policy.uses_relay().then_some(relay),
         )
         .await?;
 
@@ -1227,26 +1209,39 @@ impl Node {
         secret_key: SecretKey,
         bind_addr: Option<std::net::SocketAddr>,
         advertise_addr: Option<std::net::SocketAddr>,
-        relay: Option<RelayConfig<'_>>,
     ) -> Result<()> {
         if self.local_verified_owner_id().await.is_none() {
             return Ok(());
         }
 
-        let mut builder = Endpoint::builder(iroh::endpoint::presets::Minimal)
+        // The owner-control listener deliberately shares the node's secret key
+        // (and therefore its iroh endpoint id) with the main mesh endpoint: the
+        // control protocol validates the dialed `target_node_id` against the
+        // main endpoint id (`verify_control_plane_target_node`), so the control
+        // endpoint MUST present that same id.
+        //
+        // Because the id is shared, this endpoint must NOT register with the
+        // relay. An iroh relay keeps only one active connection per endpoint id:
+        // a second same-id registration evicts the first ("Another endpoint
+        // connected with the same endpoint id. No more messages will be
+        // received."). The control listener binds *after* the main mesh
+        // endpoint, so if it also joined the relay it would steal the main
+        // endpoint's relay slot and silently cut off all relay-delivered mesh
+        // traffic (gossip, joins, inference routing) — breaking relay fallback
+        // for any peer that cannot reach this node directly. Keeping the control
+        // endpoint relay-disabled leaves the main mesh endpoint as the sole
+        // relay registrant for this id. Owner-control is therefore reachable
+        // over its direct / advertised address only; relay-assisted remote
+        // owner-control is intentionally unsupported while the control and mesh
+        // endpoints share one id.
+        let endpoint = Endpoint::builder(iroh::endpoint::presets::Minimal)
             .secret_key(secret_key)
             .alpns(vec![ALPN_CONTROL_V1.to_vec()])
-            .bind_addr(bind_addr.unwrap_or_else(default_control_bind_addr))?;
-        builder = configure_control_relay(builder, relay)?;
-        let endpoint = builder.bind().await?;
-        if relay.is_some_and(|relay| relay.policy.uses_relay()) {
-            wait_for_endpoint_online(
-                &endpoint,
-                "Owner-control relay connected",
-                "Owner-control relay connection timed out (5s) — proceeding with direct endpoint addresses only",
-            )
-            .await;
-        }
+            .clear_ip_transports()
+            .bind_addr(bind_addr.unwrap_or_else(default_control_bind_addr))?
+            .relay_mode(iroh::endpoint::RelayMode::Disabled)
+            .bind()
+            .await?;
         let token = encode_endpoint_addr_token(&control_endpoint_addr(&endpoint, advertise_addr));
         let shutdown_requested = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let shutdown = Arc::new(tokio::sync::Notify::new());

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/admission/helpers.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/admission/helpers.rs
@@ -169,7 +169,7 @@ pub(super) async fn start_owner_control_test_server(
     *node.owner_attestation.lock().await = Some(ownership);
     *node.owner_summary.lock().await = owner_summary;
     *node.trust_store.lock().await = trust_store;
-    node.maybe_start_control_listener(secret_key.clone(), None, None, None)
+    node.maybe_start_control_listener(secret_key.clone(), None, None)
         .await?;
     Ok((node, secret_key, config_path))
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/control_listener.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/control_listener.rs
@@ -41,7 +41,7 @@ async fn control_plane_listener_starts_with_owner() -> anyhow::Result<()> {
         Node::new_for_tests_with_secret(super::super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
 
-    node.maybe_start_control_listener(secret_key, None, None, None)
+    node.maybe_start_control_listener(secret_key, None, None)
         .await?;
 
     let endpoint = node
@@ -60,6 +60,57 @@ async fn control_plane_listener_starts_with_owner() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Regression test for the owner-control / main-mesh relay endpoint-id
+/// collision.
+///
+/// The owner-control listener shares the node's secret key (and therefore its
+/// iroh endpoint id) with the main mesh endpoint, because the control protocol
+/// validates the dialed `target_node_id` against the main endpoint id. An iroh
+/// relay keeps only one active connection per endpoint id, so if the control
+/// endpoint also registered with the relay it would evict the main mesh
+/// endpoint's relay registration ("Another endpoint connected with the same
+/// endpoint id. No more messages will be received."), silently killing all
+/// relay-delivered mesh traffic — gossip, joins, inference routing — for peers
+/// that cannot reach this node directly. That defeats relay fallback and is the
+/// root cause of consume-side "connects but never joins / catalog never syncs".
+///
+/// The fix keeps the control endpoint relay-disabled. This test pins the
+/// observable invariant: the control endpoint token must advertise NO relay
+/// URLs, so it can never contend for the shared id's relay slot. If someone
+/// re-enables relay on the control endpoint, this fails.
+#[tokio::test]
+async fn control_plane_listener_token_carries_no_relay_urls() -> anyhow::Result<()> {
+    let (node, secret_key) =
+        Node::new_for_tests_with_secret(super::super::NodeRole::Worker).await?;
+    *node.owner_summary.lock().await = verified_owner_summary("owner-a");
+
+    node.maybe_start_control_listener(secret_key, None, None)
+        .await?;
+
+    let endpoint = node
+        .control_endpoint()
+        .await
+        .expect("verified owner should start a control listener");
+    let decoded = Node::decode_invite_token(&endpoint)?;
+
+    // Same id as the main mesh endpoint (required by target-node validation)...
+    assert_eq!(decoded.id, node.endpoint.id());
+    // ...but ZERO relay URLs, so it cannot evict the main endpoint's relay slot.
+    let relay_addrs = decoded
+        .addrs
+        .iter()
+        .filter(|addr| matches!(addr, iroh::TransportAddr::Relay(_)))
+        .count();
+    assert_eq!(
+        relay_addrs, 0,
+        "owner-control token must not advertise relay URLs (shares the main \
+         endpoint id; a relay registration would evict the main mesh endpoint)"
+    );
+
+    node.shutdown_control_listener().await;
+    Ok(())
+}
+
 #[tokio::test]
 async fn control_plane_listener_uses_explicit_advertised_address() -> anyhow::Result<()> {
     let (node, secret_key) =
@@ -67,7 +118,7 @@ async fn control_plane_listener_uses_explicit_advertised_address() -> anyhow::Re
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
     let advertised_addr = std::net::SocketAddr::from(([203, 0, 113, 10], 18443));
 
-    node.maybe_start_control_listener(secret_key, None, Some(advertised_addr), None)
+    node.maybe_start_control_listener(secret_key, None, Some(advertised_addr))
         .await?;
 
     let endpoint = node
@@ -92,13 +143,8 @@ async fn control_plane_listener_disabled_without_owner() -> anyhow::Result<()> {
     let (node, secret_key) =
         Node::new_for_tests_with_secret(super::super::NodeRole::Worker).await?;
 
-    node.maybe_start_control_listener(
-        secret_key,
-        Some("127.0.0.1:7447".parse().unwrap()),
-        None,
-        None,
-    )
-    .await?;
+    node.maybe_start_control_listener(secret_key, Some("127.0.0.1:7447".parse().unwrap()), None)
+        .await?;
 
     assert!(node.control_endpoint().await.is_none());
     Ok(())
@@ -109,7 +155,7 @@ async fn control_plane_listener_accepts_only_control_alpn() -> anyhow::Result<()
     let (node, secret_key) =
         Node::new_for_tests_with_secret(super::super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
-    node.maybe_start_control_listener(secret_key, None, None, None)
+    node.maybe_start_control_listener(secret_key, None, None)
         .await?;
     let endpoint = Node::decode_invite_token(
         &node
@@ -186,7 +232,7 @@ async fn control_plane_endpoint_not_in_gossip_or_status() -> anyhow::Result<()> 
     let (node, secret_key) =
         Node::new_for_tests_with_secret(super::super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
-    node.maybe_start_control_listener(secret_key, None, None, None)
+    node.maybe_start_control_listener(secret_key, None, None)
         .await?;
     let control_endpoint = node
         .control_endpoint()
@@ -223,7 +269,7 @@ async fn control_plane_listener_shutdown_stops_listener_task() -> anyhow::Result
     let (node, secret_key) =
         Node::new_for_tests_with_secret(super::super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
-    node.maybe_start_control_listener(secret_key, None, None, None)
+    node.maybe_start_control_listener(secret_key, None, None)
         .await?;
     let endpoint = Node::decode_invite_token(
         &node

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/control_listener.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/control_listener.rs
@@ -107,6 +107,21 @@ async fn control_plane_listener_token_carries_no_relay_urls() -> anyhow::Result<
          endpoint id; a relay registration would evict the main mesh endpoint)"
     );
 
+    // Invariant (defence-in-depth): the control endpoint is loopback-only by
+    // default — it must NOT advertise any non-loopback IP transport. This keeps
+    // the control plane non-routable off-box unless an explicit advertise addr
+    // is configured (see the dedicated test), preserving the separation intent
+    // of the split-control design (#539) while fixing the relay-slot eviction.
+    for addr in &decoded.addrs {
+        if let iroh::TransportAddr::Ip(sock) = addr {
+            assert!(
+                sock.ip().is_loopback(),
+                "owner-control token must only advertise loopback IPs by default, \
+                 found non-loopback {sock}"
+            );
+        }
+    }
+
     node.shutdown_control_listener().await;
     Ok(())
 }


### PR DESCRIPTION
## Problem

A node with a **verified owner identity** starts a *second* iroh endpoint — the
owner-control listener (`ALPN mesh-llm-control/1`) — using the **same secret key**
as the main mesh endpoint, so both present the **same iroh endpoint id**. The
control protocol requires the shared id: it validates the dialed `target_node_id`
against the main endpoint id (`verify_control_plane_target_node`).

An iroh relay keeps only **one active connection per endpoint id**
(`iroh-relay` `server/clients.rs`: a second same-id registration does
`std::mem::replace(&mut state.active, client)` and the old one "can still send
messages, but won't receive anything"). The control listener enables relay and
binds **after** the main mesh endpoint, so it **evicts the main endpoint's relay
registration** — logged as:

```
Relay server reports problem: Another endpoint connected with the same endpoint id.
No more messages will be received.
```

The main mesh endpoint then goes dark on the relay. All relay-delivered mesh
traffic (gossip, joins, inference routing) stops. Any peer that cannot reach the
node **directly** never completes its join, never syncs the model catalog, and
every inference returns 429/503.

## Impact

Consumers on a network where the direct path does not establish (common: NAT /
LAN-hairpin) are left with **no relay fallback**, because the fallback path was
silently destroyed. Consume appears to "connect but never join".

## Fix

Bind the owner-control listener with `RelayMode::Disabled` so it never contends
for the shared id's relay slot. The main mesh endpoint is **unchanged** and keeps
relay + NAT traversal; it becomes the sole relay registrant for the id. Also
`clear_ip_transports()` on the control endpoint so an explicit IPv4 bind does not
leave iroh's implicit `[::]:0` socket (which can trip `MultipathNotNegotiated`
with relay disabled) — mirroring the main endpoint's LAN-only handling.

Removed the now-unused `configure_control_relay` helper, its `relay` parameter,
and the control-endpoint relay `online()` wait.

## Trade-off

Owner-control becomes reachable over its **direct / advertised address only**;
relay-assisted remote owner-control across NAT is unsupported while control and
mesh share one id. Giving control its own relay presence would require a distinct
endpoint id, which the control target validation forbids (would be a
protocol-level change). Buzz — the downstream that hit this — never dials
owner-control, so this trade-off is invisible there.

## Verification

- New regression test `control_plane_listener_token_carries_no_relay_urls`
  asserts the control token advertises zero relay URLs while keeping the main
  endpoint id. All 6 `control_plane_listener` tests pass.
- Live A/B, two Macs, owner identity present both sides:
  - **Before:** consumer logs the "same endpoint id" eviction, never joins.
  - **After:** consumer joins over the relay and inference returns HTTP 200.

## Notes

- Also available as a minimal backport onto the `v0.73.1` release layout
  (branch `micn/fix-owner-control-relay-collision-v0.73.1`) for downstreams
  pinning that tag.
- **A separate, pre-existing direct-hole-punch reliability problem** (native
  mesh's direct LAN path is flaky where raw iroh's is not) is filed separately as
  a blocker issue — it is **not** caused by this change (reproduces on unpatched
  `v0.73.1` too) and is orthogonal to this relay-slot fix.
