### PR TITLE
fix: ignore stale native runtime cache manifests

### DIFF
--- a/crates/mesh-llm-native-runtime/src/cache.rs
+++ b/crates/mesh-llm-native-runtime/src/cache.rs
@@ -122,7 +122,10 @@ impl NativeRuntimeCache {
     /// TODO(issue #1162): Remove this resolver-specific compatibility boundary
     /// once the oldest supported upgrade path no longer contains pre-checksum
     /// runtime caches, if full-cache resolver enumeration is safe again.
-    pub fn installed_for_version(&self, mesh_version: &str) -> Result<Vec<InstalledNativeRuntime>> {
+    pub(crate) fn installed_for_version(
+        &self,
+        mesh_version: &str,
+    ) -> Result<Vec<InstalledNativeRuntime>> {
         installed_in_version_dir(&self.root.join(mesh_version))
     }
 

--- a/crates/mesh-llm-native-runtime/src/cache.rs
+++ b/crates/mesh-llm-native-runtime/src/cache.rs
@@ -108,21 +108,22 @@ impl NativeRuntimeCache {
             if !version_entry.file_type()?.is_dir() {
                 continue;
             }
-            for runtime_entry in fs::read_dir(version_entry.path())? {
-                let runtime_entry = runtime_entry?;
-                if !runtime_entry.file_type()?.is_dir() {
-                    continue;
-                }
-                if let Some(runtime) = installed_runtime_from_dir(&runtime_entry.path())? {
-                    installed.push(runtime);
-                }
-            }
+            installed.extend(installed_in_version_dir(&version_entry.path())?);
         }
         installed.sort_by(|left, right| {
             (&left.mesh_version, &left.native_runtime_id)
                 .cmp(&(&right.mesh_version, &right.native_runtime_id))
         });
         Ok(installed)
+    }
+
+    /// Returns strictly validated runtimes for one MeshLLM version.
+    ///
+    /// TODO(issue #1162): Remove this resolver-specific compatibility boundary
+    /// once the oldest supported upgrade path no longer contains pre-checksum
+    /// runtime caches, if full-cache resolver enumeration is safe again.
+    pub fn installed_for_version(&self, mesh_version: &str) -> Result<Vec<InstalledNativeRuntime>> {
+        installed_in_version_dir(&self.root.join(mesh_version))
     }
 
     pub fn find_installed(
@@ -242,6 +243,26 @@ fn installed_runtime_from_dir(dir: &Path) -> Result<Option<InstalledNativeRuntim
     }))
 }
 
+fn installed_in_version_dir(version_dir: &Path) -> Result<Vec<InstalledNativeRuntime>> {
+    let mut installed = Vec::new();
+    if !version_dir.exists() {
+        return Ok(installed);
+    }
+    for runtime_entry in fs::read_dir(version_dir)
+        .with_context(|| format!("read native runtime cache {}", version_dir.display()))?
+    {
+        let runtime_entry = runtime_entry?;
+        if !runtime_entry.file_type()?.is_dir() {
+            continue;
+        }
+        if let Some(runtime) = installed_runtime_from_dir(&runtime_entry.path())? {
+            installed.push(runtime);
+        }
+    }
+    installed.sort_by(|left, right| left.native_runtime_id.cmp(&right.native_runtime_id));
+    Ok(installed)
+}
+
 fn copy_dir_recursive(source: &Path, target: &Path) -> Result<()> {
     fs::create_dir_all(target).with_context(|| format!("create {}", target.display()))?;
     for entry in fs::read_dir(source).with_context(|| format!("read {}", source.display()))? {
@@ -307,6 +328,41 @@ mod tests {
 
         assert_eq!(installed.mesh_version, "0.68.0");
         assert!(installed.path.ends_with("meshllm-native-linux-x86_64-cpu"));
+    }
+
+    #[test]
+    fn installed_for_version_ignores_legacy_cache_versions() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache = NativeRuntimeCache::new(temp.path().join("cache"));
+        write_runtime(
+            &cache.runtime_dir("0.75.0", "meshllm-native-linux-x86_64-cpu"),
+            "0.75.0",
+            "meshllm-native-linux-x86_64-cpu",
+        );
+
+        let legacy = cache.runtime_dir("0.74.0", "meshllm-native-linux-x86_64-cpu");
+        fs::create_dir_all(legacy.join("lib")).unwrap();
+        fs::write(legacy.join("lib/libmeshllm_ffi.so"), b"legacy runtime").unwrap();
+        fs::write(
+            legacy.join(NATIVE_RUNTIME_MANIFEST_FILE),
+            r#"{
+  "runtime": {
+    "id": "meshllm-native-linux-x86_64-cpu",
+    "mesh_version": "0.74.0",
+    "skippy_abi": "0.1.25",
+    "platform": {"os": "linux", "arch": "x86_64"},
+    "backend": {"kind": "cpu"},
+    "libraries": ["lib/libmeshllm_ffi.so"]
+  }
+}"#,
+        )
+        .unwrap();
+
+        let installed = cache.installed_for_version("0.75.0").unwrap();
+
+        assert_eq!(installed.len(), 1);
+        assert_eq!(installed[0].mesh_version, "0.75.0");
+        assert!(cache.installed().is_err());
     }
 
     #[test]

--- a/crates/mesh-llm-native-runtime/src/cache.rs
+++ b/crates/mesh-llm-native-runtime/src/cache.rs
@@ -248,7 +248,7 @@ fn installed_runtime_from_dir(dir: &Path) -> Result<Option<InstalledNativeRuntim
 
 fn installed_in_version_dir(version_dir: &Path) -> Result<Vec<InstalledNativeRuntime>> {
     let mut installed = Vec::new();
-    if !version_dir.exists() {
+    if !version_dir.is_dir() {
         return Ok(installed);
     }
     for runtime_entry in fs::read_dir(version_dir)
@@ -366,6 +366,18 @@ mod tests {
         assert_eq!(installed.len(), 1);
         assert_eq!(installed[0].mesh_version, "0.75.0");
         assert!(cache.installed().is_err());
+    }
+
+    #[test]
+    fn installed_for_version_ignores_file_at_version_path() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache = NativeRuntimeCache::new(temp.path().join("cache"));
+        fs::create_dir_all(cache.root()).unwrap();
+        fs::write(cache.root().join("0.75.0"), b"partial cache artifact").unwrap();
+
+        let installed = cache.installed_for_version("0.75.0").unwrap();
+
+        assert!(installed.is_empty());
     }
 
     #[test]

--- a/crates/mesh-llm-native-runtime/src/resolver.rs
+++ b/crates/mesh-llm-native-runtime/src/resolver.rs
@@ -179,7 +179,9 @@ impl NativeRuntimeResolver {
                 artifacts.push(artifact);
             }
         }
-        for installed in self.cache.installed()? {
+        // Older cache versions can contain pre-checksum manifests (#1162), and
+        // they cannot satisfy this resolver's exact MeshLLM version anyway.
+        for installed in self.cache.installed_for_version(&self.mesh_version)? {
             let artifact = installed.manifest.runtime;
             if seen.insert(artifact_key(&artifact)) {
                 artifacts.push(artifact);
@@ -912,6 +914,53 @@ mod tests {
         .resolve(&RuntimeSelection::Recommended)
         .unwrap();
 
+        assert!(matches!(resolution.source, NativeRuntimeSource::Missing));
+    }
+
+    #[test]
+    fn legacy_cached_manifest_does_not_block_current_resolution() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache = NativeRuntimeCache::new(temp.path().join("cache"));
+        let legacy = cache.runtime_dir("0.67.0", "meshllm-runtime-linux-x86_64-cpu");
+        std::fs::create_dir_all(legacy.join("lib")).unwrap();
+        std::fs::write(legacy.join("lib/libllama.so"), b"legacy runtime").unwrap();
+        std::fs::write(
+            legacy.join(crate::NATIVE_RUNTIME_MANIFEST_FILE),
+            r#"{
+  "runtime": {
+    "id": "meshllm-runtime-linux-x86_64-cpu",
+    "mesh_version": "0.67.0",
+    "skippy_abi": "0.1.25",
+    "platform": {"os": "linux", "arch": "x86_64"},
+    "backend": {"kind": "cpu"},
+    "libraries": ["lib/libllama.so"]
+  }
+}"#,
+        )
+        .unwrap();
+
+        let resolution = NativeRuntimeResolver::new(
+            "0.68.0",
+            HostRuntimeProfile {
+                available_flavors: BTreeSet::from([NativeRuntimeBackendKind::Cpu]),
+                cuda: None,
+                ..profile()
+            },
+            NativeRuntimeReleaseManifest {
+                mesh_version: "0.68.0".to_string(),
+                skippy_abi: "0.1.25".to_string(),
+                artifacts: vec![artifact(
+                    "meshllm-runtime-linux-x86_64-cpu",
+                    NativeRuntimeBackend::cpu(),
+                )],
+            },
+            cache,
+        )
+        .with_skippy_abi_version("0.1.25")
+        .resolve(&RuntimeSelection::Recommended)
+        .unwrap();
+
+        assert_eq!(resolution.selected.id, "meshllm-runtime-linux-x86_64-cpu");
         assert!(matches!(resolution.source, NativeRuntimeSource::Missing));
     }
 }

--- a/crates/mesh-llm-runtime-install/src/lib.rs
+++ b/crates/mesh-llm-runtime-install/src/lib.rs
@@ -705,6 +705,68 @@ mod tests {
     }
 
     #[test]
+    fn legacy_cached_manifest_does_not_block_valid_bundle_install() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("bundle");
+        let profile = host_runtime_profile();
+        let mut artifact = artifact_with_sha(None);
+        artifact.id = "valid-bundle-runtime".to_string();
+        artifact.platform.os = profile.os;
+        artifact.platform.arch = profile.arch;
+        artifact.platform.target = profile.target_triple;
+        artifact.url = None;
+        artifact.sha256 = None;
+        std::fs::create_dir_all(bundle.join("lib")).unwrap();
+        std::fs::write(bundle.join("lib/libllama.so"), b"valid runtime").unwrap();
+        NativeRuntimeManifest {
+            runtime: artifact.clone(),
+        }
+        .write_to_dir(&bundle)
+        .unwrap();
+
+        let install = |cache_dir: PathBuf| {
+            tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .unwrap()
+                .block_on(install_native_runtime(NativeRuntimeInstallOptions {
+                    selection: RuntimeSelection::Id(artifact.id.clone()),
+                    bundle_dirs: vec![bundle.clone()],
+                    cache_dir: Some(cache_dir),
+                    bundle_install_policy:
+                        NativeRuntimeBundleInstallPolicy::InstallExplicitBundlesIntoCache,
+                    allow_download: false,
+                    ..Default::default()
+                }))
+        };
+
+        install(temp.path().join("fresh-cache"))
+            .expect("the valid bundle should install into a fresh cache");
+
+        let polluted_cache = temp.path().join("polluted-cache");
+        let legacy_runtime = polluted_cache.join("0.74.0/legacy-cache-runtime");
+        std::fs::create_dir_all(legacy_runtime.join("lib")).unwrap();
+        std::fs::write(legacy_runtime.join("lib/libllama.so"), b"legacy runtime").unwrap();
+        std::fs::write(
+            legacy_runtime.join(NATIVE_RUNTIME_MANIFEST_FILE),
+            r#"{
+  "runtime": {
+    "id": "legacy-cache-runtime",
+    "mesh_version": "0.74.0",
+    "skippy_abi": "0.1.25",
+    "platform": {"os": "windows", "arch": "x86_64"},
+    "backend": {"kind": "vulkan"},
+    "libraries": ["lib/libllama.so"]
+  }
+}"#,
+        )
+        .unwrap();
+
+        install(polluted_cache)
+            .expect("a legacy cached manifest must not block the valid bundle install");
+    }
+
+    #[test]
     fn bundled_runtime_is_used_in_place_without_cache_copy() {
         let bundle = tempfile::tempdir().unwrap();
         let cache_root = tempfile::tempdir().unwrap();


### PR DESCRIPTION

## Summary

Fixes native runtime installation failing when the cache contains runtime manifests from older MeshLLM releases that predate per-file checksums.

## Root cause

Resolver candidate discovery strictly validated every cached runtime before applying the requested MeshLLM version filter. A legacy cached manifest therefore aborted installation before a valid explicit bundle could be selected.

## Changes

- Add strict, version-scoped cache enumeration for resolver candidate discovery.
- Keep full-cache inventory and explicit/current runtime checksum validation strict.
- Add cache, resolver, and end-to-end installer regressions covering legacy manifests.
- Mark the compatibility boundary for future cleanup once pre-checksum caches are no longer part of supported upgrade paths.

Fixes #1162

## Validation

- `cargo fmt --all --check`
- `cargo test -p mesh-llm-native-runtime --lib`
- `cargo test -p mesh-llm-runtime-install --lib`
- `cargo check -p mesh-llm-native-runtime`
- `cargo check -p mesh-llm-runtime-install`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm-native-runtime --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm-runtime-install --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime selection to use only installations compatible with the requested MeshLLM version.
  * Legacy or incompatible cached runtimes no longer interfere with runtime resolution or bundle installation.
  * Added validation and consistent ordering when listing installed runtimes.
  * Files stored at version paths are now ignored when they are not valid runtime entries.
* **Tests**
  * Added coverage for version-specific runtime discovery and installation with stale cache entries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->