### PR TITLE
ci: fix v0.74 release GPU builds (sccache disk-only + force_hosted_runners)

### DIFF
--- a/.github/actions/configure-sccache-gha/action.yml
+++ b/.github/actions/configure-sccache-gha/action.yml
@@ -8,6 +8,36 @@ runs:
       uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8
       with:
         script: |
+          // Honor an explicit job-level opt-out of the GitHub Actions cache
+          // backend. Long-running lanes (CUDA/ROCm/Vulkan release builds that
+          // exceed the ephemeral Actions cache token lifetime) set
+          // SCCACHE_GHA_ENABLED=false. Keep those lanes disk-only: an sccache
+          // server started after the token expires probes the gha tier at
+          // startup, and that storage read fails permanently (HTTP 400),
+          // aborting the build before any fail-open policy applies. Clearing the
+          // cache URL/token as well prevents any residual gha configuration
+          // from re-enabling the remote tier.
+          if ((process.env.SCCACHE_GHA_ENABLED || '').toLowerCase() === 'false') {
+            core.info(
+              'SCCACHE_GHA_ENABLED=false is set; using baked sccache with disk-only cache.',
+            );
+            core.exportVariable('SCCACHE_MULTILEVEL_CHAIN', 'disk');
+            core.exportVariable('SCCACHE_IGNORE_SERVER_IO_ERROR', '1');
+            core.exportVariable('ACTIONS_CACHE_URL', '');
+            core.exportVariable('ACTIONS_RESULTS_URL', '');
+            core.exportVariable('ACTIONS_RUNTIME_TOKEN', '');
+            await exec.exec('sccache', ['--stop-server'], {
+              ignoreReturnCode: true,
+            });
+            const diskOnlyExitCode = await exec.exec('sccache', ['--start-server'], {
+              ignoreReturnCode: true,
+            });
+            if (diskOnlyExitCode !== 0) {
+              core.setFailed('Unable to start baked sccache with its disk-only cache.');
+            }
+            return;
+          }
+
           const cacheUrl = process.env.ACTIONS_CACHE_URL || '';
           const resultsUrl = process.env.ACTIONS_RESULTS_URL || '';
           const runtimeToken = process.env.ACTIONS_RUNTIME_TOKEN || '';

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,11 @@ on:
         required: true
         default: false
         type: boolean
+      force_hosted_runners:
+        description: Route self-hosted release lanes (x86_64 CUDA, ARM64 smoke) to GitHub-hosted runners for this run only
+        required: true
+        default: false
+        type: boolean
 
 concurrency:
   group: release-${{ github.repository }}-${{ github.ref }}
@@ -49,6 +54,7 @@ jobs:
       prerelease: ${{ steps.meta.outputs.prerelease }}
       skip_gpu_bundles: ${{ steps.meta.outputs.skip_gpu_bundles }}
       canary: ${{ steps.meta.outputs.canary }}
+      force_hosted_runners: ${{ steps.meta.outputs.force_hosted_runners }}
     steps:
       - id: meta
         shell: bash
@@ -56,6 +62,7 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_SKIP_GPU_BUNDLES: ${{ inputs.skip_gpu_bundles || 'false' }}
           INPUT_CANARY: ${{ inputs.canary || 'false' }}
+          INPUT_FORCE_HOSTED_RUNNERS: ${{ inputs.force_hosted_runners || 'false' }}
         run: |
           set -euo pipefail
           tag="${GITHUB_REF_NAME}"
@@ -78,6 +85,7 @@ jobs:
             echo "prerelease=$prerelease"
             echo "skip_gpu_bundles=$INPUT_SKIP_GPU_BUNDLES"
             echo "canary=$INPUT_CANARY"
+            echo "force_hosted_runners=$INPUT_FORCE_HOSTED_RUNNERS"
           } >> "$GITHUB_OUTPUT"
 
   build:
@@ -391,7 +399,7 @@ jobs:
     name: Build native runtime Linux x86_64 CUDA (${{ matrix.cuda_major }})
     needs: metadata
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
-    runs-on: ${{ fromJson(vars.USE_SELF_HOSTED == 'true' && '["self-hosted","Linux","X64","amd64","gpu-nvidia"]' || '["ubuntu-24.04"]') }}
+    runs-on: ${{ fromJson(vars.USE_SELF_HOSTED == 'true' && needs.metadata.outputs.force_hosted_runners != 'true' && '["self-hosted","Linux","X64","amd64","gpu-nvidia"]' || '["ubuntu-24.04"]') }}
     strategy:
       fail-fast: false
       matrix:
@@ -695,7 +703,7 @@ jobs:
     name: Smoke Linux ARM64 artifact
     needs: [metadata, build_linux_arm64]
     if: ${{ needs.build_linux_arm64.result == 'success' }}
-    runs-on: ${{ fromJson(vars.USE_SELF_HOSTED == 'true' && '["self-hosted","Linux","ARM64"]' || '["ubuntu-24.04-arm"]') }}
+    runs-on: ${{ fromJson(vars.USE_SELF_HOSTED == 'true' && needs.metadata.outputs.force_hosted_runners != 'true' && '["self-hosted","Linux","ARM64"]' || '["ubuntu-24.04-arm"]') }}
     steps:
       - uses: actions/download-artifact@v7
         with:
@@ -788,7 +796,7 @@ jobs:
     name: Build Linux CUDA (${{ matrix.cuda_version }})
     needs: metadata
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
-    runs-on: ${{ fromJson(vars.USE_SELF_HOSTED == 'true' && '["self-hosted","Linux","X64","amd64","gpu-nvidia"]' || '["ubuntu-24.04"]') }}
+    runs-on: ${{ fromJson(vars.USE_SELF_HOSTED == 'true' && needs.metadata.outputs.force_hosted_runners != 'true' && '["self-hosted","Linux","X64","amd64","gpu-nvidia"]' || '["ubuntu-24.04"]') }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What this fixes

Restores the ability to cut a **`v0.74.0` release with GPU bundles**. RC attempts (rc1–rc3) failed on the CUDA/ROCm/Vulkan lanes for **two independent, non-code reasons**:

1. **sccache token expiry** — long GPU builds outlive the ephemeral GitHub Actions cache token; a late sccache server probes the `gha` tier at startup, that read fails permanently (HTTP 400), and the build aborts.
2. **node24 missing on the self-hosted ARC pods** — x86_64 CUDA ran on ARC pods whose image lacks `/__e/node24`, so container jobs died instantly at checkout.

Both are addressed here, scoped so nothing else in CI changes.

## 1. sccache disk-only for GPU lanes

`configure-sccache-gha` unconditionally forced `SCCACHE_MULTILEVEL_CHAIN=disk,gha` and `SCCACHE_GHA_ENABLED=true`, overriding the `SCCACHE_GHA_ENABLED=false` the CUDA/ROCm/Vulkan jobs already declare. Keeping `gha` in the chain leaves a startup storage probe that hard-fails once the token expires — which is why #1079's fail-open policies didn't help (they don't cover the startup read probe; confirmed against sccache 0.16 internals).

This PR makes the action **honor a job-level `SCCACHE_GHA_ENABLED=false`**: those lanes run **disk-only**, and the cache URL/token are cleared so no residual `gha` config re-enables the remote tier. Fast lanes keep the best-effort `disk,gha` behavior unchanged.

## 2. `force_hosted_runners` release input (node24, scoped to one run)

Adds an opt-in `workflow_dispatch` input, `force_hosted_runners` (default `false`). When set, it routes the self-hosted release lanes (x86_64 CUDA, ARM64 smoke) to GitHub-hosted `ubuntu-24.04` runners **for that run only**, without touching the repo-wide `USE_SELF_HOSTED` variable.

On hosted runners `/__e/node24` is mounted from the host runner (verified in the `docker create` line of the last successful GPU release, v0.72.0-rc6 Jun 29), independent of the container image — so the node24 failure disappears with no digest bump or image republish. This leaves CI and PR-build self-hosted routing (and @ndizazzo's #1075 direction) untouched.

**To cut rc4:** dispatch release with `force_hosted_runners=true`.

## Validation

- `actionlint -config-file .github/actionlint.yaml` — pass
- `git diff --check` — clean
- `cargo run -p xtask -- repo-consistency release-targets` — pass

## Rollback

- Revert either commit independently; both default to prior behavior.
- No repo variables changed, no images published, no digests bumped.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a job-level opt-out for GitHub Actions-backed compiler caching via `SCCACHE_GHA_ENABLED=false` (disk-only mode).
  - Updated the release workflow to support a manual `force_hosted_runners` input to route selected release runs to GitHub-hosted runners for that execution.

- **Bug Fixes**
  - When disk-only caching is enabled, remote cache services are no longer used.
  - If disk-only cache startup fails, the job now fails immediately and stops further cache setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->