### PR TITLE
task: support Pascal GPUs in CUDA 12 runtimes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1019,8 +1019,8 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
     env:
       LLAMA_STAGE_BACKEND: cuda
-      LLAMA_STAGE_CUDA_ARCHITECTURES: "75;80;86;87;89;90"
-      LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-dynamic-cuda-sm75_80_86_87_89_90
+      LLAMA_STAGE_CUDA_ARCHITECTURES: "61;75;80;86;87;89;90"
+      LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-dynamic-cuda-sm61_75_80_86_87_89_90
       MESH_CUDA_VERSION: "12.9.2"
       MESH_LLM_CUDA_TOOLKIT_MAJOR: "12"
       # CI containers have no GPU driver (libcuda.so.1). Disable VMM and NCCL

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -538,8 +538,8 @@ jobs:
             cuda_major: '12'
             runner_image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:c5b85ef527230f77cf9933ef40bcb44316f9bbcb8fd2ce0651b58acda5143dfd
             toolchain_epoch: mesh-llm-cuda-runner-sha256-c5b85ef527230f77cf9933ef40bcb44316f9bbcb8fd2ce0651b58acda5143dfd
-            cuda_architectures: '75;80;86;87;89;90'
-            cuda_architectures_cache: '75_80_86_87_89_90'
+            cuda_architectures: '61;75;80;86;87;89;90'
+            cuda_architectures_cache: '61_75_80_86_87_89_90'
           - cuda_version: '13.1.2'
             cuda_major: '13'
             runner_image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:6b87598605f5d8deeafecfb1a55027e0ca9e47f4fc6f230d030487c450c31aa6
@@ -1434,7 +1434,7 @@ jobs:
         include:
           - name: CUDA
             backend: cuda
-            cuda_architectures: '75;80;86;87;89;90'
+            cuda_architectures: '61;75;80;86;87;89;90'
             artifact_name: release-native-runtime-windows-x86_64-cuda12
           - name: ROCm
             backend: rocm

--- a/Justfile
+++ b/Justfile
@@ -183,7 +183,7 @@ release-build-aarch64: release-host-build
 release-build-aarch64-cuda: release-host-build
     @cuda_version="${MESH_CUDA_VERSION:-12}"; \
       MESH_LLM_CUDA_TOOLKIT_MAJOR="${MESH_LLM_CUDA_TOOLKIT_MAJOR:-${cuda_version%%.*}}" \
-      LLAMA_STAGE_CUDA_ARCHITECTURES="$(if [[ "$cuda_version" == 13.* ]]; then echo '75;80;86;87;89;90;110'; else echo '75;80;86;87;89;90'; fi)" \
+      LLAMA_STAGE_CUDA_ARCHITECTURES="$(if [[ "$cuda_version" == 13.* ]]; then echo '75;80;86;87;89;90;110'; else echo '61;75;80;86;87;89;90'; fi)" \
       scripts/package-native-runtime.sh --build --backend cuda --target aarch64-unknown-linux-gnu
 
 # Prepare the pinned llama.cpp checkout and apply the Mesh-LLM ABI patch queue.
@@ -209,10 +209,10 @@ release-host-build-windows:
 release-build-cuda: release-host-build
     @cuda_version="${MESH_CUDA_VERSION:-12}"; \
       MESH_LLM_CUDA_TOOLKIT_MAJOR="${MESH_LLM_CUDA_TOOLKIT_MAJOR:-${cuda_version%%.*}}" \
-      LLAMA_STAGE_CUDA_ARCHITECTURES="$(if [[ "$cuda_version" == 13.* ]]; then echo '75;80;86;87;89;90;100;103;120;121'; else echo '75;80;86;87;89;90'; fi)" \
+      LLAMA_STAGE_CUDA_ARCHITECTURES="$(if [[ "$cuda_version" == 13.* ]]; then echo '75;80;86;87;89;90;100;103;120;121'; else echo '61;75;80;86;87;89;90'; fi)" \
       scripts/package-native-runtime.sh --build --backend cuda --target x86_64-unknown-linux-gnu
 
-release-build-cuda-windows cuda_arch="75;80;86;87;89;90":
+release-build-cuda-windows cuda_arch="61;75;80;86;87;89;90":
     @powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-windows.ps1 -Backend cuda -CudaArch "{{ cuda_arch }}" -BuildProfile release -DynamicHost
 
 # Build a Linux ROCm ABI release artifact with an explicit architecture list.

--- a/crates/mesh-llm-native-runtime/src/resolver.rs
+++ b/crates/mesh-llm-native-runtime/src/resolver.rs
@@ -875,6 +875,27 @@ mod tests {
     }
 
     #[test]
+    fn cuda12_runtime_with_pascal_arch_is_selected_for_61() {
+        let mut host = profile();
+        host.cuda.as_mut().unwrap().gpu_arches = BTreeSet::from(["61".to_string()]);
+        let manifest = NativeRuntimeReleaseManifest {
+            mesh_version: "0.68.0".to_string(),
+            skippy_abi: "0.1.25".to_string(),
+            artifacts: vec![cuda_runtime(
+                "meshllm-runtime-linux-x86_64-cuda12",
+                12,
+                &["61", "75", "80", "86", "87", "89", "90"],
+            )],
+        };
+
+        let selected =
+            select_native_runtime(&manifest, &host, "0.68.0", &RuntimeSelection::Recommended)
+                .expect("CUDA 12 runtime with Pascal kernels should be compatible");
+
+        assert_eq!(selected.artifact.id, "meshllm-runtime-linux-x86_64-cuda12");
+    }
+
+    #[test]
     fn unsupported_rocm_apu_arch_falls_back_to_cpu() {
         let manifest = NativeRuntimeReleaseManifest {
             mesh_version: "0.68.0".to_string(),

--- a/docs/cuda-release-lanes.md
+++ b/docs/cuda-release-lanes.md
@@ -29,7 +29,7 @@ workflow builds both.
 
 | Asset suffix | Toolkit | Arch coverage | Driver requirement |
 |---|---|---|---|
-| `-cuda` (primary) | CUDA 12.6.3 | sm_61, sm_75, sm_80, sm_86, sm_87, sm_89, sm_90 (Pascal → Hopper) | R535+ (CUDA 12.2 native) |
+| `-cuda` (primary) | CUDA 12.9.2 | sm_61, sm_75, sm_80, sm_86, sm_87, sm_89, sm_90 (Pascal → Hopper) | R535+ (CUDA 12.2 native) |
 | `-cuda-blackwell` | CUDA 12.8 | sm_75..sm_90 plus sm_100, sm_120 (adds Blackwell) | R550+ (CUDA 12.4 native) |
 
 - **Primary `-cuda`** covers the currently-deployed A30/A100/Ada/Hopper

--- a/docs/cuda-release-lanes.md
+++ b/docs/cuda-release-lanes.md
@@ -29,7 +29,7 @@ workflow builds both.
 
 | Asset suffix | Toolkit | Arch coverage | Driver requirement |
 |---|---|---|---|
-| `-cuda` (primary) | CUDA 12.6.3 | sm_75, sm_80, sm_86, sm_87, sm_89, sm_90 (Turing → Hopper) | R535+ (CUDA 12.2 native) |
+| `-cuda` (primary) | CUDA 12.6.3 | sm_61, sm_75, sm_80, sm_86, sm_87, sm_89, sm_90 (Pascal → Hopper) | R535+ (CUDA 12.2 native) |
 | `-cuda-blackwell` | CUDA 12.8 | sm_75..sm_90 plus sm_100, sm_120 (adds Blackwell) | R550+ (CUDA 12.4 native) |
 
 - **Primary `-cuda`** covers the currently-deployed A30/A100/Ada/Hopper

--- a/scripts/tests/test_ci_workflow_artifacts.py
+++ b/scripts/tests/test_ci_workflow_artifacts.py
@@ -107,7 +107,7 @@ class CiWorkflowArtifactTests(unittest.TestCase):
         expected = {
             "cuda": (
                 "sha256:c5b85ef527230f77cf9933ef40bcb44316f9bbcb8fd2ce0651b58acda5143dfd",
-                'LLAMA_STAGE_CUDA_ARCHITECTURES: "75;80;86;87;89;90"',
+                'LLAMA_STAGE_CUDA_ARCHITECTURES: "61;75;80;86;87;89;90"',
             ),
             "rocm": (
                 "sha256:0e13e5d2d2c121df265ff6c69be81e468989e09f81d6b7ff049b110cc0bb0d2b",

--- a/scripts/tests/test_ci_workflow_artifacts.py
+++ b/scripts/tests/test_ci_workflow_artifacts.py
@@ -136,6 +136,13 @@ class CiWorkflowArtifactTests(unittest.TestCase):
                 )
                 self.assertIn(image, runtime)
                 self.assertIn(backend_env, runtime)
+                if backend == "cuda":
+                    self.assertIn(
+                        "LLAMA_STAGE_BUILD_DIR: "
+                        ".deps/llama-build/build-stage-abi-dynamic-cuda-"
+                        "sm61_75_80_86_87_89_90",
+                        runtime,
+                    )
                 self.assertIn(
                     "uses: ./.github/actions/prepare-native-runtime-input",
                     runtime,

--- a/scripts/tests/test_justfile_release_runtime.py
+++ b/scripts/tests/test_justfile_release_runtime.py
@@ -38,6 +38,22 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
                 recipe,
             )
 
+    def test_cuda12_release_recipes_include_pascal_sm61(self) -> None:
+        contents = JUSTFILE.read_text(encoding="utf-8")
+
+        self.assertIn(
+            "else echo '61;75;80;86;87;89;90'",
+            self.recipe("release-build-cuda"),
+        )
+        self.assertIn(
+            "else echo '61;75;80;86;87;89;90'",
+            self.recipe("release-build-aarch64-cuda"),
+        )
+        self.assertIn(
+            'release-build-cuda-windows cuda_arch="61;75;80;86;87;89;90"',
+            contents,
+        )
+
     def test_bundle_uses_the_product_packager_and_copies_its_checksum(self) -> None:
         recipe = self.recipe("bundle")
 

--- a/scripts/tests/test_justfile_release_runtime.py
+++ b/scripts/tests/test_justfile_release_runtime.py
@@ -50,6 +50,14 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
             self.recipe("release-build-aarch64-cuda"),
         )
         self.assertIn(
+            "if [[ \"$cuda_version\" == 13.* ]]; then echo '75;80;86;87;89;90;100;103;120;121'",
+            self.recipe("release-build-cuda"),
+        )
+        self.assertIn(
+            "if [[ \"$cuda_version\" == 13.* ]]; then echo '75;80;86;87;89;90;110'",
+            self.recipe("release-build-aarch64-cuda"),
+        )
+        self.assertIn(
             'release-build-cuda-windows cuda_arch="61;75;80;86;87;89;90"',
             contents,
         )

--- a/scripts/tests/test_release_workflow_artifacts.py
+++ b/scripts/tests/test_release_workflow_artifacts.py
@@ -557,6 +557,14 @@ class ReleaseWorkflowArtifactTests(unittest.TestCase):
             linux_cuda,
         )
         self.assertIn(
+            "cuda_architectures: '75;80;86;87;89;90;100;103;120;121'",
+            linux_cuda,
+        )
+        self.assertIn(
+            "cuda_architectures_cache: '75_80_86_87_89_90_100_103_120_121'",
+            linux_cuda,
+        )
+        self.assertIn(
             "cuda_architectures: '61;75;80;86;87;89;90'",
             windows_cuda,
         )

--- a/scripts/tests/test_release_workflow_artifacts.py
+++ b/scripts/tests/test_release_workflow_artifacts.py
@@ -535,6 +535,32 @@ class ReleaseWorkflowArtifactTests(unittest.TestCase):
             producer,
         )
 
+    def test_cuda12_release_runtime_includes_pascal_sm61(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        linux_cuda = job_block(
+            workflow,
+            "build_native_runtime_linux_x86_64_cuda",
+            "build_native_runtime_linux_x86_64_rocm",
+        )
+        windows_cuda = job_block(
+            workflow,
+            "build_native_runtime_windows_gpu",
+            "publish",
+        )
+
+        self.assertIn(
+            "cuda_architectures: '61;75;80;86;87;89;90'",
+            linux_cuda,
+        )
+        self.assertIn(
+            "cuda_architectures_cache: '61_75_80_86_87_89_90'",
+            linux_cuda,
+        )
+        self.assertIn(
+            "cuda_architectures: '61;75;80;86;87;89;90'",
+            windows_cuda,
+        )
+
     def test_linux_cuda_composition_uses_hosted_runner(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         composer = job_block(


### PR DESCRIPTION
Closes #1203

## Summary

Add Pascal `sm_61` coverage to the CUDA 12 native-runtime lane so GPUs such as the NVIDIA Quadro P5000 can select the published Linux x86_64 CUDA runtime.

## Root cause

The CUDA 12 runtime was built only for `75, 80, 86, 87, 89, 90`, so runtime selection correctly rejected hosts reporting compute capability `61`.

## Changes

- Add `61` to the CUDA 12 Linux x86_64 release artifact.
- Add the same coverage to the Windows CUDA 12 release artifact and local release recipes.
- Extend the main CUDA compatibility build to compile the Pascal target.
- Add resolver, workflow, and recipe regression tests.
- Document Pascal coverage in the CUDA release-lane guide.
- Keep CUDA 13/Blackwell architecture coverage unchanged.

## Validation

Passed:
- `cargo fmt --all --check`
- `cargo test --locked -p mesh-llm-native-runtime --lib`
- `cargo check --locked -p mesh-llm-native-runtime`
- `cargo clippy --locked -p mesh-llm-native-runtime --all-targets -- -D warnings`
- `actionlint -config-file .github/actionlint.yaml`
- 47 workflow/recipe contract tests
- 7 native-runtime packaging tests
- `git diff --check`

`cargo check --locked -p mesh-llm` passed. The shipped-binary clippy gate remains blocked by 28 pre-existing unfulfilled `dead_code` lint expectations in `mesh-llm-host-runtime`; no changed file is involved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added CUDA 12 runtime support for Pascal GPUs (SM 6.1) across Linux, Windows, and ARM64 release builds.
  * Expanded the primary CUDA release lane to support Pascal through Hopper architectures.
  * Updated the primary CUDA release lane to CUDA 12.9.2.

* **Bug Fixes**
  * Improved runtime selection for hosts using Pascal GPUs.

* **Tests**
  * Added coverage verifying Pascal architecture support in runtime builds, release recipes, and workflow artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->