### PR TITLE
ci: register isolated Depot canary

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -8,7 +8,11 @@ self-hosted-runner:
     - gpu-nvidia
     - mesh-llm-amd64
     - mesh-llm-arm64
-    - blacksmith-4vcpu-ubuntu-2404
-    - blacksmith-6vcpu-macos-15
-    - blacksmith-4vcpu-ubuntu-2404-arm
-    - blacksmith-8vcpu-windows-2025
+    - depot-ubuntu-24.04
+    - depot-ubuntu-24.04-4
+    - depot-ubuntu-24.04-8
+    - depot-ubuntu-24.04-16
+    - depot-ubuntu-24.04-arm
+    - depot-ubuntu-24.04-arm-4
+    - depot-ubuntu-24.04-arm-8
+    - depot-ubuntu-24.04-arm-16

--- a/.github/workflows/depot-canary.yml
+++ b/.github/workflows/depot-canary.yml
@@ -18,6 +18,10 @@ concurrency:
 jobs:
   runner:
     name: ${{ matrix.runner }}
+    if: >-
+      github.repository == 'Mesh-LLM/mesh-llm' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main'
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/depot-canary.yml
+++ b/.github/workflows/depot-canary.yml
@@ -1,0 +1,166 @@
+name: Depot Runner Canary
+
+on:
+  workflow_dispatch:
+    inputs:
+      expect_cache_hit:
+        description: Fail unless this is a warm Depot Cache run.
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+concurrency:
+  group: depot-runner-canary
+  cancel-in-progress: false
+
+jobs:
+  runner:
+    name: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - depot-ubuntu-24.04
+          - depot-ubuntu-24.04-4
+          - depot-ubuntu-24.04-8
+          - depot-ubuntu-24.04-16
+          - depot-ubuntu-24.04-arm
+          - depot-ubuntu-24.04-arm-8
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 10
+    steps:
+      - name: Verify ephemeral runner resources
+        shell: bash
+        env:
+          CANARY_RUNNER_LABEL: ${{ matrix.runner }}
+        run: |
+          set -euo pipefail
+
+          expected_arch=x86_64
+          if [[ "$CANARY_RUNNER_LABEL" == *-arm* ]]; then
+            expected_arch=aarch64
+          fi
+          actual_arch="$(uname -m)"
+          if [[ "$actual_arch" != "$expected_arch" ]]; then
+            echo "runner architecture mismatch: expected $expected_arch, got $actual_arch" >&2
+            exit 1
+          fi
+          if [[ -z "${SCCACHE_WEBDAV_ENDPOINT:-}" ]]; then
+            echo "Depot Cache WebDAV endpoint was not injected" >&2
+            exit 1
+          fi
+          if [[ -z "${ImageOS:-}" || -z "${ImageVersion:-}" ]]; then
+            echo "Depot runner image identity was not injected" >&2
+            exit 1
+          fi
+          if [[ -z "${DEPOT_CACHE_TOKEN:-}" &&
+                -z "${SCCACHE_WEBDAV_TOKEN:-}" ]]; then
+            echo "Depot Cache authentication was not injected" >&2
+            exit 1
+          fi
+
+          {
+            echo "### ${{ matrix.runner }}"
+            echo
+            echo "| Signal | Value |"
+            echo "| --- | --- |"
+            printf '| architecture | %s |\n' "$(uname -m)"
+            printf '| logical CPUs | %s |\n' "$(nproc)"
+            printf '| memory KiB | %s |\n' "$(awk '/MemTotal/ { print $2 }' /proc/meminfo)"
+            printf '| workspace free KiB | %s |\n' "$(df -Pk "$GITHUB_WORKSPACE" | awk 'NR == 2 { print $4 }')"
+            printf '| runner image | %s %s |\n' "$ImageOS" "$ImageVersion"
+            echo "| Depot cache endpoint injected | yes |"
+            echo "| Depot cache authentication injected | yes |"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Install sccache
+        uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+
+      - name: Exercise authenticated Depot sccache
+        shell: bash
+        env:
+          EXPECT_CACHE_HIT: ${{ inputs.expect_cache_hit }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${SCCACHE_WEBDAV_TOKEN:-}" ]]; then
+            export SCCACHE_WEBDAV_TOKEN="$DEPOT_CACHE_TOKEN"
+          fi
+          if sccache --stop-server >/dev/null 2>&1; then
+            :
+          fi
+          sccache --zero-stats
+          mkdir -p .depot-sccache-canary
+          printf 'int depot_sccache_probe(void) { return 42; }\n' \
+            > .depot-sccache-canary/probe.c
+          sccache cc \
+            -c .depot-sccache-canary/probe.c \
+            -o .depot-sccache-canary/probe.o
+          sccache --show-stats --stats-format json \
+            > "$RUNNER_TEMP/depot-sccache-stats.json"
+
+          python3 - \
+            "$RUNNER_TEMP/depot-sccache-stats.json" \
+            "$EXPECT_CACHE_HIT" \
+            "$GITHUB_STEP_SUMMARY" <<'PY'
+          import json
+          import sys
+
+          stats_path, expect_cache_hit, summary_path = sys.argv[1:]
+          with open(stats_path, encoding="utf-8") as handle:
+              payload = json.load(handle)
+
+          location = str(payload.get("cache_location", "")).lower()
+          if "webdav" not in location and "depot" not in location:
+              raise SystemExit("sccache did not select the Depot WebDAV backend")
+
+          stats = payload["stats"]
+          hits = sum(stats["cache_hits"]["counts"].values())
+          misses = sum(stats["cache_misses"]["counts"].values())
+          cache_errors = sum(stats["cache_errors"]["counts"].values())
+          cache_errors += stats["cache_read_errors"]
+          cache_errors += stats["cache_write_errors"]
+          writes = stats["cache_writes"]
+
+          if cache_errors:
+              raise SystemExit(
+                  f"Depot sccache reported {cache_errors} cache errors"
+              )
+          if not hits and not writes:
+              raise SystemExit(
+                  "Depot sccache produced neither a cache hit nor a cache write"
+              )
+          if expect_cache_hit == "true" and not hits:
+              raise SystemExit("expected a warm Depot sccache hit")
+
+          with open(summary_path, "a", encoding="utf-8") as summary:
+              summary.write(f"| sccache hits | {hits} |\n")
+              summary.write(f"| sccache misses | {misses} |\n")
+              summary.write(f"| sccache writes | {writes} |\n")
+          PY
+
+      - name: Restore Depot cache probe
+        id: cache
+        uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .depot-canary-cache
+          key: depot-runner-canary-v1-${{ matrix.runner }}
+
+      - name: Record cache probe
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.cache.outputs.cache-hit }}
+          EXPECT_CACHE_HIT: ${{ inputs.expect_cache_hit }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$EXPECT_CACHE_HIT" == "true" && "$CACHE_HIT" != "true" ]]; then
+            echo "expected a warm Depot Cache hit for ${{ matrix.runner }}" >&2
+            exit 1
+          fi
+          mkdir -p .depot-canary-cache
+          printf 'Depot cache canary\n' > .depot-canary-cache/probe.txt
+          printf '| cache hit | %s |\n' "${CACHE_HIT:-false}" \
+            >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Scope

Registers the reviewed, no-checkout Depot runner/cache canary on the default branch so GitHub can dispatch it. Updates only the actionlint runner-label allowlist needed to validate that workflow and removes retired runner labels.

This does **not** enable Depot for PR, main, release, or GPU CI. `DEPOT_RUNNERS_ENABLED` remains unset/false.

## Validation

- full actionlint: clean
- all workflow YAML parsed
- `git diff --check`: clean
- retired-provider sweep under `.github`: clean
- canary permissions: `{}`
- no checkout or repository code execution

After this bootstrap is merged, the authorized sequence is one cold dispatch with `expect_cache_hit=false`, followed by one warm dispatch with `expect_cache_hit=true`. No release workflow is involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated CI runner label allowlist to include new Linux x86_64 and ARM variants (including additional `-4`, `-8`, and `-16` forms).
  * Added a manually triggered “Depot Runner Canary” workflow for the main branch to validate runner architecture, prerequisite injection, sccache setup, and Depot-backed cache behavior.
  * Enhanced canary coverage with cache hit/write/error assertions, probe state restore, and optional warm-hit verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->