### PR TITLE
Publish Rust crate API docs with the website

### DIFF
--- a/.github/workflows/website-pages.yml
+++ b/.github/workflows/website-pages.yml
@@ -9,6 +9,12 @@ on:
       - "install.sh"
       - "install.ps1"
       - "install.md"
+      - "Cargo.lock"
+      - "Cargo.toml"
+      - "Justfile"
+      - "crates/**"
+      - "scripts/build-crate-docs.sh"
+      - "scripts/publish-crates.sh"
       - ".github/workflows/website-pages.yml"
 
 permissions:
@@ -23,11 +29,17 @@ jobs:
     name: Build public website
     if: github.event_name != 'workflow_dispatch' || github.ref == 'refs/heads/main'
     runs-on: ubuntu-24.04
-    timeout-minutes: 20
+    timeout-minutes: 40
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+
+      - name: Set up Rust
+        uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
+
+      - name: Install just
+        uses: taiki-e/install-action@3d23c1bbdafe696dfccad2664945a04f47d03dc3 # just
 
       - name: Set up Node.js
         uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
@@ -48,6 +60,9 @@ jobs:
         working-directory: website
         run: npm run build
 
+      - name: Build published crate API docs
+        run: just crate-docs
+
       - name: Stage Pages artifact
         run: |
           set -euo pipefail
@@ -67,6 +82,7 @@ jobs:
           cp -R docs/catalog "$artifact_dir/"
           cp -R docs/.well-known "$artifact_dir/"
           cp -R docs/docs "$artifact_dir/"
+          cp -R docs/crates "$artifact_dir/"
           cp -R docs/pagefind "$artifact_dir/"
 
       - name: Upload Pages artifact

--- a/.gitignore
+++ b/.gitignore
@@ -50,5 +50,6 @@ sdk/swift/Generated/MeshLLMFFI.xcframework/
 /docs/assets/
 /docs/catalog/
 /docs/docs/
+/docs/crates/
 /docs/pagefind/
 /website/src/assets/site.generated.css

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,16 +40,18 @@ existing Markdown documentation. The root `docs/` tree is therefore mixed
 ownership by path: generated website artifacts live at `docs/index.html`,
 `docs/CNAME`, `docs/install.sh`, `docs/install.ps1`, `docs/setup-mesh`,
 `docs/mesh-llm-logo.svg`, `docs/funding.json`, `docs/.well-known/`,
-`docs/catalog/`, `docs/assets/`, `docs/pagefind/`, and `docs/docs/`; project
+`docs/catalog/`, `docs/assets/`, `docs/pagefind/`, `docs/docs/`, and
+`docs/crates/`; project
 documentation Markdown such as `docs/MESHES.md`, `docs/design/**`,
 `docs/plugins/**`, and `docs/specs/**` remains source. Do not hand-edit the
 generated website artifact paths; update files under `website/src/` and rebuild
 instead.
 
 ```bash
-just website-build # cd website && npm run build; writes generated output to docs/
+just website-build # build website and crate API docs into docs/
 just website-dev   # Eleventy dev server on port 8765
 just website-clean # remove generated website output while preserving docs/ source
+just crate-docs    # regenerate only the published crate API docs
 ```
 
 The website build runs Tailwind first, then Eleventy, then Pagefind. Eleventy

--- a/Justfile
+++ b/Justfile
@@ -419,7 +419,12 @@ ui-dev-public: (ui-dev "https://public.meshllm.cloud")
 
 # Build the public website into docs/ for static hosting.
 website-build:
-    cd "{{ website_dir }}" && npm run build
+    cd "{{ website_dir }}" && npm run clean && npm run build
+    just crate-docs
+
+# Build Rustdoc for the crates published by the release workflow.
+crate-docs:
+    scripts/build-crate-docs.sh
 
 # Run the public website dev server on port 8765.
 website-dev:

--- a/scripts/build-crate-docs.sh
+++ b/scripts/build-crate-docs.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+mapfile -t crates < <(
+    sed -n '/^publish_crates=(/,/^)/p' scripts/publish-crates.sh \
+        | sed -n 's/^    \([[:alnum:]_-]*\)$/\1/p'
+)
+
+if [[ "${#crates[@]}" -eq 0 ]]; then
+    echo "No crates found in scripts/publish-crates.sh" >&2
+    exit 1
+fi
+
+echo "Building Rustdoc for ${#crates[@]} published crates"
+
+cargo clean --doc
+
+cargo_args=(doc --locked --no-deps)
+for crate in "${crates[@]}"; do
+    cargo_args+=(--package "$crate")
+done
+cargo "${cargo_args[@]}"
+
+landing_page=""
+if [[ -f docs/crates/index.html ]]; then
+    landing_page="$(mktemp)"
+    cp docs/crates/index.html "$landing_page"
+fi
+
+rm -rf docs/crates
+mkdir -p docs/crates
+cp -R target/doc/. docs/crates/
+
+if [[ -n "$landing_page" ]]; then
+    cp "$landing_page" docs/crates/index.html
+    rm -f "$landing_page"
+fi
+
+echo "Published crate docs to docs/crates/"

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -13,12 +13,12 @@ Project-specific instructions and references for AI agents working on the Mesh L
 
 - `website/` is the maintained source tree for the public static site.
 - `docs/` at the mesh-llm repo root is mixed by path: generated website output lives alongside authored project Markdown docs.
-- Generated website artifact paths are `../docs/index.html`, `../docs/CNAME`, `../docs/install.sh`, `../docs/install.ps1`, `../docs/setup-mesh`, `../docs/mesh-llm-logo.svg`, `../docs/funding.json`, `../docs/.well-known/`, `../docs/assets/`, `../docs/catalog/`, `../docs/docs/`, and `../docs/pagefind/`.
+- Generated website artifact paths are `../docs/index.html`, `../docs/CNAME`, `../docs/install.sh`, `../docs/install.ps1`, `../docs/setup-mesh`, `../docs/mesh-llm-logo.svg`, `../docs/funding.json`, `../docs/.well-known/`, `../docs/assets/`, `../docs/catalog/`, `../docs/docs/`, `../docs/crates/`, and `../docs/pagefind/`.
 - Authored project docs such as `../docs/MESHES.md`, `../docs/design/**`, `../docs/plugins/**`, and `../docs/specs/**` remain source and should be edited in place.
 - Do not hand-edit generated website artifact paths; edit `src/**` and rebuild.
 - Production build order is Tailwind CSS -> Eleventy -> Pagefind.
 - `npm run build` writes Tailwind output to `src/assets/site.generated.css`, runs Eleventy with output `../docs`, then indexes `../docs` with Pagefind.
-- From the mesh-llm repo root, use `just website-build` for production output, `just website-dev` for the local dev server, and `just website-clean` to remove generated website output while preserving authored docs.
+- From the mesh-llm repo root, use `just website-build` for production output including crate API docs, `just crate-docs` to regenerate only the crate docs, `just website-dev` for the local dev server, and `just website-clean` to remove generated website output while preserving authored docs.
 - Eleventy passthrough copies `src/CNAME`, `src/funding.json`, `src/.well-known/`, `src/assets/`, `src/mesh-llm-logo.svg`, and repo-root `../install.sh` / `../install.ps1` (plus `../install.md` published as `setup-mesh`) into the generated `docs/` tree.
 - `src/assets/site.generated.css`, `node_modules/`, Eleventy caches, and browser/test artifacts are generated/local artifacts, not source.
 
@@ -126,6 +126,7 @@ src/
 ├── _data/           /* Global data files */
 ├── _includes/       /* Layouts and partial templates */
 ├── catalog/         /* Catalog viewer */
+├── crates/          /* Crate API reference landing page */
 ├── docs/            /* Public documentation pages */
 └── index.njk        /* Homepage template */
 ```

--- a/website/README.md
+++ b/website/README.md
@@ -1,6 +1,8 @@
 # Mesh LLM Website
 
 The public website is built with Eleventy and emitted into `../docs` for static hosting.
+The root-level `just website-build` recipe also generates the published Rust
+crate API reference under `../docs/crates/`.
 
 ```sh
 cd website
@@ -22,6 +24,8 @@ just website-dev
 just website-build
 ```
 
+Use `just crate-docs` to regenerate only the Rust crate API reference.
+
 `npm run dev` runs Eleventy with watch mode, incremental builds, and browser
 reload on port 8765.
 
@@ -30,6 +34,7 @@ Source files live in `website/src`:
 - `index.njk` - landing page
 - `catalog/index.njk` - live Hugging Face catalog page
 - `docs/index.njk` - docs landing page
+- `crates/index.njk` - crate API reference landing page
 - `docs/pages/*.md` - public documentation pages
 - `_includes/` - shared layouts, nav, footer, and hero visual
 - `assets/site.tailwind.css` - shared styling source (generates `site.generated.css`)

--- a/website/scripts/clean-generated-site.mjs
+++ b/website/scripts/clean-generated-site.mjs
@@ -17,6 +17,7 @@ const generatedPaths = [
   "docs/assets",
   "docs/catalog",
   "docs/docs",
+  "docs/crates",
   "docs/pagefind",
   "website/src/assets/site.generated.css",
 ];

--- a/website/src/_data/crates.js
+++ b/website/src/_data/crates.js
@@ -1,0 +1,15 @@
+import { readFileSync } from "node:fs";
+
+const publishScript = readFileSync(new URL("../../../scripts/publish-crates.sh", import.meta.url), "utf8");
+const publishList = publishScript.match(/publish_crates=\(([\s\S]*?)\n\)/)?.[1];
+
+if (!publishList) {
+  throw new Error("Unable to determine the published crate list");
+}
+
+const crateNames = Array.from(publishList.matchAll(/^    ([a-z0-9_-]+)$/gm), ([, name]) => name);
+
+export default crateNames.map((name) => ({
+  name,
+  rustdocName: name.replaceAll("-", "_"),
+}));

--- a/website/src/_data/docs.js
+++ b/website/src/_data/docs.js
@@ -108,6 +108,7 @@ export default [
     description: "API reference, CLI commands, testing, and technical reference documentation.",
     links: [
       ["API reference", "/docs/pages/api-reference/"],
+      ["Crate API reference", "/crates/"],
       ["Skippy native API", "/docs/pages/skippy-api/"],
       ["OpenAI-compatible API", "/docs/pages/openai-compatible-api/"],
       ["CLI reference", "/docs/pages/CLI/"],

--- a/website/src/crates/index.njk
+++ b/website/src/crates/index.njk
@@ -1,0 +1,25 @@
+---
+layout: docs-base.njk
+title: Crate API reference
+description: Rust API documentation for the crates published by Mesh LLM.
+permalink: /crates/index.html
+---
+<main class="shell min-w-0 py-12 sm:py-16" data-pagefind-ignore="all">
+  <header class="docs-page-hero">
+    <p class="eyebrow">Rust API</p>
+    <h1 class="text-balance font-display text-[clamp(2.5rem,12vw,5rem)] leading-[0.95] text-fg">Crate API reference</h1>
+    <p class="lead mt-4 max-w-[42rem] text-pretty text-base leading-7 text-muted sm:text-lg">Browse the current API surface for the crates Mesh LLM publishes to crates.io. For versioned documentation, use the docs.rs link on each crate.</p>
+  </header>
+
+  <section class="mt-10 grid min-w-0 grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3" aria-label="Published crates">
+    {% for crate in crates %}
+      <article class="card grid min-w-0 gap-2 rounded-mesh border border-line-soft bg-surface/55 p-[18px] shadow-none">
+        <a class="font-mono text-sm font-semibold text-fg hover:text-blue-3" href="/crates/{{ crate.rustdocName }}/index.html">{{ crate.name }}</a>
+        <div class="flex flex-wrap gap-x-4 gap-y-1 text-xs text-muted">
+          <a class="hover:text-blue-3" href="/crates/{{ crate.rustdocName }}/index.html">Current API →</a>
+          <a class="external-link hover:text-blue-3" href="https://docs.rs/{{ crate.name }}/latest/" target="_blank" rel="noreferrer">docs.rs ↗</a>
+        </div>
+      </article>
+    {% endfor %}
+  </section>
+</main>


### PR DESCRIPTION
## What changed

The public website now publishes Rustdoc for every crate in the release workflow's crates.io publish list.

- Adds a `/crates/` landing page with current API links and docs.rs links.
- Generates Rustdoc from the same publish list used by `scripts/publish-crates.sh`.
- Includes generated docs in the GitHub Pages artifact and removes stale output during clean builds.
- Rebuilds the website when published crate sources or Cargo metadata change.
- Documents the new `just crate-docs` and `just website-build` behavior.

## Validation

- `just website-build`
- `cargo run -p xtask -- repo-consistency release-targets`
- `cargo run -p xtask -- repo-consistency ci-crate-lists`
- `actionlint .github/workflows/website-pages.yml`
- `just --fmt --check`
- `git diff --check`

Rustdoc emits existing warnings in several crates, but generation completes successfully.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a crate API reference section to the website.
  * Added a developer documentation link and responsive crate listing.
  * Included generated Rust API documentation for published crates in website builds.

* **Documentation**
  * Updated website and build documentation with crate API reference instructions.

* **Chores**
  * Improved website build automation, including Rust documentation generation and extended build timeouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->