### PR TITLE
build: disable mtmd video to fix iOS Swift XCFramework build

### DIFF
--- a/scripts/build-llama.sh
+++ b/scripts/build-llama.sh
@@ -165,6 +165,11 @@ CMAKE_ARGS=(
   -DLLAMA_BUILD_TESTS=OFF
   -DLLAMA_CURL=OFF
   -DCMAKE_POSITION_INDEPENDENT_CODE=ON
+  # mtmd video shells out to ffmpeg via sheredom/subprocess.h, which calls
+  # posix_spawn_file_actions_addchdir_np - unavailable on iOS, so it breaks the
+  # Swift XCFramework build. mesh-llm does not use mtmd video; opt out on all
+  # platforms.
+  -DMTMD_VIDEO=OFF
 )
 
 if command -v ninja >/dev/null 2>&1; then

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -1060,7 +1060,10 @@ Invoke-InRepo {
         "-DLLAMA_CURL=OFF",
         "-DLLAMA_BUILD_EXAMPLES=OFF",
         "-DLLAMA_BUILD_TESTS=OFF",
-        "-DGGML_BUILD_TESTS=OFF"
+        "-DGGML_BUILD_TESTS=OFF",
+        # mtmd video pulls in the ffmpeg subprocess path (sheredom/subprocess.h)
+        # that mesh-llm does not use; keep it off to match build-llama.sh.
+        "-DMTMD_VIDEO=OFF"
     )
 
     $rcPath = Resolve-CommandPath "rc"


### PR DESCRIPTION
## What this fixes

The `v0.74.0-rc7` release build failed on the **Swift SDK XCFramework** (iOS slice):

```
FAILED: tools/mtmd/CMakeFiles/mtmd.dir/mtmd-helper.cpp.o
.deps/llama.cpp/tools/mtmd/../../vendor/sheredom/subprocess.h:1215:19:
error: 'posix_spawn_file_actions_addchdir_np' is unavailable: not available on iOS
```

## Why it broke

The refreshed llama.cpp patch queue (#1085) brought in upstream's mtmd **video** support, whose CMake option `MTMD_VIDEO` defaults `ON`. With it on, `tools/mtmd/mtmd-helper.cpp` includes `sheredom/subprocess.h` to shell out to ffmpeg. That header calls `posix_spawn_file_actions_addchdir_np`, which the iOS SDK marks unavailable, so the iOS target of the XCFramework fails to compile `mtmd-helper.cpp`.

`mtmd` is a required library target for mesh-llm (built alongside `llama` and `llama-common`), so this is not optional at the target level - but the video/subprocess path itself is fully gated behind `MTMD_VIDEO`, and upstream provides a graceful "video is not supported in this build" fallback when it is off.

This is release-build only; rc6 (which predates #1085) built the Swift SDK fine.

## Fix

Set `-DMTMD_VIDEO=OFF`:
- `scripts/build-llama.sh` base CMake args - covers Linux, macOS, and the Apple XCFramework targets (which call `build-llama.sh` per target).
- `scripts/build-windows.ps1` for parity (Windows did not fail, but should not pull in the unused ffmpeg-subprocess path either).

mesh-llm does not use mtmd video.

## Validation

- `bash -n scripts/build-llama.sh` - clean
- `git diff --check` - clean
- **Local build proof:** `LLAMA_STAGE_BACKEND=metal LLAMA_STAGE_FORCE_BUILD=1 bash scripts/build-llama.sh` -> `Built target mtmd` (exit 0), `mtmd-helper.cpp` compiled without pulling in `subprocess.h`.

## Rollback

Single revert; no other behavior affected.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability across supported platforms by disabling unsupported video processing components.
  * Updated Windows builds to use the same streamlined configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->