### PR TITLE
fix: make release composition self-contained

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -50,6 +50,10 @@ place runtimes at `mesh-bundle/native-runtimes/<runtime-id>`; Debian/Arch
 packages use `/usr/local/lib/mesh-llm/<version>/native-runtimes`; Homebrew uses
 formula-owned `libexec/native-runtimes`.
 
+The Windows host input also carries the checksum-protected `xtask` executable
+that performed producer-side attestation. Windows product composers invoke that
+prebuilt verifier for the immutable host instead of compiling workspace code.
+
 `ci.yml` applies the same executable-product rule to trusted main validation:
 Linux and macOS debug artifact producers upload both the backend-neutral host
 and its adjacent runtime; their consumer reruns JSON client readiness from those

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -200,6 +200,9 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@stable
+      - name: Install macOS attestation verifier linker
+        if: runner.os == 'macOS'
+        run: brew install lld
       - name: Download immutable host input
         uses: actions/download-artifact@v7
         with:
@@ -933,6 +936,7 @@ jobs:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: scripts/release-version.sh "$RELEASE_TAG"
       - name: Compose aarch64 CUDA release bundle from producer inputs
+        shell: bash
         env:
           MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE: ${{ runner.temp }}/mesh-release-attestation-public-key.json
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
@@ -1016,6 +1020,7 @@ jobs:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: scripts/release-version.sh "$RELEASE_TAG"
       - name: Compose CUDA release bundle from producer inputs
+        shell: bash
         env:
           MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE: ${{ runner.temp }}/mesh-release-attestation-public-key.json
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
@@ -1089,6 +1094,7 @@ jobs:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: scripts/release-version.sh "$RELEASE_TAG"
       - name: Compose ROCm release bundle from producer inputs
+        shell: bash
         env:
           MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE: ${{ runner.temp }}/mesh-release-attestation-public-key.json
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
@@ -1159,6 +1165,7 @@ jobs:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: scripts/release-version.sh "$RELEASE_TAG"
       - name: Compose Vulkan release bundle from producer inputs
+        shell: bash
         env:
           MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE: ${{ runner.temp }}/mesh-release-attestation-public-key.json
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
@@ -1234,6 +1241,9 @@ jobs:
           Copy-Item target\release\mesh-llm.exe host-input\mesh-llm.exe -Force
           cargo run -q -p xtask -- release-attestation stamp --binary host-input\mesh-llm.exe --signing-key-file $env:MESH_RELEASE_ATTESTATION_SIGNING_KEY_FILE
           cargo run -q -p xtask -- release-attestation inspect --binary host-input\mesh-llm.exe --public-key-file $env:MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE --json
+          Copy-Item target\debug\xtask.exe host-input\release-attestation-verifier.exe -Force
+          $verifierHash = (Get-FileHash -Algorithm SHA256 host-input\release-attestation-verifier.exe).Hash.ToLowerInvariant()
+          Set-Content -Path host-input\release-attestation-verifier.exe.sha256 -Value "$verifierHash  release-attestation-verifier.exe" -NoNewline
           python scripts\verify-host-dependencies.py host-input\mesh-llm.exe --report host-input\host-imports.json
           $hash = (Get-FileHash -Algorithm SHA256 host-input\mesh-llm.exe).Hash.ToLowerInvariant()
           Set-Content -Path host-input\mesh-llm.exe.sha256 -Value "$hash  mesh-llm.exe" -NoNewline
@@ -1305,6 +1315,7 @@ jobs:
           MESH_LLM_RELEASE_BIN_DIR: ${{ github.workspace }}\host-input
           MESH_LLM_NATIVE_RUNTIME_ROOT: ${{ github.workspace }}\runtime-root
           MESH_RELEASE_HOST_PRESTAMPED: "1"
+          MESH_RELEASE_ATTESTATION_VERIFIER: ${{ github.workspace }}\host-input\release-attestation-verifier.exe
         run: |
           Set-Content -Path $env:MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE -Value $env:RELEASE_ATTESTATION_PUBLIC_KEY -NoNewline
           $expectedHash = (Get-Content host-input\mesh-llm.exe.sha256).Split()[0]
@@ -1356,6 +1367,7 @@ jobs:
           MESH_LLM_RELEASE_BIN_DIR: ${{ github.workspace }}\host-input
           MESH_LLM_NATIVE_RUNTIME_ROOT: ${{ github.workspace }}\runtime-root
           MESH_RELEASE_HOST_PRESTAMPED: "1"
+          MESH_RELEASE_ATTESTATION_VERIFIER: ${{ github.workspace }}\host-input\release-attestation-verifier.exe
         run: |
           Set-Content -Path $env:MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE -Value $env:RELEASE_ATTESTATION_PUBLIC_KEY -NoNewline
           $expectedHash = (Get-Content host-input\mesh-llm.exe.sha256).Split()[0]

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -219,7 +219,9 @@ subgraph PRCI["pr_builds.yml · PR Builds"]
   composition that records both immutable digests while retaining
   compatibility archive names. Host producers attest and import-check the host;
   consumers verify and copy those exact bytes rather than rebuilding or
-  re-stamping them. Product consumers never rebuild a missing producer. It
+  re-stamping them. The Windows host input includes a checksum-protected
+  producer-built attestation verifier so Windows composers do not compile
+  workspace code. Product consumers never rebuild a missing producer. It
   dispatches the completed release to `Mesh-LLM/mesh-packaging`,
   which owns package, GHCR, and npm publication.
 - `fly-deploy-console.yml` is a manual (`workflow_dispatch`) deploy of the

--- a/scripts/package-release.ps1
+++ b/scripts/package-release.ps1
@@ -21,6 +21,7 @@ $nativeRuntimeRoot = if ($env:MESH_LLM_NATIVE_RUNTIME_ROOT) {
 }
 $attestationSigningKeyFile = $env:MESH_RELEASE_ATTESTATION_SIGNING_KEY_FILE
 $attestationPublicKeyFile = $env:MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE
+$attestationVerifier = $env:MESH_RELEASE_ATTESTATION_VERIFIER
 
 Add-Type -AssemblyName System.IO.Compression.FileSystem
 
@@ -194,6 +195,26 @@ function Require-File {
     }
 }
 
+function Assert-FileChecksum {
+    param(
+        [string]$Path,
+        [string]$ChecksumPath
+    )
+
+    Require-File $Path
+    Require-File $ChecksumPath
+    $checksumText = (Get-Content -Path $ChecksumPath -Raw).Trim()
+    $expectedHash = ($checksumText -split '\s+')[0].ToLowerInvariant()
+    if ($expectedHash -notmatch '^[0-9a-f]{64}$') {
+        throw "Invalid SHA-256 checksum in ${ChecksumPath}"
+    }
+
+    $actualHash = Get-Sha256Hex $Path
+    if ($actualHash -ne $expectedHash) {
+        throw "SHA-256 checksum mismatch for ${Path}"
+    }
+}
+
 function Get-PythonCommand {
     foreach ($name in @("python3", "python")) {
         $command = Get-Command $name -ErrorAction SilentlyContinue
@@ -254,23 +275,34 @@ function Invoke-ReleaseAttestationStamp {
         if (-not (Test-Path $attestationPublicKeyFile) -or (Get-Item $attestationPublicKeyFile).Length -eq 0) {
             throw "MESH_RELEASE_HOST_PRESTAMPED=1 requires a non-empty MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE"
         }
-        Push-Location $repoRoot
-        try {
-            $inspectJson = & cargo run -q -p xtask -- release-attestation inspect `
+        if (Test-HasValue $attestationVerifier) {
+            Assert-FileChecksum -Path $attestationVerifier -ChecksumPath "${attestationVerifier}.sha256"
+            $inspectJson = & $attestationVerifier release-attestation inspect `
                 --binary $BinaryPath `
                 --public-key-file $attestationPublicKeyFile `
                 --json
             if ($LASTEXITCODE -ne 0) {
-                throw "release-attestation inspect failed for pre-stamped $BinaryPath"
+                throw "prebuilt release-attestation verifier failed for pre-stamped $BinaryPath"
             }
-            $inspectStatus = ($inspectJson | ConvertFrom-Json).status
-            if ($inspectStatus -ne "valid") {
-                throw "pre-stamped release host attestation reported status '$inspectStatus' for $BinaryPath"
+        } else {
+            Push-Location $repoRoot
+            try {
+                $inspectJson = & cargo run -q -p xtask -- release-attestation inspect `
+                    --binary $BinaryPath `
+                    --public-key-file $attestationPublicKeyFile `
+                    --json
+                if ($LASTEXITCODE -ne 0) {
+                    throw "release-attestation inspect failed for pre-stamped $BinaryPath"
+                }
+            } finally {
+                Pop-Location
             }
-            Write-Host "Release attestation: verified pre-stamped host"
-        } finally {
-            Pop-Location
         }
+        $inspectStatus = ($inspectJson | ConvertFrom-Json).status
+        if ($inspectStatus -ne "valid") {
+            throw "pre-stamped release host attestation reported status '$inspectStatus' for $BinaryPath"
+        }
+        Write-Host "Release attestation: verified pre-stamped host"
         return
     }
 

--- a/scripts/tests/test_package_release_ps1.py
+++ b/scripts/tests/test_package_release_ps1.py
@@ -33,6 +33,36 @@ class PackageReleasePowerShellTests(unittest.TestCase):
         self.assertIn("ForEach-Object { $_.Trim() }", selector)
         self.assertNotIn(").Trim()", selector)
 
+    def test_prestamped_host_can_use_checksum_verified_prebuilt_verifier(self) -> None:
+        contents = SCRIPT.read_text(encoding="utf-8")
+        prestamped_start = contents.index(
+            'if ($env:MESH_RELEASE_HOST_PRESTAMPED -eq "1") {',
+            contents.index("function Invoke-ReleaseAttestationStamp"),
+        )
+        prestamped_end = contents.index(
+            'if (-not (Test-HasValue $attestationSigningKeyFile))',
+            prestamped_start,
+        )
+        prestamped = contents[prestamped_start:prestamped_end]
+
+        self.assertIn(
+            "$attestationVerifier = $env:MESH_RELEASE_ATTESTATION_VERIFIER",
+            contents,
+        )
+        self.assertIn(
+            'Assert-FileChecksum -Path $attestationVerifier '
+            '-ChecksumPath "${attestationVerifier}.sha256"',
+            prestamped,
+        )
+        self.assertIn(
+            "& $attestationVerifier release-attestation inspect",
+            prestamped,
+        )
+        self.assertIn(
+            "& cargo run -q -p xtask -- release-attestation inspect",
+            prestamped,
+        )
+
     def selector_block(self) -> str:
         contents = SCRIPT.read_text(encoding="utf-8")
         start = contents.index("$cudaMajor =")

--- a/scripts/tests/test_release_workflow_artifacts.py
+++ b/scripts/tests/test_release_workflow_artifacts.py
@@ -9,6 +9,44 @@ RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 
 
 class ReleaseWorkflowArtifactTests(unittest.TestCase):
+    def test_macos_cpu_composer_installs_attestation_linker(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        composer = self.job_block(workflow, "compose_cpu_products", "inference_smoke_tests")
+
+        self.assertIn("Install macOS attestation verifier linker", composer)
+        self.assertIn("if: runner.os == 'macOS'", composer)
+        self.assertIn("run: brew install lld", composer)
+
+    def test_container_product_composers_run_bash(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        for step_name in (
+            "Compose aarch64 CUDA release bundle from producer inputs",
+            "Compose CUDA release bundle from producer inputs",
+            "Compose ROCm release bundle from producer inputs",
+            "Compose Vulkan release bundle from producer inputs",
+        ):
+            step_start = workflow.index(f"- name: {step_name}")
+            env_start = workflow.index("        env:", step_start)
+            self.assertIn("        shell: bash", workflow[step_start:env_start])
+
+    def test_windows_composers_reuse_checksum_verified_host_verifier(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "Copy-Item target\\debug\\xtask.exe "
+            "host-input\\release-attestation-verifier.exe -Force",
+            workflow,
+        )
+        self.assertIn(
+            "host-input\\release-attestation-verifier.exe.sha256",
+            workflow,
+        )
+        self.assertEqual(
+            workflow.count("MESH_RELEASE_ATTESTATION_VERIFIER:"),
+            2,
+        )
+
     def test_unix_composition_restores_downloaded_host_executable_bit(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         readiness_command = (
@@ -42,6 +80,12 @@ class ReleaseWorkflowArtifactTests(unittest.TestCase):
             "python3 scripts/compose-product-bundle.py",
             workflow,
         )
+
+    @staticmethod
+    def job_block(workflow: str, start_job: str, next_job: str) -> str:
+        start = workflow.index(f"  {start_job}:")
+        end = workflow.index(f"  {next_job}:", start)
+        return workflow[start:end]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- install Homebrew `lld` in the macOS CPU composer before the prestamped attestation inspection
- run every containerized Linux product composer explicitly with Bash
- carry the producer-built Windows attestation verifier and checksum in `host-input`, then reuse it in CPU/GPU composers without invoking Cargo

## Failure context

Fixes the deterministic composer failures in release run https://github.com/Mesh-LLM/mesh-llm/actions/runs/30476334753:

- macOS job 90664461264: configured `/opt/homebrew/bin/ld64.lld` was absent
- Vulkan job 90664461242: GitHub selected `sh -e` for Bash-only `mapfile`/process substitution
- Windows CPU job 90664550845: `package-release.ps1` rebuilt `xtask` and failed because the static llama ABI was absent

The release was not rerun or dispatched from this branch.

## Validation

- `actionlint -config-file .github/actionlint.yaml`
- `python3 -m unittest scripts.tests.test_package_release_ps1 scripts.tests.test_release_workflow_artifacts scripts.tests.test_package_release`
- `cargo run -p xtask -- repo-consistency release-targets`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Windows release packaging now validates and uses a checksum-protected attestation verifier.
  * macOS CPU release composition installs the required linker automatically.
  * Linux GPU release composition runs with improved shell consistency.

* **Bug Fixes**
  * Improved reliability and integrity checks when validating pre-stamped release bundles.

* **Tests**
  * Added coverage for platform-specific release workflow and verifier behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->