### PR TITLE
feat(openai): configure trusted agent session header

### DIFF
--- a/crates/openai-frontend/README.md
+++ b/crates/openai-frontend/README.md
@@ -50,6 +50,7 @@ For the concrete benchy command and contract, see
 | Request body limit | Supported | Configurable via `OpenAiFrontendConfig`; defaults to 4 MiB. |
 | Request IDs | Supported | Propagates or generates `x-request-id`, returns it on every response, and emits a tracing event with method, URI, status, and request ID. |
 | Backend timeout | Supported | Configurable via `OpenAiFrontendConfig`; defaults to 300 seconds and maps timeouts to OpenAI-shaped 504 errors. |
+| Agent session header | Supported | Set `MESH_AGENT_SESSION_HEADER` to accept a trusted upstream header as the stable agent-session identity. |
 | embeddings/rerank/infill/audio/vision | Out of scope | Not needed for staged text benchmark entrypoints. |
 
 ## Shape

--- a/crates/openai-frontend/src/router.rs
+++ b/crates/openai-frontend/src/router.rs
@@ -47,6 +47,13 @@ use crate::{
     sse::{done_event, json_event},
 };
 
+const AGENT_SESSION_HEADER_ENV: &str = "MESH_AGENT_SESSION_HEADER";
+
+fn configured_agent_session_header() -> Option<HeaderName> {
+    let value = std::env::var(AGENT_SESSION_HEADER_ENV).ok()?;
+    HeaderName::from_bytes(value.as_bytes()).ok()
+}
+
 #[derive(Clone)]
 struct FrontendState {
     backend: SharedBackend,
@@ -92,7 +99,7 @@ impl Default for OpenAiFrontendConfig {
         Self {
             max_request_body_bytes: Self::DEFAULT_MAX_REQUEST_BODY_BYTES,
             backend_timeout: Some(Self::DEFAULT_BACKEND_TIMEOUT),
-            agent_session_header: None,
+            agent_session_header: configured_agent_session_header(),
         }
     }
 }

--- a/crates/openai-frontend/src/router.rs
+++ b/crates/openai-frontend/src/router.rs
@@ -49,9 +49,33 @@ use crate::{
 
 const AGENT_SESSION_HEADER_ENV: &str = "MESH_AGENT_SESSION_HEADER";
 
-fn configured_agent_session_header() -> Option<HeaderName> {
-    let value = std::env::var(AGENT_SESSION_HEADER_ENV).ok()?;
+fn parse_agent_session_header(value: &str) -> Option<HeaderName> {
     HeaderName::from_bytes(value.as_bytes()).ok()
+}
+
+fn configured_agent_session_header() -> Option<HeaderName> {
+    let value = match std::env::var(AGENT_SESSION_HEADER_ENV) {
+        Ok(value) => value,
+        Err(std::env::VarError::NotPresent) => return None,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            tracing::warn!(
+                env = AGENT_SESSION_HEADER_ENV,
+                "ignoring non-UTF-8 trusted agent-session header configuration"
+            );
+            return None;
+        }
+    };
+    match parse_agent_session_header(&value) {
+        Some(header) => Some(header),
+        None => {
+            tracing::warn!(
+                env = AGENT_SESSION_HEADER_ENV,
+                value = %value,
+                "ignoring invalid trusted agent-session header configuration"
+            );
+            None
+        }
+    }
 }
 
 #[derive(Clone)]
@@ -722,6 +746,19 @@ mod tests {
     use tower::ServiceExt;
 
     use super::*;
+
+    #[test]
+    fn trusted_agent_session_header_parser_accepts_valid_names() {
+        assert_eq!(
+            parse_agent_session_header("x-litellm-session-id"),
+            Some(HeaderName::from_static("x-litellm-session-id"))
+        );
+    }
+
+    #[test]
+    fn trusted_agent_session_header_parser_rejects_invalid_names() {
+        assert!(parse_agent_session_header("not a header").is_none());
+    }
     use crate::{
         FinishReason,
         backend::{


### PR DESCRIPTION
## Problem

The OpenAI frontend supports a configurable trusted agent-session header, but the default router ignored that configuration. A Mesh process launched with a trusted upstream session-header setting therefore treated every request as stateless.

## Change

`OpenAiFrontendConfig::default()` now reads the optional `MESH_AGENT_SESSION_HEADER` environment variable and applies it as the trusted header. Existing callers remain unchanged when the variable is absent, and explicit `with_agent_session_header` configuration still takes precedence.

Invalid or non-UTF-8 values emit a startup warning and are ignored rather than silently looking like a valid configuration. Parser coverage covers valid and invalid names.

This keeps the boundary generic: Mesh does not hard-code Cacheline or a benchmark-specific header name.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p openai-frontend --lib` (153 passed)
- `cargo clippy -p openai-frontend --lib --all-targets -- -D warnings`