### PR TITLE
Upgrade nostr-sdk to 0.45.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -432,20 +432,21 @@ dependencies = [
 
 [[package]]
 name = "async-wsocket"
-version = "0.13.2"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c92385c7c8b3eb2de1b78aeca225212e4c9a69a78b802832759b108681a5069"
+checksum = "2c713e1f14c7b82e32ea159af1c6e2f070cfadbdf23fb2512acce9af0a26f1a2"
 dependencies = [
- "async-utility",
  "futures",
  "futures-util",
  "js-sys",
  "tokio",
+ "tokio-happy-eyeballs",
  "tokio-rustls",
  "tokio-socks",
  "tokio-tungstenite",
  "url",
  "wasm-bindgen",
+ "wasm-bindgen-futures",
  "web-sys",
 ]
 
@@ -468,12 +469,6 @@ checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
 dependencies = [
  "bytemuck",
 ]
-
-[[package]]
-name = "atomic-destructor"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef49f5882e4b6afaac09ad239a4f8c70a24b8f2b0897edb1f706008efd109cf4"
 
 [[package]]
 name = "atomic-waker"
@@ -613,9 +608,9 @@ dependencies = [
 
 [[package]]
 name = "bech32"
-version = "0.11.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
+checksum = "efbd3e1070bbdf4cd88a75264e18e8a26f7cb5c6949eadf0ceb85fb159cf08f8"
 
 [[package]]
 name = "bip39"
@@ -623,7 +618,7 @@ version = "2.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "90dbd31c98227229239363921e60fcf5e558e43ec69094d46fc4996f08d1d5bc"
 dependencies = [
- "bitcoin_hashes",
+ "bitcoin_hashes 0.14.101",
  "serde",
  "unicode-normalization",
 ]
@@ -658,7 +653,7 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b2d6094e2a1ba3c93b5a596fe5a10d1a10c3c6e06785cde89f693a044c01aa40"
 dependencies = [
- "bitcoin-internals",
+ "bitcoin-internals 0.5.0",
 ]
 
 [[package]]
@@ -669,6 +664,12 @@ checksum = "a30a22d1f112dde8e16be7b45c63645dc165cef254f835b3e1e9553e485cfa64"
 dependencies = [
  "hex-conservative 0.3.2",
 ]
+
+[[package]]
+name = "bitcoin-internals"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d573f4cf32996a8dce612e4348cece65a241f1882ed594047c9ba348e8869fa5"
 
 [[package]]
 name = "bitcoin-io"
@@ -687,6 +688,17 @@ checksum = "bca4c7abb40c8817d77403c880988cfd484f23ab2365726afb2f798363e2c4a2"
 dependencies = [
  "bitcoin-io",
  "hex-conservative 0.2.2",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5304e53726dbe5f93141535e102ed97b5bf4714fbecefdda8f9fb98d7fdaff0e"
+dependencies = [
+ "bitcoin-consensus-encoding",
+ "bitcoin-internals 0.6.0",
+ "hex-conservative 1.2.0",
  "serde",
 ]
 
@@ -1952,6 +1964,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
 
 [[package]]
+name = "faster-hex"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7223ae2d2f179b803433d9c830478527e92b8117eab39460edae7f1614d9fb73"
+dependencies = [
+ "heapless",
+ "serde",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2410,6 +2432,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2462,6 +2493,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0049b265b7f201ca9ab25475b22b47fe444060126a51abe00f77d986fc5cc52e"
 
 [[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2493,6 +2534,15 @@ name = "hex-conservative"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "hex-conservative"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35431185f361ccf3ffc58254628af5f1f5d5f28531da2e02e5d6c82bbc282a10"
 dependencies = [
  "arrayvec",
 ]
@@ -3025,18 +3075,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if 1.0.4",
- "js-sys",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "ipconfig"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3210,7 +3248,7 @@ dependencies = [
  "iroh-base",
  "iroh-dns",
  "iroh-metrics",
- "lru 0.18.0",
+ "lru",
  "n0-error",
  "n0-future",
  "noq",
@@ -3571,12 +3609,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
 ]
-
-[[package]]
-name = "lru"
-version = "0.16.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 
 [[package]]
 name = "lru"
@@ -4814,79 +4846,70 @@ dependencies = [
 
 [[package]]
 name = "nostr"
-version = "0.44.4"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98cf5d15d70d1f8f4059e5f79923ac15891eb691d2843d01191e0585fb064d70"
+checksum = "5dde8c76076d334409d86c2e1db3e97abe5deb8cb92744f939cbc1fa45bd69e7"
 dependencies = [
  "base64",
  "bech32",
  "bip39",
- "bitcoin_hashes",
+ "bitcoin_hashes 1.2.0",
  "cbc",
  "chacha20 0.9.1",
  "chacha20poly1305",
- "getrandom 0.2.17",
- "hex",
- "instant",
- "scrypt",
+ "faster-hex",
+ "opaquerr",
+ "rand 0.10.1",
  "secp256k1",
  "serde",
  "serde_json",
  "unicode-normalization",
+ "universal-time",
  "url",
+ "zeroize",
 ]
 
 [[package]]
 name = "nostr-database"
-version = "0.44.0"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7462c9d8ae5ef6a28d66a192d399ad2530f1f2130b13186296dbb11bdef5b3d1"
+checksum = "4b1fdb9fcba732e32719662afad1b267e50322dbe89e506017ec13f24361bddf"
 dependencies = [
- "lru 0.16.4",
  "nostr",
- "tokio",
+ "opaquerr",
 ]
 
 [[package]]
 name = "nostr-gossip"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade30de16869618919c6b5efc8258f47b654a98b51541eb77f85e8ec5e3c83a6"
+checksum = "fa07539e52a71cb91fe0d693facaa298f03fcf9edcd66a521094e18e286e2336"
 dependencies = [
  "nostr",
-]
-
-[[package]]
-name = "nostr-relay-pool"
-version = "0.44.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91b2c039df4f96c4bf7dae52a74fd5516ad6dda83a11c0c69dea91b5255a4f37"
-dependencies = [
- "async-utility",
- "async-wsocket",
- "atomic-destructor",
- "hex",
- "lru 0.16.4",
- "negentropy",
- "nostr",
- "nostr-database",
- "tokio",
- "tracing",
+ "opaquerr",
 ]
 
 [[package]]
 name = "nostr-sdk"
-version = "0.44.1"
+version = "0.45.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "471732576710e779b64f04c55e3f8b5292f865fea228436daf19694f0bf70393"
+checksum = "26c86342f367bd9b173ec4a697e936e3a82d6dad5b4aa06c0d35d9b4f88a8e72"
 dependencies = [
  "async-utility",
+ "async-wsocket",
+ "faster-hex",
+ "futures",
+ "lru",
+ "negentropy",
  "nostr",
  "nostr-database",
  "nostr-gossip",
- "nostr-relay-pool",
+ "opaquerr",
+ "rand 0.10.1",
  "tokio",
+ "tokio-stream",
  "tracing",
+ "universal-time",
 ]
 
 [[package]]
@@ -5202,6 +5225,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
+name = "opaquerr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f933a4265d5cdad61d19bbdfc972ea5726d56cd8d3d57b8f2d3c365dd42bee9"
+
+[[package]]
 name = "openai-frontend"
 version = "0.72.1"
 dependencies = [
@@ -5472,16 +5501,6 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
-
-[[package]]
-name = "pbkdf2"
-version = "0.12.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ed6a7761f76e3b9f92dfb0a60a6a6477c61024b775147ff0973a02653abaf2"
-dependencies = [
- "digest 0.10.7",
- "hmac",
-]
 
 [[package]]
 name = "pem"
@@ -6245,7 +6264,7 @@ dependencies = [
  "hashbrown 0.17.1",
  "itertools",
  "kasuari",
- "lru 0.18.0",
+ "lru",
  "palette",
  "serde",
  "strum",
@@ -6916,26 +6935,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "scrypt"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0516a385866c09368f0b5bcd1caff3366aace790fcd46e2bb032697bb172fd1f"
-dependencies = [
- "password-hash",
- "pbkdf2",
- "salsa20",
- "sha2 0.10.9",
-]
-
-[[package]]
 name = "secp256k1"
-version = "0.29.1"
+version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
+ "bitcoin_hashes 0.14.101",
  "rand 0.8.6",
  "secp256k1-sys",
- "serde",
 ]
 
 [[package]]
@@ -8018,6 +8025,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-happy-eyeballs"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8564c32dfb6f4257f8bc6edfc178a34af97520e0b7b9815500c55eb3d092f29f"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8113,9 +8129,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9daff607c6d2bf6c16fd681ccb7eecc83e4e2cdc1ca067ffaadfca5de7f084"
+checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
 dependencies = [
  "futures-util",
  "log",
@@ -8450,9 +8466,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.26.2"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
+checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
 dependencies = [
  "bytes",
  "data-encoding",
@@ -8698,6 +8714,12 @@ dependencies = [
  "crypto-common 0.1.7",
  "subtle",
 ]
+
+[[package]]
+name = "universal-time"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47a939edecc3c5a7b83c02e5f6b3c31d2bc69eabcc9a87ab12c6d37ee6dbc856"
 
 [[package]]
 name = "unsafe-libyaml"

--- a/crates/mesh-client/Cargo.toml
+++ b/crates/mesh-client/Cargo.toml
@@ -34,7 +34,7 @@ tokio = { version = "1", features = ["io-util", "sync", "net", "time", "rt-multi
 prost = "0.14"
 bytes = "1"
 anyhow = "1"
-nostr-sdk = { version = "0.44.1", default-features = false }
+nostr-sdk = { version = "0.45.1", default-features = false }
 rustls = "0.23"
 thiserror = "2"
 serde = { version = "1", features = ["derive"] }

--- a/crates/mesh-client/src/network/nostr.rs
+++ b/crates/mesh-client/src/network/nostr.rs
@@ -77,7 +77,7 @@ pub struct Publisher {
 impl Publisher {
     pub async fn new(keys: Keys, relays: &[String]) -> Result<Self> {
         let _ = rustls::crypto::ring::default_provider().install_default();
-        let client = Client::new(keys.clone());
+        let client = Client::new();
         for relay in relays {
             client.add_relay(relay).await?;
         }
@@ -94,16 +94,15 @@ impl Publisher {
         let content = serde_json::to_string(listing)?;
 
         let tags = vec![
-            Tag::custom(TagKind::Custom("d".into()), vec!["mesh-llm".to_string()]),
-            Tag::custom(TagKind::Custom("k".into()), vec!["mesh-llm".to_string()]),
-            Tag::custom(
-                TagKind::Custom("expiration".into()),
-                vec![expiration.to_string()],
-            ),
+            Tag::custom("d", vec!["mesh-llm".to_string()]),
+            Tag::custom("k", vec!["mesh-llm".to_string()]),
+            Tag::custom("expiration", vec![expiration.to_string()]),
         ];
 
-        let builder = EventBuilder::new(Kind::Custom(MESH_SERVICE_KIND), content).tags(tags);
-        self.client.send_event_builder(builder).await?;
+        let event = EventBuilder::new(Kind::Custom(MESH_SERVICE_KIND), content)
+            .tags(tags)
+            .finalize(&self.keys)?;
+        self.client.send_event(&event).await?;
         Ok(())
     }
 
@@ -114,14 +113,14 @@ impl Publisher {
             .limit(10);
         let events = self
             .client
-            .fetch_events(filter, Duration::from_secs(5))
+            .fetch_events(filter)
+            .timeout(Duration::from_secs(5))
             .await?;
         for event in events.iter() {
             let request = EventDeletionRequest::new().id(event.id);
-            let _ = self
-                .client
-                .send_event_builder(EventBuilder::delete(request))
-                .await;
+            if let Ok(deletion) = request.finalize(&self.keys) {
+                let _ = self.client.send_event(&deletion).await;
+            }
         }
         Ok(())
     }
@@ -178,9 +177,9 @@ pub struct DiscoveryClient {
 }
 
 impl DiscoveryClient {
-    pub async fn new(keys: Keys, relays: &[String]) -> Result<Self> {
+    pub async fn new(relays: &[String]) -> Result<Self> {
         let _ = rustls::crypto::ring::default_provider().install_default();
-        let client = Client::new(keys);
+        let client = Client::new();
         let mut added = 0;
         for relay in relays {
             match client.add_relay(relay).await {
@@ -209,8 +208,7 @@ pub async fn discover(
         &cc.client
     } else {
         let _ = rustls::crypto::ring::default_provider().install_default();
-        let keys = Keys::generate();
-        let c = Client::new(keys);
+        let c = Client::new();
         let mut added = 0;
         for relay in relays {
             match c.add_relay(relay).await {
@@ -231,14 +229,12 @@ pub async fn discover(
 
     let nostr_filter = Filter::new()
         .kind(Kind::Custom(MESH_SERVICE_KIND))
-        .custom_tag(
-            SingleLetterTag::lowercase(Alphabet::K),
-            "mesh-llm".to_string(),
-        )
+        .custom_tag(SingleLetterTag::LOWERCASE_K, "mesh-llm".to_string())
         .limit(100);
 
     let events = match client
-        .fetch_events(nostr_filter, Duration::from_secs(5))
+        .fetch_events(nostr_filter)
+        .timeout(Duration::from_secs(5))
         .await
     {
         Ok(e) => e,

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -72,7 +72,7 @@ base64 = "0.22"
 dirs = "6.0.0"
 hex = "0.4.3"
 json5 = "1.3.1"
-nostr-sdk = { version = "0.44.1", default-features = false }
+nostr-sdk = { version = "0.45.1", default-features = false }
 opentelemetry = { version = "0.31.0", default-features = false, features = ["metrics"] }
 opentelemetry_sdk = { version = "0.31.0", default-features = false, features = ["metrics"] }
 opentelemetry-otlp = { version = "0.31.0", default-features = false, features = ["metrics", "http-proto", "reqwest-blocking-client"] }

--- a/crates/mesh-llm-host-runtime/src/network/nostr/discovery.rs
+++ b/crates/mesh-llm-host-runtime/src/network/nostr/discovery.rs
@@ -81,8 +81,7 @@ pub struct DiscoveryClient {
 impl DiscoveryClient {
     pub async fn new(relays: &[String]) -> Result<Self> {
         let _ = rustls::crypto::ring::default_provider().install_default();
-        let keys = Keys::generate();
-        let client = Client::new(keys);
+        let client = Client::new();
         let mut added = 0;
         for relay in relays {
             match client.add_relay(relay).await {
@@ -122,14 +121,12 @@ pub async fn discover(
 
     let nostr_filter = Filter::new()
         .kind(Kind::Custom(MESH_SERVICE_KIND))
-        .custom_tag(
-            SingleLetterTag::lowercase(Alphabet::K),
-            "mesh-llm".to_string(),
-        )
+        .custom_tag(SingleLetterTag::LOWERCASE_K, "mesh-llm".to_string())
         .limit(100);
 
     let events = match client
-        .fetch_events(nostr_filter, Duration::from_secs(5))
+        .fetch_events(nostr_filter)
+        .timeout(Duration::from_secs(5))
         .await
     {
         Ok(e) => e,
@@ -168,8 +165,7 @@ pub async fn discover(
 
 async fn build_discovery_client(relays: &[String]) -> Result<Client> {
     let _ = rustls::crypto::ring::default_provider().install_default();
-    let keys = Keys::generate();
-    let client = Client::new(keys);
+    let client = Client::new();
     let mut added = 0;
     for relay in relays {
         match client.add_relay(relay).await {
@@ -187,7 +183,9 @@ async fn build_discovery_client(relays: &[String]) -> Result<Client> {
     Ok(client)
 }
 
-fn latest_events_by_pubkey<'a>(events: &'a Events) -> std::collections::HashMap<String, &'a Event> {
+fn latest_events_by_pubkey<'a>(
+    events: &'a std::collections::BTreeSet<Event>,
+) -> std::collections::HashMap<String, &'a Event> {
     let mut latest: std::collections::HashMap<String, &'a Event> = std::collections::HashMap::new();
     for event in events.iter() {
         let pubkey = event.pubkey.to_hex();

--- a/crates/mesh-llm-host-runtime/src/network/nostr/publish.rs
+++ b/crates/mesh-llm-host-runtime/src/network/nostr/publish.rs
@@ -48,7 +48,7 @@ pub struct Publisher {
 impl Publisher {
     pub async fn new(keys: Keys, relays: &[String]) -> Result<Self> {
         let _ = rustls::crypto::ring::default_provider().install_default();
-        let client = Client::new(keys.clone());
+        let client = Client::new();
         for relay in relays {
             client.add_relay(relay).await?;
         }
@@ -67,16 +67,15 @@ impl Publisher {
         let content = serde_json::to_string(listing)?;
 
         let tags = vec![
-            Tag::custom(TagKind::Custom("d".into()), vec!["mesh-llm".to_string()]),
-            Tag::custom(TagKind::Custom("k".into()), vec!["mesh-llm".to_string()]),
-            Tag::custom(
-                TagKind::Custom("expiration".into()),
-                vec![expiration.to_string()],
-            ),
+            Tag::custom("d", vec!["mesh-llm".to_string()]),
+            Tag::custom("k", vec!["mesh-llm".to_string()]),
+            Tag::custom("expiration", vec![expiration.to_string()]),
         ];
 
-        let builder = EventBuilder::new(Kind::Custom(MESH_SERVICE_KIND), content).tags(tags);
-        self.client.send_event_builder(builder).await?;
+        let event = EventBuilder::new(Kind::Custom(MESH_SERVICE_KIND), content)
+            .tags(tags)
+            .finalize(&self.keys)?;
+        self.client.send_event(&event).await?;
         Ok(())
     }
 
@@ -89,14 +88,14 @@ impl Publisher {
             .limit(10);
         let events = self
             .client
-            .fetch_events(filter, Duration::from_secs(5))
+            .fetch_events(filter)
+            .timeout(Duration::from_secs(5))
             .await?;
         for event in events.iter() {
             let request = EventDeletionRequest::new().id(event.id);
-            let _ = self
-                .client
-                .send_event_builder(EventBuilder::delete(request))
-                .await;
+            if let Ok(deletion) = request.finalize(&self.keys) {
+                let _ = self.client.send_event(&deletion).await;
+            }
         }
         Ok(())
     }


### PR DESCRIPTION
Mesh discovery and publishing now run on `nostr-sdk` 0.45.1 (up from 0.44.1).

There is no user-visible behaviour change: public meshes still publish, refresh, and delist exactly as before, and `mesh-llm client --auto` still discovers them. This is a dependency upgrade that keeps us on a supported nostr-sdk line.

## Protocol

**Compatible — no wire change.** The published event shape is unchanged: kind `31990`, the same `d` / `k` / `expiration` tags, and the same JSON listing content. Nodes on this branch and nodes on older releases publish and discover each other's listings normally, because the change is entirely in how we call the SDK, not in what goes on the relay.

## Architecture

`nostr-sdk` 0.45 made several breaking API changes; both `mesh-llm-host-runtime` and the mirrored `mesh-client` copy were updated:

- `Client::new()` no longer takes keys. Signing is now explicit at the event level, so listings and deletion requests are finalized with the publisher keys before `send_event()`.
- `send_event_builder()` and `EventBuilder::delete()` are gone. Deletion now goes through `EventDeletionRequest::finalize()`.
- `fetch_events()` takes its timeout via a builder `.timeout()` instead of a second argument, and returns `BTreeSet<Event>` instead of the removed `Events` type.
- `TagKind::Custom` is replaced by plain string tag kinds, and `SingleLetterTag::lowercase(Alphabet::K)` by `SingleLetterTag::LOWERCASE_K`.

Discovery clients no longer generate throwaway keypairs. In 0.45 a read-only client does not need a signer, so `DiscoveryClient::new()` in `mesh-client` drops its now-unused `keys` parameter (the host-runtime equivalent already took none).

## Validation

- `cargo check --workspace` — clean
- `cargo clippy --all-targets -- -D warnings` on `mesh-llm-host-runtime`, `mesh-llm-client`, and `mesh-llm` — clean
- `cargo fmt --all --check` — clean
- `cargo test -p mesh-llm-host-runtime --lib` — 1924 passed
- `cargo test -p mesh-llm-client --lib` — 95 passed
- `network::nostr::discovery::integration_tests::publish_discover_round_trip` (the `--ignored` live-relay test) — passed against real public relays, exercising publish, discover, and delete end to end on the new API


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Nostr connectivity to improve compatibility with the latest SDK.
  * Improved event publishing, deletion, discovery, filtering, and retrieval behavior.
  * Added consistent timeout handling for relay requests.
  * Prevented unnecessary key generation during discovery and client setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->