### PR TITLE
fix(release): verify published crates with dynamic runtime

### DIFF
--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -233,7 +233,11 @@ run_cargo_publish_once() {
     fi
 
     echo "cargo ${args[*]}"
-    if output="$(cargo "${args[@]}" 2>&1)"; then
+    # Registry verification runs from the isolated package tarball, where the
+    # repository-only patched llama.cpp build inputs are intentionally absent.
+    # Verify the Rust package surface through skippy-ffi's dynamic link mode;
+    # this does not change the uploaded crate contents or feature defaults.
+    if output="$(LLAMA_STAGE_LINK_MODE=dynamic cargo "${args[@]}" 2>&1)"; then
         last_publish_output="$output"
         print_publish_output "$output"
         return 0

--- a/scripts/tests/test_publish_crates.py
+++ b/scripts/tests/test_publish_crates.py
@@ -16,6 +16,20 @@ SCRIPT = ROOT / "scripts" / "publish-crates.sh"
 
 
 class PublishCratesScriptTests(unittest.TestCase):
+    def test_publish_verification_uses_dynamic_llama_link_mode(self) -> None:
+        with PublishCratesFixture() as fixture:
+            fixture.write_curl_statuses({})
+            fixture.write_fake_cargo()
+            fixture.write_fake_sleep()
+            fixture.write_fake_date()
+
+            result = fixture.run(["--dry-run", "--allow-dirty"])
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            link_modes = fixture.read_log("cargo-link-mode.log").splitlines()
+            self.assertTrue(link_modes)
+            self.assertEqual(set(link_modes), {"dynamic"})
+
     def test_retries_cargo_publish_429_then_continues_chain(self) -> None:
         with PublishCratesFixture() as fixture:
             fixture.write_curl_statuses({})
@@ -226,6 +240,7 @@ for arg in "$@"; do
     prev="$arg"
 done
 echo "$*" >> "{self.tmp_path}/cargo.log"
+echo "${{LLAMA_STAGE_LINK_MODE:-}}" >> "{self.tmp_path}/cargo-link-mode.log"
 case "$crate" in
 {self._cargo_case_arms(fail_cases, failure_path)}
 esac


### PR DESCRIPTION
## Summary

- run Cargo publish verification with `LLAMA_STAGE_LINK_MODE=dynamic`
- prevent isolated crate verification from requiring repository-only patched llama build inputs
- add regression coverage for every publish invocation

## Validation

- `python3 -m unittest scripts.tests.test_publish_crates`
- `shellcheck scripts/publish-crates.sh`
- `cargo run -p xtask -- repo-consistency publish-crates`
- exact `v0.75.0` detached dry-run for `skippy-runtime` passed against published `skippy-ffi@0.75.0`

This fixes future release publication. Recovering the partially published v0.75.0 chain must still use the exact tag snapshot with the dynamic link mode supplied externally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved package publishing verification by using dynamic linking during Cargo checks.
  * Preserved existing output handling, redaction, and status reporting.

* **Tests**
  * Added coverage to verify that dry-run publishing uses the expected dynamic linking mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->