### PR TITLE
Fix split GGUF stage inventory discovery

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
@@ -55,6 +55,7 @@ pub use materialization::{
     prune_unpinned_materialized_stages, remove_materialized_stages_for_sources,
     resolve_hf_package_to_local,
 };
+pub(crate) use package::direct_gguf_source_paths;
 pub use package::{
     SkippyPackageIdentity, identity_from_layer_package, synthetic_direct_gguf_package,
 };

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/package.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/package.rs
@@ -172,10 +172,7 @@ fn synthetic_manifest_sha256(input: SyntheticManifestInput<'_>) -> Result<String
     Ok(hex_lower(&Sha256::digest(bytes)))
 }
 
-fn direct_gguf_source_files(
-    model_path: &Path,
-    digest_cache: Option<&SidecarDigestCache>,
-) -> Result<Vec<SkippyPackageSourceFile>> {
+pub(crate) fn direct_gguf_source_paths(model_path: &Path) -> Result<Vec<PathBuf>> {
     let canonical = model_path
         .canonicalize()
         .with_context(|| format!("canonicalize GGUF path {}", model_path.display()))?;
@@ -183,8 +180,7 @@ fn direct_gguf_source_files(
         anyhow::bail!("GGUF path has no UTF-8 filename: {}", canonical.display());
     };
     let Some(shard) = model_ref::split_gguf_shard_info(file_name) else {
-        let file = source_file(&canonical, digest_cache)?;
-        return Ok(vec![file]);
+        return Ok(vec![canonical]);
     };
     anyhow::ensure!(
         shard.part == "00001",
@@ -206,7 +202,7 @@ fn direct_gguf_source_files(
     for index in 1..=total {
         let shard_name = format!("{}-{index:05}-of-{:05}.gguf", shard.prefix, total);
         let path = parent.join(shard_name);
-        files.push(source_file(&path, digest_cache).with_context(|| {
+        files.push(path.canonicalize().with_context(|| {
             format!(
                 "read split GGUF shard {index}/{total} for {}",
                 canonical.display()
@@ -214,6 +210,16 @@ fn direct_gguf_source_files(
         })?);
     }
     Ok(files)
+}
+
+fn direct_gguf_source_files(
+    model_path: &Path,
+    digest_cache: Option<&SidecarDigestCache>,
+) -> Result<Vec<SkippyPackageSourceFile>> {
+    direct_gguf_source_paths(model_path)?
+        .into_iter()
+        .map(|path| source_file(&path, digest_cache))
+        .collect()
 }
 
 fn source_file(

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/inventory.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/inventory.rs
@@ -41,24 +41,44 @@ pub(super) fn resolve_inventory_source(request: &StageInventoryRequest) -> Optio
     }
 
     for candidate in inventory_source_candidates(request) {
-        if !candidate.exists() {
-            continue;
+        if let Some(source) = resolve_direct_gguf_inventory_source(&candidate) {
+            return Some(source);
         }
-        let layer_count = crate::inference::skippy::infer_layer_count(&candidate).ok()?;
-        let kind = if is_split_gguf_path(&candidate) {
-            SourceModelKind::SplitGguf
-        } else {
-            SourceModelKind::PlainGguf
-        };
-        let bytes = crate::inference::election::total_model_bytes(&candidate);
-        return Some(InventorySource {
-            path: candidate,
-            bytes: Some(bytes),
-            layer_count,
-            kind,
-        });
     }
     None
+}
+
+fn resolve_direct_gguf_inventory_source(candidate: &Path) -> Option<InventorySource> {
+    let source_paths = match crate::inference::skippy::direct_gguf_source_paths(candidate) {
+        Ok(paths) => paths,
+        Err(error) => {
+            tracing::debug!(
+                path = %candidate.display(),
+                "direct GGUF inventory source is unavailable: {error:#}"
+            );
+            return None;
+        }
+    };
+    let source_path = source_paths.first()?.clone();
+    let layer_count = crate::models::gguf::scan_gguf_compact_meta(&source_path)
+        .map(|meta| meta.layer_count)
+        .filter(|layer_count| *layer_count > 0)
+        .or_else(|| crate::inference::skippy::infer_layer_count(&source_path).ok())?;
+    let bytes = source_paths
+        .iter()
+        .filter_map(|path| path.metadata().ok().map(|metadata| metadata.len()))
+        .sum();
+    let kind = if is_split_gguf_path(&source_path) {
+        SourceModelKind::SplitGguf
+    } else {
+        SourceModelKind::PlainGguf
+    };
+    Some(InventorySource {
+        path: source_path,
+        bytes: Some(bytes),
+        layer_count,
+        kind,
+    })
 }
 
 pub(super) fn inventory_source_candidates(request: &StageInventoryRequest) -> Vec<PathBuf> {

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/tests.rs
@@ -1,10 +1,11 @@
 use super::*;
 use std::{
+    fs,
     sync::Arc,
     time::{Duration, Instant},
 };
 
-use super::inventory::inventory_source_candidates;
+use super::inventory::{inventory_source_candidates, resolve_inventory_source};
 use anyhow::{Result, anyhow};
 use skippy_protocol::{FlashAttentionType, LoadMode, StageDevice};
 use tokio::sync::{Mutex as TokioMutex, oneshot};
@@ -79,6 +80,26 @@ fn coordinator_claim_from_load(
         topology_hash: "topology".to_string(),
         lease_until_unix_ms: u64::MAX,
     }
+}
+
+fn push_gguf_string(bytes: &mut Vec<u8>, value: &str) {
+    bytes.extend_from_slice(&(value.len() as u64).to_le_bytes());
+    bytes.extend_from_slice(value.as_bytes());
+}
+
+fn write_metadata_only_gguf(path: &std::path::Path, layer_count: u32) {
+    let mut bytes = Vec::new();
+    bytes.extend_from_slice(b"GGUF");
+    bytes.extend_from_slice(&3u32.to_le_bytes());
+    bytes.extend_from_slice(&0i64.to_le_bytes());
+    bytes.extend_from_slice(&2i64.to_le_bytes());
+    push_gguf_string(&mut bytes, "general.architecture");
+    bytes.extend_from_slice(&8u32.to_le_bytes());
+    push_gguf_string(&mut bytes, "deepseek4");
+    push_gguf_string(&mut bytes, "deepseek4.block_count");
+    bytes.extend_from_slice(&4u32.to_le_bytes());
+    bytes.extend_from_slice(&layer_count.to_le_bytes());
+    fs::write(path, bytes).unwrap();
 }
 
 struct BlockingPackagePrefetcher {
@@ -724,6 +745,40 @@ fn inventory_source_candidates_prefer_explicit_gguf_ref() {
     assert_eq!(
         candidates[0],
         std::path::PathBuf::from("/tmp/source-model.gguf")
+    );
+}
+
+#[test]
+fn inventory_source_resolves_metadata_only_first_shard() {
+    let dir = tempfile::tempdir().unwrap();
+    let first = dir.path().join("DeepSeek-V4-Flash-00001-of-00003.gguf");
+    write_metadata_only_gguf(&first, 61);
+    fs::write(
+        dir.path().join("DeepSeek-V4-Flash-00002-of-00003.gguf"),
+        vec![0u8; 7],
+    )
+    .unwrap();
+    fs::write(
+        dir.path().join("DeepSeek-V4-Flash-00003-of-00003.gguf"),
+        vec![0u8; 11],
+    )
+    .unwrap();
+    let expected_bytes = fs::metadata(&first).unwrap().len() + 7 + 11;
+
+    let inventory = resolve_inventory_source(&StageInventoryRequest {
+        model_id: "local-gguf/deepseek-v4-flash".to_string(),
+        package_ref: format!("gguf://{}", first.display()),
+        manifest_sha256: "manifest".to_string(),
+    })
+    .expect("metadata-only first shard should still advertise inventory");
+
+    assert_eq!(inventory.layer_count, 61);
+    assert_eq!(inventory.bytes, Some(expected_bytes));
+    assert_eq!(inventory.kind, SourceModelKind::SplitGguf);
+    assert!(
+        inventory
+            .path
+            .ends_with("DeepSeek-V4-Flash-00001-of-00003.gguf")
     );
 }
 


### PR DESCRIPTION

## Summary

Fixes direct split-GGUF stage inventory discovery for models whose first shard is metadata-only, stacked on #1194.

## Root cause

Stage inventory discovery inferred the layer count only by scanning tensor names. DeepSeek-V4 split GGUFs can place metadata in the first shard while storing all tensors in later shards, so the tensor scan returned no layers and the peer advertised an empty inventory. Split readiness then waited indefinitely even though the mesh connection itself was healthy.

## Fix

- Reuse direct-GGUF shard expansion to validate and enumerate every shard.
- Read the layer count from compact GGUF metadata first, retaining tensor inspection as a fallback.
- Compute the advertised source size across all validated shards.
- Add a regression test for a metadata-only first shard.

## Validation

- `just build`
- `cargo test -p mesh-llm-host-runtime --lib inventory_source_resolves_metadata_only_first_shard`
- `cargo fmt --all --check`
- `cargo check -p mesh-llm-host-runtime`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings -A unfulfilled-lint-expectations`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings -A unfulfilled-lint-expectations`

Strict clippy remains blocked by 28 pre-existing `unfulfilled_lint_expectations` errors in the parent PR branch; none are in this diff.
