### PR TITLE
fix(client): prevent auto model assignment

### DIFF
--- a/crates/mesh-llm-host-runtime/src/runtime/auto_join.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/auto_join.rs
@@ -470,8 +470,16 @@ pub(super) async fn pick_model_assignment(
             let Some(size_label) = cat.size.as_deref() else {
                 continue;
             };
-            let size_bytes = parse_size_str(size_label);
-            let needed = (size_bytes as f64 * 1.1) as u64;
+            let Some(needed) = catalog_model_required_bytes(size_label) else {
+                let _ = emit_event(OutputEvent::Info {
+                    message: format!(
+                        "Skipping {} — catalog size {:?} is missing or invalid",
+                        m, size_label
+                    ),
+                    context: None,
+                });
+                continue;
+            };
             if needed <= my_vram {
                 downloadable.push((m.clone(), d.request_count));
             } else {
@@ -540,6 +548,24 @@ pub(super) async fn pick_model_assignment_for_role(
         None
     } else {
         pick_model_assignment(node, local_models).await
+    }
+}
+
+pub(super) fn catalog_model_required_bytes(size_label: &str) -> Option<u64> {
+    parse_size_str(size_label)
+        .filter(|size| *size > 0)
+        .map(|size| (size as f64 * 1.1) as u64)
+}
+
+pub(super) async fn pick_run_auto_model_assignment(
+    is_client: bool,
+    node: &mesh::Node,
+    local_models: &[String],
+) -> Option<String> {
+    if is_client {
+        None
+    } else {
+        pick_model_assignment_for_role(node, local_models).await
     }
 }
 
@@ -1129,7 +1155,8 @@ pub(super) async fn select_run_auto_model_path(
     });
     tokio::time::sleep(std::time::Duration::from_secs(5)).await;
 
-    let assignment = pick_model_assignment_for_role(ctx.node, ctx.local_models).await;
+    let assignment =
+        pick_run_auto_model_assignment(ctx.is_client, ctx.node, ctx.local_models).await;
     let assignment = if assignment.is_none()
         && (ctx.options.auto || ctx.options.discover.is_some())
         && !ctx.is_client

--- a/crates/mesh-llm-host-runtime/src/runtime/startup_models.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/startup_models.rs
@@ -1038,14 +1038,14 @@ pub(super) fn should_show_serve_config_help(
         reason = "legacy size parsing remains covered by capacity compatibility tests"
     )
 )]
-pub(super) fn parse_size_str(s: &str) -> u64 {
+pub(super) fn parse_size_str(s: &str) -> Option<u64> {
     let s = s.trim();
     if let Some(gb) = s.strip_suffix("GB") {
-        (gb.parse::<f64>().unwrap_or(0.0) * 1e9) as u64
+        gb.parse::<f64>().ok().map(|gb| (gb * 1e9) as u64)
     } else if let Some(mb) = s.strip_suffix("MB") {
-        (mb.parse::<f64>().unwrap_or(0.0) * 1e6) as u64
+        mb.parse::<f64>().ok().map(|mb| (mb * 1e6) as u64)
     } else {
-        0
+        None
     }
 }
 

--- a/crates/mesh-llm-host-runtime/src/runtime/tests/auto_join.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/tests/auto_join.rs
@@ -87,6 +87,29 @@ async fn model_assignment_is_derived_from_node_role() {
     );
 }
 
+#[tokio::test]
+async fn client_mode_skips_model_assignment_even_for_worker_role() {
+    let node = mesh::Node::new_for_tests(mesh::NodeRole::Worker)
+        .await
+        .expect("test node");
+
+    assert_eq!(
+        pick_run_auto_model_assignment(true, &node, &["model-on-disk".to_string()]).await,
+        None,
+        "client mode must enter the passive proxy path without checking assignments"
+    );
+}
+
+#[test]
+fn catalog_size_parser_rejects_unknown_and_zero_sizes() {
+    assert_eq!(parse_size_str("36 layers"), None);
+    assert_eq!(parse_size_str("0GB"), Some(0));
+    assert_eq!(parse_size_str("12.5GB"), Some(12_500_000_000));
+    assert_eq!(catalog_model_required_bytes("36 layers"), None);
+    assert_eq!(catalog_model_required_bytes("0GB"), None);
+    assert_eq!(catalog_model_required_bytes("1GB"), Some(1_100_000_000));
+}
+
 fn make_cli(args: &[&str]) -> RuntimeOptions {
     runtime_options_for_test(args)
 }


### PR DESCRIPTION
## Summary

- Keep `mesh-llm client --auto` out of model assignment regardless of node role.
- Treat unknown, invalid, and zero catalog sizes as ineligible for automatic downloads.
- Add regression coverage for client-only assignment and catalog-size handling.

## Root cause

The legacy automatic model-selection path invoked model assignment before applying the explicit client-mode invariant. Catalog size parsing also collapsed unrecognized values such as `36 layers` to zero, allowing a zero-capacity client to appear eligible.

## Validation

- `cargo test -p mesh-llm-host-runtime --lib runtime::tests::auto_join` (29 passed)
- `cargo check -p mesh-llm-host-runtime`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -A unfulfilled-lint-expectations -D warnings`
- `cargo fmt --all --check`
- `git diff --check`

The exact clippy `-D warnings` command is currently blocked by pre-existing `unfulfilled_lint_expectations` warnings in unrelated compatibility code.

Closes #1072

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model size validation by rejecting missing, invalid, zero, and unsupported values.
  * Prevented automatic model assignment in client mode.
  * Ensured worker nodes are not assigned unusable models.

* **Tests**
  * Added coverage for client-mode assignment behavior and various catalog size formats, including decimal values and unsupported units.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->