### PR TITLE
mesh: direct-path hole-punching via modern iroh (1.0.3) + owner-control relay fix

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
  "x11rb",
 ]
 
@@ -790,7 +790,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -928,9 +928,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "cfg_aliases"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
 
 [[package]]
 name = "chacha20"
@@ -1077,7 +1077,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1502,36 +1502,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn 2.0.118",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1549,22 +1525,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn 2.0.118",
 ]
@@ -1606,7 +1571,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 2.0.118",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -1688,37 +1653,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn 2.0.118",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
- "syn 2.0.118",
-]
-
-[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1787,7 +1721,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1971,7 +1905,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3126,7 +3060,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
@@ -3169,9 +3103,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2e38557969901f8b356d1ebd882253bab98cc81500d53e7bcbf33f56082303"
+checksum = "460de6bc52163b41b1646931f2897e5ab986f0966ade444467fec25024751a72"
 dependencies = [
  "axum",
  "backon",
@@ -3221,9 +3155,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-base"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cdf012298adc13f5c2c821ad87214fecc9ac54c751301d45bf62b229a85da1"
+checksum = "6be73e16ee21c923aca9b3121aaa0db936f7c7ecc156ff47b8dac944c68d59a8"
 dependencies = [
  "curve25519-dalek 5.0.0-rc.0",
  "data-encoding",
@@ -3240,9 +3174,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c24b83aae5ed4eced1c3724204c083c28c84c5d225a88e277eceeccce3dc3bd"
+checksum = "46f6a9b39d18e6345f5c151afd299f2488e2cb5c520fe41b107b6bd3dc4c3349"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -3299,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f16a5505939f9250297ff2f1210b5142d13618f496eab03ce3f964fc47e2e2b"
+checksum = "24bd586cf927f7b700f56ec3639b53cb5fa901ce284784051ff71092bfbf8193"
 dependencies = [
  "blake3",
  "bytes",
@@ -3351,7 +3285,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "url",
- "vergen-gitcl",
  "webpki-roots 1.0.8",
  "ws_stream_wasm",
 ]
@@ -4793,9 +4726,9 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bf95190af1bd4a00a10e8255ca0c8ddd9e9a9f5e79151d7a7eb6d56aff5dc89"
+checksum = "e11803df44ac03a30988d61585ea50885d5428e42da944fe1e498799da7886a2"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -4815,9 +4748,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa6c890013591e709a3e45dd53501351b7e27e7ff3c7e9fc3dce43e300e7e9d3"
+checksum = "334c3c9833f7b2c573cceb9896ddc7aaeb58c8807cbb63211b24d1fe88bf866e"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -4843,9 +4776,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.1"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e"
+checksum = "bde7a5d5102f1cff03d482240f0ed20551661f63663620f4b26112ed751165e9"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -4946,7 +4879,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6131,7 +6064,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6641,7 +6574,7 @@ version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "proc-macro2",
  "quote",
  "serde_json",
@@ -6719,7 +6652,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6812,7 +6745,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7051,7 +6984,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7827,7 +7760,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8784,43 +8717,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "vergen"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-gitcl"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77ff3b5300a085d6bcd8fc96a507f706a28ae3814693236c9b409db71a1d15b9"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
- "time",
- "vergen",
- "vergen-lib",
-]
-
-[[package]]
-name = "vergen-lib"
-version = "9.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
-dependencies = [
- "anyhow",
- "derive_builder",
- "rustversion",
-]
-
-[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9143,7 +9039,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3942,7 +3942,6 @@ dependencies = [
  "http",
  "http-body-util",
  "httparse",
- "if-addrs",
  "iroh",
  "iroh-relay",
  "json5",

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -67,7 +67,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_yaml = "0.9"
 socket2 = { version = "0.6", features = ["all"] }
-if-addrs = "0.15"
 anyhow = "1"
 async-trait = "0.1"
 rand = "0.10"

--- a/crates/mesh-llm-host-runtime/src/api/tests/control_plane.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests/control_plane.rs
@@ -181,8 +181,7 @@ async fn config_apply_does_not_emit_peer_churn() {
 #[serial]
 async fn control_plane_api_cli_requires_explicit_endpoint_and_runs_local_orchestration() {
     let temp = tempfile::tempdir().unwrap();
-    // TODO: Audit that the environment access only happens in single-threaded code.
-    unsafe { std::env::set_var("HOME", temp.path()) };
+    let _home_guard = HomeEnvGuard::set(temp.path());
     let owner = OwnerKeypair::generate();
     let keystore_path = default_keystore_path().unwrap();
     save_keystore(&keystore_path, &owner, None, true).unwrap();
@@ -230,8 +229,7 @@ async fn control_plane_api_cli_requires_explicit_endpoint_and_runs_local_orchest
 #[serial]
 async fn control_plane_api_apply_config_uses_full_mesh_config_contract() {
     let temp = tempfile::tempdir().unwrap();
-    // TODO: Audit that the environment access only happens in single-threaded code.
-    unsafe { std::env::set_var("HOME", temp.path()) };
+    let _home_guard = HomeEnvGuard::set(temp.path());
     let owner = OwnerKeypair::generate();
     let keystore_path = default_keystore_path().unwrap();
     save_keystore(&keystore_path, &owner, None, true).unwrap();
@@ -323,8 +321,7 @@ async fn control_plane_api_apply_config_uses_full_mesh_config_contract() {
 #[serial]
 async fn control_plane_api_apply_config_reports_revision_conflict() {
     let temp = tempfile::tempdir().unwrap();
-    // TODO: Audit that the environment access only happens in single-threaded code.
-    unsafe { std::env::set_var("HOME", temp.path()) };
+    let _home_guard = HomeEnvGuard::set(temp.path());
     let owner = OwnerKeypair::generate();
     let keystore_path = default_keystore_path().unwrap();
     save_keystore(&keystore_path, &owner, None, true).unwrap();
@@ -422,8 +419,7 @@ async fn control_route_rejects_non_loopback() {
 #[serial]
 async fn control_plane_api_reports_remote_endpoint_unreachable() {
     let temp = tempfile::tempdir().unwrap();
-    // TODO: Audit that the environment access only happens in single-threaded code.
-    unsafe { std::env::set_var("HOME", temp.path()) };
+    let _home_guard = HomeEnvGuard::set(temp.path());
     let owner = OwnerKeypair::generate();
     let keystore_path = default_keystore_path().unwrap();
     save_keystore(&keystore_path, &owner, None, true).unwrap();
@@ -464,8 +460,7 @@ async fn control_plane_api_reports_remote_endpoint_unreachable() {
 #[serial]
 async fn control_plane_api_cli_uses_custom_owner_key_path() {
     let temp = tempfile::tempdir().unwrap();
-    // TODO: Audit that the environment access only happens in single-threaded code.
-    unsafe { std::env::set_var("HOME", temp.path()) };
+    let _home_guard = HomeEnvGuard::set(temp.path());
     let custom_owner_key = temp.path().join("custom-owner.json");
     save_keystore(&custom_owner_key, &OwnerKeypair::generate(), None, true).unwrap();
 

--- a/crates/mesh-llm-host-runtime/src/api/tests/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests/mod.rs
@@ -23,6 +23,30 @@ use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, oneshot};
 
+struct HomeEnvGuard {
+    original_home: Option<std::ffi::OsString>,
+}
+
+impl HomeEnvGuard {
+    fn set(home: &std::path::Path) -> Self {
+        let original_home = std::env::var_os("HOME");
+        // SAFETY: callers use `#[serial]`, and Drop restores the previous value.
+        unsafe { std::env::set_var("HOME", home) };
+        Self { original_home }
+    }
+}
+
+impl Drop for HomeEnvGuard {
+    fn drop(&mut self) {
+        match &self.original_home {
+            // SAFETY: callers use `#[serial]`, and this restores the saved value.
+            Some(home) => unsafe { std::env::set_var("HOME", home) },
+            // SAFETY: callers use `#[serial]`, and HOME was originally unset.
+            None => unsafe { std::env::remove_var("HOME") },
+        }
+    }
+}
+
 mod apply_config_diagnostics;
 mod apply_config_validation_authority;
 mod runtime_config;

--- a/crates/mesh-llm-host-runtime/src/mesh/connections.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/connections.rs
@@ -109,38 +109,6 @@ pub(crate) fn default_control_bind_addr() -> std::net::SocketAddr {
     std::net::SocketAddr::from(([127, 0, 0, 1], 0))
 }
 
-/// Detect this host's primary **private LAN** IPv4 without sending any packets.
-///
-/// Returns a genuine RFC1918 LAN address (`10/8`, `172.16/12`, `192.168/16`)
-/// or `None`. It deliberately never returns a public, CGNAT (`100.64/10`), or
-/// VPN/tunnel address, so the caller can safely pin QUIC's bind to it.
-///
-/// Detection has two phases:
-///
-/// 1. **Default-route source probe.** Open an unconnected UDP socket and
-///    `connect()` it to a routable target so the kernel fills in the source IP
-///    it would use to reach that target. No datagrams are sent. This is the
-///    fast, accurate answer on a normal single-LAN host — but on a full-tunnel
-///    VPN host the default route points at the tunnel, so the source is a
-///    VPN/utun address. We therefore accept this result **only if it is a
-///    private LAN IPv4**.
-/// 2. **Interface scan fallback.** If the probe yields a non-private address
-///    (VPN default route) or fails (no default route on an isolated LAN), scan
-///    local interfaces and pick the first private, operational, non-loopback,
-///    non-link-local, non-point-to-point IPv4. Point-to-point interfaces are
-///    skipped because VPN/tunnel interfaces present as p2p.
-///
-/// Used to auto-pin QUIC's bind address to the real LAN interface on
-/// multi-homed hosts (e.g. macOS with several `utun`/VPN interfaces). Binding
-/// `0.0.0.0` on such hosts lets the kernel pick a wrong source for an
-/// unconnected QUIC `sendmsg` (yielding `EHOSTUNREACH` or a slow WAN-hairpin
-/// path) and breaks/degrades direct LAN connectivity in either dial direction.
-/// Returning only a private LAN IPv4 (or `None`) means a wrong default route
-/// can never hard-pin relay-less QUIC off-LAN; we fall back to `0.0.0.0`
-/// instead. Public-relay (Nostr) mode keeps its IPv6/relay paths regardless, so
-/// long-haul reachability to a remote mesh is never sacrificed for the LAN hint.
-pub use lan_bootstrap::detect_primary_lan_ipv4;
-
 pub(crate) fn is_public_ipv4_candidate(socket: &SocketAddr) -> bool {
     match socket.ip() {
         IpAddr::V4(ip) => is_global_ipv4_candidate(ip),

--- a/crates/mesh-llm-host-runtime/src/mesh/direct_path.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/direct_path.rs
@@ -1,157 +1,18 @@
-//! Direct UDP path maintenance for mesh peers.
+//! Compatibility handling for legacy direct-path repair requests.
 //!
-//! This module keeps direct-path repair close to the iroh/mesh layer. It is
-//! deliberately targeted: one peer per tick, per-peer cooldowns on both sender
-//! and receiver, and no gossip fanout.
+//! Modern nodes let iroh own NAT traversal and no longer emit these requests.
+//! The receiver remains so mixed-version meshes can safely accept the additive
+//! stream type from older peers.
 
-use super::{
-    ConnectionCaptureEvent, NODE_PROTOCOL_GENERATION, Node, connect_mesh, connection_protocol,
-    endpoint_id_hex, heartbeat,
-};
-use crate::protocol::{
-    STREAM_DIRECT_PATH_REQUEST, ValidateControlFrame, read_len_prefixed, write_len_prefixed,
-};
+use super::{ConnectionCaptureEvent, Node, connect_mesh, connection_protocol};
+use crate::protocol::{ValidateControlFrame, read_len_prefixed};
 use anyhow::{Context, Result};
-use iroh::{EndpointAddr, EndpointId, TransportAddr, endpoint::Connection};
+use iroh::endpoint::Connection;
+use iroh::{EndpointAddr, EndpointId, TransportAddr};
 use prost::Message;
-use std::collections::HashMap;
 
-pub(super) const DIRECT_PATH_MAINTENANCE_CHECK_SECS: u64 = 30;
-pub(super) const DIRECT_PATH_REPAIR_GRACE_SECS: u64 = 15;
-pub(super) const DIRECT_PATH_REPAIR_COOLDOWN_SECS: u64 = 120;
 pub(super) const DIRECT_PATH_REQUEST_COOLDOWN_SECS: u64 = 120;
 const DIRECT_PATH_REQUEST_TIMEOUT_SECS: u64 = 10;
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) enum DirectPathRepairReason {
-    RelaySelected,
-    UnknownSelected,
-}
-
-impl DirectPathRepairReason {
-    pub(crate) fn label(self) -> &'static str {
-        match self {
-            Self::RelaySelected => "selected path is relay",
-            Self::UnknownSelected => "selected path is unknown",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Default)]
-pub(super) struct DirectPathPeerHealth {
-    pub(super) non_direct_since: Option<std::time::Instant>,
-    pub(super) last_request_at: Option<std::time::Instant>,
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub(crate) struct DirectPathObservation {
-    pub(super) peer_id: EndpointId,
-    pub(super) snapshot: heartbeat::RelayPathSnapshot,
-    pub(super) has_direct_candidate: bool,
-}
-
-#[derive(Default)]
-pub(super) struct DirectPathMaintenanceController {
-    peer_health: HashMap<EndpointId, DirectPathPeerHealth>,
-}
-
-impl DirectPathMaintenanceController {
-    pub(super) fn plan_request<I>(
-        &mut self,
-        observations: I,
-        now: std::time::Instant,
-        inflight_requests: u64,
-    ) -> Option<(EndpointId, DirectPathRepairReason)>
-    where
-        I: IntoIterator<Item = DirectPathObservation>,
-    {
-        let mut observations: Vec<DirectPathObservation> = observations.into_iter().collect();
-        observations.sort_by_key(|observation| endpoint_id_hex(observation.peer_id));
-
-        if observations.is_empty() {
-            self.peer_health.clear();
-            return None;
-        }
-
-        let active_peers: std::collections::HashSet<EndpointId> = observations
-            .iter()
-            .map(|observation| observation.peer_id)
-            .collect();
-        self.peer_health
-            .retain(|peer_id, _| active_peers.contains(peer_id));
-
-        if inflight_requests > 0 {
-            for observation in observations {
-                self.observe_peer(observation, now);
-            }
-            return None;
-        }
-
-        for observation in observations {
-            let health = self.observe_peer(observation, now);
-            if let Some(reason) = direct_path_repair_reason(health, observation, now) {
-                return Some((observation.peer_id, reason));
-            }
-        }
-
-        None
-    }
-
-    pub(crate) fn observe_peer(
-        &mut self,
-        observation: DirectPathObservation,
-        now: std::time::Instant,
-    ) -> &DirectPathPeerHealth {
-        let health = self.peer_health.entry(observation.peer_id).or_default();
-        match (observation.snapshot.kind, observation.has_direct_candidate) {
-            (heartbeat::SelectedPathKind::Direct, _) | (_, false) => {
-                health.non_direct_since = None;
-            }
-            (heartbeat::SelectedPathKind::Relay | heartbeat::SelectedPathKind::Unknown, true) => {
-                if health.non_direct_since.is_none() {
-                    health.non_direct_since = Some(now);
-                }
-            }
-        }
-        health
-    }
-
-    pub(super) fn record_request_attempt(&mut self, peer_id: EndpointId, now: std::time::Instant) {
-        self.peer_health.entry(peer_id).or_default().last_request_at = Some(now);
-    }
-
-    #[cfg(test)]
-    pub(super) fn peer_health(&self, peer_id: EndpointId) -> Option<&DirectPathPeerHealth> {
-        self.peer_health.get(&peer_id)
-    }
-}
-
-pub(super) fn direct_path_repair_reason(
-    health: &DirectPathPeerHealth,
-    observation: DirectPathObservation,
-    now: std::time::Instant,
-) -> Option<DirectPathRepairReason> {
-    if !observation.has_direct_candidate
-        || observation.snapshot.kind == heartbeat::SelectedPathKind::Direct
-    {
-        return None;
-    }
-    if health.last_request_at.is_some_and(|last| {
-        now.duration_since(last) < std::time::Duration::from_secs(DIRECT_PATH_REPAIR_COOLDOWN_SECS)
-    }) {
-        return None;
-    }
-    if !health.non_direct_since.is_some_and(|started| {
-        now.duration_since(started) >= std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS)
-    }) {
-        return None;
-    }
-    match observation.snapshot.kind {
-        heartbeat::SelectedPathKind::Relay => Some(DirectPathRepairReason::RelaySelected),
-        heartbeat::SelectedPathKind::Unknown => Some(DirectPathRepairReason::UnknownSelected),
-        heartbeat::SelectedPathKind::Direct => None,
-    }
-}
 
 pub(crate) fn endpoint_addr_has_direct_candidate(addr: &EndpointAddr) -> bool {
     addr.addrs
@@ -173,109 +34,6 @@ pub(super) fn endpoint_addr_with_previously_advertised_direct_candidates(
 }
 
 impl Node {
-    /// Start bounded mesh-level direct path maintenance.
-    ///
-    /// This is not gossip-driven. Each tick selects at most one admitted peer
-    /// whose selected path is non-direct while a direct UDP candidate exists,
-    /// then sends a targeted request asking that peer to dial our current
-    /// advertised endpoint address. The receiver has its own per-peer cooldown.
-    pub fn start_direct_path_maintenance(&self) {
-        let node = self.clone();
-        tokio::spawn(async move {
-            let mut controller = DirectPathMaintenanceController::default();
-
-            loop {
-                tokio::time::sleep(std::time::Duration::from_secs(
-                    DIRECT_PATH_MAINTENANCE_CHECK_SECS,
-                ))
-                .await;
-
-                let now = std::time::Instant::now();
-                let observations = node.direct_path_observations().await;
-                let inflight_requests = node.inflight_requests();
-                let Some((peer_id, reason)) =
-                    controller.plan_request(observations, now, inflight_requests)
-                else {
-                    continue;
-                };
-
-                controller.record_request_attempt(peer_id, now);
-                let _ = node.request_direct_path_from_peer(peer_id, reason).await;
-            }
-        });
-    }
-
-    pub(crate) async fn direct_path_observations(&self) -> Vec<DirectPathObservation> {
-        let state = self.state.lock().await;
-        state
-            .peers
-            .iter()
-            .filter_map(|(peer_id, peer)| {
-                if !peer.is_admitted() {
-                    return None;
-                }
-                let conn = state.connections.get(peer_id)?;
-                Some(DirectPathObservation {
-                    peer_id: *peer_id,
-                    snapshot: heartbeat::selected_path_snapshot(conn),
-                    has_direct_candidate: endpoint_addr_has_direct_candidate(&peer.addr),
-                })
-            })
-            .collect()
-    }
-
-    pub(crate) async fn request_direct_path_from_peer(
-        &self,
-        peer_id: EndpointId,
-        reason: DirectPathRepairReason,
-    ) -> bool {
-        let Some(conn) = self.direct_path_request_connection(peer_id).await else {
-            return false;
-        };
-        let Some(request) = self.build_direct_path_request(peer_id) else {
-            return false;
-        };
-
-        tracing::debug!(
-            peer = %peer_id.fmt_short(),
-            reason = reason.label(),
-            "Direct path maintenance requesting reverse dial"
-        );
-        let result = tokio::time::timeout(
-            std::time::Duration::from_secs(DIRECT_PATH_REQUEST_TIMEOUT_SECS),
-            send_direct_path_request(conn, request),
-        )
-        .await;
-        log_direct_path_request_result(peer_id, result)
-    }
-
-    pub(crate) fn build_direct_path_request(
-        &self,
-        peer_id: EndpointId,
-    ) -> Option<crate::proto::node::DirectPathRequest> {
-        let Ok(serialized_addr) = serde_json::to_vec(&self.endpoint_addr_for_advertisement())
-        else {
-            tracing::debug!(
-                peer = %peer_id.fmt_short(),
-                "Direct path maintenance could not serialize local endpoint address"
-            );
-            return None;
-        };
-        Some(crate::proto::node::DirectPathRequest {
-            requester_id: self.endpoint.id().as_bytes().to_vec(),
-            r#gen: NODE_PROTOCOL_GENERATION,
-            serialized_addr,
-        })
-    }
-
-    pub(crate) async fn direct_path_request_connection(
-        &self,
-        peer_id: EndpointId,
-    ) -> Option<Connection> {
-        let state = self.state.lock().await;
-        state.connections.get(&peer_id).cloned()
-    }
-
     pub(super) fn spawn_direct_path_request_stream(
         &self,
         remote: EndpointId,
@@ -320,41 +78,6 @@ impl Node {
         }
         self.dial_direct_path_request_peer(remote, addr).await;
         Ok(())
-    }
-}
-
-pub(crate) async fn send_direct_path_request(
-    conn: Connection,
-    request: crate::proto::node::DirectPathRequest,
-) -> Result<()> {
-    let (mut send, _) = conn.open_bi().await?;
-    send.write_all(&[STREAM_DIRECT_PATH_REQUEST]).await?;
-    write_len_prefixed(&mut send, &request.encode_to_vec()).await?;
-    let _ = send.finish();
-    Ok(())
-}
-
-pub(crate) fn log_direct_path_request_result(
-    peer_id: EndpointId,
-    result: Result<Result<()>, tokio::time::error::Elapsed>,
-) -> bool {
-    match result {
-        Ok(Ok(())) => true,
-        Ok(Err(error)) => {
-            tracing::debug!(
-                peer = %peer_id.fmt_short(),
-                error = %error,
-                "Direct path maintenance request failed"
-            );
-            false
-        }
-        Err(_) => {
-            tracing::debug!(
-                peer = %peer_id.fmt_short(),
-                "Direct path maintenance request timed out"
-            );
-            false
-        }
     }
 }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/lan_bootstrap.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/lan_bootstrap.rs
@@ -1,15 +1,7 @@
 #[cfg(test)]
 use super::is_public_ipv4_candidate;
 use iroh::{EndpointAddr, TransportAddr};
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-
-/// Detect the most likely LAN IPv4 address for mDNS-only meshes.
-pub fn detect_primary_lan_ipv4() -> Option<IpAddr> {
-    if let Some(ip) = default_route_source_ipv4().filter(is_private_lan_interface_ipv4) {
-        return Some(IpAddr::V4(ip));
-    }
-    first_private_lan_interface_ipv4().map(IpAddr::V4)
-}
+use std::net::{Ipv4Addr, SocketAddr};
 
 pub(super) fn lan_ipv4_candidates(addr: &EndpointAddr) -> Vec<std::net::SocketAddrV4> {
     addr.addrs
@@ -23,47 +15,6 @@ pub(super) fn lan_ipv4_candidates(addr: &EndpointAddr) -> Vec<std::net::SocketAd
 
 pub(crate) fn is_private_lan_ipv4(ip: &Ipv4Addr) -> bool {
     ip.is_private()
-}
-
-pub(crate) fn is_private_lan_interface_ipv4(ip: &Ipv4Addr) -> bool {
-    is_private_lan_ipv4(ip) && !is_container_bridge_ipv4(ip)
-}
-
-pub(crate) fn is_container_bridge_ipv4(ip: &Ipv4Addr) -> bool {
-    matches!(
-        ip.octets(),
-        [10, 88 | 89, _, _] | [10, 96..=111, _, _] | [10, 244, _, _] | [172, 17, _, _]
-    )
-}
-
-/// Source IPv4 the kernel would use for the default route, via a connect-trick.
-///
-/// 192.88.99.1 is a routable, globally-assigned target; connecting a UDP socket
-/// to it only drives route/source selection — it sends nothing. Returns `None`
-/// when there is no default route or the source is unspecified/loopback.
-pub(crate) fn default_route_source_ipv4() -> Option<Ipv4Addr> {
-    let socket = std::net::UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 0)).ok()?;
-    socket.connect((Ipv4Addr::new(192, 88, 99, 1), 9)).ok()?;
-    match socket.local_addr().ok()?.ip() {
-        IpAddr::V4(v4) if !v4.is_unspecified() && !v4.is_loopback() => Some(v4),
-        _ => None,
-    }
-}
-
-/// First operational private-LAN IPv4 from the local interface table.
-///
-/// Skips loopback, link-local, point-to-point, and common container bridge
-/// addresses so the result is a host LAN interface peers can directly reach.
-pub(crate) fn first_private_lan_interface_ipv4() -> Option<Ipv4Addr> {
-    let interfaces = if_addrs::get_if_addrs().ok()?;
-    interfaces
-        .into_iter()
-        .filter(|iface| !iface.is_loopback() && !iface.is_link_local() && !iface.is_p2p())
-        .filter_map(|iface| match iface.addr {
-            if_addrs::IfAddr::V4(v4) => Some(v4.ip),
-            if_addrs::IfAddr::V6(_) => None,
-        })
-        .find(is_private_lan_interface_ipv4)
 }
 
 #[cfg(test)]
@@ -94,21 +45,6 @@ mod tests {
             Ipv4Addr::new(172, 32, 0, 1),
         ] {
             assert!(!is_private_lan_ipv4(&ip), "{ip} must not be treated as LAN");
-        }
-    }
-
-    #[test]
-    pub(crate) fn common_container_bridge_ranges_are_not_selected_as_local_interfaces() {
-        for ip in [
-            Ipv4Addr::new(172, 17, 0, 1),
-            Ipv4Addr::new(10, 88, 0, 1),
-            Ipv4Addr::new(10, 96, 0, 1),
-            Ipv4Addr::new(10, 244, 0, 1),
-        ] {
-            assert!(
-                !is_private_lan_interface_ipv4(&ip),
-                "{ip} must not be selected as a local LAN interface"
-            );
         }
     }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -1,9 +1,9 @@
 //! Mesh membership via iroh QUIC connections.
 //!
 //! Mesh control traffic uses QUIC ALPN `mesh-llm/1` and multiplexes bi-streams
-//! by first byte. Latency-sensitive and path-maintenance flows keep dedicated
-//! stream bytes. Skippy activation transport remains on the latency-sensitive
-//! `skippy-stage/2` ALPN.
+//! by first byte. The legacy direct-path repair stream remains accepted for
+//! mixed-version compatibility. Skippy activation transport remains on the
+//! latency-sensitive `skippy-stage/2` ALPN.
 
 pub use mesh_llm_types::mesh::{
     MAX_SPLIT_RTT_MS, ModelDemand, ModelRuntimeDescriptor, ModelSourceKind, ServedModelDescriptor,
@@ -116,7 +116,7 @@ use stage_artifacts::*;
 use stage_transport::*;
 use stun::*;
 
-pub use connections::{QuicBindSelection, RelayConfig, RelayPolicy, detect_primary_lan_ipv4};
+pub use connections::{QuicBindSelection, RelayConfig, RelayPolicy};
 pub use gossip::backfill_legacy_descriptors;
 #[expect(
     unused_imports,

--- a/crates/mesh-llm-host-runtime/src/mesh/node.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node.rs
@@ -258,23 +258,6 @@ pub(crate) fn init_owner_runtime(
     })
 }
 
-pub(crate) fn configure_control_relay(
-    mut builder: iroh::endpoint::Builder,
-    relay: Option<RelayConfig<'_>>,
-) -> Result<iroh::endpoint::Builder> {
-    if let Some(relay) = relay.filter(|relay| relay.policy.uses_relay()) {
-        let urls = effective_relay_urls(relay.policy, relay.urls);
-        tracing::info!("Owner-control relay: {:?}", urls);
-        builder = builder.relay_mode(iroh::endpoint::RelayMode::Custom(relay_map_from_urls(
-            &urls,
-            relay.auths,
-        )?));
-    } else {
-        builder = builder.relay_mode(iroh::endpoint::RelayMode::Disabled);
-    }
-    Ok(builder)
-}
-
 pub(crate) fn default_plugin_event_source(endpoint_id: EndpointId, source_peer_id: &mut String) {
     if source_peer_id.is_empty() {
         *source_peer_id = endpoint_id_hex(endpoint_id);
@@ -1060,7 +1043,6 @@ impl Node {
             owner_config
                 .as_ref()
                 .and_then(|config| config.control_advertise_addr),
-            relay.policy.uses_relay().then_some(relay),
         )
         .await?;
 
@@ -1227,26 +1209,39 @@ impl Node {
         secret_key: SecretKey,
         bind_addr: Option<std::net::SocketAddr>,
         advertise_addr: Option<std::net::SocketAddr>,
-        relay: Option<RelayConfig<'_>>,
     ) -> Result<()> {
         if self.local_verified_owner_id().await.is_none() {
             return Ok(());
         }
 
-        let mut builder = Endpoint::builder(iroh::endpoint::presets::Minimal)
+        // The owner-control listener deliberately shares the node's secret key
+        // (and therefore its iroh endpoint id) with the main mesh endpoint: the
+        // control protocol validates the dialed `target_node_id` against the
+        // main endpoint id (`verify_control_plane_target_node`), so the control
+        // endpoint MUST present that same id.
+        //
+        // Because the id is shared, this endpoint must NOT register with the
+        // relay. An iroh relay keeps only one active connection per endpoint id:
+        // a second same-id registration evicts the first ("Another endpoint
+        // connected with the same endpoint id. No more messages will be
+        // received."). The control listener binds *after* the main mesh
+        // endpoint, so if it also joined the relay it would steal the main
+        // endpoint's relay slot and silently cut off all relay-delivered mesh
+        // traffic (gossip, joins, inference routing) — breaking relay fallback
+        // for any peer that cannot reach this node directly. Keeping the control
+        // endpoint relay-disabled leaves the main mesh endpoint as the sole
+        // relay registrant for this id. Owner-control is therefore reachable
+        // over its direct / advertised address only; relay-assisted remote
+        // owner-control is intentionally unsupported while the control and mesh
+        // endpoints share one id.
+        let endpoint = Endpoint::builder(iroh::endpoint::presets::Minimal)
             .secret_key(secret_key)
             .alpns(vec![ALPN_CONTROL_V1.to_vec()])
-            .bind_addr(bind_addr.unwrap_or_else(default_control_bind_addr))?;
-        builder = configure_control_relay(builder, relay)?;
-        let endpoint = builder.bind().await?;
-        if relay.is_some_and(|relay| relay.policy.uses_relay()) {
-            wait_for_endpoint_online(
-                &endpoint,
-                "Owner-control relay connected",
-                "Owner-control relay connection timed out (5s) — proceeding with direct endpoint addresses only",
-            )
-            .await;
-        }
+            .clear_ip_transports()
+            .bind_addr(bind_addr.unwrap_or_else(default_control_bind_addr))?
+            .relay_mode(iroh::endpoint::RelayMode::Disabled)
+            .bind()
+            .await?;
         let token = encode_endpoint_addr_token(&control_endpoint_addr(&endpoint, advertise_addr));
         let shutdown_requested = Arc::new(std::sync::atomic::AtomicBool::new(false));
         let shutdown = Arc::new(tokio::sync::Notify::new());

--- a/crates/mesh-llm-host-runtime/src/mesh/node.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node.rs
@@ -44,37 +44,24 @@ pub(crate) async fn startup_secret_key(role: &NodeRole) -> Result<SecretKey> {
 }
 
 pub(crate) fn startup_transport_config() -> iroh::endpoint::QuicTransportConfig {
-    // Keep QUIC connections alive during long inference calls.
+    // We only raise the concurrent bidi-stream ceiling; everything else uses
+    // iroh's tuned defaults.
     //
-    // noq-proto's default `max_idle_timeout` is ~30s and `keep_alive_interval`
-    // is `None`. A non-streaming inference request (e.g. MoA reducer or any
-    // `stream:false` call) sends nothing on the wire while the remote model is
-    // generating tokens. Under concurrent load (multiple in-flight model
-    // requests + gossip + heartbeats) noq's multipath bookkeeping will close
-    // an idle path, and if it is the last open path the whole connection
-    // drops mid-stream. The in-flight stream errors with `connection lost`
-    // and the caller has to retry from scratch.
-    //
-    // A 10s keep-alive sends a small PING every 10s on each path, keeping
-    // paths and the connection healthy during long compute. The 5-minute idle
-    // timeout is defense in depth for truly silent connections (paused
-    // agents, suspended laptops); short-term silence is handled by
-    // keep-alive.
-    let max_idle = iroh::endpoint::IdleTimeout::try_from(std::time::Duration::from_secs(300))
-        .expect("5-minute idle timeout fits in a VarInt");
-    let keep_alive = std::time::Duration::from_secs(10);
-    let path_idle = std::time::Duration::from_secs(300);
+    // History: this function used to override keep-alive (10s) and idle
+    // timeouts (300s conn + 300s per-path) to stop long silent inference
+    // connections being reaped mid-generation. Those overrides are now removed:
+    //   - iroh 1.0.x hard-CLAMPS per-path idle to 15s (values above are ignored
+    //     with a warning), so the 300s per-path setting never took effect.
+    //   - iroh's defaults already send keep-alive PINGs every 5s (connection AND
+    //     per-path) — more frequent than our old 10s — which keeps silent
+    //     inference paths alive without any override.
+    //   - The old overrides desynchronised connection- vs path-level liveness
+    //     and were part of what left upgraded direct paths idle long enough to
+    //     be reaped (see mesh-llm issue #1065).
+    // Mesh multiplexes many concurrent streams (gossip + heartbeat + inference
+    // tunnels) over one connection per peer, so we keep a generous bidi ceiling.
     iroh::endpoint::QuicTransportConfig::builder()
         .max_concurrent_bidi_streams(1024u32.into())
-        .keep_alive_interval(keep_alive)
-        .max_idle_timeout(Some(max_idle))
-        // noq-proto's multipath uses per-path idle timers independent of the
-        // connection-level idle. Without these, a path can be torn down while
-        // the connection idle timer is fine, and when the last path closes the
-        // connection dies with `LastOpenPath`. Mirror connection-level
-        // settings onto the default per-path config.
-        .default_path_max_idle_timeout(path_idle)
-        .default_path_keep_alive_interval(keep_alive)
         .build()
 }
 

--- a/crates/mesh-llm-host-runtime/src/mesh/node.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node.rs
@@ -48,16 +48,10 @@ pub(crate) fn startup_transport_config() -> iroh::endpoint::QuicTransportConfig 
     // iroh's tuned defaults.
     //
     // History: this function used to override keep-alive (10s) and idle
-    // timeouts (300s conn + 300s per-path) to stop long silent inference
-    // connections being reaped mid-generation. Those overrides are now removed:
-    //   - iroh 1.0.x hard-CLAMPS per-path idle to 15s (values above are ignored
-    //     with a warning), so the 300s per-path setting never took effect.
-    //   - iroh's defaults already send keep-alive PINGs every 5s (connection AND
-    //     per-path) — more frequent than our old 10s — which keeps silent
-    //     inference paths alive without any override.
-    //   - The old overrides desynchronised connection- vs path-level liveness
-    //     and were part of what left upgraded direct paths idle long enough to
-    //     be reaped (see mesh-llm issue #1065).
+    // timeouts (300s connection + 300s per path). iroh 1.0 clamps per-path idle
+    // to 15s and already sends keep-alive PINGs every 5s, so those overrides do
+    // not provide the intended behavior and needlessly diverge from iroh's path
+    // management defaults.
     // Mesh multiplexes many concurrent streams (gossip + heartbeat + inference
     // tunnels) over one connection per peer, so we keep a generous bidi ceiling.
     iroh::endpoint::QuicTransportConfig::builder()

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/admission/helpers.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/admission/helpers.rs
@@ -169,7 +169,7 @@ pub(super) async fn start_owner_control_test_server(
     *node.owner_attestation.lock().await = Some(ownership);
     *node.owner_summary.lock().await = owner_summary;
     *node.trust_store.lock().await = trust_store;
-    node.maybe_start_control_listener(secret_key.clone(), None, None, None)
+    node.maybe_start_control_listener(secret_key.clone(), None, None)
         .await?;
     Ok((node, secret_key, config_path))
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/control_listener.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/control_listener.rs
@@ -41,7 +41,7 @@ async fn control_plane_listener_starts_with_owner() -> anyhow::Result<()> {
         Node::new_for_tests_with_secret(super::super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
 
-    node.maybe_start_control_listener(secret_key, None, None, None)
+    node.maybe_start_control_listener(secret_key, None, None)
         .await?;
 
     let endpoint = node
@@ -60,6 +60,57 @@ async fn control_plane_listener_starts_with_owner() -> anyhow::Result<()> {
     Ok(())
 }
 
+/// Regression test for the owner-control / main-mesh relay endpoint-id
+/// collision.
+///
+/// The owner-control listener shares the node's secret key (and therefore its
+/// iroh endpoint id) with the main mesh endpoint, because the control protocol
+/// validates the dialed `target_node_id` against the main endpoint id. An iroh
+/// relay keeps only one active connection per endpoint id, so if the control
+/// endpoint also registered with the relay it would evict the main mesh
+/// endpoint's relay registration ("Another endpoint connected with the same
+/// endpoint id. No more messages will be received."), silently killing all
+/// relay-delivered mesh traffic — gossip, joins, inference routing — for peers
+/// that cannot reach this node directly. That defeats relay fallback and is the
+/// root cause of consume-side "connects but never joins / catalog never syncs".
+///
+/// The fix keeps the control endpoint relay-disabled. This test pins the
+/// observable invariant: the control endpoint token must advertise NO relay
+/// URLs, so it can never contend for the shared id's relay slot. If someone
+/// re-enables relay on the control endpoint, this fails.
+#[tokio::test]
+async fn control_plane_listener_token_carries_no_relay_urls() -> anyhow::Result<()> {
+    let (node, secret_key) =
+        Node::new_for_tests_with_secret(super::super::NodeRole::Worker).await?;
+    *node.owner_summary.lock().await = verified_owner_summary("owner-a");
+
+    node.maybe_start_control_listener(secret_key, None, None)
+        .await?;
+
+    let endpoint = node
+        .control_endpoint()
+        .await
+        .expect("verified owner should start a control listener");
+    let decoded = Node::decode_invite_token(&endpoint)?;
+
+    // Same id as the main mesh endpoint (required by target-node validation)...
+    assert_eq!(decoded.id, node.endpoint.id());
+    // ...but ZERO relay URLs, so it cannot evict the main endpoint's relay slot.
+    let relay_addrs = decoded
+        .addrs
+        .iter()
+        .filter(|addr| matches!(addr, iroh::TransportAddr::Relay(_)))
+        .count();
+    assert_eq!(
+        relay_addrs, 0,
+        "owner-control token must not advertise relay URLs (shares the main \
+         endpoint id; a relay registration would evict the main mesh endpoint)"
+    );
+
+    node.shutdown_control_listener().await;
+    Ok(())
+}
+
 #[tokio::test]
 async fn control_plane_listener_uses_explicit_advertised_address() -> anyhow::Result<()> {
     let (node, secret_key) =
@@ -67,7 +118,7 @@ async fn control_plane_listener_uses_explicit_advertised_address() -> anyhow::Re
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
     let advertised_addr = std::net::SocketAddr::from(([203, 0, 113, 10], 18443));
 
-    node.maybe_start_control_listener(secret_key, None, Some(advertised_addr), None)
+    node.maybe_start_control_listener(secret_key, None, Some(advertised_addr))
         .await?;
 
     let endpoint = node
@@ -92,13 +143,8 @@ async fn control_plane_listener_disabled_without_owner() -> anyhow::Result<()> {
     let (node, secret_key) =
         Node::new_for_tests_with_secret(super::super::NodeRole::Worker).await?;
 
-    node.maybe_start_control_listener(
-        secret_key,
-        Some("127.0.0.1:7447".parse().unwrap()),
-        None,
-        None,
-    )
-    .await?;
+    node.maybe_start_control_listener(secret_key, Some("127.0.0.1:7447".parse().unwrap()), None)
+        .await?;
 
     assert!(node.control_endpoint().await.is_none());
     Ok(())
@@ -109,7 +155,7 @@ async fn control_plane_listener_accepts_only_control_alpn() -> anyhow::Result<()
     let (node, secret_key) =
         Node::new_for_tests_with_secret(super::super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
-    node.maybe_start_control_listener(secret_key, None, None, None)
+    node.maybe_start_control_listener(secret_key, None, None)
         .await?;
     let endpoint = Node::decode_invite_token(
         &node
@@ -186,7 +232,7 @@ async fn control_plane_endpoint_not_in_gossip_or_status() -> anyhow::Result<()> 
     let (node, secret_key) =
         Node::new_for_tests_with_secret(super::super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
-    node.maybe_start_control_listener(secret_key, None, None, None)
+    node.maybe_start_control_listener(secret_key, None, None)
         .await?;
     let control_endpoint = node
         .control_endpoint()
@@ -223,7 +269,7 @@ async fn control_plane_listener_shutdown_stops_listener_task() -> anyhow::Result
     let (node, secret_key) =
         Node::new_for_tests_with_secret(super::super::NodeRole::Worker).await?;
     *node.owner_summary.lock().await = verified_owner_summary("owner-a");
-    node.maybe_start_control_listener(secret_key, None, None, None)
+    node.maybe_start_control_listener(secret_key, None, None)
         .await?;
     let endpoint = Node::decode_invite_token(
         &node

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/control_listener.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/control_listener.rs
@@ -107,6 +107,21 @@ async fn control_plane_listener_token_carries_no_relay_urls() -> anyhow::Result<
          endpoint id; a relay registration would evict the main mesh endpoint)"
     );
 
+    // Invariant (defence-in-depth): the control endpoint is loopback-only by
+    // default — it must NOT advertise any non-loopback IP transport. This keeps
+    // the control plane non-routable off-box unless an explicit advertise addr
+    // is configured (see the dedicated test), preserving the separation intent
+    // of the split-control design (#539) while fixing the relay-slot eviction.
+    for addr in &decoded.addrs {
+        if let iroh::TransportAddr::Ip(sock) = addr {
+            assert!(
+                sock.ip().is_loopback(),
+                "owner-control token must only advertise loopback IPs by default, \
+                 found non-loopback {sock}"
+            );
+        }
+    }
+
     node.shutdown_control_listener().await;
     Ok(())
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/direct_path.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/direct_path.rs
@@ -1,98 +1,10 @@
-use super::super::direct_path::{
-    DIRECT_PATH_REPAIR_COOLDOWN_SECS, DIRECT_PATH_REPAIR_GRACE_SECS,
-    DirectPathMaintenanceController, DirectPathObservation, DirectPathRepairReason,
-    endpoint_addr_with_previously_advertised_direct_candidates,
-};
-use super::super::heartbeat::{RelayPathSnapshot, SelectedPathKind};
+use super::super::direct_path::endpoint_addr_with_previously_advertised_direct_candidates;
 use super::{
     PendingConnectionOutcome, PendingConnectionReservation, configure_requirement_node,
     connect_mesh, make_test_endpoint_id, make_test_node, requirement_policy,
     test_release_signer_key_id,
 };
 use iroh::{EndpointAddr, TransportAddr};
-
-#[test]
-fn direct_path_maintenance_requires_candidate_and_grace_period() {
-    let now = std::time::Instant::now();
-    let peer = make_test_endpoint_id(31);
-    let mut controller = DirectPathMaintenanceController::default();
-    let relay_observation = DirectPathObservation {
-        peer_id: peer,
-        snapshot: RelayPathSnapshot {
-            kind: SelectedPathKind::Relay,
-            rtt_ms: Some(200),
-        },
-        has_direct_candidate: true,
-    };
-
-    assert_eq!(
-        controller.plan_request([relay_observation], now, 0),
-        None,
-        "first non-direct observation starts the grace timer"
-    );
-    assert_eq!(
-        controller.plan_request(
-            [relay_observation],
-            now + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS + 2),
-            0,
-        ),
-        Some((peer, DirectPathRepairReason::RelaySelected))
-    );
-
-    let mut no_candidate_controller = DirectPathMaintenanceController::default();
-    assert_eq!(
-        no_candidate_controller.plan_request(
-            [DirectPathObservation {
-                has_direct_candidate: false,
-                ..relay_observation
-            }],
-            now + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS + 1),
-            0,
-        ),
-        None,
-        "without a direct candidate there is nothing useful to request"
-    );
-}
-
-#[test]
-fn direct_path_maintenance_cooldown_and_inflight_suppress_requests() {
-    let now = std::time::Instant::now();
-    let peer = make_test_endpoint_id(32);
-    let mut controller = DirectPathMaintenanceController::default();
-    let observation = DirectPathObservation {
-        peer_id: peer,
-        snapshot: RelayPathSnapshot {
-            kind: SelectedPathKind::Unknown,
-            rtt_ms: None,
-        },
-        has_direct_candidate: true,
-    };
-
-    assert_eq!(controller.plan_request([observation], now, 1), None);
-    assert!(
-        controller
-            .peer_health(peer)
-            .and_then(|health| health.non_direct_since)
-            .is_some(),
-        "active requests suppress repair but still record path state"
-    );
-
-    let ready_at = now + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_GRACE_SECS + 1);
-    assert_eq!(
-        controller.plan_request([observation], ready_at, 0),
-        Some((peer, DirectPathRepairReason::UnknownSelected))
-    );
-    controller.record_request_attempt(peer, ready_at);
-    assert_eq!(
-        controller.plan_request(
-            [observation],
-            ready_at + std::time::Duration::from_secs(DIRECT_PATH_REPAIR_COOLDOWN_SECS - 1),
-            0,
-        ),
-        None,
-        "cooldown prevents repeated reverse-dial requests"
-    );
-}
 
 #[test]
 fn direct_path_request_keeps_only_previously_advertised_direct_candidates() {

--- a/crates/mesh-llm-host-runtime/src/network/lan_bootstrap.rs
+++ b/crates/mesh-llm-host-runtime/src/network/lan_bootstrap.rs
@@ -10,16 +10,10 @@ pub(crate) fn effective_quic_bind_ip(options: &RuntimeOptions) -> Option<IpAddr>
         return Some(ip);
     }
 
-    // Default: bind iroh's wildcard sockets (0.0.0.0 + [::]) and let iroh own
-    // candidate discovery. We used to auto-pin the detected primary LAN IPv4
-    // here, which created a SECOND local UDP socket alongside iroh's wildcard
-    // socket on one endpoint id. iroh's docs are explicit that manual binding is
-    // advanced/usually-unnecessary and replaces the wildcard bind; pinning one
-    // family left a stray socket whose 4-tuple diverged from the path iroh
-    // validated, contributing to direct paths idling out. With QAD supplying the
-    // public reflexive candidate and iroh's own NAT traversal, LAN pinning is no
-    // longer needed. Override with --bind-ip for genuinely special cases.
-    // See mesh-llm issue #1065.
+    // Use iroh's default wildcard sockets and candidate discovery unless the
+    // operator explicitly needs to select an interface. Auto-pinning a detected
+    // LAN IPv4 restricted iroh's normal dual-stack path set and duplicated
+    // address-selection logic that iroh already owns.
     None
 }
 

--- a/crates/mesh-llm-host-runtime/src/network/lan_bootstrap.rs
+++ b/crates/mesh-llm-host-runtime/src/network/lan_bootstrap.rs
@@ -5,22 +5,22 @@ use std::net::IpAddr;
 use tokio::task::JoinHandle;
 
 pub(crate) fn effective_quic_bind_ip(options: &RuntimeOptions) -> Option<IpAddr> {
+    // Explicit operator override always wins.
     if let Some(ip) = options.bind_ip {
         return Some(ip);
     }
 
-    let detected = mesh::detect_primary_lan_ipv4();
-    if let Some(ip) = detected {
-        tracing::info!(
-            "Auto-binding QUIC endpoint to detected LAN address {ip}; override with --bind-ip"
-        );
-        Some(ip)
-    } else {
-        tracing::debug!(
-            "Unable to detect a LAN IPv4 address for QUIC bind; using wildcard socket bind"
-        );
-        None
-    }
+    // Default: bind iroh's wildcard sockets (0.0.0.0 + [::]) and let iroh own
+    // candidate discovery. We used to auto-pin the detected primary LAN IPv4
+    // here, which created a SECOND local UDP socket alongside iroh's wildcard
+    // socket on one endpoint id. iroh's docs are explicit that manual binding is
+    // advanced/usually-unnecessary and replaces the wildcard bind; pinning one
+    // family left a stray socket whose 4-tuple diverged from the path iroh
+    // validated, contributing to direct paths idling out. With QAD supplying the
+    // public reflexive candidate and iroh's own NAT traversal, LAN pinning is no
+    // longer needed. Override with --bind-ip for genuinely special cases.
+    // See mesh-llm issue #1065.
+    None
 }
 
 /// Background tasks spawned by [`spawn_mdns_reverse_dial`] for relay-less LAN

--- a/crates/mesh-llm-host-runtime/src/runtime/auto_join.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/auto_join.rs
@@ -839,8 +839,8 @@ pub(crate) async fn run_plugin_mcp(options: &RuntimeOptions) -> Result<()> {
         .await;
     node.start_heartbeat();
     node.start_rtt_refresh();
-    // Direct-path maintenance / reverse-dial removed — iroh 1.0.x does NAT
-    // traversal + relay->direct migration itself. See issue #1065.
+    // iroh owns NAT traversal and relay-to-direct migration; modern nodes do
+    // not start the legacy application-level reverse-dial sender.
     start_relay_health_monitor_for_discovery_mode(&node, options.mesh_discovery_mode);
     join_mesh_for_mcp(options, &node).await?;
 

--- a/crates/mesh-llm-host-runtime/src/runtime/auto_join.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/auto_join.rs
@@ -839,7 +839,8 @@ pub(crate) async fn run_plugin_mcp(options: &RuntimeOptions) -> Result<()> {
         .await;
     node.start_heartbeat();
     node.start_rtt_refresh();
-    node.start_direct_path_maintenance();
+    // Direct-path maintenance / reverse-dial removed — iroh 1.0.x does NAT
+    // traversal + relay->direct migration itself. See issue #1065.
     start_relay_health_monitor_for_discovery_mode(&node, options.mesh_discovery_mode);
     join_mesh_for_mcp(options, &node).await?;
 

--- a/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
@@ -729,11 +729,8 @@ pub(super) async fn build_run_auto_node_setup(
     node.set_available_models(local_models.clone()).await;
     node.start_heartbeat();
     node.start_rtt_refresh();
-    // Direct-path maintenance / reverse-dial removed: iroh 1.0.x performs NAT
-    // traversal and relay->direct migration itself (QAD + QNT, incl. the hard-NAT
-    // case). The app-level repair reverse-dialled peers on a separate stream,
-    // creating extra short-lived connections that raced iroh's own path
-    // management and left the upgraded direct path idle. See issue #1065.
+    // iroh owns NAT traversal and relay-to-direct migration; modern nodes do
+    // not start the legacy application-level reverse-dial sender.
     start_relay_health_monitor_for_discovery_mode(&node, options.mesh_discovery_mode);
     let lan_bootstrap_tasks = spawn_mdns_reverse_dial(options, &node);
 

--- a/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
@@ -729,7 +729,11 @@ pub(super) async fn build_run_auto_node_setup(
     node.set_available_models(local_models.clone()).await;
     node.start_heartbeat();
     node.start_rtt_refresh();
-    node.start_direct_path_maintenance();
+    // Direct-path maintenance / reverse-dial removed: iroh 1.0.x performs NAT
+    // traversal and relay->direct migration itself (QAD + QNT, incl. the hard-NAT
+    // case). The app-level repair reverse-dialled peers on a separate stream,
+    // creating extra short-lived connections that raced iroh's own path
+    // management and left the upgraded direct path idle. See issue #1065.
     start_relay_health_monitor_for_discovery_mode(&node, options.mesh_discovery_mode);
     let lan_bootstrap_tasks = spawn_mdns_reverse_dial(options, &node);
 


### PR DESCRIPTION
## Goal

Let iroh 1.0.3 own NAT traversal and path management so mesh relay-to-direct migration behaves like bare iroh. This also includes the owner-control relay-slot fix from #1064.

## Changes

- Keep owner-control on its own loopback-only listener instead of sharing the mesh relay slot.
- Upgrade iroh from 1.0.1 to 1.0.3.
- Use iroh's wildcard QUIC binds and transport defaults instead of auto-pinning one LAN IPv4 or overriding path liveness.
- Remove the application-level direct-path repair sender/controller; iroh owns probing and relay-to-direct migration.
- Retain the legacy direct-path request receiver and its admission/cooldown checks so mixed-version peers remain compatible.
- Remove the now-unused LAN-interface detector and direct `if-addrs` dependency.
- Restore `HOME` after serialized owner-control tests so the full host-runtime suite is deterministic.

QAD from #1066, admission control, owner identity, relay fallback, and both mesh ALPN generations remain intact.

## Qlog diagnosis

The failed mesh trace negotiates the same QUIC multipath/NAT-traversal parameters as the working bare dialer (`initial_max_path_id=7`, `max_remote_nat_traversal_addresses=32`). It emits `PATH_CHALLENGE` probes, then retries because no challenge or response arrives and the IP path never validates.

Follow-up probes falsified the earlier mesh-specific leading theories:

- Bare iroh still migrated to direct with port mapping disabled.
- Three concurrent bare connections to the same peer all migrated to direct.
- Bare probes remained direct while the mesh runtime was busy.
- The qlog-enabled mesh transport reached direct paths repeatedly on USE1, EUC1, and APS1 relays (3/3 each); relay generation was not causal.

The original failure is intermittent rather than a deterministic multiple-connection race, and matches the class of upstream path-selection failure tracked in n0-computer/iroh#4247. This PR therefore removes the redundant mesh workaround instead of adding another path manager or pinning a relay subset.

## Validation

- `just build`
- `MESH_LLM_DYNAMIC_NATIVE_RUNTIME=0 just release-build`
- `cargo fmt --all --check`
- `cargo check -p mesh-llm-host-runtime`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `cargo test -p mesh-llm-host-runtime --lib` — 1706 passed, 0 failed, 8 ignored
- Exact static release build, M5 serve -> Mini client: 3/3 fresh connections became direct and remained direct at the five-second recheck. One began on relay and migrated to direct.
- Mini `/v1/models` returned the M5-hosted model, and a chat completion tunneled through the Mini client returned the requested response.

The final lab runs used normal relay selection; no newer-relay-only source change is included.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated network connection handling to rely on automatic transport and candidate discovery.
  * Simplified control-plane connectivity by disabling relay addresses for owner-control endpoints.
  * Increased supported concurrent mesh streams.
  * Preserved compatibility with older peers that send legacy direct-path repair requests.
* **Bug Fixes**
  * Improved test isolation when configuring temporary home directories.
  * Removed legacy network-interface detection and direct-path maintenance behavior that could cause unnecessary connection management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->