### PR TITLE
fix: speed up dependency-heavy container rebuilds

### DIFF
--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -15,24 +15,34 @@
 # syntax=docker/dockerfile:1.7
 
 FROM node:24-alpine AS ui-builder
-RUN npm install -g pnpm
+ARG TARGETARCH
+RUN --mount=type=cache,id=mesh-llm-npm-alpine-node24-${TARGETARCH},target=/root/.npm,sharing=locked \
+    npm install -g pnpm
 WORKDIR /app
 COPY crates/mesh-llm-ui/package.json crates/mesh-llm-ui/pnpm-lock.yaml crates/mesh-llm-ui/pnpm-workspace.yaml ./
-RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+RUN --mount=type=cache,id=mesh-llm-pnpm-store-alpine-node24-${TARGETARCH},target=/root/.local/share/pnpm/store,sharing=locked \
     pnpm install --frozen-lockfile
 COPY crates/mesh-llm-ui/ ./
 RUN pnpm run build
 # Output: /app/dist
 
 FROM debian:bookworm-slim AS rust-deps
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential \
-    && rm -rf /var/lib/apt/lists/*
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+ARG TARGETARCH
+ARG SCCACHE_VERSION=0.16.0
+RUN --mount=type=cache,id=mesh-llm-apt-lists-debian-bookworm-${TARGETARCH},target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,id=mesh-llm-apt-archives-debian-bookworm-${TARGETARCH},target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential
+COPY scripts/install-sccache.sh /usr/local/bin/install-sccache
+RUN --mount=type=cache,id=mesh-llm-downloads-debian-bookworm-sccache-${TARGETARCH},target=/var/cache/mesh-downloads,sharing=locked \
+    TARGETARCH="$TARGETARCH" SCCACHE_VERSION="$SCCACHE_VERSION" install-sccache
+RUN --mount=type=cache,id=mesh-llm-rustup-stable-debian-bookworm-${TARGETARCH},target=/root/.rustup/downloads,sharing=locked \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:$PATH"
 ENV LLAMA_STAGE_BUILD_DIR=".deps/llama.cpp/build-stage-abi-static"
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
+RUN --mount=type=cache,id=mesh-llm-cargo-registry-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/registry,sharing=locked \
+    --mount=type=cache,id=mesh-llm-cargo-git-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/git,sharing=locked \
     cargo install cargo-chef --version 0.1.68 --locked
 WORKDIR /src
 # Satisfy GitHub Actions preflight checks (exact strings required)
@@ -94,16 +104,21 @@ COPY tools/xtask/ tools/xtask/
 COPY scripts/prepare-llama.sh scripts/build-llama.sh scripts/
 COPY third_party/llama.cpp/upstream.txt third_party/llama.cpp/upstream.txt
 COPY third_party/llama.cpp/patches/ third_party/llama.cpp/patches/
-RUN LLAMA_STAGE_USE_SCCACHE=0 scripts/prepare-llama.sh pinned && \
-    LLAMA_STAGE_USE_SCCACHE=0 scripts/build-llama.sh
+RUN --mount=type=cache,id=mesh-llm-sccache-debian-bookworm-gcc12-cpu-${TARGETARCH},target=/root/.cache/sccache,sharing=locked \
+    scripts/prepare-llama.sh pinned && \
+    SCCACHE_DIR=/root/.cache/sccache \
+    MESH_LLM_REQUIRE_SCCACHE=1 \
+    LLAMA_STAGE_USE_SCCACHE=1 \
+    scripts/build-llama.sh
 RUN mkdir -p crates/mesh-llm-ui/dist && echo '<html></html>' > crates/mesh-llm-ui/dist/index.html
 RUN cargo chef prepare --recipe-path recipe.json
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
-    --mount=type=cache,target=/src/target \
+RUN --mount=type=cache,id=mesh-llm-cargo-registry-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/registry,sharing=locked \
+    --mount=type=cache,id=mesh-llm-cargo-git-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/git,sharing=locked \
+    --mount=type=cache,id=mesh-llm-cargo-target-debian-bookworm-rust-stable-cpu-${TARGETARCH},target=/src/target,sharing=locked \
     cargo chef cook --release --locked --recipe-path recipe.json
 
 FROM rust-deps AS rust-builder
+ARG TARGETARCH
 WORKDIR /src
 RUN rm -rf crates/mesh-llm-ui/dist
 COPY --from=ui-builder /app/dist crates/mesh-llm-ui/dist
@@ -164,17 +179,20 @@ COPY crates/skippy-bench/ crates/skippy-bench/
 COPY crates/skippy-prompt/ crates/skippy-prompt/
 COPY crates/mesh-mixture-of-agents/ crates/mesh-mixture-of-agents/
 COPY tools/xtask/ tools/xtask/
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
-    --mount=type=cache,target=/src/target \
+RUN --mount=type=cache,id=mesh-llm-cargo-registry-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/registry,sharing=locked \
+    --mount=type=cache,id=mesh-llm-cargo-git-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/git,sharing=locked \
+    --mount=type=cache,id=mesh-llm-cargo-target-debian-bookworm-rust-stable-cpu-${TARGETARCH},target=/src/target,sharing=locked \
     cargo build --release --locked -p mesh-llm && \
     mkdir -p /out && \
     cp /src/target/release/mesh-llm /out/mesh-llm
 
 FROM debian:bookworm-slim AS runtime
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libgomp1 libdbus-1-3 \
-    && rm -rf /var/lib/apt/lists/*
+ARG TARGETARCH
+RUN --mount=type=cache,id=mesh-llm-apt-lists-debian-bookworm-${TARGETARCH},target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,id=mesh-llm-apt-archives-debian-bookworm-${TARGETARCH},target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libgomp1 libdbus-1-3
 COPY --from=rust-builder /out/mesh-llm /usr/local/bin/mesh-llm
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/docker/skippy-wan-lab/Dockerfile
+++ b/docker/skippy-wan-lab/Dockerfile
@@ -1,8 +1,13 @@
 # syntax=docker/dockerfile:1.7
 
 FROM debian:bookworm-slim AS builder
+ARG TARGETARCH
+ARG SCCACHE_VERSION=0.16.0
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,id=mesh-llm-apt-lists-debian-bookworm-${TARGETARCH},target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,id=mesh-llm-apt-archives-debian-bookworm-${TARGETARCH},target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     cmake \
     curl \
@@ -12,27 +17,33 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl-dev \
     ninja-build \
     pkg-config \
-    python3 \
-    && rm -rf /var/lib/apt/lists/*
+    python3
 
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
+COPY scripts/install-sccache.sh /usr/local/bin/install-sccache
+RUN --mount=type=cache,id=mesh-llm-downloads-debian-bookworm-sccache-${TARGETARCH},target=/var/cache/mesh-downloads,sharing=locked \
+    TARGETARCH="$TARGETARCH" SCCACHE_VERSION="$SCCACHE_VERSION" install-sccache
+
+RUN --mount=type=cache,id=mesh-llm-rustup-stable-debian-bookworm-${TARGETARCH},target=/root/.rustup/downloads,sharing=locked \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs \
     | sh -s -- -y --default-toolchain stable --profile minimal
-
 ENV PATH="/root/.cargo/bin:${PATH}"
 ENV LLAMA_STAGE_BUILD_DIR=".deps/llama.cpp/build-stage-abi-static"
 WORKDIR /src
 
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
+RUN --mount=type=cache,id=mesh-llm-cargo-registry-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/registry,sharing=locked \
+    --mount=type=cache,id=mesh-llm-cargo-git-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/git,sharing=locked \
     cargo install just --locked
 
 COPY . .
 
-RUN LLAMA_STAGE_USE_SCCACHE=0 just llama-build
-
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
-    --mount=type=cache,target=/src/target \
+RUN --mount=type=cache,id=mesh-llm-sccache-debian-bookworm-gcc12-cpu-${TARGETARCH},target=/root/.cache/sccache,sharing=locked \
+    SCCACHE_DIR=/root/.cache/sccache \
+    MESH_LLM_REQUIRE_SCCACHE=1 \
+    LLAMA_STAGE_USE_SCCACHE=1 \
+    just llama-build
+RUN --mount=type=cache,id=mesh-llm-cargo-registry-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/registry,sharing=locked \
+    --mount=type=cache,id=mesh-llm-cargo-git-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/git,sharing=locked \
+    --mount=type=cache,id=mesh-llm-cargo-target-debian-bookworm-rust-stable-cpu-${TARGETARCH},target=/src/target,sharing=locked \
     just skippy-wan-lab-build-bins && \
     mkdir -p /out && \
     cp /src/target/release/skippy-server /out/skippy-server && \
@@ -41,8 +52,12 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
     cp /src/target/release/skippy-model-package /out/skippy-model-package
 
 FROM debian:bookworm-slim AS runtime
+ARG TARGETARCH
 
-RUN apt-get update && apt-get install -y --no-install-recommends \
+RUN --mount=type=cache,id=mesh-llm-apt-lists-debian-bookworm-${TARGETARCH},target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,id=mesh-llm-apt-archives-debian-bookworm-${TARGETARCH},target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends \
     bash \
     ca-certificates \
     curl \
@@ -54,8 +69,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libssl3 \
     netcat-openbsd \
     python3 \
-    tini \
-    && rm -rf /var/lib/apt/lists/*
+    tini
 
 COPY --from=builder /out/skippy-server /usr/local/bin/skippy-server
 COPY --from=builder /out/skippy-prompt /usr/local/bin/skippy-prompt

--- a/docs/BUILD_CACHE_BENCHMARKS.md
+++ b/docs/BUILD_CACHE_BENCHMARKS.md
@@ -1,0 +1,23 @@
+# Container build cache benchmarks
+
+## llama.cpp compiler cache
+
+Measured 2026-08-02 on `mesh1.patio51.com` (Linux ARM64) with Debian Bookworm,
+GCC 12.2, sccache 0.16.0, and BuildKit 0.31.2. Each timed sample rebuilt the
+same patched llama.cpp CPU/static source tree in a clean build directory. The
+compiler cache was the only persistent native-build state.
+
+| Sample | sccache result | Compile step |
+|---|---:|---:|
+| Control 1 | disabled | 122.1s |
+| Control 2 | disabled | 121.2s |
+| Cache population | 0/273 hits, 273 misses, 0 errors | 125.8s |
+| Warm cache | 273/273 hits, 0 misses, 0 errors | 3.55s |
+
+The warm compiler-cache path reduced the forced compile step by 97.1% versus
+the faster control. The one-time population cost was 3.8% above that control.
+This supports keeping the mount while full llama.cpp compilation remains in
+the container path.
+
+The cache ID separates Debian Bookworm, GCC 12, the CPU backend, and target
+architecture. Package downloads use a separate architecture-specific mount.

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -7,6 +7,7 @@
 # syntax=docker/dockerfile:1.7
 
 FROM node:24-alpine AS ui-builder
+ARG TARGETARCH
 ARG VITE_API_URL=https://public.meshllm.cloud
 ARG VITE_APP_VERSION=
 ARG VITE_STORAGE_NAMESPACE=mesh-llm-ui-production
@@ -14,19 +15,28 @@ ARG NODE_ENV=production
 ENV NODE_ENV=$NODE_ENV
 ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_STORAGE_NAMESPACE=$VITE_STORAGE_NAMESPACE
-RUN npm install -g pnpm
+RUN --mount=type=cache,id=mesh-llm-npm-alpine-node24-${TARGETARCH},target=/root/.npm,sharing=locked \
+    npm install -g pnpm
 WORKDIR /app
 COPY crates/mesh-llm-ui/package.json crates/mesh-llm-ui/pnpm-lock.yaml crates/mesh-llm-ui/pnpm-workspace.yaml ./
-RUN --mount=type=cache,id=pnpm-store,target=/root/.local/share/pnpm/store \
+RUN --mount=type=cache,id=mesh-llm-pnpm-store-alpine-node24-${TARGETARCH},target=/root/.local/share/pnpm/store,sharing=locked \
     pnpm install --frozen-lockfile
 COPY crates/mesh-llm-ui/ ./
 RUN VITE_APP_VERSION="${VITE_APP_VERSION:-$(node -p 'JSON.parse(require("fs").readFileSync("package.json", "utf8")).version')}" pnpm run build
 
 FROM debian:bookworm-slim AS builder
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential \
-    && rm -rf /var/lib/apt/lists/*
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
+ARG TARGETARCH
+ARG SCCACHE_VERSION=0.16.0
+RUN --mount=type=cache,id=mesh-llm-apt-lists-debian-bookworm-${TARGETARCH},target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,id=mesh-llm-apt-archives-debian-bookworm-${TARGETARCH},target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl git cmake ninja-build pkg-config libssl-dev libdbus-1-dev python3 build-essential
+COPY scripts/install-sccache.sh /usr/local/bin/install-sccache
+RUN --mount=type=cache,id=mesh-llm-downloads-debian-bookworm-sccache-${TARGETARCH},target=/var/cache/mesh-downloads,sharing=locked \
+    TARGETARCH="$TARGETARCH" SCCACHE_VERSION="$SCCACHE_VERSION" install-sccache
+RUN --mount=type=cache,id=mesh-llm-rustup-stable-debian-bookworm-${TARGETARCH},target=/root/.rustup/downloads,sharing=locked \
+    curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable --profile minimal
 ENV PATH="/root/.cargo/bin:$PATH"
 WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
@@ -97,19 +107,26 @@ COPY tools/xtask/ tools/xtask/
 COPY scripts/prepare-llama.sh scripts/build-llama.sh scripts/
 COPY third_party/llama.cpp/upstream.txt third_party/llama.cpp/upstream.txt
 COPY third_party/llama.cpp/patches/ third_party/llama.cpp/patches/
-RUN LLAMA_STAGE_USE_SCCACHE=0 scripts/prepare-llama.sh pinned && \
-    LLAMA_STAGE_USE_SCCACHE=0 scripts/build-llama.sh
+RUN --mount=type=cache,id=mesh-llm-sccache-debian-bookworm-gcc12-cpu-${TARGETARCH},target=/root/.cache/sccache,sharing=locked \
+    scripts/prepare-llama.sh pinned && \
+    SCCACHE_DIR=/root/.cache/sccache \
+    MESH_LLM_REQUIRE_SCCACHE=1 \
+    LLAMA_STAGE_USE_SCCACHE=1 \
+    scripts/build-llama.sh
 COPY --from=ui-builder /app/dist crates/mesh-llm-ui/dist
-RUN --mount=type=cache,target=/root/.cargo/registry \
-    --mount=type=cache,target=/root/.cargo/git \
-    --mount=type=cache,target=/src/target \
+RUN --mount=type=cache,id=mesh-llm-cargo-registry-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/registry,sharing=locked \
+    --mount=type=cache,id=mesh-llm-cargo-git-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/git,sharing=locked \
+    --mount=type=cache,id=mesh-llm-cargo-target-debian-bookworm-rust-stable-cpu-${TARGETARCH},target=/src/target,sharing=locked \
     cargo build --release --locked -p mesh-llm && \
     cp target/release/mesh-llm /usr/local/bin/mesh-llm
 
 FROM debian:bookworm-slim
-RUN apt-get update && apt-get install -y --no-install-recommends \
-    ca-certificates libgomp1 libdbus-1-3 \
-    && rm -rf /var/lib/apt/lists/*
+ARG TARGETARCH
+RUN --mount=type=cache,id=mesh-llm-apt-lists-debian-bookworm-${TARGETARCH},target=/var/lib/apt/lists,sharing=locked \
+    --mount=type=cache,id=mesh-llm-apt-archives-debian-bookworm-${TARGETARCH},target=/var/cache/apt,sharing=locked \
+    rm -f /etc/apt/apt.conf.d/docker-clean && \
+    apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates libgomp1 libdbus-1-3
 COPY --from=builder /usr/local/bin/mesh-llm /usr/local/bin/mesh-llm
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh

--- a/scripts/install-sccache.sh
+++ b/scripts/install-sccache.sh
@@ -29,8 +29,10 @@ if [[ ! "$expected_sha" =~ ^[[:xdigit:]]{64}$ ]] \
   rm -f "$archive_path" "$checksum_path"
   archive_tmp="$(mktemp "${archive_path}.tmp.XXXXXX")"
   checksum_tmp="$(mktemp "${checksum_path}.tmp.XXXXXX")"
-  if ! curl -fsSL --retry 3 "${base}/${archive}" -o "$archive_tmp" \
-      || ! curl -fsSL --retry 3 "${base}/${archive}.sha256" -o "$checksum_tmp"; then
+  if ! curl -fsSL --retry 3 --connect-timeout 10 --max-time 120 \
+      "${base}/${archive}" -o "$archive_tmp" \
+      || ! curl -fsSL --retry 3 --connect-timeout 10 --max-time 120 \
+        "${base}/${archive}.sha256" -o "$checksum_tmp"; then
     rm -f "$archive_tmp" "$checksum_tmp"
     exit 1
   fi

--- a/scripts/install-sccache.sh
+++ b/scripts/install-sccache.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${TARGETARCH:?TARGETARCH is required}"
+: "${SCCACHE_VERSION:?SCCACHE_VERSION is required}"
+
+download_cache="${DOWNLOAD_CACHE_DIR:-/var/cache/mesh-downloads}"
+install_dir="${SCCACHE_INSTALL_DIR:-/usr/local/bin}"
+mkdir -p "$download_cache"
+mkdir -p "$install_dir"
+
+case "$TARGETARCH" in
+  amd64) rust_arch=x86_64 ;;
+  arm64) rust_arch=aarch64 ;;
+  *) echo "unsupported architecture: $TARGETARCH" >&2; exit 1 ;;
+esac
+
+archive="sccache-v${SCCACHE_VERSION}-${rust_arch}-unknown-linux-musl.tar.gz"
+base="https://github.com/mozilla/sccache/releases/download/v${SCCACHE_VERSION}"
+archive_path="${download_cache}/${archive}"
+checksum_path="${archive_path}.sha256"
+
+expected_sha=""
+if [[ -s "$archive_path" && -s "$checksum_path" ]]; then
+  expected_sha="$(awk 'NR == 1 { print $1 }' "$checksum_path")"
+fi
+if [[ ! "$expected_sha" =~ ^[[:xdigit:]]{64}$ ]] \
+    || ! printf '%s  %s\n' "$expected_sha" "$archive_path" | sha256sum -c - >/dev/null 2>&1; then
+  rm -f "$archive_path" "$checksum_path"
+  archive_tmp="$(mktemp "${archive_path}.tmp.XXXXXX")"
+  checksum_tmp="$(mktemp "${checksum_path}.tmp.XXXXXX")"
+  if ! curl -fsSL --retry 3 "${base}/${archive}" -o "$archive_tmp" \
+      || ! curl -fsSL --retry 3 "${base}/${archive}.sha256" -o "$checksum_tmp"; then
+    rm -f "$archive_tmp" "$checksum_tmp"
+    exit 1
+  fi
+  expected_sha="$(awk 'NR == 1 { print $1 }' "$checksum_tmp")"
+  if [[ ! "$expected_sha" =~ ^[[:xdigit:]]{64}$ ]] \
+      || ! printf '%s  %s\n' "$expected_sha" "$archive_tmp" | sha256sum -c -; then
+    rm -f "$archive_tmp" "$checksum_tmp"
+    exit 1
+  fi
+  mv -f "$archive_tmp" "$archive_path"
+  mv -f "$checksum_tmp" "$checksum_path"
+fi
+
+temporary="$(mktemp -d)"
+trap 'rm -rf "$temporary"' EXIT
+tar -xzf "$archive_path" -C "$temporary"
+install -m 0755 \
+  "$temporary/sccache-v${SCCACHE_VERSION}-${rust_arch}-unknown-linux-musl/sccache" \
+  "$install_dir/sccache"
+"$install_dir/sccache" --version

--- a/scripts/prepare-llama.sh
+++ b/scripts/prepare-llama.sh
@@ -247,11 +247,13 @@ if (( ${#PATCHES[@]} > 0 )); then
       GIT_COMMITTER_DATE \
       GIT_COMMITTER_EMAIL \
       GIT_COMMITTER_NAME
-    git -C "$LLAMA_WORKDIR" am \
+    # `git am --no-verify` was added after the Git shipped by Debian Bookworm.
+    # Disable hooks through configuration instead so container and local Git
+    # versions produce the same non-interactive patch application.
+    git -c core.hooksPath=/dev/null -C "$LLAMA_WORKDIR" am \
       --3way \
       --committer-date-is-author-date \
       --no-gpg-sign \
-      --no-verify \
       "${PATCHES[@]}"
   )
 fi

--- a/scripts/tests/test_install_sccache.py
+++ b/scripts/tests/test_install_sccache.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Regression tests for atomic, self-healing sccache downloads."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+import subprocess
+import tarfile
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+INSTALLER = ROOT / "scripts" / "install-sccache.sh"
+VERSION = "0.16.0"
+ARCHIVE = f"sccache-v{VERSION}-x86_64-unknown-linux-musl.tar.gz"
+
+
+class InstallSccacheTests(unittest.TestCase):
+    def make_fixture(self, root: Path) -> tuple[Path, Path]:
+        source = root / "source"
+        payload = source / f"sccache-v{VERSION}-x86_64-unknown-linux-musl"
+        payload.mkdir(parents=True)
+        binary = payload / "sccache"
+        binary.write_text("#!/bin/sh\necho 'sccache 0.16.0'\n", encoding="utf-8")
+        binary.chmod(0o755)
+
+        archive = source / ARCHIVE
+        with tarfile.open(archive, "w:gz") as bundle:
+            bundle.add(payload, arcname=payload.name)
+        checksum = source / f"{ARCHIVE}.sha256"
+        checksum.write_text(
+            f"{hashlib.sha256(archive.read_bytes()).hexdigest()}\n",
+            encoding="utf-8",
+        )
+        return archive, checksum
+
+    def make_curl(self, root: Path, source: Path, *, fail: bool = False) -> Path:
+        fake_bin = root / "bin"
+        fake_bin.mkdir(parents=True, exist_ok=True)
+        curl = fake_bin / "curl"
+        if fail:
+            curl.write_text("#!/bin/sh\nexit 22\n", encoding="utf-8")
+        else:
+            curl.write_text(
+                """#!/bin/sh
+set -eu
+url=''
+destination=''
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    -o) destination="$2"; shift 2 ;;
+    -*) shift ;;
+    *) url="$1"; shift ;;
+  esac
+done
+cp "$SCCACHE_TEST_SOURCE/${url##*/}" "$destination"
+""",
+                encoding="utf-8",
+            )
+        curl.chmod(0o755)
+        return fake_bin
+
+    def run_installer(
+        self, root: Path, source: Path, fake_bin: Path
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(INSTALLER)],
+            cwd=ROOT,
+            env=os.environ
+            | {
+                "DOWNLOAD_CACHE_DIR": str(root / "cache"),
+                "PATH": f"{fake_bin}:{os.environ['PATH']}",
+                "SCCACHE_INSTALL_DIR": str(root / "install"),
+                "SCCACHE_TEST_SOURCE": str(source),
+                "SCCACHE_VERSION": VERSION,
+                "TARGETARCH": "amd64",
+            },
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_invalid_cache_is_replaced_before_atomic_promotion(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="mesh-install-sccache-") as temp:
+            root = Path(temp)
+            archive, checksum = self.make_fixture(root)
+            cache = root / "cache"
+            cache.mkdir()
+            (cache / ARCHIVE).write_bytes(b"partial archive")
+            (cache / f"{ARCHIVE}.sha256").write_text("invalid\n", encoding="utf-8")
+
+            result = self.run_installer(root, archive.parent, self.make_curl(root, archive.parent))
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual((cache / ARCHIVE).read_bytes(), archive.read_bytes())
+            self.assertEqual(
+                (cache / f"{ARCHIVE}.sha256").read_text(encoding="utf-8"),
+                checksum.read_text(encoding="utf-8"),
+            )
+            self.assertTrue((root / "install" / "sccache").is_file())
+            self.assertEqual(list(cache.glob("*.tmp.*")), [])
+
+            failing_bin = self.make_curl(root / "offline", archive.parent, fail=True)
+            cached = self.run_installer(root, archive.parent, failing_bin)
+            self.assertEqual(cached.returncode, 0, cached.stderr)
+
+    def test_failed_refresh_leaves_no_partial_cache_entry(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="mesh-install-sccache-failure-") as temp:
+            root = Path(temp)
+            archive, _ = self.make_fixture(root)
+            cache = root / "cache"
+            cache.mkdir()
+            (cache / ARCHIVE).write_bytes(b"corrupt")
+
+            result = self.run_installer(
+                root, archive.parent, self.make_curl(root, archive.parent, fail=True)
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertFalse((cache / ARCHIVE).exists())
+            self.assertFalse((cache / f"{ARCHIVE}.sha256").exists())
+            self.assertEqual(list(cache.glob("*.tmp.*")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_prepare_llama.py
+++ b/scripts/tests/test_prepare_llama.py
@@ -127,6 +127,8 @@ class PrepareLlamaTests(unittest.TestCase):
             author = root / "author"
             patch_dir = root / "patches"
             pin_file = root / "upstream.txt"
+            hook_dir = root / "hooks"
+            hook_marker = root / "hook-ran"
 
             self.run_git(root, "init", "--initial-branch=master", str(upstream))
             self.run_git(upstream, "config", "user.name", "Patch Author")
@@ -149,6 +151,13 @@ class PrepareLlamaTests(unittest.TestCase):
                 author, "format-patch", "-1", "--stdout", capture_output=True
             ).stdout
             (patch_dir / "0001-local.patch").write_text(patch, encoding="utf-8")
+            hook_dir.mkdir()
+            for hook_name in ("applypatch-msg", "pre-applypatch"):
+                hook = hook_dir / hook_name
+                hook.write_text(
+                    f"#!/bin/sh\ntouch '{hook_marker}'\nexit 1\n", encoding="utf-8"
+                )
+                hook.chmod(0o755)
 
             patched_shas = []
             for index, (committer_date, timezone) in enumerate(
@@ -164,9 +173,11 @@ class PrepareLlamaTests(unittest.TestCase):
                     "GIT_COMMITTER_DATE": committer_date,
                     "GIT_COMMITTER_EMAIL": f"committer-{index}@example.com",
                     "GIT_COMMITTER_NAME": f"Ambient Committer {index}",
-                    "GIT_CONFIG_COUNT": "1",
+                    "GIT_CONFIG_COUNT": "2",
                     "GIT_CONFIG_KEY_0": "commit.gpgsign",
                     "GIT_CONFIG_VALUE_0": "true",
+                    "GIT_CONFIG_KEY_1": "core.hooksPath",
+                    "GIT_CONFIG_VALUE_1": str(hook_dir),
                     "TZ": timezone,
                     "LLAMA_UPSTREAM_URL": f"file://{upstream}",
                     "LLAMA_WORKDIR": str(workdir),
@@ -191,6 +202,7 @@ class PrepareLlamaTests(unittest.TestCase):
                     .strip(),
                     "2",
                 )
+                self.assertFalse(hook_marker.exists())
 
             self.assertEqual(patched_shas[0], patched_shas[1])
 


### PR DESCRIPTION
## Summary

- add stable architecture/toolchain-scoped BuildKit caches for apt, npm, pnpm, rustup, Cargo, Cargo target output, downloads, and sccache
- enable required sccache for the full llama.cpp compilation still present in the client, Fly, and WAN-lab container paths
- make sccache downloads atomic, checksum-verified, and self-healing
- replace `git am --no-verify` with a Bookworm-compatible hook override
- document the forced-recompile benchmark and add regression coverage

## Measured impact

The same patched llama.cpp CPU/static source tree was compiled from clean build directories on Linux ARM64:

| Sample | Compile time |
|---|---:|
| Faster no-sccache control | 121.2s |
| Cache population, 273 misses | 125.8s |
| Warm sccache, 273 hits | 3.55s |

The warm compiler-cache path is 97.1% faster than the control, with zero cache errors.

## Release-path audit

- `just check-release` passes the release-target consistency gate.
- Native runtime release jobs compile through `prepare-native-runtime-input` and `package-native-runtime.sh`.
- Static ABI release jobs directly run `prepare-llama.sh` and `build-llama.sh`.
- Native SDK release jobs consume the typed static ABI input and package through `prepare-native-sdk-input`.
- The Bookworm Git fix is therefore exercised by canonical Linux release compilation.
- The three Dockerfiles changed here are auxiliary container paths; canonical published package/image assembly remains in `mesh-packaging`.

## Validation

- `just check-release`
- 115 focused cache and release-contract tests
- exact pinned llama preparation: 47/47 patches applied, patched SHA `e43d604fb427e769ce3c09ebb462743e456d0c99`
- ShellCheck, shell syntax, and actionlint
- BuildKit checks for all three Dockerfiles on amd64 and arm64
- forced compile benchmark with 273/273 warm sccache hits


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved container build times with architecture-aware caching for dependencies, toolchains, and build artifacts.
  * Added compiler-cache support for faster repeated llama and Rust builds.

* **Documentation**
  * Added ARM64 container build-cache benchmarks and performance comparisons.

* **Reliability**
  * Added verified, cache-aware installation for the compiler cache tool.
  * Improved patch application compatibility across Git versions.

* **Tests**
  * Added coverage for cache validation, recovery, reuse, and Git hook handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->