### PR TITLE
fix: keep Windows release verifier native-ABI-free

### DIFF
--- a/.github/actions/compute-changes/action.yml
+++ b/.github/actions/compute-changes/action.yml
@@ -296,7 +296,7 @@ runs:
         WINDOWS_CPU_BUILD_REQUIRED="false"
         WINDOWS_GPU_BUILD_REQUIRED="false"
         if [[ -n "$CHANGED_FILES" ]]; then
-          WINDOWS_CPU_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^crates/mesh-llm-nodejs/|^crates/skippy-ffi/|^scripts/build-windows\.ps1$|^third_party/llama\.cpp/|^Cargo\.toml$|^Cargo\.lock$|^\.github/cache-version\.txt$)' || true)
+          WINDOWS_CPU_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^crates/mesh-llm-release-footer/|^crates/mesh-llm-nodejs/|^crates/skippy-ffi/|^scripts/build-windows\.ps1$|^third_party/llama\.cpp/|^Cargo\.toml$|^Cargo\.lock$|^\.github/cache-version\.txt$)' || true)
           WINDOWS_GPU_INPUTS=$(echo "$CHANGED_FILES" | grep -E '(^crates/skippy-ffi/|^scripts/(build-windows|install-windows-sdk)\.ps1$|^scripts/(package-native-runtime|verify-native-runtime-package)\.sh$|^scripts/windows-native-runtime-deps\.py$|^scripts/tests/test_windows_native_runtime_deps\.py$|^third_party/llama\.cpp/|^\.github/cache-version\.txt$|^\.github/actions/(compute-changes/action\.yml$|setup-windows-rocm-sdk/))' || true)
           if [[ -n "$WINDOWS_CPU_INPUTS" ]] || [[ "$BACKEND_RECIPE_CHANGED" == "true" ]]; then
             WINDOWS_CPU_BUILD_REQUIRED="true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,6 +129,7 @@ jobs:
               - 'Cargo.lock'
               - '.github/workflows/docker.yml'
             windows_cpu:
+              - 'crates/mesh-llm-release-footer/**'
               - 'crates/mesh-llm-nodejs/**'
               - 'crates/skippy-ffi/**'
               - 'scripts/build-windows.ps1'

--- a/.github/workflows/docker-precheck.yml
+++ b/.github/workflows/docker-precheck.yml
@@ -69,9 +69,11 @@ jobs:
             crates/mesh-llm-hardware-profile/ \
             crates/mesh-llm-identity/ \
             crates/mesh-llm-native-runtime/ \
+            crates/mesh-llm-release-footer/ \
             crates/mesh-llm-protocol/ \
             crates/mesh-llm-routing/ \
             crates/mesh-llm-runtime-install/ \
+            crates/mesh-llm-system/ \
             crates/mesh-llm-guardrails/ \
             crates/mesh-llm-types/ \
             crates/mesh-llm-config/ \

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -117,6 +117,7 @@ jobs:
             nodejs_release:
               - 'crates/mesh-llm-nodejs/**'
             windows_cpu:
+              - 'crates/mesh-llm-release-footer/**'
               - 'crates/mesh-llm-nodejs/**'
               - 'crates/skippy-ffi/**'
               - 'scripts/build-windows.ps1'

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4114,6 +4114,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "mesh-llm-release-footer"
+version = "0.72.1"
+dependencies = [
+ "hex",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+]
+
+[[package]]
 name = "mesh-llm-routing"
 version = "0.72.1"
 dependencies = [
@@ -4182,6 +4192,7 @@ dependencies = [
  "mesh-llm-build-info",
  "mesh-llm-gpu-bench",
  "mesh-llm-native-runtime",
+ "mesh-llm-release-footer",
  "mesh-llm-runtime-install",
  "reqwest 0.12.28",
  "semver",
@@ -9694,7 +9705,7 @@ dependencies = [
  "ed25519-dalek",
  "getrandom 0.3.4",
  "hex",
- "mesh-llm-system",
+ "mesh-llm-release-footer",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/mesh-llm-identity",
     "crates/mesh-llm-native-runtime",
     "crates/mesh-llm-protocol",
+    "crates/mesh-llm-release-footer",
     "crates/mesh-llm-routing",
     "crates/mesh-llm-runtime-install",
     "crates/mesh-llm-sdk",
@@ -74,6 +75,7 @@ anyhow = "1"
 blake3 = "1"
 clap = { version = "4", features = ["derive"] }
 mesh-llm-build-info = { path = "crates/mesh-llm-build-info", version = "0.72.1" }
+mesh-llm-release-footer = { path = "crates/mesh-llm-release-footer", version = "0.72.1" }
 mesh-llm-skills = { path = "crates/mesh-llm-skills", version = "0.72.1" }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/ci/linux-test.dockerfile
+++ b/ci/linux-test.dockerfile
@@ -24,6 +24,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates/mesh-llm-ui/ crates/mesh-llm-ui/
 COPY crates/mesh-llm-identity/ crates/mesh-llm-identity/
 COPY crates/mesh-llm-protocol/ crates/mesh-llm-protocol/
+COPY crates/mesh-llm-release-footer/ crates/mesh-llm-release-footer/
 COPY crates/mesh-llm-routing/ crates/mesh-llm-routing/
 COPY crates/mesh-llm-guardrails/ crates/mesh-llm-guardrails/
 COPY crates/mesh-llm-system/ crates/mesh-llm-system/

--- a/crates/mesh-llm-release-footer/Cargo.toml
+++ b/crates/mesh-llm-release-footer/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "mesh-llm-release-footer"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Dependency-light encoding and verification for embedded MeshLLM release footers"
+repository = "https://github.com/Mesh-LLM/mesh-llm"
+homepage = "https://github.com/Mesh-LLM/mesh-llm"
+
+[dependencies]
+hex = "0.4.3"
+sha2.workspace = true
+
+[dev-dependencies]
+serde.workspace = true
+serde_json.workspace = true

--- a/crates/mesh-llm-release-footer/README.md
+++ b/crates/mesh-llm-release-footer/README.md
@@ -1,0 +1,8 @@
+# mesh-llm-release-footer
+
+Dependency-light encoding, parsing, and verification for the attestation footer
+embedded in MeshLLM release binaries.
+
+This crate owns only the stable binary footer format and payload-verifier
+contract. Attestation claims, key handling, and release orchestration remain
+owned by their callers.

--- a/crates/mesh-llm-release-footer/src/lib.rs
+++ b/crates/mesh-llm-release-footer/src/lib.rs
@@ -1,3 +1,5 @@
+//! Dependency-light encoding and verification for MeshLLM release footers.
+
 use sha2::{Digest, Sha256};
 
 /// Fixed footer appended after the raw signed payload bytes.

--- a/crates/mesh-llm-system/Cargo.toml
+++ b/crates/mesh-llm-system/Cargo.toml
@@ -18,6 +18,7 @@ libloading = "0.8"
 mesh-llm-build-info.workspace = true
 mesh-llm-gpu-bench = { path = "../mesh-llm-gpu-bench", version = "0.72.1"  }
 mesh-llm-native-runtime = { path = "../mesh-llm-native-runtime", version = "0.72.1" }
+mesh-llm-release-footer.workspace = true
 mesh-llm-runtime-install = { path = "../mesh-llm-runtime-install", version = "0.72.1" }
 reqwest = { version = "0.12", features = ["stream", "json"] }
 semver = "1"

--- a/crates/mesh-llm-system/src/lib.rs
+++ b/crates/mesh-llm-system/src/lib.rs
@@ -3,7 +3,7 @@ pub mod autoupdate;
 pub mod backend;
 pub mod benchmark;
 pub mod benchmark_prompts;
-pub mod embedded_release_footer;
+pub use mesh_llm_release_footer as embedded_release_footer;
 pub mod hardware;
 pub mod process;
 pub mod release_target;

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -41,6 +41,7 @@ COPY crates/mesh-llm-ui/ crates/mesh-llm-ui/
 COPY crates/mesh-llm-identity/ crates/mesh-llm-identity/
 COPY crates/mesh-llm-native-runtime/ crates/mesh-llm-native-runtime/
 COPY crates/mesh-llm-protocol/ crates/mesh-llm-protocol/
+COPY crates/mesh-llm-release-footer/ crates/mesh-llm-release-footer/
 COPY crates/mesh-llm-routing/ crates/mesh-llm-routing/
 COPY crates/mesh-llm-guardrails/ crates/mesh-llm-guardrails/
 COPY crates/mesh-llm-system/ crates/mesh-llm-system/
@@ -113,6 +114,7 @@ COPY crates/mesh-llm-ui/ crates/mesh-llm-ui/
 COPY crates/mesh-llm-identity/ crates/mesh-llm-identity/
 COPY crates/mesh-llm-native-runtime/ crates/mesh-llm-native-runtime/
 COPY crates/mesh-llm-protocol/ crates/mesh-llm-protocol/
+COPY crates/mesh-llm-release-footer/ crates/mesh-llm-release-footer/
 COPY crates/mesh-llm-routing/ crates/mesh-llm-routing/
 COPY crates/mesh-llm-guardrails/ crates/mesh-llm-guardrails/
 COPY crates/mesh-llm-system/ crates/mesh-llm-system/

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -34,6 +34,7 @@ COPY crates/mesh-llm-ui/ crates/mesh-llm-ui/
 COPY crates/mesh-llm-gpu-bench/ crates/mesh-llm-gpu-bench/
 COPY crates/mesh-llm-identity/ crates/mesh-llm-identity/
 COPY crates/mesh-llm-protocol/ crates/mesh-llm-protocol/
+COPY crates/mesh-llm-release-footer/ crates/mesh-llm-release-footer/
 COPY crates/mesh-llm-routing/ crates/mesh-llm-routing/
 COPY crates/mesh-llm-guardrails/ crates/mesh-llm-guardrails/
 COPY crates/mesh-llm-system/ crates/mesh-llm-system/

--- a/scripts/affected-crates.sh
+++ b/scripts/affected-crates.sh
@@ -20,6 +20,7 @@ WORKSPACE_MEMBERS=(
   "mesh-llm-identity"
   "mesh-llm-native-runtime"
   "mesh-llm-protocol"
+  "mesh-llm-release-footer"
   "mesh-llm-routing"
   "mesh-llm-runtime-install"
   "mesh-llm-sdk"

--- a/scripts/plan-clippy-batches.sh
+++ b/scripts/plan-clippy-batches.sh
@@ -23,6 +23,7 @@ WORKSPACE_MEMBERS=(
   "mesh-llm-identity"
   "mesh-llm-native-runtime"
   "mesh-llm-protocol"
+  "mesh-llm-release-footer"
   "mesh-llm-routing"
   "mesh-llm-runtime-install"
   "mesh-llm-sdk"
@@ -163,6 +164,7 @@ weights = {
     "mesh-llm-routing": 2,
     "mesh-llm-sdk": 2,
     "mesh-llm-protocol": 2,
+    "mesh-llm-release-footer": 1,
     "mesh-llm-types": 2,
     "mesh-llm-console-server": 2,
     "mesh-llm-embedded-runtime": 8,

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -346,6 +346,7 @@ unpublished_registry_deps() {
                 mesh-llm-build-info \
                 mesh-llm-gpu-bench \
                 mesh-llm-native-runtime \
+                mesh-llm-release-footer \
                 mesh-llm-runtime-install \
                 skippy-runtime
             ;;
@@ -482,6 +483,7 @@ publish_crates=(
     mesh-llm-api-client
     mesh-llm-events
     mesh-llm-build-info
+    mesh-llm-release-footer
     mesh-llm-config
     mesh-llm-ui
     mesh-llm-console-server

--- a/tools/xtask/Cargo.toml
+++ b/tools/xtask/Cargo.toml
@@ -8,7 +8,7 @@ publish = false
 ed25519-dalek = { version = "=3.0.0-rc.0", features = ["rand_core"] }
 getrandom = "0.3"
 hex = "0.4"
-mesh-llm-system = { path = "../../crates/mesh-llm-system" }
+mesh-llm-release-footer.workspace = true
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/tools/xtask/src/attestation.rs
+++ b/tools/xtask/src/attestation.rs
@@ -2,7 +2,7 @@ use crate::command::{DynResult, ensure_eq, print_json, write_json_file};
 use crate::repo_consistency::default_node_version;
 use ed25519_dalek::{Signer, SigningKey};
 use getrandom::fill as fill_random;
-use mesh_llm_system::embedded_release_footer::{
+use mesh_llm_release_footer::{
     EmbeddedReleaseFooterStatus, EmbeddedReleasePayloadSummary, EmbeddedReleasePayloadVerifier,
     read_embedded_release_footer, stamp_embedded_release_payload, strip_embedded_release_footer,
     verify_embedded_release_footer,

--- a/tools/xtask/src/tests.rs
+++ b/tools/xtask/src/tests.rs
@@ -4,7 +4,7 @@ use crate::attestation::{
 };
 use crate::command::{DynResult, unique_temp_dir, write_json_file};
 use ed25519_dalek::SigningKey;
-use mesh_llm_system::embedded_release_footer::read_embedded_release_footer;
+use mesh_llm_release_footer::read_embedded_release_footer;
 use std::fs;
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
## Summary

- extract embedded release-footer encoding and verification into a dependency-light `mesh-llm-release-footer` crate
- make `xtask` depend directly on that crate instead of `mesh-llm-system`
- preserve `mesh_llm_system::embedded_release_footer` as a compatibility re-export
- update publishing, Docker contexts, CI crate lists, and Windows CPU change routing

## Why

The fresh `v0.75.0-rc1` release run built the immutable Windows host successfully, then failed while building the attestation verifier. `xtask` depended on `mesh-llm-system`, which transitively pulled `mesh-llm-runtime-install -> skippy-ffi` and attempted to build the native llama.cpp ABI in the host-only lane.

The Windows-target `xtask` dependency graph now contains none of `mesh-llm-system`, `mesh-llm-runtime-install`, `skippy-ffi`, or `skippy-runtime`.

## Validation

- `actionlint`
- 156 Python CI tests (7 skipped)
- `cargo fmt --all --check`
- 7/7 `mesh-llm-release-footer` tests
- 13/13 `xtask` tests
- `cargo check` and Clippy with warnings denied for `mesh-llm-release-footer`, `xtask`, `mesh-llm-system`, and `mesh-llm`
- release-target, CI crate-list, publish-order, and test-all coverage consistency checks
- `cargo publish --locked -p mesh-llm-release-footer --dry-run --allow-dirty`

This is the focused release unblock extracted from the broader composable CI work in #1113.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a standalone release-footer component for encoding, parsing, and verifying attestation data in release binaries.
  * Integrated release-footer support into system builds and attestation tooling.

* **Documentation**
  * Added documentation describing the release-footer format and verification responsibilities.

* **Build & Infrastructure**
  * Updated Rust, Docker, CI, testing, linting, and publishing workflows to include the new component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->