### PR TITLE
fix: keep Windows per-GPU VRAM aligned with adapter order

### DIFF
--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -235,6 +235,17 @@ fn read_windows_total_ram_bytes() -> Option<u64> {
     parse_windows_total_physical_memory(&output)
 }
 
+/// Per-GPU VRAM in adapter order.
+///
+/// Adapters that report no VRAM (virtual and headless displays commonly report
+/// none) keep a zero entry so this stays index-aligned with the adapter name
+/// list that `hydrate_gpu_facts_with_identities` indexes into. Dropping those
+/// entries shifts every later adapter's VRAM onto the wrong device.
+#[cfg(any(target_os = "windows", test))]
+fn windows_per_gpu_vram(controllers: &[(String, u64)]) -> Vec<u64> {
+    controllers.iter().map(|(_, ram)| *ram).collect()
+}
+
 #[cfg(target_os = "windows")]
 fn read_windows_video_controllers() -> Vec<(String, u64)> {
     let Some(output) = powershell_output(
@@ -677,11 +688,7 @@ impl Collector for DefaultCollector {
                         survey.vram_bytes = total + (ram_offload as f64 * 0.90) as u64;
                     }
                 } else {
-                    let per_gpu: Vec<u64> = windows_gpus
-                        .iter()
-                        .map(|(_, ram)| *ram)
-                        .filter(|ram| *ram > 0)
-                        .collect();
+                    let per_gpu: Vec<u64> = windows_per_gpu_vram(&windows_gpus);
                     let total: u64 = per_gpu.iter().sum();
                     if total > 0 {
                         survey.gpu_vram = per_gpu;

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -690,8 +690,8 @@ impl Collector for DefaultCollector {
                 } else {
                     let per_gpu: Vec<u64> = windows_per_gpu_vram(&windows_gpus);
                     let total: u64 = per_gpu.iter().sum();
+                    survey.gpu_vram = per_gpu;
                     if total > 0 {
-                        survey.gpu_vram = per_gpu;
                         let ram_offload = system_ram.saturating_sub(total);
                         survey.vram_bytes = total + (ram_offload as f64 * 0.90) as u64;
                     } else if system_ram > 0 {

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -834,6 +834,42 @@ fn test_parse_windows_video_controller_json_single_object() {
 }
 
 #[test]
+fn test_windows_per_gpu_vram_keeps_zero_vram_adapters_aligned() {
+    let controllers = vec![
+        ("Virtual Display Adapter".to_string(), 0),
+        ("AMD Radeon RX 9070 XT".to_string(), 4_293_918_720),
+    ];
+
+    assert_eq!(
+        windows_per_gpu_vram(&controllers),
+        vec![0, 4_293_918_720],
+        "adapters reporting no VRAM must keep a slot so later adapters stay aligned"
+    );
+}
+
+#[test]
+fn test_windows_zero_vram_adapter_does_not_shift_vram_onto_wrong_gpu() {
+    let controllers = vec![
+        ("Virtual Display Adapter".to_string(), 0),
+        ("AMD Radeon RX 9070 XT".to_string(), 4_293_918_720),
+    ];
+    let names: Vec<String> = controllers.iter().map(|(name, _)| name.clone()).collect();
+    let mut survey = HardwareSurvey {
+        gpu_count: 2,
+        gpu_vram: windows_per_gpu_vram(&controllers),
+        ..Default::default()
+    };
+
+    hydrate_gpu_facts_with_identities(&mut survey, &[Metric::GpuFacts], &[], names, 2, false);
+
+    assert_eq!(survey.gpus.len(), 2);
+    assert_eq!(survey.gpus[0].display_name, "Virtual Display Adapter");
+    assert_eq!(survey.gpus[0].vram_bytes, 0);
+    assert_eq!(survey.gpus[1].display_name, "AMD Radeon RX 9070 XT");
+    assert_eq!(survey.gpus[1].vram_bytes, 4_293_918_720);
+}
+
+#[test]
 fn test_parse_windows_total_physical_memory() {
     assert_eq!(
         parse_windows_total_physical_memory("68719476736\r\n"),

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -848,6 +848,16 @@ fn test_windows_per_gpu_vram_keeps_zero_vram_adapters_aligned() {
 }
 
 #[test]
+fn test_windows_per_gpu_vram_keeps_all_zero_adapters_aligned() {
+    let controllers = vec![
+        ("Virtual Display Adapter".to_string(), 0),
+        ("Headless Display Adapter".to_string(), 0),
+    ];
+
+    assert_eq!(windows_per_gpu_vram(&controllers), vec![0, 0]);
+}
+
+#[test]
 fn test_windows_zero_vram_adapter_does_not_shift_vram_onto_wrong_gpu() {
     let controllers = vec![
         ("Virtual Display Adapter".to_string(), 0),


### PR DESCRIPTION
Fixes #1163.

## Problem

In the Windows hardware fallback, the per-GPU VRAM vector is built with

```rust
.filter(|ram| *ram > 0)
```

which compacts the vector, while `gpu_name` and `gpu_count` are built from the
unfiltered adapter list. `hydrate_gpu_facts_with_identities` then reads
`survey.gpu_vram.get(index)` using the name index, so the two no longer line up
and VRAM lands on the wrong device.

Virtual and headless display adapters commonly report no VRAM. On a machine
where one is enumerated first, `mesh-llm gpus` credits the virtual adapter with
the real GPU's VRAM and reports the real GPU as unknown:

```
GPU 0
  Name: Meta Virtual Monitor
  VRAM: 4 GB

GPU 1
  Name: AMD Radeon RX 9070 XT
  VRAM: unknown
```

VRAM feeds capacity planning and mesh advertisement, so this is not only a
display problem.

## Change

Extract the per-GPU VRAM construction into `windows_per_gpu_vram()` and keep a
zero entry for adapters that report no VRAM, so the vector stays index-aligned
with the adapter list.

Totals are unaffected, since zero entries do not change the sum. The existing
`total > 0` guard still selects the system-RAM fallback when no adapter reports
any VRAM.

## Tests

Two tests added in `crates/mesh-llm-system/src/hardware/tests.rs`:

- `test_windows_per_gpu_vram_keeps_zero_vram_adapters_aligned` covers the
  vector shape directly.
- `test_windows_zero_vram_adapter_does_not_shift_vram_onto_wrong_gpu` runs the
  result through `hydrate_gpu_facts_with_identities` and asserts each adapter
  keeps its own VRAM.

Both fail on the previous behavior. The second one reproduces the reported
symptom exactly, asserting `4293918720` where `0` is expected on GPU 0.

Verified with `cargo test -p mesh-llm-system --features dynamic-native-runtime
--lib hardware::` on Windows: 72 passed, 0 failed. The
`dynamic-native-runtime` feature was needed only to build the crate locally,
since `skippy-ffi` otherwise requires prepared llama.cpp static archives that
`build.rs` cannot produce on Windows. It does not affect the code changed here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows GPU detection to preserve adapters with zero reported VRAM.
  * Ensured GPU names and VRAM values remain correctly matched across all detected adapters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->