### PR TITLE
fix: include Windows native library load details

### DIFF
--- a/crates/skippy-ffi/src/dynamic_library.rs
+++ b/crates/skippy-ffi/src/dynamic_library.rs
@@ -16,10 +16,28 @@ fn format_load_error(path: &Path, error: &libloading::Error) -> String {
             os_error,
         ),
         None => format!(
-            "failed to load native runtime library {}: {} (OS error 0)",
+            "failed to load native runtime library {}: {} (OS error {})",
             path.display(),
             error,
+            source_less_os_error_label(error),
         ),
+    }
+}
+
+fn source_less_os_error_label(error: &libloading::Error) -> &'static str {
+    #[cfg(target_os = "windows")]
+    {
+        if matches!(error, libloading::Error::LoadLibraryExWUnknown) {
+            "0"
+        } else {
+            "unavailable"
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    {
+        let _ = error;
+        "unavailable"
     }
 }
 
@@ -51,13 +69,41 @@ mod tests {
     #[test]
     fn load_error_includes_library_path_and_os_error() {
         let path = Path::new("mesh-llm-missing-native-runtime.dll");
-        let error = match unsafe { Library::new(path) } {
+        let expected_error = match unsafe { Library::new(path) } {
             Ok(_) => panic!("unexpectedly loaded missing test library"),
             Err(error) => error,
         };
 
-        let message = format_load_error(path, &error);
+        let message =
+            unsafe { super::load(path) }.expect_err("unexpectedly loaded missing test library");
         assert!(message.contains(path.to_string_lossy().as_ref()));
         assert!(message.contains("OS error"));
+        assert!(message.contains(&expected_error.to_string()));
+
+        if let Some(os_error) = std::error::Error::source(&expected_error)
+            .and_then(|source| source.downcast_ref::<std::io::Error>())
+            && let Some(code) = os_error.raw_os_error()
+        {
+            assert!(message.contains(&format!("OS error {code}")));
+        }
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    #[test]
+    fn source_less_non_windows_errors_report_unavailable_os_error() {
+        let path = Path::new("mesh-llm-missing-native-runtime.dll");
+        let message = format_load_error(path, &libloading::Error::DlOpenUnknown);
+
+        assert!(message.contains("OS error unavailable"));
+        assert!(!message.contains("OS error 0"));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn unknown_windows_errors_report_os_error_zero() {
+        let path = Path::new("mesh-llm-missing-native-runtime.dll");
+        let message = format_load_error(path, &libloading::Error::LoadLibraryExWUnknown);
+
+        assert!(message.contains("OS error 0"));
     }
 }

--- a/crates/skippy-ffi/src/dynamic_library.rs
+++ b/crates/skippy-ffi/src/dynamic_library.rs
@@ -1,18 +1,63 @@
 use libloading::Library;
+use std::error::Error;
+use std::io;
 use std::path::Path;
 
+fn format_load_error(path: &Path, error: &libloading::Error) -> String {
+    let os_error = error
+        .source()
+        .and_then(|source| source.downcast_ref::<io::Error>());
+    match os_error {
+        Some(os_error) => format!(
+            "failed to load native runtime library {}: {} (OS error {}: {})",
+            path.display(),
+            error,
+            os_error.raw_os_error().unwrap_or(0),
+            os_error,
+        ),
+        None => format!(
+            "failed to load native runtime library {}: {} (OS error 0)",
+            path.display(),
+            error,
+        ),
+    }
+}
+
 #[cfg(target_os = "windows")]
-pub(crate) unsafe fn load(path: &Path) -> Result<Library, libloading::Error> {
+pub(crate) unsafe fn load(path: &Path) -> Result<Library, String> {
     use libloading::os::windows::{LOAD_WITH_ALTERED_SEARCH_PATH, Library as WindowsLibrary};
 
     // LoadLibraryExW normally searches the application directory for a
     // dependent DLL, even when the requested DLL has an absolute path. Native
     // runtimes are installed elsewhere, so make the loaded DLL's directory the
     // first dependency search location.
-    unsafe { WindowsLibrary::load_with_flags(path, LOAD_WITH_ALTERED_SEARCH_PATH) }.map(Into::into)
+    let result = unsafe { WindowsLibrary::load_with_flags(path, LOAD_WITH_ALTERED_SEARCH_PATH) };
+    result
+        .map(Into::into)
+        .map_err(|error| format_load_error(path, &error))
 }
 
 #[cfg(not(target_os = "windows"))]
-pub(crate) unsafe fn load(path: &Path) -> Result<Library, libloading::Error> {
-    unsafe { Library::new(path) }
+pub(crate) unsafe fn load(path: &Path) -> Result<Library, String> {
+    unsafe { Library::new(path) }.map_err(|error| format_load_error(path, &error))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::format_load_error;
+    use libloading::Library;
+    use std::path::Path;
+
+    #[test]
+    fn load_error_includes_library_path_and_os_error() {
+        let path = Path::new("mesh-llm-missing-native-runtime.dll");
+        let error = match unsafe { Library::new(path) } {
+            Ok(_) => panic!("unexpectedly loaded missing test library"),
+            Err(error) => error,
+        };
+
+        let message = format_load_error(path, &error);
+        assert!(message.contains(path.to_string_lossy().as_ref()));
+        assert!(message.contains("OS error"));
+    }
 }


### PR DESCRIPTION
Fixes #1161

## What changed
- include the exact native runtime library path in dynamic-load failures
- preserve and report libloading's underlying OS error code and message, including an explicit zero when Windows reports no error
- add a unit test for diagnostic context

## Root cause
The loader converted `libloading::Error` to `to_string()`, which dropped the failing manifest library path and the underlying Windows error source. The host could therefore report only the runtime directory.

## Validation
- `cargo fmt --all -- --check`
- `cargo test -p skippy-ffi --lib`
- `cargo clippy -p skippy-ffi --all-targets -- -D warnings`

Windows-specific LoadLibraryExW validation still needs a Windows runner.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic library loading errors with clearer, more actionable messages.
  * Error messages now include the library path, underlying cause, and available operating system details.
  * Added consistent error reporting across supported platforms.
  * Added coverage to verify that load errors include useful diagnostic information, including cases where operating system details are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->