### PR TITLE
fix: remove stale ngram app-tab option

### DIFF
--- a/crates/mesh-llm-ui/src/features/app-tabs/data.test.ts
+++ b/crates/mesh-llm-ui/src/features/app-tabs/data.test.ts
@@ -142,7 +142,7 @@ describe('CONFIGURATION_DEFAULTS', () => {
 
   it('uses current speculation values and includes incoming draft tuning controls', () => {
     expectChoice('speculation-mode', 'mode', 'auto', 'segmented')
-    expect(choiceValues('speculation-mode')).toEqual(['auto', 'disabled', 'draft', 'ngram'])
+    expect(choiceValues('speculation-mode')).toEqual(['auto', 'disabled', 'draft'])
     expectChoice('incompatible-pairing-behavior', 'pairing_fault', 'warn_disable', 'toggle')
     expect(choiceValues('incompatible-pairing-behavior')).toEqual(['warn_disable', 'fail_closed'])
 

--- a/crates/mesh-llm-ui/src/features/app-tabs/data.ts
+++ b/crates/mesh-llm-ui/src/features/app-tabs/data.ts
@@ -1206,8 +1206,7 @@ export const CONFIGURATION_DEFAULTS = {
         options: [
           { value: 'auto', label: 'auto' },
           { value: 'disabled', label: 'disabled' },
-          { value: 'draft', label: 'draft' },
-          { value: 'ngram', label: 'n-gram' }
+          { value: 'draft', label: 'draft' }
         ]
       }
     },

--- a/crates/mesh-llm-ui/src/features/configuration/pages/ConfigurationPage.test.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/pages/ConfigurationPage.test.tsx
@@ -1605,11 +1605,6 @@ describe('ConfigurationPage', () => {
     await user.click(screen.getByRole('button', { name: /show advanced/i }))
     expect(screen.getByRole('slider', { name: 'Default draft acceptance threshold' })).toBeDisabled()
 
-    await user.click(modeControl().getByRole('radio', { name: 'n-gram' }))
-    expect(draftPolicyControl().getByRole('radio', { name: 'auto' })).toBeDisabled()
-    expect(pairingBehaviorControl().getByRole('radio', { name: 'Warn & Disable' })).toBeDisabled()
-    expect(screen.getByRole('slider', { name: 'Default draft max tokens' })).toBeDisabled()
-
     await user.click(modeControl().getByRole('radio', { name: 'draft' }))
     expect(draftPolicyControl().getByRole('radio', { name: 'auto' })).not.toBeDisabled()
     expect(pairingBehaviorControl().getByRole('radio', { name: 'Warn & Disable' })).not.toBeDisabled()


### PR DESCRIPTION
Fixes #1056.

The app-tabs configuration surface still exposed `ngram` even though the backend schema and configuration UI no longer accept it. This removes the stale option and updates the app-tabs regression test to keep the UI aligned with the supported values: `auto`, `disabled`, and `draft`.

Validation:
- `pnpm exec vitest run src/features/app-tabs/data.test.ts`
- `just build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Updates**
  - Removed the obsolete **n-gram** option from the speculation mode setting.
  - Speculation mode now supports **Auto**, **Disabled**, and **Draft**.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->