### PR TITLE
fix(mesh): enable QUIC Address Discovery (QAD) on managed relays

### DIFF
--- a/crates/mesh-client/src/client/builder.rs
+++ b/crates/mesh-client/src/client/builder.rs
@@ -566,7 +566,10 @@ fn relay_map_from_endpoint_addr(addr: &EndpointAddr) -> Option<iroh::RelayMap> {
     let configs: Vec<_> = addr
         .relay_urls()
         .cloned()
-        .map(|url| iroh::RelayConfig::new(url, None))
+        // Preserve iroh's default QUIC Address Discovery (QAD). `new(url, None)`
+        // disables it, preventing reflexive candidate discovery and direct-path
+        // upgrades across NAT (see issue #1065). `RelayUrl::into()` keeps QAD on.
+        .map(|url| -> iroh::RelayConfig { url.into() })
         .collect();
     if configs.is_empty() {
         None

--- a/crates/mesh-client/src/client/control_plane.rs
+++ b/crates/mesh-client/src/client/control_plane.rs
@@ -835,7 +835,10 @@ fn relay_map_from_endpoint_addr(addr: &EndpointAddr) -> Option<iroh::RelayMap> {
     let configs: Vec<_> = addr
         .relay_urls()
         .cloned()
-        .map(|url| iroh::RelayConfig::new(url, None))
+        // Preserve iroh's default QUIC Address Discovery (QAD). `new(url, None)`
+        // disables it, preventing reflexive candidate discovery and direct-path
+        // upgrades across NAT (see issue #1065). `RelayUrl::into()` keeps QAD on.
+        .map(|url| -> iroh::RelayConfig { url.into() })
         .collect();
     if configs.is_empty() {
         None

--- a/crates/mesh-llm-host-runtime/src/mesh/connections.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/connections.rs
@@ -200,6 +200,8 @@ pub(crate) fn effective_relay_urls(policy: RelayPolicy, relay_urls: &[String]) -
         RelayPolicy::DefaultPublic if relay_urls.is_empty() => vec![
             "https://usw1-2.relay.michaelneale.mesh-llm.iroh.link./".into(),
             "https://aps1-1.relay.michaelneale.mesh-llm.iroh.link./".into(),
+            "https://euc1-1.relay.michaelneale.mesh-llm.iroh.link./".into(),
+            "https://use1-1.relay.michaelneale.mesh-llm.iroh.link./".into(),
         ],
         RelayPolicy::DefaultPublic => relay_urls.to_vec(),
     }
@@ -256,10 +258,17 @@ pub(crate) fn relay_map_from_urls(
     auths: &std::collections::HashMap<String, String>,
 ) -> Result<iroh::RelayMap> {
     let configs = urls.iter().map(|url| {
-        let parsed = url
+        let parsed: iroh::RelayUrl = url
             .parse()
             .with_context(|| format!("invalid relay URL `{url}`"))?;
-        let cfg = iroh::RelayConfig::new(parsed, None);
+        // Preserve iroh's default QUIC Address Discovery (QAD, UDP 7842).
+        // `iroh::RelayConfig::new(parsed, None)` explicitly DISABLES QAD, so
+        // net-report never learns a reflexive public UDP candidate and direct
+        // paths across NAT cannot form (nodes fall back to relay). Constructing
+        // via `RelayUrl::into()` keeps QAD enabled — iroh's default. QAD is
+        // client-driven and gated behind `has_ip_transports`, so relay-only and
+        // LAN-only endpoints are unaffected. See issue #1065.
+        let cfg: iroh::RelayConfig = parsed.into();
         Ok(match auths.get(url) {
             Some(token) => cfg.with_auth_token(token.clone()),
             None => cfg,
@@ -289,6 +298,17 @@ mod relay_map_tests {
         assert!(
             cfgs[0].auth_token.is_none(),
             "no auth supplied → no auth_token set"
+        );
+        // QAD must be enabled (issue #1065): the relay config must carry a QUIC
+        // address-discovery config on the default port, else nodes never learn a
+        // reflexive candidate and direct-path upgrades across NAT cannot form.
+        let quic = cfgs[0]
+            .quic
+            .as_ref()
+            .expect("default QUIC address discovery (QAD) should be enabled");
+        assert_eq!(
+            quic.port, 7842,
+            "QAD should use iroh's default relay QUIC port"
         );
     }
 


### PR DESCRIPTION
## Problem

Relay maps were built with `iroh::RelayConfig::new(url, None)`. The trailing
`None` **explicitly disables** iroh's QUIC Address Discovery (QAD).

This was not a deliberate decision. The call predates the iroh **0.98 → 1.0**
upgrade: on 0.98 `new(url, None)` meant "use QAD defaults"; on 1.0 it means
"QAD **off**", and the blessed constructor became `RelayUrl::into()`. The stale
call silently flipped QAD off across the upgrade and nobody caught it.

**Consequence:** `net-report` never learns a reflexive public UDP candidate, so
a node's `local_candidates` are LAN-only and direct-path (hole-punch) upgrades
across NAT cannot form — nodes fall back to relay. This degrades direct
connectivity for **every** node on the managed relays (single- or dual-endpoint,
owner or not). The Inkling multi-node work hit this independently.

## Fix

Construct relay configs via `RelayUrl::into()`, preserving iroh's default QAD
(UDP 7842). Applied at all three sites that build relay maps:

- `mesh-llm-host-runtime` data plane — `connections.rs::relay_map_from_urls`
- `mesh-client` builder dial path — `builder.rs`
- `mesh-client` owner-control dial path — `control_plane.rs`

Also adds the managed `euc1-1` and `use1-1` relays to the default public set.

## Safety

- **Restores an iroh default**, not a new feature.
- QAD is **client-driven** and iroh gates it behind `has_ip_transports`, so
  relay-only / LAN-only endpoints are unaffected (no `MultipathNotNegotiated`
  risk in those modes).
- The only thing revealed is the node's public IP:port to **its own relay** —
  which already terminates its traffic. No new trust surface.

## Verification

- With the fix, a client's `local_candidates` include the reflexive public
  address and the invite token carries it (confirmed on a two-node cross-NAT
  A/B).
- Regression test asserts the relay config exposes QAD on port 7842.

## Scope note

QAD is **necessary but not sufficient** for owner-identity nodes to hole-punch
directly. The dual same-endpoint-id issue (#1065) is a separate, independent
defect that also blocks direct for owner nodes. Full matrix in #1065. This PR is
the standalone QAD win that benefits the whole network regardless of that.

Refs #1065


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection reliability by preserving QUIC Address Discovery for relay connections, supporting better NAT traversal.
  * Enabled relay connections to use the default QUIC relay port.

* **Improvements**
  * Expanded the default public relay selection with additional managed relay endpoints in Europe and the US East region.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->