### PR TITLE
Add measured Depot Registry pull-through canary

### DIFF
--- a/.agents/skills/manage-ci/SKILL.md
+++ b/.agents/skills/manage-ci/SKILL.md
@@ -210,6 +210,13 @@ update the skill resources in the same change.
   selected-workflow restriction, and every selected runner label before
   enabling Depot. Hardware-qualified GPU execution remains on a restricted
   device runner.
+- Treat Depot Registry pull-through caching as an opt-in, trusted-build
+  optimization. Benchmark an upstream digest and its cached mirror on fresh
+  ephemeral runners, require identical manifest digests, and adopt a mirror
+  only when at least five samples show both 20% and 10 seconds of median pull
+  improvement. Never pass the pull token to PR code or use pull timing as
+  evidence for package installation, dependency resolution, compilation, or
+  Docker layer-export improvements.
 
 ## Dependencies and runner setup
 

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -27,6 +27,7 @@ the commands at the end before operational changes.
 | `nightly-stability.yml` | Schedule, dispatch | Nightly operator entry point |
 | `nightly-stability-run.yml` | Reusable call | Stability probes and evidence |
 | `llama-upstream-canary.yml` | Schedule, dispatch | Upstream llama.cpp compatibility canary |
+| `depot-registry-canary.yml` | Dispatch from `main` | Five-pair fresh-runner comparison of one digest-pinned upstream image and its Depot pull-through mirror |
 | `queue-unsloth-layer-packages.yml` | Schedule, dispatch | Hugging Face layer-package job queueing |
 | `windows-warm-caches.yml` | Main path push, dispatch | Trusted Windows ABI cache warming |
 | `website-pages.yml` | Main website path push, dispatch | Public website Pages build/deploy |
@@ -268,6 +269,16 @@ repository/workflow allowlist. Inspect that policy with organization-admin
 authority before enabling the global gate. The separate `mesh-llm` group owns
 the two dedicated GPU scale sets and is not the Depot group.
 
+The manual `depot-registry-canary.yml` is the pull-through adoption boundary.
+It accepts only a digest-pinned public reference and a safe relative Depot
+repository name on an exact `main` dispatch. Five upstream jobs and five Depot
+jobs each receive a fresh ephemeral Depot runner. The summary rejects digest
+drift and requires at least 20% and 10 seconds of median pull improvement.
+`DEPOT_REGISTRY_HOST` supplies the nonsecret organization registry host;
+the cached pull step uses GitHub OIDC to mint a short-lived read-only
+`depot pull-token`. No stored registry secret is used, and the OIDC permission
+is not available to PR code.
+
 Bounded rollout evidence:
 
 - cold and warm six-label canaries
@@ -289,9 +300,12 @@ Bounded rollout evidence:
   nine Depot jobs included exact static-ABI cache hits with zero compilation
   and roughly 95% sccache hits in both Linux native-SDK consumers.
 
-`DEPOT_RUNNERS_ENABLED` remains unset: `main` still lacks an enforceable
-review/status protection boundary, so only exact-main manual `use_depot=true`
-canaries are authorized.
+Live inspection on 2026-08-02 found `DEPOT_RUNNERS_ENABLED=true`. The checked-in
+selector still restricts Depot to eligible trusted `main` push/dispatch jobs,
+but `main` has no classic branch protection and the available token cannot
+fully inspect the organization runner-group workflow allowlist. Treat that
+administrative boundary as unverified until an organization administrator
+confirms it.
 
 The checked-out local selector is not the security boundary because PRs can
 modify workflow and local-action files. The Depot runner group must use
@@ -438,6 +452,7 @@ All GitHub Actions variables are strings.
 | `USE_SELF_HOSTED` | Exact `true` selects supported self-hosted GPU/release lanes; otherwise hosted |
 | `DEPOT_PR_RUNNERS_ENABLED` | Deprecated compatibility variable; the current selector ignores it and all PR jobs remain GitHub-hosted |
 | `DEPOT_RUNNERS_ENABLED` | Exact `true` routes eligible trusted main/release Linux jobs to Depot; otherwise GitHub-hosted |
+| `DEPOT_REGISTRY_HOST` | Depot organization registry host (`<org-id>.registry.depot.dev`) used only by the manual pull-through canary; required for that workflow |
 | `CUDA_VERSION` | Windows CUDA toolkit selection; Linux CUDA lanes use digest-pinned backend images |
 | `VULKAN_SDK_VERSION` | Windows Vulkan SDK; fallback `1.4.328.1` |
 | `LLAMA_UPSTREAM_CANARY_SMOKE` | Enables canary smoke; fallback `1` |

--- a/.github/workflows/depot-registry-canary.yml
+++ b/.github/workflows/depot-registry-canary.yml
@@ -1,0 +1,182 @@
+name: Depot Registry Pull-Through Canary
+
+on:
+  workflow_dispatch:
+    inputs:
+      upstream_image:
+        description: Digest-pinned public image (for example ubuntu@sha256:...).
+        required: true
+        type: string
+      depot_repository:
+        description: Depot pull-through repository name that mirrors the upstream repository.
+        required: true
+        type: string
+      enforce_threshold:
+        description: Fail unless the pull-through mirror meets the adoption gate.
+        required: false
+        default: false
+        type: boolean
+
+permissions:
+  contents: read
+
+env:
+  DEPOT_PROJECT_ID: mzm95zcv7p
+
+concurrency:
+  group: depot-registry-canary
+  cancel-in-progress: false
+
+jobs:
+  policy:
+    runs-on: ubuntu-24.04
+    outputs:
+      digest: ${{ steps.validate.outputs.digest }}
+      depot_image: ${{ steps.validate.outputs.depot_image }}
+    steps:
+      - name: Validate trusted invocation and image references
+        id: validate
+        shell: bash
+        env:
+          DEPOT_REGISTRY_HOST: ${{ vars.DEPOT_REGISTRY_HOST }}
+          DEPOT_REPOSITORY: ${{ inputs.depot_repository }}
+          UPSTREAM_IMAGE: ${{ inputs.upstream_image }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$GITHUB_REPOSITORY" != "Mesh-LLM/mesh-llm" ||
+                "$GITHUB_EVENT_NAME" != "workflow_dispatch" ||
+                "$GITHUB_REF" != "refs/heads/main" ]]; then
+            echo "registry canaries are restricted to a manual main-ref invocation" >&2
+            exit 1
+          fi
+          if [[ ! "$DEPOT_REGISTRY_HOST" =~ ^[a-z0-9-]+\.registry\.depot\.dev$ ]]; then
+            echo "DEPOT_REGISTRY_HOST must be an organization Depot Registry host" >&2
+            exit 1
+          fi
+          if [[ ! "$DEPOT_REPOSITORY" =~ ^[a-z0-9]+([._/-]?[a-z0-9]+)*$ ||
+                "$DEPOT_REPOSITORY" == *..* ]]; then
+            echo "depot_repository is not a safe repository path" >&2
+            exit 1
+          fi
+          if [[ ! "$UPSTREAM_IMAGE" =~ @sha256:([a-f0-9]{64})$ ]]; then
+            echo "upstream_image must be pinned by sha256 digest" >&2
+            exit 1
+          fi
+
+          digest="sha256:${BASH_REMATCH[1]}"
+          {
+            echo "digest=$digest"
+            echo "depot_image=$DEPOT_REGISTRY_HOST/$DEPOT_REPOSITORY@$digest"
+          } >> "$GITHUB_OUTPUT"
+
+  pull:
+    needs: policy
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        source: [upstream, depot]
+        sample: [1, 2, 3, 4, 5]
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 15
+    steps:
+      - name: Set up Depot CLI
+        if: ${{ matrix.source == 'depot' }}
+        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
+        with:
+          version: 2.101.77
+      - name: Authenticate to Depot Registry
+        if: ${{ matrix.source == 'depot' }}
+        shell: bash
+        env:
+          DEPOT_REGISTRY_HOST: ${{ vars.DEPOT_REGISTRY_HOST }}
+        run: |
+          set -euo pipefail
+
+          depot pull-token --project "$DEPOT_PROJECT_ID" |
+            docker login "$DEPOT_REGISTRY_HOST" --username x-token --password-stdin
+
+      - name: Pull exact image on a fresh runner
+        shell: bash
+        env:
+          DEPOT_IMAGE: ${{ needs.policy.outputs.depot_image }}
+          EXPECTED_DIGEST: ${{ needs.policy.outputs.digest }}
+          SAMPLE: ${{ matrix.sample }}
+          SOURCE: ${{ matrix.source }}
+          UPSTREAM_IMAGE: ${{ inputs.upstream_image }}
+        run: |
+          set -euo pipefail
+
+          image="$UPSTREAM_IMAGE"
+          if [[ "$SOURCE" == "depot" ]]; then
+            image="$DEPOT_IMAGE"
+          fi
+
+          start_ns="$(date +%s%N)"
+          docker pull "$image"
+          end_ns="$(date +%s%N)"
+          elapsed_ms="$(( (end_ns - start_ns) / 1000000 ))"
+          resolved_digest="$(docker image inspect "$image" \
+            --format '{{join .RepoDigests "\n"}}' | sed -n 's/.*@\(sha256:[a-f0-9]\{64\}\)$/\1/p' | head -1)"
+          if [[ "$resolved_digest" != "$EXPECTED_DIGEST" ]]; then
+            echo "digest mismatch: expected $EXPECTED_DIGEST, got $resolved_digest" >&2
+            exit 1
+          fi
+
+          python3 - "$SOURCE" "$SAMPLE" "$elapsed_ms" "$resolved_digest" <<'PY'
+          import json
+          import sys
+
+          source, sample, elapsed_ms, digest = sys.argv[1:]
+          with open("observation.json", "w", encoding="utf-8") as handle:
+              json.dump(
+                  {
+                      "source": source,
+                      "sample": int(sample),
+                      "elapsed_ms": int(elapsed_ms),
+                      "digest": digest,
+                  },
+                  handle,
+              )
+              handle.write("\n")
+          PY
+
+      - name: Upload pull observation
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
+        with:
+          name: depot-registry-pull-${{ matrix.source }}-${{ matrix.sample }}
+          path: observation.json
+          retention-days: 14
+
+  summary:
+    if: ${{ !cancelled() }}
+    needs: [policy, pull]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+      - name: Download pull observations
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          pattern: depot-registry-pull-*
+          path: registry-pull-observations
+      - name: Evaluate adoption gate
+        shell: bash
+        env:
+          ENFORCE_THRESHOLD: ${{ inputs.enforce_threshold }}
+        run: |
+          set -euo pipefail
+
+          args=(
+            --json-out "$RUNNER_TEMP/depot-registry-pulls.json"
+            --markdown-out "$GITHUB_STEP_SUMMARY"
+          )
+          if [[ "$ENFORCE_THRESHOLD" == "true" ]]; then
+            args+=(--enforce)
+          fi
+          python3 scripts/summarize-depot-registry-pulls.py \
+            "${args[@]}" registry-pull-observations

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -232,13 +232,16 @@ Activation prerequisites:
    workflow, and must never pass a caller-provided label to `runs-on`.
 8. Set `DEPOT_RUNNERS_ENABLED=true` only after the administrative trust
    boundary is verified and comparable trusted canaries meet the rollout
-   targets. It remains unset.
+   targets. Live inspection on 2026-08-02 found it set to `true` even though
+   the administrative boundary remains unverified with the available token;
+   an organization administrator must confirm that boundary.
 
 The initial main allowlist is:
 
 ```text
 Mesh-LLM/mesh-llm/.github/workflows/ci.yml@refs/heads/main
 Mesh-LLM/mesh-llm/.github/workflows/pr_quality.yml@refs/heads/main
+Mesh-LLM/mesh-llm/.github/workflows/depot-registry-canary.yml@refs/heads/main
 Mesh-LLM/mesh-llm/.github/workflows/native-sdk-artifact.yml@refs/heads/main
 Mesh-LLM/mesh-llm/.github/workflows/static-abi-artifact.yml@refs/heads/main
 ```
@@ -284,7 +287,7 @@ repository now allocate ephemeral Depot runners, superseding the 2026-07-29
 observation that public access was disabled. The available token currently gets
 403 when reading organization runner-group settings, so the exact live
 repository/workflow restrictions remain administratively unverified. Re-check
-them with organization-admin authority before setting the global gate. The
+them with organization-admin authority. The
 separate `mesh-llm` group owns two dedicated GPU scale sets and is not the Depot
 group.
 
@@ -310,9 +313,11 @@ The bounded evidence is:
   exact cache entries without compiling, and both Linux native-SDK consumers
   reported roughly 95% sccache hits.
 
-The canaries do not satisfy the trust prerequisite by themselves.
-`DEPOT_RUNNERS_ENABLED` remains unset because `main` has no enforceable
-review/status protection boundary.
+The canaries do not satisfy the trust prerequisite by themselves. Live
+inspection on 2026-08-02 found `DEPOT_RUNNERS_ENABLED=true`, while `main` still
+has no classic branch protection and the exact organization runner-group
+allowlist remains unverified with the available token. Treat this as an
+unresolved administrative risk, not evidence that the prerequisite is met.
 
 Depot redirects every GitHub Actions cache API consumer on its runners,
 including `actions/cache`, `actions/setup-node`, and third-party cache actions.
@@ -435,6 +440,17 @@ Depot Registry pull-through reference and the containerd layer store against
 the exact same GHCR index/child digests. Adopt either only with at least 20%
 and 10 seconds of median pull improvement; never expose the registry or cache
 token to PR code.
+
+The checked-in `depot-registry-canary.yml` implements that measurement gate for
+any digest-pinned public base or runner image. Configure each upstream
+repository as a distinct Depot pull-through repository, set the nonsecret
+`DEPOT_REGISTRY_HOST` repository variable, and permit the job's GitHub OIDC
+identity to mint a short-lived read-only `depot pull-token`. No stored registry
+secret is required. Run the workflow from `main` with the exact upstream digest
+and relative Depot repository name. It allocates five fresh ephemeral runners
+per source, verifies digest identity, retains raw timing observations for 14
+days, and reports whether both thresholds pass. Do not enable a mirror in
+normal builds until its own retained cohort passes.
 
 ### `Mesh-LLM/mesh-packaging`
 

--- a/ci/METRICS.md
+++ b/ci/METRICS.md
@@ -192,6 +192,24 @@ retain the raw observations. Until those records exist, the proposed role-size,
 cold-pull, and publication-time thresholds in
 [`DEPOT_MIGRATION.md`](DEPOT_MIGRATION.md) are design budgets, not baselines.
 
+## Depot Registry pull-through measurements
+
+Use the manual `depot-registry-canary.yml` workflow for registry comparisons.
+The upstream input must be digest-pinned, and the Depot repository must mirror
+that exact upstream repository. Each source receives five fresh ephemeral
+Depot runners so local layer reuse cannot turn a warm local pull into a false
+registry result. Downloaded observation artifacts can be reevaluated with:
+
+```bash
+python3 scripts/summarize-depot-registry-pulls.py \
+  --enforce /tmp/depot-registry-pull-observations
+```
+
+Adoption requires identical resolved digests, at least five unique samples per
+source, at least 20% median improvement, and at least 10 seconds saved at the
+median. This result applies only to image transfer. Do not attribute it to
+`apt`, Cargo, pnpm/npm, native backend compilation, or Docker layer export.
+
 | Phase | Change class | Provider / runner | Samples | p50 | p90 | p95 | Notes |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
 | Product-v2 PR graph | full CI refactor | hosted mix | 1 | 1h 7m 34s | 1h 7m 34s | 1h 7m 34s | Green; queue-contaminated; composition 10s–70s |

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -165,6 +165,7 @@ flowchart TD
         MainCI["ci.yml\npush main / dispatch"]
         WebsiteDeploy["website-pages.yml\nActions Pages deploy\nPublic Website environment"]
         DockerValidate["docker.yml\nmanual client Dockerfile validation"]
+        DepotRegistryCanary["depot-registry-canary.yml\nfresh-runner upstream vs pull-through pulls"]
         Release["release.yml\nrelease artifacts + package/image/npm dispatch"]
         FlyConsole["fly-deploy-console.yml\nmanual Fly console deploy"]
     end
@@ -585,8 +586,11 @@ all passed. The warm release canary used nine Depot jobs, restored both static
 ABI inputs without compilation, and produced roughly 95% sccache hit rates in
 both Linux native-SDK consumers. The feature-ref run was skipped before runner
 allocation and its main-identical temporary ref was removed.
-`DEPOT_RUNNERS_ENABLED` remains unset because `main` lacks an enforceable
-review/status protection boundary.
+Live inspection on 2026-08-02 found `DEPOT_RUNNERS_ENABLED=true`, although
+`main` has no classic branch protection and the exact organization runner-group
+workflow allowlist remains unverified with the available token. This is an
+unresolved administrative risk; the checked-in trust gates and hosted PR
+fallback remain required.
 
 Current GitHub-hosted PR jobs may share the `mesh-llm` native-cache key
 namespace because GitHub scopes `actions/cache` PR writes to the merge ref;
@@ -605,6 +609,17 @@ mode-independent Rust dependency cache and only trusted main pushes save it.
 Hardware-qualified GPU execution stays on dedicated runners. See
 [`DEPOT_MIGRATION.md`](DEPOT_MIGRATION.md) for activation prerequisites,
 baseline metrics, target service levels, and the cross-repository plan.
+
+Depot Registry pull-through caching has a separate manual adoption gate. An
+exact-main dispatch of `depot-registry-canary.yml` compares one digest-pinned
+public reference with a configured Depot mirror using five fresh ephemeral
+runner samples per source. The workflow verifies that every pull resolves to
+the same manifest digest and requires both 20% and 10 seconds of median pull
+improvement before a mirror is eligible for broader use. Its read-only pull
+token is minted through GitHub OIDC only in the cached pull step; no stored
+registry secret is used, and the OIDC permission is never available to PR code.
+This measures registry transfer only; it does not measure package-manager,
+Cargo, npm/pnpm, native compilation, or Docker export work.
 
 ## Public website deployment
 

--- a/scripts/summarize-depot-registry-pulls.py
+++ b/scripts/summarize-depot-registry-pulls.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""Summarize paired upstream and Depot Registry cold-pull observations."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import statistics
+from pathlib import Path
+
+
+SOURCES = ("upstream", "depot")
+
+
+def load_observations(root: Path) -> list[dict[str, object]]:
+    observations: list[dict[str, object]] = []
+    for path in sorted(root.rglob("*.json")):
+        with path.open(encoding="utf-8") as handle:
+            observation = json.load(handle)
+        if observation.get("source") not in SOURCES:
+            raise ValueError(f"{path}: source must be upstream or depot")
+        if not isinstance(observation.get("sample"), int):
+            raise ValueError(f"{path}: sample must be an integer")
+        if not isinstance(observation.get("elapsed_ms"), int):
+            raise ValueError(f"{path}: elapsed_ms must be an integer")
+        digest = observation.get("digest")
+        if not isinstance(digest, str) or not digest.startswith("sha256:"):
+            raise ValueError(f"{path}: digest must be a sha256 digest")
+        observations.append(observation)
+    return observations
+
+
+def summarize(
+    observations: list[dict[str, object]], minimum_samples: int
+) -> dict[str, object]:
+    by_source = {
+        source: [item for item in observations if item["source"] == source]
+        for source in SOURCES
+    }
+    for source, items in by_source.items():
+        samples = {item["sample"] for item in items}
+        if len(items) < minimum_samples or len(samples) != len(items):
+            raise ValueError(
+                f"{source}: need at least {minimum_samples} unique samples"
+            )
+
+    digests = {item["digest"] for item in observations}
+    if len(digests) != 1:
+        raise ValueError("upstream and Depot observations used different digests")
+
+    upstream_ms = statistics.median(
+        int(item["elapsed_ms"]) for item in by_source["upstream"]
+    )
+    depot_ms = statistics.median(
+        int(item["elapsed_ms"]) for item in by_source["depot"]
+    )
+    improvement_ms = upstream_ms - depot_ms
+    improvement_percent = (improvement_ms / upstream_ms) * 100 if upstream_ms else 0
+    eligible = improvement_ms >= 10_000 and improvement_percent >= 20
+    return {
+        "digest": digests.pop(),
+        "upstream_median_ms": upstream_ms,
+        "depot_median_ms": depot_ms,
+        "improvement_ms": improvement_ms,
+        "improvement_percent": improvement_percent,
+        "eligible": eligible,
+        "samples_per_source": {
+            source: len(items) for source, items in by_source.items()
+        },
+    }
+
+
+def markdown(summary: dict[str, object]) -> str:
+    return "\n".join(
+        (
+            "## Depot Registry pull-through result",
+            "",
+            "| Signal | Value |",
+            "| --- | ---: |",
+            f"| Upstream median | {int(summary['upstream_median_ms']) / 1000:.3f}s |",
+            f"| Depot median | {int(summary['depot_median_ms']) / 1000:.3f}s |",
+            f"| Improvement | {int(summary['improvement_ms']) / 1000:.3f}s "
+            f"({float(summary['improvement_percent']):.1f}%) |",
+            f"| Adoption gate | {'pass' if summary['eligible'] else 'fail'} |",
+            "",
+            f"Digest: `{summary['digest']}`",
+            "",
+            "The gate requires at least five fresh-runner samples per source, "
+            "identical manifest digests, at least 20% improvement, and at least "
+            "10 seconds saved at the median.",
+        )
+    )
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("observations", type=Path)
+    parser.add_argument("--minimum-samples", type=int, default=5)
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--markdown-out", type=Path)
+    parser.add_argument("--enforce", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    result = summarize(load_observations(args.observations), args.minimum_samples)
+    report = markdown(result)
+    if args.json_out:
+        args.json_out.write_text(json.dumps(result, indent=2) + "\n", encoding="utf-8")
+    if args.markdown_out:
+        args.markdown_out.write_text(report + "\n", encoding="utf-8")
+    else:
+        print(report)
+    return 1 if args.enforce and not result["eligible"] else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_depot_registry_canary_workflow.py
+++ b/scripts/tests/test_depot_registry_canary_workflow.py
@@ -1,0 +1,41 @@
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "depot-registry-canary.yml"
+
+
+class DepotRegistryCanaryWorkflowTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def test_canary_is_manual_and_main_only(self) -> None:
+        self.assertIn("workflow_dispatch:", self.workflow)
+        self.assertNotIn("pull_request:", self.workflow)
+        self.assertNotIn("push:", self.workflow)
+        self.assertIn('"refs/heads/main"', self.workflow)
+
+    def test_pull_token_is_short_lived_and_oidc_scoped(self) -> None:
+        self.assertIn("id-token: write", self.workflow)
+        self.assertIn("depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461", self.workflow)
+        self.assertIn('depot pull-token --project "$DEPOT_PROJECT_ID"', self.workflow)
+        self.assertIn("docker login", self.workflow)
+        self.assertNotIn("secrets.", self.workflow)
+        self.assertNotIn("DEPOT_REGISTRY_PULL_TOKEN", self.workflow)
+        self.assertNotIn("printenv", self.workflow)
+
+    def test_canary_uses_fresh_runner_samples_and_exact_digest(self) -> None:
+        self.assertIn("source: [upstream, depot]", self.workflow)
+        self.assertIn("sample: [1, 2, 3, 4, 5]", self.workflow)
+        self.assertIn("runs-on: depot-ubuntu-24.04", self.workflow)
+        self.assertIn("upstream_image must be pinned by sha256 digest", self.workflow)
+        self.assertIn("digest mismatch", self.workflow)
+
+    def test_canary_uses_pinned_artifact_actions(self) -> None:
+        self.assertIn("actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f", self.workflow)
+        self.assertIn("actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131", self.workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_summarize_depot_registry_pulls.py
+++ b/scripts/tests/test_summarize_depot_registry_pulls.py
@@ -1,0 +1,51 @@
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "summarize-depot-registry-pulls.py"
+SPEC = importlib.util.spec_from_file_location("registry_pulls", SCRIPT)
+assert SPEC and SPEC.loader
+REGISTRY_PULLS = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(REGISTRY_PULLS)
+
+
+def observations(upstream: list[int], depot: list[int]) -> list[dict[str, object]]:
+    digest = "sha256:" + "a" * 64
+    return [
+        {"source": source, "sample": index, "elapsed_ms": elapsed, "digest": digest}
+        for source, values in (("upstream", upstream), ("depot", depot))
+        for index, elapsed in enumerate(values, start=1)
+    ]
+
+
+class DepotRegistryPullSummaryTests(unittest.TestCase):
+    def test_accepts_both_absolute_and_relative_improvement(self) -> None:
+        result = REGISTRY_PULLS.summarize(
+            observations([60_000] * 5, [40_000] * 5), 5
+        )
+        self.assertTrue(result["eligible"])
+        self.assertEqual(result["improvement_ms"], 20_000)
+
+    def test_rejects_fast_percentage_only_improvement(self) -> None:
+        result = REGISTRY_PULLS.summarize(
+            observations([20_000] * 5, [14_000] * 5), 5
+        )
+        self.assertFalse(result["eligible"])
+
+    def test_rejects_digest_mismatch(self) -> None:
+        values = observations([60_000] * 5, [40_000] * 5)
+        values[-1]["digest"] = "sha256:" + "b" * 64
+        with self.assertRaisesRegex(ValueError, "different digests"):
+            REGISTRY_PULLS.summarize(values, 5)
+
+    def test_requires_unique_samples_per_source(self) -> None:
+        values = observations([60_000] * 5, [40_000] * 5)
+        values[-1]["sample"] = 4
+        with self.assertRaisesRegex(ValueError, "unique samples"):
+            REGISTRY_PULLS.summarize(values, 5)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a manual trusted-main canary that compares five fresh-runner upstream pulls with five Depot pull-through pulls
- require identical image digests and report the 20% plus 10-second adoption gate
- document the security boundary, measurement limits, and current Depot runner state

## Validation
- `python3 -m unittest scripts.tests.test_depot_registry_canary_workflow scripts.tests.test_summarize_depot_registry_pulls`
- `actionlint .github/workflows/depot-registry-canary.yml`
- `git diff --check`

Pull-through caching remains disabled in normal builds until each mapping passes the canary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a manually triggered registry performance canary for main-branch builds.
  - Compares upstream and mirrored image pulls using pinned images, fresh runners, digest verification, and secure short-lived access.
  - Produces retained timing results and optional threshold enforcement.

- **Documentation**
  - Documented registry performance criteria, rollout safeguards, operational risks, and CI workflow coverage.
  - Adoption requires matching image digests, five samples, and at least 20% plus 10 seconds of median pull-time improvement.

- **Tests**
  - Added coverage for workflow security, triggering rules, sampling, digest validation, and performance-report calculations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->