### PR TITLE
Keep client-only nodes out of model election

### DIFF
--- a/crates/mesh-llm-host-runtime/src/runtime/auto_join.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/auto_join.rs
@@ -520,6 +520,18 @@ pub(super) async fn pick_model_assignment(
     None
 }
 
+/// Pick a model assignment only when this node's mesh role can serve models.
+pub(super) async fn pick_model_assignment_for_role(
+    node: &mesh::Node,
+    local_models: &[String],
+) -> Option<String> {
+    if matches!(node.role().await, NodeRole::Client) {
+        None
+    } else {
+        pick_model_assignment(node, local_models).await
+    }
+}
+
 /// Check if a standby node should promote to serve a model.
 /// Uses demand signals — promotes for unserved models with active demand,
 /// or for demand-based rebalancing when one model is much hotter than others.
@@ -527,18 +539,6 @@ pub(super) async fn pick_model_assignment(
 /// Rebalancing uses `last_active` to gate on recency (only models active within
 /// the last 60 minutes are considered), then `request_count / servers` for
 /// relative hotness among those recent models.
-pub(super) async fn pick_model_assignment_for_role(
-    node: &mesh::Node,
-    local_models: &[String],
-    is_client: bool,
-) -> Option<String> {
-    if is_client {
-        None
-    } else {
-        pick_model_assignment(node, local_models).await
-    }
-}
-
 pub(super) async fn check_unserved_model(
     node: &mesh::Node,
     local_models: &[String],
@@ -1091,8 +1091,7 @@ pub(super) async fn select_run_auto_model_path(
     });
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-    let assignment =
-        pick_model_assignment_for_role(ctx.node, ctx.local_models, ctx.is_client).await;
+    let assignment = pick_model_assignment_for_role(ctx.node, ctx.local_models).await;
     let assignment = if assignment.is_none()
         && (ctx.options.auto || ctx.options.discover.is_some())
         && !ctx.is_client

--- a/crates/mesh-llm-host-runtime/src/runtime/auto_join.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/auto_join.rs
@@ -527,6 +527,18 @@ pub(super) async fn pick_model_assignment(
 /// Rebalancing uses `last_active` to gate on recency (only models active within
 /// the last 60 minutes are considered), then `request_count / servers` for
 /// relative hotness among those recent models.
+pub(super) async fn pick_model_assignment_for_role(
+    node: &mesh::Node,
+    local_models: &[String],
+    is_client: bool,
+) -> Option<String> {
+    if is_client {
+        None
+    } else {
+        pick_model_assignment(node, local_models).await
+    }
+}
+
 pub(super) async fn check_unserved_model(
     node: &mesh::Node,
     local_models: &[String],
@@ -1079,7 +1091,8 @@ pub(super) async fn select_run_auto_model_path(
     });
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-    let assignment = pick_model_assignment(ctx.node, ctx.local_models).await;
+    let assignment =
+        pick_model_assignment_for_role(ctx.node, ctx.local_models, ctx.is_client).await;
     let assignment = if assignment.is_none()
         && (ctx.options.auto || ctx.options.discover.is_some())
         && !ctx.is_client

--- a/crates/mesh-llm-host-runtime/src/runtime/tests/auto_join.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/tests/auto_join.rs
@@ -58,16 +58,32 @@ fn mdns_discovery_starts_lan_rediscovery_only_with_join_token() {
 }
 
 #[tokio::test]
-async fn client_role_never_receives_model_assignment() {
-    let node = mesh::Node::new_for_tests(mesh::NodeRole::Client)
+async fn model_assignment_is_derived_from_node_role() {
+    let model_file = tempfile::Builder::new()
+        .suffix(".gguf")
+        .tempfile()
+        .expect("temporary model file");
+    std::fs::write(model_file.path(), b"test model").expect("write temporary model");
+    let model_ref = models::model_ref_for_path(model_file.path());
+    let local_models = [model_ref.clone()];
+
+    let mut node = mesh::Node::new_for_tests(mesh::NodeRole::Client)
         .await
         .expect("test node");
-    node.record_request("unserved-model");
+    node.vram_bytes = 1_000_000_000;
+    node.record_request(&model_ref);
 
-    assert!(
-        pick_model_assignment_for_role(&node, &[], true)
-            .await
-            .is_none()
+    assert_eq!(
+        pick_model_assignment_for_role(&node, &local_models).await,
+        None,
+        "client roles must remain proxy-only"
+    );
+
+    node.set_role(mesh::NodeRole::Worker).await;
+    assert_eq!(
+        pick_model_assignment_for_role(&node, &local_models).await,
+        Some(model_ref),
+        "worker roles must still receive normal assignments"
     );
 }
 

--- a/crates/mesh-llm-host-runtime/src/runtime/tests/auto_join.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/tests/auto_join.rs
@@ -57,6 +57,20 @@ fn mdns_discovery_starts_lan_rediscovery_only_with_join_token() {
     ));
 }
 
+#[tokio::test]
+async fn client_role_never_receives_model_assignment() {
+    let node = mesh::Node::new_for_tests(mesh::NodeRole::Client)
+        .await
+        .expect("test node");
+    node.record_request("unserved-model");
+
+    assert!(
+        pick_model_assignment_for_role(&node, &[], true)
+            .await
+            .is_none()
+    );
+}
+
 fn make_cli(args: &[&str]) -> RuntimeOptions {
     runtime_options_for_test(args)
 }


### PR DESCRIPTION
Client-only nodes now remain proxy-only after joining a mesh, even when active demand includes an unserved model. This prevents zero-capacity clients from electing themselves, downloading a large model, and delaying management API startup.

Validation:
- focused host-runtime regression test passed
- host-runtime Clippy passed with warnings denied on the source branch
- formatting and diff checks passed on this focused branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Client-mode nodes no longer receive automatic model assignments during host election or model selection.
  * Improved role-aware handling of model selection.

* **Tests**
  * Added a new async test verifying model assignment is derived from node role (returns no assignment for client role, assigns one for worker role).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->