### PR TITLE
fix: use published mesh-llm-hf-hub crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3889,9 +3889,9 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-hf-hub"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7862ddcdf3979479ab8d667b4d234aa558ca2bdf3b35b1d18f24fe9fe4d04d"
+checksum = "43088a838cf0c6715c65f65a5ac99045fd6d6e90949a8a4183b8104ab791e96b"
 dependencies = [
  "base64",
  "bon",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,7 +183,7 @@ dependencies = [
  "objc2-foundation",
  "parking_lot",
  "percent-encoding",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
  "x11rb",
 ]
 
@@ -1077,7 +1077,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1413,19 +1413,13 @@ dependencies = [
 
 [[package]]
 name = "ctor"
-version = "0.6.3"
+version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "424e0138278faeb2b401f174ad17e715c829512d74f3d1e81eb43365c2e0590e"
+checksum = "e9bb72bb94fdc1bd619f4c18cc91ecf6302aeb333d31b3c6ec0bb841cd920209"
 dependencies = [
- "ctor-proc-macro",
- "dtor",
+ "link-section",
+ "linktime-proc-macro",
 ]
-
-[[package]]
-name = "ctor-proc-macro"
-version = "0.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52560adf09603e58c9a7ee1fe1dcb95a16927b17c127f0ac02d6e768a0e25bc1"
 
 [[package]]
 name = "ctr"
@@ -1571,7 +1565,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccc2776f0c61eca1ca32528f85548abd1a4be8fb53d1b21c013e4f18da1e7090"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1721,7 +1715,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1766,21 +1760,6 @@ checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
 dependencies = [
  "litrs",
 ]
-
-[[package]]
-name = "dtor"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "404d02eeb088a82cfd873006cb713fe411306c7d182c344905e101fb1167d301"
-dependencies = [
- "dtor-proc-macro",
-]
-
-[[package]]
-name = "dtor-proc-macro"
-version = "0.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f678cf4a922c215c63e0de95eb1ff08a958a81d47e485cf9da1e27bf6305cfa5"
 
 [[package]]
 name = "dunce"
@@ -1905,7 +1884,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2519,44 +2498,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "hf-hub"
-version = "1.0.0"
-source = "git+https://github.com/Mesh-LLM/hf-hub?branch=mesh-llm#fd3bfcabba1b9b827e685649cbcc8bf45ec6b310"
-dependencies = [
- "base64",
- "bon",
- "bytes",
- "futures",
- "globset",
- "hf-xet",
- "hyper",
- "pathdiff",
- "reqwest 0.13.4",
- "serde",
- "serde_json",
- "sha2 0.11.0",
- "thiserror 2.0.18",
- "tokio",
- "tokio-retry",
- "tokio-util",
- "tracing",
- "url",
-]
-
-[[package]]
 name = "hf-xet"
-version = "1.5.2"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "430b33fa84f92796d4d263070b6c0d3ca219df7b9a0e1853ee431029b1612bcd"
+checksum = "3005542f8cad13a23c2a85674aeeb888e2eb67cc6f413853c8ef169504e284bc"
 dependencies = [
+ "anyhow",
  "async-trait",
  "bytes",
  "http",
  "more-asserts",
  "serde",
+ "serde_json",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tokio_with_wasm",
  "tracing",
  "uuid",
  "xet-client",
@@ -3534,6 +3491,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "link-section"
+version = "0.19.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc98458dfe90986c5e2f6ddcf68360c7e5c4252600153e06aa4ee8176c0f8d1"
+
+[[package]]
+name = "linktime-proc-macro"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c7b0a3383c2a1002d11349c92c85a666a5fb679e96c79d782cf0dbe557fd6ee"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3801,12 +3770,12 @@ dependencies = [
  "chrono",
  "dirs",
  "hex",
- "hf-hub",
  "iroh",
  "json5",
  "mesh-llm-build-info",
  "mesh-llm-cli",
  "mesh-llm-config",
+ "mesh-llm-hf-hub",
  "mesh-llm-identity",
  "mesh-llm-native-runtime",
  "mesh-llm-plugin-manager",
@@ -3919,6 +3888,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "mesh-llm-hf-hub"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7862ddcdf3979479ab8d667b4d234aa558ca2bdf3b35b1d18f24fe9fe4d04d"
+dependencies = [
+ "base64",
+ "bon",
+ "bytes",
+ "futures",
+ "getrandom 0.2.17",
+ "globset",
+ "hf-xet",
+ "hyper",
+ "pathdiff",
+ "percent-encoding",
+ "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "sha2 0.11.0",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-retry",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "mesh-llm-host-runtime"
 version = "0.72.1"
 dependencies = [
@@ -3938,7 +3936,6 @@ dependencies = [
  "flate2",
  "futures-util",
  "hex",
- "hf-hub",
  "http",
  "http-body-util",
  "httparse",
@@ -3954,6 +3951,7 @@ dependencies = [
  "mesh-llm-config",
  "mesh-llm-events",
  "mesh-llm-guardrails",
+ "mesh-llm-hf-hub",
  "mesh-llm-identity",
  "mesh-llm-native-runtime",
  "mesh-llm-node",
@@ -4330,7 +4328,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "dirs",
- "hf-hub",
+ "mesh-llm-hf-hub",
  "model-artifact",
  "model-ref",
  "serde",
@@ -4349,7 +4347,7 @@ dependencies = [
  "bytes",
  "chrono",
  "futures",
- "hf-hub",
+ "mesh-llm-hf-hub",
  "model-hf",
  "model-ref",
  "reqwest 0.12.28",
@@ -4878,7 +4876,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6063,7 +6061,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6651,7 +6649,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6744,7 +6742,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6983,7 +6981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7194,7 +7192,6 @@ dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.2.17",
  "digest 0.10.7",
- "sha2-asm",
 ]
 
 [[package]]
@@ -7206,15 +7203,6 @@ dependencies = [
  "cfg-if 1.0.4",
  "cpufeatures 0.3.0",
  "digest 0.11.3",
-]
-
-[[package]]
-name = "sha2-asm"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b845214d6175804686b2bd482bcffe96651bb2d1200742b712003504a2dac1ab"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -7759,7 +7747,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8130,6 +8118,30 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tokio-util",
+]
+
+[[package]]
+name = "tokio_with_wasm"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34e40fbbbd95441133fe9483f522db15dbfd26dc636164ebd8f2dd28759a6aa6"
+dependencies = [
+ "js-sys",
+ "tokio",
+ "tokio_with_wasm_proc",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
+name = "tokio_with_wasm_proc"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d01145a2c788d6aae4cd653afec1e8332534d7d783d01897cefcafe4428de992"
+dependencies = [
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -9038,7 +9050,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9520,20 +9532,18 @@ dependencies = [
 
 [[package]]
 name = "xet-client"
-version = "1.5.2"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e1e496dcbe6a09017acdfaf48e1a646735e7ff5b2a49e2c7e081cca77a59bc8"
+checksum = "3b4ebf97728991933d7bdfbb4118173b773e5423d66433fecb969f1aa7786a70"
 dependencies = [
  "anyhow",
  "async-trait",
  "base64",
  "bytes",
- "clap",
  "crc32fast",
  "futures",
  "http",
  "hyper",
- "lazy_static",
  "more-asserts",
  "rand 0.10.1",
  "redb",
@@ -9547,8 +9557,8 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-retry",
+ "tokio_with_wasm",
  "tracing",
- "tracing-subscriber",
  "url",
  "urlencoding",
  "web-time",
@@ -9558,24 +9568,21 @@ dependencies = [
 
 [[package]]
 name = "xet-core-structures"
-version = "1.5.2"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb838aa8eb67d730af301584cf003caad407487606058292a6750711b603fbee"
+checksum = "bbe69515f98acd9e3b357dce5f6ebff234c9626b01aa7dd436593747034fe7fd"
 dependencies = [
  "async-trait",
  "base64",
  "blake3",
  "bytemuck",
  "bytes",
- "clap",
  "countio",
- "csv",
  "futures",
  "futures-util",
  "getrandom 0.4.3",
  "heapify",
  "itertools",
- "lazy_static",
  "lz4_flex",
  "more-asserts",
  "rand 0.10.1",
@@ -9583,7 +9590,6 @@ dependencies = [
  "safe-transmute",
  "serde",
  "static_assertions",
- "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
@@ -9595,32 +9601,31 @@ dependencies = [
 
 [[package]]
 name = "xet-data"
-version = "1.5.2"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67fd409bef621411a9d9013798540bb8036cb2678f03ab39af89a5e88034ed8c"
+checksum = "580ba26ccca44d41f1f7dcec838ffb166f629e9c72fb7172839f6d092439a61c"
 dependencies = [
  "anyhow",
  "async-trait",
  "bytes",
  "chrono",
- "clap",
  "gearhash",
  "http",
  "itertools",
- "lazy_static",
  "more-asserts",
  "rand 0.10.1",
  "serde",
  "serde_json",
- "sha2 0.10.9",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tokio_with_wasm",
  "tracing",
  "url",
  "uuid",
- "walkdir",
+ "web-time",
  "xet-client",
  "xet-core-structures",
  "xet-runtime",
@@ -9628,9 +9633,9 @@ dependencies = [
 
 [[package]]
 name = "xet-runtime"
-version = "1.5.2"
+version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15d8f121c33866f7648b737abe70d0e2dd9c0af4ffdd7219207531d0283aa63d"
+checksum = "ca7a88ab94bba9dbf47ca966ca3bb5e6eb1167752a5aff881276bf786cc5d522"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -9638,13 +9643,12 @@ dependencies = [
  "chrono",
  "colored",
  "const-str",
- "ctor 0.6.3",
+ "ctor 1.0.11",
  "dirs",
  "futures",
  "git-version",
  "humantime",
  "konst",
- "lazy_static",
  "libc",
  "more-asserts",
  "oneshot",
@@ -9658,9 +9662,11 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "tokio_with_wasm",
  "tracing",
  "tracing-appender",
  "tracing-subscriber",
+ "web-time",
  "whoami",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,9 +80,6 @@ serde_json = "1"
 sha2 = "0.10"
 strum = { version = "0.28", features = ["derive"] }
 
-[patch.crates-io]
-hf-hub = { git = "https://github.com/Mesh-LLM/hf-hub", branch = "mesh-llm" }
-
 [workspace.lints.clippy]
 cognitive_complexity = "warn"
 too_many_lines = "warn"

--- a/crates/mesh-llm-commands/Cargo.toml
+++ b/crates/mesh-llm-commands/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
-hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.0", default-features = false, features = ["blocking"] }
+hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.2", default-features = false, features = ["blocking"] }
 hex = "0.4.3"
 iroh = "1.0.0"
 json5 = "1.3.1"

--- a/crates/mesh-llm-commands/Cargo.toml
+++ b/crates/mesh-llm-commands/Cargo.toml
@@ -18,7 +18,7 @@ workspace = true
 anyhow.workspace = true
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
-hf_hub = { package = "hf-hub", version = "1.0.0-rc.1", default-features = false, features = ["blocking"] }
+hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.0", default-features = false, features = ["blocking"] }
 hex = "0.4.3"
 iroh = "1.0.0"
 json5 = "1.3.1"

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -110,7 +110,7 @@ schemars = "1"
 prost = "0.14"
 toml = "0.9"
 zip = { version = "2", default-features = false, features = ["deflate"] }
-hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.0", default-features = false, features = ["blocking"] }
+hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.2", default-features = false, features = ["blocking"] }
 tabwriter = "1"
 tempfile = "3"
 

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -110,7 +110,7 @@ schemars = "1"
 prost = "0.14"
 toml = "0.9"
 zip = { version = "2", default-features = false, features = ["deflate"] }
-hf_hub = { package = "hf-hub", version = "1.0.0-rc.1", default-features = false, features = ["blocking"] }
+hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.0", default-features = false, features = ["blocking"] }
 tabwriter = "1"
 tempfile = "3"
 

--- a/crates/model-hf/Cargo.toml
+++ b/crates/model-hf/Cargo.toml
@@ -12,7 +12,7 @@ anyhow.workspace = true
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
-hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.0", default-features = false, features = ["blocking"] }
+hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.2", default-features = false, features = ["blocking"] }
 model-artifact = { path = "../model-artifact", version = "0.72.1" }
 model-ref = { path = "../model-ref", version = "0.72.1" }
 serde.workspace = true

--- a/crates/model-hf/Cargo.toml
+++ b/crates/model-hf/Cargo.toml
@@ -12,7 +12,7 @@ anyhow.workspace = true
 async-trait = "0.1"
 chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
-hf_hub = { package = "hf-hub", version = "1.0.0-rc.1", default-features = false, features = ["blocking"] }
+hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.0", default-features = false, features = ["blocking"] }
 model-artifact = { path = "../model-artifact", version = "0.72.1" }
 model-ref = { path = "../model-ref", version = "0.72.1" }
 serde.workspace = true

--- a/crates/model-package/Cargo.toml
+++ b/crates/model-package/Cargo.toml
@@ -15,7 +15,7 @@ sha2.workspace = true
 anyhow.workspace = true
 bytes = "1"
 chrono = "0.4"
-hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.0", default-features = false, features = ["blocking"] }
+hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.2", default-features = false, features = ["blocking"] }
 model-hf = { path = "../model-hf", version = "0.72.1"  }
 model-ref = { path = "../model-ref", version = "0.72.1"  }
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/crates/model-package/Cargo.toml
+++ b/crates/model-package/Cargo.toml
@@ -15,7 +15,7 @@ sha2.workspace = true
 anyhow.workspace = true
 bytes = "1"
 chrono = "0.4"
-hf_hub = { package = "hf-hub", version = "1.0.0-rc.1", default-features = false, features = ["blocking"] }
+hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.0", default-features = false, features = ["blocking"] }
 model-hf = { path = "../model-hf", version = "0.72.1"  }
 model-ref = { path = "../model-ref", version = "0.72.1"  }
 reqwest = { version = "0.12", features = ["json", "stream"] }

--- a/crates/model-package/src/bin/queue-unsloth-layer-packages.rs
+++ b/crates/model-package/src/bin/queue-unsloth-layer-packages.rs
@@ -977,7 +977,7 @@ fn json_layer_package_repo(value: &Value, target_namespace: &str) -> Option<Stri
 async fn write_queue_marker(client: &HFClient, candidate: &Candidate, args: &Args) -> Result<()> {
     client
         .create_repository()
-        .repo_id(candidate.target_repo.clone())
+        .repo_id(&candidate.target_repo)
         .repo_type(RepoTypeModel)
         .exist_ok(true)
         .send()


### PR DESCRIPTION
## Summary

- Switch all published hf-hub consumers to the `mesh-llm-hf-hub` crates.io package.
- Remove the workspace-only `[patch.crates-io]` Git override.
- Fix `model-package` to borrow `repo_id`, matching the published fork API.

This addresses the dependency-resolution gap in #1094: the workspace and crates.io package verification now compile against the same published fork instead of silently resolving `hf-hub` upstream outside the workspace.

@michaelneale — please review the fork/package dependency decision and the compatibility fix.

## Validation

- `cargo check -p model-hf -p model-package -p mesh-llm-commands -p mesh-llm-host-runtime`
- `cargo clippy -p model-package --all-targets -- -D warnings`
- `cargo fmt -p model-package -- crates/model-package/src/bin/queue-unsloth-layer-packages.rs`

The registry-backed check initially reproduced the `repo_id(String)` failure from #1094; after the borrow fix it passes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated model, host runtime, and command components to use the standard Hugging Face Hub integration (newer HF Hub library version).
  * Removed a custom workspace override so dependency resolution follows the default crates registry behavior.
* **Bug Fixes**
  * Improved queued package upload marker behavior by avoiding unnecessary string cloning when generating the Hugging Face repository identifier.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->