### PR TITLE
ci: make release sccache failures non-fatal

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -36,8 +36,9 @@ Local actions:
 - `.github/actions/compute-changes` owns path, crate, backend, SDK, UI, website,
   Windows, and docs-only routing outputs.
 - `.github/actions/configure-sccache-gha` exports ephemeral Actions cache
-  credentials to the baked `sccache`, probes the GHA backend, and restarts the
-  server with job-local storage when the probe fails.
+  credentials to the baked `sccache`, configures job-local disk storage ahead
+  of GHA in a fail-open multi-level cache, and restarts the server with disk-only
+  storage when the remote probe fails.
 - `.github/actions/restore-smoke-inputs` owns producer artifact staging and
   model restoration for smoke consumers.
 - `.github/actions/setup-windows-rocm-sdk` owns reusable Windows ROCm setup.
@@ -127,11 +128,15 @@ change cannot be delivered by a MeshLLM pull request.
 
 Public-image Rust jobs use the baked `sccache` binary and start with
 `SCCACHE_GHA_ENABLED=false`. The local `configure-sccache-gha` action exports
-the ephemeral Actions cache URL/token, enables the GHA backend, and probes it by
-starting the server. If that probe fails, the action stops the remote-configured
-server and restarts `sccache` with its job-local disk cache. Persistent Cargo
-target and ABI reuse remains owned by `Swatinem/rust-cache` and `actions/cache`.
-Do not reintroduce the sccache download action merely to export credentials.
+the ephemeral Actions cache URL/token, enables a `disk,gha` cache chain, ignores
+cache write errors, and probes it by starting the server. The disk tier uses a
+job-local directory beside, rather than inside, the checkout. Cache read
+failures degrade to misses, cache write failures are warnings, and compiler
+invocations fall back locally if the server becomes unavailable. If the
+initial remote probe fails, the action stops the remote-configured server and
+restarts `sccache` with disk-only storage. Persistent Cargo target and ABI reuse
+remains owned by `Swatinem/rust-cache` and `actions/cache`. Do not reintroduce
+the sccache download action merely to export credentials.
 
 `USE_SELF_HOSTED` currently controls selected GPU/release routes. Unset or a
 value other than the exact string `true` selects the hosted fallback. Any new

--- a/.github/actions/configure-sccache-gha/action.yml
+++ b/.github/actions/configure-sccache-gha/action.yml
@@ -1,5 +1,5 @@
 name: Configure baked sccache GHA backend
-description: Use Actions cache from the baked sccache binary with a job-local fallback.
+description: Use job-local disk plus best-effort Actions cache from the baked sccache binary.
 
 runs:
   using: composite
@@ -19,6 +19,9 @@ runs:
           core.exportVariable('ACTIONS_CACHE_URL', cacheUrl);
           core.exportVariable('ACTIONS_RESULTS_URL', resultsUrl);
           core.exportVariable('ACTIONS_RUNTIME_TOKEN', runtimeToken);
+          core.exportVariable('SCCACHE_IGNORE_SERVER_IO_ERROR', '1');
+          core.exportVariable('SCCACHE_MULTILEVEL_CHAIN', 'disk,gha');
+          core.exportVariable('SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY', 'ignore');
 
           await exec.exec('sccache', ['--stop-server'], {
             ignoreReturnCode: true,
@@ -29,7 +32,9 @@ runs:
             ignoreReturnCode: true,
           });
           if (remoteExitCode === 0) {
-            core.info('Baked sccache is using the GitHub Actions cache backend.');
+            core.info(
+              'Baked sccache is using job-local disk with a best-effort GitHub Actions cache.',
+            );
             return;
           }
 
@@ -40,6 +45,7 @@ runs:
             ignoreReturnCode: true,
           });
           core.exportVariable('SCCACHE_GHA_ENABLED', 'false');
+          core.exportVariable('SCCACHE_MULTILEVEL_CHAIN', 'disk');
 
           const localExitCode = await exec.exec('sccache', ['--start-server'], {
             ignoreReturnCode: true,

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,11 @@ permissions:
 
 env:
   CACHE_NAMESPACE: mesh-llm
+  SCCACHE_DIR: ${{ github.workspace }}/../.sccache
   SCCACHE_GHA_ENABLED: "true"
+  SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
+  SCCACHE_MULTILEVEL_CHAIN: disk,gha
+  SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY: ignore
 
 jobs:
   metadata:

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -298,11 +298,15 @@ itself prove that an existing package is anonymously readable.
 The public image already contains `sccache`. Public-image Rust jobs start with
 its GHA remote backend disabled, then use the repository-local
 `configure-sccache-gha` action to export the ephemeral Actions cache URL/token
-and probe the remote backend. A failed probe stops the remote-configured server
-and restarts `sccache` with its job-local disk cache, so cache availability
-cannot block compiler startup. Persistent Cargo target and ABI caches continue
-through the existing cache actions. Do not download a second sccache binary
-just to configure the GHA backend.
+and start a `disk,gha` multi-level cache. The disk cache serves as L0, GHA is a
+best-effort L1, and the disk tier uses a job-local directory beside the checkout
+so it does not make release sources appear dirty. Cache read failures degrade to
+misses, and cache write failures only emit warnings. Compiler invocations also
+fall back locally if the sccache server becomes unavailable. A failed initial
+remote probe stops the remote-configured server and restarts `sccache` with
+disk-only storage. Persistent Cargo target and ABI caches continue through the
+existing cache actions. Do not download a second sccache binary just to
+configure the GHA backend.
 
 ## Public website deployment
 

--- a/tools/xtask/src/workflow_checks.rs
+++ b/tools/xtask/src/workflow_checks.rs
@@ -436,6 +436,27 @@ fn check_release_container_contracts(
     const PINNED_GITHUB_SCRIPT: &str =
         "uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd";
 
+    for (required, context) in [
+        (
+            "  SCCACHE_DIR: ${{ github.workspace }}/../.sccache",
+            "release workflow sccache disk cache",
+        ),
+        (
+            "  SCCACHE_IGNORE_SERVER_IO_ERROR: \"1\"",
+            "release workflow sccache compiler fallback",
+        ),
+        (
+            "  SCCACHE_MULTILEVEL_CHAIN: disk,gha",
+            "release workflow sccache cache chain",
+        ),
+        (
+            "  SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY: ignore",
+            "release workflow sccache write fallback",
+        ),
+    ] {
+        ensure_contains(release_workflow, required, context)?;
+    }
+
     ensure_contains(
         configure_sccache_action,
         PINNED_GITHUB_SCRIPT,
@@ -462,6 +483,22 @@ fn check_release_container_contracts(
         (
             "core.exportVariable('SCCACHE_GHA_ENABLED', 'false')",
             "sccache GHA action job-local fallback",
+        ),
+        (
+            "core.exportVariable('SCCACHE_IGNORE_SERVER_IO_ERROR', '1')",
+            "sccache GHA action compiler fallback",
+        ),
+        (
+            "core.exportVariable('SCCACHE_MULTILEVEL_CHAIN', 'disk,gha')",
+            "sccache GHA action cache chain",
+        ),
+        (
+            "core.exportVariable('SCCACHE_MULTILEVEL_CHAIN', 'disk')",
+            "sccache GHA action disk-only fallback",
+        ),
+        (
+            "core.exportVariable('SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY', 'ignore')",
+            "sccache GHA action write fallback",
         ),
         ("['--start-server']", "sccache GHA action server start"),
         ("['--stop-server']", "sccache GHA action server stop"),
@@ -685,11 +722,20 @@ core.exportVariable('ACTIONS_RESULTS_URL'
 core.exportVariable('ACTIONS_RUNTIME_TOKEN'
 core.exportVariable('SCCACHE_GHA_ENABLED', 'true')
 core.exportVariable('SCCACHE_GHA_ENABLED', 'false')
+core.exportVariable('SCCACHE_IGNORE_SERVER_IO_ERROR', '1')
+core.exportVariable('SCCACHE_MULTILEVEL_CHAIN', 'disk,gha')
+core.exportVariable('SCCACHE_MULTILEVEL_CHAIN', 'disk')
+core.exportVariable('SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY', 'ignore')
 ['--start-server']
 ['--stop-server']
 "#;
 
-    const VALID_CONTAINER_WORKFLOW: &str = r#"jobs:
+    const VALID_CONTAINER_WORKFLOW: &str = r#"env:
+  SCCACHE_DIR: ${{ github.workspace }}/../.sccache
+  SCCACHE_IGNORE_SERVER_IO_ERROR: "1"
+  SCCACHE_MULTILEVEL_CHAIN: disk,gha
+  SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY: ignore
+jobs:
   build_linux_cuda:
     container:
       image: example.invalid/runner@sha256:digest
@@ -748,5 +794,26 @@ core.exportVariable('SCCACHE_GHA_ENABLED', 'false')
         let error =
             check_release_container_contracts(VALID_CONTAINER_WORKFLOW, &action).unwrap_err();
         assert!(error.to_string().contains("job-local fallback"));
+    }
+
+    #[test]
+    fn release_container_contract_requires_fail_open_sccache_writes() {
+        let workflow = VALID_CONTAINER_WORKFLOW
+            .replace("  SCCACHE_MULTILEVEL_WRITE_ERROR_POLICY: ignore\n", "");
+
+        let error = check_release_container_contracts(&workflow, VALID_SCCACHE_ACTION).unwrap_err();
+        assert!(error.to_string().contains("write fallback"));
+    }
+
+    #[test]
+    fn release_container_contract_requires_disk_first_sccache_chain() {
+        let action = VALID_SCCACHE_ACTION.replace(
+            "core.exportVariable('SCCACHE_MULTILEVEL_CHAIN', 'disk,gha')",
+            "",
+        );
+
+        let error =
+            check_release_container_contracts(VALID_CONTAINER_WORKFLOW, &action).unwrap_err();
+        assert!(error.to_string().contains("cache chain"));
     }
 }


### PR DESCRIPTION
## Summary

- put a job-local disk cache in front of the GitHub Actions sccache backend
- treat cache write and server I/O failures as non-fatal compiler fallbacks
- preserve the existing disk-only startup fallback and enforce the contract in xtask
- synchronize the CI topology documentation and inventory

## Investigation

Release run https://github.com/Mesh-LLM/mesh-llm/actions/runs/30063516285 failed for two cache-related reasons:

- four Linux GPU jobs received an Actions cache service-unavailable HTML response while sccache was starting during compiler probing
- the Windows ROCm native-runtime job aborted when sccache could not persist a temporary cache file

Both failures blocked release artifacts even though the compiler inputs and build logic were otherwise valid.

## Validation

- `actionlint -config-file .github/actionlint.yaml`
- `git diff --check`
- `just check-release`
- `just with-lld cargo test -p xtask workflow_checks`
- `just with-lld cargo fmt --all -- --check`
- `just with-lld cargo check -p xtask`
- `just with-lld cargo clippy -p xtask --all-targets -- -D warnings`

A release workflow dispatch was not started: the repository CI policy requires explicit authorization for that expensive live operation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Improved build-cache reliability with a disk-first cache and best-effort remote caching.
  * Cache connection and write failures now degrade gracefully without interrupting builds.
  * Builds fall back to local compiler execution when the remote cache service is unavailable.

* **Documentation**
  * Updated CI and runner guidance to clarify cache behavior, fallback handling, and configuration requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->