### PR TITLE
Add Qwen3.6 27B and 35B-A3B to the model catalog

### DIFF
--- a/crates/mesh-client/src/models/catalog.json
+++ b/crates/mesh-client/src/models/catalog.json
@@ -256,6 +256,32 @@
     }
   },
   {
+    "name": "Qwen3.6-27B-UD-Q4_K_XL",
+    "file": "Qwen3.6-27B-UD-Q4_K_XL.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/Qwen3.6-27B-UD-Q4_K_XL.gguf",
+    "size": "16.4GB",
+    "description": "Qwen3.6 27B dense, vision + text, strong reasoning and coding",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "Qwen3.6-27B-mmproj-BF16.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/mmproj-BF16.gguf"
+    }
+  },
+  {
+    "name": "Qwen3.6-35B-A3B-UD-Q4_K_XL",
+    "file": "Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
+    "size": "20.8GB",
+    "description": "Qwen3.6 35B MoE (3B active), vision + text, fast reasoning and coding",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "Qwen3.6-35B-A3B-mmproj-BF16.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/mmproj-BF16.gguf"
+    }
+  },
+  {
     "name": "Qwen3-Coder-Next-Q4_K_M",
     "file": "Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",
     "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M/Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",

--- a/crates/mesh-llm-node/src/catalog.json
+++ b/crates/mesh-llm-node/src/catalog.json
@@ -256,6 +256,32 @@
     }
   },
   {
+    "name": "Qwen3.6-27B-UD-Q4_K_XL",
+    "file": "Qwen3.6-27B-UD-Q4_K_XL.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/Qwen3.6-27B-UD-Q4_K_XL.gguf",
+    "size": "16.4GB",
+    "description": "Qwen3.6 27B dense, vision + text, strong reasoning and coding",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "Qwen3.6-27B-mmproj-BF16.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-27B-GGUF/resolve/main/mmproj-BF16.gguf"
+    }
+  },
+  {
+    "name": "Qwen3.6-35B-A3B-UD-Q4_K_XL",
+    "file": "Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/Qwen3.6-35B-A3B-UD-Q4_K_XL.gguf",
+    "size": "20.8GB",
+    "description": "Qwen3.6 35B MoE (3B active), vision + text, fast reasoning and coding",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "Qwen3.6-35B-A3B-mmproj-BF16.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.6-35B-A3B-GGUF/resolve/main/mmproj-BF16.gguf"
+    }
+  },
+  {
     "name": "Qwen3-Coder-Next-Q4_K_M",
     "file": "Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",
     "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M/Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",


### PR DESCRIPTION
Qwen3.6 models are on Hugging Face but were missing from the bundled catalog, so you could only run them by typing a full repo reference. Now they appear in model listings, search, and the console catalog alongside Qwen3.5:

- **Qwen3.6-27B-UD-Q4_K_XL** — 16.4GB dense
- **Qwen3.6-35B-A3B-UD-Q4_K_XL** — 20.8GB MoE, 3B active

Both are advertised as vision-capable, since both ship an `mmproj` asset and their configs carry `vision_config` with `*ForConditionalGeneration` architectures.

Neither entry sets a draft model. Qwen3.6 uses a 248320-token vocabulary, so the `Qwen3-0.6B` draft used by the Qwen3.5 entry is not tokenizer-compatible. Speculative decoding for these would need a matching-vocab draft.

No code changes — Qwen3.6 loads as llama.cpp `qwen35` / `qwen35moe`, which is already supported, and `is_qwen35_series` already matches the `qwen36` spelling. This is catalog data only.

## Validation

Both download URLs return HTTP 200 at the sizes listed above, and both models serve and generate locally on Metal (M5 Max, `just build`, no env overrides):

| Model | Arch reported | Decode |
|---|---|---|
| Qwen3.6-35B-A3B | \`qwen35moe\` | ~62 tok/s |
| Qwen3.6-27B | \`qwen35\` | ~21.5 tok/s |

\`\`\`
$ curl -s localhost:9667/v1/chat/completions -d '{"model":"unsloth/Qwen3.6-27B-GGUF:UD-Q4_K_XL", ...}'
A mixture-of-experts model is a machine learning architecture that combines
the outputs of multiple specialized sub-models...
\`\`\`

- \`cargo test -p mesh-llm-node --lib\` — 9 passed
- \`cargo test -p mesh-llm-client --lib\` — 89 passed

Both bundled copies of \`catalog.json\` are kept byte-identical, as they were before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for two Qwen3.6 vision-language models:
    - 27B dense model for image and text workloads.
    - 35B-A3B mixture-of-experts model for image and text workloads.
  - Included downloadable GGUF model assets and corresponding BF16 multimodal projectors.
  - Added model descriptions and size information to the available catalog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->