### PR TITLE
fix(openai): cancel timed-out generation before releasing its lane

### DIFF
--- a/crates/openai-frontend/src/backend.rs
+++ b/crates/openai-frontend/src/backend.rs
@@ -8,6 +8,7 @@ use std::{
 
 use async_trait::async_trait;
 use futures_core::Stream;
+use tokio::sync::Notify;
 
 use crate::{
     chat::{ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse},
@@ -23,9 +24,15 @@ pub type CompletionStream =
 
 pub type OpenAiResult<T> = Result<T, OpenAiError>;
 
+#[derive(Debug, Default)]
+struct CancellationState {
+    cancelled: AtomicBool,
+    notify: Notify,
+}
+
 #[derive(Debug, Clone, Default)]
 pub struct CancellationToken {
-    cancelled: Arc<AtomicBool>,
+    state: Arc<CancellationState>,
 }
 
 impl CancellationToken {
@@ -34,11 +41,23 @@ impl CancellationToken {
     }
 
     pub fn cancel(&self) {
-        self.cancelled.store(true, Ordering::Relaxed);
+        if !self.state.cancelled.swap(true, Ordering::AcqRel) {
+            self.state.notify.notify_waiters();
+        }
     }
 
     pub fn is_cancelled(&self) -> bool {
-        self.cancelled.load(Ordering::Relaxed)
+        self.state.cancelled.load(Ordering::Acquire)
+    }
+
+    pub async fn cancelled(&self) {
+        loop {
+            let notified = self.state.notify.notified();
+            if self.is_cancelled() {
+                return;
+            }
+            notified.await;
+        }
     }
 }
 
@@ -74,6 +93,14 @@ pub trait OpenAiBackend: Send + Sync + 'static {
         request: ChatCompletionRequest,
     ) -> OpenAiResult<ChatCompletionResponse>;
 
+    async fn chat_completion_with_context(
+        &self,
+        request: ChatCompletionRequest,
+        _context: OpenAiRequestContext,
+    ) -> OpenAiResult<ChatCompletionResponse> {
+        self.chat_completion(request).await
+    }
+
     async fn chat_completion_stream(
         &self,
         request: ChatCompletionRequest,
@@ -84,6 +111,14 @@ pub trait OpenAiBackend: Send + Sync + 'static {
         Err(OpenAiError::unsupported(
             "/v1/completions is not supported by this backend",
         ))
+    }
+
+    async fn completion_with_context(
+        &self,
+        request: CompletionRequest,
+        _context: OpenAiRequestContext,
+    ) -> OpenAiResult<CompletionResponse> {
+        self.completion(request).await
     }
 
     async fn completion_stream(

--- a/crates/openai-frontend/src/guardrails/compact.rs
+++ b/crates/openai-frontend/src/guardrails/compact.rs
@@ -64,8 +64,17 @@ impl OpenAiBackend for CompactingOpenAiBackend {
         &self,
         request: ChatCompletionRequest,
     ) -> OpenAiResult<ChatCompletionResponse> {
+        self.chat_completion_with_context(request, OpenAiRequestContext::new())
+            .await
+    }
+
+    async fn chat_completion_with_context(
+        &self,
+        request: ChatCompletionRequest,
+        context: OpenAiRequestContext,
+    ) -> OpenAiResult<ChatCompletionResponse> {
         self.backend
-            .chat_completion(self.compact_request(request)?)
+            .chat_completion_with_context(self.compact_request(request)?, context)
             .await
     }
 
@@ -80,7 +89,16 @@ impl OpenAiBackend for CompactingOpenAiBackend {
     }
 
     async fn completion(&self, request: CompletionRequest) -> OpenAiResult<CompletionResponse> {
-        self.backend.completion(request).await
+        self.completion_with_context(request, OpenAiRequestContext::new())
+            .await
+    }
+
+    async fn completion_with_context(
+        &self,
+        request: CompletionRequest,
+        context: OpenAiRequestContext,
+    ) -> OpenAiResult<CompletionResponse> {
+        self.backend.completion_with_context(request, context).await
     }
 
     async fn completion_stream(

--- a/crates/openai-frontend/src/guardrails/mod.rs
+++ b/crates/openai-frontend/src/guardrails/mod.rs
@@ -75,6 +75,7 @@ impl GuardedOpenAiBackend {
     async fn guarded_chat_completion(
         &self,
         request: ChatCompletionRequest,
+        context: OpenAiRequestContext,
     ) -> OpenAiResult<ChatCompletionResponse> {
         let _guardrail_error_catalog = guardrail_error_catalog();
         let policy = self.policy.snapshot();
@@ -90,13 +91,15 @@ impl GuardedOpenAiBackend {
                     GuardrailTelemetryOutcome::PassThrough,
                     None,
                 );
-                self.backend.chat_completion(request).await
+                self.backend
+                    .chat_completion_with_context(request, context)
+                    .await
             }
             GuardrailRequestOutcome::Reject { kind } => Err(errors::guardrail_error(*kind)),
             GuardrailRequestOutcome::Guarded { backend_request } => {
                 if matches!(policy.mode, GuardrailMode::MetricsOnly) {
                     return self
-                        .metrics_only_chat_completion(request, &engine, &prepared)
+                        .metrics_only_chat_completion(request, &engine, &prepared, context)
                         .await;
                 }
 
@@ -107,7 +110,7 @@ impl GuardedOpenAiBackend {
                 loop {
                     let response = self
                         .backend
-                        .chat_completion(attempt_request.clone())
+                        .chat_completion_with_context(attempt_request.clone(), context.clone())
                         .await?;
                     let classified = engine.classify_response(&prepared, &response);
                     let contract = telemetry_contract(&prepared.state.request_contract);
@@ -165,8 +168,12 @@ impl GuardedOpenAiBackend {
         request: ChatCompletionRequest,
         engine: &GuardrailEngine,
         prepared: &state::PreparedGuardrailRequest,
+        context: OpenAiRequestContext,
     ) -> OpenAiResult<ChatCompletionResponse> {
-        let response = self.backend.chat_completion(request).await?;
+        let response = self
+            .backend
+            .chat_completion_with_context(request, context)
+            .await?;
         let classified = engine.classify_response(prepared, &response);
         self.record_outcome(
             prepared.state.mode,
@@ -303,7 +310,16 @@ impl OpenAiBackend for GuardedOpenAiBackend {
         &self,
         request: ChatCompletionRequest,
     ) -> OpenAiResult<ChatCompletionResponse> {
-        self.guarded_chat_completion(request).await
+        self.guarded_chat_completion(request, OpenAiRequestContext::new())
+            .await
+    }
+
+    async fn chat_completion_with_context(
+        &self,
+        request: ChatCompletionRequest,
+        context: OpenAiRequestContext,
+    ) -> OpenAiResult<ChatCompletionResponse> {
+        self.guarded_chat_completion(request, context).await
     }
 
     async fn chat_completion_stream(
@@ -315,7 +331,16 @@ impl OpenAiBackend for GuardedOpenAiBackend {
     }
 
     async fn completion(&self, request: CompletionRequest) -> OpenAiResult<CompletionResponse> {
-        self.backend.completion(request).await
+        self.completion_with_context(request, OpenAiRequestContext::new())
+            .await
+    }
+
+    async fn completion_with_context(
+        &self,
+        request: CompletionRequest,
+        context: OpenAiRequestContext,
+    ) -> OpenAiResult<CompletionResponse> {
+        self.backend.completion_with_context(request, context).await
     }
 
     async fn completion_stream(

--- a/crates/openai-frontend/src/hooks.rs
+++ b/crates/openai-frontend/src/hooks.rs
@@ -129,11 +129,22 @@ impl OpenAiBackend for HookedOpenAiBackend {
 
     async fn chat_completion(
         &self,
+        request: ChatCompletionRequest,
+    ) -> OpenAiResult<ChatCompletionResponse> {
+        self.chat_completion_with_context(request, OpenAiRequestContext::new())
+            .await
+    }
+
+    async fn chat_completion_with_context(
+        &self,
         mut request: ChatCompletionRequest,
+        context: OpenAiRequestContext,
     ) -> OpenAiResult<ChatCompletionResponse> {
         let outcome = self.hooks.before_chat_completion(&mut request).await?;
         apply_chat_hook_outcome(&mut request, &outcome);
-        self.backend.chat_completion(request).await
+        self.backend
+            .chat_completion_with_context(request, context)
+            .await
     }
 
     async fn chat_completion_stream(
@@ -147,7 +158,16 @@ impl OpenAiBackend for HookedOpenAiBackend {
     }
 
     async fn completion(&self, request: CompletionRequest) -> OpenAiResult<CompletionResponse> {
-        self.backend.completion(request).await
+        self.completion_with_context(request, OpenAiRequestContext::new())
+            .await
+    }
+
+    async fn completion_with_context(
+        &self,
+        request: CompletionRequest,
+        context: OpenAiRequestContext,
+    ) -> OpenAiResult<CompletionResponse> {
+        self.backend.completion_with_context(request, context).await
     }
 
     async fn completion_stream(

--- a/crates/openai-frontend/src/router.rs
+++ b/crates/openai-frontend/src/router.rs
@@ -169,10 +169,13 @@ async fn chat_completions(
         let model = request.model.clone();
         let context = OpenAiRequestContext::new();
         let cancellation = context.cancellation_token();
-        let stream = backend_call(
+        let stream = backend_call_with_cancellation(
             &state,
             "chat_completion_stream",
-            state.backend.chat_completion_stream(request, context),
+            &context,
+            state
+                .backend
+                .chat_completion_stream(request, context.clone()),
         )
         .await?;
         let prelude = stream::once(async move { json_event(&ChatCompletionChunk::role(model)) });
@@ -187,11 +190,15 @@ async fn chat_completions(
             .chain(stream::once(async { done_event() }));
         Ok(sse_response(events, cancellation))
     } else {
+        let context = OpenAiRequestContext::new();
         Ok(Json(
-            backend_call(
+            backend_call_with_cancellation(
                 &state,
                 "chat_completion",
-                state.backend.chat_completion(request),
+                &context,
+                state
+                    .backend
+                    .chat_completion_with_context(request, context.clone()),
             )
             .await?,
         )
@@ -221,10 +228,13 @@ async fn responses(
             let context = OpenAiRequestContext::new();
             let cancellation = context.cancellation_token();
             let state_machine = Arc::new(Mutex::new(ResponseSseState::new(request.model.clone())));
-            let stream = backend_call(
+            let stream = backend_call_with_cancellation(
                 &state,
                 "responses_stream",
-                state.backend.chat_completion_stream(request, context),
+                &context,
+                state
+                    .backend
+                    .chat_completion_stream(request, context.clone()),
             )
             .await?;
             let body_state = state_machine.clone();
@@ -415,8 +425,16 @@ async fn responses(
             Ok(sse_response(events, cancellation))
         }
         _ => {
-            let response =
-                backend_call(&state, "responses", state.backend.chat_completion(request)).await?;
+            let context = OpenAiRequestContext::new();
+            let response = backend_call_with_cancellation(
+                &state,
+                "responses",
+                &context,
+                state
+                    .backend
+                    .chat_completion_with_context(request, context.clone()),
+            )
+            .await?;
             let translated = translate_chat_completion_response_to_responses(&response)?;
             Ok(Json(translated).into_response())
         }
@@ -435,10 +453,11 @@ async fn completions(
         let include_usage = request.include_usage();
         let context = OpenAiRequestContext::new();
         let cancellation = context.cancellation_token();
-        let stream = backend_call(
+        let stream = backend_call_with_cancellation(
             &state,
             "completion_stream",
-            state.backend.completion_stream(request, context),
+            &context,
+            state.backend.completion_stream(request, context.clone()),
         )
         .await?;
         let events = stream
@@ -452,10 +471,19 @@ async fn completions(
             .chain(stream::once(async { done_event() }));
         Ok(sse_response(events, cancellation))
     } else {
-        Ok(
-            Json(backend_call(&state, "completion", state.backend.completion(request)).await?)
-                .into_response(),
+        let context = OpenAiRequestContext::new();
+        Ok(Json(
+            backend_call_with_cancellation(
+                &state,
+                "completion",
+                &context,
+                state
+                    .backend
+                    .completion_with_context(request, context.clone()),
+            )
+            .await?,
         )
+        .into_response())
     }
 }
 
@@ -492,6 +520,59 @@ fn resolve_agent_session(
         (Some(header), _) => Ok(Some(header)),
         (None, protocol) => Ok(protocol),
     }
+}
+
+struct CancelOnDrop {
+    context: OpenAiRequestContext,
+    armed: bool,
+}
+
+impl CancelOnDrop {
+    fn new(context: &OpenAiRequestContext) -> Self {
+        Self {
+            context: context.clone(),
+            armed: true,
+        }
+    }
+
+    fn disarm(&mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for CancelOnDrop {
+    fn drop(&mut self) {
+        if self.armed {
+            self.context.cancel();
+        }
+    }
+}
+
+async fn backend_call_with_cancellation<T, F>(
+    state: &FrontendState,
+    operation: &'static str,
+    context: &OpenAiRequestContext,
+    future: F,
+) -> OpenAiResult<T>
+where
+    F: Future<Output = OpenAiResult<T>>,
+{
+    let mut cancel_on_drop = CancelOnDrop::new(context);
+    let result = match state.config.backend_timeout {
+        Some(timeout) => match tokio::time::timeout(timeout, future).await {
+            Ok(result) => result,
+            Err(_) => {
+                context.cancel();
+                return Err(OpenAiError::timeout(format!(
+                    "{operation} timed out after {} ms",
+                    timeout.as_millis()
+                )));
+            }
+        },
+        None => future.await,
+    };
+    cancel_on_drop.disarm();
+    result
 }
 
 async fn backend_call<T, F>(
@@ -867,6 +948,42 @@ mod tests {
             unreachable!("agent-session tests use non-streaming requests")
         }
     }
+
+    struct NonStreamingCancellationBackend {
+        token: Arc<Mutex<Option<CancellationToken>>>,
+    }
+
+    #[async_trait]
+    impl OpenAiBackend for NonStreamingCancellationBackend {
+        async fn models(&self) -> OpenAiResult<Vec<ModelObject>> {
+            Ok(vec![ModelObject::new("cancel-model")])
+        }
+
+        async fn chat_completion(
+            &self,
+            _request: ChatCompletionRequest,
+        ) -> OpenAiResult<ChatCompletionResponse> {
+            unreachable!("frontend must use the context-aware non-streaming path")
+        }
+
+        async fn chat_completion_with_context(
+            &self,
+            _request: ChatCompletionRequest,
+            context: OpenAiRequestContext,
+        ) -> OpenAiResult<ChatCompletionResponse> {
+            *self.token.lock().expect("token lock poisoned") = Some(context.cancellation_token());
+            std::future::pending().await
+        }
+
+        async fn chat_completion_stream(
+            &self,
+            _request: ChatCompletionRequest,
+            _context: OpenAiRequestContext,
+        ) -> OpenAiResult<ChatCompletionStream> {
+            unreachable!("cancellation backend test only calls non-streaming")
+        }
+    }
+
     #[async_trait]
     impl OpenAiBackend for CancellationBackend {
         async fn models(&self) -> OpenAiResult<Vec<ModelObject>> {
@@ -1388,6 +1505,84 @@ mod tests {
         tokio::task::yield_now().await;
 
         assert!(cancellation.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn non_streaming_timeout_cancels_request_context() {
+        let token = Arc::new(Mutex::new(None));
+        let app = router_for_with_config(
+            Arc::new(NonStreamingCancellationBackend {
+                token: token.clone(),
+            }),
+            OpenAiFrontendConfig::default().with_backend_timeout(Duration::from_millis(5)),
+        );
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/chat/completions")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        json!({
+                            "model": "cancel-model",
+                            "messages": [{"role": "user", "content": "hello"}]
+                        })
+                        .to_string(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
+        let cancellation = token
+            .lock()
+            .expect("token lock poisoned")
+            .clone()
+            .expect("backend saw request context");
+        assert!(cancellation.is_cancelled());
+    }
+
+    #[tokio::test]
+    async fn dropping_non_streaming_request_cancels_request_context() {
+        let token = Arc::new(Mutex::new(None));
+        let app = router_for_with_config(
+            Arc::new(NonStreamingCancellationBackend {
+                token: token.clone(),
+            }),
+            OpenAiFrontendConfig::default().without_backend_timeout(),
+        );
+        let request = Request::builder()
+            .method("POST")
+            .uri("/v1/chat/completions")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                json!({
+                    "model": "cancel-model",
+                    "messages": [{"role": "user", "content": "hello"}]
+                })
+                .to_string(),
+            ))
+            .unwrap();
+        let task = tokio::spawn(app.oneshot(request));
+
+        let cancellation = tokio::time::timeout(Duration::from_millis(100), async {
+            loop {
+                if let Some(token) = token.lock().expect("token lock poisoned").clone() {
+                    break token;
+                }
+                tokio::task::yield_now().await;
+            }
+        })
+        .await
+        .expect("backend received request context");
+        assert!(!cancellation.is_cancelled());
+
+        task.abort();
+        let _ = task.await;
+        tokio::time::timeout(Duration::from_millis(100), cancellation.cancelled())
+            .await
+            .expect("dropped request cancelled backend context");
     }
 
     #[tokio::test]

--- a/crates/skippy-server/src/frontend/admission.rs
+++ b/crates/skippy-server/src/frontend/admission.rs
@@ -45,10 +45,20 @@ impl GenerationTokenBudget {
         }
     }
 
+    #[cfg(test)]
     pub(super) fn reserve(
         self: &Arc<Self>,
         request: GenerationTokenBudgetRequest,
         admission_timeout: Duration,
+    ) -> OpenAiResult<GenerationTokenReservation> {
+        self.reserve_cancellable(request, admission_timeout, None)
+    }
+
+    pub(super) fn reserve_cancellable(
+        self: &Arc<Self>,
+        request: GenerationTokenBudgetRequest,
+        admission_timeout: Duration,
+        cancellation: Option<&openai_frontend::CancellationToken>,
     ) -> OpenAiResult<GenerationTokenReservation> {
         let tokens = request.reservation_tokens(self.capacity_tokens);
         let deadline = Instant::now() + admission_timeout;
@@ -57,6 +67,9 @@ impl GenerationTokenBudget {
             .lock()
             .map_err(|_| OpenAiError::backend("generation token budget lock poisoned"))?;
         loop {
+            if cancellation.is_some_and(openai_frontend::CancellationToken::is_cancelled) {
+                return Err(OpenAiError::backend("request cancelled"));
+            }
             if state.active_tokens.saturating_add(tokens) <= self.capacity_tokens {
                 state.active_tokens = state.active_tokens.saturating_add(tokens);
                 return Ok(GenerationTokenReservation {
@@ -76,13 +89,17 @@ impl GenerationTokenBudget {
                 ));
             }
 
-            let wait_for = deadline.saturating_duration_since(now);
+            let wait_for = deadline.saturating_duration_since(now).min(
+                cancellation
+                    .map(|_| Duration::from_millis(10))
+                    .unwrap_or(admission_timeout),
+            );
             let (next_state, wait_result) = self
                 .released
                 .wait_timeout(state, wait_for)
                 .map_err(|_| OpenAiError::backend("generation token budget lock poisoned"))?;
             state = next_state;
-            if wait_result.timed_out() {
+            if wait_result.timed_out() && Instant::now() >= deadline {
                 return Err(generation_token_budget_timeout_error(
                     admission_timeout,
                     tokens,

--- a/crates/skippy-server/src/frontend/backend.rs
+++ b/crates/skippy-server/src/frontend/backend.rs
@@ -51,6 +51,26 @@ use tokio::sync::OwnedSemaphorePermit;
 use tokio::sync::mpsc;
 use tokio::task;
 
+fn request_cancelled_error() -> OpenAiError {
+    OpenAiError::backend("request cancelled")
+}
+
+pub(in crate::frontend) async fn run_blocking_generation_worker<T, F>(
+    permit: OwnedSemaphorePermit,
+    context: OpenAiRequestContext,
+    work: F,
+) -> Result<T, task::JoinError>
+where
+    T: Send + 'static,
+    F: FnOnce(openai_frontend::CancellationToken) -> T + Send + 'static,
+{
+    task::spawn_blocking(move || {
+        let _permit = permit;
+        work(context.cancellation_token())
+    })
+    .await
+}
+
 #[async_trait]
 impl OpenAiBackend for StageOpenAiBackend {
     async fn models(&self) -> OpenAiResult<Vec<ModelObject>> {
@@ -59,7 +79,16 @@ impl OpenAiBackend for StageOpenAiBackend {
 
     async fn chat_completion(
         &self,
+        request: ChatCompletionRequest,
+    ) -> OpenAiResult<ChatCompletionResponse> {
+        self.chat_completion_with_context(request, OpenAiRequestContext::new())
+            .await
+    }
+
+    async fn chat_completion_with_context(
+        &self,
         mut request: ChatCompletionRequest,
+        context: OpenAiRequestContext,
     ) -> OpenAiResult<ChatCompletionResponse> {
         let ids = OpenAiGenerationIds::new(
             OpenAiCacheHints::from_chat_request(&request),
@@ -105,6 +134,7 @@ impl OpenAiBackend for StageOpenAiBackend {
                 request.stop.clone(),
                 sampling,
                 Some(request.clone()),
+                context,
                 ids.clone(),
             )
             .await?;
@@ -220,7 +250,16 @@ impl OpenAiBackend for StageOpenAiBackend {
         })))
     }
 
-    async fn completion(&self, mut request: CompletionRequest) -> OpenAiResult<CompletionResponse> {
+    async fn completion(&self, request: CompletionRequest) -> OpenAiResult<CompletionResponse> {
+        self.completion_with_context(request, OpenAiRequestContext::new())
+            .await
+    }
+
+    async fn completion_with_context(
+        &self,
+        mut request: CompletionRequest,
+        context: OpenAiRequestContext,
+    ) -> OpenAiResult<CompletionResponse> {
         let ids = OpenAiGenerationIds::new(
             OpenAiCacheHints::from_completion_request(&request),
             request.agent_session(),
@@ -251,6 +290,7 @@ impl OpenAiBackend for StageOpenAiBackend {
                 request.stop.clone(),
                 sampling,
                 None,
+                context,
                 ids.clone(),
             )
             .await?;
@@ -448,6 +488,7 @@ impl StageOpenAiBackend {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
     async fn run_generation(
         &self,
         prompt: PreparedGenerationPrompt,
@@ -455,10 +496,17 @@ impl StageOpenAiBackend {
         stop: Option<openai_frontend::StopSequence>,
         sampling: SamplingConfig,
         hook_request: Option<ChatCompletionRequest>,
+        context: OpenAiRequestContext,
         ids: OpenAiGenerationIds,
     ) -> OpenAiResult<GeneratedText> {
         let admit_timer = PhaseTimer::start();
-        let permit = self.acquire_generation_permit().await?;
+        let cancellation = context.cancellation_token();
+        let permit = tokio::select! {
+            permit = self.acquire_generation_permit() => permit?,
+            () = cancellation.cancelled() => {
+                return Err(request_cancelled_error());
+            }
+        };
         let mut admit_attrs = self.openai_attrs(&ids);
         admit_attrs.insert(
             "llama_stage.openai_phase".to_string(),
@@ -467,22 +515,32 @@ impl StageOpenAiBackend {
         self.emit_openai_phase("stage.openai_generation_admit", admit_timer, admit_attrs);
         let backend = self.clone();
         let hook_runtime = Some(tokio::runtime::Handle::current());
-        task::spawn_blocking(move || {
-            let _permit = permit;
-            backend.generate_text(
+        let worker_context = context.clone();
+        let result = run_blocking_generation_worker(permit, worker_context.clone(), move |token| {
+            let output = backend.generate_text(
                 prompt,
                 max_tokens,
                 stop.as_ref(),
                 sampling,
                 hook_request,
                 hook_runtime,
-                None,
+                Some(&token),
                 ids,
                 |_| Ok(()),
-            )
+            );
+            if worker_context.is_cancelled() {
+                Err(request_cancelled_error())
+            } else {
+                output
+            }
         })
         .await
-        .map_err(|error| OpenAiError::backend(format!("generation task failed: {error}")))?
+        .map_err(|error| OpenAiError::backend(format!("generation task failed: {error}")))?;
+        if context.is_cancelled() {
+            Err(request_cancelled_error())
+        } else {
+            result
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -500,7 +558,13 @@ impl StageOpenAiBackend {
         ids: OpenAiGenerationIds,
     ) -> OpenAiResult<GenerationStream> {
         let admit_timer = PhaseTimer::start();
-        let permit = self.acquire_generation_permit().await?;
+        let cancellation = context.cancellation_token();
+        let permit = tokio::select! {
+            permit = self.acquire_generation_permit() => permit?,
+            () = cancellation.cancelled() => {
+                return Err(request_cancelled_error());
+            }
+        };
         let mut admit_attrs = self.openai_attrs(&ids);
         admit_attrs.insert(
             "llama_stage.openai_phase".to_string(),

--- a/crates/skippy-server/src/frontend/generation_flow/text_generation.rs
+++ b/crates/skippy-server/src/frontend/generation_flow/text_generation.rs
@@ -24,6 +24,9 @@ impl StageOpenAiBackend {
         on_text_chunk: impl FnMut(&str) -> OpenAiResult<()>,
     ) -> OpenAiResult<GeneratedText> {
         let generation_timer = PhaseTimer::start();
+        if cancellation.is_some_and(openai_frontend::CancellationToken::is_cancelled) {
+            return Err(OpenAiError::backend("request cancelled"));
+        }
         if prompt.text.is_empty() {
             return Err(OpenAiError::invalid_request(
                 "request prompt/messages produced no text",
@@ -50,6 +53,9 @@ impl StageOpenAiBackend {
             .collect::<Vec<_>>();
         let tokenize_timer = PhaseTimer::start();
         let prompt_token_ids = self.tokenize(&prompt.text)?;
+        if cancellation.is_some_and(openai_frontend::CancellationToken::is_cancelled) {
+            return Err(OpenAiError::backend("request cancelled"));
+        }
         let mut tokenize_attrs = self.openai_attrs(&ids);
         tokenize_attrs.insert(
             "llama_stage.prompt_chars".to_string(),
@@ -65,9 +71,10 @@ impl StageOpenAiBackend {
         }
         let max_tokens = max_tokens.resolve(prompt_token_ids.len(), self.ctx_size)?;
         let token_admit_timer = PhaseTimer::start();
-        let token_budget_reservation = self.generation_token_budget.reserve(
+        let token_budget_reservation = self.generation_token_budget.reserve_cancellable(
             GenerationTokenBudgetRequest::new(prompt_token_ids.len(), max_tokens),
             GENERATION_ADMISSION_TIMEOUT,
+            cancellation,
         )?;
         let mut token_admit_attrs = self.openai_attrs(&ids);
         token_admit_attrs.insert(

--- a/crates/skippy-server/src/frontend/generation_flow/text_generation.rs
+++ b/crates/skippy-server/src/frontend/generation_flow/text_generation.rs
@@ -76,6 +76,9 @@ impl StageOpenAiBackend {
             GENERATION_ADMISSION_TIMEOUT,
             cancellation,
         )?;
+        if cancellation.is_some_and(openai_frontend::CancellationToken::is_cancelled) {
+            return Err(OpenAiError::backend("request cancelled"));
+        }
         let mut token_admit_attrs = self.openai_attrs(&ids);
         token_admit_attrs.insert(
             "llama_stage.prompt_token_count".to_string(),

--- a/crates/skippy-server/src/frontend/linear_proposal/execution.rs
+++ b/crates/skippy-server/src/frontend/linear_proposal/execution.rs
@@ -214,12 +214,6 @@ impl StageOpenAiBackend {
                 }
             }
         }
-        if committed_tokens.is_empty() {
-            return Err(OpenAiError::backend(
-                "linear proposal classifier committed no target prediction",
-            ));
-        }
-
         let canonical_position = params
             .base_position
             .checked_add(
@@ -239,6 +233,12 @@ impl StageOpenAiBackend {
                 prompt_token_count: params.prompt_token_count,
             })
         })?;
+
+        if committed_tokens.is_empty() {
+            return Err(OpenAiError::backend(
+                "linear proposal classifier committed no target prediction",
+            ));
+        }
 
         Ok(Some(LinearProposalExecution {
             decision,
@@ -423,6 +423,26 @@ mod tests {
                 .unwrap_err()
                 .to_string()
                 .contains("synthetic callback failure")
+        );
+    }
+
+    #[test]
+    fn cancellation_error_is_returned_only_after_repair_runs() {
+        let repair_ran = Cell::new(false);
+        let result = finish_linear_proposal_after_repair(
+            Some(OpenAiError::backend("request cancelled")),
+            || {
+                repair_ran.set(true);
+                Ok(())
+            },
+        );
+
+        assert!(repair_ran.get());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("request cancelled")
         );
     }
 }

--- a/crates/skippy-server/src/frontend/linear_proposal/execution.rs
+++ b/crates/skippy-server/src/frontend/linear_proposal/execution.rs
@@ -60,8 +60,10 @@ impl StageOpenAiBackend {
         &self,
         params: LinearProposalExecutionParams<'_>,
         queried: QueriedLinearProposal,
+        cancellation: Option<&openai_frontend::CancellationToken>,
         on_token: &mut impl FnMut(i32) -> OpenAiResult<TokenControl>,
     ) -> OpenAiResult<Option<LinearProposalReceipt>> {
+        ensure_request_active(cancellation)?;
         let proposal_token_count = queried.proposal.token_ids.len();
         let mut verify_inputs = Vec::with_capacity(proposal_token_count.saturating_add(1));
         verify_inputs.push(params.current);
@@ -71,6 +73,7 @@ impl StageOpenAiBackend {
             params,
             &queried.proposal.token_ids,
             &verify_inputs,
+            cancellation,
             on_token,
         )?
         else {
@@ -134,8 +137,10 @@ impl StageOpenAiBackend {
         params: LinearProposalExecutionParams<'_>,
         proposal_tokens: &[i32],
         verify_inputs: &[i32],
+        cancellation: Option<&openai_frontend::CancellationToken>,
         on_token: &mut impl FnMut(i32) -> OpenAiResult<TokenControl>,
     ) -> OpenAiResult<Option<LinearProposalExecution>> {
+        ensure_request_active(cancellation)?;
         let verify_timer = Instant::now();
         let verify_lock_timer = Instant::now();
         let mut runtime = self
@@ -192,6 +197,10 @@ impl StageOpenAiBackend {
         let mut reached_stop = false;
         let mut callback_error = None;
         for token in predictions.iter().copied().take(decision.commit_count) {
+            if cancellation.is_some_and(openai_frontend::CancellationToken::is_cancelled) {
+                callback_error = Some(OpenAiError::backend("request cancelled"));
+                break;
+            }
             committed_tokens.push(token);
             match on_token(token) {
                 Ok(TokenControl::Continue) => {}
@@ -320,6 +329,16 @@ impl StageOpenAiBackend {
             runtime_lock_hold_us,
             runtime_lock_acquires: 1,
         })
+    }
+}
+
+fn ensure_request_active(
+    cancellation: Option<&openai_frontend::CancellationToken>,
+) -> OpenAiResult<()> {
+    if cancellation.is_some_and(openai_frontend::CancellationToken::is_cancelled) {
+        Err(OpenAiError::backend("request cancelled"))
+    } else {
+        Ok(())
     }
 }
 

--- a/crates/skippy-server/src/frontend/local_generation/linear_decode.rs
+++ b/crates/skippy-server/src/frontend/local_generation/linear_decode.rs
@@ -28,6 +28,12 @@ impl StageOpenAiBackend {
         let Some(committed_token_ids) = state.linear_context_tokens.as_mut() else {
             return Ok(LinearProposalProgress::NotUsed);
         };
+        if request
+            .cancellation
+            .is_some_and(openai_frontend::CancellationToken::is_cancelled)
+        {
+            return Err(OpenAiError::backend("request cancelled"));
+        }
         let remaining_new_tokens =
             (request.max_tokens as usize).saturating_sub(state.decoded_tokens);
         // Prefill leaves the final prompt token undecoded. When whole-prompt
@@ -81,6 +87,12 @@ impl StageOpenAiBackend {
         let Some(queried) = queried else {
             return Ok(LinearProposalProgress::NotUsed);
         };
+        if request
+            .cancellation
+            .is_some_and(openai_frontend::CancellationToken::is_cancelled)
+        {
+            return Err(OpenAiError::backend("request cancelled"));
+        }
         let decision_id = queried.proposal.decision_id.clone();
         let receipt = execute_linear_proposal_with_terminal_discard(config, &decision_id, || {
             self.execute_local_linear_proposal(
@@ -95,6 +107,7 @@ impl StageOpenAiBackend {
                     prompt_token_count: request.prompt_token_ids.len(),
                 },
                 queried,
+                request.cancellation,
                 emit_token,
             )
         })?;

--- a/crates/skippy-server/src/frontend/local_generation/linear_decode.rs
+++ b/crates/skippy-server/src/frontend/local_generation/linear_decode.rs
@@ -84,15 +84,15 @@ impl StageOpenAiBackend {
             }
             LinearProposalQueryOutcome::Ready(queried) => Some(queried),
         };
-        let Some(queried) = queried else {
-            return Ok(LinearProposalProgress::NotUsed);
-        };
         if request
             .cancellation
             .is_some_and(openai_frontend::CancellationToken::is_cancelled)
         {
             return Err(OpenAiError::backend("request cancelled"));
         }
+        let Some(queried) = queried else {
+            return Ok(LinearProposalProgress::NotUsed);
+        };
         let decision_id = queried.proposal.decision_id.clone();
         let receipt = execute_linear_proposal_with_terminal_discard(config, &decision_id, || {
             self.execute_local_linear_proposal(

--- a/crates/skippy-server/src/frontend/local_generation/tests.rs
+++ b/crates/skippy-server/src/frontend/local_generation/tests.rs
@@ -163,7 +163,10 @@ fn local_generation_eventually_delivers_receipts_and_cleanup_survives_sink_error
         decode_frame_batcher,
     };
     let sampling = SamplingConfig::default();
-    let prompt_token_ids = [1];
+    // A multi-token prompt takes the whole-prompt prefill path. Keep this
+    // above one token so the test exercises a fresh runtime session before
+    // its batch size is queried.
+    let prompt_token_ids = [1, 2];
     let ids = OpenAiGenerationIds::new(OpenAiCacheHints::default(), None);
     let mut emitted = Vec::new();
     backend.generate_local_tokens(

--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -125,6 +125,12 @@ impl StageOpenAiBackend {
             Ok(control)
         };
         let result = (|| {
+            if request
+                .cancellation
+                .is_some_and(openai_frontend::CancellationToken::is_cancelled)
+            {
+                return Err(OpenAiError::backend("request cancelled"));
+            }
             let prefill = self.prefill_prompt(&request, &session_id, &mut cache_stats)?;
             self.configure_chat_sampling_if_needed(
                 &request,
@@ -742,6 +748,12 @@ impl StageOpenAiBackend {
             .expect("checked non-empty prompt");
         let mut stopped = false;
         if let Some(predicted) = prompt_prefill_sample {
+            if request
+                .cancellation
+                .is_some_and(openai_frontend::CancellationToken::is_cancelled)
+            {
+                return Err(OpenAiError::backend("request cancelled"));
+            }
             current = predicted;
             decoded_tokens += 1;
             stopped = emit_token(current)? == TokenControl::Stop;

--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -184,7 +184,7 @@ impl StageOpenAiBackend {
             .ensure_session_active(session_id)
             .map_err(openai_backend_error)?;
         let batch_size = runtime
-            .session_batch_size(session_id)
+            .admit_session_batch_size(session_id)
             .map_err(openai_backend_error)?;
         Ok(prompt_fits_single_prefill_sample(
             request.prompt_token_ids.len(),
@@ -760,7 +760,7 @@ impl StageOpenAiBackend {
                 .lock()
                 .map_err(|_| OpenAiError::backend("runtime lock poisoned"))?;
             runtime
-                .session_batch_size(session_id)
+                .admit_session_batch_size(session_id)
                 .map_err(openai_backend_error)?
                 .saturating_sub(1)
         } else {

--- a/crates/skippy-server/src/frontend/tests/generation.rs
+++ b/crates/skippy-server/src/frontend/tests/generation.rs
@@ -1,4 +1,6 @@
 use super::*;
+use crate::frontend::backend::run_blocking_generation_worker;
+use std::sync::atomic::AtomicBool;
 
 fn assert_generation_rate_limit(error: OpenAiError, message_fragment: &str) {
     assert_eq!(error.status(), StatusCode::TOO_MANY_REQUESTS);
@@ -98,6 +100,70 @@ async fn generation_admission_waits_for_released_lane() {
     release_task.await.unwrap();
     assert_eq!(generation_queue_depth.load(Ordering::Acquire), 0);
     drop(permit);
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn cancelled_worker_stops_before_the_next_request_acquires_the_only_lane() {
+    let generation_limit = Arc::new(Semaphore::new(1));
+    let queue_depth = Arc::new(AtomicUsize::new(0));
+    let first_permit = acquire_generation_permit_with_queue(
+        generation_limit.clone(),
+        queue_depth.clone(),
+        1,
+        Duration::from_secs(1),
+    )
+    .await
+    .unwrap();
+    let first_context = OpenAiRequestContext::new();
+    let worker_started = Arc::new(AtomicBool::new(false));
+    let worker_stopped = Arc::new(AtomicBool::new(false));
+    let started = worker_started.clone();
+    let stopped = worker_stopped.clone();
+    let first_worker = tokio::spawn(run_blocking_generation_worker(
+        first_permit,
+        first_context.clone(),
+        move |cancellation| {
+            started.store(true, Ordering::Release);
+            while !cancellation.is_cancelled() {
+                std::thread::sleep(Duration::from_millis(1));
+            }
+            stopped.store(true, Ordering::Release);
+        },
+    ));
+
+    tokio::time::timeout(Duration::from_millis(100), async {
+        while !worker_started.load(Ordering::Acquire) {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("first generation worker started");
+
+    let second_limit = generation_limit.clone();
+    let second_queue_depth = queue_depth.clone();
+    let second = tokio::spawn(async move {
+        let permit = acquire_generation_permit_with_queue(
+            second_limit,
+            second_queue_depth,
+            1,
+            Duration::from_secs(1),
+        )
+        .await
+        .unwrap();
+        assert!(
+            worker_stopped.load(Ordering::Acquire),
+            "the first worker must stop before its permit is released"
+        );
+        drop(permit);
+    });
+
+    first_context.cancel();
+    tokio::time::timeout(Duration::from_millis(200), second)
+        .await
+        .expect("second request acquired the lane promptly")
+        .unwrap();
+    first_worker.await.unwrap().unwrap();
+    assert_eq!(generation_limit.available_permits(), 1);
 }
 
 #[test]

--- a/crates/skippy-server/src/kv_integration/resident_prefix.rs
+++ b/crates/skippy-server/src/kv_integration/resident_prefix.rs
@@ -186,7 +186,7 @@ impl KvStageIntegration {
         runtime: &mut RuntimeState,
         session_id: &str,
     ) -> Result<ResidentPrefixEviction> {
-        let target_tokens = runtime.session_batch_size(session_id)? as u64;
+        let target_tokens = runtime.active_session_batch_size(session_id)? as u64;
         self.evict_resident_prefix_for_tokens(runtime, session_id, target_tokens)
     }
 

--- a/crates/skippy-server/src/runtime_state/frame_operations.rs
+++ b/crates/skippy-server/src/runtime_state/frame_operations.rs
@@ -120,7 +120,7 @@ impl RuntimeState {
     }
 
     /// Returns the batch size of an already admitted session.
-    pub fn active_session_batch_size(&self, session_id: &str) -> Result<usize> {
+    pub fn active_session_batch_size(&mut self, session_id: &str) -> Result<usize> {
         self.active_session(session_id)?.batch_size()
     }
 

--- a/crates/skippy-server/src/runtime_state/frame_operations.rs
+++ b/crates/skippy-server/src/runtime_state/frame_operations.rs
@@ -114,8 +114,14 @@ impl RuntimeState {
         result
     }
 
-    pub fn session_batch_size(&mut self, session_id: &str) -> Result<usize> {
+    /// Returns a session's batch size, admitting a new session when necessary.
+    pub fn admit_session_batch_size(&mut self, session_id: &str) -> Result<usize> {
         self.session(session_id)?.batch_size()
+    }
+
+    /// Returns the batch size of an already admitted session.
+    pub fn active_session_batch_size(&self, session_id: &str) -> Result<usize> {
+        self.active_session(session_id)?.batch_size()
     }
 
     pub fn ensure_session_active(&mut self, session_id: &str) -> Result<()> {

--- a/crates/skippy-server/src/runtime_state/frame_operations.rs
+++ b/crates/skippy-server/src/runtime_state/frame_operations.rs
@@ -115,7 +115,7 @@ impl RuntimeState {
     }
 
     pub fn session_batch_size(&mut self, session_id: &str) -> Result<usize> {
-        self.active_session(session_id)?.batch_size()
+        self.session(session_id)?.batch_size()
     }
 
     pub fn ensure_session_active(&mut self, session_id: &str) -> Result<()> {


### PR DESCRIPTION
## Problem

When an OpenAI request timed out, dropping the async request future did not stop the blocking generation worker. The request could return and release its concurrency lane while that worker was still using the model runtime.

A subsequent request could then acquire the same lane and overlap with stale work from the timed-out request, breaking the lane's isolation and making timeout behavior dependent on worker timing.

## Fix

Cancellation is propagated through the OpenAI and Skippy layers, and the timed-out worker is allowed to stop before its lane permit is released.

This is necessary because a blocking worker continues after its async wrapper is dropped; releasing the lane immediately would only hide the work, not cancel it. Tying lane release to confirmed worker termination preserves the existing concurrency contract.

## Validation

OpenAI tests pass (154/154) and Skippy Server tests pass (353/353), including the single-lane timeout regression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cancellation support for chat, completion, response, and streaming generation requests.
  * Requests can now stop promptly when cancelled, timed out, or abandoned.
  * Cancellation context is preserved through retries, hooks, guardrails, and local generation.

* **Bug Fixes**
  * Prevented cancelled requests from holding generation capacity longer than necessary.
  * Improved cancellation handling during token generation and proposal execution.
  * Improved session admission and batch-size handling for generation workloads.

* **Tests**
  * Added coverage for cancellation during active and non-streaming generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->