### PR TITLE
ci: disable sccache for Windows ROCm native runtime build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1175,6 +1175,12 @@ jobs:
             backend: rocm
             rocm_architectures: gfx90a;gfx942;gfx1100;gfx1101;gfx1102;gfx1103;gfx1151;gfx1200;gfx1201
             artifact_name: release-native-runtime-windows-x86_64-rocm
+            # sccache + hipcc is broken on Windows: HIP's multi-offload-arch
+            # compile pipeline plus the long arch-derived build directory pushes
+            # object paths past MAX_PATH, and sccache fails to persist its temp
+            # file (os error 3). Disable the compiler launcher for this row only;
+            # CUDA/Vulkan keep sccache.
+            use_sccache: '0'
           - name: Vulkan
             backend: vulkan
             artifact_name: release-native-runtime-windows-x86_64-vulkan
@@ -1230,6 +1236,7 @@ jobs:
           LLAMA_STAGE_BACKEND: ${{ matrix.backend }}
           LLAMA_STAGE_CUDA_ARCHITECTURES: ${{ matrix.cuda_architectures }}
           LLAMA_STAGE_AMDGPU_TARGETS: ${{ matrix.rocm_architectures }}
+          LLAMA_STAGE_USE_SCCACHE: ${{ matrix.use_sccache || '1' }}
           MESH_LLM_CUDA_TOOLKIT_MAJOR: '12'
         run: |
           scripts/package-native-runtime.sh \


### PR DESCRIPTION
## What this fixes

The final blocker for a complete **`v0.74.0` GPU release**. rc4 got every Linux CUDA/ROCm/Vulkan and Windows CUDA/Vulkan lane green (node24 + sccache-token-expiry both fixed in #1086), but one lane failed deterministically:

**`Build native runtime Windows x86_64 ROCm`** →
```
sccache: error: failed to persist temporary file: The system cannot find the path specified. (os error 3)
ninja: build stopped: subcommand failed. exit code 127
```

## Root cause

sccache + hipcc is broken on Windows for this build. HIP compiles one host action plus one device action **per `--offload-arch`** (9 arches here) and bundles them; combined with the long arch-derived build directory (`build-stage-abi-dynamic-rocm-gfx90a_..._gfx1201`), object paths exceed Windows `MAX_PATH`, and sccache fails the final atomic temp-file persist (`os error 3`).

Evidence this is ROCm-native-specific, not a general path/sccache/shell problem:

| Lane | Build dir | sccache | Result |
| --- | --- | --- | --- |
| Windows CUDA native | short | on | ✅ |
| Windows Vulkan native | short | on | ✅ |
| Windows ROCm **release bundle** | `build-stage-abi-rocm` (short) | on | ✅ |
| Windows ROCm **native runtime** | `build-stage-abi-dynamic-rocm-<9 arches>` (long) | on | ❌ |

sccache's HIP support is known-fragile (PyTorch disables ccache/sccache for HIP for similar reasons).

## Fix

Set `LLAMA_STAGE_USE_SCCACHE=0` for the Windows ROCm native-runtime matrix row only. `scripts/build-llama.sh` already honors this by omitting the HIP compiler launcher, so the build proceeds without the caching layer that can't handle these paths. **CUDA and Vulkan keep sccache unchanged** (defaulted to `1` via `matrix.use_sccache || '1'`).

## Validation

- `actionlint -config-file .github/actionlint.yaml` — pass
- `git diff --check` — clean
- `cargo run -p xtask -- repo-consistency release-targets` — pass

Real end-to-end proof is the next RC (rc5) once merged.

## Rollback

- Single revert; no other lanes affected. No repo variables changed, no images published.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows GPU runtime release builds by applying the appropriate compiler cache settings for different GPU backends.
  * Disabled compiler caching for ROCm builds to improve build reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->