### PR TITLE
Honor configured reasoning defaults for agent requests

### DIFF
--- a/crates/skippy-server/src/frontend/request.rs
+++ b/crates/skippy-server/src/frontend/request.rs
@@ -306,9 +306,11 @@ fn default_reasoning_enabled(value: Option<EmbeddedReasoningEnabled>) -> Option<
 fn default_reasoning_budget_enabled(value: Option<EmbeddedReasoningBudget>) -> Option<bool> {
     match value {
         Some(EmbeddedReasoningBudget::Tokens(0)) => Some(false),
-        Some(EmbeddedReasoningBudget::Tokens(_)) | Some(EmbeddedReasoningBudget::Effort(_)) => {
-            Some(true)
+        Some(EmbeddedReasoningBudget::Tokens(_)) => Some(true),
+        Some(EmbeddedReasoningBudget::Effort(openai_frontend::ReasoningEffort::None)) => {
+            Some(false)
         }
+        Some(EmbeddedReasoningBudget::Effort(_)) => Some(true),
         Some(EmbeddedReasoningBudget::Auto) | None => None,
     }
 }

--- a/crates/skippy-server/src/frontend/tests/request.rs
+++ b/crates/skippy-server/src/frontend/tests/request.rs
@@ -396,6 +396,14 @@ fn request_default_reasoning_budget_controls_chat_template() {
     for (configured, expected) in [
         (EmbeddedReasoningBudget::Tokens(0), Some(false)),
         (EmbeddedReasoningBudget::Tokens(256), Some(true)),
+        (
+            EmbeddedReasoningBudget::Effort(openai_frontend::ReasoningEffort::None),
+            Some(false),
+        ),
+        (
+            EmbeddedReasoningBudget::Effort(openai_frontend::ReasoningEffort::Low),
+            Some(true),
+        ),
         (EmbeddedReasoningBudget::Auto, None),
     ] {
         let defaults = EmbeddedOpenAiRequestDefaults {


### PR DESCRIPTION
## Summary

- apply configured `reasoning_enabled` when a chat request omits an explicit reasoning control
- fall back to configured `reasoning_budget` when `reasoning_enabled` is auto or omitted
- preserve explicit request-level reasoning as the highest-precedence value

## Why

The configuration surface already accepts and resolves these defaults, but the chat-template path previously ignored them. Models whose native template enables reasoning could therefore reason even when the serving configuration disabled it.

## Validation

- `cargo fmt --all --check`
- `cargo test -p skippy-server --lib` (338 passed)
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Requests now automatically apply configured defaults for thinking and reasoning when these options are omitted.
  * Reasoning budgets and explicit enable/disable settings are recognized when determining whether thinking is enabled.
  * Explicit request settings take precedence over configured defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->