### PR TITLE
fix: restore release host executable bit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,7 @@ jobs:
           printf '%s' "$RELEASE_ATTESTATION_PUBLIC_KEY" > "$MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE"
           test -s host-input/mesh-llm.sha256
           (cd host-input && shasum -a 256 -c mesh-llm.sha256)
+          chmod +x host-input/mesh-llm
           mkdir -p runtime-root
           runtime_archive=""
           runtime_archive_count=0
@@ -830,6 +831,7 @@ jobs:
           set -euo pipefail
           printf '%s' "$RELEASE_ATTESTATION_PUBLIC_KEY" > "$MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE"
           (cd host-input && sha256sum -c mesh-llm.sha256)
+          chmod +x host-input/mesh-llm
           mkdir -p runtime-root
           mapfile -t runtime_archives < <(find runtime-input -name '*.tar.gz' -type f -print)
           test "${#runtime_archives[@]}" -eq 1
@@ -941,6 +943,7 @@ jobs:
         run: |
           printf '%s' "$RELEASE_ATTESTATION_PUBLIC_KEY" > "$MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE"
           (cd host-input && sha256sum -c mesh-llm.sha256)
+          chmod +x host-input/mesh-llm
           mkdir -p runtime-root
           mapfile -t runtime_archives < <(find runtime-input -name '*.tar.gz' -type f -print)
           test "${#runtime_archives[@]}" -eq 1
@@ -1023,6 +1026,7 @@ jobs:
         run: |
           printf '%s' "$RELEASE_ATTESTATION_PUBLIC_KEY" > "$MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE"
           (cd host-input && sha256sum -c mesh-llm.sha256)
+          chmod +x host-input/mesh-llm
           mkdir -p runtime-root
           mapfile -t runtime_archives < <(find runtime-input -name '*.tar.gz' -type f -print)
           test "${#runtime_archives[@]}" -eq 1
@@ -1095,6 +1099,7 @@ jobs:
         run: |
           printf '%s' "$RELEASE_ATTESTATION_PUBLIC_KEY" > "$MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE"
           (cd host-input && sha256sum -c mesh-llm.sha256)
+          chmod +x host-input/mesh-llm
           mkdir -p runtime-root
           mapfile -t runtime_archives < <(find runtime-input -name '*.tar.gz' -type f -print)
           test "${#runtime_archives[@]}" -eq 1
@@ -1164,6 +1169,7 @@ jobs:
         run: |
           printf '%s' "$RELEASE_ATTESTATION_PUBLIC_KEY" > "$MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE"
           (cd host-input && sha256sum -c mesh-llm.sha256)
+          chmod +x host-input/mesh-llm
           mkdir -p runtime-root
           mapfile -t runtime_archives < <(find runtime-input -name '*.tar.gz' -type f -print)
           test "${#runtime_archives[@]}" -eq 1

--- a/scripts/tests/test_release_workflow_artifacts.py
+++ b/scripts/tests/test_release_workflow_artifacts.py
@@ -9,6 +9,19 @@ RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 
 
 class ReleaseWorkflowArtifactTests(unittest.TestCase):
+    def test_unix_composition_restores_downloaded_host_executable_bit(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        readiness_command = (
+            "scripts/ci-client-readiness-smoke.sh "
+            "host-input/mesh-llm runtime-root"
+        )
+
+        self.assertEqual(workflow.count(readiness_command), 6)
+        self.assertEqual(
+            workflow.count("chmod +x host-input/mesh-llm"),
+            workflow.count(readiness_command),
+        )
+
     def test_inference_smoke_consumes_composed_product(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
 


### PR DESCRIPTION
## Summary

- restore the executable bit after Unix host artifacts are downloaded
- cover every Unix product composition lane (macOS, Linux CPU, CUDA, ROCm, and Vulkan)
- add a regression test tying every Unix readiness smoke to executable restoration

## Context

The v0.75.0-rc1 publishing run failed in Compose Linux ARM64 CPU product because GitHub artifact extraction restored host-input/mesh-llm as a non-executable file. The run was cancelled before downstream packaging.

## Validation

- actionlint .github/workflows/release.yml
- python3 -m unittest scripts.tests.test_release_workflow_artifacts
- cargo test -p xtask
- cargo run -p xtask -- repo-consistency release-targets
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release bundles now correctly preserve executable permissions for the host binary across supported Linux CPU, ARM64, CUDA, ROCm, and Vulkan builds.

* **Tests**
  * Added automated coverage to verify executable permissions are restored consistently during release artifact creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->