### PR TITLE
fix(plugin): deliver generation abort after callback failure

### DIFF
--- a/crates/mesh-native-serving-plugin-host/src/lib.rs
+++ b/crates/mesh-native-serving-plugin-host/src/lib.rs
@@ -775,6 +775,7 @@ mod tests {
 
     struct FakeState {
         start_delay: Duration,
+        begin_fails: bool,
         events: Arc<Mutex<Vec<&'static str>>>,
         abort_count: Arc<AtomicUsize>,
     }
@@ -799,7 +800,11 @@ mod tests {
     ) -> abi::PluginStatus {
         let state = unsafe { &*instance.cast::<FakeState>() };
         state.events.lock().unwrap().push("begin");
-        abi::PluginStatus::OK
+        if state.begin_fails {
+            abi::PluginStatus::INTERNAL_ERROR
+        } else {
+            abi::PluginStatus::OK
+        }
     }
 
     unsafe extern "C" fn fake_commit(
@@ -914,6 +919,17 @@ mod tests {
         Arc<Mutex<Vec<&'static str>>>,
         Arc<AtomicUsize>,
     ) {
+        fake_active_with_options(start_delay, false)
+    }
+
+    fn fake_active_with_options(
+        start_delay: Duration,
+        begin_fails: bool,
+    ) -> (
+        ActivePlugin,
+        Arc<Mutex<Vec<&'static str>>>,
+        Arc<AtomicUsize>,
+    ) {
         let table = Box::leak(Box::new(fake_table()));
         let definition = Arc::new(LoadedDefinition {
             _library: None,
@@ -924,6 +940,7 @@ mod tests {
         let abort_count = Arc::new(AtomicUsize::new(0));
         let state = Box::new(FakeState {
             start_delay,
+            begin_fails,
             events: Arc::clone(&events),
             abort_count: Arc::clone(&abort_count),
         });
@@ -1058,7 +1075,39 @@ mod tests {
     }
 
     #[test]
-    fn generation_abort_reaches_plugin_after_prior_callback_failure() {
+    fn lifecycle_callback_failure_is_observed_without_poisoning_the_driver() {
+        let (active, _, _) = fake_active_with_options(Duration::ZERO, true);
+        let driver = Arc::new(PluginDriver::spawn(active).unwrap());
+        let ingress = NativeLifecycleIngress {
+            driver: Arc::clone(&driver),
+        };
+        ingress
+            .try_submit(GenerationLifecycleObservation::Started(GenerationStart {
+                request_id: 7,
+                session_id: 9,
+                agent_session_id: None,
+                prompt_token_ids: Arc::from([3]),
+            }))
+            .unwrap();
+
+        driver
+            .propose(LinearProposalQuery::new(
+                7,
+                9,
+                1,
+                1,
+                0,
+                8,
+                Instant::now() + Duration::from_millis(100),
+            ))
+            .unwrap();
+
+        assert_eq!(driver.lifecycle_delivery_failures(), 1);
+        assert!(driver.ensure_healthy().is_ok());
+    }
+
+    #[test]
+    fn generation_abort_bypasses_unhealthy_driver_gate() {
         let (active, _, abort_count) = fake_active_with_observations(Duration::ZERO);
         let driver = Arc::new(PluginDriver::spawn(active).unwrap());
         *driver.fatal_error.lock().unwrap() = Some("report proposal failed".to_string());

--- a/crates/mesh-native-serving-plugin-host/src/lib.rs
+++ b/crates/mesh-native-serving-plugin-host/src/lib.rs
@@ -455,7 +455,9 @@ impl GenerationLifecycleIngress for NativeLifecycleIngress {
         let command = match observation {
             GenerationLifecycleObservation::Started(start) => PluginCommand::Begin(start),
             GenerationLifecycleObservation::Committed(commit) => PluginCommand::Committed(commit),
-            GenerationLifecycleObservation::Aborted(abort) => PluginCommand::Abort(abort),
+            GenerationLifecycleObservation::Aborted(abort) => {
+                return self.driver.enqueue_recovery(PluginCommand::Abort(abort));
+            }
             GenerationLifecycleObservation::Completed(receipt) => PluginCommand::Finish(receipt),
             _ => return Ok(()),
         };
@@ -552,6 +554,14 @@ impl PluginDriver {
 
     fn enqueue(&self, command: PluginCommand) -> Result<()> {
         self.ensure_healthy()?;
+        self.enqueue_recovery(command)
+    }
+
+    /// Deliver lifecycle cleanup even after an earlier callback failed.
+    ///
+    /// This bypasses only the health gate. The command still uses the same
+    /// bounded FIFO queue and fails if the worker has stopped or is full.
+    fn enqueue_recovery(&self, command: PluginCommand) -> Result<()> {
         self.sender.try_send(command).map_err(|error| match error {
             TrySendError::Full(_) => anyhow!("native serving plugin command queue is full"),
             TrySendError::Disconnected(_) => anyhow!("native serving plugin worker stopped"),
@@ -766,6 +776,7 @@ mod tests {
     struct FakeState {
         start_delay: Duration,
         events: Arc<Mutex<Vec<&'static str>>>,
+        abort_count: Arc<AtomicUsize>,
     }
 
     unsafe extern "C" fn fake_activate(
@@ -801,9 +812,11 @@ mod tests {
     }
 
     unsafe extern "C" fn fake_abort(
-        _instance: abi::PluginInstance,
+        instance: abi::PluginInstance,
         _event: *const abi::GenerationAbort,
     ) -> abi::PluginStatus {
+        let state = unsafe { &*instance.cast::<FakeState>() };
+        state.abort_count.fetch_add(1, Ordering::SeqCst);
         abi::PluginStatus::OK
     }
 
@@ -890,6 +903,17 @@ mod tests {
     fn fake_active_with_events(
         start_delay: Duration,
     ) -> (ActivePlugin, Arc<Mutex<Vec<&'static str>>>) {
+        let (active, events, _) = fake_active_with_observations(start_delay);
+        (active, events)
+    }
+
+    fn fake_active_with_observations(
+        start_delay: Duration,
+    ) -> (
+        ActivePlugin,
+        Arc<Mutex<Vec<&'static str>>>,
+        Arc<AtomicUsize>,
+    ) {
         let table = Box::leak(Box::new(fake_table()));
         let definition = Arc::new(LoadedDefinition {
             _library: None,
@@ -897,9 +921,11 @@ mod tests {
             name: "test-serving-plugin".to_string(),
         });
         let events = Arc::new(Mutex::new(Vec::new()));
+        let abort_count = Arc::new(AtomicUsize::new(0));
         let state = Box::new(FakeState {
             start_delay,
             events: Arc::clone(&events),
+            abort_count: Arc::clone(&abort_count),
         });
         (
             ActivePlugin {
@@ -908,6 +934,7 @@ mod tests {
                 proposal_token_buffer: vec![0; MAX_NATIVE_PLUGIN_PROPOSAL_TOKENS],
             },
             events,
+            abort_count,
         )
     }
 
@@ -1028,5 +1055,26 @@ mod tests {
             .unwrap();
 
         assert_eq!(*events.lock().unwrap(), ["begin", "commit", "proposal"]);
+    }
+
+    #[test]
+    fn generation_abort_reaches_plugin_after_prior_callback_failure() {
+        let (active, _, abort_count) = fake_active_with_observations(Duration::ZERO);
+        let driver = Arc::new(PluginDriver::spawn(active).unwrap());
+        *driver.fatal_error.lock().unwrap() = Some("report proposal failed".to_string());
+        let ingress = NativeLifecycleIngress {
+            driver: Arc::clone(&driver),
+        };
+
+        ingress
+            .try_submit(GenerationLifecycleObservation::Aborted(GenerationAbort {
+                request_id: 7,
+                session_id: 9,
+            }))
+            .unwrap();
+
+        drop(ingress);
+        drop(driver);
+        assert_eq!(abort_count.load(Ordering::SeqCst), 1);
     }
 }


### PR DESCRIPTION
## Why this matters

When something goes wrong, Mesh might fail to tell a plugin that the request has ended. That can leave the plugin carrying unfinished work into later requests.

This change makes sure the final abort notification still gets delivered after an earlier callback failure. It is the equivalent of ensuring cleanup in a `finally` block always runs.

## Technical details

- route generation-abort lifecycle observations through an explicit recovery enqueue path
- bypass only the plugin health gate while retaining the same bounded FIFO queue
- continue to fail when the queue is full or the worker has stopped
- add a regression test that marks the driver unhealthy and proves abort still reaches the plugin

Current `main` only marks shutdown failures fatal, but other serving changes can broaden that policy. Encoding abort recovery explicitly prevents future health-policy changes from silently dropping lifecycle cleanup.

## Validation

- `cargo fmt --check`
- `cargo test -p mesh-native-serving-plugin-host` — 7 passed

This PR is based directly on `main` and has no dependency on the companion verification fixes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Lifecycle abort events are now recorded even when the plugin driver is unhealthy.
  * Abort delivery continues to report meaningful errors when the worker is stopped or the queue is full.
  * Lifecycle callback failures no longer incorrectly degrade the driver’s health status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->