### PR TITLE
fix: repair the Fly console image build

### DIFF
--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -103,8 +103,12 @@ COPY crates/mesh-llm-native-runtime/ crates/mesh-llm-native-runtime/
 COPY crates/mesh-llm-runtime-install/ crates/mesh-llm-runtime-install/
 COPY crates/mesh-llm-sdk/ crates/mesh-llm-sdk/
 COPY crates/mesh-llm-tui/ crates/mesh-llm-tui/
+COPY crates/skippy-tokenizer/ crates/skippy-tokenizer/
+COPY crates/mesh-native-serving-plugin-api/ crates/mesh-native-serving-plugin-api/
+COPY crates/mesh-native-serving-plugin-host/ crates/mesh-native-serving-plugin-host/
 COPY tools/xtask/ tools/xtask/
 COPY scripts/prepare-llama.sh scripts/build-llama.sh scripts/
+COPY scripts/lib/ scripts/lib/
 COPY third_party/llama.cpp/upstream.txt third_party/llama.cpp/upstream.txt
 COPY third_party/llama.cpp/patches/ third_party/llama.cpp/patches/
 RUN --mount=type=cache,id=mesh-llm-sccache-debian-bookworm-gcc12-cpu-${TARGETARCH},target=/root/.cache/sccache,sharing=locked \


### PR DESCRIPTION
The **Deploy Fly Console** workflow currently fails for every ref, because the Fly console image cannot be built at all. This restores it, so deploying `public.meshllm.cloud` works from the Actions tab again.

Both causes are build-context gaps in `fly/Dockerfile`:

1. **Missing `scripts/lib/`.** `scripts/build-llama.sh` sources `scripts/lib/cuda-toolkit.sh`, but the image only copied `prepare-llama.sh` and `build-llama.sh`. The llama.cpp step aborted after applying the whole patch queue:

   ```
   scripts/build-llama.sh: line 7: /src/scripts/lib/cuda-toolkit.sh: No such file or directory
   ```

2. **Stale crate copy list.** `fly/Dockerfile` enumerates every workspace crate by hand, and had fallen behind by three: `skippy-tokenizer`, `mesh-native-serving-plugin-api`, `mesh-native-serving-plugin-host`. `cargo build --locked` then failed to load the workspace manifest:

   ```
   failed to load manifest for dependency `skippy-tokenizer`
   failed to read `/src/crates/skippy-tokenizer/Cargo.toml`
   ```

## Validation

Both fixes were applied and used to deploy the real app before this PR was opened — `mesh-llm-console` is now on v0.75.1 (up from 0.72.1), release v94:

```
$ curl -s https://public.meshllm.cloud/api/status
version 0.75.1  node b5e0004325  peers 8
```

Verified after deploy: `/v1/models`, non-streaming inference, SSE streaming, `model=mesh` MoA routing, and the console UI.

## Note

The hand-maintained crate list in `fly/Dockerfile` will keep going stale — nothing verifies it, and `docker.yml` only runs `buildx build --check` (a linter, not a build) on manual dispatch. `docker/Dockerfile.client` has the same two problems today and is missing 14 crates. Replacing the enumeration with `COPY crates/` would fix this class of bug permanently, since `.dockerignore` already excludes `target/`, `node_modules/`, and `dist/`. Left out of here to keep this a minimal repair.