### PR TITLE
test(mesh): harden QAD relay regression coverage

### DIFF
--- a/crates/mesh-client/src/client/builder.rs
+++ b/crates/mesh-client/src/client/builder.rs
@@ -634,3 +634,31 @@ fn socket_addr(base_url: &str) -> Result<String, String> {
         .map(|value| value.to_string())
         .ok_or_else(|| format!("invalid API base URL: {base_url}"))
 }
+
+#[cfg(test)]
+mod relay_map_tests {
+    use super::relay_map_from_endpoint_addr;
+    use iroh::{EndpointAddr, RelayUrl, SecretKey};
+    use std::str::FromStr;
+
+    #[test]
+    fn endpoint_addr_relays_preserve_default_qad() {
+        let addr = EndpointAddr::new(SecretKey::generate().public())
+            .with_relay_url(
+                RelayUrl::from_str("https://relay-a.example.com").expect("relay URL parses"),
+            )
+            .with_relay_url(
+                RelayUrl::from_str("https://relay-b.example.com").expect("relay URL parses"),
+            );
+
+        let map = relay_map_from_endpoint_addr(&addr).expect("relay map should be enabled");
+        let configs = map.relays::<Vec<_>>();
+
+        assert_eq!(configs.len(), 2);
+        assert!(
+            configs
+                .iter()
+                .all(|config| { config.quic.as_ref().is_some_and(|quic| quic.port == 7842) })
+        );
+    }
+}

--- a/crates/mesh-client/src/client/builder.rs
+++ b/crates/mesh-client/src/client/builder.rs
@@ -566,7 +566,10 @@ fn relay_map_from_endpoint_addr(addr: &EndpointAddr) -> Option<iroh::RelayMap> {
     let configs: Vec<_> = addr
         .relay_urls()
         .cloned()
-        .map(|url| iroh::RelayConfig::new(url, None))
+        // Preserve iroh's default QUIC Address Discovery (QAD). `new(url, None)`
+        // disables it, preventing reflexive candidate discovery and direct-path
+        // upgrades across NAT (see issue #1065). `RelayUrl::into()` keeps QAD on.
+        .map(|url| -> iroh::RelayConfig { url.into() })
         .collect();
     if configs.is_empty() {
         None

--- a/crates/mesh-client/src/client/control_plane.rs
+++ b/crates/mesh-client/src/client/control_plane.rs
@@ -960,6 +960,27 @@ mod tests {
     }
 
     #[test]
+    fn endpoint_addr_relays_preserve_default_qad() {
+        let addr = EndpointAddr::new(iroh::SecretKey::generate().public())
+            .with_relay_url(
+                iroh::RelayUrl::from_str("https://relay-a.example.com").expect("relay URL parses"),
+            )
+            .with_relay_url(
+                iroh::RelayUrl::from_str("https://relay-b.example.com").expect("relay URL parses"),
+            );
+
+        let map = relay_map_from_endpoint_addr(&addr).expect("relay map should be enabled");
+        let configs = map.relays::<Vec<_>>();
+
+        assert_eq!(configs.len(), 2);
+        assert!(
+            configs
+                .iter()
+                .all(|config| { config.quic.as_ref().is_some_and(|quic| quic.port == 7842) })
+        );
+    }
+
+    #[test]
     fn relay_mode_is_disabled_without_endpoint_relays() {
         let addr = EndpointAddr::new(iroh::SecretKey::generate().public());
 

--- a/crates/mesh-client/src/client/control_plane.rs
+++ b/crates/mesh-client/src/client/control_plane.rs
@@ -835,7 +835,10 @@ fn relay_map_from_endpoint_addr(addr: &EndpointAddr) -> Option<iroh::RelayMap> {
     let configs: Vec<_> = addr
         .relay_urls()
         .cloned()
-        .map(|url| iroh::RelayConfig::new(url, None))
+        // Preserve iroh's default QUIC Address Discovery (QAD). `new(url, None)`
+        // disables it, preventing reflexive candidate discovery and direct-path
+        // upgrades across NAT (see issue #1065). `RelayUrl::into()` keeps QAD on.
+        .map(|url| -> iroh::RelayConfig { url.into() })
         .collect();
     if configs.is_empty() {
         None

--- a/crates/mesh-llm-host-runtime/src/mesh/connections.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/connections.rs
@@ -200,6 +200,8 @@ pub(crate) fn effective_relay_urls(policy: RelayPolicy, relay_urls: &[String]) -
         RelayPolicy::DefaultPublic if relay_urls.is_empty() => vec![
             "https://usw1-2.relay.michaelneale.mesh-llm.iroh.link./".into(),
             "https://aps1-1.relay.michaelneale.mesh-llm.iroh.link./".into(),
+            "https://euc1-1.relay.michaelneale.mesh-llm.iroh.link./".into(),
+            "https://use1-1.relay.michaelneale.mesh-llm.iroh.link./".into(),
         ],
         RelayPolicy::DefaultPublic => relay_urls.to_vec(),
     }
@@ -256,10 +258,17 @@ pub(crate) fn relay_map_from_urls(
     auths: &std::collections::HashMap<String, String>,
 ) -> Result<iroh::RelayMap> {
     let configs = urls.iter().map(|url| {
-        let parsed = url
+        let parsed: iroh::RelayUrl = url
             .parse()
             .with_context(|| format!("invalid relay URL `{url}`"))?;
-        let cfg = iroh::RelayConfig::new(parsed, None);
+        // Preserve iroh's default QUIC Address Discovery (QAD, UDP 7842).
+        // `iroh::RelayConfig::new(parsed, None)` explicitly DISABLES QAD, so
+        // net-report never learns a reflexive public UDP candidate and direct
+        // paths across NAT cannot form (nodes fall back to relay). Constructing
+        // via `RelayUrl::into()` keeps QAD enabled — iroh's default. QAD is
+        // client-driven and gated behind `has_ip_transports`, so relay-only and
+        // LAN-only endpoints are unaffected. See issue #1065.
+        let cfg: iroh::RelayConfig = parsed.into();
         Ok(match auths.get(url) {
             Some(token) => cfg.with_auth_token(token.clone()),
             None => cfg,
@@ -289,6 +298,17 @@ mod relay_map_tests {
         assert!(
             cfgs[0].auth_token.is_none(),
             "no auth supplied → no auth_token set"
+        );
+        // QAD must be enabled (issue #1065): the relay config must carry a QUIC
+        // address-discovery config on the default port, else nodes never learn a
+        // reflexive candidate and direct-path upgrades across NAT cannot form.
+        let quic = cfgs[0]
+            .quic
+            .as_ref()
+            .expect("default QUIC address discovery (QAD) should be enabled");
+        assert_eq!(
+            quic.port, 7842,
+            "QAD should use iroh's default relay QUIC port"
         );
     }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/connections.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/connections.rs
@@ -215,7 +215,15 @@ mod relay_policy_tests {
     pub(crate) fn default_policy_uses_managed_relays_when_no_urls_are_given() {
         let urls = effective_relay_urls(RelayPolicy::DefaultPublic, &[]);
 
-        assert!(urls.iter().any(|url| url.contains("relay.michaelneale")));
+        assert_eq!(
+            urls,
+            vec![
+                "https://usw1-2.relay.michaelneale.mesh-llm.iroh.link./",
+                "https://aps1-1.relay.michaelneale.mesh-llm.iroh.link./",
+                "https://euc1-1.relay.michaelneale.mesh-llm.iroh.link./",
+                "https://use1-1.relay.michaelneale.mesh-llm.iroh.link./",
+            ]
+        );
     }
 
     #[test]
@@ -290,25 +298,21 @@ mod relay_map_tests {
     }
 
     #[test]
-    pub(crate) fn builds_map_without_auth_when_empty() {
-        let urls = vec!["https://r1.example/".to_string()];
+    pub(crate) fn builds_map_with_default_qad_without_auth() {
+        let urls = vec![
+            "https://r1.example/".to_string(),
+            "https://r2.example/".to_string(),
+        ];
         let map = relay_map_from_urls(&urls, &HashMap::new()).expect("relay map should build");
         let cfgs = configs(&map);
-        assert_eq!(cfgs.len(), 1);
-        assert!(
-            cfgs[0].auth_token.is_none(),
-            "no auth supplied → no auth_token set"
-        );
+        assert_eq!(cfgs.len(), 2);
+        assert!(cfgs.iter().all(|config| config.auth_token.is_none()));
         // QAD must be enabled (issue #1065): the relay config must carry a QUIC
         // address-discovery config on the default port, else nodes never learn a
         // reflexive candidate and direct-path upgrades across NAT cannot form.
-        let quic = cfgs[0]
-            .quic
-            .as_ref()
-            .expect("default QUIC address discovery (QAD) should be enabled");
-        assert_eq!(
-            quic.port, 7842,
-            "QAD should use iroh's default relay QUIC port"
+        assert!(
+            cfgs.iter()
+                .all(|config| { config.quic.as_ref().is_some_and(|quic| quic.port == 7842) })
         );
     }
 
@@ -436,11 +440,18 @@ mod gated_relay_e2e_tests {
         relay_urls: &[String],
         relay_auths: &HashMap<String, String>,
     ) -> Endpoint {
+        let relay_map =
+            relay_map_from_urls(relay_urls, relay_auths).expect("relay map should build");
+        assert!(
+            relay_map
+                .relays::<Vec<_>>()
+                .iter()
+                .all(|config| { config.quic.as_ref().is_some_and(|quic| quic.port == 7842) }),
+            "end-to-end relay configs should keep default QAD enabled"
+        );
         Endpoint::builder(presets::Minimal)
             .secret_key(SecretKey::generate())
-            .relay_mode(RelayMode::Custom(
-                relay_map_from_urls(relay_urls, relay_auths).expect("relay map should build"),
-            ))
+            .relay_mode(RelayMode::Custom(relay_map))
             .ca_tls_config(CaTlsConfig::insecure_skip_verify())
             .bind()
             .await
@@ -448,7 +459,7 @@ mod gated_relay_e2e_tests {
     }
 
     #[tokio::test]
-    pub(crate) async fn matching_token_admits_endpoint_to_gated_relay() {
+    pub(crate) async fn qad_enabled_map_admits_endpoint_to_gated_relay() {
         const TOKEN: &str = "secret-token";
         let (relay_url, _server) = spawn_gated_relay(TOKEN).await;
 


### PR DESCRIPTION
## Summary

Adds the follow-up regression coverage requested on #1066:

- tests both `mesh-client` endpoint-address relay conversion paths and verifies every relay preserves default QAD on UDP 7842
- asserts the complete managed default relay set, including `euc1-1` and `use1-1`
- expands host relay-map coverage from the first relay to every relay in the map
- extends the in-process gated-relay health test so the live endpoint is proven to use QAD-enabled configs

## Why

PR #1066 restores iroh's default QAD behavior after the 1.0 constructor semantics changed. These tests protect each affected construction path and the expanded default relay policy from future drift.

## Impact

Test-only follow-up; production behavior remains owned by #1066. This PR should merge into that branch before #1066 lands.

## Validation

- `cargo fmt --all --check`
- `cargo test -p mesh-llm-client --lib` (80 passed)
- `cargo test -p mesh-llm-host-runtime --lib mesh::connections::` (11 passed)
- `cargo check -p mesh-llm-client`
- `cargo clippy -p mesh-llm-client --all-targets -- -D warnings`
- `cargo check -p mesh-llm-host-runtime`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`

The full host-runtime library suite progressed through the relevant QAD tests successfully but stalled in unrelated long-running tests and was stopped; the focused `mesh::connections::` suite was then rerun to a clean zero exit.