### PR TITLE
docs: document libgomp1 for minimal Linux images

### DIFF
--- a/website/src/docs/pages/installing-linux.md
+++ b/website/src/docs/pages/installing-linux.md
@@ -30,6 +30,15 @@ sudo apt-get update
 sudo apt-get install -y libgomp1
 ```
 
+When building a container image, the build usually runs as `root`, so use the
+equivalent Dockerfile form without `sudo` and clean up the apt lists:
+
+```Dockerfile
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libgomp1 \
+ && rm -rf /var/lib/apt/lists/*
+```
+
 This is especially important for `nvidia/cuda:*runtime` images, which commonly
 omit `libgomp1`. The maintained Mesh OCI images already include this package.
 

--- a/website/src/docs/pages/installing-linux.md
+++ b/website/src/docs/pages/installing-linux.md
@@ -20,6 +20,19 @@ Check the install:
 mesh-llm --version
 ```
 
+### Minimal Linux images
+
+The Linux native runtime uses the GNU OpenMP runtime. On minimal Debian or
+Ubuntu images, install `libgomp1` before running Mesh:
+
+```sh
+sudo apt-get update
+sudo apt-get install -y libgomp1
+```
+
+This is especially important for `nvidia/cuda:*runtime` images, which commonly
+omit `libgomp1`. The maintained Mesh OCI images already include this package.
+
 ## Native packages and containers
 
 Versioned Ubuntu 24.04 `.deb` and Arch Linux `.pkg.tar.zst` files are published


### PR DESCRIPTION
## Summary

- document the `libgomp1` runtime prerequisite for minimal Debian/Ubuntu Linux images
- call out the common `nvidia/cuda:*runtime` case from issue #931
- note that the maintained Mesh OCI images already include the dependency

## Root cause

The Linux native runtime uses GNU OpenMP. Minimal CUDA runtime images commonly omit `libgomp1`, causing the installed Mesh binary/runtime to fail before startup with `libgomp.so.1: cannot open shared object file`.

## Validation

- `git diff --check`
- `just website-build`

Fixes #931


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added installation guidance for minimal Debian and Ubuntu images.
  * Documented the need to install the GNU OpenMP runtime package before running Mesh, especially with CUDA runtime images.
  * Clarified that Mesh-maintained OCI images already include this package.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->