### PR TITLE
fix(console-ui): chat transcript snapping during live status updates

### DIFF
--- a/crates/mesh-llm-ui/src/features/chat/layouts/ChatLayout.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/layouts/ChatLayout.tsx
@@ -15,6 +15,8 @@ const DESKTOP_SIDEBAR_QUERY = '(min-width: 1024px)'
 const CHAT_LAYOUT_FALLBACK_HEIGHT = 'calc(100dvh - 180px)'
 const CHAT_LAYOUT_MIN_HEIGHT = 320
 const CHAT_LAYOUT_KEYBOARD_GUTTER = 12
+// Keep this above the transcript's bottom padding: scrollIntoView aligns the anchor above that padding.
+const CHAT_STICK_TO_BOTTOM_THRESHOLD = 64
 
 type ChatLayoutStyle = CSSProperties & {
   '--chat-layout-height': string
@@ -30,6 +32,8 @@ type ChatLayoutProps = {
   children: ReactNode
   composer: ReactNode
   onMessageAreaClick?: () => void
+  /** Change this value to resume following the latest message after an explicit user action. */
+  stickToBottomKey?: string
 }
 
 function shouldUseDesktopSidebarFallback() {
@@ -126,11 +130,13 @@ export function ChatLayout({
   actions,
   children,
   composer,
-  onMessageAreaClick
+  onMessageAreaClick,
+  stickToBottomKey
 }: ChatLayoutProps) {
   const layoutRef = useRef<HTMLDivElement | null>(null)
   const messageListRef = useRef<HTMLDivElement | null>(null)
   const messageEndRef = useRef<HTMLDivElement | null>(null)
+  const shouldStickToBottomRef = useRef(true)
   const chatLayoutHeight = useChatVisualViewportHeight(layoutRef)
   const desktopSidebarViewport = useDesktopSidebarViewport()
   const showDesktopSidebar =
@@ -140,6 +146,13 @@ export function ChatLayout({
       onMessageAreaClick?.()
     }
   }
+  const handleMessageListScroll = () => {
+    const messageList = messageListRef.current
+    if (!messageList) return
+
+    const distanceFromBottom = messageList.scrollHeight - messageList.clientHeight - messageList.scrollTop
+    shouldStickToBottomRef.current = distanceFromBottom <= CHAT_STICK_TO_BOTTOM_THRESHOLD
+  }
 
   const chatLayoutStyle: ChatLayoutStyle = {
     '--chat-layout-height': chatLayoutHeight,
@@ -148,10 +161,15 @@ export function ChatLayout({
   }
 
   useLayoutEffect(() => {
+    shouldStickToBottomRef.current = true
+  }, [stickToBottomKey])
+
+  useLayoutEffect(() => {
     const messageList = messageListRef.current
-    if (!messageList) return undefined
+    if (!messageList || !shouldStickToBottomRef.current) return undefined
 
     const scrollToBottom = () => {
+      if (!shouldStickToBottomRef.current) return
       messageList.scrollTop = messageList.scrollHeight
       messageEndRef.current?.scrollIntoView({ block: 'end' })
     }
@@ -200,6 +218,7 @@ export function ChatLayout({
             className="chat-message-scrollbar min-h-0 flex-1 overflow-x-hidden overflow-y-auto px-4 py-4 sm:px-[26px] sm:py-5"
             data-testid="chat-message-list"
             onPointerDown={handleMessageAreaPointerDown}
+            onScroll={handleMessageListScroll}
           >
             {children}
             <div aria-hidden={true} data-chat-scroll-anchor="true" ref={messageEndRef} />

--- a/crates/mesh-llm-ui/src/features/chat/layouts/ChatLayout.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/layouts/ChatLayout.tsx
@@ -15,7 +15,6 @@ const DESKTOP_SIDEBAR_QUERY = '(min-width: 1024px)'
 const CHAT_LAYOUT_FALLBACK_HEIGHT = 'calc(100dvh - 180px)'
 const CHAT_LAYOUT_MIN_HEIGHT = 320
 const CHAT_LAYOUT_KEYBOARD_GUTTER = 12
-// Keep this above the transcript's bottom padding: scrollIntoView aligns the anchor above that padding.
 const CHAT_STICK_TO_BOTTOM_THRESHOLD = 64
 
 type ChatLayoutStyle = CSSProperties & {
@@ -32,7 +31,6 @@ type ChatLayoutProps = {
   children: ReactNode
   composer: ReactNode
   onMessageAreaClick?: () => void
-  /** Change this value to resume following the latest message after an explicit user action. */
   stickToBottomKey?: string
 }
 

--- a/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.test.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.test.tsx
@@ -455,6 +455,25 @@ async function expectPartialAssistantReply() {
   await waitFor(() => expect(screen.getByText('Partial assistant reply')).toBeInTheDocument())
 }
 
+function chatLayout(status: string, stickToBottomKey = 'conversation-a:0') {
+  return (
+    <ChatLayout
+      actions={<span>{status}</span>}
+      composer={<textarea aria-label="Prompt" />}
+      sidebar={<div role="tablist" aria-label="Chat sidebar views" />}
+      stickToBottomKey={stickToBottomKey}
+      title="Chat"
+    >
+      <div data-testid="message-content">Messages</div>
+    </ChatLayout>
+  )
+}
+
+function setMessageListDimensions(messageList: HTMLElement) {
+  Object.defineProperty(messageList, 'scrollHeight', { configurable: true, value: 1400 })
+  Object.defineProperty(messageList, 'clientHeight', { configurable: true, value: 420 })
+}
+
 describe('ChatPage', () => {
   afterEach(() => {
     cleanup()
@@ -541,6 +560,101 @@ describe('ChatPage', () => {
       'overflow-y-auto',
       'overflow-x-hidden'
     )
+  })
+
+  it('preserves a manual transcript scroll position across unrelated rerenders', () => {
+    const { rerender } = render(chatLayout('1 node'))
+    const messageList = screen.getByTestId('chat-message-list')
+
+    setMessageListDimensions(messageList)
+    messageList.scrollTop = 320
+    fireEvent.scroll(messageList)
+    scrollIntoViewMock.mockClear()
+
+    rerender(chatLayout('2 nodes'))
+
+    expect(messageList.scrollTop).toBe(320)
+    expect(scrollIntoViewMock).not.toHaveBeenCalled()
+  })
+
+  it('resumes following transcript updates when the reader returns near the bottom', () => {
+    const { rerender } = render(chatLayout('1 node'))
+    const messageList = screen.getByTestId('chat-message-list')
+
+    setMessageListDimensions(messageList)
+    messageList.scrollTop = 320
+    fireEvent.scroll(messageList)
+    rerender(chatLayout('2 nodes'))
+    expect(messageList.scrollTop).toBe(320)
+
+    messageList.scrollTop = 940
+    fireEvent.scroll(messageList)
+    scrollIntoViewMock.mockClear()
+    rerender(chatLayout('3 nodes'))
+
+    expect(messageList.scrollTop).toBe(1400)
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'end' })
+  })
+
+  it('uses the sticky-scroll threshold boundary when following transcript updates', () => {
+    const { rerender } = render(chatLayout('1 node'))
+    const messageList = screen.getByTestId('chat-message-list')
+
+    setMessageListDimensions(messageList)
+    messageList.scrollTop = 915
+    fireEvent.scroll(messageList)
+    scrollIntoViewMock.mockClear()
+    rerender(chatLayout('2 nodes'))
+    expect(messageList.scrollTop).toBe(915)
+    expect(scrollIntoViewMock).not.toHaveBeenCalled()
+
+    messageList.scrollTop = 916
+    fireEvent.scroll(messageList)
+    rerender(chatLayout('3 nodes'))
+    expect(messageList.scrollTop).toBe(1400)
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'end' })
+  })
+
+  it('does not run a queued transcript scroll after the reader scrolls upward', () => {
+    const animationFrames: FrameRequestCallback[] = []
+    const requestAnimationFrameSpy = vi.spyOn(window, 'requestAnimationFrame').mockImplementation((callback) => {
+      animationFrames.push(callback)
+      return animationFrames.length
+    })
+    const cancelAnimationFrameSpy = vi.spyOn(window, 'cancelAnimationFrame').mockImplementation(() => undefined)
+
+    try {
+      render(chatLayout('1 node'))
+      const messageList = screen.getByTestId('chat-message-list')
+
+      setMessageListDimensions(messageList)
+      messageList.scrollTop = 320
+      fireEvent.scroll(messageList)
+      scrollIntoViewMock.mockClear()
+
+      animationFrames.at(-1)?.(0)
+
+      expect(messageList.scrollTop).toBe(320)
+      expect(scrollIntoViewMock).not.toHaveBeenCalled()
+    } finally {
+      requestAnimationFrameSpy.mockRestore()
+      cancelAnimationFrameSpy.mockRestore()
+    }
+  })
+
+  it('returns to the latest transcript message when the sticky-scroll key changes', () => {
+    const { rerender } = render(chatLayout('1 node', 'conversation-a:0'))
+    const messageList = screen.getByTestId('chat-message-list')
+
+    setMessageListDimensions(messageList)
+    messageList.scrollTop = 320
+    fireEvent.scroll(messageList)
+    scrollIntoViewMock.mockClear()
+
+    rerender(chatLayout('1 node', 'conversation-b:0'))
+
+    expect(messageList.scrollTop).toBe(1400)
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'end' })
   })
 
   it('falls back to harness conversations when persisted chat state is malformed', async () => {
@@ -981,11 +1095,18 @@ describe('ChatPage', () => {
     renderChatPage({ mode: 'live' })
 
     await waitFor(() => expect(screen.getByText('Restored persisted body')).toBeInTheDocument())
+    const messageList = screen.getByTestId('chat-message-list')
+    setMessageListDimensions(messageList)
+    messageList.scrollTop = 320
+    fireEvent.scroll(messageList)
+    scrollIntoViewMock.mockClear()
 
     await user.click((await screen.findAllByRole('button', { name: /Live first/i }))[0])
 
     expect(screen.queryByText('Restored persisted body')).not.toBeInTheDocument()
     await waitFor(() => expect(screen.getByText('First persisted body')).toBeInTheDocument())
+    expect(messageList.scrollTop).toBe(1400)
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'end' })
   })
 
   it('creates a live thread on send, enables Stop while streaming, preserves partial text on stop, and retries with reload semantics', async () => {
@@ -1031,12 +1152,19 @@ describe('ChatPage', () => {
 
     chatMock.reloadAssistantText = 'Retried assistant reply'
     chatMock.reloadErrorMessage = 'Retry failed after replacing the last assistant reply'
+    const messageList = screen.getByTestId('chat-message-list')
+    setMessageListDimensions(messageList)
+    messageList.scrollTop = 320
+    fireEvent.scroll(messageList)
+    scrollIntoViewMock.mockClear()
 
     await user.click(screen.getByRole('button', { name: 'Retry last' }))
 
     expect(await screen.findByText('Retried assistant reply')).toBeInTheDocument()
     expect(screen.queryByText('Partial assistant reply')).not.toBeInTheDocument()
     expect(screen.getByRole('alert')).toHaveTextContent('Retry failed after replacing the last assistant reply')
+    expect(messageList.scrollTop).toBe(1400)
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'end' })
 
     await waitFor(() => {
       const latestState = vi.mocked(saveChatState).mock.calls.at(-1)?.[1]
@@ -1451,14 +1579,15 @@ describe('ChatPage', () => {
     })
   })
 
-  it('keeps newly inserted chat messages pinned fully into view at the bottom', async () => {
+  it('returns to the latest message when the reader sends while scrolled up', async () => {
     const user = userEvent.setup()
 
     renderChatPage({ mode: 'live' })
 
     const messageList = screen.getByTestId('chat-message-list')
-    Object.defineProperty(messageList, 'scrollHeight', { configurable: true, value: 1400 })
-    Object.defineProperty(messageList, 'clientHeight', { configurable: true, value: 420 })
+    setMessageListDimensions(messageList)
+    messageList.scrollTop = 320
+    fireEvent.scroll(messageList)
 
     await user.type(screen.getByLabelText('Prompt'), 'Follow the latest message')
     scrollIntoViewMock.mockClear()
@@ -1528,12 +1657,19 @@ describe('ChatPage', () => {
     expect(await screen.findByText('Streaming response...')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Queue' })).toBeDisabled()
 
+    const messageList = screen.getByTestId('chat-message-list')
+    setMessageListDimensions(messageList)
+    messageList.scrollTop = 320
+    fireEvent.scroll(messageList)
     await user.type(screen.getByLabelText('Prompt'), 'Run this next')
+    scrollIntoViewMock.mockClear()
     await user.click(screen.getByRole('button', { name: 'Queue' }))
 
     expect(screen.getByLabelText('Prompt')).toHaveValue('')
     expect(screen.getByText('Run this next')).toBeInTheDocument()
     expect(screen.getByText('Queued')).toBeInTheDocument()
+    expect(messageList.scrollTop).toBe(1400)
+    expect(scrollIntoViewMock).toHaveBeenCalledWith({ block: 'end' })
 
     await user.click(screen.getByRole('combobox', { name: 'Select model' }))
     await user.click(await screen.findByText('Qwen3.5-0.8B-UD'))

--- a/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.tsx
+++ b/crates/mesh-llm-ui/src/features/chat/pages/ChatPage.tsx
@@ -506,6 +506,7 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
   >({})
   const [selectedAttachmentPreview, setSelectedAttachmentPreview] = useState<SubmittedAttachmentPreview | null>(null)
   const [failedSubmission, setFailedSubmission] = useState<FailedSubmission | null>(null)
+  const [latestTurnToken, setLatestTurnToken] = useState(0)
   const queuedSubmissionsRef = useRef<QueuedSubmission[]>([])
   const queueDrainInFlightRef = useRef(false)
   const submittedAttachmentUrlsRef = useRef<Set<string>>(new Set())
@@ -553,6 +554,9 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
     previousAssistantMessageIds: Set<string>
   } | null>(null)
   const handledChatErrorRef = useRef<{ conversationId: string; message: string } | null>(null)
+  const requestJumpToLatest = useCallback(() => {
+    setLatestTurnToken((current) => current + 1)
+  }, [])
   const revokeSubmittedAttachmentPreviews = useCallback((previews: SubmittedAttachmentPreview[]) => {
     for (const preview of previews) {
       revokeObjectUrl(preview.objectUrl)
@@ -1020,6 +1024,7 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
     const nextPrompt = composerDraft.prompt.trim()
     if (!nextPrompt && composerDraft.attachments.length === 0) return
 
+    requestJumpToLatest()
     const submission: ComposerSubmission = { prompt: composerDraft.prompt, attachments: [...composerDraft.attachments] }
 
     if (composerShouldQueue) {
@@ -1042,7 +1047,14 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
     }
 
     await submitPromptNow(submission, composerConversationId)
-  }, [clearComposerDraft, composerConversationId, composerDraft, composerShouldQueue, submitPromptNow])
+  }, [
+    clearComposerDraft,
+    composerConversationId,
+    composerDraft,
+    composerShouldQueue,
+    requestJumpToLatest,
+    submitPromptNow
+  ])
 
   useEffect(() => {
     queuedSubmissionsRef.current = queuedSubmissions
@@ -1086,6 +1098,7 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
 
   const retryLastResponse = useCallback(async () => {
     if (!canRetry) return
+    requestJumpToLatest()
     const ensuredConversationId = ensureConversation()
     clearStoppedConversation(ensuredConversationId)
     setFailedSubmission(null)
@@ -1098,7 +1111,7 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
       )
     }
     await chat.reload()
-  }, [activeModelName, canRetry, chat, clearStoppedConversation, ensureConversation])
+  }, [activeModelName, canRetry, chat, clearStoppedConversation, ensureConversation, requestJumpToLatest])
 
   const stopStreamingResponse = useCallback(() => {
     const latestLiveMessage = liveMessagesWithModels.at(-1)
@@ -1249,6 +1262,7 @@ export function ChatPageContent({ data = CHAT_HARNESS }: ChatPageProps) {
       <ChatLayout
         sidebar={sidebar}
         hideSidebar={conversations.conversations.length === 0}
+        stickToBottomKey={`${displayedConversationId}:${latestTurnToken}`}
         title={data.title}
         subtitle={activeConversation?.title}
         actions={actions}


### PR DESCRIPTION
Fixes #1077.

## Original problem

In live mode, frequent status updates rerendered `ChatLayout`, whose layout effect unconditionally returned the transcript to the latest message. Readers scrolling through a long response were repeatedly snapped back to the bottom.

## Diagnostics

The live status stream produced 49 payloads in 12 seconds. Each payload updated the status query, rerendered the chat layout, and ran the unconditional scroll effect. Safari applied the user's scroll normally before the next React render overwrote the position.

## Fix

- Track whether the transcript is within 64px of the bottom and only follow new content while that remains true.
- Resume following when the reader returns near the bottom.
- Return to the latest message on conversation switches and explicit Send, Queue, or Retry actions.
- Re-check reader intent inside the deferred animation-frame scroll.
- Add regression coverage for unrelated rerenders, threshold behavior, conversation changes, send/queue/retry flows, and the animation-frame race.

This is a UI-only behavior change with no protocol, storage, or migration impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat transcripts now preserve your manual scroll position when you read older messages.
  * Automatic scrolling resumes when you’re near the bottom of the conversation.
  * Sending a message, retrying a response, or switching conversations returns the view to the latest message.

* **Bug Fixes**
  * Prevented delayed scrolling from overriding upward scrolling.
  * Improved transcript positioning during live updates, retries, and queued messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->