### PR TITLE
chore(code-quality): generalized code-quality refactoring

### DIFF
--- a/crates/mesh-client/src/client/control_plane.rs
+++ b/crates/mesh-client/src/client/control_plane.rs
@@ -6,10 +6,11 @@ use crate::proto::node::{
     OwnerControlDrainModelResponse, OwnerControlEnsureModelRequest,
     OwnerControlEnsureModelResponse, OwnerControlEnvelope, OwnerControlError,
     OwnerControlErrorCode, OwnerControlGetConfigRequest, OwnerControlHandshake,
-    OwnerControlLoadModelRequest, OwnerControlLoadModelResponse, OwnerControlRefreshInventory,
-    OwnerControlRefreshInventoryRequest, OwnerControlRequest, OwnerControlResponse,
-    OwnerControlUnloadModelRequest, OwnerControlUnloadModelResponse, OwnerControlWatchAccepted,
-    OwnerControlWatchConfigRequest, OwnerControlWatchConfigResponse, SignedNodeOwnership,
+    OwnerControlLoadModelRequest, OwnerControlLoadModelResponse, OwnerControlModelRef,
+    OwnerControlRefreshInventory, OwnerControlRefreshInventoryRequest, OwnerControlRequest,
+    OwnerControlResponse, OwnerControlUnloadModelRequest, OwnerControlUnloadModelResponse,
+    OwnerControlWatchAccepted, OwnerControlWatchConfigRequest, OwnerControlWatchConfigResponse,
+    SignedNodeOwnership,
 };
 use crate::protocol::{
     ALPN_CONTROL_V1, ALPN_V1, NODE_PROTOCOL_GENERATION, decode_owner_control_envelope,
@@ -315,6 +316,38 @@ fn map_legacy_lifecycle_unsupported(
     }
 }
 
+enum LifecycleCommand {
+    Load(OwnerControlLoadModelRequest),
+    Unload(OwnerControlUnloadModelRequest),
+    Ensure(OwnerControlEnsureModelRequest),
+    Drain(OwnerControlDrainModelRequest),
+}
+
+impl LifecycleCommand {
+    fn operation(&self) -> &'static str {
+        match self {
+            Self::Load(_) => "load_model",
+            Self::Unload(_) => "unload_model",
+            Self::Ensure(_) => "ensure_model",
+            Self::Drain(_) => "drain_model",
+        }
+    }
+
+    fn into_request(self, request_id: u64) -> OwnerControlRequest {
+        let mut request = OwnerControlRequest {
+            request_id,
+            ..Default::default()
+        };
+        match self {
+            Self::Load(command) => request.load_model = Some(command),
+            Self::Unload(command) => request.unload_model = Some(command),
+            Self::Ensure(command) => request.ensure_model = Some(command),
+            Self::Drain(command) => request.drain_model = Some(command),
+        }
+        request
+    }
+}
+
 impl OwnerControlClient {
     async fn connect(
         endpoint_token: String,
@@ -505,32 +538,17 @@ impl OwnerControlClient {
         profile: Option<String>,
     ) -> Result<OwnerControlLoadModelResponse, ControlPlaneClientError> {
         let expected_model_ref = model_ref.clone();
-        let request = OwnerControlLoadModelRequest {
-            requester_node_id: self.endpoint.id().as_bytes().to_vec(),
-            target_node_id: self.connection.remote_id().as_bytes().to_vec(),
-            model: Some(crate::proto::node::OwnerControlModelRef {
-                canonical_model_ref: model_ref,
-                instance_id: None,
-            }),
-            profile,
-        };
         let response = self
-            .send_unary_request(
-                std::time::Duration::from_secs(OWNER_CONTROL_UNARY_RESPONSE_TIMEOUT_SECS),
-                |request_id, _, _| OwnerControlRequest {
-                    request_id,
-                    get_config: None,
-                    watch_config: None,
-                    apply_config: None,
-                    refresh_inventory: None,
-                    load_model: Some(request.clone()),
-                    unload_model: None,
-                    ensure_model: None,
-                    drain_model: None,
-                },
-            )
-            .await
-            .map_err(|error| map_legacy_lifecycle_unsupported("load_model", error))?;
+            .send_lifecycle_request(LifecycleCommand::Load(OwnerControlLoadModelRequest {
+                requester_node_id: self.endpoint.id().as_bytes().to_vec(),
+                target_node_id: self.connection.remote_id().as_bytes().to_vec(),
+                model: Some(OwnerControlModelRef {
+                    canonical_model_ref: model_ref,
+                    instance_id: None,
+                }),
+                profile,
+            }))
+            .await?;
         let response = response.load_model.ok_or_else(|| {
             ControlPlaneClientError::Protocol(
                 "owner-control load_model response missing payload".to_string(),
@@ -555,31 +573,16 @@ impl OwnerControlClient {
     ) -> Result<OwnerControlUnloadModelResponse, ControlPlaneClientError> {
         let (expected_model_ref, expected_instance_id) =
             validate_absent_model_target(model_ref, instance_id)?;
-        let request = OwnerControlUnloadModelRequest {
-            requester_node_id: self.endpoint.id().as_bytes().to_vec(),
-            target_node_id: self.connection.remote_id().as_bytes().to_vec(),
-            model: Some(crate::proto::node::OwnerControlModelRef {
-                canonical_model_ref: expected_model_ref.clone(),
-                instance_id: expected_instance_id.clone(),
-            }),
-        };
         let response = self
-            .send_unary_request(
-                std::time::Duration::from_secs(OWNER_CONTROL_UNARY_RESPONSE_TIMEOUT_SECS),
-                |request_id, _, _| OwnerControlRequest {
-                    request_id,
-                    get_config: None,
-                    watch_config: None,
-                    apply_config: None,
-                    refresh_inventory: None,
-                    load_model: None,
-                    unload_model: Some(request.clone()),
-                    ensure_model: None,
-                    drain_model: None,
-                },
-            )
-            .await
-            .map_err(|error| map_legacy_lifecycle_unsupported("unload_model", error))?;
+            .send_lifecycle_request(LifecycleCommand::Unload(OwnerControlUnloadModelRequest {
+                requester_node_id: self.endpoint.id().as_bytes().to_vec(),
+                target_node_id: self.connection.remote_id().as_bytes().to_vec(),
+                model: Some(OwnerControlModelRef {
+                    canonical_model_ref: expected_model_ref.clone(),
+                    instance_id: expected_instance_id.clone(),
+                }),
+            }))
+            .await?;
         let response = response.unload_model.ok_or_else(|| {
             ControlPlaneClientError::Protocol(
                 "owner-control unload_model response missing payload".to_string(),
@@ -603,32 +606,17 @@ impl OwnerControlClient {
         profile: Option<String>,
     ) -> Result<OwnerControlEnsureModelResponse, ControlPlaneClientError> {
         let expected_model_ref = model_ref.clone();
-        let request = OwnerControlEnsureModelRequest {
-            requester_node_id: self.endpoint.id().as_bytes().to_vec(),
-            target_node_id: self.connection.remote_id().as_bytes().to_vec(),
-            model: Some(crate::proto::node::OwnerControlModelRef {
-                canonical_model_ref: model_ref,
-                instance_id: None,
-            }),
-            profile,
-        };
         let response = self
-            .send_unary_request(
-                std::time::Duration::from_secs(OWNER_CONTROL_UNARY_RESPONSE_TIMEOUT_SECS),
-                |request_id, _, _| OwnerControlRequest {
-                    request_id,
-                    get_config: None,
-                    watch_config: None,
-                    apply_config: None,
-                    refresh_inventory: None,
-                    load_model: None,
-                    unload_model: None,
-                    ensure_model: Some(request.clone()),
-                    drain_model: None,
-                },
-            )
-            .await
-            .map_err(|error| map_legacy_lifecycle_unsupported("ensure_model", error))?;
+            .send_lifecycle_request(LifecycleCommand::Ensure(OwnerControlEnsureModelRequest {
+                requester_node_id: self.endpoint.id().as_bytes().to_vec(),
+                target_node_id: self.connection.remote_id().as_bytes().to_vec(),
+                model: Some(OwnerControlModelRef {
+                    canonical_model_ref: model_ref,
+                    instance_id: None,
+                }),
+                profile,
+            }))
+            .await?;
         let response = response.ensure_model.ok_or_else(|| {
             ControlPlaneClientError::Protocol(
                 "owner-control ensure_model response missing payload".to_string(),
@@ -653,32 +641,17 @@ impl OwnerControlClient {
     ) -> Result<OwnerControlDrainModelResponse, ControlPlaneClientError> {
         let (expected_model_ref, expected_instance_id) =
             validate_absent_model_target(model_ref, instance_id)?;
-        let request = OwnerControlDrainModelRequest {
-            requester_node_id: self.endpoint.id().as_bytes().to_vec(),
-            target_node_id: self.connection.remote_id().as_bytes().to_vec(),
-            model: Some(crate::proto::node::OwnerControlModelRef {
-                canonical_model_ref: expected_model_ref.clone(),
-                instance_id: expected_instance_id.clone(),
-            }),
-            drain_timeout_secs: None,
-        };
         let response = self
-            .send_unary_request(
-                std::time::Duration::from_secs(OWNER_CONTROL_UNARY_RESPONSE_TIMEOUT_SECS),
-                |request_id, _, _| OwnerControlRequest {
-                    request_id,
-                    get_config: None,
-                    watch_config: None,
-                    apply_config: None,
-                    refresh_inventory: None,
-                    load_model: None,
-                    unload_model: None,
-                    ensure_model: None,
-                    drain_model: Some(request.clone()),
-                },
-            )
-            .await
-            .map_err(|error| map_legacy_lifecycle_unsupported("drain_model", error))?;
+            .send_lifecycle_request(LifecycleCommand::Drain(OwnerControlDrainModelRequest {
+                requester_node_id: self.endpoint.id().as_bytes().to_vec(),
+                target_node_id: self.connection.remote_id().as_bytes().to_vec(),
+                model: Some(OwnerControlModelRef {
+                    canonical_model_ref: expected_model_ref.clone(),
+                    instance_id: expected_instance_id.clone(),
+                }),
+                drain_timeout_secs: None,
+            }))
+            .await?;
         let response = response.drain_model.ok_or_else(|| {
             ControlPlaneClientError::Protocol(
                 "owner-control drain_model response missing payload".to_string(),
@@ -694,6 +667,19 @@ impl OwnerControlClient {
             expected_instance_id.as_deref(),
         )?;
         Ok(response)
+    }
+
+    async fn send_lifecycle_request(
+        &self,
+        command: LifecycleCommand,
+    ) -> Result<OwnerControlResponse, ControlPlaneClientError> {
+        let operation = command.operation();
+        self.send_unary_request(
+            std::time::Duration::from_secs(OWNER_CONTROL_UNARY_RESPONSE_TIMEOUT_SECS),
+            move |request_id, _, _| command.into_request(request_id),
+        )
+        .await
+        .map_err(|error| map_legacy_lifecycle_unsupported(operation, error))
     }
 
     pub async fn watch_config(

--- a/crates/mesh-client/src/network/affinity.rs
+++ b/crates/mesh-client/src/network/affinity.rs
@@ -2,7 +2,7 @@
 
 use crate::inference::election;
 use iroh::EndpointId;
-use mesh_llm_routing::prefix_affinity::{PrefixAffinity, PrefixAffinityStats};
+use mesh_llm_routing::prefix_affinity::PrefixAffinity;
 use serde::Serialize;
 use serde_json::Value;
 use std::sync::{Arc, Mutex};
@@ -22,6 +22,8 @@ pub struct AffinityStatsSnapshot {
     pub learned: u64,
     pub evicted: u64,
 }
+
+mesh_llm_routing::impl_prefix_affinity_stats_snapshot!(AffinityStatsSnapshot);
 
 fn prefix_only_enabled() -> bool {
     std::env::var("MESH_LLM_PREFIX_ONLY")
@@ -70,7 +72,7 @@ impl AffinityRouter {
     }
 
     pub fn stats_snapshot(&self) -> AffinityStatsSnapshot {
-        affinity_stats_snapshot(
+        AffinityStatsSnapshot::from_prefix_affinity_stats(
             self.inner.lock().unwrap().snapshot(),
             self.config.prefix_enabled,
             self.config.sticky_enabled,
@@ -120,27 +122,6 @@ impl AffinityRouter {
             .lock()
             .unwrap()
             .forget(model, prefix_hash, target);
-    }
-}
-
-fn affinity_stats_snapshot(
-    stats: PrefixAffinityStats,
-    prefix_enabled: bool,
-    sticky_enabled: bool,
-) -> AffinityStatsSnapshot {
-    AffinityStatsSnapshot {
-        prefix_enabled,
-        sticky_enabled,
-        prefix_entries: stats.entries,
-        prefix_lookups: stats.lookups,
-        prefix_hits: stats.hits,
-        prefix_misses: stats.misses,
-        prefix_stale: stats.stale,
-        prefix_routes: stats.routes,
-        sticky_routes: stats.sticky_routes,
-        session_routes: stats.session_routes,
-        learned: stats.learned,
-        evicted: stats.evicted,
     }
 }
 

--- a/crates/mesh-client/src/network/affinity.rs
+++ b/crates/mesh-client/src/network/affinity.rs
@@ -2,14 +2,10 @@
 
 use crate::inference::election;
 use iroh::EndpointId;
+use mesh_llm_routing::prefix_affinity::{PrefixAffinity, PrefixAffinityStats};
 use serde::Serialize;
 use serde_json::Value;
-use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
-
-const AFFINITY_TTL: Duration = Duration::from_secs(20 * 60);
-const AFFINITY_MAX_ENTRIES: usize = 4096;
 
 #[derive(Clone, Debug, Default, Serialize)]
 pub struct AffinityStatsSnapshot {
@@ -48,35 +44,16 @@ impl AffinityConfig {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-struct AffinityKey {
-    model: String,
-    prefix_hash: u64,
-}
-
-#[derive(Clone, Debug)]
-struct AffinityEntry {
-    target: election::InferenceTarget,
-    last_used: Instant,
-}
-
-#[derive(Default)]
-struct AffinityState {
-    entries: HashMap<AffinityKey, AffinityEntry>,
-    lru: VecDeque<AffinityKey>,
-    stats: AffinityStatsSnapshot,
-}
-
 #[derive(Clone)]
 pub struct AffinityRouter {
-    inner: Arc<Mutex<AffinityState>>,
+    inner: Arc<Mutex<PrefixAffinity<election::InferenceTarget>>>,
     config: Arc<AffinityConfig>,
 }
 
 impl AffinityRouter {
     pub fn new() -> Self {
         Self {
-            inner: Arc::new(Mutex::new(AffinityState::default())),
+            inner: Arc::new(Mutex::new(PrefixAffinity::default())),
             config: Arc::new(AffinityConfig::from_env()),
         }
     }
@@ -84,7 +61,7 @@ impl AffinityRouter {
     #[cfg(test)]
     fn with_config(prefix_enabled: bool, sticky_enabled: bool) -> Self {
         Self {
-            inner: Arc::new(Mutex::new(AffinityState::default())),
+            inner: Arc::new(Mutex::new(PrefixAffinity::default())),
             config: Arc::new(AffinityConfig {
                 prefix_enabled,
                 sticky_enabled,
@@ -93,13 +70,11 @@ impl AffinityRouter {
     }
 
     pub fn stats_snapshot(&self) -> AffinityStatsSnapshot {
-        let mut state = self.inner.lock().unwrap();
-        state.prune_expired();
-        let mut stats = state.stats.clone();
-        stats.prefix_entries = state.entries.len();
-        stats.prefix_enabled = self.config.prefix_enabled;
-        stats.sticky_enabled = self.config.sticky_enabled;
-        stats
+        affinity_stats_snapshot(
+            self.inner.lock().unwrap().snapshot(),
+            self.config.prefix_enabled,
+            self.config.sticky_enabled,
+        )
     }
 
     pub fn sticky_enabled(&self) -> bool {
@@ -107,13 +82,11 @@ impl AffinityRouter {
     }
 
     pub fn record_sticky_route(&self) {
-        let mut state = self.inner.lock().unwrap();
-        state.stats.sticky_routes += 1;
+        self.inner.lock().unwrap().record_sticky_route();
     }
 
     pub fn record_session_route(&self) {
-        let mut state = self.inner.lock().unwrap();
-        state.stats.session_routes += 1;
+        self.inner.lock().unwrap().record_session_route();
     }
 
     pub fn lookup_target(
@@ -125,33 +98,10 @@ impl AffinityRouter {
         if !self.config.prefix_enabled {
             return None;
         }
-        let key = AffinityKey {
-            model: model.to_string(),
-            prefix_hash,
-        };
-        let mut state = self.inner.lock().unwrap();
-        state.prune_expired();
-        state.stats.prefix_lookups += 1;
-        let entry = match state.entries.get(&key).cloned() {
-            Some(entry) => entry,
-            None => {
-                state.stats.prefix_misses += 1;
-                return None;
-            }
-        };
-        if !candidates.contains(&entry.target) {
-            state.remove_key(&key);
-            state.stats.prefix_stale += 1;
-            state.stats.prefix_misses += 1;
-            return None;
-        }
-        state.touch_key(&key);
-        if let Some(existing) = state.entries.get_mut(&key) {
-            existing.last_used = Instant::now();
-        }
-        state.stats.prefix_hits += 1;
-        state.stats.prefix_routes += 1;
-        Some(entry.target)
+        self.inner
+            .lock()
+            .unwrap()
+            .lookup(model, prefix_hash, candidates)
     }
 
     pub fn learn_target(&self, model: &str, prefix_hash: u64, target: &election::InferenceTarget) {
@@ -159,95 +109,44 @@ impl AffinityRouter {
             return;
         }
 
-        let key = AffinityKey {
-            model: model.to_string(),
-            prefix_hash,
-        };
-        let now = Instant::now();
-        let mut state = self.inner.lock().unwrap();
-        state.prune_expired();
-        state.entries.insert(
-            key.clone(),
-            AffinityEntry {
-                target: target.clone(),
-                last_used: now,
-            },
-        );
-        state.touch_key(&key);
-        state.stats.learned += 1;
-        while state.entries.len() > AFFINITY_MAX_ENTRIES {
-            if let Some(oldest) = state.lru.pop_front() {
-                if state.entries.remove(&oldest).is_some() {
-                    state.stats.evicted += 1;
-                }
-            } else {
-                break;
-            }
-        }
+        self.inner.lock().unwrap().learn(model, prefix_hash, target);
     }
 
     pub fn forget_target(&self, model: &str, prefix_hash: u64, target: &election::InferenceTarget) {
         if !self.config.prefix_enabled {
             return;
         }
-        let key = AffinityKey {
-            model: model.to_string(),
-            prefix_hash,
-        };
-        let mut state = self.inner.lock().unwrap();
-        if state
-            .entries
-            .get(&key)
-            .map(|entry| &entry.target == target)
-            .unwrap_or(false)
-        {
-            state.remove_key(&key);
-            state.stats.prefix_stale += 1;
-        }
+        self.inner
+            .lock()
+            .unwrap()
+            .forget(model, prefix_hash, target);
+    }
+}
+
+fn affinity_stats_snapshot(
+    stats: PrefixAffinityStats,
+    prefix_enabled: bool,
+    sticky_enabled: bool,
+) -> AffinityStatsSnapshot {
+    AffinityStatsSnapshot {
+        prefix_enabled,
+        sticky_enabled,
+        prefix_entries: stats.entries,
+        prefix_lookups: stats.lookups,
+        prefix_hits: stats.hits,
+        prefix_misses: stats.misses,
+        prefix_stale: stats.stale,
+        prefix_routes: stats.routes,
+        sticky_routes: stats.sticky_routes,
+        session_routes: stats.session_routes,
+        learned: stats.learned,
+        evicted: stats.evicted,
     }
 }
 
 impl Default for AffinityRouter {
     fn default() -> Self {
         Self::new()
-    }
-}
-
-impl AffinityState {
-    fn prune_expired(&mut self) {
-        let now = Instant::now();
-
-        while let Some(front_key) = self.lru.front().cloned() {
-            match self.entries.get(&front_key) {
-                Some(entry) => {
-                    if now.duration_since(entry.last_used) > AFFINITY_TTL {
-                        self.lru.pop_front();
-                        if self.entries.remove(&front_key).is_some() {
-                            self.stats.prefix_stale += 1;
-                        }
-                    } else {
-                        break;
-                    }
-                }
-                None => {
-                    self.lru.pop_front();
-                }
-            }
-        }
-    }
-
-    fn touch_key(&mut self, key: &AffinityKey) {
-        if let Some(pos) = self.lru.iter().position(|existing| existing == key) {
-            self.lru.remove(pos);
-        }
-        self.lru.push_back(key.clone());
-    }
-
-    fn remove_key(&mut self, key: &AffinityKey) {
-        self.entries.remove(key);
-        if let Some(pos) = self.lru.iter().position(|existing| existing == key) {
-            self.lru.remove(pos);
-        }
     }
 }
 
@@ -582,17 +481,104 @@ mod tests {
         SecretKey::from_bytes(&bytes).public()
     }
 
+    fn remote(seed: u8) -> election::InferenceTarget {
+        election::InferenceTarget::Remote(make_id(seed))
+    }
+
     fn parse_body(body: &str) -> Value {
         serde_json::from_str(body).unwrap()
     }
 
     #[test]
     fn test_extract_session_hint_from_body_user_preferred() {
-        let body = parse_body(r#"{"user":"bob","session_id":"sess-1"}"#);
+        let body =
+            parse_body(r#"{"prompt_cache_key":"ignored","user":"bob","session_id":"sess-1"}"#);
         assert_eq!(
             extract_session_hint_from_body(&body),
             Some("bob".to_string())
         );
+    }
+
+    #[test]
+    fn user_only_chat_has_no_scaffold_prefix_hash() {
+        let body = parse_body(r#"{"messages":[{"role":"user","content":"hello"}]}"#);
+
+        assert_eq!(scaffold_prefix_hash_from_body(&body), None);
+    }
+
+    #[test]
+    fn prefix_cache_tracks_hits_misses_and_stale_candidates() {
+        let affinity = AffinityRouter::with_config(true, true);
+        let cached = remote(1);
+        let available = [cached.clone()];
+
+        assert_eq!(affinity.lookup_target("qwen", 7, &available), None);
+        affinity.learn_target("qwen", 7, &cached);
+        assert_eq!(affinity.lookup_target("qwen", 7, &available), Some(cached));
+        assert_eq!(affinity.lookup_target("qwen", 7, &[remote(2)]), None);
+
+        let stats = affinity.stats_snapshot();
+        assert_eq!(stats.prefix_entries, 0);
+        assert_eq!(stats.prefix_lookups, 3);
+        assert_eq!(stats.prefix_hits, 1);
+        assert_eq!(stats.prefix_misses, 2);
+        assert_eq!(stats.prefix_stale, 1);
+        assert_eq!(stats.prefix_routes, 1);
+        assert_eq!(stats.learned, 1);
+    }
+
+    #[test]
+    fn prefix_capacity_evicts_the_least_recently_used_entry() {
+        let affinity = AffinityRouter::with_config(true, true);
+        let target = remote(1);
+        for prefix_hash in 0..=mesh_llm_routing::prefix_affinity::PREFIX_AFFINITY_MAX_ENTRIES as u64
+        {
+            affinity.learn_target("qwen", prefix_hash, &target);
+        }
+
+        let stats = affinity.stats_snapshot();
+
+        assert_eq!(
+            stats.prefix_entries,
+            mesh_llm_routing::prefix_affinity::PREFIX_AFFINITY_MAX_ENTRIES
+        );
+        assert_eq!(stats.evicted, 1);
+        assert_eq!(affinity.lookup_target("qwen", 0, &[target]), None);
+    }
+
+    #[test]
+    fn forgetting_a_different_target_preserves_the_entry() {
+        let affinity = AffinityRouter::with_config(true, true);
+        let cached = remote(1);
+        affinity.learn_target("qwen", 13, &cached);
+
+        affinity.forget_target("qwen", 13, &remote(2));
+
+        assert_eq!(
+            affinity.lookup_target("qwen", 13, std::slice::from_ref(&cached)),
+            Some(cached)
+        );
+        assert_eq!(affinity.stats_snapshot().prefix_stale, 0);
+    }
+
+    #[test]
+    fn disabled_prefix_affinity_is_side_effect_free() {
+        let affinity = AffinityRouter::with_config(false, true);
+        let target = remote(1);
+
+        affinity.learn_target("qwen", 17, &target);
+        assert_eq!(
+            affinity.lookup_target("qwen", 17, std::slice::from_ref(&target)),
+            None
+        );
+        affinity.forget_target("qwen", 17, &target);
+
+        let stats = affinity.stats_snapshot();
+        assert!(!stats.prefix_enabled);
+        assert_eq!(stats.prefix_entries, 0);
+        assert_eq!(stats.prefix_lookups, 0);
+        assert_eq!(stats.prefix_stale, 0);
+        assert_eq!(stats.learned, 0);
     }
 
     #[test]

--- a/crates/mesh-client/tests/control_plane_lifecycle_client.rs
+++ b/crates/mesh-client/tests/control_plane_lifecycle_client.rs
@@ -1,0 +1,211 @@
+use base64::Engine;
+use iroh::{Endpoint, EndpointAddr, SecretKey};
+use mesh_client::proto::node::{
+    OwnerControlDrainModelResponse, OwnerControlEnsureModelResponse, OwnerControlEnvelope,
+    OwnerControlLoadModelResponse, OwnerControlRequest, OwnerControlResponse,
+    OwnerControlUnloadModelResponse,
+};
+use mesh_client::protocol::{
+    ALPN_CONTROL_V1, NODE_PROTOCOL_GENERATION, decode_owner_control_envelope, read_len_prefixed,
+    write_len_prefixed,
+};
+use mesh_client::{
+    ClientBuilder, ControlPlaneBootstrapOptions, ControlPlaneConnection, InviteToken,
+    OwnerControlClient, OwnerKeypair,
+};
+use prost::Message;
+use std::str::FromStr;
+use std::sync::Arc;
+use tokio::sync::{Mutex, oneshot};
+
+fn owner_keypair() -> OwnerKeypair {
+    OwnerKeypair::from_bytes(&[0x31; 32], &[0x32; 32]).expect("test owner keypair must be valid")
+}
+
+fn endpoint_token(addr: &EndpointAddr) -> String {
+    base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_vec(addr).expect("endpoint addr should serialize"))
+}
+
+async fn read_envelope(recv: &mut iroh::endpoint::RecvStream) -> OwnerControlEnvelope {
+    let bytes = read_len_prefixed(recv)
+        .await
+        .expect("frame should be len-prefixed");
+    decode_owner_control_envelope(&bytes).expect("owner-control envelope should decode")
+}
+
+async fn write_envelope(send: &mut iroh::endpoint::SendStream, envelope: OwnerControlEnvelope) {
+    write_len_prefixed(send, &envelope.encode_to_vec())
+        .await
+        .expect("owner-control envelope should write");
+}
+
+fn success_response(request: &OwnerControlRequest) -> OwnerControlResponse {
+    let mut response = OwnerControlResponse {
+        request_id: request.request_id,
+        ..Default::default()
+    };
+    if let Some(command) = request.load_model.as_ref() {
+        response.load_model = Some(OwnerControlLoadModelResponse {
+            intent_id: "load-intent".to_string(),
+            accepted_state: "present".to_string(),
+            target: command.model.clone(),
+        });
+    } else if let Some(command) = request.unload_model.as_ref() {
+        response.unload_model = Some(OwnerControlUnloadModelResponse {
+            intent_id: "unload-intent".to_string(),
+            accepted_state: "absent".to_string(),
+            target: command.model.clone(),
+        });
+    } else if let Some(command) = request.ensure_model.as_ref() {
+        response.ensure_model = Some(OwnerControlEnsureModelResponse {
+            intent_id: "ensure-intent".to_string(),
+            accepted_state: "present".to_string(),
+            target: command.model.clone(),
+        });
+    } else if let Some(command) = request.drain_model.as_ref() {
+        response.drain_model = Some(OwnerControlDrainModelResponse {
+            intent_id: "drain-intent".to_string(),
+            accepted_state: "draining".to_string(),
+            target: command.model.clone(),
+        });
+    } else {
+        panic!("expected one lifecycle command");
+    }
+    response
+}
+
+async fn spawn_lifecycle_server() -> (
+    Endpoint,
+    String,
+    Arc<Mutex<Vec<OwnerControlRequest>>>,
+    oneshot::Sender<()>,
+) {
+    let endpoint = Endpoint::builder(iroh::endpoint::presets::Minimal)
+        .secret_key(SecretKey::generate())
+        .alpns(vec![ALPN_CONTROL_V1.to_vec()])
+        .relay_mode(iroh::endpoint::RelayMode::Disabled)
+        .bind_addr(std::net::SocketAddr::from(([127, 0, 0, 1], 0)))
+        .expect("test bind address should be valid")
+        .bind()
+        .await
+        .expect("test endpoint should bind");
+    let token = endpoint_token(&endpoint.addr());
+    let requests = Arc::new(Mutex::new(Vec::new()));
+    let server_endpoint = endpoint.clone();
+    let received = Arc::clone(&requests);
+    let (shutdown_tx, shutdown_rx) = oneshot::channel();
+    tokio::spawn(async move {
+        let incoming = server_endpoint
+            .accept()
+            .await
+            .expect("server should accept connection");
+        let connection = incoming.await.expect("server connection should complete");
+        for _ in 0..4 {
+            let (mut send, mut recv) = connection.accept_bi().await.expect("stream should open");
+            let _handshake = read_envelope(&mut recv).await;
+            let request = read_envelope(&mut recv)
+                .await
+                .request
+                .expect("second envelope should contain a request");
+            let response = success_response(&request);
+            received.lock().await.push(request);
+            write_envelope(
+                &mut send,
+                OwnerControlEnvelope {
+                    r#gen: NODE_PROTOCOL_GENERATION,
+                    response: Some(response),
+                    ..Default::default()
+                },
+            )
+            .await;
+            send.finish().expect("response stream should finish");
+        }
+        let _ = shutdown_rx.await;
+    });
+    (endpoint, token, requests, shutdown_tx)
+}
+
+async fn connect(token: String) -> OwnerControlClient {
+    let client = ClientBuilder::new(
+        owner_keypair(),
+        InviteToken::from_str("mesh-test:lifecycle").expect("test invite should parse"),
+    )
+    .build()
+    .expect("mesh client should build");
+    match client
+        .connect_control_plane(ControlPlaneBootstrapOptions::new().with_control_endpoint(token))
+        .await
+        .expect("control session should connect")
+    {
+        ControlPlaneConnection::OwnerControl(client) => *client,
+    }
+}
+
+#[tokio::test]
+async fn lifecycle_commands_preserve_payloads_request_ids_and_responses() {
+    let (server, token, requests, shutdown) = spawn_lifecycle_server().await;
+    let control = connect(token).await;
+
+    let load = control
+        .load_model("repo/load:Q4_K_M".to_string(), Some("fast".to_string()))
+        .await
+        .expect("load should succeed");
+    let unload = control
+        .unload_model(String::new(), Some("instance-unload".to_string()))
+        .await
+        .expect("unload should succeed");
+    let ensure = control
+        .ensure_model("repo/ensure:Q6_K".to_string(), Some("balanced".to_string()))
+        .await
+        .expect("ensure should succeed");
+    let drain = control
+        .drain_model(String::new(), Some("instance-drain".to_string()))
+        .await
+        .expect("drain should succeed");
+
+    assert_eq!(load.intent_id, "load-intent");
+    assert_eq!(unload.intent_id, "unload-intent");
+    assert_eq!(ensure.intent_id, "ensure-intent");
+    assert_eq!(drain.intent_id, "drain-intent");
+
+    let requests = requests.lock().await;
+    assert_eq!(requests.len(), 4);
+    assert_eq!(
+        requests
+            .iter()
+            .map(|request| request.request_id)
+            .collect::<Vec<_>>(),
+        vec![1, 2, 3, 4]
+    );
+
+    let load = requests[0].load_model.as_ref().expect("load payload");
+    assert_eq!(
+        load.model.as_ref().unwrap().canonical_model_ref,
+        "repo/load:Q4_K_M"
+    );
+    assert_eq!(load.profile.as_deref(), Some("fast"));
+    let unload = requests[1].unload_model.as_ref().expect("unload payload");
+    assert_eq!(unload.model.as_ref().unwrap().canonical_model_ref, "");
+    assert_eq!(
+        unload.model.as_ref().unwrap().instance_id.as_deref(),
+        Some("instance-unload")
+    );
+    let ensure = requests[2].ensure_model.as_ref().expect("ensure payload");
+    assert_eq!(
+        ensure.model.as_ref().unwrap().canonical_model_ref,
+        "repo/ensure:Q6_K"
+    );
+    assert_eq!(ensure.profile.as_deref(), Some("balanced"));
+    let drain = requests[3].drain_model.as_ref().expect("drain payload");
+    assert_eq!(drain.model.as_ref().unwrap().canonical_model_ref, "");
+    assert_eq!(
+        drain.model.as_ref().unwrap().instance_id.as_deref(),
+        Some("instance-drain")
+    );
+    assert_eq!(drain.drain_timeout_secs, None);
+
+    control.close().await;
+    let _ = shutdown.send(());
+    server.close().await;
+}

--- a/crates/mesh-llm-commands/src/setup/summary.rs
+++ b/crates/mesh-llm-commands/src/setup/summary.rs
@@ -204,6 +204,7 @@ mod tests {
     use crate::setup::SetupEnvironment;
     use crate::setup::SetupPlatform;
     use crate::setup::github::SetupGitHubOutcome;
+    use crate::terminal::strip_ansi_styles;
 
     fn actions_with_github_outcome(github_outcome: SetupGitHubOutcome) -> CliSetupActions<'static> {
         let mut actions = CliSetupActions::new(
@@ -222,13 +223,19 @@ mod tests {
     fn github_brief_reports_unavailable_cli() {
         let actions = actions_with_github_outcome(SetupGitHubOutcome::CliUnavailable);
 
-        assert_eq!(github_brief(&actions), Some("gh unavailable".to_string()));
+        assert_eq!(
+            github_brief(&actions).map(|brief| strip_ansi_styles(&brief)),
+            Some("gh unavailable".to_string())
+        );
     }
 
     #[test]
     fn github_brief_reports_unauthenticated_cli() {
         let actions = actions_with_github_outcome(SetupGitHubOutcome::NotAuthenticated);
 
-        assert_eq!(github_brief(&actions), Some("gh signed out".to_string()));
+        assert_eq!(
+            github_brief(&actions).map(|brief| strip_ansi_styles(&brief)),
+            Some("gh signed out".to_string())
+        );
     }
 }

--- a/crates/mesh-llm-commands/src/terminal.rs
+++ b/crates/mesh-llm-commands/src/terminal.rs
@@ -83,3 +83,43 @@ fn style(text: &str, ansi_code: &str) -> String {
         text.to_string()
     }
 }
+
+#[cfg(test)]
+pub(crate) fn strip_ansi_styles(text: &str) -> String {
+    let bytes = text.as_bytes();
+    let mut plain = String::with_capacity(text.len());
+    let mut cursor = 0;
+
+    while cursor < bytes.len() {
+        if bytes[cursor] == b'\x1b' && bytes.get(cursor + 1) == Some(&b'[') {
+            let mut end = cursor + 2;
+            while bytes
+                .get(end)
+                .is_some_and(|byte| byte.is_ascii_digit() || *byte == b';')
+            {
+                end += 1;
+            }
+            if bytes.get(end) == Some(&b'm') {
+                cursor = end + 1;
+                continue;
+            }
+        }
+
+        let character = text[cursor..].chars().next().expect("valid UTF-8 boundary");
+        plain.push(character);
+        cursor += character.len_utf8();
+    }
+
+    plain
+}
+
+#[cfg(test)]
+mod tests {
+    use super::strip_ansi_styles;
+
+    #[test]
+    fn strip_ansi_styles_preserves_plain_and_unicode_text() {
+        assert_eq!(strip_ansi_styles("plain ✓"), "plain ✓");
+        assert_eq!(strip_ansi_styles("\x1b[1;32m✓\x1b[0m ready"), "✓ ready");
+    }
+}

--- a/crates/mesh-llm-commands/src/uninstall.rs
+++ b/crates/mesh-llm-commands/src/uninstall.rs
@@ -636,6 +636,14 @@ fn detect_user_id() -> Result<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::terminal::strip_ansi_styles;
+
+    fn plain_lines(lines: Vec<String>) -> Vec<String> {
+        lines
+            .into_iter()
+            .map(|line| strip_ansi_styles(&line))
+            .collect()
+    }
 
     fn env(temp: &Path, platform: UninstallPlatform) -> UninstallEnvironment {
         UninstallEnvironment {
@@ -856,7 +864,7 @@ mod tests {
         let temp = tempfile::tempdir().expect("tempdir");
         let plan = plan_uninstall(&options(), &env(temp.path(), UninstallPlatform::Linux));
 
-        let lines = plan_lines(&plan, false);
+        let lines = plain_lines(plan_lines(&plan, false));
 
         assert_eq!(lines[0], "! Mesh uninstall dry run");
         assert!(lines.iter().any(|line| line == "  Config   preserved"));
@@ -895,7 +903,7 @@ mod tests {
             warnings: Vec::new(),
         };
 
-        let lines = outcome_lines(&outcome, false);
+        let lines = plain_lines(outcome_lines(&outcome, false));
 
         assert_eq!(lines[0], "✓ Mesh uninstall complete");
         assert!(lines.iter().any(|line| line == "  Removed  1 item"));

--- a/crates/mesh-llm-host-runtime/src/api/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/mod.rs
@@ -749,9 +749,8 @@ impl MeshApi {
         ));
         for model in &mut models {
             let target = target_lookup
-                .by_model_name
-                .get(&model.name)
-                .or_else(|| target_lookup.by_model_ref.get(&model.name));
+                .target_by_model_name(&model.name)
+                .or_else(|| target_lookup.target_by_model_ref(&model.name));
             if let Some(target) = target {
                 model.target_rank = Some(target.rank);
                 model.explicit_interest_count = Some(target.explicit_interest_count);

--- a/crates/mesh-llm-host-runtime/src/api/model_targets.rs
+++ b/crates/mesh-llm-host-runtime/src/api/model_targets.rs
@@ -45,9 +45,23 @@ impl ModelTargetKey {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ModelTargetLookup {
     pub(crate) targets: Vec<ModelTargetPayload>,
-    pub(crate) by_model_name: HashMap<String, ModelTargetPayload>,
-    pub(crate) by_model_ref: HashMap<String, ModelTargetPayload>,
+    by_model_name: HashMap<String, usize>,
+    by_model_ref: HashMap<String, usize>,
     pub(crate) wanted_model_refs: Vec<String>,
+}
+
+impl ModelTargetLookup {
+    pub(crate) fn target_by_model_name(&self, model_name: &str) -> Option<&ModelTargetPayload> {
+        self.by_model_name
+            .get(model_name)
+            .and_then(|index| self.targets.get(*index))
+    }
+
+    pub(crate) fn target_by_model_ref(&self, model_ref: &str) -> Option<&ModelTargetPayload> {
+        self.by_model_ref
+            .get(model_ref)
+            .and_then(|index| self.targets.get(*index))
+    }
 }
 
 #[derive(Debug, Default)]
@@ -373,13 +387,10 @@ fn build_target_lookup(mut payloads: Vec<ModelTargetPayload>) -> ModelTargetLook
         .collect::<Vec<_>>();
     let mut by_model_name = HashMap::new();
     let mut by_model_ref = HashMap::new();
-    for payload in &payloads {
-        by_model_ref.insert(target_identity_ref(payload), payload.clone());
+    for (index, payload) in payloads.iter().enumerate() {
+        by_model_ref.insert(target_identity_ref(payload), index);
         if let Some(model_name) = &payload.model_name {
-            by_model_name.insert(
-                model_identity_ref(model_name, &payload.profile),
-                payload.clone(),
-            );
+            by_model_name.insert(model_identity_ref(model_name, &payload.profile), index);
         }
     }
     payloads.shrink_to_fit();
@@ -596,7 +607,10 @@ mod tests {
         });
 
         assert_eq!(
-            lookup.by_model_ref[synthetic_ref].display_name,
+            lookup
+                .target_by_model_ref(synthetic_ref)
+                .expect("missing synthetic target")
+                .display_name,
             "MyModel-7B-Q4_K_M"
         );
 
@@ -685,8 +699,42 @@ mod tests {
             lookup.wanted_model_refs,
             vec!["model#fast".to_string(), "model#quality".to_string()]
         );
-        assert!(lookup.by_model_ref.contains_key("model#fast"));
-        assert!(lookup.by_model_ref.contains_key("model#quality"));
+        assert!(lookup.target_by_model_ref("model#fast").is_some());
+        assert!(lookup.target_by_model_ref("model#quality").is_some());
+    }
+
+    #[test]
+    fn target_lookup_preserves_payload_order_and_last_alias_wins() {
+        let mut first = target("first-ref");
+        first.model_name = Some("shared-name".to_string());
+        let mut second = target("second-ref");
+        second.model_name = Some("shared-name".to_string());
+        let payloads = build_target_payloads(
+            vec![first, second],
+            &mesh::NodeRole::Worker,
+            0,
+            &[],
+            &ModelTargetSizeLookup::default(),
+        );
+
+        let lookup = build_target_lookup(payloads);
+
+        assert_eq!(lookup.targets[0].model_ref, "first-ref");
+        assert_eq!(lookup.targets[1].model_ref, "second-ref");
+        assert_eq!(
+            lookup
+                .target_by_model_name("shared-name")
+                .expect("missing shared alias")
+                .model_ref,
+            "second-ref"
+        );
+        assert_eq!(
+            lookup
+                .target_by_model_ref("first-ref")
+                .expect("missing first target")
+                .model_ref,
+            "first-ref"
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
+++ b/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
@@ -111,9 +111,8 @@ impl MeshApi {
         let node = self.inner.lock().await.node.clone();
         let model_target_lookup = self.model_target_lookup().await;
         let capacity_advice = model_target_lookup
-            .by_model_ref
-            .get(model_ref)
-            .or_else(|| model_target_lookup.by_model_name.get(model_ref))
+            .target_by_model_ref(model_ref)
+            .or_else(|| model_target_lookup.target_by_model_name(model_ref))
             .map(|target| target.capacity_advice.clone());
 
         let role = node.role().await;

--- a/crates/mesh-llm-host-runtime/src/network/affinity.rs
+++ b/crates/mesh-llm-host-runtime/src/network/affinity.rs
@@ -3,19 +3,19 @@
 use crate::inference::election;
 use crate::network::target_health::{TargetHealth, TargetHealthOutcome, TargetReputationStats};
 use iroh::EndpointId;
+#[cfg(test)]
+use mesh_llm_routing::prefix_affinity::PREFIX_AFFINITY_MAX_ENTRIES;
+use mesh_llm_routing::prefix_affinity::{PREFIX_AFFINITY_TTL, PrefixAffinity, PrefixAffinityStats};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
-const AFFINITY_TTL: Duration = Duration::from_secs(20 * 60);
-const AFFINITY_MAX_ENTRIES: usize = 4096;
-
 /// How long a remembered auto-routed model stays valid for a given session
 /// key. Matches the prefix affinity TTL so sticky chats and sticky routing
 /// expire in lockstep.
-const AUTO_MODEL_TTL: Duration = AFFINITY_TTL;
+const AUTO_MODEL_TTL: Duration = PREFIX_AFFINITY_TTL;
 /// Upper bound on the auto-model cache. Each entry is small (session hash +
 /// model name + timestamp) so this is generous.
 const AUTO_MODEL_MAX_ENTRIES: usize = 1024;
@@ -58,18 +58,6 @@ impl AffinityConfig {
     }
 }
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq)]
-struct AffinityKey {
-    model: String,
-    prefix_hash: u64,
-}
-
-#[derive(Clone, Debug)]
-struct AffinityEntry {
-    target: election::InferenceTarget,
-    last_used: Instant,
-}
-
 #[derive(Clone, Debug)]
 struct AutoModelEntry {
     model: String,
@@ -78,9 +66,7 @@ struct AutoModelEntry {
 
 #[derive(Default)]
 struct AffinityState {
-    entries: HashMap<AffinityKey, AffinityEntry>,
-    lru: VecDeque<AffinityKey>,
-    stats: AffinityStatsSnapshot,
+    prefix: PrefixAffinity<election::InferenceTarget>,
     auto_models: HashMap<u64, AutoModelEntry>,
     auto_lru: VecDeque<u64>,
 }
@@ -115,11 +101,11 @@ impl AffinityRouter {
 
     pub fn stats_snapshot(&self) -> AffinityStatsSnapshot {
         let mut state = self.inner.lock().unwrap();
-        state.prune_expired();
-        let mut stats = state.stats.clone();
-        stats.prefix_entries = state.entries.len();
-        stats.prefix_enabled = self.config.prefix_enabled;
-        stats.sticky_enabled = self.config.sticky_enabled;
+        let mut stats = affinity_stats_snapshot(
+            state.prefix.snapshot(),
+            self.config.prefix_enabled,
+            self.config.sticky_enabled,
+        );
         stats.target_reputation = self.target_health.reputation_stats();
         stats
     }
@@ -155,13 +141,11 @@ impl AffinityRouter {
     }
 
     pub fn record_sticky_route(&self) {
-        let mut state = self.inner.lock().unwrap();
-        state.stats.sticky_routes += 1;
+        self.inner.lock().unwrap().prefix.record_sticky_route();
     }
 
     pub fn record_session_route(&self) {
-        let mut state = self.inner.lock().unwrap();
-        state.stats.session_routes += 1;
+        self.inner.lock().unwrap().prefix.record_session_route();
     }
 
     pub fn lookup_target(
@@ -173,33 +157,11 @@ impl AffinityRouter {
         if !self.config.prefix_enabled {
             return None;
         }
-        let key = AffinityKey {
-            model: model.to_string(),
-            prefix_hash,
-        };
-        let mut state = self.inner.lock().unwrap();
-        state.prune_expired();
-        state.stats.prefix_lookups += 1;
-        let entry = match state.entries.get(&key).cloned() {
-            Some(entry) => entry,
-            None => {
-                state.stats.prefix_misses += 1;
-                return None;
-            }
-        };
-        if !candidates.contains(&entry.target) {
-            state.remove_key(&key);
-            state.stats.prefix_stale += 1;
-            state.stats.prefix_misses += 1;
-            return None;
-        }
-        state.touch_key(&key);
-        if let Some(existing) = state.entries.get_mut(&key) {
-            existing.last_used = Instant::now();
-        }
-        state.stats.prefix_hits += 1;
-        state.stats.prefix_routes += 1;
-        Some(entry.target)
+        self.inner
+            .lock()
+            .unwrap()
+            .prefix
+            .lookup(model, prefix_hash, candidates)
     }
 
     pub fn learn_target(&self, model: &str, prefix_hash: u64, target: &election::InferenceTarget) {
@@ -207,51 +169,22 @@ impl AffinityRouter {
             return;
         }
 
-        let key = AffinityKey {
-            model: model.to_string(),
-            prefix_hash,
-        };
-        let now = Instant::now();
-        let mut state = self.inner.lock().unwrap();
-        state.prune_expired();
-        state.entries.insert(
-            key.clone(),
-            AffinityEntry {
-                target: target.clone(),
-                last_used: now,
-            },
-        );
-        state.touch_key(&key);
-        state.stats.learned += 1;
-        while state.entries.len() > AFFINITY_MAX_ENTRIES {
-            if let Some(oldest) = state.lru.pop_front() {
-                if state.entries.remove(&oldest).is_some() {
-                    state.stats.evicted += 1;
-                }
-            } else {
-                break;
-            }
-        }
+        self.inner
+            .lock()
+            .unwrap()
+            .prefix
+            .learn(model, prefix_hash, target);
     }
 
     pub fn forget_target(&self, model: &str, prefix_hash: u64, target: &election::InferenceTarget) {
         if !self.config.prefix_enabled {
             return;
         }
-        let key = AffinityKey {
-            model: model.to_string(),
-            prefix_hash,
-        };
-        let mut state = self.inner.lock().unwrap();
-        if state
-            .entries
-            .get(&key)
-            .map(|entry| &entry.target == target)
-            .unwrap_or(false)
-        {
-            state.remove_key(&key);
-            state.stats.prefix_stale += 1;
-        }
+        self.inner
+            .lock()
+            .unwrap()
+            .prefix
+            .forget(model, prefix_hash, target);
     }
 
     /// Look up a previously-classified model name for an auto-routed session.
@@ -305,6 +238,28 @@ impl AffinityRouter {
     }
 }
 
+fn affinity_stats_snapshot(
+    stats: PrefixAffinityStats,
+    prefix_enabled: bool,
+    sticky_enabled: bool,
+) -> AffinityStatsSnapshot {
+    AffinityStatsSnapshot {
+        prefix_enabled,
+        sticky_enabled,
+        prefix_entries: stats.entries,
+        prefix_lookups: stats.lookups,
+        prefix_hits: stats.hits,
+        prefix_misses: stats.misses,
+        prefix_stale: stats.stale,
+        prefix_routes: stats.routes,
+        sticky_routes: stats.sticky_routes,
+        session_routes: stats.session_routes,
+        learned: stats.learned,
+        evicted: stats.evicted,
+        target_reputation: TargetReputationStats::default(),
+    }
+}
+
 /// Compute the session-level key used to cache an auto-routed model choice.
 ///
 /// Prefers an explicit cache/session hint from the request body (e.g.
@@ -322,48 +277,6 @@ impl Default for AffinityRouter {
 }
 
 impl AffinityState {
-    fn prune_expired(&mut self) {
-        let now = Instant::now();
-
-        while let Some(key) = self.lru.front() {
-            let front_key = key.clone();
-
-            match self.entries.get(&front_key) {
-                Some(entry) => {
-                    if now.duration_since(entry.last_used) > AFFINITY_TTL {
-                        // Oldest entry is expired: evict it.
-                        self.lru.pop_front();
-                        if self.entries.remove(&front_key).is_some() {
-                            self.stats.prefix_stale += 1;
-                        }
-                        // Continue to check next-oldest entry.
-                    } else {
-                        // Oldest entry is not expired; newer ones cannot be expired yet.
-                        break;
-                    }
-                }
-                None => {
-                    // Key is in LRU but missing from entries; drop it from LRU and continue.
-                    self.lru.pop_front();
-                }
-            }
-        }
-    }
-
-    fn touch_key(&mut self, key: &AffinityKey) {
-        if let Some(pos) = self.lru.iter().position(|existing| existing == key) {
-            self.lru.remove(pos);
-        }
-        self.lru.push_back(key.clone());
-    }
-
-    fn remove_key(&mut self, key: &AffinityKey) {
-        self.entries.remove(key);
-        if let Some(pos) = self.lru.iter().position(|existing| existing == key) {
-            self.lru.remove(pos);
-        }
-    }
-
     fn prune_auto_expired(&mut self) {
         let now = Instant::now();
         while let Some(key) = self.auto_lru.front().copied() {
@@ -790,6 +703,77 @@ mod tests {
             extract_session_hint_from_body(&body),
             Some("cache-1".to_string())
         );
+    }
+
+    #[test]
+    fn prefix_cache_tracks_hits_misses_and_stale_candidates() {
+        let affinity = AffinityRouter::with_config(true, true);
+        let cached = remote(1);
+        let available = [cached.clone()];
+
+        assert_eq!(affinity.lookup_target("qwen", 7, &available), None);
+        affinity.learn_target("qwen", 7, &cached);
+        assert_eq!(affinity.lookup_target("qwen", 7, &available), Some(cached));
+        assert_eq!(affinity.lookup_target("qwen", 7, &[remote(2)]), None);
+
+        let stats = affinity.stats_snapshot();
+        assert_eq!(stats.prefix_entries, 0);
+        assert_eq!(stats.prefix_lookups, 3);
+        assert_eq!(stats.prefix_hits, 1);
+        assert_eq!(stats.prefix_misses, 2);
+        assert_eq!(stats.prefix_stale, 1);
+        assert_eq!(stats.prefix_routes, 1);
+        assert_eq!(stats.learned, 1);
+    }
+
+    #[test]
+    fn prefix_capacity_evicts_the_least_recently_used_entry() {
+        let affinity = AffinityRouter::with_config(true, true);
+        let target = remote(1);
+        for prefix_hash in 0..=PREFIX_AFFINITY_MAX_ENTRIES as u64 {
+            affinity.learn_target("qwen", prefix_hash, &target);
+        }
+
+        let stats = affinity.stats_snapshot();
+
+        assert_eq!(stats.prefix_entries, PREFIX_AFFINITY_MAX_ENTRIES);
+        assert_eq!(stats.evicted, 1);
+        assert_eq!(affinity.lookup_target("qwen", 0, &[target]), None);
+    }
+
+    #[test]
+    fn forgetting_a_different_target_preserves_the_entry() {
+        let affinity = AffinityRouter::with_config(true, true);
+        let cached = remote(1);
+        affinity.learn_target("qwen", 13, &cached);
+
+        affinity.forget_target("qwen", 13, &remote(2));
+
+        assert_eq!(
+            affinity.lookup_target("qwen", 13, std::slice::from_ref(&cached)),
+            Some(cached)
+        );
+        assert_eq!(affinity.stats_snapshot().prefix_stale, 0);
+    }
+
+    #[test]
+    fn disabled_prefix_affinity_is_side_effect_free() {
+        let affinity = AffinityRouter::with_config(false, true);
+        let target = remote(1);
+
+        affinity.learn_target("qwen", 17, &target);
+        assert_eq!(
+            affinity.lookup_target("qwen", 17, std::slice::from_ref(&target)),
+            None
+        );
+        affinity.forget_target("qwen", 17, &target);
+
+        let stats = affinity.stats_snapshot();
+        assert!(!stats.prefix_enabled);
+        assert_eq!(stats.prefix_entries, 0);
+        assert_eq!(stats.prefix_lookups, 0);
+        assert_eq!(stats.prefix_stale, 0);
+        assert_eq!(stats.learned, 0);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/affinity.rs
+++ b/crates/mesh-llm-host-runtime/src/network/affinity.rs
@@ -5,7 +5,7 @@ use crate::network::target_health::{TargetHealth, TargetHealthOutcome, TargetRep
 use iroh::EndpointId;
 #[cfg(test)]
 use mesh_llm_routing::prefix_affinity::PREFIX_AFFINITY_MAX_ENTRIES;
-use mesh_llm_routing::prefix_affinity::{PREFIX_AFFINITY_TTL, PrefixAffinity, PrefixAffinityStats};
+use mesh_llm_routing::prefix_affinity::{PREFIX_AFFINITY_TTL, PrefixAffinity};
 use serde::Serialize;
 use serde_json::Value;
 use std::collections::{HashMap, VecDeque};
@@ -36,6 +36,10 @@ pub struct AffinityStatsSnapshot {
     pub evicted: u64,
     pub target_reputation: TargetReputationStats,
 }
+
+mesh_llm_routing::impl_prefix_affinity_stats_snapshot!(AffinityStatsSnapshot {
+    target_reputation: TargetReputationStats::default(),
+});
 
 fn prefix_only_enabled() -> bool {
     std::env::var("MESH_LLM_PREFIX_ONLY")
@@ -101,7 +105,7 @@ impl AffinityRouter {
 
     pub fn stats_snapshot(&self) -> AffinityStatsSnapshot {
         let mut state = self.inner.lock().unwrap();
-        let mut stats = affinity_stats_snapshot(
+        let mut stats = AffinityStatsSnapshot::from_prefix_affinity_stats(
             state.prefix.snapshot(),
             self.config.prefix_enabled,
             self.config.sticky_enabled,
@@ -235,28 +239,6 @@ impl AffinityRouter {
     pub fn forget_auto_model(&self, session_key: u64) {
         let mut state = self.inner.lock().unwrap();
         state.remove_auto_key(session_key);
-    }
-}
-
-fn affinity_stats_snapshot(
-    stats: PrefixAffinityStats,
-    prefix_enabled: bool,
-    sticky_enabled: bool,
-) -> AffinityStatsSnapshot {
-    AffinityStatsSnapshot {
-        prefix_enabled,
-        sticky_enabled,
-        prefix_entries: stats.entries,
-        prefix_lookups: stats.lookups,
-        prefix_hits: stats.hits,
-        prefix_misses: stats.misses,
-        prefix_stale: stats.stale,
-        prefix_routes: stats.routes,
-        sticky_routes: stats.sticky_routes,
-        session_routes: stats.session_routes,
-        learned: stats.learned,
-        evicted: stats.evicted,
-        target_reputation: TargetReputationStats::default(),
     }
 }
 

--- a/crates/mesh-llm-routing/src/lib.rs
+++ b/crates/mesh-llm-routing/src/lib.rs
@@ -3,6 +3,8 @@ use std::path::Path;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+pub mod prefix_affinity;
+
 /// Calculate total model size, summing all split files if present.
 /// Split files follow the pattern: name-00001-of-00004.gguf.
 pub fn total_model_bytes(model: &Path) -> u64 {

--- a/crates/mesh-llm-routing/src/prefix_affinity.rs
+++ b/crates/mesh-llm-routing/src/prefix_affinity.rs
@@ -1,4 +1,4 @@
-use std::collections::{HashMap, VecDeque};
+use std::collections::{BTreeMap, HashMap};
 use std::time::{Duration, Instant};
 
 pub const PREFIX_AFFINITY_TTL: Duration = Duration::from_secs(20 * 60);
@@ -18,6 +18,36 @@ pub struct PrefixAffinityStats {
     pub evicted: u64,
 }
 
+#[doc(hidden)]
+#[macro_export]
+macro_rules! impl_prefix_affinity_stats_snapshot {
+    ($snapshot:ty $({ $($field:ident: $value:expr),+ $(,)? })?) => {
+        impl $snapshot {
+            fn from_prefix_affinity_stats(
+                stats: $crate::prefix_affinity::PrefixAffinityStats,
+                prefix_enabled: bool,
+                sticky_enabled: bool,
+            ) -> Self {
+                Self {
+                    prefix_enabled,
+                    sticky_enabled,
+                    prefix_entries: stats.entries,
+                    prefix_lookups: stats.lookups,
+                    prefix_hits: stats.hits,
+                    prefix_misses: stats.misses,
+                    prefix_stale: stats.stale,
+                    prefix_routes: stats.routes,
+                    sticky_routes: stats.sticky_routes,
+                    session_routes: stats.session_routes,
+                    learned: stats.learned,
+                    evicted: stats.evicted,
+                    $($($field: $value),+)?
+                }
+            }
+        }
+    };
+}
+
 #[derive(Clone, Debug, Hash, PartialEq, Eq)]
 struct AffinityKey {
     model: String,
@@ -28,11 +58,13 @@ struct AffinityKey {
 struct AffinityEntry<T> {
     target: T,
     last_used: Instant,
+    order: u64,
 }
 
 pub struct PrefixAffinity<T> {
     entries: HashMap<AffinityKey, AffinityEntry<T>>,
-    lru: VecDeque<AffinityKey>,
+    lru: BTreeMap<u64, AffinityKey>,
+    next_order: u64,
     stats: PrefixAffinityStats,
     ttl: Duration,
     max_entries: usize,
@@ -56,34 +88,62 @@ impl<T> PrefixAffinity<T> {
 
     fn prune_expired(&mut self) {
         let now = Instant::now();
-        while let Some(front_key) = self.lru.front().cloned() {
-            match self.entries.get(&front_key) {
-                Some(entry) if now.duration_since(entry.last_used) > self.ttl => {
-                    self.lru.pop_front();
-                    if self.entries.remove(&front_key).is_some() {
-                        self.stats.stale += 1;
-                    }
-                }
-                Some(_) => break,
-                None => {
-                    self.lru.pop_front();
-                }
+        while let Some((_, front_key)) = self.lru.first_key_value() {
+            if self
+                .entries
+                .get(front_key)
+                .is_some_and(|entry| now.duration_since(entry.last_used) <= self.ttl)
+            {
+                break;
+            }
+            let Some((_, front_key)) = self.lru.pop_first() else {
+                break;
+            };
+            if self.entries.remove(&front_key).is_some() {
+                self.stats.stale += 1;
             }
         }
     }
 
     fn touch_key(&mut self, key: &AffinityKey) {
-        if let Some(position) = self.lru.iter().position(|existing| existing == key) {
-            self.lru.remove(position);
+        let Some(previous_order) = self.entries.get(key).map(|entry| entry.order) else {
+            return;
+        };
+        self.lru.remove(&previous_order);
+        let order = self.take_next_order();
+        if let Some(entry) = self.entries.get_mut(key) {
+            entry.order = order;
         }
-        self.lru.push_back(key.clone());
+        self.lru.insert(order, key.clone());
     }
 
     fn remove_key(&mut self, key: &AffinityKey) {
-        self.entries.remove(key);
-        if let Some(position) = self.lru.iter().position(|existing| existing == key) {
-            self.lru.remove(position);
+        if let Some(entry) = self.entries.remove(key) {
+            self.lru.remove(&entry.order);
         }
+    }
+
+    fn take_next_order(&mut self) -> u64 {
+        if self.next_order == u64::MAX {
+            self.rebase_orders();
+        }
+        let order = self.next_order;
+        self.next_order += 1;
+        order
+    }
+
+    fn rebase_orders(&mut self) {
+        let mut next_order = 0;
+        let mut rebased = BTreeMap::new();
+        for (_, key) in std::mem::take(&mut self.lru) {
+            if let Some(entry) = self.entries.get_mut(&key) {
+                entry.order = next_order;
+                rebased.insert(next_order, key);
+                next_order += 1;
+            }
+        }
+        self.lru = rebased;
+        self.next_order = next_order;
     }
 }
 
@@ -95,12 +155,9 @@ impl<T: Clone + PartialEq> PrefixAffinity<T> {
             model: model.to_string(),
             prefix_hash,
         };
-        let entry = match self.entries.get(&key).cloned() {
-            Some(entry) => entry,
-            None => {
-                self.stats.misses += 1;
-                return None;
-            }
+        let Some(entry) = self.entries.get(&key) else {
+            self.stats.misses += 1;
+            return None;
         };
         if !candidates.contains(&entry.target) {
             self.remove_key(&key);
@@ -108,13 +165,14 @@ impl<T: Clone + PartialEq> PrefixAffinity<T> {
             self.stats.misses += 1;
             return None;
         }
+        let target = entry.target.clone();
         self.touch_key(&key);
         if let Some(existing) = self.entries.get_mut(&key) {
             existing.last_used = Instant::now();
         }
         self.stats.hits += 1;
         self.stats.routes += 1;
-        Some(entry.target)
+        Some(target)
     }
 
     pub fn learn(&mut self, model: &str, prefix_hash: u64, target: &T) {
@@ -123,17 +181,20 @@ impl<T: Clone + PartialEq> PrefixAffinity<T> {
             model: model.to_string(),
             prefix_hash,
         };
+        self.remove_key(&key);
+        let order = self.take_next_order();
         self.entries.insert(
             key.clone(),
             AffinityEntry {
                 target: target.clone(),
                 last_used: Instant::now(),
+                order,
             },
         );
-        self.touch_key(&key);
+        self.lru.insert(order, key);
         self.stats.learned += 1;
         while self.entries.len() > self.max_entries {
-            let Some(oldest) = self.lru.pop_front() else {
+            let Some((_, oldest)) = self.lru.pop_first() else {
                 break;
             };
             if self.entries.remove(&oldest).is_some() {
@@ -162,7 +223,8 @@ impl<T> Default for PrefixAffinity<T> {
     fn default() -> Self {
         Self {
             entries: HashMap::new(),
-            lru: VecDeque::new(),
+            lru: BTreeMap::new(),
+            next_order: 0,
             stats: PrefixAffinityStats::default(),
             ttl: PREFIX_AFFINITY_TTL,
             max_entries: PREFIX_AFFINITY_MAX_ENTRIES,
@@ -172,7 +234,36 @@ impl<T> Default for PrefixAffinity<T> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicUsize, Ordering},
+    };
+
     use super::*;
+
+    #[derive(Debug)]
+    struct CloneTracked {
+        id: u8,
+        clone_count: Arc<AtomicUsize>,
+    }
+
+    impl Clone for CloneTracked {
+        fn clone(&self) -> Self {
+            self.clone_count.fetch_add(1, Ordering::Relaxed);
+            Self {
+                id: self.id,
+                clone_count: Arc::clone(&self.clone_count),
+            }
+        }
+    }
+
+    impl PartialEq for CloneTracked {
+        fn eq(&self, other: &Self) -> bool {
+            self.id == other.id
+        }
+    }
+
+    impl Eq for CloneTracked {}
 
     #[test]
     fn expired_entry_is_pruned_before_snapshot() {
@@ -211,6 +302,52 @@ mod tests {
         assert_eq!(stats.stale, 1);
         assert_eq!(stats.routes, 2);
         assert_eq!(stats.learned, 3);
+        assert_eq!(stats.evicted, 1);
+    }
+
+    #[test]
+    fn lookup_clones_only_returned_target() {
+        let clone_count = Arc::new(AtomicUsize::new(0));
+        let target = CloneTracked {
+            id: 1,
+            clone_count: Arc::clone(&clone_count),
+        };
+        let mut affinity = PrefixAffinity::default();
+        affinity.learn("model", 1, &target);
+        clone_count.store(0, Ordering::Relaxed);
+
+        let unavailable = CloneTracked {
+            id: 2,
+            clone_count: Arc::new(AtomicUsize::new(0)),
+        };
+        assert_eq!(affinity.lookup("model", 1, &[unavailable]), None);
+        assert_eq!(clone_count.load(Ordering::Relaxed), 0);
+
+        affinity.learn("model", 1, &target);
+        clone_count.store(0, Ordering::Relaxed);
+        let available = CloneTracked {
+            id: 1,
+            clone_count: Arc::clone(&clone_count),
+        };
+        assert_eq!(affinity.lookup("model", 1, &[available]).unwrap().id, 1);
+        assert_eq!(clone_count.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
+    fn relearning_key_refreshes_lru_without_duplicate_order_entries() {
+        let mut affinity = PrefixAffinity {
+            max_entries: 2,
+            ..PrefixAffinity::default()
+        };
+        affinity.learn("model", 1, &1u8);
+        affinity.learn("model", 2, &2u8);
+        affinity.learn("model", 1, &1u8);
+        affinity.learn("model", 3, &3u8);
+
+        assert_eq!(affinity.lookup("model", 2, &[1, 2, 3]), None);
+        assert_eq!(affinity.lookup("model", 1, &[1, 2, 3]), Some(1));
+        let stats = affinity.snapshot();
+        assert_eq!(stats.entries, 2);
         assert_eq!(stats.evicted, 1);
     }
 }

--- a/crates/mesh-llm-routing/src/prefix_affinity.rs
+++ b/crates/mesh-llm-routing/src/prefix_affinity.rs
@@ -1,0 +1,216 @@
+use std::collections::{HashMap, VecDeque};
+use std::time::{Duration, Instant};
+
+pub const PREFIX_AFFINITY_TTL: Duration = Duration::from_secs(20 * 60);
+pub const PREFIX_AFFINITY_MAX_ENTRIES: usize = 4096;
+
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct PrefixAffinityStats {
+    pub entries: usize,
+    pub lookups: u64,
+    pub hits: u64,
+    pub misses: u64,
+    pub stale: u64,
+    pub routes: u64,
+    pub sticky_routes: u64,
+    pub session_routes: u64,
+    pub learned: u64,
+    pub evicted: u64,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+struct AffinityKey {
+    model: String,
+    prefix_hash: u64,
+}
+
+#[derive(Clone, Debug)]
+struct AffinityEntry<T> {
+    target: T,
+    last_used: Instant,
+}
+
+pub struct PrefixAffinity<T> {
+    entries: HashMap<AffinityKey, AffinityEntry<T>>,
+    lru: VecDeque<AffinityKey>,
+    stats: PrefixAffinityStats,
+    ttl: Duration,
+    max_entries: usize,
+}
+
+impl<T> PrefixAffinity<T> {
+    pub fn record_sticky_route(&mut self) {
+        self.stats.sticky_routes += 1;
+    }
+
+    pub fn record_session_route(&mut self) {
+        self.stats.session_routes += 1;
+    }
+
+    pub fn snapshot(&mut self) -> PrefixAffinityStats {
+        self.prune_expired();
+        let mut stats = self.stats.clone();
+        stats.entries = self.entries.len();
+        stats
+    }
+
+    fn prune_expired(&mut self) {
+        let now = Instant::now();
+        while let Some(front_key) = self.lru.front().cloned() {
+            match self.entries.get(&front_key) {
+                Some(entry) if now.duration_since(entry.last_used) > self.ttl => {
+                    self.lru.pop_front();
+                    if self.entries.remove(&front_key).is_some() {
+                        self.stats.stale += 1;
+                    }
+                }
+                Some(_) => break,
+                None => {
+                    self.lru.pop_front();
+                }
+            }
+        }
+    }
+
+    fn touch_key(&mut self, key: &AffinityKey) {
+        if let Some(position) = self.lru.iter().position(|existing| existing == key) {
+            self.lru.remove(position);
+        }
+        self.lru.push_back(key.clone());
+    }
+
+    fn remove_key(&mut self, key: &AffinityKey) {
+        self.entries.remove(key);
+        if let Some(position) = self.lru.iter().position(|existing| existing == key) {
+            self.lru.remove(position);
+        }
+    }
+}
+
+impl<T: Clone + PartialEq> PrefixAffinity<T> {
+    pub fn lookup(&mut self, model: &str, prefix_hash: u64, candidates: &[T]) -> Option<T> {
+        self.prune_expired();
+        self.stats.lookups += 1;
+        let key = AffinityKey {
+            model: model.to_string(),
+            prefix_hash,
+        };
+        let entry = match self.entries.get(&key).cloned() {
+            Some(entry) => entry,
+            None => {
+                self.stats.misses += 1;
+                return None;
+            }
+        };
+        if !candidates.contains(&entry.target) {
+            self.remove_key(&key);
+            self.stats.stale += 1;
+            self.stats.misses += 1;
+            return None;
+        }
+        self.touch_key(&key);
+        if let Some(existing) = self.entries.get_mut(&key) {
+            existing.last_used = Instant::now();
+        }
+        self.stats.hits += 1;
+        self.stats.routes += 1;
+        Some(entry.target)
+    }
+
+    pub fn learn(&mut self, model: &str, prefix_hash: u64, target: &T) {
+        self.prune_expired();
+        let key = AffinityKey {
+            model: model.to_string(),
+            prefix_hash,
+        };
+        self.entries.insert(
+            key.clone(),
+            AffinityEntry {
+                target: target.clone(),
+                last_used: Instant::now(),
+            },
+        );
+        self.touch_key(&key);
+        self.stats.learned += 1;
+        while self.entries.len() > self.max_entries {
+            let Some(oldest) = self.lru.pop_front() else {
+                break;
+            };
+            if self.entries.remove(&oldest).is_some() {
+                self.stats.evicted += 1;
+            }
+        }
+    }
+
+    pub fn forget(&mut self, model: &str, prefix_hash: u64, target: &T) {
+        let key = AffinityKey {
+            model: model.to_string(),
+            prefix_hash,
+        };
+        if self
+            .entries
+            .get(&key)
+            .is_some_and(|entry| &entry.target == target)
+        {
+            self.remove_key(&key);
+            self.stats.stale += 1;
+        }
+    }
+}
+
+impl<T> Default for PrefixAffinity<T> {
+    fn default() -> Self {
+        Self {
+            entries: HashMap::new(),
+            lru: VecDeque::new(),
+            stats: PrefixAffinityStats::default(),
+            ttl: PREFIX_AFFINITY_TTL,
+            max_entries: PREFIX_AFFINITY_MAX_ENTRIES,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn expired_entry_is_pruned_before_snapshot() {
+        let mut affinity = PrefixAffinity::<u8>::default();
+        affinity.learn("model", 1, &7);
+        affinity.entries.values_mut().next().unwrap().last_used =
+            Instant::now() - PREFIX_AFFINITY_TTL - Duration::from_secs(1);
+
+        let stats = affinity.snapshot();
+
+        assert_eq!(stats.entries, 0);
+        assert_eq!(stats.stale, 1);
+    }
+
+    #[test]
+    fn lookup_learn_forget_and_lru_stats_are_stable() {
+        let mut affinity = PrefixAffinity {
+            max_entries: 2,
+            ..PrefixAffinity::default()
+        };
+        affinity.learn("model", 1, &1u8);
+        affinity.learn("model", 2, &2u8);
+        assert_eq!(affinity.lookup("model", 1, &[1, 2]), Some(1));
+        affinity.learn("model", 3, &3u8);
+        assert_eq!(affinity.lookup("model", 2, &[1, 2, 3]), None);
+        affinity.forget("model", 1, &9);
+        assert_eq!(affinity.lookup("model", 1, &[1, 3]), Some(1));
+        affinity.forget("model", 1, &1);
+
+        let stats = affinity.snapshot();
+
+        assert_eq!(stats.entries, 1);
+        assert_eq!(stats.lookups, 3);
+        assert_eq!(stats.hits, 2);
+        assert_eq!(stats.misses, 1);
+        assert_eq!(stats.stale, 1);
+        assert_eq!(stats.routes, 2);
+        assert_eq!(stats.learned, 3);
+        assert_eq!(stats.evicted, 1);
+    }
+}

--- a/crates/mesh-llm-types/src/models/capabilities.rs
+++ b/crates/mesh-llm-types/src/models/capabilities.rs
@@ -10,6 +10,28 @@ pub enum CapabilityLevel {
     Supported,
 }
 
+impl CapabilityLevel {
+    fn is_supported(self) -> bool {
+        self == Self::Supported
+    }
+
+    fn status(self) -> &'static str {
+        match self {
+            Self::Supported => "supported",
+            Self::Likely => "likely",
+            Self::None => "none",
+        }
+    }
+
+    fn label(self) -> Option<&'static str> {
+        match self {
+            Self::Supported => Some("yes"),
+            Self::Likely => Some("likely"),
+            Self::None => None,
+        }
+    }
+}
+
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct ModelCapabilities {
     pub multimodal: bool,
@@ -39,11 +61,11 @@ impl ModelCapabilities {
     }
 
     pub fn supports_vision_runtime(self) -> bool {
-        matches!(self.vision, CapabilityLevel::Supported)
+        self.vision.is_supported()
     }
 
     pub fn supports_audio_runtime(self) -> bool {
-        matches!(self.audio, CapabilityLevel::Supported)
+        self.audio.is_supported()
     }
 
     pub fn multimodal_status(self) -> &'static str {
@@ -63,67 +85,35 @@ impl ModelCapabilities {
     }
 
     pub fn vision_status(self) -> &'static str {
-        match self.vision {
-            CapabilityLevel::Supported => "supported",
-            CapabilityLevel::Likely => "likely",
-            CapabilityLevel::None => "none",
-        }
+        self.vision.status()
     }
 
     pub fn vision_label(self) -> Option<&'static str> {
-        match self.vision {
-            CapabilityLevel::Supported => Some("yes"),
-            CapabilityLevel::Likely => Some("likely"),
-            CapabilityLevel::None => None,
-        }
+        self.vision.label()
     }
 
     pub fn audio_status(self) -> &'static str {
-        match self.audio {
-            CapabilityLevel::Supported => "supported",
-            CapabilityLevel::Likely => "likely",
-            CapabilityLevel::None => "none",
-        }
+        self.audio.status()
     }
 
     pub fn audio_label(self) -> Option<&'static str> {
-        match self.audio {
-            CapabilityLevel::Supported => Some("yes"),
-            CapabilityLevel::Likely => Some("likely"),
-            CapabilityLevel::None => None,
-        }
+        self.audio.label()
     }
 
     pub fn reasoning_status(self) -> &'static str {
-        match self.reasoning {
-            CapabilityLevel::Supported => "supported",
-            CapabilityLevel::Likely => "likely",
-            CapabilityLevel::None => "none",
-        }
+        self.reasoning.status()
     }
 
     pub fn reasoning_label(self) -> Option<&'static str> {
-        match self.reasoning {
-            CapabilityLevel::Supported => Some("yes"),
-            CapabilityLevel::Likely => Some("likely"),
-            CapabilityLevel::None => None,
-        }
+        self.reasoning.label()
     }
 
     pub fn tool_use_status(self) -> &'static str {
-        match self.tool_use {
-            CapabilityLevel::Supported => "supported",
-            CapabilityLevel::Likely => "likely",
-            CapabilityLevel::None => "none",
-        }
+        self.tool_use.status()
     }
 
     pub fn tool_use_label(self) -> Option<&'static str> {
-        match self.tool_use {
-            CapabilityLevel::Supported => Some("yes"),
-            CapabilityLevel::Likely => Some("likely"),
-            CapabilityLevel::None => None,
-        }
+        self.tool_use.label()
     }
 
     pub fn upgrade_vision(&mut self, level: CapabilityLevel) {
@@ -157,40 +147,8 @@ impl ModelCapabilities {
 }
 
 pub fn merge_name_signals(mut caps: ModelCapabilities, values: &[&str]) -> ModelCapabilities {
-    if values.iter().any(|value| strong_vision_name_signal(value)) {
-        caps.upgrade_vision(CapabilityLevel::Supported);
-    } else if values.iter().any(|value| likely_vision_name_signal(value)) {
-        caps.upgrade_vision(CapabilityLevel::Likely);
-    }
-
-    if values.iter().any(|value| strong_audio_name_signal(value)) {
-        caps.upgrade_audio(CapabilityLevel::Supported);
-    } else if values.iter().any(|value| likely_audio_name_signal(value)) {
-        caps.upgrade_audio(CapabilityLevel::Likely);
-    }
-
-    if values
-        .iter()
-        .any(|value| strong_reasoning_name_signal(value))
-    {
-        caps.upgrade_reasoning(CapabilityLevel::Supported);
-    } else if values
-        .iter()
-        .any(|value| likely_reasoning_name_signal(value))
-    {
-        caps.upgrade_reasoning(CapabilityLevel::Likely);
-    }
-
-    if values
-        .iter()
-        .any(|value| strong_tool_use_name_signal(value))
-    {
-        caps.upgrade_tool_use(CapabilityLevel::Supported);
-    } else if values
-        .iter()
-        .any(|value| likely_tool_use_name_signal(value))
-    {
-        caps.upgrade_tool_use(CapabilityLevel::Likely);
+    for value in values {
+        merge_name_signal(&mut caps, value, true);
     }
 
     caps.normalize()
@@ -275,119 +233,65 @@ pub fn merge_config_signals(mut caps: ModelCapabilities, config: &Value) -> Mode
         }
     }
 
-    if config
-        .get("architectures")
-        .and_then(|value| value.as_array())
-        .into_iter()
-        .flatten()
-        .filter_map(|value| value.as_str())
-        .any(strong_vision_name_signal)
-    {
-        caps.upgrade_vision(CapabilityLevel::Supported);
-    }
-
-    if config
-        .get("architectures")
-        .and_then(|value| value.as_array())
-        .into_iter()
-        .flatten()
-        .filter_map(|value| value.as_str())
-        .any(strong_audio_name_signal)
-    {
-        caps.upgrade_audio(CapabilityLevel::Supported);
-    } else if config
-        .get("architectures")
-        .and_then(|value| value.as_array())
-        .into_iter()
-        .flatten()
-        .filter_map(|value| value.as_str())
-        .any(likely_audio_name_signal)
-    {
-        caps.upgrade_audio(CapabilityLevel::Likely);
-    }
-
-    if config
-        .get("model_type")
-        .and_then(|value| value.as_str())
-        .map(strong_vision_name_signal)
-        .unwrap_or(false)
-    {
-        caps.upgrade_vision(CapabilityLevel::Supported);
-    }
-
-    if let Some(model_type) = config.get("model_type").and_then(|value| value.as_str()) {
-        if strong_audio_name_signal(model_type) {
-            caps.upgrade_audio(CapabilityLevel::Supported);
-        } else if likely_audio_name_signal(model_type) {
-            caps.upgrade_audio(CapabilityLevel::Likely);
+    if let Some(architectures) = config.get("architectures").and_then(Value::as_array) {
+        for architecture in architectures.iter().filter_map(Value::as_str) {
+            merge_name_signal(&mut caps, architecture, false);
         }
+    }
+
+    if let Some(model_type) = config.get("model_type").and_then(Value::as_str) {
+        merge_name_signal(&mut caps, model_type, false);
     }
 
     if json_contains_reasoning_tokens(config) {
         caps.upgrade_reasoning(CapabilityLevel::Supported);
     }
 
-    if config
-        .get("architectures")
-        .and_then(|value| value.as_array())
-        .into_iter()
-        .flatten()
-        .filter_map(|value| value.as_str())
-        .any(strong_reasoning_name_signal)
-    {
-        caps.upgrade_reasoning(CapabilityLevel::Supported);
-    } else if config
-        .get("architectures")
-        .and_then(|value| value.as_array())
-        .into_iter()
-        .flatten()
-        .filter_map(|value| value.as_str())
-        .any(likely_reasoning_name_signal)
-    {
-        caps.upgrade_reasoning(CapabilityLevel::Likely);
-    }
-
-    if let Some(model_type) = config.get("model_type").and_then(|value| value.as_str()) {
-        if strong_reasoning_name_signal(model_type) {
-            caps.upgrade_reasoning(CapabilityLevel::Supported);
-        } else if likely_reasoning_name_signal(model_type) {
-            caps.upgrade_reasoning(CapabilityLevel::Likely);
-        }
-    }
-
     if json_contains_tool_use_tokens(config) {
         caps.upgrade_tool_use(CapabilityLevel::Supported);
     }
 
-    if config
-        .get("architectures")
-        .and_then(|value| value.as_array())
-        .into_iter()
-        .flatten()
-        .filter_map(|value| value.as_str())
-        .any(strong_tool_use_name_signal)
-    {
-        caps.upgrade_tool_use(CapabilityLevel::Supported);
-    } else if config
-        .get("architectures")
-        .and_then(|value| value.as_array())
-        .into_iter()
-        .flatten()
-        .filter_map(|value| value.as_str())
-        .any(likely_tool_use_name_signal)
-    {
-        caps.upgrade_tool_use(CapabilityLevel::Likely);
-    }
-
-    if let Some(model_type) = config.get("model_type").and_then(|value| value.as_str()) {
-        if strong_tool_use_name_signal(model_type) {
-            caps.upgrade_tool_use(CapabilityLevel::Supported);
-        } else if likely_tool_use_name_signal(model_type) {
-            caps.upgrade_tool_use(CapabilityLevel::Likely);
-        }
-    }
-
     caps.normalize()
+}
+
+fn merge_name_signal(caps: &mut ModelCapabilities, value: &str, allow_likely_vision: bool) {
+    let vision = if strong_vision_name_signal(value) {
+        CapabilityLevel::Supported
+    } else if allow_likely_vision && likely_vision_name_signal(value) {
+        CapabilityLevel::Likely
+    } else {
+        CapabilityLevel::None
+    };
+    caps.upgrade_vision(vision);
+    caps.upgrade_audio(name_signal_level(
+        value,
+        strong_audio_name_signal,
+        likely_audio_name_signal,
+    ));
+    caps.upgrade_reasoning(name_signal_level(
+        value,
+        strong_reasoning_name_signal,
+        likely_reasoning_name_signal,
+    ));
+    caps.upgrade_tool_use(name_signal_level(
+        value,
+        strong_tool_use_name_signal,
+        likely_tool_use_name_signal,
+    ));
+}
+
+fn name_signal_level(
+    value: &str,
+    strong: fn(&str) -> bool,
+    likely: fn(&str) -> bool,
+) -> CapabilityLevel {
+    if strong(value) {
+        CapabilityLevel::Supported
+    } else if likely(value) {
+        CapabilityLevel::Likely
+    } else {
+        CapabilityLevel::None
+    }
 }
 
 fn strong_vision_name_signal(value: &str) -> bool {
@@ -558,7 +462,134 @@ fn json_contains_tool_use_tokens(value: &Value) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use super::{CapabilityLevel, merge_name_signals};
+    use serde_json::json;
+
+    use super::{
+        CapabilityLevel, ModelCapabilities, merge_config_signals, merge_name_signals,
+        merge_sibling_signals,
+    };
+
+    #[test]
+    fn capability_level_status_and_label_matrix_is_stable() {
+        let cases = [
+            (CapabilityLevel::None, "none", None),
+            (CapabilityLevel::Likely, "likely", Some("likely")),
+            (CapabilityLevel::Supported, "supported", Some("yes")),
+        ];
+
+        for (level, expected_status, expected_label) in cases {
+            let caps = ModelCapabilities {
+                vision: level,
+                audio: level,
+                reasoning: level,
+                tool_use: level,
+                ..Default::default()
+            };
+
+            assert_eq!(caps.vision_status(), expected_status);
+            assert_eq!(caps.vision_label(), expected_label);
+            assert_eq!(caps.audio_status(), expected_status);
+            assert_eq!(caps.audio_label(), expected_label);
+            assert_eq!(caps.reasoning_status(), expected_status);
+            assert_eq!(caps.reasoning_label(), expected_label);
+            assert_eq!(caps.tool_use_status(), expected_status);
+            assert_eq!(caps.tool_use_label(), expected_label);
+        }
+    }
+
+    #[test]
+    fn strong_name_evidence_dominates_likely_and_existing_values() {
+        let caps = ModelCapabilities {
+            vision: CapabilityLevel::Likely,
+            audio: CapabilityLevel::Supported,
+            reasoning: CapabilityLevel::Likely,
+            tool_use: CapabilityLevel::Likely,
+            ..Default::default()
+        };
+
+        let merged = merge_name_signals(
+            caps,
+            &["generic-image-model", "Whisper-Reasoning-Tool-Calling"],
+        );
+
+        assert_eq!(merged.vision, CapabilityLevel::Likely);
+        assert_eq!(merged.audio, CapabilityLevel::Supported);
+        assert_eq!(merged.reasoning, CapabilityLevel::Supported);
+        assert_eq!(merged.tool_use, CapabilityLevel::Supported);
+        assert!(merged.multimodal);
+    }
+
+    #[test]
+    fn config_architectures_preserve_all_capability_results() {
+        let config = json!({
+            "architectures": [
+                "Qwen3VLForConditionalGeneration",
+                "WhisperForConditionalGeneration",
+                "ReasoningToolCallingModel"
+            ],
+            "model_type": "generic"
+        });
+
+        let caps = merge_config_signals(Default::default(), &config);
+
+        assert_eq!(caps.vision, CapabilityLevel::Supported);
+        assert_eq!(caps.audio, CapabilityLevel::Supported);
+        assert_eq!(caps.reasoning, CapabilityLevel::Supported);
+        assert_eq!(caps.tool_use, CapabilityLevel::Likely);
+        assert!(caps.multimodal);
+    }
+
+    #[test]
+    fn config_model_type_preserves_likely_and_supported_levels() {
+        let likely = merge_config_signals(
+            Default::default(),
+            &json!({ "model_type": "voice-r1-coding" }),
+        );
+        let supported = merge_config_signals(
+            Default::default(),
+            &json!({ "model_type": "qwen3vl-whisper-reasoning-tool-calling" }),
+        );
+
+        assert_eq!(likely.vision, CapabilityLevel::None);
+        assert_eq!(likely.audio, CapabilityLevel::Likely);
+        assert_eq!(likely.reasoning, CapabilityLevel::Likely);
+        assert_eq!(likely.tool_use, CapabilityLevel::Likely);
+        assert_eq!(supported.vision, CapabilityLevel::Supported);
+        assert_eq!(supported.audio, CapabilityLevel::Supported);
+        assert_eq!(supported.reasoning, CapabilityLevel::Supported);
+        assert_eq!(supported.tool_use, CapabilityLevel::Supported);
+    }
+
+    #[test]
+    fn sibling_signals_preserve_current_extension_precedence() {
+        let caps = merge_sibling_signals(
+            Default::default(),
+            [
+                "model-mmproj.gguf",
+                "audio-adapter.bin",
+                "tokenizer_config.json",
+                "function-template.json",
+            ],
+        );
+
+        assert_eq!(caps.vision, CapabilityLevel::Supported);
+        assert_eq!(caps.audio, CapabilityLevel::Likely);
+        assert_eq!(caps.reasoning, CapabilityLevel::Likely);
+        assert_eq!(caps.tool_use, CapabilityLevel::Likely);
+        assert!(caps.multimodal);
+    }
+
+    #[test]
+    fn unknown_metadata_remains_unknown_without_false_positive() {
+        let config = json!({
+            "architectures": ["PlainCausalLM"],
+            "model_type": "plain_text"
+        });
+
+        let caps = merge_config_signals(Default::default(), &config);
+
+        assert_eq!(caps, ModelCapabilities::default());
+    }
 
     #[test]
     fn qwen3vl_name_signal_is_supported_vision() {

--- a/crates/mesh-llm-types/src/models/capabilities.rs
+++ b/crates/mesh-llm-types/src/models/capabilities.rs
@@ -11,11 +11,11 @@ pub enum CapabilityLevel {
 }
 
 impl CapabilityLevel {
-    fn is_supported(self) -> bool {
-        self == Self::Supported
+    const fn is_supported(self) -> bool {
+        matches!(self, Self::Supported)
     }
 
-    fn status(self) -> &'static str {
+    const fn status(self) -> &'static str {
         match self {
             Self::Supported => "supported",
             Self::Likely => "likely",
@@ -23,7 +23,7 @@ impl CapabilityLevel {
         }
     }
 
-    fn label(self) -> Option<&'static str> {
+    const fn label(self) -> Option<&'static str> {
         match self {
             Self::Supported => Some("yes"),
             Self::Likely => Some("likely"),
@@ -255,26 +255,27 @@ pub fn merge_config_signals(mut caps: ModelCapabilities, config: &Value) -> Mode
 }
 
 fn merge_name_signal(caps: &mut ModelCapabilities, value: &str, allow_likely_vision: bool) {
-    let vision = if strong_vision_name_signal(value) {
-        CapabilityLevel::Supported
-    } else if allow_likely_vision && likely_vision_name_signal(value) {
-        CapabilityLevel::Likely
-    } else {
-        CapabilityLevel::None
-    };
-    caps.upgrade_vision(vision);
+    caps.upgrade_vision(name_signal_level(
+        value,
+        allow_likely_vision,
+        strong_vision_name_signal,
+        likely_vision_name_signal,
+    ));
     caps.upgrade_audio(name_signal_level(
         value,
+        true,
         strong_audio_name_signal,
         likely_audio_name_signal,
     ));
     caps.upgrade_reasoning(name_signal_level(
         value,
+        true,
         strong_reasoning_name_signal,
         likely_reasoning_name_signal,
     ));
     caps.upgrade_tool_use(name_signal_level(
         value,
+        true,
         strong_tool_use_name_signal,
         likely_tool_use_name_signal,
     ));
@@ -282,12 +283,13 @@ fn merge_name_signal(caps: &mut ModelCapabilities, value: &str, allow_likely_vis
 
 fn name_signal_level(
     value: &str,
+    allow_likely: bool,
     strong: fn(&str) -> bool,
     likely: fn(&str) -> bool,
 ) -> CapabilityLevel {
     if strong(value) {
         CapabilityLevel::Supported
-    } else if likely(value) {
+    } else if allow_likely && likely(value) {
         CapabilityLevel::Likely
     } else {
         CapabilityLevel::None
@@ -469,6 +471,10 @@ mod tests {
         merge_sibling_signals,
     };
 
+    const _: bool = CapabilityLevel::Supported.is_supported();
+    const _: &str = CapabilityLevel::Likely.status();
+    const _: Option<&str> = CapabilityLevel::None.label();
+
     #[test]
     fn capability_level_status_and_label_matrix_is_stable() {
         let cases = [
@@ -498,7 +504,7 @@ mod tests {
     }
 
     #[test]
-    fn strong_name_evidence_dominates_likely_and_existing_values() {
+    fn name_signals_only_upgrade_existing_levels() {
         let caps = ModelCapabilities {
             vision: CapabilityLevel::Likely,
             audio: CapabilityLevel::Supported,

--- a/crates/model-artifact/src/lib.rs
+++ b/crates/model-artifact/src/lib.rs
@@ -165,73 +165,71 @@ fn select_primary_file(
     let safetensors_exact = format!("{selector}.safetensors").to_ascii_lowercase();
     let safetensors_split_prefix = format!("{selector}-00001-of-").to_ascii_lowercase();
 
-    files
-        .iter()
-        .filter_map(|file| {
-            let lower = file.path.to_ascii_lowercase();
-            let basename = basename_lower(&file.path);
-            let rank = if lower == selector_lower || basename == selector_lower {
-                0
-            } else if gguf_matches_quant_selector(&file.path, selector) {
-                1
-            } else if basename == safetensors_exact {
-                2
-            } else if basename.starts_with(&safetensors_split_prefix)
-                && basename.ends_with(".safetensors")
-            {
-                3
-            } else if basename == gguf_exact {
-                4
-            } else if basename.starts_with(&gguf_split_prefix) && basename.ends_with(".gguf") {
-                5
-            } else {
-                return None;
-            };
-            Some((
-                rank,
-                artifact_preference_score(&file.path),
-                file.path.clone(),
-                file.clone(),
-            ))
-        })
-        .min_by(|left, right| (left.0, left.1, &left.2).cmp(&(right.0, right.1, &right.2)))
-        .map(|(_, _, _, file)| file)
-        .ok_or_else(|| {
-            anyhow::anyhow!("no model artifact matching selector '{selector}' in repository")
-        })
+    select_ranked_file(files, |file, lower, basename| {
+        if lower == selector_lower || basename == selector_lower {
+            Some(0)
+        } else if gguf_matches_quant_selector(&file.path, selector) {
+            Some(1)
+        } else if basename == safetensors_exact {
+            Some(2)
+        } else if basename.starts_with(&safetensors_split_prefix)
+            && basename.ends_with(".safetensors")
+        {
+            Some(3)
+        } else if basename == gguf_exact {
+            Some(4)
+        } else if basename.starts_with(&gguf_split_prefix) && basename.ends_with(".gguf") {
+            Some(5)
+        } else {
+            None
+        }
+    })
+    .ok_or_else(|| {
+        anyhow::anyhow!("no model artifact matching selector '{selector}' in repository")
+    })
 }
 
 fn select_default_file(files: &[ModelArtifactFile]) -> Result<ModelArtifactFile> {
+    select_ranked_file(files, |_file, lower, basename| {
+        if basename == "model.safetensors" {
+            Some(0)
+        } else if is_split_safetensors_first_shard(basename) {
+            Some(1)
+        } else if lower.ends_with(".gguf") {
+            if is_known_gguf_sidecar(basename) {
+                return None;
+            }
+            if lower.contains("-000") && !lower.contains("-00001-of-") {
+                return None;
+            }
+            Some(if lower.contains("-00001-of-") { 2 } else { 3 })
+        } else {
+            None
+        }
+    })
+    .ok_or_else(|| anyhow::anyhow!("no supported model artifact files found in repository"))
+}
+
+fn select_ranked_file(
+    files: &[ModelArtifactFile],
+    mut rank: impl FnMut(&ModelArtifactFile, &str, &str) -> Option<u8>,
+) -> Option<ModelArtifactFile> {
     files
         .iter()
         .filter_map(|file| {
             let lower = file.path.to_ascii_lowercase();
             let basename = basename_lower(&file.path);
-            let rank = if basename == "model.safetensors" {
-                0
-            } else if is_split_safetensors_first_shard(&basename) {
-                1
-            } else if lower.ends_with(".gguf") {
-                if is_known_gguf_sidecar(&basename) {
-                    return None;
-                }
-                if lower.contains("-000") && !lower.contains("-00001-of-") {
-                    return None;
-                }
-                if lower.contains("-00001-of-") { 2 } else { 3 }
-            } else {
-                return None;
-            };
-            Some((
-                rank,
-                artifact_preference_score(&file.path),
-                file.path.clone(),
-                file.clone(),
-            ))
+            rank(file, &lower, &basename).map(|rank| {
+                (
+                    rank,
+                    artifact_preference_score(&file.path),
+                    file.path.as_str(),
+                    file,
+                )
+            })
         })
-        .min_by(|left, right| (left.0, left.1, &left.2).cmp(&(right.0, right.1, &right.2)))
-        .map(|(_, _, _, file)| file)
-        .ok_or_else(|| anyhow::anyhow!("no supported model artifact files found in repository"))
+        .min_by(|left, right| (left.0, left.1, left.2).cmp(&(right.0, right.1, right.2)))
+        .map(|(_, _, _, file)| file.clone())
 }
 
 fn artifact_file_set(primary_file: &str, files: &[ModelArtifactFile]) -> Vec<ModelArtifactFile> {
@@ -449,6 +447,27 @@ mod tests {
     }
 
     #[test]
+    fn exact_filename_precedes_quant_selector_match() {
+        let files = files(&["Model-Q4_K_M.gguf", "Q4_K_M"]);
+
+        let selected = select_primary_artifact_file(Some("Q4_K_M"), &files).unwrap();
+
+        assert_eq!(selected.path, "Q4_K_M");
+    }
+
+    #[test]
+    fn selector_ranking_is_independent_of_input_order() {
+        let first_order = files(&["z/Model-Q4_K_M.gguf", "a/Model-Q4_K_M.gguf"]);
+        let second_order = files(&["a/Model-Q4_K_M.gguf", "z/Model-Q4_K_M.gguf"]);
+
+        let first = select_primary_artifact_file(Some("Q4_K_M"), &first_order).unwrap();
+        let second = select_primary_artifact_file(Some("Q4_K_M"), &second_order).unwrap();
+
+        assert_eq!(first.path, "a/Model-Q4_K_M.gguf");
+        assert_eq!(second.path, first.path);
+    }
+
+    #[test]
     fn public_selector_api_resolves_mesh_mlx_shorthand() {
         let files = files(&[
             "model-00002-of-00048.safetensors",
@@ -485,6 +504,18 @@ mod tests {
         let selected = select_primary_artifact_file(None, &files).unwrap();
 
         assert_eq!(selected.path, "model.safetensors");
+    }
+
+    #[test]
+    fn default_selection_rejects_sidecars_and_non_first_split_shards() {
+        let files = files(&["mmproj-model-f16.gguf", "Model-Q4_K_M-00002-of-00002.gguf"]);
+
+        let error = select_primary_artifact_file(None, &files).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "no supported model artifact files found in repository"
+        );
     }
 
     #[test]
@@ -549,10 +580,9 @@ mod tests {
             .await
             .unwrap_err();
 
-        assert!(
-            error
-                .to_string()
-                .contains("no model artifact matching selector")
+        assert_eq!(
+            error.to_string(),
+            "no model artifact matching selector 'Q5_K_M' in repository"
         );
     }
 }


### PR DESCRIPTION
## Summary

Reduces duplicated routing, model-selection, capability-detection, and lifecycle code while preserving existing behavior and compatibility.

This work follows an audit of all 56 workspace crates and retains only reductions with measurable production-code or runtime benefits.

## Changes

- Share prefix-affinity TTL/LRU mechanics between host and client routing.
- Consolidate model-artifact candidate ranking.
- Reduce repeated model-capability matches and metadata scans.
- Consolidate owner-control lifecycle request construction.
- Replace duplicated model-target payload maps with lightweight indexes.
- Add characterization coverage for ordering, precedence, expiry, eviction, errors, and mixed-version behavior.

## Impact

- Approximately **115 fewer raw production lines**.
- Approximately **120 fewer nonblank production lines**.
- Removes 30 `if` and 6 `match` nodes.
- Avoids up to two full `ModelTargetPayload` clones per target.
- Removes one duplicated prefix-affinity state machine.
- No public API, mesh protocol, plugin protocol, Skippy ABI, serialization, or dependency-policy changes.

Total repository LoC increases because of the added characterization and integration tests.

## Validation

- Focused tests, package checks, and warning-denying Clippy checks passed.
- `cargo fmt --all --check` and changed-file diagnostics passed.
- `just build` passed.
- Two-node client/serving routing smoke passed.
- Mixed-version v0.72.0/v0.72.1 routing passed in both directions.
- Mixed-version load, unload, ensure, drain, and legacy `control_unsupported` behavior passed.
- A complete `just test-all` run passed.

Subsequent exact-final-state suite reruns encountered unrelated existing system and UI flakes. Each failing test passed in isolated repeated runs; none touches files changed by this PR.

## Compatibility

This change is behavior-preserving:

- Host and client request-key precedence remain distinct.
- Host health, reputation, and auto-model state remain host-owned.
- Lifecycle request IDs, timeouts, errors, and legacy fallback remain unchanged.
- Model-target ordering and alias precedence remain unchanged.
- Model selection, split-shard ordering, capability projections, and serialized output remain unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streamlined control-plane model lifecycle commands (load/unload/ensure/drain) with consistent handling and preserved request tracking.
  * Enhanced prefix-based routing affinity, including TTL pruning, capacity eviction, and richer hit/miss/stale/learning counters.

* **Bug Fixes**
  * More reliable model target resolution by name or reference, improving readiness/capacity reporting.
  * Deterministic model artifact selection with clearer rejection of unsupported artifacts.

* **Tests**
  * Added/expanded integration and unit tests, including normalized terminal output assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->