### PR TITLE
fix: stale pre-0.75 runtime cache entries no longer break startup for SDK embedders

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/routes/runtime_control_state_sources.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/runtime_control_state_sources.rs
@@ -80,9 +80,9 @@ fn gpu_state(gpus: &[crate::system::hardware::GpuFacts]) -> RuntimeOptionsState 
 fn native_backend_state() -> RuntimeOptionsState {
     let mut kinds = crate::system::native_runtime_install::host_runtime_profile().available_flavors;
     if let Ok(cache) = crate::system::native_runtime_install::default_native_runtime_cache()
-        && let Ok(installed) = cache.installed()
+        && let Ok(scan) = cache.installed_lenient()
     {
-        for runtime in installed {
+        for runtime in scan.runtimes {
             kinds.insert(runtime.manifest.runtime.backend.kind);
         }
     }

--- a/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
@@ -278,7 +278,15 @@ mod dynamic {
         target_skippy_abi: Option<&str>,
         selection: &RuntimeSelection,
     ) -> Result<Option<NativeRuntimeStartupLoadPlan>> {
-        let installed = cache.installed()?;
+        let scan = cache.installed_lenient()?;
+        for skipped in &scan.skipped {
+            tracing::warn!(
+                path = %skipped.path.display(),
+                reason = %skipped.reason,
+                "Skipping unusable native runtime cache entry during startup"
+            );
+        }
+        let installed = scan.runtimes;
         if installed.is_empty() {
             return Ok(None);
         }
@@ -519,6 +527,57 @@ mod dynamic {
                 plan.libraries,
                 vec![runtime_dir.join(test_library_rel_path())]
             );
+        }
+
+        #[test]
+        fn stale_pre_checksum_cache_entry_does_not_block_startup_plan() {
+            let temp = tempfile::tempdir().unwrap();
+            let cache = NativeRuntimeCache::new(temp.path().join("cache"));
+            let runtime_id = "meshllm-native-runtime-test-cpu";
+            let release_version = "0.75.0";
+            let runtime_dir = cache.runtime_dir(release_version, runtime_id);
+            write_runtime(&runtime_dir, release_version, runtime_id);
+
+            // Simulate a cache entry written by a pre-0.75 loader: the
+            // manifest has no per-file checksums (issue #1162).
+            let legacy_dir = cache.runtime_dir("0.74.0", runtime_id);
+            let library_rel_path = test_library_rel_path();
+            fs::create_dir_all(legacy_dir.join(library_rel_path.parent().unwrap())).unwrap();
+            fs::write(legacy_dir.join(&library_rel_path), b"legacy runtime").unwrap();
+            fs::write(
+                legacy_dir.join("manifest.json"),
+                format!(
+                    r#"{{
+  "runtime": {{
+    "id": "{runtime_id}",
+    "mesh_version": "0.74.0",
+    "skippy_abi": "0.1.25",
+    "platform": {{"os": "{os}", "arch": "{arch}"}},
+    "backend": {{"kind": "cpu"}},
+    "libraries": ["{library}"]
+  }}
+}}"#,
+                    os = std::env::consts::OS,
+                    arch = std::env::consts::ARCH,
+                    library = library_rel_path.to_string_lossy().replace('\\', "/"),
+                ),
+            )
+            .unwrap();
+
+            let plan = resolve_installed_native_runtime_plan(
+                &cache,
+                &HostRuntimeProfile::current_without_gpu_probe(),
+                release_version,
+                release_version,
+                Some("0.1.25"),
+                &RuntimeSelection::Recommended,
+            )
+            .unwrap()
+            .expect("a stale pre-checksum cache entry must not block the valid runtime");
+
+            assert_eq!(plan.cache_mesh_version, release_version);
+            assert_eq!(plan.native_runtime_id, runtime_id);
+            assert_eq!(plan.source, NativeRuntimePlanSource::CacheHit);
         }
 
         #[test]

--- a/crates/mesh-llm-native-runtime/src/cache.rs
+++ b/crates/mesh-llm-native-runtime/src/cache.rs
@@ -159,8 +159,32 @@ impl NativeRuntimeCache {
                     continue;
                 }
                 let runtime_dir = runtime_entry.path();
-                if !runtime_dir.join(NATIVE_RUNTIME_MANIFEST_FILE).exists() {
-                    continue;
+                let manifest_path = runtime_dir.join(NATIVE_RUNTIME_MANIFEST_FILE);
+                match fs::metadata(&manifest_path) {
+                    Ok(metadata) if metadata.is_file() => {}
+                    Ok(_) => {
+                        scan.skipped.push(SkippedNativeRuntime {
+                            path: runtime_dir,
+                            reason: format!("{NATIVE_RUNTIME_MANIFEST_FILE} is not a regular file"),
+                        });
+                        continue;
+                    }
+                    Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                        scan.skipped.push(SkippedNativeRuntime {
+                            path: runtime_dir,
+                            reason: format!("{NATIVE_RUNTIME_MANIFEST_FILE} is missing"),
+                        });
+                        continue;
+                    }
+                    Err(error) => {
+                        scan.skipped.push(SkippedNativeRuntime {
+                            path: runtime_dir,
+                            reason: format!(
+                                "read {NATIVE_RUNTIME_MANIFEST_FILE} metadata: {error}"
+                            ),
+                        });
+                        continue;
+                    }
                 }
                 match installed_runtime_from_dir(&runtime_dir) {
                     Ok(Some(runtime)) => scan.runtimes.push(runtime),
@@ -471,6 +495,36 @@ mod tests {
         );
         // The strict scan still fails on the same cache; startup must not use it.
         assert!(cache.installed().is_err());
+    }
+
+    #[test]
+    fn installed_lenient_reports_runtime_dir_without_manifest_as_skipped() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache = NativeRuntimeCache::new(temp.path().join("cache"));
+        write_runtime(
+            &cache.runtime_dir("0.75.0", "meshllm-native-linux-x86_64-cpu"),
+            "0.75.0",
+            "meshllm-native-linux-x86_64-cpu",
+        );
+
+        let orphan = cache.runtime_dir("0.75.0", "meshllm-native-linux-x86_64-vulkan");
+        fs::create_dir_all(orphan.join("lib")).unwrap();
+        fs::write(orphan.join("lib/libmeshllm_ffi.so"), b"orphan runtime").unwrap();
+
+        let scan = cache.installed_lenient().unwrap();
+
+        assert_eq!(scan.runtimes.len(), 1);
+        assert_eq!(
+            scan.runtimes[0].native_runtime_id,
+            "meshllm-native-linux-x86_64-cpu"
+        );
+        assert_eq!(scan.skipped.len(), 1);
+        assert_eq!(scan.skipped[0].path, orphan);
+        assert!(
+            scan.skipped[0].reason.contains("missing"),
+            "unexpected skip reason: {}",
+            scan.skipped[0].reason
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-native-runtime/src/cache.rs
+++ b/crates/mesh-llm-native-runtime/src/cache.rs
@@ -29,6 +29,22 @@ pub struct InstalledNativeRuntime {
     pub manifest: NativeRuntimeManifest,
 }
 
+/// A cache entry that could not be read as a valid installed runtime during a
+/// lenient scan, together with the reason it was skipped.
+#[derive(Clone, Debug)]
+pub struct SkippedNativeRuntime {
+    pub path: PathBuf,
+    pub reason: String,
+}
+
+/// Result of leniently enumerating the runtime cache: every readable runtime
+/// plus every entry that had to be skipped.
+#[derive(Debug, Default)]
+pub struct LenientInstalledScan {
+    pub runtimes: Vec<InstalledNativeRuntime>,
+    pub skipped: Vec<SkippedNativeRuntime>,
+}
+
 impl InstalledNativeRuntime {
     /// Resolve the manifest-verified GPU benchmark helper inside this runtime.
     pub fn gpu_benchmark_tool(&self) -> Result<PathBuf> {
@@ -115,6 +131,52 @@ impl NativeRuntimeCache {
                 .cmp(&(&right.mesh_version, &right.native_runtime_id))
         });
         Ok(installed)
+    }
+
+    /// Enumerates the whole cache leniently: entries whose manifests are
+    /// missing, malformed, or fail checksum verification are collected as
+    /// skipped instead of failing the scan.
+    ///
+    /// Startup paths must use this instead of [`Self::installed`] so a stale
+    /// entry written by an older MeshLLM version (pre-checksum manifests,
+    /// issue #1162) can never abort runtime resolution while a valid runtime
+    /// is present or installable.
+    pub fn installed_lenient(&self) -> Result<LenientInstalledScan> {
+        let mut scan = LenientInstalledScan::default();
+        if !self.root.exists() {
+            return Ok(scan);
+        }
+        for version_entry in fs::read_dir(&self.root)
+            .with_context(|| format!("read native runtime cache {}", self.root.display()))?
+        {
+            let version_entry = version_entry?;
+            if !version_entry.file_type()?.is_dir() {
+                continue;
+            }
+            for runtime_entry in fs::read_dir(version_entry.path())? {
+                let runtime_entry = runtime_entry?;
+                if !runtime_entry.file_type()?.is_dir() {
+                    continue;
+                }
+                let runtime_dir = runtime_entry.path();
+                if !runtime_dir.join(NATIVE_RUNTIME_MANIFEST_FILE).exists() {
+                    continue;
+                }
+                match installed_runtime_from_dir(&runtime_dir) {
+                    Ok(Some(runtime)) => scan.runtimes.push(runtime),
+                    Ok(None) => {}
+                    Err(error) => scan.skipped.push(SkippedNativeRuntime {
+                        path: runtime_dir,
+                        reason: format!("{error:#}"),
+                    }),
+                }
+            }
+        }
+        scan.runtimes.sort_by(|left, right| {
+            (&left.mesh_version, &left.native_runtime_id)
+                .cmp(&(&right.mesh_version, &right.native_runtime_id))
+        });
+        Ok(scan)
     }
 
     /// Returns strictly validated runtimes for one MeshLLM version.
@@ -365,6 +427,49 @@ mod tests {
 
         assert_eq!(installed.len(), 1);
         assert_eq!(installed[0].mesh_version, "0.75.0");
+        assert!(cache.installed().is_err());
+    }
+
+    #[test]
+    fn installed_lenient_skips_legacy_manifest_and_keeps_valid_runtime() {
+        let temp = tempfile::tempdir().unwrap();
+        let cache = NativeRuntimeCache::new(temp.path().join("cache"));
+        write_runtime(
+            &cache.runtime_dir("0.75.0", "meshllm-native-linux-x86_64-cpu"),
+            "0.75.0",
+            "meshllm-native-linux-x86_64-cpu",
+        );
+
+        let legacy = cache.runtime_dir("0.74.0", "meshllm-native-linux-x86_64-cpu");
+        fs::create_dir_all(legacy.join("lib")).unwrap();
+        fs::write(legacy.join("lib/libmeshllm_ffi.so"), b"legacy runtime").unwrap();
+        fs::write(
+            legacy.join(NATIVE_RUNTIME_MANIFEST_FILE),
+            r#"{
+  "runtime": {
+    "id": "meshllm-native-linux-x86_64-cpu",
+    "mesh_version": "0.74.0",
+    "skippy_abi": "0.1.25",
+    "platform": {"os": "linux", "arch": "x86_64"},
+    "backend": {"kind": "cpu"},
+    "libraries": ["lib/libmeshllm_ffi.so"]
+  }
+}"#,
+        )
+        .unwrap();
+
+        let scan = cache.installed_lenient().unwrap();
+
+        assert_eq!(scan.runtimes.len(), 1);
+        assert_eq!(scan.runtimes[0].mesh_version, "0.75.0");
+        assert_eq!(scan.skipped.len(), 1);
+        assert_eq!(scan.skipped[0].path, legacy);
+        assert!(
+            scan.skipped[0].reason.contains("checksum"),
+            "unexpected skip reason: {}",
+            scan.skipped[0].reason
+        );
+        // The strict scan still fails on the same cache; startup must not use it.
         assert!(cache.installed().is_err());
     }
 

--- a/crates/mesh-llm-native-runtime/src/cache.rs
+++ b/crates/mesh-llm-native-runtime/src/cache.rs
@@ -149,16 +149,51 @@ impl NativeRuntimeCache {
         for version_entry in fs::read_dir(&self.root)
             .with_context(|| format!("read native runtime cache {}", self.root.display()))?
         {
-            let version_entry = version_entry?;
-            if !version_entry.file_type()?.is_dir() {
+            let Ok(version_entry) = version_entry else {
                 continue;
-            }
-            for runtime_entry in fs::read_dir(version_entry.path())? {
-                let runtime_entry = runtime_entry?;
-                if !runtime_entry.file_type()?.is_dir() {
+            };
+            let version_path = version_entry.path();
+            let version_is_dir = match version_entry.file_type() {
+                Ok(file_type) => file_type.is_dir(),
+                Err(error) => {
+                    scan.skipped.push(SkippedNativeRuntime {
+                        path: version_path,
+                        reason: format!("read cache version metadata: {error}"),
+                    });
                     continue;
                 }
+            };
+            if !version_is_dir {
+                continue;
+            }
+            let runtime_entries = match fs::read_dir(&version_path) {
+                Ok(entries) => entries,
+                Err(error) => {
+                    scan.skipped.push(SkippedNativeRuntime {
+                        path: version_path,
+                        reason: format!("read native runtime cache version: {error}"),
+                    });
+                    continue;
+                }
+            };
+            for runtime_entry in runtime_entries {
+                let Ok(runtime_entry) = runtime_entry else {
+                    continue;
+                };
                 let runtime_dir = runtime_entry.path();
+                let runtime_is_dir = match runtime_entry.file_type() {
+                    Ok(file_type) => file_type.is_dir(),
+                    Err(error) => {
+                        scan.skipped.push(SkippedNativeRuntime {
+                            path: runtime_dir,
+                            reason: format!("read native runtime entry metadata: {error}"),
+                        });
+                        continue;
+                    }
+                };
+                if !runtime_is_dir {
+                    continue;
+                }
                 let manifest_path = runtime_dir.join(NATIVE_RUNTIME_MANIFEST_FILE);
                 match fs::metadata(&manifest_path) {
                     Ok(metadata) if metadata.is_file() => {}

--- a/crates/mesh-llm-native-runtime/src/lib.rs
+++ b/crates/mesh-llm-native-runtime/src/lib.rs
@@ -8,8 +8,9 @@ mod manifest;
 mod resolver;
 
 pub use cache::{
-    CachePrunePlan, GPU_BENCHMARK_TOOL_PATH, InstalledNativeRuntime, NativeRuntimeCache,
-    NativeRuntimeCacheRoot, NativeRuntimePruneMode, native_runtime_cache_root,
+    CachePrunePlan, GPU_BENCHMARK_TOOL_PATH, InstalledNativeRuntime, LenientInstalledScan,
+    NativeRuntimeCache, NativeRuntimeCacheRoot, NativeRuntimePruneMode, SkippedNativeRuntime,
+    native_runtime_cache_root,
 };
 pub use flavor::{
     CudaRuntimeRequirements, NativeRuntimeBackend, NativeRuntimeBackendKind, NativeRuntimeFlavor,


### PR DESCRIPTION
## Summary

Upgrading to 0.75.x with an existing native runtime cache no longer aborts startup for SDK embedders. A cache entry written by a pre-0.75 loader (manifest without per-file checksums) is now skipped with a warning during startup runtime resolution, instead of failing the whole cache scan before the download/install fallback can run.

This is the startup-path completion of #1170 (issue #1162). #1170 fixed the resolver's cache enumeration, but the startup fast-path in `mesh-llm-host-runtime` still used the strict full-cache `NativeRuntimeCache::installed()`, where one stale manifest `?`-aborts everything.

## Who hits this

Anyone embedding the host runtime via the SDK (`initialize_host_runtime()`) on a machine with a pre-0.75 runtime cache — observed during the Buzz desktop upgrade to v0.75.0:

```
native runtime artifact meshllm-native-runtime-darwin-aarch64-metal does not declare file checksums
```

The installed CLI was unaffected *by accident of packaging*: `install.sh` ships a `native-runtimes/` directory beside the binary, so startup takes the bundle-discovery branch (which reads manifests leniently) and never reaches the strict cache scan. SDK embedders have no adjacent bundle dir, fall into `resolve_installed_native_runtime_plan` → `cache.installed()`, and failed hard — before `allow_download` could rescue them.

## What changed

- New `NativeRuntimeCache::installed_lenient()` enumerates the whole cache and collects unreadable entries (missing/malformed/checksum-failing manifests) as `skipped` instead of failing the scan.
- Startup runtime resolution (`resolve_installed_native_runtime_plan`) uses the lenient scan and emits a `tracing::warn!` per skipped entry with path and reason.
- The runtime-control backend options view uses it too, so one stale entry no longer hides all installed backend kinds from the console.
- Strict verification is unchanged where it matters: installs, downloads, and the load plan for the selected runtime still enforce per-file checksums. Only *enumeration of neighbors* is lenient.

## Validation

- New test `stale_pre_checksum_cache_entry_does_not_block_startup_plan` (host runtime): a valid current-version runtime plus a pre-checksum 0.74.0 cache entry resolves to the valid runtime.
- New test `installed_lenient_skips_legacy_manifest_and_keeps_valid_runtime` (native-runtime crate): lenient scan returns the valid runtime, reports the stale one as skipped, and asserts the strict scan still errors on the same cache (documenting why startup must not use it).
- `cargo test -p mesh-llm-host-runtime --lib` — 1924 passed.
- `cargo test -p mesh-llm-native-runtime --lib` — 27 passed.
- `cargo fmt --all --check`, `cargo clippy -p mesh-llm-native-runtime --all-targets -- -D warnings` — clean. (`-p mesh-llm-host-runtime` clippy has 28 pre-existing unfulfilled-lint-expectation errors on main, unchanged by this PR.)
- Empirical repro on macOS arm64: a binary with no adjacent bundle dir and an isolated cache containing only a stale pre-checksum 0.74.0 entry — v0.75.0 fails startup with the checksum error; this branch warns, skips, and proceeds to normal runtime resolution.

## Protocol

No wire or protocol impact. Cache-directory compatibility only: pre-0.75 cache entries are now skipped (and pruned by existing maintenance) rather than fatal. No manifest format change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved runtime discovery so valid runtimes continue loading even when unusable or legacy cache entries are present.
  * Added clearer logging when invalid runtime entries are skipped.
  * Prevented legacy pre-checksum cache entries from blocking startup or runtime state detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->