### PR TITLE
Record Depot timing dimensions

### DIFF
--- a/ci/METRICS.md
+++ b/ci/METRICS.md
@@ -112,8 +112,9 @@ Migration success targets:
 | Rust compilation cache | at least 80% hit rate on comparable warm runs |
 | Artifact consumers | zero host, runtime, or ABI rebuilds |
 
-`collect-ci-metrics.py` measures timing and runner queue only; it does not
-measure sccache. Compile jobs retain machine-readable
+`collect-ci-metrics.py` measures workflow, job, and (when returned by the jobs
+API) step timing, runner queue, and runner dimensions derived from labels. It
+does not measure sccache. Compile jobs retain machine-readable
 `sccache --show-stats --stats-format json` evidence separately. Zero the
 counters immediately before the measured compilation and define aggregate hit
 rate as:
@@ -233,6 +234,45 @@ cohorts because they produced no pull observations.
 | Phase | Change class | Provider / runner | Samples | p50 | p90 | p95 | Notes |
 | --- | --- | --- | ---: | ---: | ---: | ---: | --- |
 | Product-v2 PR graph | full CI refactor | hosted mix | 1 | 1h 7m 34s | 1h 7m 34s | 1h 7m 34s | Green; queue-contaminated; composition 10s–70s |
-| Depot canary cold | trusted main canary | Depot | pending | — | — | — | Restricted workflow allowlist |
-| Depot canary warm | trusted main canary | Depot | pending | — | — | — | Same SHA, runner size, and image |
+| Depot canary cold | trusted main canary | Depot | 1 | 37s | 37s | 37s | Six resource/cache probes; not a full build |
+| Depot canary warm | trusted main canary | Depot | 1 | 37s | 37s | 37s | Six resource/cache probes; not a full build |
 | Main after rollout | full main | mixed | pending | — | — | — | Five comparable green runs minimum |
+
+## Post-Depot observations and tuning decision
+
+The following read-only observations are from the MeshLLM repository. The two
+canary runs compile one tiny C file and validate runner/cache plumbing; their
+wall times are not native-build or packaging measurements.
+
+| Run | Workload | Measured wall time | Measured Depot job evidence |
+| --- | --- | ---: | --- |
+| [30525111329](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30525111329) | Cold canary | 37s; jobs 30–34s | Six labels: default, 4, 8, 16, ARM default, ARM-8 |
+| [30525247727](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30525247727) | Warm canary | 37s; jobs 29–33s | Same six labels; probe-only cache hit signal |
+| [30590595090](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30590595090) | Same-SHA warm non-GPU release | 53m 11s; 9 Depot jobs | CPU/native SDK/static ABI producers on x86/ARM-8 took 1m 37s–4m 20s; composers on x86/ARM-4 took 1m 17s–1m 31s |
+| [30586470043](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30586470043) | Same-SHA prerelease backend slice | 1h 41m 51s; 15 Depot jobs | x86 CPU `-8`: 2m 23s; x86 Vulkan `-16`: 3m 46s; x86 ROCm `-16`: 13m 25s; native SDK x86/ARM-8: 11m 16s/12m 38s |
+
+The two full-build runs share SHA `851888d0`, but they are not a controlled
+cold/warm pair: the release run restored exact static-ABI cache entries and
+reported native-SDK sccache hit rates of 95.5% (x86) and 95.0% (ARM), while the
+prerelease run has different workflow inputs and cache state. The warm release
+also shows architecture variance within the same role: native runtime x86/ARM
+was 1m 37s/2m 02s, native SDK was 4m 09s/4m 20s, static ABI was 1m 57s/1m 47s,
+and composition was 1m 31s/1m 17s. These are observations, not runner-size
+experiments.
+
+No same-backend `-4`/`-8`/`-16` A/B exists in the retained evidence. The `-16`
+ROCm and Vulkan rows therefore do not justify moving CPU or SDK rows to a
+larger runner; their elapsed-time benefit and additional runner cost were not
+measured. Keep the checked-in role split: `-8` for CPU/native-SDK/static-ABI
+producers, `-4` for composition, and `-16` only for the existing high-parallel
+ROCm/Vulkan runtime rows. No matrix-concurrency change is justified without a
+queue/capacity series or a controlled completion-time comparison.
+
+This repository has no Bake-group, Depot-project/billing, CPU-utilization, or
+BuildKit context-upload/cache-import/export telemetry. The runner-image
+repository owns the image BuildKit lifecycle; MeshLLM owns the workflow graph,
+runner selectors, and cache-key contracts. Consequently this change does not
+alter runner size, matrix concurrency, bake groups, cache project boundaries,
+or cache identities. Step timestamps and label-derived runner dimensions are
+now retained by `collect-ci-metrics.py` so a future comparable cohort can
+measure build phases without inferring unavailable cache or upload timings.

--- a/scripts/collect-ci-metrics.py
+++ b/scripts/collect-ci-metrics.py
@@ -97,8 +97,29 @@ def summarize(values: list[float | None]) -> dict[str, float | int | None]:
     }
 
 
+def normalize_step(raw: dict[str, Any]) -> dict[str, Any]:
+    started = timestamp(pick(raw, "started_at", "startedAt"))
+    completed = timestamp(pick(raw, "completed_at", "completedAt"))
+    return {
+        "name": str(pick(raw, "name", default="unknown step")),
+        "number": pick(raw, "number"),
+        "conclusion": str(pick(raw, "conclusion", default="")),
+        "started": started,
+        "completed": completed,
+        "duration_seconds": elapsed(started, completed),
+    }
+
+
 def normalize_job(raw: dict[str, Any]) -> dict[str, Any]:
     labels = pick(raw, "labels", "runner_labels", default=[])
+    raw_steps = pick(raw, "steps", default=[])
+    steps = []
+    if isinstance(raw_steps, list):
+        steps = [
+            normalize_step(step)
+            for step in raw_steps
+            if isinstance(step, dict)
+        ]
     return {
         "id": pick(raw, "id", "databaseId", "database_id"),
         "name": str(pick(raw, "name", default="unknown job")),
@@ -110,6 +131,7 @@ def normalize_job(raw: dict[str, Any]) -> dict[str, Any]:
         "labels": [str(label) for label in labels]
         if isinstance(labels, list)
         else [],
+        "steps": steps,
     }
 
 
@@ -258,6 +280,61 @@ def fetch_runs(args: argparse.Namespace) -> list[dict[str, Any]]:
     return runs
 
 
+def runner_dimensions(labels: list[str]) -> dict[str, str | None]:
+    """Derive only dimensions encoded by the selected runner label.
+
+    Depot labels encode architecture and vCPU size. Hosted and legacy labels
+    identify a provider/architecture in the checked-in runner contract, but do
+    not expose a comparable Depot size, so their runner_size remains null.
+    """
+
+    normalized = {label.lower() for label in labels}
+    depot_label = next(
+        (label for label in sorted(normalized) if label.startswith("depot-")),
+        None,
+    )
+    if depot_label:
+        suffix = depot_label.rsplit("-", 1)[-1]
+        return {
+            "provider": "depot",
+            "architecture": "arm64" if "-arm" in depot_label else "amd64",
+            "runner_size": suffix if suffix in {"4", "8", "16"} else "default",
+        }
+
+    if "mesh-llm-arm64" in normalized or "ubuntu-24.04-arm" in normalized:
+        architecture = "arm64"
+    elif "macos-15" in normalized:
+        architecture = "arm64"
+    elif (
+        "macos-15-intel" in normalized
+        or "windows-2022" in normalized
+        or "ubuntu-24.04" in normalized
+        or "x64" in normalized
+        or "amd64" in normalized
+    ):
+        architecture = "amd64"
+    else:
+        architecture = None
+
+    if "self-hosted" in normalized or any(
+        label.startswith("mesh-llm-") for label in normalized
+    ):
+        provider = "self-hosted"
+    elif architecture is not None or any(
+        label.startswith(("ubuntu-", "macos-", "windows-"))
+        for label in normalized
+    ):
+        provider = "github-hosted"
+    else:
+        provider = "unknown"
+
+    return {
+        "provider": provider,
+        "architecture": architecture,
+        "runner_size": None,
+    }
+
+
 def observation(run: dict[str, Any], job: dict[str, Any]) -> dict[str, Any]:
     return {
         "run_id": run["id"],
@@ -275,6 +352,7 @@ def observation(run: dict[str, Any], job: dict[str, Any]) -> dict[str, Any]:
             else None
         ),
         "runner_labels": job["labels"],
+        "runner_dimensions": runner_dimensions(job["labels"]),
     }
 
 
@@ -307,6 +385,10 @@ def analyze(
     observations: list[dict[str, Any]] = []
     run_reports = []
     terminal_counts = collections.Counter()
+    runner_groups: dict[
+        tuple[str | None, str | None, str | None], list[dict[str, Any]]
+    ] = collections.defaultdict(list)
+    step_observations: list[dict[str, Any]] = []
     wall_times = []
     queue_times = []
     workflow_timing_excluded_reruns = 0
@@ -314,6 +396,27 @@ def analyze(
         jobs = [job for job in run["jobs"] if job["conclusion"] != SKIPPED]
         samples = [observation(run, job) for job in jobs]
         observations.extend(samples)
+        for sample, job in zip(samples, jobs):
+            dimensions = sample["runner_dimensions"]
+            runner_groups[
+                (
+                    dimensions["provider"],
+                    dimensions["architecture"],
+                    dimensions["runner_size"],
+                )
+            ].append(sample)
+            for step in job["steps"]:
+                step_observations.append(
+                    {
+                        "run_id": run["id"],
+                        "job_id": job["id"],
+                        "job_name": job["name"],
+                        "step_name": step["name"],
+                        "conclusion": step["conclusion"],
+                        "duration_seconds": step["duration_seconds"],
+                        "runner_dimensions": dimensions,
+                    }
+                )
         completed = [job for job in jobs if job["completed"] is not None]
         terminal = (
             max(completed, key=lambda job: job["completed"]) if completed else None
@@ -410,8 +513,59 @@ def analyze(
         }
         for name, count in terminal_counts.most_common(top)
     ]
+    by_runner = []
+    for (provider, architecture, runner_size), samples in runner_groups.items():
+        by_runner.append(
+            {
+                "provider": provider,
+                "architecture": architecture,
+                "runner_size": runner_size,
+                "sample_count": len(samples),
+                "job_names": sorted({sample["name"] for sample in samples}),
+                "duration_seconds": summarize(
+                    [sample["duration_seconds"] for sample in samples]
+                ),
+                "queue_seconds": summarize(
+                    [sample["queue_seconds"] for sample in samples]
+                ),
+            }
+        )
+    by_runner.sort(
+        key=lambda item: (
+            item["duration_seconds"]["p95"] or -1,
+            item["duration_seconds"]["mean"] or -1,
+        ),
+        reverse=True,
+    )
+
+    step_groups: dict[
+        tuple[str, str], list[dict[str, Any]]
+    ] = collections.defaultdict(list)
+    for sample in step_observations:
+        step_groups[(sample["job_name"], sample["step_name"])].append(sample)
+    by_step = [
+        {
+            "job_name": job_name,
+            "step_name": step_name,
+            "sample_count": len(samples),
+            "duration_seconds": summarize(
+                [sample["duration_seconds"] for sample in samples]
+            ),
+            "conclusions": dict(
+                sorted(collections.Counter(s["conclusion"] for s in samples).items())
+            ),
+        }
+        for (job_name, step_name), samples in step_groups.items()
+    ]
+    by_step.sort(
+        key=lambda item: (
+            item["duration_seconds"]["p95"] or -1,
+            item["duration_seconds"]["mean"] or -1,
+        ),
+        reverse=True,
+    )
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "generated_at": dt.datetime.now(dt.timezone.utc)
         .isoformat()
         .replace("+00:00", "Z"),
@@ -435,6 +589,10 @@ def analyze(
             "terminal_job": (
                 "last non-skipped job to finish; a critical-path candidate"
             ),
+            "runner_dimensions": (
+                "provider, architecture, and Depot runner size derived from labels"
+            ),
+            "step_duration_seconds": "step started_at to completed_at",
         },
         "selection": {
             "requested_status": requested_status,
@@ -459,8 +617,13 @@ def analyze(
                 [sample["start_delay_seconds"] for sample in observations]
             ),
             "by_name": by_name,
+            "by_runner": by_runner,
             "critical_finish_candidates": critical,
             "slowest_observations": slowest,
+        },
+        "steps": {
+            "sample_count": len(step_observations),
+            "by_name": by_step,
         },
         "runs": run_reports,
     }
@@ -515,6 +678,45 @@ def render_markdown(report: dict[str, Any], top: int) -> str:
             f"| {label} | {stats['count']} | {human(stats['p50'])} | "
             f"{human(stats['p90'])} | {human(stats['p95'])} | "
             f"{human(stats['max'])} |"
+        )
+    lines += [
+        "",
+        "## Runner dimensions",
+        "",
+        "| Provider | Architecture | Depot size | Jobs | Duration p50 | Duration p95 | Queue p95 |",
+        "| --- | --- | --- | ---: | ---: | ---: | ---: |",
+    ]
+    for item in jobs["by_runner"][:top]:
+        lines.append(
+            f"| {markdown_escape(item['provider'])} | "
+            f"{markdown_escape(item['architecture'] or 'n/a')} | "
+            f"{markdown_escape(item['runner_size'] or 'n/a')} | "
+            f"{item['sample_count']} | "
+            f"{human(item['duration_seconds']['p50'])} | "
+            f"{human(item['duration_seconds']['p95'])} | "
+            f"{human(item['queue_seconds']['p95'])} |"
+        )
+    lines += [
+        "",
+        "## Step timing",
+        "",
+    ]
+    if report["steps"]["by_name"]:
+        lines += [
+            "| Job | Step | Samples | Duration p50 | Duration p95 |",
+            "| --- | --- | ---: | ---: | ---: |",
+        ]
+        for item in report["steps"]["by_name"][:top]:
+            lines.append(
+                f"| {markdown_escape(item['job_name'])} | "
+                f"{markdown_escape(item['step_name'])} | {item['sample_count']} | "
+                f"{human(item['duration_seconds']['p50'])} | "
+                f"{human(item['duration_seconds']['p95'])} |"
+            )
+    else:
+        lines.append(
+            "No job step timestamps were available; cache, context-upload, and "
+            "export/import phases are not inferred from logs."
         )
     lines += [
         "",
@@ -591,7 +793,7 @@ def labels(values: list[str]) -> dict[str, str]:
 
 def parse_args(argv: list[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Collect read-only GitHub Actions wall, queue, and job metrics."
+        description="Collect read-only GitHub Actions timing and runner metrics."
     )
     parser.add_argument("--repo", default="Mesh-LLM/mesh-llm")
     parser.add_argument("--workflow")

--- a/scripts/collect-ci-metrics.py
+++ b/scripts/collect-ci-metrics.py
@@ -396,7 +396,7 @@ def analyze(
         jobs = [job for job in run["jobs"] if job["conclusion"] != SKIPPED]
         samples = [observation(run, job) for job in jobs]
         observations.extend(samples)
-        for sample, job in zip(samples, jobs):
+        for sample, job in zip(samples, jobs, strict=True):
             dimensions = sample["runner_dimensions"]
             runner_groups[
                 (
@@ -539,14 +539,33 @@ def analyze(
     )
 
     step_groups: dict[
-        tuple[str, str], list[dict[str, Any]]
+        tuple[
+            str,
+            str,
+            str | None,
+            str | None,
+            str | None,
+        ],
+        list[dict[str, Any]],
     ] = collections.defaultdict(list)
     for sample in step_observations:
-        step_groups[(sample["job_name"], sample["step_name"])].append(sample)
+        dimensions = sample["runner_dimensions"]
+        step_groups[
+            (
+                sample["job_name"],
+                sample["step_name"],
+                dimensions["provider"],
+                dimensions["architecture"],
+                dimensions["runner_size"],
+            )
+        ].append(sample)
     by_step = [
         {
             "job_name": job_name,
             "step_name": step_name,
+            "provider": provider,
+            "architecture": architecture,
+            "runner_size": runner_size,
             "sample_count": len(samples),
             "duration_seconds": summarize(
                 [sample["duration_seconds"] for sample in samples]
@@ -555,7 +574,13 @@ def analyze(
                 sorted(collections.Counter(s["conclusion"] for s in samples).items())
             ),
         }
-        for (job_name, step_name), samples in step_groups.items()
+        for (
+            job_name,
+            step_name,
+            provider,
+            architecture,
+            runner_size,
+        ), samples in step_groups.items()
     ]
     by_step.sort(
         key=lambda item: (
@@ -703,12 +728,15 @@ def render_markdown(report: dict[str, Any], top: int) -> str:
     ]
     if report["steps"]["by_name"]:
         lines += [
-            "| Job | Step | Samples | Duration p50 | Duration p95 |",
-            "| --- | --- | ---: | ---: | ---: |",
+            "| Provider | Architecture | Runner size | Job | Step | Samples | Duration p50 | Duration p95 |",
+            "| --- | --- | --- | --- | --- | ---: | ---: | ---: |",
         ]
         for item in report["steps"]["by_name"][:top]:
             lines.append(
-                f"| {markdown_escape(item['job_name'])} | "
+                f"| {markdown_escape(item['provider'] or 'n/a')} | "
+                f"{markdown_escape(item['architecture'] or 'n/a')} | "
+                f"{markdown_escape(item['runner_size'] or 'n/a')} | "
+                f"{markdown_escape(item['job_name'])} | "
                 f"{markdown_escape(item['step_name'])} | {item['sample_count']} | "
                 f"{human(item['duration_seconds']['p50'])} | "
                 f"{human(item['duration_seconds']['p95'])} |"

--- a/scripts/tests/test_collect_ci_metrics.py
+++ b/scripts/tests/test_collect_ci_metrics.py
@@ -324,7 +324,30 @@ class CollectCiMetricsTests(unittest.TestCase):
                             "completed_at": "2026-07-03T00:01:44Z",
                         },
                     ],
-                )
+                ),
+                job(
+                    "Linux CPU runtime",
+                    "2026-07-03T00:00:05Z",
+                    "2026-07-03T00:00:06Z",
+                    "2026-07-03T00:02:30Z",
+                    labels=["depot-ubuntu-24.04-arm-8"],
+                    steps=[
+                        {
+                            "name": "Restore native cache",
+                            "number": 1,
+                            "conclusion": "success",
+                            "started_at": "2026-07-03T00:00:07Z",
+                            "completed_at": "2026-07-03T00:00:27Z",
+                        },
+                        {
+                            "name": "Build runtime",
+                            "number": 2,
+                            "conclusion": "success",
+                            "started_at": "2026-07-03T00:00:27Z",
+                            "completed_at": "2026-07-03T00:02:27Z",
+                        },
+                    ],
+                ),
             ],
         )
         report = self.collector.analyze(
@@ -335,20 +358,39 @@ class CollectCiMetricsTests(unittest.TestCase):
             labels={},
         )
 
-        self.assertEqual(
-            report["jobs"]["by_runner"][0]["provider"],
-            "depot",
-        )
-        self.assertEqual(
-            report["jobs"]["by_runner"][0]["runner_size"],
-            "8",
-        )
-        self.assertEqual(report["jobs"]["by_runner"][0]["architecture"], "amd64")
-        steps = {
-            item["step_name"]: item for item in report["steps"]["by_name"]
+        depot_runners = {
+            item["architecture"]: item
+            for item in report["jobs"]["by_runner"]
+            if item["provider"] == "depot"
         }
-        self.assertEqual(steps["Restore native cache"]["duration_seconds"]["p50"], 10.0)
-        self.assertEqual(steps["Build runtime"]["duration_seconds"]["p50"], 90.0)
+        self.assertEqual(set(depot_runners), {"amd64", "arm64"})
+        self.assertEqual(depot_runners["amd64"]["runner_size"], "8")
+        self.assertEqual(depot_runners["arm64"]["runner_size"], "8")
+        steps = {
+            (
+                item["architecture"],
+                item["runner_size"],
+                item["step_name"],
+            ): item
+            for item in report["steps"]["by_name"]
+        }
+        self.assertEqual(len(steps), 4)
+        self.assertEqual(
+            steps[("amd64", "8", "Restore native cache")]["duration_seconds"]["p50"],
+            10.0,
+        )
+        self.assertEqual(
+            steps[("amd64", "8", "Build runtime")]["duration_seconds"]["p50"],
+            90.0,
+        )
+        self.assertEqual(
+            steps[("arm64", "8", "Restore native cache")]["duration_seconds"]["p50"],
+            20.0,
+        )
+        self.assertEqual(
+            steps[("arm64", "8", "Build runtime")]["duration_seconds"]["p50"],
+            120.0,
+        )
         slowest = report["jobs"]["slowest_observations"][0]
         self.assertEqual(slowest["runner_dimensions"]["runner_size"], "8")
 

--- a/scripts/tests/test_collect_ci_metrics.py
+++ b/scripts/tests/test_collect_ci_metrics.py
@@ -26,6 +26,7 @@ def job(
     *,
     conclusion="success",
     labels=None,
+    steps=None,
 ):
     return {
         "id": hash((name, started_at)) & 0xFFFF,
@@ -37,6 +38,7 @@ def job(
         "completed_at": completed_at,
         "html_url": f"https://example.test/jobs/{name}",
         "labels": labels or ["ubuntu-24.04"],
+        "steps": steps or [],
     }
 
 
@@ -285,11 +287,70 @@ class CollectCiMetricsTests(unittest.TestCase):
 
             report = json.loads(json_path.read_text(encoding="utf-8"))
             markdown = markdown_path.read_text(encoding="utf-8")
-            self.assertEqual(report["schema_version"], 1)
+            self.assertEqual(report["schema_version"], 2)
             self.assertEqual(report["benchmark_labels"], {"provider": "fixture"})
             self.assertIn("# CI timing summary", markdown)
+            self.assertIn("Runner dimensions", markdown)
+            self.assertIn("Step timing", markdown)
             self.assertIn("Slow job families", markdown)
             self.assertIn("20m 0s", markdown)
+
+    def test_analysis_preserves_runner_dimensions_and_step_timing(self):
+        raw = run(
+            104,
+            "2026-07-03T00:00:00Z",
+            "2026-07-03T00:00:01Z",
+            "2026-07-03T00:03:00Z",
+            [
+                job(
+                    "Linux CPU runtime",
+                    "2026-07-03T00:00:02Z",
+                    "2026-07-03T00:00:03Z",
+                    "2026-07-03T00:02:00Z",
+                    labels=["depot-ubuntu-24.04-8"],
+                    steps=[
+                        {
+                            "name": "Restore native cache",
+                            "number": 1,
+                            "conclusion": "success",
+                            "started_at": "2026-07-03T00:00:04Z",
+                            "completed_at": "2026-07-03T00:00:14Z",
+                        },
+                        {
+                            "name": "Build runtime",
+                            "number": 2,
+                            "conclusion": "success",
+                            "started_at": "2026-07-03T00:00:14Z",
+                            "completed_at": "2026-07-03T00:01:44Z",
+                        },
+                    ],
+                )
+            ],
+        )
+        report = self.collector.analyze(
+            [self.collector.normalize_run(raw)],
+            requested_status="success",
+            top=5,
+            source={"description": "step fixture"},
+            labels={},
+        )
+
+        self.assertEqual(
+            report["jobs"]["by_runner"][0]["provider"],
+            "depot",
+        )
+        self.assertEqual(
+            report["jobs"]["by_runner"][0]["runner_size"],
+            "8",
+        )
+        self.assertEqual(report["jobs"]["by_runner"][0]["architecture"], "amd64")
+        steps = {
+            item["step_name"]: item for item in report["steps"]["by_name"]
+        }
+        self.assertEqual(steps["Restore native cache"]["duration_seconds"]["p50"], 10.0)
+        self.assertEqual(steps["Build runtime"]["duration_seconds"]["p50"], 90.0)
+        slowest = report["jobs"]["slowest_observations"][0]
+        self.assertEqual(slowest["runner_dimensions"]["runner_size"], "8")
 
     def test_cli_rejects_run_list_json_without_detailed_jobs(self):
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
## Summary

- Preserve the current runner, matrix, and cache allocations based on the available evidence.
- Record GitHub Actions step timing and label-derived provider, architecture, and Depot runner-size dimensions.
- Document the measured cold/warm and per-role observations without inferring unavailable cost or resource metrics.

## Validation

- `python3 scripts/tests/test_collect_ci_metrics.py`
- `git diff --check`

This PR intentionally adds observability and does not make speculative runner-size or concurrency changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Expanded CI metrics documentation with workflow, job, step, runner, cache, and build observations.
  * Added canary and full-build findings, including timing results and telemetry limitations.

* **Improvements**
  * CI metrics reports now include runner characteristics and per-step timing.
  * Added clearer fallback messaging when step timestamps are unavailable.
  * Updated report output to the latest schema version.
  * Documented cold and warm build measurements from the latest migration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->