### PR TITLE
ci: bump Linux CUDA slim container to gha-convention base runner

### DIFF
--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -328,7 +328,7 @@ jobs:
         include:
           - name: CUDA slim
             backend: cuda
-            container: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:c5b85ef527230f77cf9933ef40bcb44316f9bbcb8fd2ce0651b58acda5143dfd
+            container: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:295341c6c9f17c9eb69281fd454bda953799406d6915f472c914fb5f024a88ed
             cache_key: linux-cuda-slim
             runs_on: '["ubuntu-24.04"]'
             self_hosted_runs_on: '["self-hosted","Linux","X64","amd64","gpu-nvidia"]'


### PR DESCRIPTION
## Summary

Pins the `Linux CUDA slim` matrix entry's `container:` image to the new digest published by Mesh-LLM/mesh-llm-runner-images [#8](https://github.com/Mesh-LLM/mesh-llm-runner-images/pull/8) — the refactor to `FROM ghcr.io/actions/actions-runner` base + GHA convention `/__e` symlinks.

| Before | After |
| --- | --- |
| `sha256:c5b85ef5...` | `sha256:295341c6c9f17c9eb69281fd454bda953799406d6915f472c914fb5f024a88ed` |

## Why

The old image was built from `mcr.microsoft.com/dotnet/runtime-deps:8.0-noble` and was missing the GHA convention mount point `/__e/node24/bin/node`. Once the ARC runner pod has a working docker CLI (baked by the new base image) and the host-path docker socket from `carrack` mounted at `/var/run/docker.sock`, the actions/runner agent execs marketplace JS actions via:

```
docker exec <container> /__e/node24/bin/node <runner-temp>/actions/checkout/dist/index.js
```

The old image lacks `/__e/node24/bin/node`, so this fails with:

```
OCI runtime exec failed: exec failed: unable to start container process: exec: "/__e/node24/bin/node": stat /__e/node24/bin/node: no such file or directory
``\]

— confirmed at `Linux CUDA slim` step 3 (`actions/checkout@v5`) on run 30146423269 job 89658307286 (in stanton-patio51 cluster build environment).

Reference: [actions/runner-container-hooks#347](https://github.com/actions/runner-container-hooks/issues/347) — exact same failure mode on K8s self-hosted DinD.

The new image inherits `ghcr.io/actions/actions-runner:latest` (Ubuntu 24.04 with built-in `runner` user, `/home/runner/externals/{node20,node24}/bin/node`, `/usr/bin/docker` CLI, and `/__e/node24` symlinks) and layers CUDA 12.9.2 + Rust + just + sccache + pnpm on top.

## Pairs with

- **stanton-patio51** commit [`31a661b`](https://github.com/ndizazzo/crusader-patio51/commit/31a661b) — bumps the corresponding self-hosted ARC runner pod image to `sha256:2dd446840d607f893ab1a747668a1554ba5cece64ec5a6dbbaa725bf3479c2f3` (self-hosted cuda12 amd64), drops the now-redundant docker-cli-installer initContainer, keeps the supplementalGroups + host-path docker socket mount.

## Verification plan

- This PR's follow-up push triggers PR Builds (this workflow).
- Expect: `Linux CUDA slim` job runs to completion (no longer errors at `actions/checkout@v5`) on stanton-patio51 self-hosted AMD64 scale-set runner.
- Other matrix cells unchanged (ROCm slim, Vulkan, macOS, Linux CPU) — they use `runs_on: [ubuntu-24.04]` (GitHub-hosted) and are not affected by this digest swap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the CUDA build environment to use a refreshed, verified container image.
  * Improved reliability and consistency for Linux CUDA build checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->