### PR TITLE
fix(skippy): discover retained exact KV states

### DIFF
--- a/crates/skippy-cache/src/exact_state.rs
+++ b/crates/skippy-cache/src/exact_state.rs
@@ -81,6 +81,18 @@ impl<E: Clone> ExactStateCache<E> {
         })
     }
 
+    pub fn token_counts_at_most(&self, max_token_count: u64) -> Vec<u64> {
+        let mut token_counts = self
+            .entries
+            .values()
+            .map(|entry| entry.token_count)
+            .filter(|token_count| *token_count <= max_token_count)
+            .collect::<Vec<_>>();
+        token_counts.sort_unstable_by(|left, right| right.cmp(left));
+        token_counts.dedup();
+        token_counts
+    }
+
     pub fn record(
         &mut self,
         page_id: String,
@@ -197,6 +209,21 @@ mod tests {
         assert!(cache.lookup("first").is_none());
         assert!(cache.lookup("second").is_some());
         assert_eq!(cache.stats().entries, 1);
+    }
+
+    #[test]
+    fn cached_token_counts_are_bounded_sorted_and_deduplicated() {
+        let mut cache = ExactStateCache::new(4, 0);
+        for (page_id, token_count) in [("a", 96), ("b", 160), ("c", 96), ("d", 224)] {
+            cache.record(
+                page_id.to_string(),
+                token_count,
+                ExactStatePayload::full_state(vec![1]),
+                (),
+            );
+        }
+
+        assert_eq!(cache.token_counts_at_most(200), vec![160, 96]);
     }
 
     #[test]

--- a/crates/skippy-cache/src/exact_state.rs
+++ b/crates/skippy-cache/src/exact_state.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use crate::{CacheBlobStore, CacheDedupeStats, ExactStatePayload};
 
@@ -10,6 +10,7 @@ pub struct ExactStateCache<E> {
     logical_bytes: u64,
     blobs: CacheBlobStore,
     entries: HashMap<String, ExactStateEntry<E>>,
+    token_count_refs: BTreeMap<u64, usize>,
 }
 
 #[derive(Debug, Clone)]
@@ -63,6 +64,7 @@ impl<E: Clone> ExactStateCache<E> {
             logical_bytes: 0,
             blobs: CacheBlobStore::default(),
             entries: HashMap::new(),
+            token_count_refs: BTreeMap::new(),
         }
     }
 
@@ -82,15 +84,11 @@ impl<E: Clone> ExactStateCache<E> {
     }
 
     pub fn token_counts_at_most(&self, max_token_count: u64) -> Vec<u64> {
-        let mut token_counts = self
-            .entries
-            .values()
-            .map(|entry| entry.token_count)
-            .filter(|token_count| *token_count <= max_token_count)
-            .collect::<Vec<_>>();
-        token_counts.sort_unstable_by(|left, right| right.cmp(left));
-        token_counts.dedup();
-        token_counts
+        self.token_count_refs
+            .range(..=max_token_count)
+            .rev()
+            .map(|(token_count, _)| *token_count)
+            .collect()
     }
 
     pub fn record(
@@ -108,6 +106,7 @@ impl<E: Clone> ExactStateCache<E> {
         let logical_bytes = payload.byte_len();
         let (payload, dedupe) = payload.dedupe_into(&mut self.blobs);
         self.logical_bytes = self.logical_bytes.saturating_add(logical_bytes);
+        self.add_token_count(token_count);
         self.entries.insert(
             page_id.clone(),
             ExactStateEntry {
@@ -182,7 +181,23 @@ impl<E: Clone> ExactStateCache<E> {
 
     fn remove_entry(&mut self, entry: ExactStateEntry<E>) {
         self.logical_bytes = self.logical_bytes.saturating_sub(entry.logical_bytes);
+        self.remove_token_count(entry.token_count);
         entry.payload.release_from(&mut self.blobs);
+    }
+
+    fn add_token_count(&mut self, token_count: u64) {
+        *self.token_count_refs.entry(token_count).or_default() += 1;
+    }
+
+    fn remove_token_count(&mut self, token_count: u64) {
+        let Some(count) = self.token_count_refs.get_mut(&token_count) else {
+            debug_assert!(false, "exact-state token-count index drifted");
+            return;
+        };
+        *count = count.saturating_sub(1);
+        if *count == 0 {
+            self.token_count_refs.remove(&token_count);
+        }
     }
 }
 
@@ -224,6 +239,32 @@ mod tests {
         }
 
         assert_eq!(cache.token_counts_at_most(200), vec![160, 96]);
+    }
+
+    #[test]
+    fn cached_token_counts_track_replacement_and_eviction() {
+        let mut cache = ExactStateCache::new(1, 0);
+        cache.record(
+            "first".to_string(),
+            96,
+            ExactStatePayload::full_state(vec![1]),
+            (),
+        );
+        cache.record(
+            "first".to_string(),
+            160,
+            ExactStatePayload::full_state(vec![2]),
+            (),
+        );
+        assert_eq!(cache.token_counts_at_most(160), vec![160]);
+
+        cache.record(
+            "second".to_string(),
+            224,
+            ExactStatePayload::full_state(vec![3]),
+            (),
+        );
+        assert_eq!(cache.token_counts_at_most(224), vec![224]);
     }
 
     #[test]

--- a/crates/skippy-server/src/kv_integration/identity.rs
+++ b/crates/skippy-server/src/kv_integration/identity.rs
@@ -58,7 +58,18 @@ impl KvStageIntegration {
         token_start: u64,
         token_ids: &[i32],
     ) -> Vec<PrefillKvIdentity> {
-        self.lookup_candidate_token_counts(token_ids.len() as u64)
+        let mut token_counts = self.lookup_candidate_token_counts(token_ids.len() as u64);
+        if self.payload.is_exact_state() {
+            token_counts.extend(
+                self.exact_states
+                    .lock()
+                    .expect("exact state cache lock poisoned")
+                    .token_counts_at_most(token_ids.len() as u64),
+            );
+            token_counts.sort_unstable_by(|left, right| right.cmp(left));
+            token_counts.dedup();
+        }
+        token_counts
             .into_iter()
             .map(|token_count| {
                 self.prefill_identity(
@@ -94,6 +105,8 @@ impl KvStageIntegration {
 
 #[cfg(test)]
 mod tests {
+    use crate::kv_integration::ExactStateExtra;
+    use skippy_cache::ExactStatePayload;
     use skippy_protocol::{
         LoadMode, SCHEMA_VERSION, StageConfig, StageKvCacheConfig, StageKvCacheMode,
         StageKvCachePayload,
@@ -234,5 +247,45 @@ mod tests {
 
         assert_eq!(recorded_shared.page_id, lookup_shared.page_id);
         assert_ne!(recorded_exact.page_id, lookup_exact.page_id);
+    }
+
+    #[test]
+    fn exact_state_lookup_probes_cached_non_grid_prefix_length() {
+        let config = StageConfig {
+            ctx_size: 8192,
+            kv_cache: Some(StageKvCacheConfig {
+                payload: StageKvCachePayload::KvRecurrent,
+                min_tokens: 256,
+                shared_prefix_stride_tokens: 128,
+                max_entries: 1,
+                ..test_config().kv_cache.expect("test cache config")
+            }),
+            ..test_config()
+        };
+        let kv = KvStageIntegration::from_config(&config)
+            .unwrap()
+            .expect("cache enabled");
+        let base = test_base();
+        let recorded_tokens = (0..2214).collect::<Vec<_>>();
+        let recorded = kv.prefill_identity(&config, &base, 0, &recorded_tokens);
+        kv.exact_states
+            .lock()
+            .expect("exact state cache lock poisoned")
+            .record(
+                recorded.page_id.clone(),
+                recorded.identity.token_count,
+                ExactStatePayload::kv_recurrent(Vec::new(), vec![1]),
+                ExactStateExtra::default(),
+            );
+        let mut lookup_tokens = recorded_tokens.clone();
+        lookup_tokens.extend(100_000..100_017);
+
+        let lookup = kv
+            .lookup_identities(&config, &base, 0, &lookup_tokens)
+            .into_iter()
+            .find(|identity| identity.identity.token_count == 2214)
+            .expect("lookup should probe the retained exact-state prefix length");
+
+        assert_eq!(lookup.page_id, recorded.page_id);
     }
 }


### PR DESCRIPTION
## Problem

Exact KV states can be retained at arbitrary token counts, but discovery only considered grid-aligned prefix lengths. A valid state recorded at a non-grid length could remain in the cache indefinitely without ever being considered for a longer compatible prompt.

For example, repeated requests sharing a 197-token prefix could miss an exact retained state if discovery only probed fixed stride boundaries.

## Fix

Exact-state discovery now considers both the normal grid candidates and a bounded set of retained token counts. Candidate identity and prompt compatibility are still verified before restoration.

Using the existing bounded retained index fixes the blind spot without scanning the entire cache or weakening exact-match correctness.

## Validation

KV cache tests pass (32/32) and Skippy Server tests pass (353/353), including non-grid retained-prefix coverage.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved exact-state lookups to recognize additional cached token-count prefixes beyond the standard candidate values.
  * Added support for retaining and matching page identities at non-grid prefix lengths.

* **Bug Fixes**
  * Removed duplicate token-count candidates and ensured lookup results are processed in descending order for more reliable matching.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->