### PR TITLE
fix(ci): unblock prerelease SDK producers

### DIFF
--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -187,6 +187,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: Trust checkout directory
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Validate release preparation inputs
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}

--- a/.github/workflows/node-sdk-addon-artifact.yml
+++ b/.github/workflows/node-sdk-addon-artifact.yml
@@ -134,7 +134,7 @@ jobs:
           (cd "$smoke_root/consumer" && npm init --yes >/dev/null && npm install "$tarball")
           node - "$smoke_root/consumer" "$expected_version" <<'NODE'
           const [root, expected] = process.argv.slice(2)
-          const sdk = require(root)
+          const sdk = require(require.resolve("@mesh-llm/sdk", { paths: [root] }))
           const actual = sdk.currentMeshVersion()
           if (actual !== expected) {
             throw new Error(`native addon version mismatch: expected ${expected}, got ${actual}`)
@@ -244,7 +244,7 @@ jobs:
           (cd "$smoke_root/consumer" && npm init --yes >/dev/null && npm install "$tarball")
           node - "$smoke_root/consumer" "$expected_version" <<'NODE'
           const [root, expected] = process.argv.slice(2)
-          const sdk = require(root)
+          const sdk = require(require.resolve("@mesh-llm/sdk", { paths: [root] }))
           const actual = sdk.currentMeshVersion()
           if (actual !== expected) {
             throw new Error(`native addon version mismatch: expected ${expected}, got ${actual}`)
@@ -338,7 +338,7 @@ jobs:
           (cd "$smoke_root/consumer" && npm init --yes >/dev/null && npm install "$tarball")
           node - "$smoke_root/consumer" "$expected_version" <<'NODE'
           const [root, expected] = process.argv.slice(2)
-          const sdk = require(root)
+          const sdk = require(require.resolve("@mesh-llm/sdk", { paths: [root] }))
           const actual = sdk.currentMeshVersion()
           if (actual !== expected) {
             throw new Error(`native addon version mismatch: expected ${expected}, got ${actual}`)

--- a/scripts/package-native-sdk.sh
+++ b/scripts/package-native-sdk.sh
@@ -252,14 +252,17 @@ fi
 if [[ "$BUILD" == "1" ]]; then
     "$SCRIPT_DIR/prepare-llama.sh" "${MESH_LLM_LLAMA_PIN_SHA:-pinned}"
     llama_build_dir="$LLAMA_STAGE_BUILD_DIR"
-    build_args=()
     if [[ "$REQUIRE_PREBUILT_LLAMA" == "1" ]]; then
-        build_args+=(--require-existing)
+        LLAMA_STAGE_BACKEND="$(build_backend)" \
+            LLAMA_BUILD_DIR="$llama_build_dir" \
+            LLAMA_STAGE_BUILD_DIR="$llama_build_dir" \
+            "$SCRIPT_DIR/build-llama.sh" --require-existing
+    else
+        LLAMA_STAGE_BACKEND="$(build_backend)" \
+            LLAMA_BUILD_DIR="$llama_build_dir" \
+            LLAMA_STAGE_BUILD_DIR="$llama_build_dir" \
+            "$SCRIPT_DIR/build-llama.sh"
     fi
-    LLAMA_STAGE_BACKEND="$(build_backend)" \
-        LLAMA_BUILD_DIR="$llama_build_dir" \
-        LLAMA_STAGE_BUILD_DIR="$llama_build_dir" \
-        "$SCRIPT_DIR/build-llama.sh" "${build_args[@]}"
 
     cargo_args=(build -p mesh-llm-ffi --no-default-features --features "host,embedded-runtime")
     if [[ "$PROFILE" == "release" ]]; then

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -780,9 +780,18 @@ class CiArtifactActionTests(unittest.TestCase):
         linux_start = producer.index("  linux_native_sdk_artifact:")
         linux_end = producer.index("  macos_native_sdk_artifact:")
         linux_producer = producer[linux_start:linux_end]
-        self.assertIn("name: Trust checkout directory", linux_producer)
+        trust_step = (
+            'name: Trust checkout directory\n'
+            '        run: git config --global --add safe.directory '
+            '"$GITHUB_WORKSPACE"'
+        )
+        self.assertIn(trust_step, linux_producer)
         self.assertLess(
-            linux_producer.index("name: Trust checkout directory"),
+            linux_producer.index("uses: actions/checkout@"),
+            linux_producer.index(trust_step),
+        )
+        self.assertLess(
+            linux_producer.index(trust_step),
             linux_producer.index("name: Prepare dispatched release version"),
         )
         self.assertIn("scripts/package-native-sdk.sh", producer_action)

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -777,6 +777,14 @@ class CiArtifactActionTests(unittest.TestCase):
             "${{ inputs.static_abi_artifact_name != '' }}",
             producer,
         )
+        linux_start = producer.index("  linux_native_sdk_artifact:")
+        linux_end = producer.index("  macos_native_sdk_artifact:")
+        linux_producer = producer[linux_start:linux_end]
+        self.assertIn("name: Trust checkout directory", linux_producer)
+        self.assertLess(
+            linux_producer.index("name: Trust checkout directory"),
+            linux_producer.index("name: Prepare dispatched release version"),
+        )
         self.assertIn("scripts/package-native-sdk.sh", producer_action)
         self.assertIn("--build", producer_action)
         self.assertIn("--require-prebuilt-llama", producer_action)

--- a/scripts/tests/test_ci_workflow_artifacts.py
+++ b/scripts/tests/test_ci_workflow_artifacts.py
@@ -595,6 +595,13 @@ class ReleaseNodeAddonArtifactTests(unittest.TestCase):
         )
         self.assertIn("currentMeshVersion()", self.producer)
         self.assertIn("npm pack", self.producer)
+        self.assertEqual(
+            self.producer.count(
+                'require.resolve("@mesh-llm/sdk", { paths: [root] })'
+            ),
+            3,
+        )
+        self.assertNotIn("const sdk = require(root)", self.producer)
         self.assertIn("$output_root/$archive.sha256", self.producer)
         self.assertIn(
             "ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:",

--- a/scripts/tests/test_static_abi_artifacts.py
+++ b/scripts/tests/test_static_abi_artifacts.py
@@ -74,10 +74,24 @@ class StaticAbiArtifactTests(unittest.TestCase):
             self.assertIn(archive, build_script)
         self.assertIn("--require-prebuilt-llama", package_script)
         self.assertNotIn("build_args=()", package_script)
+        build_section = package_script.split(
+            'if [[ "$BUILD" == "1" ]]; then',
+            maxsplit=1,
+        )[1].split("    cargo_args=", maxsplit=1)[0]
+        prebuilt_branch, normal_branch = build_section.split(
+            "    else\n",
+            maxsplit=1,
+        )
+        self.assertIn(
+            'if [[ "$REQUIRE_PREBUILT_LLAMA" == "1" ]]; then',
+            prebuilt_branch,
+        )
         self.assertIn(
             '"$SCRIPT_DIR/build-llama.sh" --require-existing',
-            package_script,
+            prebuilt_branch,
         )
+        self.assertIn('"$SCRIPT_DIR/build-llama.sh"', normal_branch)
+        self.assertNotIn("--require-existing", normal_branch)
         self.assertIn("SKIPPY_LLAMA_AUTO_BUILD=0", package_script)
         self.assertIn("MESH_LLM_AUTO_BUILD_LLAMA=0", package_script)
 

--- a/scripts/tests/test_static_abi_artifacts.py
+++ b/scripts/tests/test_static_abi_artifacts.py
@@ -73,6 +73,11 @@ class StaticAbiArtifactTests(unittest.TestCase):
         ):
             self.assertIn(archive, build_script)
         self.assertIn("--require-prebuilt-llama", package_script)
+        self.assertNotIn("build_args=()", package_script)
+        self.assertIn(
+            '"$SCRIPT_DIR/build-llama.sh" --require-existing',
+            package_script,
+        )
         self.assertIn("SKIPPY_LLAMA_AUTO_BUILD=0", package_script)
         self.assertIn("MESH_LLM_AUTO_BUILD_LLAMA=0", package_script)
 


### PR DESCRIPTION
## Summary

Fix the three deterministic SDK producer failures exposed by GitHub-hosted prerelease run 30576684407:

- avoid expanding an empty Bash array in `package-native-sdk.sh`, which fails under macOS Bash with `set -u`
- trust the checkout inside the Linux native-SDK container before `release-version.sh` enumerates tracked manifests
- resolve the freshly installed `@mesh-llm/sdk` package from the consumer project instead of requiring the consumer project itself

## Evidence

- failing release: https://github.com/Mesh-LLM/mesh-llm/actions/runs/30576684407
- 366 Python CI tests passed, 7 skipped
- 72 focused producer/action tests passed
- actionlint clean
- ShellCheck and Bash syntax clean
- 43 workflow/action YAML files parsed
- fresh npm pack/install resolves `@mesh-llm/sdk` to its installed `index.js`
- `git diff --check` clean

Depot remains disabled and this change does not alter runner-group or repository settings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of Linux native SDK artifact builds in environments with strict Git directory trust settings.
  * Updated Node addon smoke validation to resolve the installed SDK package more robustly across platforms.
  * Refined native SDK packaging to handle prebuilt components with the correct build behavior.
* **Tests**
  * Strengthened CI workflow checks for step ordering, module resolution, and native SDK reuse/verification behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Post-merge evidence

Post-merge main evidence: [CI 30582317065](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30582317065) completed with 32 successful jobs and zero failures at merge commit `851888d0b0ce19916d6b0d7d73ce49246eef67d6`; [Quality 30582316707](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30582316707) also passed. The hosted run validated the Kotlin native-SDK prebuilt path, Node SDK checks, Swift full producer and smoke, Rust/Kotlin SDK smokes, and Linux/macOS/Windows host-runtime-product composition.