### PR TITLE
build: select iroh TLS backend explicitly (tls-aws-lc-rs) instead of defaults

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4762,6 +4762,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "334c3c9833f7b2c573cceb9896ddc7aaeb58c8807cbb63211b24d1fe88bf866e"
 dependencies = [
  "aes-gcm",
+ "aws-lc-rs",
  "bytes",
  "derive_more",
  "enum-assoc",
@@ -8117,6 +8118,7 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5"
 dependencies = [
+ "aws-lc-rs",
  "base64",
  "bytes",
  "futures-core",

--- a/crates/mesh-client/Cargo.toml
+++ b/crates/mesh-client/Cargo.toml
@@ -22,7 +22,7 @@ host-io = ["mesh-llm-identity/host-io"]
 # model-artifact, iroh, tokio, prost, bytes, rustls, quinn, serde, serde_json, thiserror, anyhow,
 # tracing, sha2, ed25519-dalek, hex, uuid, url, http, base64, async-trait, httparse
 # (httparse is a transitive dep of iroh; not in forbidden list)
-iroh = "1.0.0"
+iroh = { version = "1.0.0", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
 mesh-llm-identity = { path = "../mesh-llm-identity", version = "0.72.1", default-features = false }
 mesh-llm-protocol = { path = "../mesh-llm-protocol", version = "0.72.1" }
 mesh-llm-routing = { path = "../mesh-llm-routing", version = "0.72.1" }

--- a/crates/mesh-llm-commands/Cargo.toml
+++ b/crates/mesh-llm-commands/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
 hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.2", default-features = false, features = ["blocking"] }
 hex = "0.4.3"
-iroh = "1.0.0"
+iroh = { version = "1.0.0", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
 json5 = "1.3.1"
 nix = { version = "0.29.0", default-features = false, features = ["signal"] }
 mesh-llm-build-info.workspace = true

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -55,7 +55,7 @@ skippy-runtime = { path = "../skippy-runtime", version = "0.72.1"  }
 skippy-ffi = { path = "../skippy-ffi", version = "0.72.1", default-features = false }
 skippy-server = { path = "../skippy-server", version = "0.72.1"  }
 skippy-topology = { path = "../skippy-topology", version = "0.72.1"  }
-iroh = "1.0.0"
+iroh = { version = "1.0.0", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/crates/mesh-llm-protocol/Cargo.toml
+++ b/crates/mesh-llm-protocol/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 anyhow.workspace = true
 hex = "0.4"
-iroh = "1.0.0"
+iroh = { version = "1.0.0", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
 prost = "0.14"
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/mesh-llm-routing/Cargo.toml
+++ b/crates/mesh-llm-routing/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["llm", "mesh", "routing", "inference"]
 categories = ["network-programming"]
 
 [dependencies]
-iroh = "1.0.0"
+iroh = { version = "1.0.0", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }


### PR DESCRIPTION
## What

Declares the `iroh` dependency explicitly in the five crates that use it (`mesh-llm-protocol`, `mesh-llm-routing`, `mesh-client`, `mesh-llm-commands`, `mesh-llm-host-runtime`), replacing the bare `iroh = "1.0.0"` with `default-features = false` plus the same feature set iroh's defaults enable today — except `tls-ring`, which is swapped for `tls-aws-lc-rs`.

## Why

Cargo features are additive: a bare `iroh = "1.0.0"` enables iroh's `default` feature, which includes `tls-ring`, and no downstream consumer can subtract it. When both TLS backends are compiled in, iroh prefers ring — so any embedder of the mesh-llm SDK ships ring in its binary no matter what it does in its own manifest.

For deployments that need FIPS 140-3 alignment this is a hard blocker: ring is not FIPS-validated, while aws-lc-rs has a validated mode and is what rustls' FIPS story is built on. Today the only workaround is `[patch.crates-io]`-ing iroh itself to redefine its defaults, which every embedder has to carry independently.

With this change the resolved graph (normal deps) becomes:

```
├── iroh feature "fast-apple-datapath"
├── iroh feature "metrics"
├── iroh feature "portmapper"
└── iroh feature "tls-aws-lc-rs"
```

— no `default`, no `tls-ring`.

## Notes

- **Behavior is unchanged** — iroh supports both backends equivalently; this only pins which one is compiled in.
- **Dev-dependencies are untouched** (`mesh-llm-host-runtime`'s `iroh`/`iroh-relay` test deps) — they don't propagate to consumers.
- Verified with `cargo tree -e normal,features -i iroh` (output above) and `cargo check` on all five crates.
- If you'd prefer to keep ring as the project default, the alternative is passthrough `tls-ring`/`tls-aws-lc-rs` features plumbed through every crate between the SDK surface and iroh. That's a much larger diff; happy to rework this PR that way if you want backend choice rather than a swap.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved connection performance on Apple devices.
  * Enabled port mapping and connection metrics.
  * Added AWS-LC-RS TLS support for secure connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->