### PR TITLE
ci: make composed product readiness hermetic

### DIFF
--- a/scripts/ci-client-readiness-smoke.sh
+++ b/scripts/ci-client-readiness-smoke.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-# Start a composed MeshLLM product in noninteractive client mode and require a
-# JSON readiness event followed by a bounded platform-appropriate graceful
-# shutdown.
+# Start a composed MeshLLM product in hermetic noninteractive client mode and
+# require a JSON readiness event followed by a bounded platform-appropriate
+# graceful shutdown. Public auto-discovery is intentionally tested elsewhere;
+# product composition must not depend on a mutable external mesh.
 
 set -euo pipefail
 
@@ -162,7 +163,8 @@ if [[ "$is_windows" == "1" ]]; then
     XDG_CONFIG_HOME="$STATE_DIR/config" \
     XDG_RUNTIME_DIR="$STATE_DIR/xdg-runtime" \
         python3 "$WINDOWS_PROCESS_HELPER" run --pid-file "$native_pid_file" --log "$LOG" -- \
-        "$MESH_LLM" --log-format json --port "$port" --no-console client --auto &
+        "$MESH_LLM" --log-format json --port "$port" --no-console \
+        client --mesh-discovery-mode mdns &
 else
     MESH_LLM_NATIVE_RUNTIME_BUNDLE_DIR="$RUNTIME_ROOT" \
     MESH_LLM_NATIVE_RUNTIME_CACHE_DIR="$STATE_DIR/runtime-cache" \
@@ -172,7 +174,8 @@ else
     XDG_CACHE_HOME="$STATE_DIR/cache" \
     XDG_CONFIG_HOME="$STATE_DIR/config" \
     XDG_RUNTIME_DIR="$STATE_DIR/xdg-runtime" \
-        "$MESH_LLM" --log-format json --port "$port" --no-console client --auto >"$LOG" 2>&1 &
+        "$MESH_LLM" --log-format json --port "$port" --no-console \
+        client --mesh-discovery-mode mdns >"$LOG" 2>&1 &
 fi
 pid=$!
 
@@ -209,5 +212,5 @@ PY
 done
 
 cat "$LOG" >&2
-echo "timed out waiting for structured client readiness" >&2
+echo "timed out waiting for hermetic structured client readiness" >&2
 exit 1

--- a/scripts/tests/test_ci_client_readiness_smoke.py
+++ b/scripts/tests/test_ci_client_readiness_smoke.py
@@ -38,6 +38,12 @@ while True:
 
 
 class CiClientReadinessSmokeTests(unittest.TestCase):
+    def test_product_readiness_is_hermetic(self):
+        script = SCRIPT.read_text(encoding="utf-8")
+
+        self.assertIn("client --mesh-discovery-mode mdns", script)
+        self.assertNotIn("client --auto", script)
+
     def run_smoke(
         self, runtime: pathlib.Path, root: pathlib.Path
     ) -> subprocess.CompletedProcess[str]:


### PR DESCRIPTION
## Summary

- run composed-product client readiness in local mDNS mode without public auto-discovery
- preserve structured readiness and bounded graceful-shutdown assertions
- add a regression test that prevents product readiness from regaining a `client --auto` dependency

## Why

Main CI run 30472968554 failed twice after the product built and listed its Metal runtime successfully. Both attempts discovered the mutable public mesh, then stalled joining it (`MultipathNotNegotiated`) before the local client API could emit readiness. Product composition should prove local startup, runtime discovery, and shutdown; public-mesh admission is an independent integration signal.

## Validation

- `shellcheck scripts/ci-client-readiness-smoke.sh`
- `python3 -m unittest scripts.tests.test_ci_client_readiness_smoke scripts.tests.test_ci_client_readiness_process -v` (7 tests)
- real composed local debug product: readiness observed and clean shutdown in ~2 seconds
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved client readiness checks by using explicit mDNS mesh discovery instead of automatic discovery.
  * Readiness checks now avoid reliance on mutable external mesh configuration.
  * Updated timeout messaging to clearly identify hermetic structured client readiness failures.

* **Tests**
  * Added validation to ensure readiness checks use mDNS discovery and do not fall back to automatic mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->