### PR TITLE
Document canonical Homebrew tap

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,9 @@ On Windows, use PowerShell:
 irm https://raw.githubusercontent.com/Mesh-LLM/mesh-llm/main/install.ps1 | iex
 ```
 
-Versioned Homebrew formulas, Ubuntu and Arch packages, checksums, SBOMs, and
-OCI images are available from the public
+Install the Apple Silicon Homebrew formula with
+`brew install Mesh-LLM/tap/mesh-llm`. Versioned formulas, Ubuntu and Arch
+packages, checksums, SBOMs, and OCI images are produced by the public
 [`Mesh-LLM/mesh-packaging`](https://github.com/Mesh-LLM/mesh-packaging)
 repository. See the [platform install guides](https://meshllm.cloud/docs/pages/installing-mesh/)
 for the supported package matrix and install commands.

--- a/docs/setup-mesh
+++ b/docs/setup-mesh
@@ -171,8 +171,14 @@ irm https://meshllm.cloud/install.ps1 | iex
 The `curl ... | bash` invocation pipes stdin, so the installer cannot auto-run
 the interactive setup step; it prints the setup command instead. Afterwards, open
 a new shell if necessary and verify `mesh-llm --version` and `mesh-llm --help`.
-Do not recommend Homebrew unless its current availability has been independently
-verified.
+
+On Apple Silicon macOS, the canonical Homebrew tap is also available:
+
+```sh
+brew install Mesh-LLM/tap/mesh-llm
+```
+
+Intel macOS is not currently available through Homebrew.
 
 If an installed release is behind, explain the difference and ask before
 running:

--- a/install.md
+++ b/install.md
@@ -171,8 +171,14 @@ irm https://meshllm.cloud/install.ps1 | iex
 The `curl ... | bash` invocation pipes stdin, so the installer cannot auto-run
 the interactive setup step; it prints the setup command instead. Afterwards, open
 a new shell if necessary and verify `mesh-llm --version` and `mesh-llm --help`.
-Do not recommend Homebrew unless its current availability has been independently
-verified.
+
+On Apple Silicon macOS, the canonical Homebrew tap is also available:
+
+```sh
+brew install Mesh-LLM/tap/mesh-llm
+```
+
+Intel macOS is not currently available through Homebrew.
 
 If an installed release is behind, explain the difference and ask before
 running:

--- a/website/src/docs/pages/installing-macos.md
+++ b/website/src/docs/pages/installing-macos.md
@@ -22,25 +22,20 @@ mesh-llm --version
 
 ## Homebrew
 
-Mesh publishes a versioned Homebrew formula for Apple Silicon with each
-[packaging release](https://github.com/Mesh-LLM/mesh-packaging/releases). The
-formula is a release asset rather than a tap, so download it before installing:
+Mesh publishes a versioned Homebrew formula for Apple Silicon through the
+canonical [`Mesh-LLM/tap`](https://github.com/Mesh-LLM/homebrew-tap) tap:
 
 ```sh
-brew tap-new mesh-llm/release
-curl -fL https://github.com/Mesh-LLM/mesh-packaging/releases/latest/download/mesh-llm.rb \
-  -o "$(brew --repository mesh-llm/release)/Formula/mesh-llm.rb"
-brew install mesh-llm/release/mesh-llm
+brew install Mesh-LLM/tap/mesh-llm
 ```
 
-Homebrew requires formulae to live in a tap. The first command creates a local
-tap; it does not clone or depend on a public `Mesh-LLM/homebrew-tap` repository.
-To update later, download the latest formula to the same path and run
-`brew upgrade mesh-llm`.
+The fully qualified formula name adds the tap automatically. Update later with
+`brew update` followed by `brew upgrade mesh-llm`.
 
 The formula downloads the checksummed Metal release archive from
-`Mesh-LLM/mesh-llm`. Intel macOS is not available through Homebrew because the
-upstream release does not include an x86_64 macOS archive.
+`Mesh-LLM/mesh-llm`. `Mesh-LLM/mesh-packaging` produces and validates each
+formula before the tap publishes it. Intel macOS is not available through
+Homebrew because the upstream release does not include an x86_64 macOS archive.
 
 ## What the installer does
 

--- a/website/src/docs/pages/installing-mesh.md
+++ b/website/src/docs/pages/installing-mesh.md
@@ -10,8 +10,9 @@ The shell and PowerShell installers below remain the simplest installation
 path. Versioned Homebrew formulas, Linux native packages, checksums, SBOMs, and
 OCI images are published by the public
 [`Mesh-LLM/mesh-packaging`](https://github.com/Mesh-LLM/mesh-packaging)
-repository. Homebrew is provided as a release formula rather than a tap, and
-Linux packages are release assets rather than apt or pacman repositories.
+repository. Homebrew formulas are published through the canonical
+[`Mesh-LLM/tap`](https://github.com/Mesh-LLM/homebrew-tap) tap, while Linux
+packages are release assets rather than apt or pacman repositories.
 
 ## Choose your platform
 


### PR DESCRIPTION
## Summary

- replace the temporary local-tap workaround with `brew install Mesh-LLM/tap/mesh-llm`
- document automatic tap updates and Apple Silicon support
- publish the verified Homebrew path in the installer guidance and README

## Validation

- public `brew install Mesh-LLM/tap/mesh-llm`
- `brew test Mesh-LLM/tap/mesh-llm`
- `just website-build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Added Apple Silicon macOS installation instructions using the official Homebrew tap.
  - Updated macOS guidance with the command to install and upgrade Mesh.
  - Clarified that Intel macOS is not supported through Homebrew.
  - Clarified that Linux packages are distributed as release assets rather than apt or pacman repositories.
  - Updated installation documentation to reflect current Homebrew and release distribution details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->