### PR TITLE
fix(skippy): wake split generation on prediction-return EOF

### DIFF
--- a/crates/skippy-server/src/binary_transport/direct_return.rs
+++ b/crates/skippy-server/src/binary_transport/direct_return.rs
@@ -547,7 +547,7 @@ mod tests {
         let session_id = 67;
         let hub = Arc::new(PredictionReturnHub::default());
         let receiver = hub.register(request_id, session_id).unwrap();
-        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let listener = TcpListener::bind("localhost:0").unwrap();
         let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
         let (server, _) = listener.accept().unwrap();
         let open = prediction_return_open_message(request_id, session_id);

--- a/crates/skippy-server/src/binary_transport/direct_return.rs
+++ b/crates/skippy-server/src/binary_transport/direct_return.rs
@@ -193,7 +193,12 @@ impl PredictionReturnHub {
                         return Ok(());
                     }
                 }
-                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(()),
+                Err(error) if error.kind() == std::io::ErrorKind::UnexpectedEof => {
+                    let _ = sender.send(Err(format!(
+                        "direct prediction return closed before the next reply: {error}"
+                    )));
+                    return Ok(());
+                }
                 Err(error) => {
                     let _ = sender.send(Err(error.to_string()));
                     return Err(error).context("read direct prediction return");
@@ -534,6 +539,30 @@ mod tests {
                 .is_none()
         );
         assert!(started.elapsed() >= Duration::from_millis(8));
+    }
+
+    #[test]
+    fn closed_prediction_return_wakes_waiter_with_error() {
+        let request_id = 61;
+        let session_id = 67;
+        let hub = Arc::new(PredictionReturnHub::default());
+        let receiver = hub.register(request_id, session_id).unwrap();
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (server, _) = listener.accept().unwrap();
+        let open = prediction_return_open_message(request_id, session_id);
+        let handle = {
+            let hub = hub.clone();
+            thread::spawn(move || hub.handle_return_connection(open, server))
+        };
+
+        drop(client);
+
+        let error = receiver
+            .recv_expected_timeout(WireReplyKind::PredictedToken, Duration::from_secs(1))
+            .expect_err("closed prediction return must wake the waiter");
+        assert!(error.to_string().contains("closed before the next reply"));
+        handle.join().unwrap().unwrap();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #951.

A direct prediction-return stream can close cleanly while a split generation is waiting for its next reply. The prediction-return hub previously treated that EOF as a normal end-of-stream and did not notify the waiting generation. The stage-0 request then waited for the full reply timeout before entering the existing stop/reconnect path, leaving the split lane unavailable for subsequent requests and producing the long hangs/502s described in #951.

This change:

- reports clean direct-return EOF to the waiting generation as an error;
- lets the existing generation cleanup retire and replace the affected lane immediately;
- adds a regression test proving that a closed return stream wakes its waiter.

## Validation

- `cargo fmt --all --check`
- `cargo test -p skippy-server --lib` — 383 passed
- `cargo check -p skippy-server`
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings` is blocked by 28 pre-existing `unfulfilled_lint_expectations` errors in `mesh-llm-host-runtime`; none are in the changed file or caused by this patch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of interrupted prediction responses.
  * Waiting requests now receive a clear error instead of remaining pending when a response connection closes unexpectedly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->