### PR TITLE
fix(skippy): treat zero-temperature sampling as greedy

### DIFF
--- a/crates/skippy-server/src/frontend/linear_proposal.rs
+++ b/crates/skippy-server/src/frontend/linear_proposal.rs
@@ -7,6 +7,7 @@ use std::{
 use anyhow::{Result, bail};
 use openai_frontend::{OpenAiError, OpenAiResult};
 use serde_json::json;
+use skippy_runtime::SamplingConfig;
 
 use crate::frontend::{
     NativeMtpVerifyWindowDecision, StageOpenAiBackend, TokenControl,
@@ -431,10 +432,16 @@ pub(crate) fn report_linear_proposal_receipt(
 }
 
 pub(crate) fn greedy_linear_proposal_admitted(
-    sampling_enabled: bool,
+    sampling: &SamplingConfig,
     chat_sampling_metadata: Option<&str>,
 ) -> bool {
-    if sampling_enabled {
+    let greedy_equivalent = !sampling.enabled
+        || (sampling.temperature <= 0.0
+            && sampling.presence_penalty == 0.0
+            && sampling.frequency_penalty == 0.0
+            && sampling.repeat_penalty == 1.0
+            && sampling.logit_bias.is_empty());
+    if !greedy_equivalent {
         return false;
     }
     match chat_sampling_metadata {
@@ -981,19 +988,45 @@ mod tests {
     }
 
     #[test]
-    fn greedy_admission_rejects_sampling_and_grammar() {
-        assert!(greedy_linear_proposal_admitted(false, None));
-        assert!(greedy_linear_proposal_admitted(false, Some("{}")));
+    fn greedy_admission_accepts_zero_temperature_and_rejects_logit_modifiers() {
+        let disabled = SamplingConfig::default();
+        let temperature_zero = SamplingConfig {
+            enabled: true,
+            temperature: 0.0,
+            top_p: 0.95,
+            top_k: 40,
+            min_p: 0.05,
+            ..SamplingConfig::default()
+        };
+        let stochastic = SamplingConfig {
+            enabled: true,
+            temperature: 0.8,
+            ..SamplingConfig::default()
+        };
+        let biased_greedy = SamplingConfig {
+            enabled: true,
+            temperature: 0.0,
+            logit_bias: vec![skippy_runtime::LogitBias {
+                token_id: 7,
+                bias: 1.0,
+            }],
+            ..SamplingConfig::default()
+        };
+
+        assert!(greedy_linear_proposal_admitted(&disabled, None));
+        assert!(greedy_linear_proposal_admitted(&disabled, Some("{}")));
         assert!(greedy_linear_proposal_admitted(
-            false,
+            &disabled,
             Some(r#"{"grammar":""}"#)
         ));
-        assert!(!greedy_linear_proposal_admitted(true, None));
+        assert!(greedy_linear_proposal_admitted(&temperature_zero, None));
+        assert!(!greedy_linear_proposal_admitted(&stochastic, None));
+        assert!(!greedy_linear_proposal_admitted(&biased_greedy, None));
         assert!(!greedy_linear_proposal_admitted(
-            false,
+            &disabled,
             Some(r#"{"grammar":"root ::= value"}"#)
         ));
-        assert!(!greedy_linear_proposal_admitted(false, Some("{")));
+        assert!(!greedy_linear_proposal_admitted(&disabled, Some("{")));
     }
 
     #[test]

--- a/crates/skippy-server/src/frontend/local_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation.rs
@@ -579,7 +579,7 @@ impl StageOpenAiBackend {
                 && !request.native_mtp_enabled
                 && !generation_hooks_active
                 && greedy_linear_proposal_admitted(
-                    request.sampling.enabled,
+                    request.sampling,
                     request.chat_sampling_metadata,
                 );
             let linear_proposal_max_tokens = if linear_proposals_enabled {


### PR DESCRIPTION
## Problem

OpenAI clients commonly use `temperature: 0` when they need reproducible output. Skippy still classified those requests as stochastic whenever sampling was enabled, so it rejected verified linear proposals even when no sampling option could change the winning token.

That meant a deterministic request behaved differently depending on whether the client omitted sampling settings or explicitly requested zero temperature.

## Fix

Admission now depends on whether the request can actually change greedy token selection. Zero temperature with neutral penalties and no logit bias is treated as deterministic. Non-zero temperature, grammar-constrained sampling, penalties, and logit bias remain excluded.

This keeps the safety boundary narrow: proposals are admitted only when verification is equivalent to greedy decoding, without special-casing a particular model or client.

## Validation

Skippy Server tests pass (353/353), including deterministic and stochastic sampling cases.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved linear proposal handling for generation requests.
  * Deterministic, zero-temperature sampling is now supported when no penalties or bias adjustments are applied.
  * Requests using stochastic sampling or logit-modifying settings continue to be handled appropriately.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->