### PR TITLE
Fix crates.io publishing for new workspace crates, and make dev builds identify themselves

### DIFF
--- a/scripts/build-host.sh
+++ b/scripts/build-host.sh
@@ -153,10 +153,11 @@ else
     echo "Skipping mesh-llm UI build because MESH_LLM_SKIP_UI=1."
 fi
 
+stamp_build_version
+
 cargo_args=(build --locked -p mesh-llm --bin mesh-llm --no-default-features \
     --features "web-ui,dynamic-native-runtime")
 if [[ "$BUILD_PROFILE" == "release" ]]; then
-    stamp_build_version
     cargo_args=(build --release --locked -p mesh-llm --bin mesh-llm --no-default-features \
         --features "web-ui,dynamic-native-runtime")
 fi

--- a/scripts/build-host.sh
+++ b/scripts/build-host.sh
@@ -87,6 +87,8 @@ configure_rust_cache() {
 stamp_build_version() {
     local release_version=""
     local pkgid=""
+    local sha=""
+    local dirty_suffix=""
 
     if [[ -n "${MESH_LLM_BUILD_VERSION:-}" ]]; then
         echo "Using preset MESH_LLM_BUILD_VERSION: $MESH_LLM_BUILD_VERSION"
@@ -105,8 +107,35 @@ stamp_build_version() {
         return 0
     fi
 
-    export MESH_LLM_BUILD_VERSION="$release_version"
-    echo "Using release MESH_LLM_BUILD_VERSION: $MESH_LLM_BUILD_VERSION"
+    # A release product reports the plain workspace version. Non-release builds
+    # append the commit SHA so `mesh-llm --version` cannot be mistaken for a
+    # release binary, and so is_sha_build() resolves native runtimes from the
+    # latest release rather than a pinned tag. This mirrors build-windows.ps1.
+    if [[ "$BUILD_PROFILE" == "release" ]]; then
+        export MESH_LLM_BUILD_VERSION="$release_version"
+        echo "Using release MESH_LLM_BUILD_VERSION: $MESH_LLM_BUILD_VERSION"
+        return 0
+    fi
+
+    if ! sha="$(git -C "$REPO_ROOT" rev-parse --short=6 HEAD 2>/dev/null)" || [[ -z "$sha" ]]; then
+        echo "Warning: unable to derive build version; git SHA unavailable." >&2
+        unset MESH_LLM_BUILD_VERSION || true
+        return 0
+    fi
+    sha="$(printf '%s' "$sha" | tr '[:lower:]' '[:upper:]')"
+
+    local status_output=""
+    if ! status_output="$(git -C "$REPO_ROOT" status --porcelain --untracked-files=all 2>/dev/null)"; then
+        echo "Warning: unable to derive build version; git status unavailable." >&2
+        unset MESH_LLM_BUILD_VERSION || true
+        return 0
+    fi
+    if [[ -n "$status_output" ]]; then
+        dirty_suffix=".dirty"
+    fi
+
+    export MESH_LLM_BUILD_VERSION="${release_version}+g${sha}${dirty_suffix}"
+    echo "Derived MESH_LLM_BUILD_VERSION: $MESH_LLM_BUILD_VERSION"
 }
 
 if [[ "${MESH_LLM_DYNAMIC_NATIVE_RUNTIME:-1}" != "1" ]]; then

--- a/scripts/ci-compose-product-input.sh
+++ b/scripts/ci-compose-product-input.sh
@@ -248,7 +248,11 @@ fi
 version="${version#v}"
 host_version_output="$("$output_dir/$INPUT_BINARY_NAME" --version)"
 host_version="$(awk '{print $NF}' <<<"$host_version_output")"
-if [[ "$host_version" != "$version" ]]; then
+# Non-release hosts carry semver build metadata (`+g<sha>[.dirty]`) so a dev
+# binary cannot be mistaken for a release one. Build metadata is not part of
+# version identity, so compare the release version and ignore any suffix.
+host_release_version="${host_version%%+*}"
+if [[ "$host_release_version" != "$version" ]]; then
     echo "composed host version mismatch: expected $version, got ${host_version:-<empty>}" >&2
     echo "Output: $host_version_output" >&2
     exit 1

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -295,168 +295,53 @@ publish_crate_with_retry() {
     return 101
 }
 
+# Publishable workspace dependencies for every crate, derived once from cargo
+# metadata into "<crate> <dep>" lines.
+#
+# This is intentionally derived rather than hand-maintained: a stale hand-written
+# map silently breaks the dry-run whenever a new crate joins the workspace, and
+# the failure only surfaces at release time, at the end of a long release build.
+registry_dep_pairs=""
+
+load_registry_dep_pairs() {
+    local metadata=""
+    if ! metadata="$(cargo metadata --format-version 1 --no-deps 2>/dev/null)"; then
+        echo "failed to read cargo metadata for workspace dependency derivation" >&2
+        exit 1
+    fi
+    if [[ -z "$metadata" ]]; then
+        echo "cargo metadata returned no workspace data" >&2
+        exit 1
+    fi
+    registry_dep_pairs="$(
+        printf '%s' "$metadata" | python3 -c '
+import json
+import sys
+
+metadata = json.load(sys.stdin)
+
+publishable = [p for p in metadata["packages"] if p.get("publish") != []]
+by_manifest_dir = {
+    p["manifest_path"].rsplit("/", 1)[0]: p["name"] for p in publishable
+}
+
+for package in publishable:
+    for dependency in package["dependencies"]:
+        if dependency.get("kind") == "dev":
+            continue
+        path = dependency.get("path")
+        if not path:
+            continue
+        name = by_manifest_dir.get(path.rstrip("/"))
+        if name and name != package["name"]:
+            print(package["name"], name)
+'
+    )"
+}
+
 unpublished_registry_deps() {
-    case "$1" in
-        model-artifact)
-            printf '%s\n' model-ref
-            ;;
-        model-hf)
-            printf '%s\n' \
-                model-artifact \
-                model-ref
-            ;;
-        mesh-llm-hardware-profile)
-            printf '%s\n' \
-                mesh-llm-native-runtime
-            ;;
-        mesh-llm-runtime-install)
-            printf '%s\n' \
-                mesh-llm-build-info \
-                mesh-llm-hardware-profile \
-                mesh-llm-native-runtime \
-                skippy-ffi
-            ;;
-        mesh-llm-client)
-            printf '%s\n' \
-                model-artifact \
-                mesh-llm-identity \
-                mesh-llm-protocol \
-                mesh-llm-routing \
-                mesh-llm-types
-            ;;
-        mesh-llm-api-client)
-            printf '%s\n' \
-                mesh-llm-client
-            ;;
-        mesh-llm-console-server)
-            printf '%s\n' \
-                mesh-llm-ui
-            ;;
-        mesh-llm-cli)
-            printf '%s\n' \
-                mesh-llm-build-info \
-                mesh-llm-events
-            ;;
-        mesh-llm-tui)
-            printf '%s\n' \
-                mesh-llm-events
-            ;;
-        mesh-llm-plugin-manager)
-            printf '%s\n' \
-                mesh-llm-skills
-            ;;
-        mesh-llm-system)
-            printf '%s\n' \
-                mesh-llm-build-info \
-                mesh-llm-gpu-bench \
-                mesh-llm-native-runtime \
-                mesh-llm-release-footer \
-                mesh-llm-runtime-install \
-                skippy-runtime
-            ;;
-        mesh-llm-config)
-            printf '%s\n' \
-                mesh-llm-types \
-                skippy-protocol
-            ;;
-        mesh-mixture-of-agents)
-            printf '%s\n' \
-                mesh-llm-guardrails
-            ;;
-        model-resolver)
-            printf '%s\n' \
-                model-artifact \
-                model-ref
-            ;;
-        model-package)
-            printf '%s\n' \
-                model-hf \
-                model-ref
-            ;;
-        openai-frontend)
-            printf '%s\n' \
-                mesh-llm-guardrails
-            ;;
-        skippy-cache)
-            printf '%s\n' \
-                skippy-protocol
-            ;;
-        skippy-runtime)
-            printf '%s\n' \
-                skippy-ffi
-            ;;
-        skippy-server)
-            printf '%s\n' \
-                openai-frontend \
-                skippy-cache \
-                skippy-metrics \
-                skippy-protocol \
-                skippy-runtime \
-                skippy-tokenizer
-            ;;
-        mesh-native-serving-plugin-host)
-            printf '%s\n' \
-                mesh-native-serving-plugin-api \
-                skippy-server
-            ;;
-        mesh-llm-host-runtime)
-            printf '%s\n' \
-                mesh-llm-api-server \
-                mesh-llm-build-info \
-                mesh-llm-client \
-                mesh-llm-config \
-                mesh-llm-events \
-                mesh-llm-guardrails \
-                mesh-llm-identity \
-                mesh-llm-native-runtime \
-                mesh-llm-node \
-                mesh-llm-plugin \
-                mesh-llm-plugin-manager \
-                mesh-llm-protocol \
-                mesh-llm-routing \
-                mesh-llm-runtime-install \
-                mesh-llm-system \
-                mesh-llm-types \
-                mesh-llm-ui \
-                mesh-mixture-of-agents \
-                mesh-native-serving-plugin-host \
-                model-artifact \
-                model-hf \
-                model-package \
-                model-ref \
-                model-resolver \
-                openai-frontend \
-                skippy-coordinator \
-                skippy-protocol \
-                skippy-runtime \
-                skippy-server \
-                skippy-topology
-            ;;
-        mesh-llm-sdk)
-            printf '%s\n' \
-                mesh-llm-api-client \
-                mesh-llm-api-server \
-                mesh-llm-console-server \
-                mesh-llm-embedded-runtime \
-                mesh-llm-runtime-install
-            ;;
-        mesh-llm-embedded-runtime)
-            printf '%s\n' \
-                mesh-llm-host-runtime
-            ;;
-        mesh-llm-node)
-            printf '%s\n' \
-                mesh-llm-types \
-                model-artifact \
-                model-hf \
-                model-ref
-            ;;
-        mesh-llm-api-server)
-            printf '%s\n' \
-                mesh-llm-api-client \
-                mesh-llm-node
-            ;;
-    esac
+    local crate="$1"
+    printf '%s\n' "$registry_dep_pairs" | awk -v crate="$crate" '$1 == crate { print $2 }'
 }
 
 should_skip_initial_dry_run() {
@@ -520,6 +405,10 @@ publish_crates=(
     mesh-llm-embedded-runtime
     mesh-llm-sdk
 )
+
+if [[ "$dry_run" -eq 1 ]]; then
+    load_registry_dep_pairs
+fi
 
 for index in "${!publish_crates[@]}"; do
     crate="${publish_crates[$index]}"

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -55,6 +55,101 @@ class BuildReleaseScriptTests(unittest.TestCase):
         with self.assertRaises(subprocess.CalledProcessError):
             self.run_build_release_with_backend("metal", dynamic_native_runtime=False)
 
+    def test_non_release_profiles_stamp_the_commit_sha(self) -> None:
+        """A dev build must not report a bare, release-shaped version.
+
+        `stamp_build_version` derives `+g<sha>` for non-release profiles, but it
+        is only useful if it actually runs for those profiles. Guard the call
+        site: stamping used to sit inside the release-only branch, so the
+        derivation was unreachable and debug builds shipped an unstamped
+        version indistinguishable from a release binary.
+        """
+        for profile in ("debug", "dev"):
+            with self.subTest(profile=profile):
+                stamped = self.run_build_host_with_profile(profile)
+                self.assertEqual(stamped, "0.68.0+gABC123")
+
+    def test_release_profile_stamps_the_plain_version(self) -> None:
+        self.assertEqual(self.run_build_host_with_profile("release"), "0.68.0")
+
+    def run_build_host_with_profile(self, profile: str) -> str:
+        """Returns MESH_LLM_BUILD_VERSION as seen by `cargo build`."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmp = Path(tmpdir)
+            scripts_dir = tmp / "scripts"
+            bin_dir = tmp / "bin"
+            scripts_dir.mkdir()
+            bin_dir.mkdir()
+
+            copied_host_script = scripts_dir / "build-host.sh"
+            shutil.copy(HOST_SCRIPT, copied_host_script)
+            copied_host_script.chmod(copied_host_script.stat().st_mode | stat.S_IXUSR)
+
+            self.write_executable(
+                scripts_dir / "build-ui.sh",
+                """
+                #!/usr/bin/env bash
+                set -euo pipefail
+                echo "stub build-ui $*"
+                """,
+            )
+            self.write_executable(
+                bin_dir / "uname",
+                """
+                #!/usr/bin/env bash
+                echo Linux
+                """,
+            )
+            self.write_executable(
+                bin_dir / "git",
+                """
+                #!/usr/bin/env bash
+                if [[ "$1" == "-C" ]]; then
+                  shift 2
+                fi
+                case "$1" in
+                  rev-parse) echo abc123 ;;
+                  status) ;;
+                  *) echo "unexpected git $*" >&2; exit 2 ;;
+                esac
+                """,
+            )
+            version_log = tmp / "build-version.log"
+            self.write_executable(
+                bin_dir / "cargo",
+                """
+                #!/usr/bin/env bash
+                set -euo pipefail
+                if [[ "$1" == "pkgid" ]]; then
+                  echo "file:///tmp/mesh-llm#0.68.0"
+                  exit 0
+                fi
+                if [[ "$1" == "build" ]]; then
+                  printf '%s' "${MESH_LLM_BUILD_VERSION:-<unset>}" > "$VERSION_LOG"
+                fi
+                """,
+            )
+
+            env = os.environ.copy()
+            env.update(
+                {
+                    "VERSION_LOG": str(version_log),
+                    "MESH_LLM_SKIP_UI": "1",
+                    "PATH": f"{bin_dir}{os.pathsep}{env['PATH']}",
+                }
+            )
+            env.pop("MESH_LLM_BUILD_VERSION", None)
+            subprocess.run(
+                [str(copied_host_script), "--profile", profile],
+                cwd=tmp,
+                env=env,
+                check=True,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+            )
+            return version_log.read_text(encoding="utf-8")
+
     def run_build_release_with_backend(
         self, backend: str, *, dynamic_native_runtime: bool = True
     ) -> str:

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -101,6 +101,13 @@ class BuildReleaseScriptTests(unittest.TestCase):
                 """,
             )
             self.write_executable(
+                bin_dir / "ld.lld",
+                """
+                #!/usr/bin/env bash
+                exit 0
+                """,
+            )
+            self.write_executable(
                 bin_dir / "git",
                 """
                 #!/usr/bin/env bash

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -1465,6 +1465,33 @@ class CiArtifactActionTests(unittest.TestCase):
             self.assertNotEqual(result.returncode, 0)
             self.assertIn("composed host version mismatch", result.stderr)
 
+    def test_product_composer_accepts_host_build_metadata(self) -> None:
+        """Non-release hosts carry `+g<sha>[.dirty]` build metadata.
+
+        Semver build metadata is not part of version identity, so a debug host
+        stamped with its commit SHA still composes against the runtime's
+        release version.
+        """
+        for host_version in ("1.2.3+gABC123", "1.2.3+gABC123.dirty"):
+            with self.subTest(host_version=host_version):
+                with tempfile.TemporaryDirectory() as temp_dir:
+                    result = self.run_product_composer(
+                        Path(temp_dir),
+                        host_version=host_version,
+                    )
+
+                    self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_product_composer_rejects_drift_despite_build_metadata(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            result = self.run_product_composer(
+                Path(temp_dir),
+                host_version="9.9.9+gABC123",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("composed host version mismatch", result.stderr)
+
     def test_product_composer_accepts_one_checksums_runtime_archive(self) -> None:
         with tempfile.TemporaryDirectory() as temp_dir:
             result = self.run_product_composer(

--- a/scripts/tests/test_publish_crates.py
+++ b/scripts/tests/test_publish_crates.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
+import re
 import stat
 import subprocess
 import tempfile
@@ -13,6 +15,26 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "publish-crates.sh"
+
+
+def _publish_chain_crates() -> list[str]:
+    """The crate order the publish script itself declares."""
+    contents = SCRIPT.read_text(encoding="utf-8")
+    array = re.search(r"publish_crates=\(\n(.*?)\n\)", contents, re.S)
+    if array is None:
+        raise AssertionError("scripts/publish-crates.sh: missing publish_crates array")
+    return [line.strip() for line in array.group(1).splitlines() if line.strip()]
+
+
+PUBLISH_CHAIN_CRATES = _publish_chain_crates()
+
+# Path dependencies the fixture models by default. These mirror a few real
+# workspace edges so the derived skip logic has something to resolve.
+DEFAULT_WORKSPACE_DEPS = {
+    "model-artifact": ["model-ref"],
+    "model-hf": ["model-artifact", "model-ref"],
+    "mesh-llm-api-server": ["mesh-llm-api-client", "mesh-llm-node"],
+}
 
 
 class PublishCratesScriptTests(unittest.TestCase):
@@ -85,6 +107,36 @@ class PublishCratesScriptTests(unittest.TestCase):
             self.assertIn(
                 "retry limit exceeded for model-artifact@0.68.0 after 2 attempts",
                 result.stderr,
+            )
+
+    def test_dry_run_skips_dependents_of_a_brand_new_workspace_crate(self) -> None:
+        """A crate added to the workspace is not yet on crates.io.
+
+        v0.75.1 failed here: `skippy-tokenizer` was new, `skippy-protocol`
+        depends on it, and the hand-maintained dependency map had no
+        `skippy-protocol` entry, so its dry-run was not skipped and
+        `cargo publish` could not resolve the dependency from the registry.
+        Deriving the map from cargo metadata must skip the dependent instead.
+        """
+        with PublishCratesFixture() as fixture:
+            fixture.write_curl_statuses({})
+            fixture.write_fake_cargo(
+                workspace_deps={"skippy-protocol": ["skippy-tokenizer"]}
+            )
+            fixture.write_fake_sleep()
+            fixture.write_fake_date()
+
+            result = fixture.run(["--dry-run", "--allow-dirty"])
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            self.assertIn(
+                "dry-run cannot verify skippy-protocol until "
+                "skippy-tokenizer@0.68.0 exists in crates.io",
+                result.stdout,
+            )
+            self.assertNotIn(
+                "-p skippy-protocol --dry-run",
+                fixture.read_log("cargo.log"),
             )
 
     def test_dry_run_skips_crates_with_unpublished_registry_deps_without_sleeping(self) -> None:
@@ -220,9 +272,14 @@ class PublishCratesFixture:
         *,
         fail_crates: dict[str, int] | None = None,
         failure_output: str = "",
+        workspace_deps: dict[str, list[str]] | None = None,
     ) -> None:
         failure_path = self.tmp_path / "cargo-failure.txt"
         failure_path.write_text(failure_output, encoding="utf-8")
+        metadata_path = self.tmp_path / "cargo-metadata.json"
+        metadata_path.write_text(
+            self._workspace_metadata_json(workspace_deps), encoding="utf-8"
+        )
         fail_cases = "\n".join(
             f"{crate}:{count}" for crate, count in (fail_crates or {}).items()
         )
@@ -230,6 +287,10 @@ class PublishCratesFixture:
             "cargo",
             f"""#!/usr/bin/env bash
 set -euo pipefail
+if [[ "${{1:-}}" == "metadata" ]]; then
+    cat "{metadata_path}"
+    exit 0
+fi
 crate=""
 prev=""
 for arg in "$@"; do
@@ -321,6 +382,41 @@ fi
         if not path.exists():
             return ""
         return path.read_text(encoding="utf-8")
+
+    def _workspace_metadata_json(
+        self, workspace_deps: dict[str, list[str]] | None
+    ) -> str:
+        """Fake `cargo metadata --no-deps` output for the publish chain.
+
+        The script derives each crate's publishable workspace dependencies from
+        this, so the fixture models path dependencies the same way Cargo does:
+        `path` points at the dependency's manifest directory.
+        """
+        deps = dict(DEFAULT_WORKSPACE_DEPS if workspace_deps is None else workspace_deps)
+        crate_names = set(PUBLISH_CHAIN_CRATES)
+        for crate, crate_deps in deps.items():
+            crate_names.add(crate)
+            crate_names.update(crate_deps)
+
+        packages = []
+        for crate in sorted(crate_names):
+            packages.append(
+                {
+                    "name": crate,
+                    "version": "0.68.0",
+                    "manifest_path": f"{self.tmp_path}/crates/{crate}/Cargo.toml",
+                    "dependencies": [
+                        {
+                            "name": dep,
+                            "req": "^0.68.0",
+                            "kind": None,
+                            "path": f"{self.tmp_path}/crates/{dep}",
+                        }
+                        for dep in deps.get(crate, [])
+                    ],
+                }
+            )
+        return json.dumps({"packages": packages})
 
     def _write_executable(self, name: str, content: str) -> None:
         path = self.bin_dir / name

--- a/scripts/tests/test_publish_crates.py
+++ b/scripts/tests/test_publish_crates.py
@@ -18,12 +18,23 @@ SCRIPT = ROOT / "scripts" / "publish-crates.sh"
 
 
 def _publish_chain_crates() -> list[str]:
-    """The crate order the publish script itself declares."""
+    """The crate order the publish script itself declares.
+
+    Mirrors the array parsing in `tools/xtask/src/publish_consistency.rs`:
+    comment lines are skipped and surrounding quotes are stripped, so a quoted
+    entry still matches the package name the script publishes.
+    """
     contents = SCRIPT.read_text(encoding="utf-8")
     array = re.search(r"publish_crates=\(\n(.*?)\n\)", contents, re.S)
     if array is None:
         raise AssertionError("scripts/publish-crates.sh: missing publish_crates array")
-    return [line.strip() for line in array.group(1).splitlines() if line.strip()]
+    entries = []
+    for line in array.group(1).splitlines():
+        trimmed = line.strip()
+        if not trimmed or trimmed.startswith("#"):
+            continue
+        entries.append(trimmed.strip('"'))
+    return entries
 
 
 PUBLISH_CHAIN_CRATES = _publish_chain_crates()

--- a/tools/xtask/src/publish_consistency.rs
+++ b/tools/xtask/src/publish_consistency.rs
@@ -22,6 +22,7 @@ pub(crate) fn check_publish_crates_consistency(repo_root: &Path) -> DynResult<()
     check_publish_crate_metadata(repo_root, &publish_crates, &packages_by_name)?;
     check_publish_crate_dependencies(&publish_order, &packages_by_name, &packages_by_dir)?;
     check_publish_literal_includes(&publish_crates, &packages_by_name)?;
+    check_publish_registry_deps_are_derived(repo_root)?;
     check_publish_catalog_sync(repo_root)?;
     check_publish_workflow_invariants(repo_root)?;
 
@@ -314,6 +315,63 @@ fn literal_include_paths(source: &str) -> Vec<String> {
         }
     }
     paths
+}
+
+/// The publish script must derive each crate's publishable workspace
+/// dependencies from `cargo metadata` rather than hand-maintaining them.
+///
+/// A hand-written map drifts silently: adding a new workspace crate updates the
+/// `publish_crates` array (which this module validates) while leaving the
+/// dependency map stale, and the resulting `cargo publish --dry-run` failure
+/// only surfaces during a release. Keep the derivation in place so a new crate
+/// cannot reintroduce that class of failure.
+fn check_publish_registry_deps_are_derived(repo_root: &Path) -> DynResult<()> {
+    let relative_path = "scripts/publish-crates.sh";
+    let contents = fs::read_to_string(repo_root.join(relative_path))?;
+    let loader = shell_function_body(&contents, "load_registry_dep_pairs")
+        .ok_or_else(|| format!("{relative_path}: missing load_registry_dep_pairs function"))?;
+    let lookup = shell_function_body(&contents, "unpublished_registry_deps")
+        .ok_or_else(|| format!("{relative_path}: missing unpublished_registry_deps function"))?;
+
+    ensure_contains(
+        loader,
+        "cargo metadata --format-version 1 --no-deps",
+        "publish script derives registry dependencies from cargo metadata",
+    )?;
+
+    for function in [loader, lookup] {
+        if let Some(branch) = hand_maintained_case_branch(function) {
+            return Err(format!(
+                "{relative_path}: workspace dependencies must be derived from cargo metadata, \
+                 but a `{branch})` branch is hand-maintained. Adding a crate to a hand-written \
+                 map is the failure mode this check exists to prevent.",
+            )
+            .into());
+        }
+    }
+
+    Ok(())
+}
+
+/// Returns the body of a top-level `name() { ... }` shell function.
+fn shell_function_body<'a>(contents: &'a str, name: &str) -> Option<&'a str> {
+    contents
+        .split_once(&format!("\n{name}() {{"))
+        .map(|(_, rest)| rest)
+        .and_then(|rest| rest.split_once("\n}"))
+        .map(|(body, _)| body)
+}
+
+/// Returns the name of a hand-maintained `<crate-name>)` case branch, if any.
+fn hand_maintained_case_branch(function: &str) -> Option<String> {
+    function.lines().map(str::trim).find_map(|line| {
+        let candidate = line.strip_suffix(')')?;
+        let is_crate_name = !candidate.is_empty()
+            && candidate
+                .bytes()
+                .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-');
+        (is_crate_name && candidate.contains('-')).then(|| candidate.to_string())
+    })
 }
 
 fn check_publish_catalog_sync(repo_root: &Path) -> DynResult<()> {


### PR DESCRIPTION
## What this fixes for you

**v0.75.1 published no crates to crates.io.** This makes the publish chain resilient to new workspace crates, and makes a dev build's `--version` tell you the truth.

Two changes, one shared cause: a fact Cargo already knows was copied by hand, and nothing checked the copy.

## The crates.io failure

`scripts/publish-crates.sh` hand-maintained every crate's workspace dependencies in a ~160-line `case` statement. `#1214` added `skippy-tokenizer`, `skippy-protocol` depends on it, and the map had no `skippy-protocol` branch — so its dry-run was not skipped, and `cargo publish` could not resolve a dependency that is not on crates.io yet:

```
error: failed to prepare local package for uploading
  no matching package named `skippy-tokenizer` found
  location searched: crates.io index
  required by package `skippy-protocol v0.75.1`
```

This was structurally guaranteed to happen eventually. xtask validated the adjacent `publish_crates` **array** (order, duplicates, completeness) but **never read the dependency map** — so the checked list and the unchecked map drifted apart, and the failure only surfaced at the end of a 2h40m release.

The map is now derived from `cargo metadata`, which found **three** edges the hand-written version had missed:

| Crate | Missing dependency |
|---|---|
| `skippy-protocol` | `skippy-tokenizer` ← broke v0.75.1 |
| `skippy-server` | `mesh-native-serving-plugin-api`, `model-artifact` |
| `mesh-llm-host-runtime` | `skippy-ffi` |

Verified against all 46 crates: zero cases where the derivation lost a dependency the old map had.

An xtask guard now rejects a reintroduced hand-maintained branch, so this class of failure cannot come back.

## Dev builds now identify themselves

`mesh-llm --version` from `main` reported `0.72.1` — a bare, release-shaped version. That makes a dev build indistinguishable from a release binary, which directly undermines the `AGENTS.md` deploy checklist ("verify `mesh-llm --version` on every node" to confirm a binary is new code).

`build-windows.ps1` already did this correctly. `build-host.sh` — the Unix path — had no SHA logic at all. Non-release Unix builds now match Windows:

| Profile | `--version` |
|---|---|
| release | `0.75.1` |
| debug/dev | `0.72.1+g1A2FEF` (`.dirty` when the tree is dirty) |

This also feeds existing behaviour: `is_sha_build()` already routes native-runtime resolution to `releases/latest` for SHA builds instead of a pinned tag, so a dev build stops asking for a runtime tagged with a version that was never released.

## Notes for review

- The derivation loads once into `registry_dep_pairs` rather than shelling out per crate — 1 `cargo metadata` call, not 46.
- It only loads on the dry-run path, so real publishing is unaffected.
- PR builds use `profile: debug`, so their host `--version` now carries a SHA suffix. `scripts/ci-compose-product-input.sh` compared the full `--version` output against the runtime's release version and rejected the suffix as drift. It now compares the release version and ignores semver build metadata, which is not part of version identity. Genuine drift is still rejected, with or without a suffix.
- `package-release.ps1` asserts `--version` matches the release tag exactly. It is invoked only from `release.yml` on release profiles, which are unstamped, so the suffix cannot reach it.

Follow-ups intentionally **not** in this PR, tracked in the linked issue: `main`'s stale workspace version, `known_mesh_llm_versions()`, and `release-version.sh` rewriting user-facing docs to a dev version.

## Validation

```
bash -n scripts/publish-crates.sh scripts/build-host.sh    # ok
shellcheck scripts/publish-crates.sh scripts/build-host.sh # clean
python3 -m unittest discover -s scripts/tests              # 390 passed, 7 skipped
cargo run -p xtask -- repo-consistency publish-crates      # passed
cargo fmt --all --check                                    # clean
cargo clippy -p xtask --all-targets -- -D warnings         # clean
```

Both guards were verified to actually fail, not just pass:

- hand-maintained branch reintroduced → rejected by name
- `cargo metadata` derivation removed → rejected
- loader function deleted → rejected
- restored → passes

And the regression test was run against the **old** hand-maintained map to confirm it reproduces the v0.75.1 failure, then against the fix to confirm it passes.

Version stamping exercised directly for all three paths: dev → `0.72.1+g1A2FEF.dirty`, release → `0.72.1`, preset `MESH_LLM_BUILD_VERSION` → respected.

Closes part of #1224.
