### PR TITLE
Unwedge PR Builds: drop dead amd64 ARC runner-image row

### DIFF
--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -175,9 +175,11 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - architecture: amd64
-            runner: mesh-llm-amd64
-            machine: x86_64
+          # NOTE: the amd64 ARC row (mesh-llm-amd64) is temporarily removed
+          # because that scale set is not scheduling pods, which wedges every
+          # PR Builds run indefinitely (no hosted fallback by design). arm64
+          # ARC coverage is retained. Restore the amd64 row once the
+          # mesh-llm-amd64 scale set is healthy again.
           - architecture: arm64
             runner: mesh-llm-arm64
             machine: aarch64

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -281,13 +281,20 @@ while runtime GPU assertions require a matching restricted self-hosted pool.
 Linux workflow-local toolchain and package setup blocks are migration debt and
 must be removed when their lane adopts an image, not copied elsewhere.
 
-PR Builds runs `public_runner_image_contract` inside the public image and a
-two-row `arc_runner_image_contract` matrix directly on `mesh-llm-amd64` and
-`mesh-llm-arm64`. The public job validates the baked dependency/tool contract.
-The ARC job checks the native machine architecture, validates the self-hosted
-image, and performs a small Rust check. It has no hosted fallback by design: it
-is the pull-request gate that detects ARC, K3s scheduling, multi-architecture
-image, and runner startup regressions.
+PR Builds runs `public_runner_image_contract` inside the public image and an
+`arc_runner_image_contract` matrix directly on the ARC scale-set labels. The
+public job validates the baked dependency/tool contract. The ARC job checks the
+native machine architecture, validates the self-hosted image, and performs a
+small Rust check. It has no hosted fallback by design: it is the pull-request
+gate that detects ARC, K3s scheduling, multi-architecture image, and runner
+startup regressions.
+
+The matrix currently contains only the `mesh-llm-arm64` row. The
+`mesh-llm-amd64` row is temporarily removed because that scale set is not
+scheduling pods, which wedged every PR Builds run indefinitely (the job has no
+hosted fallback). Restore the amd64 row once the `mesh-llm-amd64` scale set is
+healthy again; the `mesh-llm-amd64` label remains in `.github/actionlint.yaml`
+so the row can be re-added without a lint change.
 
 Repository visibility and GHCR package visibility are separate controls. If an
 anonymous pull still returns `401` or `403`, public-container jobs must grant


### PR DESCRIPTION
## What this does

PR Builds runs again. Right now every open PR's **PR Builds** run is stuck `queued` (some for 8+ hours) and cannot complete, so nothing can merge. This removes the single job that is wedging the queue.

## Why

The `Runner image / ARC amd64` job runs on the self-hosted `mesh-llm-amd64` ARC scale set, which is currently **not scheduling any pods**. That job has **no hosted fallback by design**, so it sits `queued` forever and holds the entire `PR Builds` run open even though every other job (Linux/macOS builds, Rust tests, smoke, SDK) has already finished.

Observed live:
- `Runner image / ARC arm64` -> completes/succeeds on every run (ARC controller, K3s, and org registration are healthy).
- `Runner image / ARC amd64` -> `queued` on every run, 0-for-N for 8+ hours.

So the fault is isolated to the `mesh-llm-amd64` scale set (dead amd64 pool / node capacity / image digest), not the ARC setup as a whole. That is a cluster-side problem a mesh-llm PR cannot fix.

## Change

- Remove the `amd64` row from the `arc_runner_image_contract` matrix in `pr_builds.yml`. **arm64 ARC coverage is kept** -- this does not delete the gate, only the row that cannot be satisfied.
- Update `ci/ci.md` topology to match.
- Retain the `mesh-llm-amd64` label in `.github/actionlint.yaml` so the row can be restored later without a lint change.

## This is temporary -- restore amd64 when the pool is healthy

This intentionally reduces coverage: the amd64 ARC contract (native-arch check + self-hosted image validation + small Rust check on amd64) is what catches amd64 ARC / K3s / runner-image regressions before merge. Re-add the amd64 matrix row once the `mesh-llm-amd64` scale set is scheduling pods again.

Suggested follow-up for whoever has cluster/org access:
- Check the amd64 ARC listener + ephemeral runners and amd64 node capacity.
- Compare the amd64 vs arm64 `AutoScalingRunnerSet` spec (image digest, node selector, resource requests, `minRunners`) since arm64 works and amd64 does not.

## Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/pr_builds.yml` -> exit 0
- `git diff --check` -> clean
- No job `needs:` `arc_runner_image_contract`, so removing the row has no downstream graph impact.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented PR validation builds from hanging when the unavailable amd64 runner scale set cannot schedule jobs.
  * PR builds now use the available arm64 runner configuration.

* **Documentation**
  * Updated CI guidance to reflect the current runner configuration and restoration criteria for amd64 support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->