### PR TITLE
Use native Depot registry auth for canary

### DIFF
--- a/.github/workflows/depot-registry-canary.yml
+++ b/.github/workflows/depot-registry-canary.yml
@@ -20,9 +20,6 @@ on:
 permissions:
   contents: read
 
-env:
-  DEPOT_PROJECT_ID: mzm95zcv7p
-
 concurrency:
   group: depot-registry-canary
   cancel-in-progress: false
@@ -74,33 +71,16 @@ jobs:
     needs: policy
     permissions:
       contents: read
-      id-token: write
     strategy:
       fail-fast: false
       matrix:
         source: [upstream, depot]
         sample: [1, 2, 3, 4, 5]
-    # Use GitHub's OIDC issuer for the Depot project trust relationship while
-    # retaining a fresh hosted VM for every timing sample.
-    runs-on: ubuntu-24.04
+    # Depot provisions a fresh runner for every sample and pre-authenticates it
+    # to the organization Registry with a short-lived job credential.
+    runs-on: depot-ubuntu-24.04
     timeout-minutes: 15
     steps:
-      - name: Set up Depot CLI
-        if: ${{ matrix.source == 'depot' }}
-        uses: depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461 # v1
-        with:
-          version: 2.101.77
-      - name: Authenticate to Depot Registry
-        if: ${{ matrix.source == 'depot' }}
-        shell: bash
-        env:
-          DEPOT_REGISTRY_HOST: ${{ vars.DEPOT_REGISTRY_HOST }}
-        run: |
-          set -euo pipefail
-
-          depot pull-token --project "$DEPOT_PROJECT_ID" |
-            docker login "$DEPOT_REGISTRY_HOST" --username x-token --password-stdin
-
       - name: Pull exact image on a fresh runner
         shell: bash
         env:
@@ -111,6 +91,11 @@ jobs:
           UPSTREAM_IMAGE: ${{ inputs.upstream_image }}
         run: |
           set -euo pipefail
+
+          if [[ "${DEPOT_ORG_ID:-}" != "1ntz5vlngn" ]]; then
+            echo "registry canaries require a pre-authenticated Mesh-LLM Depot runner" >&2
+            exit 1
+          fi
 
           image="$UPSTREAM_IMAGE"
           if [[ "$SOURCE" == "depot" ]]; then

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -444,13 +444,15 @@ token to PR code.
 The checked-in `depot-registry-canary.yml` implements that measurement gate for
 any digest-pinned public base or runner image. Configure each upstream
 repository as a distinct Depot pull-through repository, set the nonsecret
-`DEPOT_REGISTRY_HOST` repository variable, and permit the job's GitHub OIDC
-identity to mint a short-lived read-only `depot pull-token`. No stored registry
-secret is required. Run the workflow from `main` with the exact upstream digest
-and relative Depot repository name. It allocates five fresh ephemeral runners
-per source, verifies digest identity, retains raw timing observations for 14
-days, and reports whether both thresholds pass. Do not enable a mirror in
-normal builds until its own retained cohort passes.
+`DEPOT_REGISTRY_HOST` repository variable, and enable Depot's native Actions-job
+Registry access for the organization. Depot pre-authenticates each trusted
+ephemeral runner with a short-lived job credential, so no stored registry secret
+or workflow-minted pull token is required. Run the workflow from `main` with the
+exact upstream digest and relative Depot repository name. It allocates five
+fresh ephemeral runners per source, verifies the injected Depot organization
+identity and digest identity, retains raw timing observations for 14 days, and
+reports whether both thresholds pass. Do not enable a mirror in normal builds
+until its own retained cohort passes.
 
 ### `Mesh-LLM/mesh-packaging`
 

--- a/ci/METRICS.md
+++ b/ci/METRICS.md
@@ -197,10 +197,10 @@ cold-pull, and publication-time thresholds in
 Use the manual `depot-registry-canary.yml` workflow for registry comparisons.
 The upstream input must be digest-pinned, and the Depot repository must mirror
 that exact upstream repository. Each source receives five fresh ephemeral
-GitHub-hosted runners so local layer reuse cannot turn a warm local pull into a
-false registry result while Depot authenticates through the project's GitHub
-Actions OIDC trust relationship. Downloaded observation artifacts can be
-reevaluated with:
+Depot-managed runners so local layer reuse cannot turn a warm local pull into a
+false registry result. Depot pre-authenticates each ephemeral runner with a
+short-lived organization Registry job credential. Downloaded observations can
+be reevaluated with:
 
 ```bash
 python3 scripts/summarize-depot-registry-pulls.py \

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -616,8 +616,8 @@ public reference with a configured Depot mirror using five fresh ephemeral
 runner samples per source. The workflow verifies that every pull resolves to
 the same manifest digest and requires both 20% and 10 seconds of median pull
 improvement before a mirror is eligible for broader use. Its read-only pull
-token is minted through GitHub OIDC only in the cached pull step; no stored
-registry secret is used, and the OIDC permission is never available to PR code.
+access comes from Depot's short-lived job credential on each trusted ephemeral
+runner; no stored registry secret or workflow-minted pull token is used.
 This measures registry transfer only; it does not measure package-manager,
 Cargo, npm/pnpm, native compilation, or Docker export work.
 

--- a/scripts/tests/test_depot_registry_canary_workflow.py
+++ b/scripts/tests/test_depot_registry_canary_workflow.py
@@ -16,11 +16,17 @@ class DepotRegistryCanaryWorkflowTests(unittest.TestCase):
         self.assertNotIn("push:", self.workflow)
         self.assertIn('"refs/heads/main"', self.workflow)
 
-    def test_pull_token_is_short_lived_and_oidc_scoped(self) -> None:
-        self.assertIn("id-token: write", self.workflow)
-        self.assertIn("depot/setup-action@15c09a5f77a0840ad4bce955686522a257853461", self.workflow)
-        self.assertIn('depot pull-token --project "$DEPOT_PROJECT_ID"', self.workflow)
-        self.assertIn("docker login", self.workflow)
+    def test_registry_auth_is_native_and_job_scoped(self) -> None:
+        self.assertIn("runs-on: depot-ubuntu-24.04", self.workflow)
+        self.assertIn('"${DEPOT_ORG_ID:-}" != "1ntz5vlngn"', self.workflow)
+        self.assertIn(
+            "registry canaries require a pre-authenticated Mesh-LLM Depot runner",
+            self.workflow,
+        )
+        self.assertNotIn("id-token: write", self.workflow)
+        self.assertNotIn("depot pull-token", self.workflow)
+        self.assertNotIn("docker login", self.workflow)
+        self.assertNotIn("DEPOT_PROJECT_ID", self.workflow)
         self.assertNotIn("secrets.", self.workflow)
         self.assertNotIn("DEPOT_REGISTRY_PULL_TOKEN", self.workflow)
         self.assertNotIn("printenv", self.workflow)
@@ -28,7 +34,7 @@ class DepotRegistryCanaryWorkflowTests(unittest.TestCase):
     def test_canary_uses_fresh_runner_samples_and_exact_digest(self) -> None:
         self.assertIn("source: [upstream, depot]", self.workflow)
         self.assertIn("sample: [1, 2, 3, 4, 5]", self.workflow)
-        self.assertIn("runs-on: ubuntu-24.04", self.workflow)
+        self.assertEqual(self.workflow.count("runs-on: depot-ubuntu-24.04"), 1)
         self.assertIn("upstream_image must be pinned by sha256 digest", self.workflow)
         self.assertIn("digest mismatch", self.workflow)
 


### PR DESCRIPTION
## Summary
- run registry timing samples on fresh Depot runners
- use Depot's native short-lived Actions job registry credential
- verify the injected Mesh-LLM organization identity and remove OIDC/pull-token authentication
- update registry canary guidance and focused tests

## Validation
- python3 -m unittest scripts.tests.test_depot_registry_canary_workflow scripts.tests.test_summarize_depot_registry_pulls
- actionlint .github/workflows/depot-registry-canary.yml
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI Improvements**
  * Registry canary jobs now use pre-authenticated Depot-managed runners with short-lived job credentials.
  * Added organization identity verification before pulling images.
  * Removed manual registry login, token generation, and stored secret requirements.

* **Documentation**
  * Updated registry migration, metrics, and CI guidance to reflect the new authentication workflow.

* **Tests**
  * Updated validation to confirm native runner authentication and prevent token-based login handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->