### PR TITLE
Fix release containers and restore sccache GHA caching

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -35,6 +35,9 @@ Local actions:
 
 - `.github/actions/compute-changes` owns path, crate, backend, SDK, UI, website,
   Windows, and docs-only routing outputs.
+- `.github/actions/configure-sccache-gha` exports ephemeral Actions cache
+  credentials to the baked `sccache`, probes the GHA backend, and restarts the
+  server with job-local storage when the probe fails.
 - `.github/actions/restore-smoke-inputs` owns producer artifact staging and
   model restoration for smoke consumers.
 - `.github/actions/setup-windows-rocm-sdk` owns reusable Windows ROCm setup.
@@ -122,11 +125,13 @@ MeshLLM workflows pin the public digest. The Flux repository must independently
 roll the ARC HelmReleases to the paired self-hosted digest; that cross-repository
 change cannot be delivered by a MeshLLM pull request.
 
-Public-image Rust jobs use the baked `sccache` binary with
-`SCCACHE_GHA_ENABLED=false`, so compiler startup does not depend on the
-availability of GitHub's cache service. Persistent Cargo target and ABI reuse
-remains owned by `Swatinem/rust-cache` and `actions/cache`. Do not reintroduce
-the sccache download action merely to export credentials.
+Public-image Rust jobs use the baked `sccache` binary and start with
+`SCCACHE_GHA_ENABLED=false`. The local `configure-sccache-gha` action exports
+the ephemeral Actions cache URL/token, enables the GHA backend, and probes it by
+starting the server. If that probe fails, the action stops the remote-configured
+server and restarts `sccache` with its job-local disk cache. Persistent Cargo
+target and ABI reuse remains owned by `Swatinem/rust-cache` and `actions/cache`.
+Do not reintroduce the sccache download action merely to export credentials.
 
 `USE_SELF_HOSTED` currently controls selected GPU/release routes. Unset or a
 value other than the exact string `true` selects the hosted fallback. Any new

--- a/.github/actions/configure-sccache-gha/action.yml
+++ b/.github/actions/configure-sccache-gha/action.yml
@@ -1,0 +1,49 @@
+name: Configure baked sccache GHA backend
+description: Use Actions cache from the baked sccache binary with a job-local fallback.
+
+runs:
+  using: composite
+  steps:
+    - name: Export cache credentials and start sccache
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
+      with:
+        script: |
+          const cacheUrl = process.env.ACTIONS_CACHE_URL || '';
+          const resultsUrl = process.env.ACTIONS_RESULTS_URL || '';
+          const runtimeToken = process.env.ACTIONS_RUNTIME_TOKEN || '';
+
+          if (runtimeToken) {
+            core.setSecret(runtimeToken);
+          }
+
+          core.exportVariable('ACTIONS_CACHE_URL', cacheUrl);
+          core.exportVariable('ACTIONS_RESULTS_URL', resultsUrl);
+          core.exportVariable('ACTIONS_RUNTIME_TOKEN', runtimeToken);
+
+          await exec.exec('sccache', ['--stop-server'], {
+            ignoreReturnCode: true,
+          });
+          core.exportVariable('SCCACHE_GHA_ENABLED', 'true');
+
+          const remoteExitCode = await exec.exec('sccache', ['--start-server'], {
+            ignoreReturnCode: true,
+          });
+          if (remoteExitCode === 0) {
+            core.info('Baked sccache is using the GitHub Actions cache backend.');
+            return;
+          }
+
+          core.warning(
+            'GitHub Actions cache is unavailable; restarting baked sccache with its job-local disk cache.',
+          );
+          await exec.exec('sccache', ['--stop-server'], {
+            ignoreReturnCode: true,
+          });
+          core.exportVariable('SCCACHE_GHA_ENABLED', 'false');
+
+          const localExitCode = await exec.exec('sccache', ['--start-server'], {
+            ignoreReturnCode: true,
+          });
+          if (localExitCode !== 0) {
+            core.setFailed('Unable to start baked sccache with either remote or job-local storage.');
+          }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -350,6 +350,7 @@ jobs:
       LLAMA_STAGE_BACKEND: cuda
       MESH_NATIVE_RUNTIME_TARGET: aarch64-unknown-linux-gnu
       MESH_LLM_CUDA_TOOLKIT_MAJOR: ${{ matrix.cuda_major }}
+      SCCACHE_GHA_ENABLED: "false"
     steps:
       - uses: actions/checkout@v5
         with:
@@ -411,6 +412,7 @@ jobs:
       LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-dynamic-cuda-sm${{ matrix.cuda_architectures_cache }}
       MESH_NATIVE_RUNTIME_TARGET: x86_64-unknown-linux-gnu
       MESH_LLM_CUDA_TOOLKIT_MAJOR: ${{ matrix.cuda_major }}
+      SCCACHE_GHA_ENABLED: "false"
     steps:
       - uses: actions/checkout@v5
         with:
@@ -462,6 +464,7 @@ jobs:
       LLAMA_STAGE_AMDGPU_TARGETS: gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201
       LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-dynamic-rocm-gfx90a_gfx942_gfx1100_gfx1101_gfx1102_gfx1103_gfx1151_gfx1200_gfx1201
       MESH_NATIVE_RUNTIME_TARGET: x86_64-unknown-linux-gnu
+      SCCACHE_GHA_ENABLED: "false"
     steps:
       - uses: actions/checkout@v5
         with:
@@ -512,10 +515,13 @@ jobs:
       LLAMA_STAGE_BACKEND: vulkan
       LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-dynamic-vulkan
       MESH_NATIVE_RUNTIME_TARGET: x86_64-unknown-linux-gnu
+      SCCACHE_GHA_ENABLED: "false"
     steps:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+      - name: Trust checkout directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
         run: verify-runner-image public vulkan
       - name: Cache native runtime Vulkan backend build
@@ -737,6 +743,7 @@ jobs:
       LLAMA_STAGE_BACKEND: cuda
       MESH_RELEASE_ARCH: aarch64
       MESH_CUDA_VERSION: ${{ matrix.cuda_version }}
+      SCCACHE_GHA_ENABLED: "false"
     steps:
       - uses: actions/checkout@v5
         with:
@@ -794,6 +801,7 @@ jobs:
       LLAMA_STAGE_BACKEND: cuda
       LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-cuda-sm${{ matrix.cuda_architectures_cache }}
       MESH_CUDA_VERSION: ${{ matrix.cuda_version }}
+      SCCACHE_GHA_ENABLED: "false"
     steps:
       - uses: actions/checkout@v5
         with:
@@ -846,6 +854,7 @@ jobs:
       LLAMA_STAGE_BACKEND: rocm
       LLAMA_STAGE_AMDGPU_TARGETS: gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201
       LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-rocm-gfx90a_gfx942_gfx1100_gfx1101_gfx1102_gfx1103_gfx1151_gfx1200_gfx1201
+      SCCACHE_GHA_ENABLED: "false"
     steps:
       - uses: actions/checkout@v5
         with:
@@ -895,10 +904,13 @@ jobs:
     env:
       LLAMA_STAGE_BACKEND: vulkan
       LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-vulkan
+      SCCACHE_GHA_ENABLED: "false"
     steps:
       - uses: actions/checkout@v5
         with:
           persist-credentials: false
+      - name: Trust checkout directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
         run: verify-runner-image public vulkan
       - name: Cache release Vulkan backend build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -359,6 +359,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
         run: verify-runner-image public cuda
+      - uses: ./.github/actions/configure-sccache-gha
       - name: Prepare dispatched release version
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -421,6 +422,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
         run: verify-runner-image public cuda
+      - uses: ./.github/actions/configure-sccache-gha
       - name: Cache native runtime CUDA backend build
         uses: actions/cache@v5
         with:
@@ -473,6 +475,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
         run: verify-runner-image public rocm
+      - uses: ./.github/actions/configure-sccache-gha
       - name: Cache native runtime ROCm backend build
         uses: actions/cache@v5
         with:
@@ -524,6 +527,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
         run: verify-runner-image public vulkan
+      - uses: ./.github/actions/configure-sccache-gha
       - name: Cache native runtime Vulkan backend build
         uses: actions/cache@v5
         with:
@@ -752,6 +756,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
         run: verify-runner-image public cuda
+      - uses: ./.github/actions/configure-sccache-gha
       - name: Prepare dispatched release version
         if: github.event_name == 'workflow_dispatch'
         env:
@@ -810,6 +815,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
         run: verify-runner-image public cuda
+      - uses: ./.github/actions/configure-sccache-gha
       - name: Cache release CUDA backend build
         uses: actions/cache@v5
         with:
@@ -863,6 +869,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
         run: verify-runner-image public rocm
+      - uses: ./.github/actions/configure-sccache-gha
       - name: Cache release ROCm backend build
         uses: actions/cache@v5
         with:
@@ -913,6 +920,7 @@ jobs:
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
         run: verify-runner-image public vulkan
+      - uses: ./.github/actions/configure-sccache-gha
       - name: Cache release Vulkan backend build
         uses: actions/cache@v5
         with:

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -295,11 +295,14 @@ anonymous pull still returns `401` or `403`, public-container jobs must grant
 and `secrets.GITHUB_TOKEN`. Making `mesh-llm-runner-images` public does not by
 itself prove that an existing package is anonymously readable.
 
-The public image already contains `sccache`. Public-image Rust jobs disable its
-GHA remote backend because the required runtime cache URL/token is normally
-exported by the downloading setup action; they retain local in-job compiler
-caching plus persistent Cargo target and ABI caches through the existing cache
-actions. Do not download a second sccache binary just to configure that backend.
+The public image already contains `sccache`. Public-image Rust jobs start with
+its GHA remote backend disabled, then use the repository-local
+`configure-sccache-gha` action to export the ephemeral Actions cache URL/token
+and probe the remote backend. A failed probe stops the remote-configured server
+and restarts `sccache` with its job-local disk cache, so cache availability
+cannot block compiler startup. Persistent Cargo target and ABI caches continue
+through the existing cache actions. Do not download a second sccache binary
+just to configure the GHA backend.
 
 ## Public website deployment
 

--- a/tools/xtask/src/workflow_checks.rs
+++ b/tools/xtask/src/workflow_checks.rs
@@ -23,6 +23,8 @@ pub(crate) fn check_docs_and_workflow_invariants(repo_root: &Path) -> DynResult<
         fs::read_to_string(repo_root.join(".github/workflows/website-pages.yml"))?;
     let compute_changes_action =
         fs::read_to_string(repo_root.join(".github/actions/compute-changes/action.yml"))?;
+    let configure_sccache_action =
+        fs::read_to_string(repo_root.join(".github/actions/configure-sccache-gha/action.yml"))?;
     let affected_crates_script = fs::read_to_string(repo_root.join("scripts/affected-crates.sh"))?;
     let ci_docs = fs::read_to_string(repo_root.join("ci/ci.md"))?;
     let pr_cleanup_workflow =
@@ -377,7 +379,7 @@ pub(crate) fn check_docs_and_workflow_invariants(repo_root: &Path) -> DynResult<
         &windows_warm_caches_workflow,
     )?;
     check_release_dispatch_version_preparation(&release_workflow)?;
-    check_release_container_contracts(&release_workflow)?;
+    check_release_container_contracts(&release_workflow, &configure_sccache_action)?;
     check_ci_crate_test_coverage(&ci_workflow, &pr_builds_workflow, &compute_changes_action)?;
 
     Ok(())
@@ -423,10 +425,49 @@ fn check_release_dispatch_version_preparation(release_workflow: &str) -> DynResu
     Ok(())
 }
 
-fn check_release_container_contracts(release_workflow: &str) -> DynResult<()> {
+fn check_release_container_contracts(
+    release_workflow: &str,
+    configure_sccache_action: &str,
+) -> DynResult<()> {
     const REQUIRED_STEP: &str = "Trust checkout directory";
     const REQUIRED_COMMAND: &str = "git config --global --add safe.directory \"$GITHUB_WORKSPACE\"";
     const LOCAL_SCCACHE_ENV: &str = "      SCCACHE_GHA_ENABLED: \"false\"";
+    const CONFIGURE_SCCACHE_ACTION: &str = "      - uses: ./.github/actions/configure-sccache-gha";
+    const PINNED_GITHUB_SCRIPT: &str =
+        "uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd";
+
+    ensure_contains(
+        configure_sccache_action,
+        PINNED_GITHUB_SCRIPT,
+        "sccache GHA action pinned credential exporter",
+    )?;
+    ensure_not_contains(
+        configure_sccache_action,
+        "mozilla-actions/sccache-action",
+        "sccache GHA action must use the baked binary",
+    )?;
+    for (required, context) in [
+        (
+            "core.exportVariable('ACTIONS_RESULTS_URL'",
+            "sccache GHA action cache URL export",
+        ),
+        (
+            "core.exportVariable('ACTIONS_RUNTIME_TOKEN'",
+            "sccache GHA action runtime token export",
+        ),
+        (
+            "core.exportVariable('SCCACHE_GHA_ENABLED', 'true')",
+            "sccache GHA action remote enable",
+        ),
+        (
+            "core.exportVariable('SCCACHE_GHA_ENABLED', 'false')",
+            "sccache GHA action job-local fallback",
+        ),
+        ("['--start-server']", "sccache GHA action server start"),
+        ("['--stop-server']", "sccache GHA action server stop"),
+    ] {
+        ensure_contains(configure_sccache_action, required, context)?;
+    }
 
     let container_jobs = release_container_job_names(release_workflow);
     if container_jobs.is_empty() {
@@ -451,6 +492,13 @@ fn check_release_container_contracts(release_workflow: &str) -> DynResult<()> {
             return Err(format!(
                 "release workflow `{job_name}`: missing job-level `{}`",
                 LOCAL_SCCACHE_ENV.trim()
+            )
+            .into());
+        }
+        if !job.lines().any(|line| line == CONFIGURE_SCCACHE_ACTION) {
+            return Err(format!(
+                "release workflow `{job_name}`: missing `{}`",
+                CONFIGURE_SCCACHE_ACTION.trim()
             )
             .into());
         }
@@ -631,6 +679,16 @@ pub(crate) fn check_ci_script_workspace_members(repo_root: &Path) -> DynResult<(
 mod tests {
     use super::check_release_container_contracts;
 
+    const VALID_SCCACHE_ACTION: &str = r#"
+uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd
+core.exportVariable('ACTIONS_RESULTS_URL'
+core.exportVariable('ACTIONS_RUNTIME_TOKEN'
+core.exportVariable('SCCACHE_GHA_ENABLED', 'true')
+core.exportVariable('SCCACHE_GHA_ENABLED', 'false')
+['--start-server']
+['--stop-server']
+"#;
+
     const VALID_CONTAINER_WORKFLOW: &str = r#"jobs:
   build_linux_cuda:
     container:
@@ -641,13 +699,14 @@ mod tests {
       - uses: actions/checkout@v5
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+      - uses: ./.github/actions/configure-sccache-gha
   publish:
     runs-on: ubuntu-24.04
 "#;
 
     #[test]
-    fn release_container_contract_accepts_local_sccache_and_safe_checkout() {
-        check_release_container_contracts(VALID_CONTAINER_WORKFLOW).unwrap();
+    fn release_container_contract_accepts_remote_sccache_with_local_fallback() {
+        check_release_container_contracts(VALID_CONTAINER_WORKFLOW, VALID_SCCACHE_ACTION).unwrap();
     }
 
     #[test]
@@ -657,7 +716,7 @@ mod tests {
             "",
         );
 
-        let error = check_release_container_contracts(&workflow).unwrap_err();
+        let error = check_release_container_contracts(&workflow, VALID_SCCACHE_ACTION).unwrap_err();
         assert!(error.to_string().contains("safe-directory"));
     }
 
@@ -666,7 +725,28 @@ mod tests {
         let workflow =
             VALID_CONTAINER_WORKFLOW.replace("      SCCACHE_GHA_ENABLED: \"false\"\n", "");
 
-        let error = check_release_container_contracts(&workflow).unwrap_err();
+        let error = check_release_container_contracts(&workflow, VALID_SCCACHE_ACTION).unwrap_err();
         assert!(error.to_string().contains("SCCACHE_GHA_ENABLED"));
+    }
+
+    #[test]
+    fn release_container_contract_requires_sccache_gha_configuration() {
+        let workflow = VALID_CONTAINER_WORKFLOW.replace(
+            "      - uses: ./.github/actions/configure-sccache-gha\n",
+            "",
+        );
+
+        let error = check_release_container_contracts(&workflow, VALID_SCCACHE_ACTION).unwrap_err();
+        assert!(error.to_string().contains("configure-sccache-gha"));
+    }
+
+    #[test]
+    fn release_container_contract_requires_sccache_job_local_fallback() {
+        let action =
+            VALID_SCCACHE_ACTION.replace("core.exportVariable('SCCACHE_GHA_ENABLED', 'false')", "");
+
+        let error =
+            check_release_container_contracts(VALID_CONTAINER_WORKFLOW, &action).unwrap_err();
+        assert!(error.to_string().contains("job-local fallback"));
     }
 }

--- a/tools/xtask/src/workflow_checks.rs
+++ b/tools/xtask/src/workflow_checks.rs
@@ -377,7 +377,7 @@ pub(crate) fn check_docs_and_workflow_invariants(repo_root: &Path) -> DynResult<
         &windows_warm_caches_workflow,
     )?;
     check_release_dispatch_version_preparation(&release_workflow)?;
-    check_release_container_safe_directories(&release_workflow)?;
+    check_release_container_contracts(&release_workflow)?;
     check_ci_crate_test_coverage(&ci_workflow, &pr_builds_workflow, &compute_changes_action)?;
 
     Ok(())
@@ -423,18 +423,19 @@ fn check_release_dispatch_version_preparation(release_workflow: &str) -> DynResu
     Ok(())
 }
 
-fn check_release_container_safe_directories(release_workflow: &str) -> DynResult<()> {
-    const CONTAINER_RELEASE_JOBS: &[&str] = &[
-        "build_linux_aarch64_cuda",
-        "build_linux_cuda",
-        "build_linux_rocm",
-    ];
+fn check_release_container_contracts(release_workflow: &str) -> DynResult<()> {
     const REQUIRED_STEP: &str = "Trust checkout directory";
     const REQUIRED_COMMAND: &str = "git config --global --add safe.directory \"$GITHUB_WORKSPACE\"";
+    const LOCAL_SCCACHE_ENV: &str = "      SCCACHE_GHA_ENABLED: \"false\"";
 
-    for job_name in CONTAINER_RELEASE_JOBS {
+    let container_jobs = release_container_job_names(release_workflow);
+    if container_jobs.is_empty() {
+        return Err("release workflow: expected at least one container job".into());
+    }
+
+    for job_name in container_jobs {
         let job = workflow_job_section(release_workflow, job_name).ok_or_else(|| {
-            format!("release workflow: missing `{job_name}` job for container safe-directory check")
+            format!("release workflow: missing `{job_name}` job for container contract check")
         })?;
         ensure_contains(
             job,
@@ -446,9 +447,32 @@ fn check_release_container_safe_directories(release_workflow: &str) -> DynResult
             REQUIRED_COMMAND,
             &format!("release workflow `{job_name}` safe-directory command"),
         )?;
+        if !job.lines().any(|line| line == LOCAL_SCCACHE_ENV) {
+            return Err(format!(
+                "release workflow `{job_name}`: missing job-level `{}`",
+                LOCAL_SCCACHE_ENV.trim()
+            )
+            .into());
+        }
     }
 
     Ok(())
+}
+
+fn release_container_job_names(release_workflow: &str) -> Vec<&str> {
+    release_workflow
+        .lines()
+        .filter_map(|line| {
+            let job_name = line.strip_prefix("  ")?.strip_suffix(':')?;
+            if job_name.is_empty() || job_name.starts_with(' ') || job_name.contains(' ') {
+                return None;
+            }
+            let job = workflow_job_section(release_workflow, job_name)?;
+            job.lines()
+                .any(|job_line| job_line == "    container:")
+                .then_some(job_name)
+        })
+        .collect()
 }
 
 fn check_windows_abi_cache_key_alignment(
@@ -601,4 +625,48 @@ pub(crate) fn check_ci_script_workspace_members(repo_root: &Path) -> DynResult<(
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::check_release_container_contracts;
+
+    const VALID_CONTAINER_WORKFLOW: &str = r#"jobs:
+  build_linux_cuda:
+    container:
+      image: example.invalid/runner@sha256:digest
+    env:
+      SCCACHE_GHA_ENABLED: "false"
+    steps:
+      - uses: actions/checkout@v5
+      - name: Trust checkout directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+  publish:
+    runs-on: ubuntu-24.04
+"#;
+
+    #[test]
+    fn release_container_contract_accepts_local_sccache_and_safe_checkout() {
+        check_release_container_contracts(VALID_CONTAINER_WORKFLOW).unwrap();
+    }
+
+    #[test]
+    fn release_container_contract_requires_safe_checkout() {
+        let workflow = VALID_CONTAINER_WORKFLOW.replace(
+            "      - name: Trust checkout directory\n        run: git config --global --add safe.directory \"$GITHUB_WORKSPACE\"\n",
+            "",
+        );
+
+        let error = check_release_container_contracts(&workflow).unwrap_err();
+        assert!(error.to_string().contains("safe-directory"));
+    }
+
+    #[test]
+    fn release_container_contract_requires_job_local_sccache() {
+        let workflow =
+            VALID_CONTAINER_WORKFLOW.replace("      SCCACHE_GHA_ENABLED: \"false\"\n", "");
+
+        let error = check_release_container_contracts(&workflow).unwrap_err();
+        assert!(error.to_string().contains("SCCACHE_GHA_ENABLED"));
+    }
 }


### PR DESCRIPTION
## Summary

- trust the checkout in every prebuilt Linux release container, including both Vulkan jobs
- connect the baked `sccache` binary to GitHub Actions cache without downloading a second binary
- start each job fail-closed with `SCCACHE_GHA_ENABLED=false`, then export the ephemeral cache URL/token and probe the remote backend
- stop and restart `sccache` with job-local disk storage when the GHA backend cannot initialize
- discover all containerized release jobs in the release consistency checker and enforce the safe-directory, cache configuration, pinned credential exporter, and local fallback contracts

## Root cause

Release run [30058024843](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30058024843) exposed two regressions from the runner-image migration:

1. The prebuilt images contain `sccache`, but the release workflow inherited `SCCACHE_GHA_ENABLED=true` without the Actions cache URL/token normally exported by a setup action. Cargo therefore failed before invoking `rustc`.
2. The Vulkan jobs were moved into containers without trusting `$GITHUB_WORKSPACE`, so `release-version.sh` failed when `git ls-files` rejected the checkout as dubious ownership.

The publish job requires every platform lane, so these failures prevented the tag, GitHub release, packaging dispatch, and crates.io publication.

## Cache behavior

The repository-local `configure-sccache-gha` action uses pinned `actions/github-script` to expose the cache credentials already present in an Actions step to the baked `sccache`. It probes the remote backend by starting the server. If initialization fails, it stops that server, disables the GHA backend, and requires a successful job-local restart before compilation continues.

## Validation

- `actionlint -config-file .github/actionlint.yaml`
- composite action YAML and embedded JavaScript syntax validation
- `git diff --check`
- `cargo fmt --all --check`
- `cargo test -p xtask` (9 passed)
- `cargo check -p xtask`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo run -p xtask -- repo-consistency release-targets`

A full `canary=true` release dispatch should be run after merge and before retrying `v0.74.0`; this PR does not dispatch a release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved GPU release workflow setup by explicitly disabling GitHub Actions sccache integration where needed and adding a standardized step to configure and start the baked sccache backend.
  * Strengthened release workflow validation to ensure consistent checkout “safe directory” handling and required sccache configuration/steps are present for container jobs.
* **New Features**
  * Added a composite action to configure baked sccache with a GitHub Actions cache probe and automatic job-local fallback.
* **Tests**
  * Added unit tests covering the release-container workflow contract checks.
* **Documentation**
  * Updated CI documentation to reflect the new sccache probe/restart and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->