### PR TITLE
fix: Skippy Nemotron MTP loading

### DIFF
--- a/crates/llama-spec-bench/src/main.rs
+++ b/crates/llama-spec-bench/src/main.rs
@@ -8,7 +8,9 @@ use anyhow::{Context, Result, bail};
 use clap::Parser;
 use serde::Serialize;
 use serde_json::Value;
-use skippy_runtime::{ModelInfo, RuntimeConfig, RuntimeLoadMode, StageModel, StageSession};
+use skippy_runtime::{
+    ModelInfo, MtpSource, RuntimeConfig, RuntimeLoadMode, StageModel, StageSession,
+};
 
 const DEFAULT_CORPUS: &str = "crates/skippy-bench/corpora/kv_mixed_prompts.jsonl";
 
@@ -242,6 +244,7 @@ fn open_full_model(path: &Path, ctx_size: u32, n_gpu_layers: i32) -> Result<Stag
             projector_path: None,
             include_embeddings: true,
             include_output: true,
+            mtp_source: MtpSource::Disabled,
             filter_tensors_on_load: false,
             mlock: false,
             mmap: Some(true),

--- a/crates/skippy-bench/src/distributed.rs
+++ b/crates/skippy-bench/src/distributed.rs
@@ -17,7 +17,7 @@ use skippy_protocol::binary::{
     write_stage_message,
 };
 use skippy_runtime::{
-    RuntimeConfig, RuntimeLoadMode, StageModel,
+    MtpSource, RuntimeConfig, RuntimeLoadMode, StageModel,
     package::{PackageStageRequest, materialize_layer_package_details},
 };
 
@@ -799,6 +799,7 @@ impl DriverTokenizer {
                 projector_path: None,
                 include_embeddings: true,
                 include_output: plan.stages.len() == 1,
+                mtp_source: MtpSource::Disabled,
                 filter_tensors_on_load: args.stage_load_mode != "runtime-slice",
             },
         )

--- a/crates/skippy-bench/src/local_split.rs
+++ b/crates/skippy-bench/src/local_split.rs
@@ -10,7 +10,7 @@ use skippy_protocol::binary::{
     StageStateHeader, StageWireMessage, WireMessageKind, WireReplyKind, recv_reply,
     write_stage_message,
 };
-use skippy_runtime::{RuntimeConfig, RuntimeLoadMode, StageModel};
+use skippy_runtime::{MtpSource, RuntimeConfig, RuntimeLoadMode, StageModel};
 use skippy_topology::{
     BoundaryDecision, NodeSpec, PlannerPolicy, TopologyPlanRequest, WireValidation,
     dense_attention_layers, infer_family_capability, plan_contiguous_with_splits,
@@ -234,6 +234,7 @@ fn run_full_model_decode(
         projector_path: None,
         include_embeddings: true,
         include_output: true,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: false,
     };
     let model = StageModel::open(model_path, &config).context("failed to open full model")?;
@@ -304,6 +305,7 @@ fn run_binary_split(args: BinarySplitConfig) -> Result<BinarySplitResult> {
         projector_path: None,
         include_embeddings: true,
         include_output: false,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: true,
     };
     let stage0 =
@@ -491,6 +493,7 @@ fn run_binary_chain(args: LocalSplitChainBinaryArgs) -> Result<BinaryChainResult
         projector_path: None,
         include_embeddings: true,
         include_output: false,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: true,
     };
     let stage0 =
@@ -848,6 +851,7 @@ pub fn local_split_inprocess(args: LocalSplitInprocessArgs) -> Result<()> {
         projector_path: None,
         include_embeddings: true,
         include_output: false,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: true,
     };
     let stage1_config = RuntimeConfig {
@@ -871,6 +875,7 @@ pub fn local_split_inprocess(args: LocalSplitInprocessArgs) -> Result<()> {
         projector_path: None,
         include_embeddings: false,
         include_output: true,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: true,
     };
 

--- a/crates/skippy-bench/src/token_lengths.rs
+++ b/crates/skippy-bench/src/token_lengths.rs
@@ -4,8 +4,8 @@ use anyhow::{Context, Result};
 use serde::Serialize;
 use serde_json::Value;
 use skippy_runtime::{
-    ChatTemplateMessage, ChatTemplateOptions, RuntimeConfig, RuntimeLoadMode, StageModel,
-    suppress_native_logs,
+    ChatTemplateMessage, ChatTemplateOptions, MtpSource, RuntimeConfig, RuntimeLoadMode,
+    StageModel, suppress_native_logs,
 };
 
 use crate::cli::TokenLengthsArgs;
@@ -91,6 +91,7 @@ pub fn token_lengths(args: TokenLengthsArgs) -> Result<()> {
             projector_path: None,
             include_embeddings: true,
             include_output: false,
+            mtp_source: MtpSource::Disabled,
             filter_tensors_on_load: true,
         },
     )

--- a/crates/skippy-bench/src/verify_window_local.rs
+++ b/crates/skippy-bench/src/verify_window_local.rs
@@ -7,8 +7,8 @@ use std::{
 use anyhow::{Context, Result, bail};
 use serde::Serialize;
 use skippy_runtime::{
-    FlashAttentionType, GenerationSignalWindow, RuntimeConfig, RuntimeLoadMode, SamplingConfig,
-    StageModel, StageSession, TokenSignal, parse_cache_type,
+    FlashAttentionType, GenerationSignalWindow, MtpSource, RuntimeConfig, RuntimeLoadMode,
+    SamplingConfig, StageModel, StageSession, TokenSignal, parse_cache_type,
 };
 
 use crate::cli::{FlashAttentionArg, MAX_VERIFY_WINDOW_WIDTH, VerifyWindowLocalArgs};
@@ -225,6 +225,7 @@ fn full_runtime_config(args: &VerifyWindowLocalArgs) -> Result<RuntimeConfig> {
         projector_path: None,
         include_embeddings: true,
         include_output: true,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: false,
     })
 }
@@ -865,6 +866,7 @@ fn split_runtime_configs(
         projector_path: None,
         include_embeddings: true,
         include_output: false,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: true,
     };
     let stage1 = RuntimeConfig {
@@ -888,6 +890,7 @@ fn split_runtime_configs(
         projector_path: None,
         include_embeddings: false,
         include_output: true,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: true,
     };
     Ok((stage0, stage1))

--- a/crates/skippy-correctness/src/runner/single_step.rs
+++ b/crates/skippy-correctness/src/runner/single_step.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, bail};
 use model_artifact::ModelIdentity;
 use serde_json::json;
 use skippy_protocol::binary::{StageWireMessage, WireReplyKind, recv_reply, write_stage_message};
-use skippy_runtime::{GGML_TYPE_F16, RuntimeConfig, RuntimeLoadMode, StageModel};
+use skippy_runtime::{GGML_TYPE_F16, MtpSource, RuntimeConfig, RuntimeLoadMode, StageModel};
 
 use crate::{
     cli::{RuntimeArgs, ServerArgs, SingleStepArgs},
@@ -129,6 +129,7 @@ pub(in crate::runner) fn run_full_model_decode(args: &RuntimeArgs) -> Result<Ful
         projector_path: None,
         include_embeddings: true,
         include_output: true,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: false,
         cache_type_k: GGML_TYPE_F16,
         cache_type_v: GGML_TYPE_F16,
@@ -211,6 +212,7 @@ pub(in crate::runner) fn run_binary_split(args: BinarySplitConfig) -> Result<Bin
         projector_path: None,
         include_embeddings: true,
         include_output: false,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: true,
         cache_type_k: GGML_TYPE_F16,
         cache_type_v: GGML_TYPE_F16,

--- a/crates/skippy-correctness/src/runner/split_chain.rs
+++ b/crates/skippy-correctness/src/runner/split_chain.rs
@@ -10,7 +10,7 @@ use anyhow::{Context, Result, bail};
 use model_artifact::ModelIdentity;
 use serde_json::json;
 use skippy_protocol::binary::{StageWireMessage, WireReplyKind, write_stage_message};
-use skippy_runtime::{GGML_TYPE_F16, RuntimeConfig, StageModel};
+use skippy_runtime::{GGML_TYPE_F16, MtpSource, RuntimeConfig, StageModel};
 
 use crate::{
     cli::{ChainArgs, DtypeMatrixArgs, FlashAttentionArg, SplitScanArgs, StageLoadMode},
@@ -333,6 +333,7 @@ fn run_binary_chain(args: BinaryChainConfig) -> Result<BinaryChainResult> {
         projector_path: None,
         include_embeddings: true,
         include_output: false,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: true,
         cache_type_k: GGML_TYPE_F16,
         cache_type_v: GGML_TYPE_F16,

--- a/crates/skippy-correctness/src/runner/stage_execution.rs
+++ b/crates/skippy-correctness/src/runner/stage_execution.rs
@@ -17,7 +17,7 @@ use skippy_protocol::binary::{
     activation_state_flags_from_frame_flags, recv_reply, write_stage_message,
 };
 use skippy_runtime::{
-    ActivationFrame, GGML_TYPE_F16, RuntimeConfig, RuntimeLoadMode,
+    ActivationFrame, GGML_TYPE_F16, MtpSource, RuntimeConfig, RuntimeLoadMode,
     package::{MaterializedPackage, PackageStageRequest, materialize_layer_package_details},
 };
 
@@ -447,6 +447,7 @@ pub(in crate::runner) fn tokenizer_model_for_state_handoff(
             projector_path: None,
             include_embeddings: true,
             include_output: false,
+            mtp_source: MtpSource::Disabled,
             filter_tensors_on_load,
             cache_type_k: GGML_TYPE_F16,
             cache_type_v: GGML_TYPE_F16,

--- a/crates/skippy-correctness/src/runner/stage_fa_parity.rs
+++ b/crates/skippy-correctness/src/runner/stage_fa_parity.rs
@@ -1,6 +1,6 @@
 use anyhow::{Context, Result, bail};
 use skippy_runtime::{
-    FlashAttentionType, GGML_TYPE_F16, RuntimeConfig, RuntimeLoadMode, StageModel,
+    FlashAttentionType, GGML_TYPE_F16, MtpSource, RuntimeConfig, RuntimeLoadMode, StageModel,
     package::{PackageStageRequest, select_layer_package_parts},
 };
 
@@ -86,6 +86,7 @@ fn decode_boundary(
         projector_path: None,
         include_embeddings: true,
         include_output: false,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: true,
     };
     let selection = select_layer_package_parts(&PackageStageRequest {

--- a/crates/skippy-correctness/src/runner/state_handoff.rs
+++ b/crates/skippy-correctness/src/runner/state_handoff.rs
@@ -9,7 +9,8 @@ use skippy_protocol::binary::{
     write_stage_message,
 };
 use skippy_runtime::{
-    ActivationFrame, GGML_TYPE_F16, RuntimeConfig, RuntimeKvPageDesc, StageModel, StageSession,
+    ActivationFrame, GGML_TYPE_F16, MtpSource, RuntimeConfig, RuntimeKvPageDesc, StageModel,
+    StageSession,
 };
 
 use crate::{
@@ -681,6 +682,7 @@ fn run_local_state_handoff(
         projector_path: None,
         include_embeddings,
         include_output,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: should_filter_state_handoff_tensors(args),
         cache_type_k: GGML_TYPE_F16,
         cache_type_v: GGML_TYPE_F16,
@@ -1424,6 +1426,7 @@ fn build_state_handoff_inputs(
         projector_path: None,
         include_embeddings: true,
         include_output: false,
+        mtp_source: MtpSource::Disabled,
         filter_tensors_on_load: true,
         cache_type_k: GGML_TYPE_F16,
         cache_type_v: GGML_TYPE_F16,

--- a/crates/skippy-correctness/tests/parity_models/mod.rs
+++ b/crates/skippy-correctness/tests/parity_models/mod.rs
@@ -11,8 +11,8 @@ use model_ref::split_gguf_shard_info;
 use serde::Deserialize;
 use serde_json::Value;
 use skippy_runtime::{
-    ActivationFrame, GGML_TYPE_F16, RuntimeConfig, RuntimeKvPage, RuntimeLoadMode, StageModel,
-    StageSession,
+    ActivationFrame, GGML_TYPE_F16, MtpSource, RuntimeConfig, RuntimeKvPage, RuntimeLoadMode,
+    StageModel, StageSession,
     package::{PackageStageRequest, inspect_layer_package, materialize_layer_package_details},
     redirect_native_logs_to_file,
 };
@@ -1106,6 +1106,7 @@ fn open_stage_model(path: &StagePath, shape: StageShape, n_gpu_layers: i32) -> R
             projector_path: None,
             include_embeddings: shape.include_embeddings,
             include_output: shape.include_output,
+            mtp_source: MtpSource::Disabled,
             filter_tensors_on_load: path.filter_tensors_on_load,
         },
     )

--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -1,6 +1,6 @@
 pub const ABI_VERSION_MAJOR: u32 = 0;
 pub const ABI_VERSION_MINOR: u32 = 1;
-pub const ABI_VERSION_PATCH: u32 = 37;
+pub const ABI_VERSION_PATCH: u32 = 38;
 pub const FEATURE_BACKEND_DEVICES: u64 = 1 << 23;
 pub const FEATURE_RUNTIME_EVENTS: u64 = 1 << 24;
 pub const FEATURE_NATIVE_MTP_N1: u64 = 1 << 25;
@@ -151,6 +151,15 @@ pub enum LoadMode {
     ArtifactSlice = 2,
 }
 
+#[repr(i32)]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum MtpSource {
+    #[default]
+    Disabled = 0,
+    Integrated = 1,
+    External = 2,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[repr(i32)]
 pub enum TensorRole {
@@ -226,6 +235,7 @@ pub struct RuntimeConfig {
     pub filter_tensors_on_load: bool,
     pub include_embeddings: bool,
     pub include_output: bool,
+    pub mtp_source: MtpSource,
     pub selected_backend_device: *const c_char,
     pub glm_dsa_policy_profile: i32,
     pub glm_dsa_policy_flags: u32,

--- a/crates/skippy-prompt/src/prompt_cli/binary_repl.rs
+++ b/crates/skippy-prompt/src/prompt_cli/binary_repl.rs
@@ -37,6 +37,7 @@ pub fn binary_repl(args: BinaryReplArgs) -> Result<()> {
             projector_path: None,
             include_embeddings: true,
             include_output: false,
+            mtp_source: MtpSource::Disabled,
             filter_tensors_on_load: true,
         },
     )
@@ -83,6 +84,7 @@ pub fn binary_repl(args: BinaryReplArgs) -> Result<()> {
                 projector_path: None,
                 include_embeddings: true,
                 include_output: false,
+                mtp_source: MtpSource::Disabled,
                 filter_tensors_on_load: true,
             },
         )

--- a/crates/skippy-prompt/src/prompt_cli/draft.rs
+++ b/crates/skippy-prompt/src/prompt_cli/draft.rs
@@ -32,6 +32,7 @@ impl DraftRunner {
                 projector_path: None,
                 include_embeddings: true,
                 include_output: true,
+                mtp_source: MtpSource::Disabled,
                 filter_tensors_on_load: true,
                 mlock: false,
                 mmap: Some(true),

--- a/crates/skippy-prompt/src/prompt_cli/mod.rs
+++ b/crates/skippy-prompt/src/prompt_cli/mod.rs
@@ -30,7 +30,7 @@ use skippy_protocol::{
     StageKvCacheConfig, StageKvCacheMode, StageKvCachePayload,
 };
 use skippy_runtime::{
-    ChatTemplateMessage, ChatTemplateOptions, GGML_TYPE_F16, ModelInfo, RuntimeConfig,
+    ChatTemplateMessage, ChatTemplateOptions, GGML_TYPE_F16, ModelInfo, MtpSource, RuntimeConfig,
     RuntimeLoadMode, StageModel, StageSession,
     package::{PackageStageRequest, inspect_layer_package, materialize_layer_package},
     restore_native_logs, suppress_native_logs,

--- a/crates/skippy-quantize/src/mtp_attach.rs
+++ b/crates/skippy-quantize/src/mtp_attach.rs
@@ -4,7 +4,8 @@ use anyhow::{Context, Result, ensure};
 use clap::Parser;
 use serde::Serialize;
 use skippy_runtime::{
-    FlashAttentionType, GGML_TYPE_F16, ModelInfo, RuntimeConfig, RuntimeLoadMode, StageModel,
+    FlashAttentionType, GGML_TYPE_F16, ModelInfo, MtpSource, RuntimeConfig, RuntimeLoadMode,
+    StageModel,
 };
 
 use crate::output::{print_json_pretty, print_success};
@@ -59,6 +60,7 @@ pub(crate) fn run_validate_mtp_attach(args: ValidateMtpAttachArgs) -> Result<()>
         args.ctx_size,
         args.n_gpu_layers,
         args.projector.as_deref(),
+        MtpSource::Disabled,
     );
     let mut target = if args.model_parts.len() == 1 {
         StageModel::open(&args.model_parts[0], &target_config)
@@ -75,7 +77,13 @@ pub(crate) fn run_validate_mtp_attach(args: ValidateMtpAttachArgs) -> Result<()>
         mtp_layer_count > 0,
         "--mtp-layer-count must be greater than zero"
     );
-    let draft_config = runtime_config(mtp_layer_count, args.ctx_size, args.n_gpu_layers, None);
+    let draft_config = runtime_config(
+        mtp_layer_count,
+        args.ctx_size,
+        args.n_gpu_layers,
+        None,
+        MtpSource::External,
+    );
     target
         .attach_mtp_draft_model(&args.mtp_draft, &draft_config)
         .context("attach MTP draft model")?;
@@ -154,6 +162,7 @@ fn runtime_config(
     ctx_size: u32,
     n_gpu_layers: i32,
     projector: Option<&Path>,
+    mtp_source: MtpSource,
 ) -> RuntimeConfig {
     RuntimeConfig {
         stage_index: 0,
@@ -176,6 +185,7 @@ fn runtime_config(
         projector_path: projector.map(|path| path.display().to_string()),
         include_embeddings: true,
         include_output: true,
+        mtp_source,
         filter_tensors_on_load: false,
     }
 }
@@ -186,7 +196,13 @@ mod tests {
 
     #[test]
     fn attach_probe_uses_small_mmap_runtime_config() {
-        let config = runtime_config(66, 64, 0, Some(Path::new("/models/mmproj.gguf")));
+        let config = runtime_config(
+            66,
+            64,
+            0,
+            Some(Path::new("/models/mmproj.gguf")),
+            MtpSource::Disabled,
+        );
 
         assert_eq!(config.layer_start, 0);
         assert_eq!(config.layer_end, 66);

--- a/crates/skippy-runtime/src/config.rs
+++ b/crates/skippy-runtime/src/config.rs
@@ -2,7 +2,7 @@ use std::ffi::CString;
 use std::ptr;
 
 use anyhow::{Context, Result, anyhow};
-use skippy_ffi::{LoadMode, RuntimeConfig as RawRuntimeConfig};
+use skippy_ffi::{LoadMode, MtpSource as RawMtpSource, RuntimeConfig as RawRuntimeConfig};
 
 pub const GGML_TYPE_F16: u32 = 1;
 pub const GGML_TYPE_Q4_0: u32 = 2;
@@ -24,6 +24,26 @@ pub enum FlashAttentionType {
     Auto = -1,
     Disabled = 0,
     Enabled = 1,
+}
+
+/// Selects whether this target keeps no MTP tensors, its integrated MTP heads,
+/// or waits for an external MTP sidecar to attach.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum MtpSource {
+    #[default]
+    Disabled,
+    Integrated,
+    External,
+}
+
+impl MtpSource {
+    const fn as_raw(self) -> RawMtpSource {
+        match self {
+            Self::Disabled => RawMtpSource::Disabled,
+            Self::Integrated => RawMtpSource::Integrated,
+            Self::External => RawMtpSource::External,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -48,6 +68,7 @@ pub struct RuntimeConfig {
     pub projector_path: Option<String>,
     pub include_embeddings: bool,
     pub include_output: bool,
+    pub mtp_source: MtpSource,
     pub filter_tensors_on_load: bool,
 }
 
@@ -137,6 +158,7 @@ impl RuntimeConfig {
                 filter_tensors_on_load: self.filter_tensors_on_load,
                 include_embeddings: self.include_embeddings,
                 include_output: self.include_output,
+                mtp_source: self.mtp_source.as_raw(),
                 selected_backend_device: selected_backend_device_ptr,
                 glm_dsa_policy_profile: 0,
                 glm_dsa_policy_flags: 0,
@@ -155,7 +177,7 @@ impl RuntimeConfig {
             .unwrap_or_else(|| default_n_batch_for_lane_count(self.lane_count));
         let n_ubatch = self.n_ubatch.unwrap_or(LLAMA_SERVER_DEFAULT_N_UBATCH);
         format!(
-            "stage_index={} layers={}..{} ctx={} lanes={} n_batch={} n_ubatch={} n_gpu_layers={} mmap={} mlock={} backend={} cache_k={} cache_v={} flash_attn={:?} load_mode={:?} include_embeddings={} include_output={} filter_tensors_on_load={}",
+            "stage_index={} layers={}..{} ctx={} lanes={} n_batch={} n_ubatch={} n_gpu_layers={} mmap={} mlock={} backend={} cache_k={} cache_v={} flash_attn={:?} load_mode={:?} include_embeddings={} include_output={} mtp_source={:?} filter_tensors_on_load={}",
             self.stage_index,
             self.layer_start,
             self.layer_end,
@@ -175,6 +197,7 @@ impl RuntimeConfig {
             self.load_mode,
             self.include_embeddings,
             self.include_output,
+            self.mtp_source,
             self.filter_tensors_on_load,
         )
     }
@@ -216,6 +239,7 @@ impl Default for RuntimeConfig {
             projector_path: None,
             include_embeddings: true,
             include_output: true,
+            mtp_source: MtpSource::Disabled,
             filter_tensors_on_load: false,
         }
     }
@@ -331,7 +355,27 @@ mod tests {
         assert_eq!(raw.glm_dsa_direct_sparse_decode_max_top_k, 0);
         assert_eq!(raw.glm_dsa_dense_sparse_mask_max_bytes, 0);
         assert_eq!(raw.glm_dsa_compact_flash_min_kv, 0);
+        assert_eq!(raw.mtp_source, RawMtpSource::Disabled);
         assert!(raw.selected_backend_device.is_null());
+        Ok(())
+    }
+
+    #[test]
+    fn runtime_config_raw_preserves_explicit_mtp_source() -> anyhow::Result<()> {
+        for (source, expected) in [
+            (MtpSource::Disabled, RawMtpSource::Disabled),
+            (MtpSource::Integrated, RawMtpSource::Integrated),
+            (MtpSource::External, RawMtpSource::External),
+        ] {
+            let raw = RuntimeConfig {
+                mtp_source: source,
+                ..RuntimeConfig::default()
+            }
+            .as_raw()?
+            .raw;
+
+            assert_eq!(raw.mtp_source, expected);
+        }
         Ok(())
     }
 

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -22,7 +22,7 @@ mod types;
 pub use activation::DecodeFrameBatchRequest;
 pub use config::{
     FlashAttentionType, GGML_TYPE_F16, GGML_TYPE_Q4_0, GGML_TYPE_Q8_0,
-    LLAMA_SERVER_DEFAULT_N_BATCH, LLAMA_SERVER_DEFAULT_N_UBATCH, RuntimeConfig,
+    LLAMA_SERVER_DEFAULT_N_BATCH, LLAMA_SERVER_DEFAULT_N_UBATCH, MtpSource, RuntimeConfig,
     SKIPPY_UNIFIED_KV_DEFAULT_N_BATCH, parse_cache_type,
 };
 pub use devices::{BackendDevice, BackendDeviceType, backend_devices};

--- a/crates/skippy-runtime/src/tests.rs
+++ b/crates/skippy-runtime/src/tests.rs
@@ -5,7 +5,7 @@ mod tests {
 
     use super::{
         ChatReasoningFormat, ChatTemplateJsonOptions, ChatTemplateMessage, FlashAttentionType,
-        GGML_TYPE_F16, ModelInfo, NativeMtpDraft, RuntimeConfig, RuntimeLoadMode, SamplingConfig,
+        GGML_TYPE_F16, ModelInfo, MtpSource, NativeMtpDraft, RuntimeConfig, RuntimeLoadMode, SamplingConfig,
         StageModel, StageSession, Status, TensorRole, format_skippy_error,
     };
     use std::{
@@ -82,6 +82,7 @@ mod tests {
             projector_path: None,
             include_embeddings: true,
             include_output: true,
+            mtp_source: MtpSource::Disabled,
             filter_tensors_on_load: false,
         };
         StageModel::open(model_path, &config)

--- a/crates/skippy-server/src/binary_transport/binary_messaging.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging.rs
@@ -25,7 +25,7 @@ use crate::{
     config::validate_config,
     frontend::{self, EmbeddedOpenAiArgs},
     kv_integration::KvStageIntegration,
-    runtime_state::load_runtime,
+    runtime_state::{RuntimeLaunchOverrides, load_runtime_with_overrides},
     telemetry::{Telemetry, lifecycle_attrs},
 };
 use anyhow::{Context, Result, anyhow, bail};
@@ -71,6 +71,7 @@ pub async fn serve_binary_stage_with_shutdown(
 }
 
 fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> Result<()> {
+    let mtp_source = options.resolved_mtp_source();
     let BinaryStageOptions {
         config,
         topology,
@@ -102,7 +103,14 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
     if warm_downstream_preconnect_enabled() {
         spawn_downstream_preconnector(config.clone(), warm_downstream.clone(), shutdown.clone());
     }
-    let runtime = load_runtime(&config)?.context("binary stage server requires model_path")?;
+    let runtime = load_runtime_with_overrides(
+        &config,
+        &RuntimeLaunchOverrides {
+            mtp_source,
+            ..RuntimeLaunchOverrides::default()
+        },
+    )?
+    .context("binary stage server requires model_path")?;
     let decode_frame_batcher = DecodeFrameBatcher::new(runtime.clone(), max_inflight);
     if max_inflight > 0 {
         let timer = Instant::now();

--- a/crates/skippy-server/src/binary_transport/options.rs
+++ b/crates/skippy-server/src/binary_transport/options.rs
@@ -2,6 +2,7 @@ use std::{net::SocketAddr, path::PathBuf};
 
 use anyhow::{Context, Result, bail};
 use skippy_protocol::{StageConfig, StageTopology, binary::WireActivationDType};
+use skippy_runtime::MtpSource;
 
 use crate::{
     cli::ServeBinaryArgs, config::load_json, frontend::SpeculativeDecodeConfig,
@@ -123,6 +124,23 @@ impl BinaryStageOptions {
             native_mtp_enabled,
             openai,
         })
+    }
+
+    pub(crate) fn resolved_mtp_source(&self) -> MtpSource {
+        if !self.native_mtp_enabled || !self.config.native_mtp_enabled {
+            return MtpSource::Disabled;
+        }
+        let Some(openai) = self.openai.as_ref() else {
+            return MtpSource::Integrated;
+        };
+        if !openai.speculative.native_mtp.enabled {
+            return MtpSource::Disabled;
+        }
+        if openai.native_mtp_draft_model_path.is_some() {
+            MtpSource::External
+        } else {
+            MtpSource::Integrated
+        }
     }
 }
 
@@ -252,6 +270,7 @@ mod tests {
         };
 
         let options = BinaryStageOptions::from_cli_args(args).expect("resolve binary stage");
+        assert_eq!(options.resolved_mtp_source(), MtpSource::Integrated);
         let openai = options.openai.expect("embedded OpenAI configuration");
 
         assert!(options.native_mtp_enabled);
@@ -263,12 +282,18 @@ mod tests {
         let dir = tempfile::tempdir().expect("create temp directory");
         let stage_path = dir.path().join("stage.json");
         let sidecar_path = dir.path().join("sidecar-mtp.gguf");
+        let plan_path = dir.path().join("speculative.json");
         fs::write(
             &stage_path,
             serde_json::to_vec(&stage_config()).expect("serialize stage config"),
         )
         .expect("write stage config");
         fs::write(&sidecar_path, b"gguf-stub").expect("write sidecar stub");
+        fs::write(
+            &plan_path,
+            serde_json::to_vec(&cache_composite_plan()).expect("serialize speculative config"),
+        )
+        .expect("write speculative config");
 
         let cli = Cli::try_parse_from([
             "skippy-server",
@@ -279,6 +304,8 @@ mod tests {
             "2048",
             "--openai-bind-addr",
             "127.0.0.1:9337",
+            "--openai-speculative-config",
+            plan_path.to_str().expect("UTF-8 speculative path"),
             "--openai-native-mtp-draft-model-path",
             sidecar_path.to_str().expect("UTF-8 sidecar path"),
         ])
@@ -288,6 +315,7 @@ mod tests {
         };
 
         let options = BinaryStageOptions::from_cli_args(args).expect("resolve binary stage");
+        assert_eq!(options.resolved_mtp_source(), MtpSource::External);
         let openai = options.openai.expect("embedded OpenAI configuration");
 
         // The sidecar attaches MTP heads to the served model; it must not be
@@ -297,6 +325,35 @@ mod tests {
             Some(sidecar_path.as_path())
         );
         assert_eq!(openai.draft_model_path, None);
+    }
+
+    #[test]
+    fn disabled_native_mtp_keeps_a_terminal_stage_out_of_integrated_mode() {
+        let dir = tempfile::tempdir().expect("create temp directory");
+        let stage_path = dir.path().join("stage.json");
+        let mut config = stage_config();
+        config.native_mtp_enabled = false;
+        fs::write(
+            &stage_path,
+            serde_json::to_vec(&config).expect("serialize stage config"),
+        )
+        .expect("write stage config");
+
+        let cli = Cli::try_parse_from([
+            "skippy-server",
+            "serve-binary",
+            "--config",
+            stage_path.to_str().expect("UTF-8 stage path"),
+            "--activation-width",
+            "2048",
+        ])
+        .expect("parse binary stage CLI");
+        let Command::ServeBinary(args) = cli.command else {
+            panic!("expected serve-binary command");
+        };
+
+        let options = BinaryStageOptions::from_cli_args(args).expect("resolve binary stage");
+        assert_eq!(options.resolved_mtp_source(), MtpSource::Disabled);
     }
 
     #[test]

--- a/crates/skippy-server/src/embedded.rs
+++ b/crates/skippy-server/src/embedded.rs
@@ -166,6 +166,7 @@ impl SkippyRuntimeHandle {
             &RuntimeLaunchOverrides {
                 n_threads: options.n_threads,
                 n_threads_batch: options.n_threads_batch,
+                mtp_source: skippy_runtime::MtpSource::Disabled,
             },
         )?
         .with_context(|| format!("stage {} requires model_path", options.config.stage_id))?;
@@ -201,6 +202,7 @@ impl SkippyRuntimeHandle {
             &RuntimeLaunchOverrides {
                 n_threads: options.n_threads,
                 n_threads_batch: options.n_threads_batch,
+                mtp_source: skippy_runtime::MtpSource::Disabled,
             },
             model_open_event_reporter.as_mut().map(|reporter| {
                 reporter.as_mut() as &mut (dyn FnMut(skippy_runtime::RuntimeEvent) + Send)

--- a/crates/skippy-server/src/frontend/generation/draft_runner.rs
+++ b/crates/skippy-server/src/frontend/generation/draft_runner.rs
@@ -5,11 +5,11 @@ use anyhow::anyhow;
 use anyhow::bail;
 use skippy_protocol::StageConfig;
 use skippy_runtime::FlashAttentionType as RuntimeFlashAttentionType;
-use skippy_runtime::ModelInfo;
 use skippy_runtime::RuntimeConfig;
 use skippy_runtime::RuntimeLoadMode;
 use skippy_runtime::StageModel;
 use skippy_runtime::StageSession;
+use skippy_runtime::{ModelInfo, MtpSource};
 use std::path::Path;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -59,6 +59,7 @@ impl DraftRunner {
                 projector_path: None,
                 include_embeddings: true,
                 include_output: true,
+                mtp_source: MtpSource::Disabled,
                 filter_tensors_on_load: false,
             },
         )
@@ -160,6 +161,7 @@ pub(in crate::frontend) fn attach_native_mtp_draft_model(
                 projector_path: None,
                 include_embeddings: true,
                 include_output: true,
+                mtp_source: MtpSource::External,
                 filter_tensors_on_load: false,
             },
         )

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -9,7 +9,7 @@ use skippy_protocol::{FlashAttentionType, LoadMode, StageConfig};
 use skippy_runtime::{
     ActivationFrame, DecodeBatchRequest, DecodeFrameBatchOutput, DecodeFrameBatchRequest,
     FlashAttentionType as RuntimeFlashAttentionType, GenerationSignalWindow, MediaInput,
-    MediaPrefill, MediaPrefillFrame, NativeMtpDraft, RuntimeConfig, RuntimeKvPage,
+    MediaPrefill, MediaPrefillFrame, MtpSource, NativeMtpDraft, RuntimeConfig, RuntimeKvPage,
     RuntimeKvPageDesc, RuntimeLoadMode, SamplingConfig, StageModel, StageSession, TokenSignal,
     parse_cache_type,
 };
@@ -23,6 +23,7 @@ mod lane_lifecycle;
 pub struct RuntimeLaunchOverrides {
     pub n_threads: Option<usize>,
     pub n_threads_batch: Option<usize>,
+    pub mtp_source: MtpSource,
 }
 
 pub struct RuntimeState {
@@ -299,6 +300,7 @@ fn runtime_config_from_stage_config(
         include_embeddings: config.layer_start == 0
             || (config.load_mode == LoadMode::LayerPackage && config.downstream.is_none()),
         include_output: config.downstream.is_none(),
+        mtp_source: overrides.mtp_source,
         filter_tensors_on_load: config.filter_tensors_on_load,
     })
 }
@@ -343,7 +345,7 @@ mod tests {
     use skippy_protocol::{FlashAttentionType, LoadMode, PeerConfig, StageConfig, StageDevice};
     use skippy_runtime::{
         ActivationDesc, ActivationFrame, FlashAttentionType as RuntimeFlashAttentionType,
-        RuntimeActivationDType, RuntimeActivationLayout, SamplingConfig,
+        MtpSource, RuntimeActivationDType, RuntimeActivationLayout, RuntimeConfig, SamplingConfig,
     };
 
     use super::{
@@ -398,6 +400,7 @@ mod tests {
         let overrides = RuntimeLaunchOverrides {
             n_threads: Some(8),
             n_threads_batch: Some(4),
+            mtp_source: MtpSource::External,
         };
 
         let runtime_config = runtime_config_from_stage_config(&config, &overrides).unwrap();
@@ -417,6 +420,7 @@ mod tests {
             runtime_config.flash_attn_type,
             RuntimeFlashAttentionType::Enabled
         );
+        assert_eq!(runtime_config.mtp_source, MtpSource::External);
     }
 
     #[test]
@@ -472,23 +476,19 @@ mod tests {
 
         assert!(runtime_config.include_embeddings);
         assert!(runtime_config.include_output);
+        assert_eq!(runtime_config.mtp_source, MtpSource::Disabled);
     }
 
-    #[test]
-    fn glm52_final_stage_package_executes_native_mtp_when_fixture_is_set() -> anyhow::Result<()> {
-        let Some(package_path) = std::env::var_os("SKIPPY_GLM52_MTP_PACKAGE") else {
-            eprintln!("skipping: SKIPPY_GLM52_MTP_PACKAGE is not set");
-            return Ok(());
-        };
-        let package_path = std::path::PathBuf::from(package_path);
+    fn glm52_mtp_fixture() -> Option<(std::path::PathBuf, StageConfig)> {
+        let package_path =
+            std::env::var_os("SKIPPY_GLM52_MTP_PACKAGE").map(std::path::PathBuf::from)?;
         if !package_path.join("model-package.json").is_file() {
             eprintln!(
                 "skipping: {} does not look like a layer package",
                 package_path.display()
             );
-            return Ok(());
+            return None;
         }
-
         let config = StageConfig {
             run_id: "glm52-mtp-smoke".to_string(),
             topology_id: "glm52-mtp-smoke-topology".to_string(),
@@ -534,12 +534,12 @@ mod tests {
             }),
             downstream: None,
         };
+        Some((package_path, config))
+    }
 
-        let runtime = load_runtime_with_overrides(&config, &RuntimeLaunchOverrides::default())?
-            .expect("GLM final stage should load from the package");
-        let mut runtime = runtime.lock().expect("runtime mutex poisoned");
+    fn glm52_mtp_input() -> ActivationFrame {
         let hidden_bytes = 6144 * std::mem::size_of::<f32>();
-        let input = ActivationFrame {
+        ActivationFrame {
             desc: ActivationDesc {
                 version: 1,
                 dtype: RuntimeActivationDType::F32,
@@ -553,7 +553,26 @@ mod tests {
                 flags: 0,
             },
             payload: vec![0; hidden_bytes],
+        }
+    }
+
+    #[test]
+    fn glm52_final_stage_package_executes_native_mtp_when_fixture_is_set() -> anyhow::Result<()> {
+        let Some((_package_path, config)) = glm52_mtp_fixture() else {
+            eprintln!("skipping: SKIPPY_GLM52_MTP_PACKAGE is not set");
+            return Ok(());
         };
+
+        let runtime = load_runtime_with_overrides(
+            &config,
+            &RuntimeLaunchOverrides {
+                mtp_source: MtpSource::Integrated,
+                ..RuntimeLaunchOverrides::default()
+            },
+        )?
+        .expect("GLM final stage should load from the package");
+        let mut runtime = runtime.lock().expect("runtime mutex poisoned");
+        let input = glm52_mtp_input();
         let sampling = SamplingConfig {
             temperature: 0.0,
             ..SamplingConfig::default()
@@ -561,6 +580,106 @@ mod tests {
         let (predicted, draft, _output) =
             runtime.decode_frame_sampled_mtp("smoke", 1, Some(&sampling), Some(&input), 0, 1)?;
         let draft = draft.expect("GLM final stage should return a native MTP draft");
+
+        assert!(predicted >= 0);
+        assert_eq!(draft.token_ids.len(), 1);
+        assert!(draft.token_ids[0] >= 0);
+        Ok(())
+    }
+
+    #[test]
+    fn glm52_final_stage_does_not_create_integrated_mtp_when_disabled() -> anyhow::Result<()> {
+        let Some((_package_path, config)) = glm52_mtp_fixture() else {
+            eprintln!("skipping: SKIPPY_GLM52_MTP_PACKAGE is not set");
+            return Ok(());
+        };
+        let runtime = load_runtime_with_overrides(
+            &config,
+            &RuntimeLaunchOverrides {
+                mtp_source: MtpSource::Disabled,
+                ..RuntimeLaunchOverrides::default()
+            },
+        )?
+        .expect("GLM final stage should load from the package");
+        let mut runtime = runtime.lock().expect("runtime mutex poisoned");
+        let sampling = SamplingConfig {
+            temperature: 0.0,
+            ..SamplingConfig::default()
+        };
+        let (predicted, draft, _output) = runtime.decode_frame_sampled_mtp(
+            "disabled-mtp",
+            1,
+            Some(&sampling),
+            Some(&glm52_mtp_input()),
+            0,
+            1,
+        )?;
+
+        assert!(predicted >= 0);
+        assert!(
+            draft.is_none(),
+            "disabled MTP must not create a draft context"
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn glm52_external_sidecar_attaches_when_target_has_integrated_mtp_tensors() -> anyhow::Result<()>
+    {
+        let Some((_package_path, config)) = glm52_mtp_fixture() else {
+            eprintln!("skipping: SKIPPY_GLM52_MTP_PACKAGE is not set");
+            return Ok(());
+        };
+        let Some(sidecar_path) = std::env::var_os("SKIPPY_GLM52_MTP_SIDECAR") else {
+            eprintln!("skipping: SKIPPY_GLM52_MTP_SIDECAR is not set");
+            return Ok(());
+        };
+        let sidecar_path = std::path::PathBuf::from(sidecar_path);
+        if !sidecar_path.is_file() {
+            eprintln!(
+                "skipping: {} is not an MTP sidecar GGUF",
+                sidecar_path.display()
+            );
+            return Ok(());
+        }
+
+        let runtime = load_runtime_with_overrides(
+            &config,
+            &RuntimeLaunchOverrides {
+                mtp_source: MtpSource::External,
+                ..RuntimeLaunchOverrides::default()
+            },
+        )?
+        .expect("GLM final stage should load from the package");
+        let mut runtime = runtime.lock().expect("runtime mutex poisoned");
+        runtime.model.attach_mtp_draft_model(
+            &sidecar_path,
+            &RuntimeConfig {
+                ctx_size: config.ctx_size,
+                lane_count: config.lane_count,
+                n_batch: config.n_batch,
+                n_ubatch: config.n_ubatch,
+                n_gpu_layers: config.n_gpu_layers,
+                mmap: config.mmap,
+                mlock: config.mlock,
+                selected_backend_device: Some("CPU".to_string()),
+                mtp_source: MtpSource::External,
+                ..RuntimeConfig::default()
+            },
+        )?;
+        let sampling = SamplingConfig {
+            temperature: 0.0,
+            ..SamplingConfig::default()
+        };
+        let (predicted, draft, _output) = runtime.decode_frame_sampled_mtp(
+            "external-mtp",
+            1,
+            Some(&sampling),
+            Some(&glm52_mtp_input()),
+            0,
+            1,
+        )?;
+        let draft = draft.expect("external MTP sidecar should attach to the target");
 
         assert!(predicted >= 0);
         assert_eq!(draft.token_ids.len(), 1);

--- a/third_party/llama.cpp/patches/0016-skippy-load-MTP-tensors-for-native-draft-attachment.patch
+++ b/third_party/llama.cpp/patches/0016-skippy-load-MTP-tensors-for-native-draft-attachment.patch
@@ -1,0 +1,97 @@
+From 323eebd494847353d76b5c7eb167be90bf8db937 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Tue, 11 Aug 2026 16:14:30 -0400
+Subject: [PATCH] skippy: retain and execute final-stage MTP tensors
+
+---
+ src/llama-model.cpp          | 12 ++++++++++--
+ src/skippy/model_loading.cpp | 15 +++++++++++++++
+ 2 files changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/src/llama-model.cpp b/src/llama-model.cpp
+index 8824c03fca09c9c64d5b011fc139b463bc3859d1..b26bded77b65340ca6905652a176be6e6b5b5d2a 100644
+--- a/src/llama-model.cpp
++++ b/src/llama-model.cpp
+@@ -2142,6 +2142,12 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+                 const bool mtp_on_hybrid_qwen35 =
+                     params.ctx_type == LLAMA_CONTEXT_TYPE_MTP &&
+                     (arch == LLM_ARCH_QWEN35 || arch == LLM_ARCH_QWEN35MOE);
++                // Nemotron-H MoE's NextN block is a dense-attention head. It
++                // needs a plain KV cache for the appended MTP layer, not the
++                // hybrid trunk cache (which intentionally excludes it).
++                const bool mtp_on_hybrid_nemotron =
++                    params.ctx_type == LLAMA_CONTEXT_TYPE_MTP &&
++                    arch == LLM_ARCH_NEMOTRON_H_MOE;
+ 
+                 if (llm_arch_is_recurrent(arch)) {
+                     res = new llama_memory_recurrent(
+@@ -2153,7 +2159,9 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+                             cparams.n_seq_max,
+                             cparams.n_rs_seq,
+                             skippy_stage_memory_filter(nullptr, params.ctx_type));
+-                } else if (llm_arch_is_hybrid(arch) && !mtp_on_hybrid_qwen35) {
++                } else if (llm_arch_is_hybrid(arch) &&
++                           !mtp_on_hybrid_qwen35 &&
++                           !mtp_on_hybrid_nemotron) {
+                     // The main difference between hybrid architectures is the
+                     // layer filters, so pick the right one here
+                     llama_memory_hybrid::layer_filter_cb filter_attn = nullptr;
+@@ -2248,7 +2256,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+                         };
+                     }
+ 
+-                    if (mtp_on_hybrid_qwen35) {
++                    if (mtp_on_hybrid_qwen35 || mtp_on_hybrid_nemotron) {
+                         filter = [&](uint32_t il) { return il >= hparams.n_layer(); };
+                     }
+ 
+diff --git a/src/skippy/model_loading.cpp b/src/skippy/model_loading.cpp
+index dd21a313f2785bd9f5c4f01f44be243176219e83..af3108411290fa81ef6e67ac9e93fdd589a580af 100644
+--- a/src/skippy/model_loading.cpp
++++ b/src/skippy/model_loading.cpp
+@@ -441,6 +441,15 @@ static bool skippy_should_create_native_mtp_sidecar(
+            has_head;
+ }
+ 
++static void skippy_enable_mtp_tensors_for_final_stage(
++        const skippy_runtime_config * config,
++        llama_model_params & params) {
++    // Final stages create an LLAMA_CONTEXT_TYPE_MTP sidecar when the model
++    // advertises NextN layers. llama.cpp normally skips those optional tensors
++    // unless this is explicitly enabled during the shared model load.
++    params.load_mtp = config != nullptr && config->include_output;
++}
++
+ extern "C" {
+ 
+ static enum skippy_status skippy_finish_model_open(
+@@ -736,6 +745,7 @@ enum skippy_status skippy_model_open_impl(
+     }
+ 
+     llama_model_params params = llama_model_default_params();
++    skippy_enable_mtp_tensors_for_final_stage(config, params);
+     if (config != nullptr) {
+         params.n_gpu_layers = config->n_gpu_layers;
+         skippy_apply_model_load_memory_config(config, params);
+@@ -822,6 +832,7 @@ enum skippy_status skippy_model_open_from_parts_impl(
+     }
+ 
+     llama_model_params params = llama_model_default_params();
++    skippy_enable_mtp_tensors_for_final_stage(config, params);
+     if (config != nullptr) {
+         params.n_gpu_layers = config->n_gpu_layers;
+         skippy_apply_model_load_memory_config(config, params);
+@@ -874,6 +885,10 @@ enum skippy_status skippy_model_attach_mtp_draft_model(
+     }
+ 
+     llama_model_params model_params = llama_model_default_params();
++    // This model backs an LLAMA_CONTEXT_TYPE_MTP draft context, so the optional
++    // NextN/MTP tensors must be retained. llama.cpp defaults this off for
++    // ordinary target-model loads.
++    model_params.load_mtp = true;
+     if (config != nullptr) {
+         model_params.n_gpu_layers = config->n_gpu_layers;
+         skippy_apply_model_load_memory_config(config, model_params);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0017-skippy-select-MTP-source-in-runtime-config.patch
+++ b/third_party/llama.cpp/patches/0017-skippy-select-MTP-source-in-runtime-config.patch
@@ -1,0 +1,52 @@
+From f9a8933fdd862f4b0c3f964352fcf21144bbf28d Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Tue, 11 Aug 2026 18:18:44 -0400
+Subject: [PATCH] skippy: select MTP source in runtime config
+
+---
+ include/skippy/common.h  | 2 +-
+ include/skippy/runtime.h | 8 ++++++++
+ 2 files changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/include/skippy/common.h b/include/skippy/common.h
+index d43424f0d..0911776cd 100644
+--- a/include/skippy/common.h
++++ b/include/skippy/common.h
+@@ -34,7 +34,7 @@ extern "C" {
+ 
+ #define SKIPPY_ABI_VERSION_MAJOR 0
+ #define SKIPPY_ABI_VERSION_MINOR 1
+-#define SKIPPY_ABI_VERSION_PATCH 37
++#define SKIPPY_ABI_VERSION_PATCH 38
+ 
+ enum skippy_feature {
+     SKIPPY_FEATURE_RUNTIME_SLICE          = 1 << 0,
+diff --git a/include/skippy/runtime.h b/include/skippy/runtime.h
+index 9aee298d3..bfb80e105 100644
+--- a/include/skippy/runtime.h
++++ b/include/skippy/runtime.h
+@@ -20,6 +20,13 @@ enum skippy_load_mode {
+     SKIPPY_LOAD_MODE_ARTIFACT_SLICE       = 2,
+ };
+ 
++/** @brief Selects whether a target loads no MTP tensors, integrated MTP tensors, or an external MTP sidecar. */
++enum skippy_mtp_source {
++    SKIPPY_MTP_SOURCE_DISABLED   = 0,
++    SKIPPY_MTP_SOURCE_INTEGRATED = 1,
++    SKIPPY_MTP_SOURCE_EXTERNAL   = 2,
++};
++
+ #define SKIPPY_GLM_DSA_POLICY_PROFILE_NONE     0
+ #define SKIPPY_GLM_DSA_POLICY_PROFILE_V1       1
+ 
+@@ -58,6 +65,7 @@ struct skippy_runtime_config {
+     bool filter_tensors_on_load;
+     bool include_embeddings;
+     bool include_output;
++    enum skippy_mtp_source mtp_source;
+ 
+     // Optional ggml backend device name, for example "CUDA0", "MTL0",
+     // "Vulkan1", or "CPU". When set, skippy loads the model only on that
+-- 
+2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0018-skippy-honor-selected-MTP-source-when-loading.patch
+++ b/third_party/llama.cpp/patches/0018-skippy-honor-selected-MTP-source-when-loading.patch
@@ -1,0 +1,86 @@
+From 2ba4d353f730a5b14dfadae4b266d536eb229597 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Tue, 11 Aug 2026 18:19:35 -0400
+Subject: [PATCH] skippy: honor selected MTP source when loading
+
+---
+ src/skippy/model_loading.cpp | 27 ++++++++++++++++-----------
+ 1 file changed, 16 insertions(+), 11 deletions(-)
+
+diff --git a/src/skippy/model_loading.cpp b/src/skippy/model_loading.cpp
+index af3108411..ba1fe345d 100644
+--- a/src/skippy/model_loading.cpp
++++ b/src/skippy/model_loading.cpp
+@@ -411,6 +411,7 @@ static bool skippy_should_create_native_mtp_sidecar(
+     if (model == nullptr ||
+         config == nullptr ||
+         !config->include_output ||
++        config->mtp_source != SKIPPY_MTP_SOURCE_INTEGRATED ||
+         model->hparams.n_layer_nextn == 0) {
+         return false;
+     }
+@@ -441,13 +442,14 @@ static bool skippy_should_create_native_mtp_sidecar(
+            has_head;
+ }
+ 
+-static void skippy_enable_mtp_tensors_for_final_stage(
++static void skippy_enable_integrated_mtp_tensors(
+         const skippy_runtime_config * config,
+         llama_model_params & params) {
+-    // Final stages create an LLAMA_CONTEXT_TYPE_MTP sidecar when the model
+-    // advertises NextN layers. llama.cpp normally skips those optional tensors
+-    // unless this is explicitly enabled during the shared model load.
+-    params.load_mtp = config != nullptr && config->include_output;
++    // A terminal stage does not imply MTP ownership. Only the resolved
++    // integrated source keeps optional NextN tensors in the target load.
++    params.load_mtp = config != nullptr &&
++                      config->include_output &&
++                      config->mtp_source == SKIPPY_MTP_SOURCE_INTEGRATED;
+ }
+ 
+ extern "C" {
+@@ -745,7 +747,7 @@ enum skippy_status skippy_model_open_impl(
+     }
+ 
+     llama_model_params params = llama_model_default_params();
+-    skippy_enable_mtp_tensors_for_final_stage(config, params);
++    skippy_enable_integrated_mtp_tensors(config, params);
+     if (config != nullptr) {
+         params.n_gpu_layers = config->n_gpu_layers;
+         skippy_apply_model_load_memory_config(config, params);
+@@ -832,7 +834,7 @@ enum skippy_status skippy_model_open_from_parts_impl(
+     }
+ 
+     llama_model_params params = llama_model_default_params();
+-    skippy_enable_mtp_tensors_for_final_stage(config, params);
++    skippy_enable_integrated_mtp_tensors(config, params);
+     if (config != nullptr) {
+         params.n_gpu_layers = config->n_gpu_layers;
+         skippy_apply_model_load_memory_config(config, params);
+@@ -879,16 +881,19 @@ enum skippy_status skippy_model_attach_mtp_draft_model(
+         skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "target_model, target context, and path are required");
+         return SKIPPY_STATUS_INVALID_ARGUMENT;
+     }
++    if (config == nullptr || config->mtp_source != SKIPPY_MTP_SOURCE_EXTERNAL) {
++        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "MTP draft attachment requires an external MTP source");
++        return SKIPPY_STATUS_INVALID_ARGUMENT;
++    }
+     if (target_model->mtp_ctx != nullptr) {
+         skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "target model already has an MTP draft context");
+         return SKIPPY_STATUS_INVALID_ARGUMENT;
+     }
+ 
+     llama_model_params model_params = llama_model_default_params();
+-    // This model backs an LLAMA_CONTEXT_TYPE_MTP draft context, so the optional
+-    // NextN/MTP tensors must be retained. llama.cpp defaults this off for
+-    // ordinary target-model loads.
+-    model_params.load_mtp = true;
++    // The explicitly external model backs an LLAMA_CONTEXT_TYPE_MTP draft
++    // context, so retain its optional NextN/MTP tensors.
++    model_params.load_mtp = config->mtp_source == SKIPPY_MTP_SOURCE_EXTERNAL;
+     if (config != nullptr) {
+         model_params.n_gpu_layers = config->n_gpu_layers;
+         skippy_apply_model_load_memory_config(config, model_params);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/website/src/docs/pages/skippy-api.md
+++ b/website/src/docs/pages/skippy-api.md
@@ -1282,11 +1282,11 @@ LLAMA_API enum skippy_status skippy_parse_chat_response_json(
 The headers also define the following enums, structs, opaque handles, and ABI constants:
 
 - `activation.h`: `skippy_activation_dtype`, `skippy_activation_layout`, `skippy_activation_desc`, `SKIPPY_ACTIVATION_FLAG_RWKV7_V_FIRST = (UINT64_C(1) << 0)`, `SKIPPY_ACTIVATION_FLAG_GEMMA3N_ALTUP = (UINT64_C(1) << 1)`, `SKIPPY_ACTIVATION_FLAG_INKLING_MTP_EMBD = (UINT64_C(1) << 2)`, `SKIPPY_ACTIVATION_FLAG_GLM_DSA_TOP_K = (UINT64_C(1) << 3)`
-- `common.h`: `skippy_feature`, `skippy_status`, `skippy_error`, `skippy_abi_version`, `SKIPPY_ABI_VERSION_MAJOR = 0`, `SKIPPY_ABI_VERSION_MINOR = 1`, `SKIPPY_ABI_VERSION_PATCH = 37`
+- `common.h`: `skippy_feature`, `skippy_status`, `skippy_error`, `skippy_abi_version`, `SKIPPY_ABI_VERSION_MAJOR = 0`, `SKIPPY_ABI_VERSION_MINOR = 1`, `SKIPPY_ABI_VERSION_PATCH = 38`
 - `devices.h`: `skippy_backend_device_type`, `skippy_backend_device_cap`, `skippy_backend_device`
 - `events.h`: `skippy_runtime_event_v1`, `skippy_runtime_event_reporter_v1`, `SKIPPY_RUNTIME_EVENT_V1_ABI_VERSION = 1`
 - `model_package.h`: `skippy_tensor_role`, `skippy_model_info`, `skippy_slice_plan`, `skippy_tensor_info`
-- `runtime.h`: `skippy_load_mode`, `skippy_model`, `skippy_session`, `skippy_runtime_config`, `SKIPPY_GLM_DSA_POLICY_PROFILE_NONE = 0`, `SKIPPY_GLM_DSA_POLICY_PROFILE_V1 = 1`, `SKIPPY_GLM_DSA_POLICY_DIRECT_SPARSE_ATTN = (UINT32_C(1) << 0)`, `SKIPPY_GLM_DSA_POLICY_DIRECT_SPARSE_PREFILL = (UINT32_C(1) << 1)`, `SKIPPY_GLM_DSA_POLICY_DISABLE_COMPACT_FLASH_ATTN = (UINT32_C(1) << 2)`, `SKIPPY_GLM_DSA_POLICY_UNPROVEN_LARGE_DIRECT_SPARSE_PREFILL = (UINT32_C(1) << 3)`
+- `runtime.h`: `skippy_load_mode`, `skippy_mtp_source`, `skippy_model`, `skippy_session`, `skippy_runtime_config`, `SKIPPY_GLM_DSA_POLICY_PROFILE_NONE = 0`, `SKIPPY_GLM_DSA_POLICY_PROFILE_V1 = 1`, `SKIPPY_GLM_DSA_POLICY_DIRECT_SPARSE_ATTN = (UINT32_C(1) << 0)`, `SKIPPY_GLM_DSA_POLICY_DIRECT_SPARSE_PREFILL = (UINT32_C(1) << 1)`, `SKIPPY_GLM_DSA_POLICY_DISABLE_COMPACT_FLASH_ATTN = (UINT32_C(1) << 2)`, `SKIPPY_GLM_DSA_POLICY_UNPROVEN_LARGE_DIRECT_SPARSE_PREFILL = (UINT32_C(1) << 3)`
 - `sampling.h`: `skippy_sampling_config`, `SKIPPY_MAX_LOGIT_BIAS = 256`
 - `signals.h`: `skippy_token_signal`, `skippy_generation_signal_window`
 - `speculative_decoding.h`: `skippy_ngram_cache`, `skippy_native_mtp_draft`, `SKIPPY_NATIVE_MTP_MAX_DRAFT_TOKENS = 8`


### PR DESCRIPTION
## Summary

- load optional NextN/MTP tensors for final-stage Skippy model loads and native MTP sidecars
- select the MTP source explicitly: disabled, integrated, or external
- use a plain KV cache for Nemotron-H MoE’s appended dense-attention MTP layer

## Root cause

`llama_model_params.load_mtp` defaults to false, so Skippy omitted Nemotron’s NextN tensors before creating its native MTP context. Once enabled, the hybrid cache path also excluded the appended MTP layer, causing MTP execution to access an invalid KV-cache index.

A terminal stage’s `include_output` flag only identifies output ownership; it does not select an MTP mode. Inferring MTP from that flag loaded NextN tensors and created an integrated context even when native MTP was disabled. It also blocked an explicitly configured external MTP sidecar from attaching.

## Impact

NVIDIA Nemotron 3.5 Lightning can load and execute native MTP speculation through Skippy. Disabled MTP now retains no optional MTP tensors or KV context, while an external sidecar can attach to a target that contains integrated MTP tensors.

## Skippy ABI change

ABI version: 0.1.37 → 0.1.38.

- Added `enum skippy_mtp_source { DISABLED, INTEGRATED, EXTERNAL }`.
- Added `enum skippy_mtp_source mtp_source` to `struct skippy_runtime_config`.
- Updated the Rust FFI mirror and regenerated the native API reference. Older native runtimes are intentionally rejected by ABI negotiation.

## Validation

- fresh pinned llama.cpp checkout replayed patches `0001`–`0018` through `scripts/prepare-llama.sh pinned`
- clean static CPU native build via `scripts/build-llama.sh`
- independent C11 and C++17 public-header compilation
- `cargo check -p skippy-server`
- `cargo test -p skippy-runtime --lib` (71 tests)
- `cargo test -p skippy-server --lib` (398 tests; model-backed GLM MTP fixtures remain opt-in)
- regenerated and checked the Skippy API reference
- `just build`
- just-built Metal runtime previously loaded `NVIDIA-Nemotron-3.5-Lightning-30B-A3B-Q4_K_M` and completed a native-MTP request: 12 drafted, 3 accepted, 0 rejected; 5 generated tokens at 42.38 tok/s


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added configurable MTP sources: disabled, integrated, or external.
  * Native and externally attached draft models now use the selected MTP source.
  * Added MTP tensor loading for supported model configurations.
  * MTP is disabled by default for existing runtime configurations.
* **Bug Fixes**
  * Prevented incompatible MTP configurations with external draft models.
* **Documentation**
  * Updated public API documentation and ABI details for MTP source configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->