### PR TITLE
Fix release host dependency verifier invocation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -159,7 +159,7 @@ jobs:
             --binary host-input/mesh-llm \
             --public-key-file "$MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE" \
             --json
-          scripts/verify-host-dependencies.py \
+          python3 scripts/verify-host-dependencies.py \
             host-input/mesh-llm \
             --report host-input/host-imports.json
           shasum -a 256 host-input/mesh-llm | awk '{print $1 "  mesh-llm"}' > host-input/mesh-llm.sha256
@@ -775,7 +775,7 @@ jobs:
           cargo run -q -p xtask -- release-attestation stamp \
             --binary host-input/mesh-llm \
             --signing-key-file "$MESH_RELEASE_ATTESTATION_SIGNING_KEY_FILE"
-          scripts/verify-host-dependencies.py \
+          python3 scripts/verify-host-dependencies.py \
             host-input/mesh-llm \
             --report host-input/host-imports.json
           shasum -a 256 host-input/mesh-llm | awk '{print $1 "  mesh-llm"}' > host-input/mesh-llm.sha256

--- a/scripts/tests/test_verify_host_dependencies.py
+++ b/scripts/tests/test_verify_host_dependencies.py
@@ -7,6 +7,7 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "verify-host-dependencies.py"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 SPEC = importlib.util.spec_from_file_location("verify_host_dependencies", SCRIPT)
 assert SPEC is not None and SPEC.loader is not None
 MODULE = importlib.util.module_from_spec(SPEC)
@@ -14,6 +15,18 @@ SPEC.loader.exec_module(MODULE)
 
 
 class VerifyHostDependenciesTests(unittest.TestCase):
+    def test_release_workflow_uses_python_for_non_executable_verifier(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertEqual(
+            workflow.count("python3 scripts/verify-host-dependencies.py"),
+            2,
+        )
+        self.assertNotIn(
+            "\n          scripts/verify-host-dependencies.py",
+            workflow,
+        )
+
     def test_parses_elf_needed_entries(self) -> None:
         imports = MODULE.parse_elf_imports(
             """


### PR DESCRIPTION
## Summary

- invoke the non-executable host dependency verifier through `python3` in Unix release jobs
- cover both neutral-host and Linux ARM64 host producers
- add a regression assertion for the release workflow

## Validation

- `python3 -m unittest scripts.tests.test_verify_host_dependencies`
- `actionlint -config-file .github/actionlint.yaml`
- `cargo run -p xtask -- repo-consistency release-targets`
- `git diff --check`

## Release evidence

- `v0.75.0-rc1` run 30466649785 failed in Linux ARM64 host production with exit 126: `scripts/verify-host-dependencies.py: Permission denied`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release host verification compatibility by explicitly invoking the dependency verification script with Python 3.
  * Updated automated checks to ensure both applicable host build workflows use the correct invocation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->