### PR TITLE
feat(catalog): add Muse Glimmer 30B to the model catalog

### DIFF
--- a/crates/mesh-client/src/models/catalog.json
+++ b/crates/mesh-client/src/models/catalog.json
@@ -282,6 +282,19 @@
     }
   },
   {
+    "name": "Muse-Glimmer-30B-UD-Q4_K_XL",
+    "file": "Muse-Glimmer-30B-UD-Q4_K_XL.gguf",
+    "url": "https://huggingface.co/unsloth/Muse-Glimmer-30B-GGUF/resolve/main/Muse-Glimmer-30B-UD-Q4_K_XL.gguf",
+    "size": "15.9GB",
+    "description": "Meta Muse Glimmer 30B dense, vision + text, agentic tool calling and reasoning",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "mmproj-Muse-Glimmer-30B-BF16.gguf",
+      "url": "https://huggingface.co/unsloth/Muse-Glimmer-30B-GGUF/resolve/main/mmproj-Muse-Glimmer-30B-BF16.gguf"
+    }
+  },
+  {
     "name": "Qwen3-Coder-Next-Q4_K_M",
     "file": "Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",
     "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M/Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",

--- a/crates/mesh-llm-node/src/catalog.json
+++ b/crates/mesh-llm-node/src/catalog.json
@@ -282,6 +282,19 @@
     }
   },
   {
+    "name": "Muse-Glimmer-30B-UD-Q4_K_XL",
+    "file": "Muse-Glimmer-30B-UD-Q4_K_XL.gguf",
+    "url": "https://huggingface.co/unsloth/Muse-Glimmer-30B-GGUF/resolve/main/Muse-Glimmer-30B-UD-Q4_K_XL.gguf",
+    "size": "15.9GB",
+    "description": "Meta Muse Glimmer 30B dense, vision + text, agentic tool calling and reasoning",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "mmproj-Muse-Glimmer-30B-BF16.gguf",
+      "url": "https://huggingface.co/unsloth/Muse-Glimmer-30B-GGUF/resolve/main/mmproj-Muse-Glimmer-30B-BF16.gguf"
+    }
+  },
+  {
     "name": "Qwen3-Coder-Next-Q4_K_M",
     "file": "Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",
     "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M/Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",


### PR DESCRIPTION
Adds Meta's Muse Glimmer 30B (UD-Q4_K_XL, 15.9GB) with its vision projector to the bundled catalog, so it shows up in model listings, search, and the console catalog instead of requiring a full repo reference.

Follows the same shape as the Qwen3.6 additions in #1184.

## Notes
- **Depends on #1232**: the `muse-glimmer` arch only exists at the new llama.cpp pin; merge that first or this catalog entry will point at a model older binaries cannot load.
- No draft entry yet: the repo's `dflash-kquant.gguf` is a DFlash speculative drafter, which is a different lane from the catalog's GGUF draft-model field; can be wired up as a follow-up if wanted.
- Validated locally on an M4 Max via #1232's branch: model loads on Metal, serves chat, makes correct tool calls, and ran goose end-to-end at ~25 tok/s.

🤖 PR prepared by micn's agent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Muse-Glimmer-30B-UD-Q4_K_XL model to the catalog.
  * Included download details for the 15.9 GB GGUF model file.
  * Added support information for agentic vision, text, and reasoning capabilities.
  * Included the associated BF16 multimodal projection file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->