### PR TITLE
fix(skippy): never block status reads on the inference lock

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
@@ -123,8 +123,12 @@ pub(crate) struct SkippyModelStatus {
     pub(crate) projector_path: Option<String>,
     pub(crate) ctx_size: u32,
     pub(crate) lane_count: u32,
+    /// Per-lane session state, possibly a frozen snapshot. Display only.
     pub(crate) lanes: Vec<SkippySessionLaneStatus>,
     pub(crate) max_session_tokens: u64,
+    /// When [`Self::lanes`] and [`Self::max_session_tokens`] were read, which
+    /// may be arbitrarily earlier than this status.
+    pub(crate) sessions_captured_at_unix_nanos: i64,
     pub(crate) n_batch: Option<u32>,
     pub(crate) n_ubatch: Option<u32>,
     pub(crate) n_gpu_layers: i32,
@@ -1156,6 +1160,7 @@ fn status_from_parts(
             })
             .collect(),
         max_session_tokens: embedded.sessions.max_session_tokens,
+        sessions_captured_at_unix_nanos: embedded.sessions_captured_at_unix_nanos,
         n_batch: config.n_batch,
         n_ubatch: config.n_ubatch,
         n_gpu_layers: config.n_gpu_layers,
@@ -1306,6 +1311,7 @@ mod tests {
                 total_session_tokens: 0,
                 lanes: vec![],
             },
+            sessions_captured_at_unix_nanos: 111,
             telemetry: TelemetryStats {
                 queued: 0,
                 sent: 0,

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -133,12 +133,17 @@ impl LocalRuntimeModelHandle {
                 let status = model.status();
                 let ctx_size = status.ctx_size as u64;
                 let now = current_time_unix_ms();
+                // Lane data may be a cached snapshot, so report when it was
+                // captured: a wedged runtime then shows a success time that
+                // stops advancing instead of looking fresh every tick.
+                let captured_unix_ms =
+                    unix_nanos_to_unix_ms(status.sessions_captured_at_unix_nanos).unwrap_or(now);
                 Some(RuntimeLlamaSlotsSnapshot {
                     status: RuntimeLlamaEndpointStatus::Ready,
                     model: Some(model_name.to_string()),
                     instance_id: instance_id.map(str::to_string),
                     last_attempt_unix_ms: Some(now),
-                    last_success_unix_ms: Some(now),
+                    last_success_unix_ms: Some(captured_unix_ms),
                     error: None,
                     slots: status
                         .lanes
@@ -180,6 +185,15 @@ pub(super) fn current_time_unix_ms() -> u64 {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default()
         .as_millis() as u64
+}
+
+/// Convert a unix-nanosecond capture time to unix milliseconds. `None` for a
+/// non-positive input, meaning "never captured" rather than the epoch.
+fn unix_nanos_to_unix_ms(unix_nanos: i64) -> Option<u64> {
+    u64::try_from(unix_nanos)
+        .ok()
+        .filter(|nanos| *nanos > 0)
+        .map(|nanos| nanos / 1_000_000)
 }
 
 pub(super) struct ManagedModelController {
@@ -847,4 +861,25 @@ pub(super) fn skippy_stage_activation_width(activation_width: u32, model_ref: &s
             "activation width {activation_width} for {model_ref} exceeds skippy stage ABI limit"
         )
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::unix_nanos_to_unix_ms;
+
+    #[test]
+    fn unix_nanos_to_unix_ms_converts_a_real_capture_time() {
+        assert_eq!(
+            unix_nanos_to_unix_ms(1_700_000_000_123_000_000),
+            Some(1_700_000_000_123)
+        );
+    }
+
+    #[test]
+    fn unix_nanos_to_unix_ms_treats_non_positive_as_never_captured() {
+        // A zero or negative capture time means "never read", not "read at the
+        // epoch". Callers must not project 1970 as a success timestamp.
+        assert_eq!(unix_nanos_to_unix_ms(0), None);
+        assert_eq!(unix_nanos_to_unix_ms(-1), None);
+    }
 }

--- a/crates/skippy-server/src/embedded.rs
+++ b/crates/skippy-server/src/embedded.rs
@@ -1,6 +1,6 @@
 use std::{
     net::SocketAddr,
-    sync::{Arc, Mutex},
+    sync::{Arc, Mutex, TryLockError},
 };
 
 use anyhow::{Context, Result};
@@ -118,6 +118,13 @@ impl SkippyRuntimeHandle {
             "stage.embedded_runtime_ready",
             lifecycle_attrs(&options.config),
         );
+        // Prime the stats snapshot while the runtime is still unshared and
+        // uncontended, so a read that loses the race to the very first
+        // generation reports real lanes instead of zeros.
+        let initial_session_stats = runtime
+            .lock()
+            .expect("runtime lock poisoned")
+            .session_stats();
         Ok(Self {
             config: Arc::new(options.config),
             topology: options.topology.map(Arc::new),
@@ -129,7 +136,7 @@ impl SkippyRuntimeHandle {
                 stopped_at_unix_nanos: None,
                 last_error: None,
             })),
-            last_session_stats: Arc::new(Mutex::new(RuntimeSessionStats::default())),
+            last_session_stats: Arc::new(Mutex::new(initial_session_stats)),
         })
     }
 
@@ -163,6 +170,13 @@ impl SkippyRuntimeHandle {
             "stage.embedded_runtime_ready",
             lifecycle_attrs(&options.config),
         );
+        // Prime the stats snapshot while the runtime is still unshared and
+        // uncontended, so a read that loses the race to the very first
+        // generation reports real lanes instead of zeros.
+        let initial_session_stats = runtime
+            .lock()
+            .expect("runtime lock poisoned")
+            .session_stats();
         Ok(Self {
             config: Arc::new(options.config),
             topology: options.topology.map(Arc::new),
@@ -174,7 +188,7 @@ impl SkippyRuntimeHandle {
                 stopped_at_unix_nanos: None,
                 last_error: None,
             })),
-            last_session_stats: Arc::new(Mutex::new(RuntimeSessionStats::default())),
+            last_session_stats: Arc::new(Mutex::new(initial_session_stats)),
         })
     }
 
@@ -420,7 +434,7 @@ fn finish_server_status(status: &Arc<Mutex<ServerHandleState>>, result: &Result<
     }
 }
 
-/// Read a value derived from `source` without ever waiting on its lock.
+/// Read a value derived from `source` without waiting on its lock.
 ///
 /// `source` here is the inference runtime, whose mutex is held for the whole
 /// duration of a decode loop. Blocking on it from an observability path makes
@@ -429,25 +443,32 @@ fn finish_server_status(status: &Arc<Mutex<ServerHandleState>>, result: &Result<
 /// worker for the length of a generation. Take the lock only when it is free,
 /// refreshing `cache`; otherwise serve the last value we published.
 ///
-/// Returns `V::default()` only if the lock is contended *and* the cache has
-/// been poisoned, which cannot happen before the first successful read.
+/// Staleness is deliberately unbounded: under sustained load every
+/// opportunistic read can lose the race, so the snapshot may lag by many
+/// turns. That is acceptable only because these stats are observability —
+/// nothing admits, routes, evicts or limits on them (`lane_count` reaching
+/// mesh gossip comes from `StageConfig`, not from here). Do not reuse this
+/// helper for a value that gates a decision.
+///
+/// A poisoned `source` still panics, exactly as the previous blocking
+/// `lock().expect(..)` did: a poisoned inference runtime means generation
+/// panicked, and reporting healthy cached stats over the top of that would
+/// hide a real failure.
 fn read_without_blocking<S, V>(source: &Mutex<S>, cache: &Mutex<V>, read: impl FnOnce(&S) -> V) -> V
 where
-    V: Clone + Default,
+    V: Clone,
 {
     match source.try_lock() {
         Ok(guard) => {
             let value = read(&guard);
             drop(guard);
-            if let Ok(mut cached) = cache.lock() {
-                cached.clone_from(&value);
-            }
+            *cache.lock().expect("stats cache lock poisoned") = value.clone();
             value
         }
-        Err(_) => cache
-            .lock()
-            .map(|cached| cached.clone())
-            .unwrap_or_default(),
+        // Inference holds the runtime: serve the last published snapshot
+        // instead of blocking for the rest of the turn.
+        Err(TryLockError::WouldBlock) => cache.lock().expect("stats cache lock poisoned").clone(),
+        Err(TryLockError::Poisoned(error)) => panic!("runtime lock poisoned: {error}"),
     }
 }
 
@@ -493,13 +514,18 @@ mod tests {
     }
 
     #[test]
-    fn read_without_blocking_returns_default_before_any_successful_read() {
-        // Contended from the very first read: no snapshot exists yet, so the
-        // caller gets the type default rather than waiting on inference.
+    #[should_panic(expected = "runtime lock poisoned")]
+    fn read_without_blocking_still_panics_on_a_poisoned_runtime() {
+        // A poisoned runtime means inference panicked. Serving cached stats
+        // over the top of that would report a healthy node, so this must keep
+        // the pre-existing panic behaviour rather than fall back to the cache.
         let source = Mutex::new(7u32);
         let cache = Mutex::new(0u32);
-        let held = source.lock().expect("lock runtime");
-        assert_eq!(read_without_blocking(&source, &cache, |v| *v), 0);
-        drop(held);
+        let _ = std::panic::catch_unwind(|| {
+            let _guard = source.lock().unwrap();
+            panic!("inference exploded");
+        });
+        assert!(source.is_poisoned(), "precondition: source is poisoned");
+        let _ = read_without_blocking(&source, &cache, |v| *v);
     }
 }

--- a/crates/skippy-server/src/embedded.rs
+++ b/crates/skippy-server/src/embedded.rs
@@ -74,6 +74,15 @@ pub struct SkippyRuntimeHandle {
     runtime: Arc<Mutex<RuntimeState>>,
     telemetry: Telemetry,
     status: Arc<Mutex<RuntimeHandleState>>,
+    /// Last session stats read successfully out of [`Self::runtime`].
+    ///
+    /// `RuntimeState` is held for the entire duration of a decode loop, so a
+    /// status read that locks it blocks for as long as the turn runs (tens of
+    /// seconds on a large model with a long prompt). Status is observability:
+    /// it must never queue behind inference. Reads take the runtime lock
+    /// opportunistically and refresh this cache; when inference holds it, they
+    /// serve the last published value instead of blocking.
+    last_session_stats: Arc<Mutex<RuntimeSessionStats>>,
 }
 
 #[derive(Debug)]
@@ -120,6 +129,7 @@ impl SkippyRuntimeHandle {
                 stopped_at_unix_nanos: None,
                 last_error: None,
             })),
+            last_session_stats: Arc::new(Mutex::new(RuntimeSessionStats::default())),
         })
     }
 
@@ -164,6 +174,7 @@ impl SkippyRuntimeHandle {
                 stopped_at_unix_nanos: None,
                 last_error: None,
             })),
+            last_session_stats: Arc::new(Mutex::new(RuntimeSessionStats::default())),
         })
     }
 
@@ -183,13 +194,23 @@ impl SkippyRuntimeHandle {
         self.telemetry.clone()
     }
 
+    /// Session stats without ever waiting on the inference lock.
+    ///
+    /// `RuntimeState` is held across a whole decode loop, so `lock()` here
+    /// would make every status/readiness/dashboard read queue behind the
+    /// in-flight turn. Take the lock only if it is free — refreshing the cache
+    /// when we get it — and otherwise serve the last published snapshot. Stats
+    /// are advisory, so a value that is one turn stale is strictly better than
+    /// a caller blocked for the length of a generation.
+    fn session_stats_non_blocking(&self) -> RuntimeSessionStats {
+        read_without_blocking(&self.runtime, &self.last_session_stats, |runtime| {
+            runtime.session_stats()
+        })
+    }
+
     pub fn status(&self) -> EmbeddedRuntimeStatus {
         let handle = self.status.lock().expect("runtime status lock poisoned");
-        let sessions = self
-            .runtime
-            .lock()
-            .expect("runtime lock poisoned")
-            .session_stats();
+        let sessions = self.session_stats_non_blocking();
         EmbeddedRuntimeStatus {
             state: handle.state,
             run_id: self.config.run_id.clone(),
@@ -396,5 +417,89 @@ fn finish_server_status(status: &Arc<Mutex<ServerHandleState>>, result: &Result<
             status.state = EmbeddedState::Failed;
             status.last_error = Some(error.to_string());
         }
+    }
+}
+
+/// Read a value derived from `source` without ever waiting on its lock.
+///
+/// `source` here is the inference runtime, whose mutex is held for the whole
+/// duration of a decode loop. Blocking on it from an observability path makes
+/// status/readiness reads queue behind the in-flight turn — and because those
+/// reads happen on async executor threads, a blocking acquire also parks a
+/// worker for the length of a generation. Take the lock only when it is free,
+/// refreshing `cache`; otherwise serve the last value we published.
+///
+/// Returns `V::default()` only if the lock is contended *and* the cache has
+/// been poisoned, which cannot happen before the first successful read.
+fn read_without_blocking<S, V>(source: &Mutex<S>, cache: &Mutex<V>, read: impl FnOnce(&S) -> V) -> V
+where
+    V: Clone + Default,
+{
+    match source.try_lock() {
+        Ok(guard) => {
+            let value = read(&guard);
+            drop(guard);
+            if let Ok(mut cached) = cache.lock() {
+                cached.clone_from(&value);
+            }
+            value
+        }
+        Err(_) => cache
+            .lock()
+            .map(|cached| cached.clone())
+            .unwrap_or_default(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_without_blocking_refreshes_cache_when_lock_is_free() {
+        let source = Mutex::new(7u32);
+        let cache = Mutex::new(0u32);
+
+        assert_eq!(read_without_blocking(&source, &cache, |v| *v), 7);
+        assert_eq!(*cache.lock().unwrap(), 7, "a free lock must refresh cache");
+    }
+
+    #[test]
+    fn read_without_blocking_serves_cache_instead_of_waiting_on_inference() {
+        // The regression: RuntimeState is held for an entire decode loop. A
+        // status read must return the last published value immediately rather
+        // than block for the length of the turn.
+        let source = Mutex::new(7u32);
+        let cache = Mutex::new(0u32);
+
+        // Prime the cache while the runtime is idle.
+        assert_eq!(read_without_blocking(&source, &cache, |v| *v), 7);
+
+        // Now inference holds the runtime lock for the whole turn.
+        let held = source.lock().expect("lock runtime");
+
+        let observed = read_without_blocking(&source, &cache, |v| *v);
+        assert_eq!(
+            observed, 7,
+            "a contended runtime must serve the cached snapshot, never block"
+        );
+
+        drop(held);
+
+        // Once the turn ends, reads go live again.
+        *source.lock().unwrap() = 9;
+        assert_eq!(read_without_blocking(&source, &cache, |v| *v), 9);
+        assert_eq!(*cache.lock().unwrap(), 9);
+    }
+
+    #[test]
+    fn read_without_blocking_returns_default_before_any_successful_read() {
+        // Contended from the very first read: no snapshot exists yet, so the
+        // caller gets the type default rather than waiting on inference.
+        let source = Mutex::new(7u32);
+        let cache = Mutex::new(0u32);
+        let held = source.lock().expect("lock runtime");
+        assert_eq!(read_without_blocking(&source, &cache, |v| *v), 0);
+        drop(held);
     }
 }

--- a/crates/skippy-server/src/embedded.rs
+++ b/crates/skippy-server/src/embedded.rs
@@ -94,6 +94,37 @@ struct RuntimeHandleState {
 }
 
 impl SkippyRuntimeHandle {
+    /// Assemble a ready handle around an already-loaded runtime.
+    ///
+    /// Shared by both loaders so the stats cache is primed exactly once, in one
+    /// place: priming has to happen while `runtime` is still unshared and
+    /// uncontended, so that a status read which loses the race to the very
+    /// first generation reports real lanes instead of zeros.
+    fn ready(
+        config: StageConfig,
+        topology: Option<StageTopology>,
+        runtime: Arc<Mutex<RuntimeState>>,
+        telemetry: Telemetry,
+    ) -> Self {
+        let initial_session_stats = runtime
+            .lock()
+            .expect("runtime lock poisoned")
+            .session_stats();
+        Self {
+            config: Arc::new(config),
+            topology: topology.map(Arc::new),
+            runtime,
+            telemetry,
+            status: Arc::new(Mutex::new(RuntimeHandleState {
+                state: EmbeddedState::Ready,
+                started_at_unix_nanos: now_unix_nanos(),
+                stopped_at_unix_nanos: None,
+                last_error: None,
+            })),
+            last_session_stats: Arc::new(Mutex::new(initial_session_stats)),
+        }
+    }
+
     pub fn load(options: EmbeddedRuntimeOptions) -> Result<Self> {
         validate_config(&options.config, options.topology.as_ref())?;
         let telemetry = Telemetry::new(
@@ -118,26 +149,12 @@ impl SkippyRuntimeHandle {
             "stage.embedded_runtime_ready",
             lifecycle_attrs(&options.config),
         );
-        // Prime the stats snapshot while the runtime is still unshared and
-        // uncontended, so a read that loses the race to the very first
-        // generation reports real lanes instead of zeros.
-        let initial_session_stats = runtime
-            .lock()
-            .expect("runtime lock poisoned")
-            .session_stats();
-        Ok(Self {
-            config: Arc::new(options.config),
-            topology: options.topology.map(Arc::new),
+        Ok(Self::ready(
+            options.config,
+            options.topology,
             runtime,
             telemetry,
-            status: Arc::new(Mutex::new(RuntimeHandleState {
-                state: EmbeddedState::Ready,
-                started_at_unix_nanos: now_unix_nanos(),
-                stopped_at_unix_nanos: None,
-                last_error: None,
-            })),
-            last_session_stats: Arc::new(Mutex::new(initial_session_stats)),
-        })
+        ))
     }
 
     pub fn load_with_open_events(
@@ -170,26 +187,12 @@ impl SkippyRuntimeHandle {
             "stage.embedded_runtime_ready",
             lifecycle_attrs(&options.config),
         );
-        // Prime the stats snapshot while the runtime is still unshared and
-        // uncontended, so a read that loses the race to the very first
-        // generation reports real lanes instead of zeros.
-        let initial_session_stats = runtime
-            .lock()
-            .expect("runtime lock poisoned")
-            .session_stats();
-        Ok(Self {
-            config: Arc::new(options.config),
-            topology: options.topology.map(Arc::new),
+        Ok(Self::ready(
+            options.config,
+            options.topology,
             runtime,
             telemetry,
-            status: Arc::new(Mutex::new(RuntimeHandleState {
-                state: EmbeddedState::Ready,
-                started_at_unix_nanos: now_unix_nanos(),
-                stopped_at_unix_nanos: None,
-                last_error: None,
-            })),
-            last_session_stats: Arc::new(Mutex::new(initial_session_stats)),
-        })
+        ))
     }
 
     pub fn config(&self) -> &StageConfig {
@@ -474,7 +477,119 @@ where
 
 #[cfg(test)]
 mod tests {
+    use std::{sync::mpsc, thread, time::Duration};
+
+    use skippy_protocol::LoadMode;
+
     use super::*;
+
+    /// A ready handle over a modelless runtime.
+    ///
+    /// `status()` only reads lane bookkeeping and handle state, so it is
+    /// exercisable without loading a GGUF. Built through
+    /// [`SkippyRuntimeHandle::ready`] rather than by hand, so these tests cover
+    /// the real cache-priming path both loaders use.
+    fn test_handle(lane_count: u32) -> SkippyRuntimeHandle {
+        let config = StageConfig {
+            run_id: "run".to_string(),
+            topology_id: "topology".to_string(),
+            model_id: "org/model:Q4_K_M".to_string(),
+            package_ref: None,
+            manifest_sha256: None,
+            source_model_path: None,
+            source_model_sha256: None,
+            source_model_bytes: None,
+            materialized_path: None,
+            materialized_pinned: false,
+            model_path: None,
+            projector_path: None,
+            stage_id: "stage-0".to_string(),
+            stage_index: 0,
+            layer_start: 0,
+            layer_end: 1,
+            ctx_size: 512,
+            lane_count,
+            n_batch: None,
+            n_ubatch: None,
+            n_gpu_layers: 0,
+            mmap: None,
+            mlock: false,
+            cache_type_k: "f16".to_string(),
+            cache_type_v: "f16".to_string(),
+            flash_attn_type: Default::default(),
+            filter_tensors_on_load: false,
+            selected_device: None,
+            kv_cache: None,
+            native_mtp_enabled: false,
+            load_mode: LoadMode::RuntimeSlice,
+            bind_addr: "127.0.0.1:0".to_string(),
+            upstream: None,
+            downstream: None,
+        };
+        let telemetry = Telemetry::new(None, 1, config.clone(), TelemetryLevel::Off);
+        let runtime = Arc::new(Mutex::new(RuntimeState::new_modelless_for_test(lane_count)));
+        SkippyRuntimeHandle::ready(config, None, runtime, telemetry)
+    }
+
+    #[test]
+    fn status_does_not_block_while_inference_holds_the_runtime() {
+        // The actual regression, pinned at the call site rather than on the
+        // helper: `status()` must stay responsive while a decode loop owns the
+        // runtime mutex for the whole turn. Asserting on the helper alone does
+        // not catch `status()` being rewired back to a blocking `lock()`.
+        let handle = Arc::new(test_handle(3));
+
+        // Inference takes the runtime for the length of the turn.
+        let held = handle.runtime.lock().expect("lock runtime");
+
+        // Probe from a detached thread. It must not be joined: if `status()`
+        // regresses to a blocking acquire the probe never returns, and joining
+        // it would hang the suite instead of reporting a failure. The timeout
+        // below is the assertion.
+        let (tx, rx) = mpsc::channel();
+        thread::spawn({
+            let handle = Arc::clone(&handle);
+            move || {
+                let _ = tx.send(handle.status());
+            }
+        });
+        let probe = rx.recv_timeout(Duration::from_secs(5));
+
+        let status = probe.expect("status() must return while the runtime lock is held");
+        assert_eq!(
+            status.sessions.lane_count, 3,
+            "a contended read must serve the primed snapshot, not zeros"
+        );
+        assert_eq!(status.state, EmbeddedState::Ready);
+
+        drop(held);
+    }
+
+    #[test]
+    fn status_reports_primed_lanes_before_any_generation() {
+        // Regression for the zeros-on-the-first-turn defect: the cache is
+        // primed during construction, so even a read that never wins the
+        // runtime lock reports real lane counts.
+        let handle = test_handle(2);
+        let held = handle.runtime.lock().expect("lock runtime");
+
+        let cached = handle.session_stats_non_blocking();
+
+        assert_eq!(cached.lane_count, 2, "priming must publish real lanes");
+        assert_eq!(cached.lanes.len(), 2);
+        drop(held);
+    }
+
+    #[test]
+    fn status_reads_live_stats_when_the_runtime_is_idle() {
+        let handle = test_handle(4);
+
+        let status = handle.status();
+
+        assert_eq!(status.sessions.lane_count, 4);
+        assert_eq!(status.sessions.active_sessions, 0);
+        assert!(status.runtime_loaded);
+    }
 
     #[test]
     fn read_without_blocking_refreshes_cache_when_lock_is_free() {

--- a/crates/skippy-server/src/embedded.rs
+++ b/crates/skippy-server/src/embedded.rs
@@ -43,7 +43,15 @@ pub struct EmbeddedRuntimeStatus {
     pub started_at_unix_nanos: i64,
     pub stopped_at_unix_nanos: Option<i64>,
     pub last_error: Option<String>,
+    /// Session stats, possibly a cached snapshot rather than a live read.
+    ///
+    /// `lane_count` is authoritative (it comes from `StageConfig`); everything
+    /// else may be frozen. Display only — never gate a decision on it.
     pub sessions: RuntimeSessionStats,
+    /// When [`Self::sessions`] was actually read, which may be arbitrarily
+    /// earlier than this status. Derive any freshness signal from this rather
+    /// than from the current time.
+    pub sessions_captured_at_unix_nanos: i64,
     pub telemetry: TelemetryStats,
 }
 
@@ -74,15 +82,21 @@ pub struct SkippyRuntimeHandle {
     runtime: Arc<Mutex<RuntimeState>>,
     telemetry: Telemetry,
     status: Arc<Mutex<RuntimeHandleState>>,
-    /// Last session stats read successfully out of [`Self::runtime`].
+    /// Last session stats read out of [`Self::runtime`], and when.
     ///
-    /// `RuntimeState` is held for the entire duration of a decode loop, so a
-    /// status read that locks it blocks for as long as the turn runs (tens of
-    /// seconds on a large model with a long prompt). Status is observability:
-    /// it must never queue behind inference. Reads take the runtime lock
-    /// opportunistically and refresh this cache; when inference holds it, they
-    /// serve the last published value instead of blocking.
-    last_session_stats: Arc<Mutex<RuntimeSessionStats>>,
+    /// A native call (long prefill, decode batch) holds the runtime lock while
+    /// it runs, so status reads take it opportunistically and fall back to
+    /// this cache rather than queueing behind inference. The capture time
+    /// travels with the value so a stalled runtime is distinguishable from an
+    /// idle one.
+    last_session_stats: Arc<Mutex<Captured<RuntimeSessionStats>>>,
+}
+
+/// A value together with when it was actually read from its source.
+#[derive(Clone, Debug)]
+struct Captured<V> {
+    value: V,
+    captured_at_unix_nanos: i64,
 }
 
 #[derive(Debug)]
@@ -106,10 +120,13 @@ impl SkippyRuntimeHandle {
         runtime: Arc<Mutex<RuntimeState>>,
         telemetry: Telemetry,
     ) -> Self {
-        let initial_session_stats = runtime
-            .lock()
-            .expect("runtime lock poisoned")
-            .session_stats();
+        let initial_session_stats = Captured {
+            value: runtime
+                .lock()
+                .expect("runtime lock poisoned")
+                .session_stats(),
+            captured_at_unix_nanos: now_unix_nanos(),
+        };
         Self {
             config: Arc::new(config),
             topology: topology.map(Arc::new),
@@ -211,15 +228,9 @@ impl SkippyRuntimeHandle {
         self.telemetry.clone()
     }
 
-    /// Session stats without ever waiting on the inference lock.
-    ///
-    /// `RuntimeState` is held across a whole decode loop, so `lock()` here
-    /// would make every status/readiness/dashboard read queue behind the
-    /// in-flight turn. Take the lock only if it is free — refreshing the cache
-    /// when we get it — and otherwise serve the last published snapshot. Stats
-    /// are advisory, so a value that is one turn stale is strictly better than
-    /// a caller blocked for the length of a generation.
-    fn session_stats_non_blocking(&self) -> RuntimeSessionStats {
+    /// Session stats without ever waiting on the inference lock, and when they
+    /// were read. A cached value carries the earlier read's time, not now.
+    fn session_stats_non_blocking(&self) -> Captured<RuntimeSessionStats> {
         read_without_blocking(&self.runtime, &self.last_session_stats, |runtime| {
             runtime.session_stats()
         })
@@ -227,7 +238,10 @@ impl SkippyRuntimeHandle {
 
     pub fn status(&self) -> EmbeddedRuntimeStatus {
         let handle = self.status.lock().expect("runtime status lock poisoned");
-        let sessions = self.session_stats_non_blocking();
+        let Captured {
+            value: sessions,
+            captured_at_unix_nanos: sessions_captured_at_unix_nanos,
+        } = self.session_stats_non_blocking();
         EmbeddedRuntimeStatus {
             state: handle.state,
             run_id: self.config.run_id.clone(),
@@ -242,6 +256,7 @@ impl SkippyRuntimeHandle {
             stopped_at_unix_nanos: handle.stopped_at_unix_nanos,
             last_error: handle.last_error.clone(),
             sessions,
+            sessions_captured_at_unix_nanos,
             telemetry: self.telemetry.stats(),
         }
     }
@@ -437,27 +452,27 @@ fn finish_server_status(status: &Arc<Mutex<ServerHandleState>>, result: &Result<
     }
 }
 
-/// Read a value derived from `source` without waiting on its lock.
+/// Read a value derived from `source` without waiting on its lock, reporting
+/// when it was actually read.
 ///
-/// `source` here is the inference runtime, whose mutex is held for the whole
-/// duration of a decode loop. Blocking on it from an observability path makes
-/// status/readiness reads queue behind the in-flight turn — and because those
-/// reads happen on async executor threads, a blocking acquire also parks a
-/// worker for the length of a generation. Take the lock only when it is free,
-/// refreshing `cache`; otherwise serve the last value we published.
+/// `source` is the inference runtime, whose mutex a native call holds for as
+/// long as it runs. Blocking on it from an observability path makes status
+/// reads queue behind that work, and since those reads happen on async
+/// executor threads it also parks a worker. So: take the lock only when free,
+/// refreshing `cache`; otherwise serve the last published value.
 ///
-/// Staleness is deliberately unbounded: under sustained load every
-/// opportunistic read can lose the race, so the snapshot may lag by many
-/// turns. That is acceptable only because these stats are observability —
-/// nothing admits, routes, evicts or limits on them (`lane_count` reaching
-/// mesh gossip comes from `StageConfig`, not from here). Do not reuse this
-/// helper for a value that gates a decision.
+/// Staleness is unbounded — under sustained load every read can lose the race.
+/// That is only safe because the capture time makes it visible, so callers
+/// must propagate it rather than stamp the value as freshly observed. Nothing
+/// may gate admission, routing, eviction or shutdown on these values.
 ///
-/// A poisoned `source` still panics, exactly as the previous blocking
-/// `lock().expect(..)` did: a poisoned inference runtime means generation
-/// panicked, and reporting healthy cached stats over the top of that would
-/// hide a real failure.
-fn read_without_blocking<S, V>(source: &Mutex<S>, cache: &Mutex<V>, read: impl FnOnce(&S) -> V) -> V
+/// A poisoned `source` still panics, as the previous blocking `lock().expect`
+/// did: cached stats over a panicked runtime would hide a real failure.
+fn read_without_blocking<S, V>(
+    source: &Mutex<S>,
+    cache: &Mutex<Captured<V>>,
+    read: impl FnOnce(&S) -> V,
+) -> Captured<V>
 where
     V: Clone,
 {
@@ -465,11 +480,15 @@ where
         Ok(guard) => {
             let value = read(&guard);
             drop(guard);
-            *cache.lock().expect("stats cache lock poisoned") = value.clone();
-            value
+            let captured = Captured {
+                value,
+                captured_at_unix_nanos: now_unix_nanos(),
+            };
+            *cache.lock().expect("stats cache lock poisoned") = captured.clone();
+            captured
         }
-        // Inference holds the runtime: serve the last published snapshot
-        // instead of blocking for the rest of the turn.
+        // Inference holds the runtime: serve the last published snapshot,
+        // carrying the time it was taken, instead of blocking.
         Err(TryLockError::WouldBlock) => cache.lock().expect("stats cache lock poisoned").clone(),
         Err(TryLockError::Poisoned(error)) => panic!("runtime lock poisoned: {error}"),
     }
@@ -575,9 +594,37 @@ mod tests {
 
         let cached = handle.session_stats_non_blocking();
 
-        assert_eq!(cached.lane_count, 2, "priming must publish real lanes");
-        assert_eq!(cached.lanes.len(), 2);
+        assert_eq!(
+            cached.value.lane_count, 2,
+            "priming must publish real lanes"
+        );
+        assert_eq!(cached.value.lanes.len(), 2);
+        assert!(
+            cached.captured_at_unix_nanos > 0,
+            "priming must record when it captured"
+        );
         drop(held);
+    }
+
+    #[test]
+    fn status_does_not_claim_a_fresh_capture_while_the_runtime_is_busy() {
+        // The false-freshness defect: a contended read must report the time of
+        // the earlier successful read, so a runtime wedged inside a native
+        // call shows a capture time that stops advancing rather than looking
+        // freshly observed on every tick.
+        let handle = test_handle(2);
+
+        let live = handle.status();
+        assert!(live.sessions_captured_at_unix_nanos > 0);
+
+        let held = handle.runtime.lock().expect("lock runtime");
+        let while_busy = handle.status();
+        drop(held);
+
+        assert_eq!(
+            while_busy.sessions_captured_at_unix_nanos, live.sessions_captured_at_unix_nanos,
+            "a cached read must not advance the capture time"
+        );
     }
 
     #[test]
@@ -591,41 +638,68 @@ mod tests {
         assert!(status.runtime_loaded);
     }
 
+    fn empty_cache(value: u32) -> Mutex<Captured<u32>> {
+        Mutex::new(Captured {
+            value,
+            captured_at_unix_nanos: 0,
+        })
+    }
+
     #[test]
     fn read_without_blocking_refreshes_cache_when_lock_is_free() {
         let source = Mutex::new(7u32);
-        let cache = Mutex::new(0u32);
+        let cache = empty_cache(0);
 
-        assert_eq!(read_without_blocking(&source, &cache, |v| *v), 7);
-        assert_eq!(*cache.lock().unwrap(), 7, "a free lock must refresh cache");
+        let read = read_without_blocking(&source, &cache, |v| *v);
+
+        assert_eq!(read.value, 7);
+        assert!(
+            read.captured_at_unix_nanos > 0,
+            "a live read must report when it happened"
+        );
+        assert_eq!(
+            cache.lock().unwrap().value,
+            7,
+            "a free lock must refresh cache"
+        );
     }
 
     #[test]
     fn read_without_blocking_serves_cache_instead_of_waiting_on_inference() {
-        // The regression: RuntimeState is held for an entire decode loop. A
-        // status read must return the last published value immediately rather
-        // than block for the length of the turn.
+        // The regression: a long native call holds the runtime for as long as
+        // it runs. A status read must return the last published value
+        // immediately rather than block behind it.
         let source = Mutex::new(7u32);
-        let cache = Mutex::new(0u32);
+        let cache = empty_cache(0);
 
         // Prime the cache while the runtime is idle.
-        assert_eq!(read_without_blocking(&source, &cache, |v| *v), 7);
+        let live = read_without_blocking(&source, &cache, |v| *v);
+        assert_eq!(live.value, 7);
 
-        // Now inference holds the runtime lock for the whole turn.
+        // Now inference holds the runtime lock.
         let held = source.lock().expect("lock runtime");
 
         let observed = read_without_blocking(&source, &cache, |v| *v);
         assert_eq!(
-            observed, 7,
+            observed.value, 7,
             "a contended runtime must serve the cached snapshot, never block"
+        );
+        assert_eq!(
+            observed.captured_at_unix_nanos, live.captured_at_unix_nanos,
+            "a cached read must report the earlier capture time, not now"
         );
 
         drop(held);
 
-        // Once the turn ends, reads go live again.
+        // Once the call ends, reads go live again.
         *source.lock().unwrap() = 9;
-        assert_eq!(read_without_blocking(&source, &cache, |v| *v), 9);
-        assert_eq!(*cache.lock().unwrap(), 9);
+        let refreshed = read_without_blocking(&source, &cache, |v| *v);
+        assert_eq!(refreshed.value, 9);
+        assert!(
+            refreshed.captured_at_unix_nanos >= live.captured_at_unix_nanos,
+            "a fresh read must advance the capture time"
+        );
+        assert_eq!(cache.lock().unwrap().value, 9);
     }
 
     #[test]
@@ -635,7 +709,7 @@ mod tests {
         // over the top of that would report a healthy node, so this must keep
         // the pre-existing panic behaviour rather than fall back to the cache.
         let source = Mutex::new(7u32);
-        let cache = Mutex::new(0u32);
+        let cache = empty_cache(0);
         let _ = std::panic::catch_unwind(|| {
             let _guard = source.lock().unwrap();
             panic!("inference exploded");

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -115,6 +115,29 @@ struct ResidentLanePrefix {
 }
 
 impl RuntimeState {
+    /// A runtime with no model behind it, for tests that exercise code paths
+    /// which never touch the model.
+    ///
+    /// [`Self::session_stats`] is pure Rust over the lane bookkeeping below, so
+    /// status/observability behaviour can be tested without loading a GGUF.
+    /// Any call that reaches [`Self::model`] will dereference a null handle, so
+    /// this must not be used to drive inference.
+    #[cfg(test)]
+    pub(crate) fn new_modelless_for_test(lane_count: u32) -> Self {
+        Self {
+            model: StageModel::new_dummy(),
+            layer_start: 0,
+            layer_end: 1,
+            lane_count,
+            next_lane_index: 0,
+            free_lane_indices: Vec::new(),
+            sessions: BTreeMap::new(),
+            idle_sessions: Vec::new(),
+            session_token_counts: BTreeMap::new(),
+            session_resident_prefixes: BTreeMap::new(),
+        }
+    }
+
     pub fn prefill(&mut self, session_id: &str, token_ids: &[i32]) -> Result<()> {
         let session = self.session(session_id)?;
         session.prefill_chunked(token_ids)?;


### PR DESCRIPTION
Fixes #1126.

Status and readiness reads no longer stall while a model is busy. Previously, hitting `/api/status` or `/v1/models` on a node that was mid-prefill would hang for tens of seconds; now both answer in milliseconds regardless of what inference is doing. The dashboard stays responsive during long turns, and — because the blocking acquire was happening on async executor threads — the node stops parking tokio workers for the length of a generation.

## Problem

`SkippyRuntimeHandle::status()` locked `Mutex<RuntimeState>` purely to read `session_stats()`. That is the inference lock, and a single native call holds it for as long as that call runs — a large model with a long prompt can sit inside one prefill for ~25s.

The dashboard context-usage tick (`DASHBOARD_CONTEXT_USAGE_REFRESH_INTERVAL`, **250ms**) reaches `status()` via `refresh_dashboard_context_usage → ctx_used_tokens`, from inside a `tokio::select!` loop. So this was a *synchronous* blocking acquire on an async executor thread.

Caught live in a stack sample during a stall:

```
runtime::startup_handles::startup_local_model_loop
  → runtime::dashboard::refresh_dashboard_context_usage
  → runtime::local::LocalRuntimeModelHandle::ctx_used_tokens
  → inference::skippy::SkippyModelHandle::status
  → skippy_server::embedded::SkippyRuntimeHandle::status
  → std::sync::Mutex<RuntimeState>::lock
  → pthread_mutex_firstfit_lock_wait        ← BLOCKED
```

Waiting on that lock is correct backpressure for *another inference request*. It is not correct for an observability read that needs no GPU and touches no inference state.

## Fix

Session stats are advisory, so read them without ever waiting: take the runtime lock only when it is free — refreshing a cached snapshot when we get it — and otherwise serve the last published value. Extracted as `read_without_blocking()` so the behaviour is unit-testable independently of a loaded model.

Because a cached read can be arbitrarily stale, the snapshot carries the time it was actually taken, and callers propagate that instead of stamping it as freshly observed. Without this, a runtime wedged inside a native call would publish `Ready`, `0/N slots busy` and a one-second-old success timestamp every 250ms, forever — the dashboard only flags staleness when `attempt > success`, so it could never fire. That is precisely the signal needed to diagnose the stall this PR fixes, so getting it wrong would have traded a slow control plane for a lying one.

No API removals, no behaviour change for inference.

## Scope: which lock sites change

I audited every `runtime.lock()` site in `skippy-server`. `status()` was the only observability reader; the rest are inference or session lifecycle, where waiting is correct and must stay:

| site | function | kind |
|---|---|---|
| `frontend/decode_batcher.rs:192` | `run_batch` | inference (per decode batch) |
| `frontend/embedded_execution.rs:83` | stage execution | inference (per stage op) |
| `frontend/generation_flow.rs:402,1023` | `generate_multimodal_text`, `generate_split_multimodal_text` | inference |
| `binary_transport/.../prefill_recording.rs:97` | `record_full_prefill_with_activations` | inference |
| `binary_transport/.../connection.rs:223,301,359` | `handle_binary_connection` | inference transport |
| `frontend/local_generation.rs:1021` | `cleanup_local_generation_session` | session teardown |
| `frontend/prefix_cache.rs:1175` | `drop_embedded_split_restore` | session teardown |
| `frontend/embedded_generation/lifecycle.rs:387` | `drop_embedded_runtime_session` | session teardown |
| `http.rs:326,360,383,422,444,463,470,599` | `message`, `text_entrypoint`, `maybe_lookup_prefill` | inference (legacy `serve` path) |

Note on the last row: the `http.rs` handlers do hold the runtime lock across a whole `for _ in 0..max_new_tokens` decode loop (`http.rs:462`), *and* they do it inside async Axum handlers. That is the same bug class on a different surface. It is not fixed here because that surface is the legacy `skippy-server serve` subcommand, which the shipped `mesh-llm` binary never reaches — host-runtime uses `start_binary_stage` and `start_openai_backend`, `start_stage_http` has no callers, and no release artifact ships the `skippy-server` binary. Its only live consumer is the `skippy-bench` local harness, issuing sequential single requests. Worth a separate look at whether that path should exist at all rather than widening this change.

## Architecture

`EmbeddedRuntimeStatus` gains `sessions_captured_at_unix_nanos`, threaded through `SkippyModelStatus` to `llama_slots_snapshot`, which now reports it as `last_success_unix_ms` rather than `now`. Within `sessions`, `lane_count` remains authoritative — it comes from `StageConfig` and never changes; every other field is display-only observability that may be frozen. Nothing in-tree gates admission, routing, eviction, or shutdown on these values (lane exhaustion is checked inside `RuntimeState::session()`; admission uses the semaphore and token budget), and none of it is gossiped.

Staleness is deliberately unbounded rather than bounded: under sustained load an opportunistic read can keep losing the race. The architecturally cleaner design is a snapshot published by the runtime owner after each batch and lifecycle change, carrying its own capture time, which would make status lock-free and staleness bounded. That is a larger change and deliberately not folded in here.

## Measured

Standalone `serve`, `unsloth/gemma-4-E4B-it-GGUF:Q4_K_M`, randomized ~30k-token prompt (cache-miss, ~25s prefill), probing throughout with a 3s timeout:

| endpoint (during prefill) | before | after |
|---|---|---|
| `/v1/models` | **3009ms timeout** | **0.5–9ms · 200** |
| `/api/status` | **3002ms timeout** | **2.4–3.4ms · 200** |
| `tcp_connect` | 0.2ms | 0.1ms |

Reproduced across repeat runs (6/6 probes fast). Both endpoints recover, including `/v1/models`, which uses async locks rather than this mutex — consistent with the blocking acquire having starved executor threads.

**Inference is unaffected:** same prefill duration and token counts (24.0s/28738 before, 26.0s/30471 and 25.1s/29480 after — variance is prompt randomisation), and replies remain correct (`7+5` → `12`, `finish_reason: stop`).

Re-measured after the follow-up commits: `/v1/models` 0.6–7.6ms, `/api/status` 2.5–3.2ms during a ~25s prefill; startup unaffected by the priming lock.

## Tests

Seven unit tests. On `read_without_blocking()`:
- free lock → reads live, refreshes the cache, reports a live capture time;
- **contended lock → serves the cached snapshot instead of blocking** (the regression), carrying the earlier capture time rather than `now`;
- poisoned runtime → still panics, rather than masking a failed generation behind cached stats.

On `status()` itself, over a real `SkippyRuntimeHandle`:
- returns while the runtime lock is held — probed from a detached thread and asserted by timeout, so a blocking regression fails in ~5s instead of hanging the suite;
- reports primed lane counts before any generation, so a read that loses the race to the very first turn does not publish zeros;
- does not advance the capture time while the runtime is busy;
- reads live when idle.

`session_stats()` is pure Rust over lane bookkeeping, so these need no GGUF: `RuntimeState::new_modelless_for_test` builds one over `StageModel::new_dummy()`, which drops safely on a null handle.

Mutation-checked, each failing fast rather than hanging:

| mutation | result |
|---|---|
| `status()` → blocking `lock()` | contention test fails on timeout, 5.01s |
| cache priming → `default()` | priming test fails, `lane_count` 0 |
| cached branch stamps `now()` | both capture-time tests fail |
| `try_lock()` → `lock()` in the helper | contended helper test deadlocks |

`cargo test -p skippy-server` 335 passed / 0 failed. `cargo test -p mesh-llm-host-runtime --lib` 1853 passed / 0 failed. fmt and clippy clean on both crates.

## Review follow-ups

An independent review of the first cut (`121749bc`) found three defects, fixed in `419de7b1`:

- **Poison masking.** `Err(_)` conflated `WouldBlock` with `Poisoned`, so a poisoned runtime would have reported a healthy node with cached stats while inference was failing. Now matches `TryLockError` explicitly and still panics on `Poisoned`, exactly as the previous `lock().expect(..)` did. Pinned by a `#[should_panic]` test.
- **Zeros on the first turn.** The cache started at `default()`, so a read that lost the race to the *very first* generation published zero lanes and zero usage for that entire turn. The cache is now primed during construction, while the runtime is still unshared and uncontended.
- **Inaccurate docs.** The helper claimed staleness was bounded to one turn and that it never blocks. Neither is true.

A second review round found two more, fixed in `e53e1bcb` and `d122ad95`:

- **Tests did not pin the fix.** They exercised `read_without_blocking` generically over a `Mutex<u32>`; nothing asserted that `status()` called it, so reverting `status()` to a blocking `lock()` left every test passing. Now covered at the call site.
- **False freshness.** `llama_slots_snapshot` stamped `last_success_unix_ms: now` unconditionally, so cached data was republished as freshly successful every tick — see Fix above.

Also corrected in this description: the original claimed `RuntimeState` is held "for the entire duration of a decode loop" and quoted a decode loop as evidence. That quote is from `http.rs:462`, the legacy path. The live path locks per decode batch (`decode_batcher.rs:192`). The stall was real; the mechanism is one long native call under the lock, not a whole-turn hold.
