### PR TITLE
fix: compile ROCm benchmark for configured GPU targets

### DIFF
--- a/scripts/package-native-runtime.sh
+++ b/scripts/package-native-runtime.sh
@@ -260,8 +260,23 @@ gpu_benchmark_tool_path() {
     fi
 }
 
+hip_offload_arch_args() {
+    local raw arch
+    local -a arches=()
+    raw="${LLAMA_STAGE_AMDGPU_TARGETS:-${SKIPPY_AMDGPU_TARGETS:-}}"
+    [[ -n "$raw" ]] || return 0
+
+    raw="${raw//;/ }"
+    raw="${raw//,/ }"
+    read -r -a arches <<< "$raw"
+    for arch in "${arches[@]}"; do
+        [[ -n "$arch" ]] && printf -- '--offload-arch=%s\n' "$arch"
+    done
+}
+
 build_gpu_benchmark_tool() {
-    local tool_rel tool_path source_root compiler
+    local tool_rel tool_path source_root compiler arch_arg
+    local -a hip_arch_args=()
     case "$BACKEND" in
         cuda|cuda-blackwell|rocm|hip|metal) ;;
         *) return 0 ;;
@@ -279,7 +294,11 @@ build_gpu_benchmark_tool() {
             ;;
         rocm|hip)
             compiler="${HIPCC:-hipcc}"
-            "$compiler" -O3 -std=c++17 "$source_root/hip/membench-fingerprint.hip" -o "$tool_path"
+            while IFS= read -r arch_arg; do
+                hip_arch_args+=("$arch_arg")
+            done < <(hip_offload_arch_args)
+            "$compiler" -O3 -std=c++17 "${hip_arch_args[@]}" \
+                "$source_root/hip/membench-fingerprint.hip" -o "$tool_path"
             ;;
         metal)
             compiler="${CC:-clang}"

--- a/scripts/tests/test_package_native_runtime.py
+++ b/scripts/tests/test_package_native_runtime.py
@@ -56,6 +56,88 @@ class PackageNativeRuntimeTests(unittest.TestCase):
             )
             self.assertEqual(manifest["runtime"]["tools"], {})
 
+    def test_rocm_benchmark_tool_uses_configured_offload_arches(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            build_dir = root / "build"
+            build_dir.mkdir()
+            (build_dir / "libllama.so").write_bytes(b"test native runtime")
+
+            tool_dir = root / "bin"
+            tool_dir.mkdir()
+            hipcc = tool_dir / "hipcc"
+            hipcc.write_text(
+                "#!/bin/sh\n"
+                "set -eu\n"
+                "printf '%s\\n' \"$@\" > \"$HIPCC_ARGS_LOG\"\n"
+                "previous=''\n"
+                "for argument in \"$@\"; do\n"
+                "  if [ \"$previous\" = '-o' ]; then output=\"$argument\"; fi\n"
+                "  previous=\"$argument\"\n"
+                "done\n"
+                ": > \"$output\"\n",
+                encoding="utf-8",
+            )
+            hipcc.chmod(0o755)
+            patchelf = tool_dir / "patchelf"
+            patchelf.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+            patchelf.chmod(0o755)
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "HIPCC": str(hipcc),
+                    "HIPCC_ARGS_LOG": str(root / "hipcc-args.log"),
+                    "LLAMA_STAGE_AMDGPU_TARGETS": "gfx90a;gfx942, gfx1151",
+                    "LLAMA_STAGE_BUILD_DIR": str(build_dir),
+                    "PATH": f"{tool_dir}{os.pathsep}{env['PATH']}",
+                }
+            )
+            result = subprocess.run(
+                [
+                    "/bin/bash",
+                    str(SCRIPT),
+                    "--backend",
+                    "rocm",
+                    "--target",
+                    "x86_64-unknown-linux-gnu",
+                    "--out",
+                    str(root / "output"),
+                ],
+                env=env,
+                text=True,
+                capture_output=True,
+            )
+
+            result.check_returncode()
+            arguments = (
+                (root / "hipcc-args.log").read_text(encoding="utf-8").splitlines()
+            )
+            self.assertEqual(
+                [
+                    argument
+                    for argument in arguments
+                    if argument.startswith("--offload-arch=")
+                ],
+                [
+                    "--offload-arch=gfx90a",
+                    "--offload-arch=gfx942",
+                    "--offload-arch=gfx1151",
+                ],
+            )
+            manifest = json.loads(
+                (
+                    root
+                    / "output"
+                    / "meshllm-native-runtime-linux-x86_64-rocm"
+                    / "manifest.json"
+                ).read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                manifest["runtime"]["backend"]["rocm"]["gpu_arches"],
+                ["gfx90a", "gfx942", "gfx1151"],
+            )
+
     def test_cuda_flavor_uses_mesh_cuda_version_major(self) -> None:
         self.assertEqual(
             self.backend_flavor("cuda", mesh_cuda_version="13.1.2"),


### PR DESCRIPTION
## Summary

- Pass the configured ROCm architecture list to the packaged HIP benchmark as explicit `--offload-arch=<target>` arguments.
- Preserve the existing `SKIPPY_AMDGPU_TARGETS` fallback for local or legacy callers.
- Add a packaging regression test that captures HIPCC arguments and verifies the ROCm manifest metadata.

## Root cause

The ROCm runtime build already receives `LLAMA_STAGE_AMDGPU_TARGETS`, but the benchmark tool compiler invocation did not. HIPCC therefore used its default target set, producing a benchmark that could not resolve kernels on devices such as gfx1151. This is the runtime-tool form of #1183 after the v0.75 packaging refactor.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 386 passed, 7 skipped
- `bash -n scripts/package-native-runtime.sh`
- `git diff --check`

ROCm hardware validation was not available locally.

Fixes #1183


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring multiple AMD GPU architectures when packaging the native runtime.
  - Accepts comma- or semicolon-separated architecture values and applies them during HIP compilation.
  - Records the normalized architecture list in the generated package manifest.

- **Tests**
  - Added coverage verifying multi-architecture ROCm packaging and manifest output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->