### PR TITLE
fix: stop auto from picking models nobody serves

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/auto_route.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/auto_route.rs
@@ -83,6 +83,18 @@ pub(crate) async fn model_has_eligible_remote_host(
     model_has_eligible_target(node, model, required_tokens, &targets, affinity).await
 }
 
+/// Whether this node itself serves `model`, independent of the target table.
+///
+/// A freshly started serve node loads its model and records it in
+/// `serving_models` / `hosted_models` before the election target table and peer
+/// gossip catch up. During that window the model has no routable target and no
+/// remote host, so a strict readiness check would exclude the node's own model
+/// from auto routing. This keeps it eligible.
+pub(crate) async fn model_is_locally_served(node: &mesh::Node, model: &str) -> bool {
+    node.hosted_models().await.iter().any(|m| m == model)
+        || node.serving_models().await.iter().any(|m| m == model)
+}
+
 pub(crate) fn pool_for_ready_models<'a>(
     available: &[router::RoutingCandidate<'a>],
     ready_models: &[&str],
@@ -130,6 +142,29 @@ mod tests {
 
         assert_eq!(pool.len(), 1);
         assert_eq!(pool[0].name, "ready-model");
+    }
+
+    #[tokio::test]
+    async fn model_served_by_nobody_is_not_locally_served() {
+        let node = mesh::Node::new_for_tests(crate::mesh::NodeRole::Worker)
+            .await
+            .expect("test node");
+
+        assert!(!model_is_locally_served(&node, "phantom/model:Q4_K_M").await);
+    }
+
+    #[tokio::test]
+    async fn freshly_loaded_local_model_stays_eligible_before_targets_populate() {
+        let node = mesh::Node::new_for_tests(crate::mesh::NodeRole::Worker)
+            .await
+            .expect("test node");
+        // A serve node records its model here before the election target table
+        // and peer gossip catch up.
+        node.set_hosted_models(vec!["local/fresh-model:Q4_K_M".to_string()])
+            .await;
+
+        assert!(model_is_locally_served(&node, "local/fresh-model:Q4_K_M").await);
+        assert!(!model_is_locally_served(&node, "some/other-model:Q4_K_M").await);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -352,7 +352,15 @@ async fn auto_route_model_has_ready_ingress_target(
         .await;
     }
 
-    true
+    // No routable local target and no peer advertises this model. Fail closed:
+    // such a model is a phantom (stale gossip, or a peer that unloaded it), and
+    // letting it stay in the pool means `auto` can pick a model that then 404s
+    // on a model the user never named. Explicit requests still 404 honestly.
+    //
+    // The one exception is a freshly started serve node: its own model is
+    // loaded and in `serving_models` before the target table and gossip catch
+    // up, so keep it eligible rather than excluding this node's own model.
+    auto_route::model_is_locally_served(node, model).await
 }
 
 fn maybe_enable_auto_route_hooks(
@@ -1044,6 +1052,61 @@ mod tests {
             request_object_request_ids: Vec::new(),
             response_adapter: proxy::ResponseAdapter::None,
         }
+    }
+
+    /// A model nobody serves must not stay in the auto pool. Before this,
+    /// the readiness check fell through to `true`, so `auto` could select a
+    /// phantom (stale gossip, or a peer that unloaded) and 404 the caller on
+    /// a model they never named.
+    #[tokio::test]
+    async fn phantom_model_is_not_auto_route_eligible() {
+        let node = mesh::Node::new_for_tests(crate::mesh::NodeRole::Worker)
+            .await
+            .expect("test node");
+        let targets = election::ModelTargets::default();
+        let affinity = affinity::AffinityRouter::new();
+
+        let eligible = auto_route_model_has_ready_ingress_target(
+            &node,
+            &targets,
+            "phantom/model:Q4_K_M",
+            None,
+            &affinity,
+        )
+        .await;
+
+        assert!(
+            !eligible,
+            "a model with no local target and no remote host must not be auto-route eligible"
+        );
+    }
+
+    /// A freshly started serve node records its model before the target table
+    /// and gossip catch up. Failing closed must not exclude this node's own
+    /// model during that window.
+    #[tokio::test]
+    async fn freshly_served_local_model_is_auto_route_eligible() {
+        let node = mesh::Node::new_for_tests(crate::mesh::NodeRole::Worker)
+            .await
+            .expect("test node");
+        node.set_hosted_models(vec!["local/fresh-model:Q4_K_M".to_string()])
+            .await;
+        let targets = election::ModelTargets::default();
+        let affinity = affinity::AffinityRouter::new();
+
+        let eligible = auto_route_model_has_ready_ingress_target(
+            &node,
+            &targets,
+            "local/fresh-model:Q4_K_M",
+            None,
+            &affinity,
+        )
+        .await;
+
+        assert!(
+            eligible,
+            "a locally served model must stay eligible before targets populate"
+        );
     }
 
     #[test]


### PR DESCRIPTION
`auto` no longer picks a model that nobody in the mesh is actually serving.

Before this, a request with `model: "auto"` could land on a "phantom" model — one still advertised in gossip but served by no peer (stale gossip, or a peer that unloaded it). The request then failed with:

```
model 'unsloth/Qwen3-8B-GGUF@main:Q4_K_M' not found (no local or remote host serving this model)
```

which is a confusing thing to receive when you asked for `auto` and never named that model.

Explicit model requests are unchanged — asking for a model nobody serves still returns an honest 404.

## Architecture

The auto readiness filter checked local targets, then remote hosts, then fell through to `true`. A model with neither was therefore treated as "ready" and stayed in the auto candidate pool, where the weighted draw could select it.

It now fails closed: no routable local target and no remote host means not auto-route eligible.

The one case that must not regress is a freshly started serve node — it records its model in `hosted_models`/`serving_models` before the election target table and peer gossip catch up, so during that window its own model has no target and no remote host. A naive fail-closed would drop the node's own model from auto. `model_is_locally_served` keeps it eligible, and there is a test for exactly that window.

## Regression origin

Two commits combined to produce this:

- **#734** (`916c3221`) added the readiness filter with the fail-open `true` default, putting phantoms in the pool.
- **#1082** (`ed286b90`) replaced the old "route to first available target" fallback with a hard 404. That is the right call for an explicit request — silently substituting a different model is worse — but it made selecting a phantom user-visible instead of silently papered over.

## Validation

- `cargo test -p mesh-llm-host-runtime --lib` — 1930 passed, 0 failed
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings` — clean
- `cargo clippy -p mesh-llm --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean

**Tests fail without the fix.** I verified this rather than assuming: temporarily reverting the fail-closed line back to `true` makes `phantom_model_is_not_auto_route_eligible` FAIL while `freshly_served_local_model_is_auto_route_eligible` still passes, then restoring it makes both pass. So the new coverage genuinely pins the regression.

### Public mesh

Ran `mesh-llm client --auto` against the public mesh (5 peers), which had a real phantom present (`unsloth/Qwen3-8B-GGUF:Q4_K_M` — advertised in `/v1/models`, served by no peer):

- 55 `model=auto` requests across two runs: no phantom ever selected, no `model_not_found`.
- Explicit call to the phantom still returns the honest 404.

One caveat worth stating plainly: on this particular mesh the phantom was *also* being masked by the big/small tier partition (`Qwen3-8B` sorts small, and big-tier models were available), so the public-mesh run alone does not prove the fix — I confirmed that by A/B-ing against an unfixed binary and getting identical results. The unit tests above are the real evidence; the mesh run is a no-regression check.

Unrelated to this change, one request in 55 returned a 503 (`all 1 target(s) for model 'local-gguf/...' failed`) — a peer whose target died mid-request. That model *is* served by a peer, so it is peer churn on a path this PR does not touch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic model routing to recognize models served locally, including during startup and routing-data updates.
  * Prevented requests from being routed to models that have no available local or remote serving targets.
  * Added coverage for unavailable models and newly loaded local models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->