### PR TITLE
fix(swift): synchronize generated binding checksums

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -121,6 +121,11 @@ Changes to the central PR/main/release workflow callers or to
 caller-owned mode, timeout, artifact, and trust-policy edits from skipping the
 reusable Swift, Kotlin, or Rust SDK contracts they change.
 
+The reusable Swift producer verifies the committed generated UniFFI binding
+after both host-only and full builds for PR, main, and tag callers. Only a
+dispatched release that deliberately prepares a versioned source tree may
+replace the tracked binding before publication.
+
 Local actions:
 
 - `.github/actions/compute-changes` owns path, crate, backend, SDK, UI, website,

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -70,6 +70,7 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
           PREPARE_RELEASE_VERSION: ${{ inputs.prepare_release_version }}
           UPDATE_RELEASE_MANIFEST: ${{ inputs.update_release_manifest }}
+          EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
           case "$SWIFT_SDK_MODE" in
@@ -83,6 +84,11 @@ jobs:
                   "$UPDATE_RELEASE_MANIFEST" == "true" ) &&
                 -z "$RELEASE_TAG" ]]; then
             echo "release_tag is required for release preparation" >&2
+            exit 1
+          fi
+          if [[ "$PREPARE_RELEASE_VERSION" == "true" &&
+                "$EVENT_NAME" != "workflow_dispatch" ]]; then
+            echo "release source preparation requires workflow_dispatch" >&2
             exit 1
           fi
 
@@ -156,8 +162,8 @@ jobs:
         if: ${{ inputs.mode == 'full' }}
         run: sdk/swift/scripts/build-xcframework.sh
 
-      - name: Verify protected Swift binding source is current
-        if: ${{ !inputs.prepare_release_version && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/')) }}
+      - name: Verify committed Swift binding source is current
+        if: ${{ !inputs.prepare_release_version }}
         run: |
           set -euo pipefail
           generated_binding="sdk/swift/Sources/MeshLLM/Generated/mesh_ffi.swift"

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -620,10 +620,12 @@ baseline metrics, target service levels, and the cross-repository plan.
   `full`. Producer and smoke are fixed to `macos-15`, and the shared native
   cache includes an explicit macOS/Xcode epoch. Rust compilation is routed
   through sccache, with per-mode/per-attempt statistics retained as CI evidence.
-  Main and tag producers reject tracked-binding drift; dispatched releases copy
-  the producer binding into the prepared tag commit. The Swift consumer cannot
-  invoke Cargo, llama.cpp compilation, native-SDK packaging, or an XCFramework
-  build.
+  PR, main, and tag producers reject tracked-binding drift after compiling the
+  native library, so a stale UniFFI checksum contract fails in the lightweight
+  host-only PR producer instead of waiting for the exhaustive main build.
+  Dispatched releases copy the producer binding into the prepared tag commit.
+  The Swift consumer cannot invoke Cargo, llama.cpp compilation, native-SDK
+  packaging, or an XCFramework build.
 - Linux native-runtime packaging uses `patchelf` to make packaged shared
   libraries relocatable with `$ORIGIN`, then verifies them without
   `LD_LIBRARY_PATH`. Release native-runtime jobs and Rust SDK smoke jobs need

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -1252,6 +1252,20 @@ class CiArtifactActionTests(unittest.TestCase):
             producer,
         )
         self.assertIn(
+            "name: Verify committed Swift binding source is current\n"
+            "        if: ${{ !inputs.prepare_release_version }}",
+            producer,
+        )
+        self.assertNotIn(
+            "!inputs.prepare_release_version && (github.ref ==",
+            producer,
+        )
+        self.assertIn("EVENT_NAME: ${{ github.event_name }}", producer)
+        self.assertIn(
+            "release source preparation requires workflow_dispatch",
+            producer,
+        )
+        self.assertIn(
             "uses: ./.github/actions/capture-sccache-stats",
             producer,
         )

--- a/sdk/swift/Sources/MeshLLM/Generated/mesh_ffi.swift
+++ b/sdk/swift/Sources/MeshLLM/Generated/mesh_ffi.swift
@@ -4704,151 +4704,151 @@ private let initializationResult: InitializationResult = {
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_create_auto_client() != 12117) {
+    if (uniffi_meshllm_ffi_checksum_func_create_auto_client() != 12517) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_create_auto_node() != 62467) {
+    if (uniffi_meshllm_ffi_checksum_func_create_auto_node() != 33432) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_create_client() != 14950) {
+    if (uniffi_meshllm_ffi_checksum_func_create_client() != 53219) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_create_node() != 53847) {
+    if (uniffi_meshllm_ffi_checksum_func_create_node() != 11855) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_current_mesh_version() != 41756) {
+    if (uniffi_meshllm_ffi_checksum_func_current_mesh_version() != 42923) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_current_skippy_abi_version() != 53670) {
+    if (uniffi_meshllm_ffi_checksum_func_current_skippy_abi_version() != 11242) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_discover_public_meshes() != 8199) {
+    if (uniffi_meshllm_ffi_checksum_func_discover_public_meshes() != 52961) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_generate_owner_keypair_hex() != 15846) {
+    if (uniffi_meshllm_ffi_checksum_func_generate_owner_keypair_hex() != 63994) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_install_native_runtime() != 5481) {
+    if (uniffi_meshllm_ffi_checksum_func_install_native_runtime() != 25162) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_installed_native_runtimes() != 37725) {
+    if (uniffi_meshllm_ffi_checksum_func_installed_native_runtimes() != 21851) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_prune_native_runtimes() != 29071) {
+    if (uniffi_meshllm_ffi_checksum_func_prune_native_runtimes() != 18336) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_remove_native_runtime() != 58516) {
+    if (uniffi_meshllm_ffi_checksum_func_remove_native_runtime() != 48639) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_consolehandle_stop() != 39251) {
+    if (uniffi_meshllm_ffi_checksum_method_consolehandle_stop() != 13931) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_consolehandle_url() != 61491) {
+    if (uniffi_meshllm_ffi_checksum_method_consolehandle_url() != 15682) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_cancel() != 32002) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_cancel() != 60947) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_chat() != 2872) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_chat() != 50040) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_inference_list_models() != 2185) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_inference_list_models() != 8792) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_reconnect() != 33566) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_reconnect() != 10889) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_responses() != 1844) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_responses() != 28930) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_start() != 48685) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_start() != 44515) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_status() != 33476) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_status() != 41037) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_stop() != 3388) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_stop() != 1554) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_cancel() != 32259) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_cancel() != 56505) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_chat() != 34892) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_chat() != 37264) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_cleanup_models() != 1157) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_cleanup_models() != 58526) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_delete_model() != 2627) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_delete_model() != 51823) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_download_model() != 20595) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_download_model() != 26002) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_inference_list_models() != 54117) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_inference_list_models() != 32433) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_installed_models() != 34553) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_installed_models() != 28122) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_load_serving_model() != 31620) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_load_serving_model() != 39783) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_model_cache_status() != 61505) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_model_cache_status() != 29059) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_prune_derived_cache() != 24829) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_prune_derived_cache() != 45852) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_recommended_models() != 43281) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_recommended_models() != 28368) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_reconnect() != 60843) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_reconnect() != 64634) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_responses() != 29255) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_responses() != 43033) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_search_models() != 6088) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_search_models() != 26120) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_served_models() != 28188) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_served_models() != 18883) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_serving_status() != 49590) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_serving_status() != 35990) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_set_device_policy() != 8567) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_set_device_policy() != 30969) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_show_model() != 35584) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_show_model() != 41215) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_start() != 46124) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_start() != 22769) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_start_console() != 34773) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_start_console() != 35615) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_status() != 48531) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_status() != 44385) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_stop() != 10537) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_stop() != 24422) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_instance() != 1091) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_instance() != 65198) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_model() != 45229) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_model() != 48491) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_model_by_id() != 9451) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_model_by_id() != 21862) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_eventlistener_on_event() != 53401) {
+    if (uniffi_meshllm_ffi_checksum_method_eventlistener_on_event() != 56769) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_nativeruntimeprogresslistener_on_progress() != 40900) {
+    if (uniffi_meshllm_ffi_checksum_method_nativeruntimeprogresslistener_on_progress() != 1578) {
         return InitializationResult.apiChecksumMismatch
     }
 


### PR DESCRIPTION
## Summary

- commit the exact 49 UniFFI checksum values emitted by the compiled Swift SDK library
- enforce generated-binding drift checks in PR host-only producers as well as main/tag full producers
- restrict release-source preparation to explicit `workflow_dispatch` callers

## Root cause

Post-merge main CI [30539068609](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30539068609) completed the full seven-target XCFramework build in 1h26m, then failed because `sdk/swift/Sources/MeshLLM/Generated/mesh_ffi.swift` contained stale checksum constants. The previous guard ran only on main/tags, so the PR host-only producer synchronized and uploaded a correct generated binding without rejecting the stale committed source.

This change commits the exact generated blob (`19ead0ac60dfeea7d58b9f190e31b337bae35c49`) from that producer and moves the guard to every non-release-preparation call. Future drift therefore fails in the lightweight PR producer before merge.

## Validation

- exact host macOS XCFramework producer: passed twice
- producer idempotence: identical binding hash before/after repeat
- host-only XCFramework verification plus real Swift consumer build/run: passed
- Python CI suite: 365 passed, 7 skipped
- focused CI/release tests: 56 passed; independent review ran 87 focused tests
- actionlint 1.7.12: clean
- 43 workflow/action YAML files parsed
- `git diff --check`: clean
- independent review: approved with no blockers; exact 49-value match to failed main log confirmed

## Cache evidence from failed main

The failed full producer reached 58.67% sccache hits (4,829 hits / 3,402 misses), with zero read errors. Its GHA L1 recorded 26 fail-open write errors and seven C/C++ cache errors; the local L0 remained healthy and the build succeeded. Because the binding guard failed before cache publication, the exact Swift ABI `actions/cache` entry was intentionally not saved and no immutable Swift artifact was uploaded.

## Safety

- no release, runner, Depot, ruleset, or organization setting changes
- dispatched release version preparation remains supported only for `workflow_dispatch`
- regular PR execution remains GitHub-hosted


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI and Release Improvements**
  * Swift SDK builds now verify committed generated bindings across pull request, main, and tag workflows.
  * Release source preparation is restricted to deliberate manual workflow dispatches.
  * Pull request validation detects stale bindings and checksum mismatches earlier, reducing delayed build failures.
* **Documentation**
  * Updated CI guidance to clarify artifact reuse, validation behavior, and Swift consumer build restrictions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->