### PR TITLE
chore: make the Node SDK installable from npm releases

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -27,7 +27,7 @@ the commands at the end before operational changes.
 | `windows-warm-caches.yml` | Main path push, dispatch | Trusted Windows ABI cache warming |
 | `website-pages.yml` | Main website path push, dispatch | Public website Pages build/deploy |
 | `fly-deploy-console.yml` | Dispatch | `fly-console` environment deployment |
-| `release.yml` | `v*` tag, dispatch | Release builds, attestations, publishing, downstream image dispatch |
+| `release.yml` | `v*` tag, dispatch | Release builds, attestations, publishing, downstream package/image/npm dispatch |
 | `reset-caches.yml` | Confirmed dispatch | Destructive repository cache reset |
 | `stale-prs.yml` | Schedule, dispatch | PR warning/closure maintenance |
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1432,7 +1432,8 @@ jobs:
                 version: $version,
                 dry_run: false,
                 publish_images: true,
-                publish_release_assets: true
+                publish_release_assets: true,
+                publish_npm: true
               }
             }' |
             gh api \

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -10,7 +10,8 @@ manifest, packages SDK console assets, creates and pushes the release tag,
 builds all platform bundles, and publishes the GitHub release. After a complete
 non-canary release succeeds, it dispatches `Mesh-LLM/mesh-packaging` to
 package the verified release archives, publish the native package release
-assets, and publish the supported GHCR image matrix. Dispatch inputs include
+assets, publish the supported GHCR image matrix, and assemble and publish the
+Node SDK to npm. Dispatch inputs include
 `skip_gpu_bundles` and `canary` (dry-run: build and smoke everything without
 publishing). Releases that intentionally skip GPU bundles do not dispatch the
 full packaging matrix.
@@ -178,7 +179,7 @@ Verify:
 
 Push a `v*` tag to run `.github/workflows/release.yml`. The upstream release
 workflow owns release archive production, but it does not publish OCI images.
-`Mesh-LLM/mesh-packaging` is the canonical GHCR producer and starts only
+`Mesh-LLM/mesh-packaging` is the canonical package, GHCR, and npm producer and starts only
 after the GitHub release and its complete archive set have published
 successfully. The upstream `docker.yml` workflow performs Dockerfile validation
 only and is not a distribution channel.

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -121,7 +121,7 @@ subgraph PRCI["pr_builds.yml · PR Builds"]
         MainCI["ci.yml\npush main / dispatch"]
         WebsiteDeploy["website-pages.yml\nActions Pages deploy\nPublic Website environment"]
         DockerValidate["docker.yml\nmanual client Dockerfile validation"]
-        Release["release.yml\nrelease artifacts + packaging dispatch"]
+        Release["release.yml\nrelease artifacts + package/image/npm dispatch"]
         FlyConsole["fly-deploy-console.yml\nmanual Fly console deploy"]
     end
 
@@ -197,11 +197,11 @@ subgraph PRCI["pr_builds.yml · PR Builds"]
   serial and rate-limited; a final summary aggregates cache shard results plus
   artifact cleanup. Cleanup-only workflow edits do not fan out into
   Rust/build/smoke jobs.
-- Docker image validation and publishing are intentionally not part of pull
-  request CI. `docker.yml` is a manual, non-publishing client Dockerfile
-  validation workflow. `release.yml` owns release archives and dispatches the
-  completed full release to `Mesh-LLM/mesh-agent-images`, which is the sole
-  GHCR publisher.
+- Docker image and npm publishing are intentionally not part of pull request
+  CI. `docker.yml` is a manual, non-publishing client Dockerfile validation
+  workflow. `release.yml` owns release archives and dispatches the completed
+  full release to `Mesh-LLM/mesh-packaging`, which owns package, GHCR, and npm
+  publication.
 - `fly-deploy-console.yml` is a manual (`workflow_dispatch`) deploy of the
   `mesh-llm-console` Fly app. It builds the image on Fly's remote builders from
   `fly/Dockerfile` and authenticates with the app-scoped `FLY_API_TOKEN` repo

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -134,12 +134,8 @@ See [Kotlin SDK examples](sdk/kotlin.md).
 
 Install the Node package in a Node.js or Electron app:
 
-```json
-{
-  "dependencies": {
-    "@meshllm/sdk": "0.72.1"
-  }
-}
+```bash
+npm install @meshllm/sdk
 ```
 
 When building from this repository, build the native N-API addon first:

--- a/docs/sdk/node.md
+++ b/docs/sdk/node.md
@@ -4,12 +4,8 @@ Use `@meshllm/sdk` from npm for Node.js and Electron applications.
 
 ## Install
 
-```json
-{
-  "dependencies": {
-    "@meshllm/sdk": "0.72.1"
-  }
-}
+```bash
+npm install @meshllm/sdk
 ```
 
 When building from this repository, build the native N-API addon first:

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -7,6 +7,15 @@ The package uses a native N-API addon built from `crates/mesh-llm-nodejs`. It is
 not a mock wrapper around the CLI. Local serving uses the same embedded runtime
 path as the Swift and Kotlin SDKs.
 
+## Install
+
+```bash
+npm install @meshllm/sdk
+```
+
+Release packages include prebuilt addons for macOS arm64/x64, Linux arm64/x64,
+and Windows x64.
+
 ## Build From Source
 
 ```bash

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -4,12 +4,21 @@
   "description": "Node.js SDK for MeshLLM client and local serving applications",
   "main": "index.js",
   "types": "index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Mesh-LLM/mesh-packaging.git"
+  },
+  "homepage": "https://github.com/Mesh-LLM/mesh-llm/tree/main/sdk/node",
+  "bugs": {
+    "url": "https://github.com/Mesh-LLM/mesh-llm/issues"
+  },
   "files": [
     "index.js",
     "index.d.ts",
     "native-runtime.js",
     "console/",
     "native/",
+    "LICENSE",
     "README.md"
   ],
   "scripts": {
@@ -28,5 +37,10 @@
     "arm64",
     "x64"
   ],
-  "license": "MIT OR Apache-2.0"
+  "license": "MIT OR Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  }
 }

--- a/sdk/node/scripts/build-native.mjs
+++ b/sdk/node/scripts/build-native.mjs
@@ -7,6 +7,7 @@ const repoRoot = resolve(fileURLToPath(new URL('../../..', import.meta.url)))
 const profile = process.env.MESH_NODE_PROFILE || 'release'
 const cargoArgs = [
   'build',
+  '--locked',
   '-p',
   'mesh-llm-nodejs',
   '--no-default-features',
@@ -14,6 +15,11 @@ const cargoArgs = [
   'embedded-runtime'
 ]
 if (profile === 'release') cargoArgs.push('--release')
+if (profile === 'release' && process.platform === 'darwin') {
+  // Avoid llvm-objcopy corrupting the LINKEDIT string pool in large Mach-O
+  // addons on current macOS runners.
+  cargoArgs.push('--config', 'profile.release.strip=false')
+}
 
 const build = spawnSync('cargo', cargoArgs, {
   cwd: repoRoot,

--- a/website/src/docs/pages/sdk-node.md
+++ b/website/src/docs/pages/sdk-node.md
@@ -8,12 +8,8 @@ Use [`@meshllm/sdk`](https://www.npmjs.com/package/@meshllm/sdk) in Node.js serv
 
 ## Install
 
-```json
-{
-  "dependencies": {
-    "@meshllm/sdk": "{{ site.sdkVersion }}"
-  }
-}
+```bash
+npm install @meshllm/sdk
 ```
 
 When building from the repository, build the addon first:


### PR DESCRIPTION
## Summary

Node.js and Electron users can install `@meshllm/sdk` with `npm install @meshllm/sdk` once the canonical packaging workflow publishes the next release.

- add npm metadata required for public provenance-aware publication
- make native addon release builds locked and safe on current macOS runners
- dispatch npm publication to Mesh-LLM/mesh-packaging#5 with the existing release payload
- update repository and website SDK guidance with the concise npm install command

This is the source-side handoff for Mesh-LLM/mesh-packaging#5 and supersedes #1062. Cross-platform build, assembly, preflight, and publication orchestration now live in `mesh-packaging`.

## Architecture

`mesh-llm` remains the SDK source repository. The package repository metadata names `Mesh-LLM/mesh-packaging` because npm trusted publishing requires it to match the workflow that runs `npm publish`; homepage and issue links continue to point to this repository.

## Validation

- Node SDK tests passed
- source package dry run passed
- public website build passed
- `actionlint -config-file .github/actionlint.yaml` passed
- `cargo run -p xtask -- repo-consistency release-targets` passed
- release YAML parsing and `git diff --check` passed
- Mesh-LLM/mesh-packaging#5 assembled a 60.7 MB five-target tarball, passed `npm publish --dry-run`, installed it in a clean consumer, and loaded the real macOS arm64 addon

cc @ndizazzo

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Node.js SDK releases now include prebuilt native addons for macOS, Linux, and Windows.
  * Release publishing now includes the Node.js SDK package on npm.

* **Documentation**
  * Updated installation instructions to use `npm install `@meshllm/sdk``.
  * Clarified package, container image, and npm publishing responsibilities.
  * Added SDK package metadata and public publishing details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->