### PR TITLE
Fix release inference smoke artifact composition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,6 +244,22 @@ jobs:
           test "$runtime_dir_count" -eq 1
           scripts/verify-native-runtime-package.sh "$runtime_dir"
           scripts/ci-client-readiness-smoke.sh host-input/mesh-llm runtime-root
+          if [[ "$MESH_RELEASE_OS" == "Linux" ]]; then
+            runtime_name="$(basename "$runtime_dir")"
+            rm -rf smoke-input
+            mkdir -p "smoke-input/native-runtimes"
+            cp host-input/mesh-llm smoke-input/mesh-llm
+            cp host-input/host-imports.json smoke-input/host-imports.json
+            cp -R "$runtime_dir" "smoke-input/native-runtimes/$runtime_name"
+            python3 scripts/compose-product-bundle.py \
+              --bundle smoke-input \
+              --host smoke-input/mesh-llm \
+              --runtime "smoke-input/native-runtimes/$runtime_name" \
+              --version "$RELEASE_TAG" \
+              --backend "$MESH_RELEASE_FLAVOR"
+            test -s smoke-input/product-manifest.json
+            test -s "smoke-input/native-runtimes/$runtime_name/manifest.json"
+          fi
           scripts/package-release.sh "$RELEASE_TAG" dist
       - name: Upload composed release product
         uses: actions/upload-artifact@v6
@@ -251,15 +267,12 @@ jobs:
           name: ${{ matrix.artifact_name }}
           path: dist/*
           if-no-files-found: error
-      - name: Upload Linux smoke binary
-        if: matrix.artifact_name == 'release-linux'
-        run: cp host-input/mesh-llm dist/mesh-llm
-      - name: Upload Linux smoke binary artifact
+      - name: Upload Linux composed smoke product
         if: matrix.artifact_name == 'release-linux'
         uses: actions/upload-artifact@v6
         with:
-          name: release-linux-inference-binary
-          path: dist/mesh-llm
+          name: release-linux-inference-product
+          path: smoke-input/
           if-no-files-found: error
 
   inference_smoke_tests:
@@ -267,7 +280,7 @@ jobs:
     if: needs.compose_cpu_products.result == 'success'
     uses: ./.github/workflows/smoke.yml
     with:
-      artifact_name: release-linux-inference-binary
+      artifact_name: release-linux-inference-product
       mesh_binary_target: target/release/mesh-llm
       cache_key_prefix: release-
       release_tag: ${{ needs.metadata.outputs.tag }}

--- a/scripts/tests/test_release_workflow_artifacts.py
+++ b/scripts/tests/test_release_workflow_artifacts.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
+
+
+class ReleaseWorkflowArtifactTests(unittest.TestCase):
+    def test_inference_smoke_consumes_composed_product(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertEqual(
+            workflow.count("release-linux-inference-product"),
+            2,
+        )
+        self.assertNotIn("release-linux-inference-binary", workflow)
+        for required_path in (
+            "smoke-input/mesh-llm",
+            "smoke-input/host-imports.json",
+            'smoke-input/native-runtimes/$runtime_name',
+            "smoke-input/product-manifest.json",
+        ):
+            self.assertIn(required_path, workflow)
+
+        self.assertIn(
+            "python3 scripts/compose-product-bundle.py",
+            workflow,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- stage the Linux release smoke input as a complete product-v2 directory
- include the immutable host, host import report, CPU native runtime, and product manifest
- make the reusable inference smoke consume the same composed host/runtime contract used by release publication
- add a regression test that prevents the release workflow from returning to a raw-host-only artifact

## Root cause

`compose_cpu_products` uploaded `release-linux-inference-binary` with only `mesh-llm`. The shared `restore-smoke-inputs` action now requires an adjacent `native-runtimes/` tree, so the next release inference smoke would fail after the host-verifier repair reached product composition.

## Validation

- `actionlint -config-file .github/actionlint.yaml .github/workflows/release.yml`
- `python3 -m unittest scripts.tests.test_release_workflow_artifacts scripts.tests.test_verify_host_dependencies -v`
- `CARGO_TARGET_DIR=/Users/ndizazzo/dev/mesh/mesh-llm/target cargo run -p xtask -- repo-consistency release-targets`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Linux release workflows now produce a composed inference product bundle for smoke validation.
  * Inference smoke tests now use the complete composed Linux product artifact.

* **Tests**
  * Added automated checks to verify the expected Linux release artifacts and workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->