### PR TITLE
Rename the Node SDK npm package scope

### DIFF
--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -9,7 +9,7 @@ MeshLLM exposes two SDK roles across Rust, Swift, Kotlin, and Node.js:
 The SDK is split into two parts:
 
 - **Language SDKs** provide the public API: Rust `mesh-llm-sdk`, Swift
-  `MeshLLM`, Kotlin `ai.meshllm`, and Node.js `@meshllm/sdk`.
+  `MeshLLM`, Kotlin `ai.meshllm`, and Node.js `@mesh-llm/sdk`.
 - **Native runtime artifacts** provide local serving for a specific
   platform/runtime flavor, such as macOS Metal or Linux CUDA.
 
@@ -43,7 +43,7 @@ The SDK packages are published from MeshLLM releases:
 | SDK | Package source |
 |---|---|
 | Rust | crates.io package `mesh-llm-sdk` |
-| Node.js | npm package `@meshllm/sdk` |
+| Node.js | npm package `@mesh-llm/sdk` |
 | Swift | GitHub Swift package from tagged `Mesh-LLM/mesh-llm` releases |
 | Kotlin/Android | GitHub Packages Maven registry for `Mesh-LLM/mesh-llm` |
 | Native runtimes | GitHub release artifacts plus `native-runtimes.json` |
@@ -135,7 +135,7 @@ See [Kotlin SDK examples](sdk/kotlin.md).
 Install the Node package in a Node.js or Electron app:
 
 ```bash
-npm install @meshllm/sdk
+npm install @mesh-llm/sdk
 ```
 
 When building from this repository, build the native N-API addon first:

--- a/docs/sdk/node.md
+++ b/docs/sdk/node.md
@@ -1,11 +1,11 @@
 # Node.js SDK
 
-Use `@meshllm/sdk` from npm for Node.js and Electron applications.
+Use `@mesh-llm/sdk` from npm for Node.js and Electron applications.
 
 ## Install
 
 ```bash
-npm install @meshllm/sdk
+npm install @mesh-llm/sdk
 ```
 
 When building from this repository, build the native N-API addon first:
@@ -17,11 +17,11 @@ npm run build:native
 
 ## Client: Public Mesh
 
-Node.js public discovery helpers are not currently exported by `@meshllm/sdk`.
+Node.js public discovery helpers are not currently exported by `@mesh-llm/sdk`.
 Use a public invite token selected by your app or service.
 
 ```js
-const { Client, generateOwnerKeypairHex } = require('@meshllm/sdk')
+const { Client, generateOwnerKeypairHex } = require('@mesh-llm/sdk')
 
 const client = Client.create({
   ownerKeypairHex: generateOwnerKeypairHex(),
@@ -41,7 +41,7 @@ await client.stop()
 ## Client: Private Mesh
 
 ```js
-const { Client, generateOwnerKeypairHex } = require('@meshllm/sdk')
+const { Client, generateOwnerKeypairHex } = require('@mesh-llm/sdk')
 
 const client = Client.create({
   ownerKeypairHex: generateOwnerKeypairHex(),
@@ -63,7 +63,7 @@ await client.stop()
 Install or resolve a native runtime before starting local serving:
 
 ```js
-const { resolveNativeRuntime } = require('@meshllm/sdk')
+const { resolveNativeRuntime } = require('@mesh-llm/sdk')
 
 await resolveNativeRuntime({
   artifactDir: process.env.MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR,
@@ -75,7 +75,7 @@ await resolveNativeRuntime({
 ## Serving: Public Mesh
 
 ```js
-const { Node, generateOwnerKeypairHex, resolveNativeRuntime } = require('@meshllm/sdk')
+const { Node, generateOwnerKeypairHex, resolveNativeRuntime } = require('@mesh-llm/sdk')
 
 await resolveNativeRuntime({
   artifactDir: process.env.MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR,
@@ -125,7 +125,7 @@ console as package resources. Use the package helper to find those assets in
 normal package usage:
 
 ```js
-const { defaultConsoleAssetDir } = require('@meshllm/sdk')
+const { defaultConsoleAssetDir } = require('@mesh-llm/sdk')
 
 const assetDir = defaultConsoleAssetDir()
 ```

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -10,7 +10,7 @@ path as the Swift and Kotlin SDKs.
 ## Install
 
 ```bash
-npm install @meshllm/sdk
+npm install @mesh-llm/sdk
 ```
 
 Release packages include prebuilt addons for macOS arm64/x64, Linux arm64/x64,
@@ -35,7 +35,7 @@ packaged Node addon is renamed to `mesh_llm_nodejs.node`.
 ## Client Mode
 
 ```js
-const { Client, generateOwnerKeypairHex } = require('@meshllm/sdk')
+const { Client, generateOwnerKeypairHex } = require('@mesh-llm/sdk')
 
 const client = Client.create({
   ownerKeypairHex: generateOwnerKeypairHex(),
@@ -67,7 +67,7 @@ const {
   Node,
   generateOwnerKeypairHex,
   resolveNativeRuntime
-} = require('@meshllm/sdk')
+} = require('@mesh-llm/sdk')
 
 const runtime = await resolveNativeRuntime({
   artifactDir: process.env.MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR,

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@meshllm/sdk",
+  "name": "@mesh-llm/sdk",
   "version": "0.72.1",
   "description": "Node.js SDK for MeshLLM client and local serving applications",
   "main": "index.js",

--- a/website/src/docs/pages/sdk-node.md
+++ b/website/src/docs/pages/sdk-node.md
@@ -4,12 +4,12 @@ title: Node.js and Electron SDK
 
 # Node.js and Electron SDK
 
-Use [`@meshllm/sdk`](https://www.npmjs.com/package/@meshllm/sdk) in Node.js services, desktop apps, and Electron applications. The package uses a native N-API addon and the same embedded serving path as the Swift and Kotlin SDKs.
+Use [`@mesh-llm/sdk`](https://www.npmjs.com/package/@mesh-llm/sdk) in Node.js services, desktop apps, and Electron applications. The package uses a native N-API addon and the same embedded serving path as the Swift and Kotlin SDKs.
 
 ## Install
 
 ```bash
-npm install @meshllm/sdk
+npm install @mesh-llm/sdk
 ```
 
 When building from the repository, build the addon first:
@@ -22,7 +22,7 @@ npm run build:native
 ## Connect as a client
 
 ```js
-const { Client, generateOwnerKeypairHex } = require('@meshllm/sdk')
+const { Client, generateOwnerKeypairHex } = require('@mesh-llm/sdk')
 
 const client = Client.create({
   ownerKeypairHex: generateOwnerKeypairHex(),
@@ -49,7 +49,7 @@ The current package expects an invite token selected by the app or service. Use 
 Serving needs a verified native runtime artifact. Bundle one with the app or explicitly allow the SDK to download a compatible release runtime:
 
 ```js
-const { resolveNativeRuntime } = require('@meshllm/sdk')
+const { resolveNativeRuntime } = require('@mesh-llm/sdk')
 
 const runtime = await resolveNativeRuntime({
   artifactDir: process.env.MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR,
@@ -66,7 +66,7 @@ const {
   Node,
   generateOwnerKeypairHex,
   resolveNativeRuntime
-} = require('@meshllm/sdk')
+} = require('@mesh-llm/sdk')
 
 await resolveNativeRuntime({
   artifactDir: process.env.MESHLLM_NATIVE_RUNTIME_ARTIFACT_DIR,


### PR DESCRIPTION
Summary

- rename the Node SDK package from the unavailable @meshllm/sdk scope to the owned @mesh-llm/sdk scope
- update the package manifest, SDK guides, examples, and maintained website source
- keep the package repository metadata pointed at Mesh-LLM/mesh-packaging, which owns npm publication

Validation

- npm test --prefix sdk/node
- npm pack --dry-run --json (confirmed package name @mesh-llm/sdk)
- just website-build
- generated sdk-node page inspected for the canonical name
- just check-release
- git diff --check

The website build completed successfully after npm ci installed the locked website dependencies. No package publication is performed by this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Corrected the Node.js SDK package name to `@mesh-llm/sdk` across installation instructions and code examples.
  * Updated examples for client mode, local serving, runtime resolution, and Electron usage.
* **Bug Fixes**
  * Aligned the published Node.js package name with the documented installation and import commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->