### PR TITLE
fix(ci): verify exact Windows cache publication

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -155,6 +155,13 @@ Local actions:
   PR/main/release runtime producers. The hosted-image epoch, architecture sets,
   and toolchain versions are compatibility boundaries; the action requires the
   key epoch to equal the build-stamp epoch and never uses restore prefixes.
+- `.github/actions/save-and-verify-actions-cache` snapshots existing exact
+  key/ref cache entries before saving a trusted miss, then requires a new,
+  non-empty entry to appear and performs a lookup-only restore with the same
+  path/key to prove the current opaque cache version exists. Windows warmers
+  therefore fail if
+  `actions/cache/save` only warns about a reservation collision without any
+  compatible upload becoming available.
 - `.github/actions/setup-windows-rocm-sdk` owns reusable Windows ROCm setup.
 
 Routing and test-planning scripts:

--- a/.github/actions/save-and-verify-actions-cache/action.yml
+++ b/.github/actions/save-and-verify-actions-cache/action.yml
@@ -1,0 +1,99 @@
+name: Save and verify exact Actions cache
+description: Save a cache miss and require a new non-empty exact key/ref entry
+
+inputs:
+  path:
+    description: Filesystem path passed to actions/cache/save
+    required: true
+  cache-key:
+    description: Exact Actions cache key to save
+    required: true
+  cache-ref:
+    description: Exact Git ref that must own the new cache entry
+    required: true
+  cache-label:
+    description: Human-readable cache label for evidence and failures
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Snapshot existing exact cache entries
+      id: existing
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        CACHE_KEY: ${{ inputs.cache-key }}
+        CACHE_REF: ${{ inputs.cache-ref }}
+      with:
+        result-encoding: string
+        script: |
+          const { data } = await github.request(
+            'GET /repos/{owner}/{repo}/actions/caches',
+            {
+              ...context.repo,
+              key: process.env.CACHE_KEY,
+              ref: process.env.CACHE_REF,
+              per_page: 100,
+            },
+          );
+          return JSON.stringify(
+            (data.actions_caches || []).map((cache) => String(cache.id)),
+          );
+    - name: Save exact cache
+      uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ inputs.cache-key }}
+    - name: Verify new exact cache publication
+      uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+      env:
+        CACHE_KEY: ${{ inputs.cache-key }}
+        CACHE_REF: ${{ inputs.cache-ref }}
+        CACHE_LABEL: ${{ inputs.cache-label }}
+        EXISTING_CACHE_IDS: ${{ steps.existing.outputs.result }}
+      with:
+        script: |
+          const key = process.env.CACHE_KEY;
+          const ref = process.env.CACHE_REF;
+          const label = process.env.CACHE_LABEL;
+          const existingIds = new Set(
+            JSON.parse(process.env.EXISTING_CACHE_IDS || '[]'),
+          );
+          for (let attempt = 1; attempt <= 12; attempt++) {
+            const { data } = await github.request(
+              'GET /repos/{owner}/{repo}/actions/caches',
+              {
+                ...context.repo,
+                key,
+                ref,
+                per_page: 100,
+              },
+            );
+            const cache = (data.actions_caches || []).find(
+              (candidate) =>
+                candidate.key === key &&
+                candidate.ref === ref &&
+                candidate.size_in_bytes > 0 &&
+                !existingIds.has(String(candidate.id)),
+            );
+            if (cache) {
+              core.notice(
+                `Verified new exact ${label} cache ${cache.id} ` +
+                `(${cache.size_in_bytes} bytes).`,
+              );
+              return;
+            }
+            if (attempt < 12) {
+              await new Promise((resolve) => setTimeout(resolve, 5000));
+            }
+          }
+          core.setFailed(
+            `No new exact ${label} cache was published for ${ref}.`,
+          );
+    - name: Verify current cache version lookup
+      uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+      with:
+        path: ${{ inputs.path }}
+        key: ${{ inputs.cache-key }}
+        lookup-only: true
+        fail-on-cache-miss: true

--- a/.github/workflows/windows-warm-caches.yml
+++ b/.github/workflows/windows-warm-caches.yml
@@ -18,6 +18,7 @@ on:
       - '.github/actions/resolve-native-toolchain-epoch/action.yml'
       - '.github/actions/setup-windows-rocm-sdk/action.yml'
       - '.github/actions/restore-windows-abi-cache/action.yml'
+      - '.github/actions/save-and-verify-actions-cache/action.yml'
       - '.github/workflows/ci.yml'
       - '.github/workflows/pr_builds.yml'
       - '.github/workflows/windows-warm-caches.yml'
@@ -112,12 +113,14 @@ jobs:
             }
             Write-Host $library.FullName
           }
-      - name: Save Windows CPU ABI cache
+      - name: Save and verify Windows CPU ABI cache
         if: steps.llama_cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        uses: ./.github/actions/save-and-verify-actions-cache
         with:
           path: ${{ env.LLAMA_STAGE_BUILD_DIR }}
-          key: ${{ steps.llama_cache.outputs.cache-primary-key }}
+          cache-key: ${{ steps.llama_cache.outputs.cache-primary-key }}
+          cache-ref: ${{ github.ref }}
+          cache-label: Windows CPU ABI
 
   warm_windows_gpu:
     name: Warm Windows ${{ matrix.name }} ABI cache
@@ -260,12 +263,14 @@ jobs:
             }
             Write-Host $library.FullName
           }
-      - name: Save Windows GPU ABI cache
+      - name: Save and verify Windows GPU ABI cache
         if: steps.llama_cache.outputs.cache-hit != 'true'
-        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        uses: ./.github/actions/save-and-verify-actions-cache
         with:
           path: ${{ env.LLAMA_STAGE_BUILD_DIR }}
-          key: ${{ steps.llama_cache.outputs.cache-primary-key }}
+          cache-key: ${{ steps.llama_cache.outputs.cache-primary-key }}
+          cache-ref: ${{ github.ref }}
+          cache-label: Windows ${{ matrix.name }} ABI
 
   prune_windows_abi_caches:
     name: Prune old Windows ABI caches

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -216,6 +216,13 @@ flowchart TD
   restore one checksummed, target-described static CPU llama ABI from
   `linux_static_abi_input`; individual consumers never rebuild or raw-extract
   the same patch queue concurrently.
+- Trusted Windows cache misses are saved through
+  `.github/actions/save-and-verify-actions-cache`. It snapshots existing exact
+  key/ref records before the upload and requires a new non-empty cache record
+  afterward, then performs a lookup-only restore with the same path and key to
+  prove the current cache version exists. A cache-service reservation warning
+  therefore cannot leave the warmer green without publishing a reusable ABI
+  input.
 
 ### Current PR Builds contract
 

--- a/scripts/tests/test_build_windows.py
+++ b/scripts/tests/test_build_windows.py
@@ -13,6 +13,13 @@ RELEASE_WORKFLOW: Final = ROOT / ".github" / "workflows" / "release.yml"
 WINDOWS_WARM_CACHES: Final = (
     ROOT / ".github" / "workflows" / "windows-warm-caches.yml"
 )
+CACHE_SAVE_VERIFIER: Final = (
+    ROOT
+    / ".github"
+    / "actions"
+    / "save-and-verify-actions-cache"
+    / "action.yml"
+)
 
 
 class BuildWindowsScriptTests(unittest.TestCase):
@@ -117,6 +124,52 @@ class BuildWindowsScriptTests(unittest.TestCase):
         ):
             with self.subTest(library_group=library_group):
                 self.assertEqual(warmer.count(library_group), 2)
+        self.assertEqual(
+            warmer.count("Save and verify Windows "),
+            2,
+        )
+        self.assertEqual(
+            warmer.count(
+                "uses: ./.github/actions/save-and-verify-actions-cache",
+            ),
+            2,
+        )
+        self.assertEqual(
+            warmer.count(
+                "cache-key: "
+                "${{ steps.llama_cache.outputs.cache-primary-key }}",
+            ),
+            2,
+        )
+        self.assertEqual(
+            warmer.count("cache-ref: ${{ github.ref }}"),
+            2,
+        )
+        verifier = CACHE_SAVE_VERIFIER.read_text(encoding="utf-8")
+        self.assertEqual(
+            verifier.count("Snapshot existing exact cache entries"),
+            1,
+        )
+        self.assertIn("!existingIds.has(String(candidate.id))", verifier)
+        self.assertIn("candidate.size_in_bytes > 0", verifier)
+        self.assertIn("name: Verify current cache version lookup", verifier)
+        self.assertIn("lookup-only: true", verifier)
+        self.assertIn("fail-on-cache-miss: true", verifier)
+        self.assertEqual(
+            verifier.count(
+                "uses: actions/cache/restore@"
+                "caa296126883cff596d87d8935842f9db880ef25",
+            ),
+            1,
+        )
+        self.assertEqual(
+            verifier.count("attempt <= 12"),
+            1,
+        )
+        self.assertIn(
+            "'.github/actions/save-and-verify-actions-cache/action.yml'",
+            warmer,
+        )
 
     def test_windows_abi_caches_live_outside_the_llama_worktree(self) -> None:
         workflows = {


### PR DESCRIPTION
## Summary

- wrap trusted Windows ABI cache saves in a composable save-and-verify action
- snapshot exact key/ref cache IDs before upload and require a new non-empty record afterward
- prove the current opaque cache version with a pinned lookup-only restore using the same path/key
- document and test the publication contract

## Root cause

Post-merge warmer run [30525101716](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30525101716) completed successfully even though the Windows CPU `actions/cache/save` step warned that it could not reserve the key. The exact CPU key remained absent, while Vulkan and ROCm records were present. A warning-only save therefore allowed a false-green warmer.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'`: 364 passed, 7 skipped
- `python3 -m unittest scripts.tests.test_build_windows`: 9 passed
- actionlint 1.7.12: clean
- 43 workflow/local-action YAML files parsed
- `git diff --check`: clean
- independent review: approved after cache-version proof was added

This PR does not enable Depot, change runner groups, publish a release, or modify organization settings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows cache warming to verify that newly saved cache data is successfully published and available for restoration.
  * Prevented cache-warming runs from treating failed or incomplete uploads as usable cache entries.

* **Documentation**
  * Documented the verification requirements for trusted Windows cache misses.

* **Tests**
  * Added coverage to confirm cache-saving workflows use the verification process and validate published cache entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->