### PR TITLE
Use GitHub OIDC for registry canary

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -272,7 +272,7 @@ the two dedicated GPU scale sets and is not the Depot group.
 The manual `depot-registry-canary.yml` is the pull-through adoption boundary.
 It accepts only a digest-pinned public reference and a safe relative Depot
 repository name on an exact `main` dispatch. Five upstream jobs and five Depot
-jobs each receive a fresh ephemeral Depot runner. The summary rejects digest
+jobs each receive a fresh ephemeral GitHub-hosted runner. The summary rejects digest
 drift and requires at least 20% and 10 seconds of median pull improvement.
 `DEPOT_REGISTRY_HOST` supplies the nonsecret organization registry host;
 the cached pull step uses GitHub OIDC to mint a short-lived read-only

--- a/.github/workflows/depot-registry-canary.yml
+++ b/.github/workflows/depot-registry-canary.yml
@@ -80,7 +80,9 @@ jobs:
       matrix:
         source: [upstream, depot]
         sample: [1, 2, 3, 4, 5]
-    runs-on: depot-ubuntu-24.04
+    # Use GitHub's OIDC issuer for the Depot project trust relationship while
+    # retaining a fresh hosted VM for every timing sample.
+    runs-on: ubuntu-24.04
     timeout-minutes: 15
     steps:
       - name: Set up Depot CLI

--- a/ci/METRICS.md
+++ b/ci/METRICS.md
@@ -197,8 +197,10 @@ cold-pull, and publication-time thresholds in
 Use the manual `depot-registry-canary.yml` workflow for registry comparisons.
 The upstream input must be digest-pinned, and the Depot repository must mirror
 that exact upstream repository. Each source receives five fresh ephemeral
-Depot runners so local layer reuse cannot turn a warm local pull into a false
-registry result. Downloaded observation artifacts can be reevaluated with:
+GitHub-hosted runners so local layer reuse cannot turn a warm local pull into a
+false registry result while Depot authenticates through the project's GitHub
+Actions OIDC trust relationship. Downloaded observation artifacts can be
+reevaluated with:
 
 ```bash
 python3 scripts/summarize-depot-registry-pulls.py \

--- a/scripts/tests/test_depot_registry_canary_workflow.py
+++ b/scripts/tests/test_depot_registry_canary_workflow.py
@@ -28,7 +28,7 @@ class DepotRegistryCanaryWorkflowTests(unittest.TestCase):
     def test_canary_uses_fresh_runner_samples_and_exact_digest(self) -> None:
         self.assertIn("source: [upstream, depot]", self.workflow)
         self.assertIn("sample: [1, 2, 3, 4, 5]", self.workflow)
-        self.assertIn("runs-on: depot-ubuntu-24.04", self.workflow)
+        self.assertIn("runs-on: ubuntu-24.04", self.workflow)
         self.assertIn("upstream_image must be pinned by sha256 digest", self.workflow)
         self.assertIn("digest mismatch", self.workflow)
 


### PR DESCRIPTION
## Summary
- run pull-through timing samples on fresh GitHub-hosted VMs
- use the Depot project's configured GitHub Actions OIDC trust relationship
- retain identical five-vs-five timing and digest validation

## Evidence
The initial main run failed all Depot-side jobs at `depot pull-token` with `permission_denied: Invalid token` while executing on Depot CI runners.

## Validation
- `python3 -m unittest scripts.tests.test_depot_registry_canary_workflow scripts.tests.test_summarize_depot_registry_pulls`
- `actionlint .github/workflows/depot-registry-canary.yml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated registry canary validation to run on fresh GitHub-hosted runners.
  - Improved consistency between upstream and Depot comparison jobs.
  - Preserved secure authentication through GitHub Actions identity trust.

- **Documentation**
  - Updated CI metrics guidance to reflect the new runner setup and comparison process.
  - Clarified that registry measurements use multiple fresh runners for more reliable results.

- **Tests**
  - Updated workflow checks to verify the standard GitHub-hosted runner configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->