### PR TITLE
Add executable provider runtime artifact contract

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -56,6 +56,341 @@ removable after this branch's runner contract is active on protected main.
 
 ## Reusable workflows and slices
 
+Only a successful, complete stable release dispatches downstream package,
+image, and npm publication. Prereleases publish their immutable GitHub Release
+inputs but never invoke `mesh-packaging`; this provides a safe artifact
+validation boundary without exposing prerelease inputs to production
+promotion.
+
+Merged
+[`mesh-packaging#16`](https://github.com/Mesh-LLM/mesh-packaging/pull/16)
+consumes that release graph without rebuilding the host, runtime, or Node
+addons. It uses typed independent selectors, one per-row
+product → package → install/QA → final image → exact-image QA chain,
+digest-only promotion, and a canonical immutable evidence index. Complete dry
+rehearsal
+[30593548823](https://github.com/Mesh-LLM/mesh-packaging/actions/runs/30593548823)
+passed 41 jobs with 15 intentional publication-only skips against
+`v0.75.0-rc1`; default-branch precheck
+[30595367445](https://github.com/Mesh-LLM/mesh-packaging/actions/runs/30595367445)
+passed merge commit `76c619bcdd82773e159248a2282187b0b2973daa`.
+
+The Windows host input also carries the checksum-protected `xtask` executable
+that performed producer-side attestation. Windows product composers invoke that
+prebuilt verifier for the immutable host instead of compiling workspace code.
+
+`ci.yml` applies the same executable-product rule to trusted main validation.
+Linux and macOS build immutable release-profile hosts and separately packaged
+CPU or Metal runtimes, then upload complete product-v2 trees from
+composition-only jobs. Linux CUDA, ROCm, and Vulkan each use an independent
+runtime producer plus a thin composer that downloads the same immutable Linux
+host; no backend waits on a matrix-wide fan-in. SDK consumers reuse the
+producer's adjacent runtime and fail if CI would silently rebuild it. Kotlin
+additionally downloads the verified native SDK runtime built by
+`native-sdk-artifact.yml` after that producer restores the shared
+`linux_static_abi_input`; it runs in parallel with the Linux product (debug on
+PR, release on main). Release nests one `static-abi-artifact.yml` producer per
+Linux native target through the same native-SDK workflow. Swift downloads an
+immutable XCFramework and exact generated `mesh_ffi.swift` from the shared
+`swift-sdk-artifact.yml` producer: PR uses `host-only`, while main and release
+use exhaustive `full` mode, all on `macos-15`. Windows likewise builds one
+immutable release-profile host, independent CPU/CUDA/ROCm/Vulkan runtime
+inputs, and composition-only products. Broad main Rust changes exercise the
+Windows CPU product; Windows GPU products remain limited to GPU/backend inputs
+or manual dispatch. Every composed backend product requires `runtime list`
+plus no-driver client readiness; hosted GPU rows neither inject a driver stub
+nor skip startup because no device is present.
+
+The exhaustive Swift producer has a 180-minute main/release cold-start budget
+because it serially builds seven Apple target ABIs. PR host-only calls retain
+their shorter budget. Exact native ABI and compiler caches remain responsible
+for reducing the warm path; the timeout is only the reliability ceiling for an
+unseeded cache.
+
+`pr_builds.yml` uses the same split producer/composer shape for Linux CPU/GPU
+and macOS Metal products while retaining debug-profile hosts for lightweight
+PR iteration. Windows broad-Rust validation stays at lightweight Cargo checks;
+the debug host plus CPU or GPU runtime/product graph runs only for its
+platform/backend input or manual dispatch. Unsupported macOS CUDA, ROCm, and
+Vulkan combinations are omitted rather than emitted as no-op jobs.
+`scripts/plan-pr-build-jobs.py` converts the central change signals into one
+ordered `required_jobs_json` list. Every conditional PR Builds job routes on
+membership in that list and retains normal dependency-success behavior through
+`needs`. Its static `PR Builds Summary` job directly needs every other
+top-level job and consumes the same plan. It accepts a skipped result only for
+an unplanned job and rejects required skips, failures, cancellations, unknown
+results, duplicate plan entries, and required IDs outside its needs graph,
+making that one non-matrix check the workflow's stable branch-protection
+target.
+
+Changes to the central PR/main/release workflow callers or to
+`compute-changes` itself fail open to the SDK producer/smoke graph. This keeps
+caller-owned mode, timeout, artifact, and trust-policy edits from skipping the
+reusable Swift, Kotlin, or Rust SDK contracts they change.
+
+The reusable Swift producer verifies the committed generated UniFFI binding
+after both host-only and full builds for PR, main, and tag callers. Only a
+dispatched release that deliberately prepares a versioned source tree may
+replace the tracked binding before publication.
+
+Local actions:
+
+- `.github/actions/compute-changes` owns path, crate, backend, SDK, UI, website,
+  Windows, and docs-only routing outputs.
+- `.github/actions/select-ci-runners` routes trusted push/dispatch jobs through
+  the Depot gate only for `refs/heads/main`, returns GitHub-hosted labels for
+  tags and every other ref, and unconditionally returns GitHub-hosted labels
+  for `pull_request` events. Repository ownership and the deprecated
+  `DEPOT_PR_RUNNERS_ENABLED` variable do not alter that decision. Its cache
+  permission is derived from the same typed trust decision.
+- `.github/actions/configure-sccache-gha` exports ephemeral Actions cache
+  credentials to the baked `sccache`, permits Depot WebDAV only for an explicit
+  trusted call, uses writable job-local disk only for PR events because the
+  pinned sccache makes a mixed chain wholly read-only and records rejected
+  writes after misses, uses disk-only
+  storage if a future pull-request trust context is ever evaluated on Depot,
+  and resets counters after configuring the server.
+- `.github/actions/capture-sccache-stats` validates and uploads one
+  machine-readable sccache evidence artifact per instrumented job or matrix
+  row. Evidence is retained for 14 days so cold/warm samples span the configured
+  Depot cache-retention window.
+- `.github/actions/prepare-host-input` owns Unix neutral-host build, optional
+  release attestation, import-policy verification, and checksumming.
+- `.github/actions/prepare-windows-host-input` owns the equivalent Windows
+  debug/release neutral-host build, optional release attestation, import-policy
+  verification, checksum, and verifier artifact.
+- `.github/actions/prepare-native-runtime-input` owns runtime build/package
+  invocation and the release-grade artifact verifier.
+- `.github/actions/prepare-native-sdk-input` owns the native SDK
+  prepare-llama/build-llama/mesh-llm-ffi/package chain, verifies the exact
+  target/backend/profile manifest, and stages a flat immutable upload. Release
+  mode adds the native runtime crate through the same path.
+- `.github/actions/prepare-static-abi-input` owns the shared Linux static llama
+  ABI build/stamp validation and emits a checksummed, target-described ABI v3
+  archive containing only the path-normalized static link closure and portable
+  OpenMP metadata. The reusable workflow caches that archive, not the local
+  CMake build graph; crate tests and native SDK producers consume it.
+- `.github/actions/resolve-native-toolchain-epoch` exports one cache-safe
+  identity to both native build stamps and cache keys. Digest-pinned Linux
+  containers use their immutable image digest; hosted macOS and Windows jobs
+  use the exact runner image revision, with compiler/CMake/Ninja versions added
+  where hosted or Depot Linux/macOS toolchains are not otherwise pinned.
+- `.github/actions/compose-product-input` verifies producer inputs, creates one
+  product-v2 tree without compiling, and runs CLI/client readiness.
+- `.github/actions/restore-smoke-inputs` owns producer artifact staging and
+  model restoration for smoke consumers.
+- `.github/actions/restore-windows-abi-cache` owns the exact Windows CPU,
+  CUDA, ROCm, and Vulkan ABI cache identity shared by the trusted warmer and
+  PR/main/release runtime producers. The hosted-image epoch, architecture sets,
+  and toolchain versions are compatibility boundaries; the action requires the
+  key epoch to equal the build-stamp epoch, includes the publication action in
+  the key hash, exports one validated absolute path for both restore and save,
+  and never uses restore prefixes.
+- `.github/actions/save-and-verify-actions-cache` snapshots existing exact
+  key/ref cache entries before saving a trusted miss, then requires a new,
+  non-empty entry to appear and performs a lookup-only restore with the same
+  path/key to prove the current opaque cache version exists. Windows warmers
+  therefore fail if
+  `actions/cache/save` only warns about a reservation collision without any
+  compatible upload becoming available.
+- `.github/actions/setup-windows-rocm-sdk` owns reusable Windows ROCm setup.
+
+Routing and test-planning scripts:
+
+- `scripts/affected-crates.sh` computes affected crates and reverse dependents.
+- `mesh-llm-provider-runtime` is a runtime-facing SDK input: changes to its
+  executable-provider artifact contract route the SDK smoke graph.
+- `scripts/plan-pr-build-jobs.py` maps PR change signals to the single ordered
+  top-level job plan consumed by both conditional PR Builds jobs and its stable
+  summary gate.
+- `scripts/plan-clippy-batches.sh` owns weighted Clippy sharding and retains a
+  checked workspace-member list for fail-open/all-rust planning.
+- `scripts/plan-test-batches.sh` owns weighted crate-test sharding. It derives
+  workspace membership from `cargo metadata`; new crates must not be added to a
+  workflow-owned test allowlist.
+- `scripts/test-portable.sh` owns the portable non-Cargo test aggregate used by
+  the local `test-all` path.
+- `scripts/summarize-sccache-stats.py` aggregates downloaded sccache JSON
+  evidence offline and can enforce the migration hit-rate threshold without
+  GitHub or network access.
+
+## Runner and image contract
+
+GitHub-hosted labels currently used:
+
+- Linux AMD64: `ubuntu-24.04`
+- Linux ARM64: `ubuntu-24.04-arm`
+- macOS: pinned `macos-15`
+- Windows: `windows-2022`
+
+Depot labels referenced behind the rollout gate:
+
+- routing/summary: `depot-ubuntu-24.04`
+- light build/planning: `depot-ubuntu-24.04-4`
+- Rust/native build: `depot-ubuntu-24.04-8`
+- measured high-parallelism native build: `depot-ubuntu-24.04-16`
+
+Current PR jobs and non-main refs never select these labels. They use the corresponding
+GitHub-hosted label regardless of repository ownership or
+`DEPOT_PR_RUNNERS_ENABLED`; that variable is ignored. Trusted main/release jobs
+use `DEPOT_RUNNERS_ENABLED`; a trusted
+main-ref manual dispatch can set `use_depot=true`. Hardware-qualified GPU
+execution is not part of the gate.
+
+The default-branch-selected `native-sdk-artifact.yml` and
+`static-abi-artifact.yml` workflows do not accept a runner label or Depot-cache
+permission from callers. Each first runs a fixed `ubuntu-24.04` policy job,
+validates `runner_size` as `default`, `4`, `8`, or `16`, maps the declared
+target to the checked-in AMD64/ARM64 hosted and Depot labels, and grants both
+the Depot runner and WebDAV cache only for exact
+`Mesh-LLM/mesh-llm` `push`/`workflow_dispatch` calls on
+`refs/heads/main` when `DEPOT_RUNNERS_ENABLED == 'true'` or when the immutable
+main-dispatch event payload has `use_depot == 'true'`. Pull requests,
+`pull_request_target`, tags, feature refs, external repositories, macOS, and a
+disabled gate without that authorized canary resolve to a GitHub-hosted runner
+with Depot cache permission false. The event-owned manual canary is evaluated
+only under the same exact repository/main/dispatch guard and is not a
+reusable-workflow input.
+
+The Depot dashboard reports the `Mesh-LLM` GitHub connection active, and
+GitHub lists both `depot-managed-runners` and `depot-code-access` installations
+for all organization repositories. Live main-ref dispatches now prove that the
+public `Mesh-LLM/mesh-llm` repository can allocate ephemeral Depot runners.
+The available token cannot re-read organization runner-group settings (GitHub
+returns 403), so this operational evidence does not prove the current
+repository/workflow allowlist. Inspect that policy with organization-admin
+authority before enabling the global gate. The separate `mesh-llm` group owns
+the two dedicated GPU scale sets and is not the Depot group.
+
+The manual `depot-registry-canary.yml` is the pull-through adoption boundary.
+It accepts only a digest-pinned public reference and a safe relative Depot
+repository name on an exact `main` dispatch. Five upstream jobs and five Depot
+jobs each receive a fresh ephemeral GitHub-hosted runner. The summary rejects digest
+drift and requires at least 20% and 10 seconds of median pull improvement.
+`DEPOT_REGISTRY_HOST` supplies the nonsecret organization registry host;
+the cached pull step uses GitHub OIDC to mint a short-lived read-only
+`depot pull-token`. No stored registry secret is used, and the OIDC permission
+is not available to PR code.
+
+Bounded rollout evidence:
+
+- cold and warm six-label canaries
+  [30525111329](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30525111329)
+  and
+  [30525247727](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30525247727)
+  passed on Intel `default`/`4`/`8`/`16` and ARM `default`/`8`;
+- denied feature-ref
+  [30593657371](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30593657371)
+  concluded skipped with no Depot allocation; its temporary ref pointed exactly
+  at main SHA `851888d0b0ce19916d6b0d7d73ce49246eef67d6` and was removed afterward;
+- exhaustive prerelease
+  [30586470043](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30586470043)
+  completed 55 jobs successfully, including 15 Depot jobs across all six
+  labels, and published the complete `v0.75.0-rc1` immutable release graph;
+- warm non-GPU release canary
+  [30590595090](https://github.com/Mesh-LLM/mesh-llm/actions/runs/30590595090)
+  completed with 36 successes, 28 intentional skips, and zero failures. Its
+  nine Depot jobs included exact static-ABI cache hits with zero compilation
+  and roughly 95% sccache hits in both Linux native-SDK consumers.
+
+Live inspection on 2026-08-02 found `DEPOT_RUNNERS_ENABLED=true`. The checked-in
+selector still restricts Depot to eligible trusted `main` push/dispatch jobs,
+but `main` has no classic branch protection and the available token cannot
+fully inspect the organization runner-group workflow allowlist. Treat that
+administrative boundary as unverified until an organization administrator
+confirms it.
+
+The checked-out local selector is not the security boundary because PRs can
+modify workflow and local-action files. The Depot runner group must use
+`restricted_to_workflows=true` and exact default-branch selected-workflow refs.
+The initial selected set includes `native-sdk-artifact.yml@refs/heads/main` and
+`static-abi-artifact.yml@refs/heads/main` because those reusable workflows
+directly allocate eligible Linux runners; a caller-only `ci.yml` entry is not
+sufficient.
+Credential-bearing `hf-download-smoke.yml`, `smoke.yml`,
+`scripted-binary-smoke.yml`, and `sdk-smoke.yml` are deliberately excluded and
+fixed to bounded GitHub-hosted labels. `swift-sdk-artifact.yml` is fixed to
+GitHub-hosted `macos-15`. No reusable workflow passes caller-provided
+runner JSON directly to `runs-on`. PR callers pass no `HF_TOKEN`; trusted
+main/release callers may pass it only on the fixed hosted smoke lanes.
+Automatic Depot Cache still grants repository-scoped cache authority to the
+whole job, so even a trusted reusable caller cannot safely execute untrusted PR
+code while that injection is enabled. PRs remain GitHub-hosted.
+
+Legacy/dedicated self-hosted label arrays currently referenced:
+
+- NVIDIA AMD64: `["self-hosted","Linux","X64","amd64","gpu-nvidia"]`
+- ARM64: `["self-hosted","Linux","ARM64"]`
+
+ARC scale-set labels for the prebuilt runner rollout:
+
+- `mesh-llm-amd64`
+- `mesh-llm-arm64`
+
+`pr_builds.yml` runs `public_runner_image_contract` in the public image when
+the runner workflow, cache integration, or cache version changes, plus manual
+dispatches. Trusted main `ci.yml` owns `arc_runner_image_contract` on both ARC
+labels for the same change class. Untrusted PR-event jobs never request those
+labels. The ARC job executes directly in each ephemeral runner pod, verifies
+the self-hosted image contract and native architecture, and runs a small Rust
+check. It intentionally has no hosted fallback.
+
+Runner images are published from
+[`Mesh-LLM/mesh-llm-runner-images`](https://github.com/Mesh-LLM/mesh-llm-runner-images)
+as `ghcr.io/mesh-llm/mesh-llm-cuda-runner`. The source repository owns:
+
+- `profiles/common.yml`
+- `profiles/backends/{cpu,vulkan,cuda,rocm}.yml`
+- `profiles/public.yml`
+- `profiles/self-hosted.yml`
+- CUDA/ROCm toolchain installers, manifest collection, dependency warming, and
+  backend compiler-probe verification
+- AMD64/ARM64 CPU, Vulkan, CUDA 12, and CUDA 13 images
+- AMD64 ROCm 7.0 and ROCm 7.2 images
+
+Production consumers must use the multi-architecture manifest digest. Tags are
+discovery inputs and are mutable absent separately verified registry controls.
+
+Merged runner-images PR
+[`#9`](https://github.com/Mesh-LLM/mesh-llm-runner-images/pull/9) changed the
+publication control plane without changing those production digests. PRs route
+affected families plus a mandatory public CPU AMD64 contract, use BuildKit
+cache read-only, and cannot stage or promote. Main pushes stage verified
+candidate digests; weekly or explicit manual runs promote a retained cohort.
+The reusable family workflow independently derives trusted runner/cache
+authority, verifies the requested MeshLLM source revision, uses content-digest
+immutable tags, and feeds one serial `latest` cohort reconciliation. Deleted
+files are included in affected-family routing.
+
+Its merge commit `4e79e68e22a5ea9bb1eedf9a2a7e7ccfc20b2bca`
+completed the trusted main
+[run 30522118156](https://github.com/Mesh-LLM/mesh-llm-runner-images/actions/runs/30522118156)
+with 35 successful jobs, four intentional skips, and zero failures.
+
+Its exhaustive Dockerfile-change PR
+[run 30504335079](https://github.com/Mesh-LLM/mesh-llm-runner-images/actions/runs/30504335079)
+completed all 20 platform rows in 6m 22s wall / 1h 13m 07s aggregate with no
+Depot jobs and no PR cache export. Treat that as validation-path evidence, not
+as proof of the trusted stage/promotion path.
+
+The public repository and its GHCR package have independent visibility. Until
+anonymous pull of the package succeeds, GitHub-hosted container jobs must grant
+`packages: read` and provide `github.actor`/`secrets.GITHUB_TOKEN` through
+`container.credentials`. Do not assume making the source repository public also
+makes an existing package public.
+
+The production rollout covers the shared public CPU environment and explicit
+public Vulkan, CUDA, and ROCm overlays in `pr_builds.yml`, `ci.yml`,
+`pr_quality.yml`, and Linux release jobs. Backend images standardize compilers
+and SDKs; actual GPU access remains a separate runner label, node resource, and
+trust-boundary contract. Do not route untrusted PR code to persistent GPU
+runners merely because the same image can also run as an ARC pod.
+
+The image family built from MeshLLM revision
+`5f341d6828fc77cce2f3be43f2a6ff26f3223433` is:
+
+| Image | Immutable index digest |
+
 | Workflow | Contract |
 | --- | --- |
 | `ci-quality-lane.yml` | Quality and runner/cache contract graph; reusable from PRs and dispatchable for main/manual |

--- a/.github/actions/compute-changes/action.yml
+++ b/.github/actions/compute-changes/action.yml
@@ -353,7 +353,7 @@ runs:
           fi
           if [[ -n "$DIRECT_SDK_INPUTS" ]]; then
             SDK_SMOKE_REQUIRED="true"
-          elif echo "$AFFECTED_CRATES" | jq -e 'index("mesh-llm-client") or index("mesh-llm-api-client") or index("mesh-llm-api-server") or index("mesh-llm-config") or index("mesh-llm-console-server") or index("mesh-llm-ffi") or index("mesh-llm-native-runtime") or index("mesh-llm-protocol") or index("mesh-llm-routing") or index("mesh-llm-types")' >/dev/null; then
+          elif echo "$AFFECTED_CRATES" | jq -e 'index("mesh-llm-client") or index("mesh-llm-api-client") or index("mesh-llm-api-server") or index("mesh-llm-config") or index("mesh-llm-console-server") or index("mesh-llm-ffi") or index("mesh-llm-native-runtime") or index("mesh-llm-provider-runtime") or index("mesh-llm-protocol") or index("mesh-llm-routing") or index("mesh-llm-types")' >/dev/null; then
             SDK_SMOKE_REQUIRED="true"
           fi
         fi

--- a/.github/workflows/docker-precheck.yml
+++ b/.github/workflows/docker-precheck.yml
@@ -71,6 +71,7 @@ jobs:
             crates/mesh-llm-hardware-profile/ \
             crates/mesh-llm-identity/ \
             crates/mesh-llm-native-runtime/ \
+            crates/mesh-llm-provider-runtime/ \
             crates/mesh-llm-release-footer/ \
             crates/mesh-llm-protocol/ \
             crates/mesh-llm-routing/ \

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,7 @@ Shared foundations:
 - `mesh-llm-identity/` — owner identity and envelope crypto primitives.
 - `mesh-llm-guardrails/` — guardrail and compaction primitives for OpenAI-compatible paths.
 - `mesh-llm-hardware-profile/`, `mesh-llm-native-runtime/`, `mesh-llm-runtime-install/` — hardware profile detection, native runtime manifest/selection, runtime download/install/cache.
+- `mesh-llm-provider-runtime/` — signed executable-provider manifests, selection, download verification, and immutable cache installation; separate from Skippy-native libraries.
 - `mesh-llm-plugin/` — plugin runtime/DSL primitives.
 - `mesh-llm-plugin-manager/` — plugin package management (catalog, install, store).
 - `mesh-llm-skills/` — agent skill data model and installer primitives.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4170,6 +4170,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "mesh-llm-provider-runtime"
+version = "0.72.1"
+dependencies = [
+ "anyhow",
+ "dirs",
+ "futures-util",
+ "reqwest 0.12.28",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "tempfile",
+ "tokio",
+ "zip",
+]
+
+[[package]]
 name = "mesh-llm-release-footer"
 version = "0.76.0-rc7"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4171,7 +4171,7 @@ dependencies = [
 
 [[package]]
 name = "mesh-llm-provider-runtime"
-version = "0.72.1"
+version = "0.76.0-rc2"
 dependencies = [
  "anyhow",
  "dirs",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/mesh-llm-hardware-profile",
     "crates/mesh-llm-identity",
     "crates/mesh-llm-native-runtime",
+    "crates/mesh-llm-provider-runtime",
     "crates/mesh-llm-protocol",
     "crates/mesh-llm-release-footer",
     "crates/mesh-llm-routing",

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -187,6 +187,142 @@ semantic domains, signals, selected slices, reasons, typed matrices, runner
 roles, cache modes and fan-out budgets. Unknown paths and malformed inputs fail
 closed.
 
+- `pr_quality.yml` is named **PR Quality Checks** and owns the earliest Rust,
+  React console, and CLI-documentation feedback: formatting, React console UI
+  quality when relevant, the CLI-docs sync guard when Rust CLI definitions
+  change, and deterministic clippy bins from
+  `scripts/plan-clippy-batches.sh`. Routing no longer waits for the compiled
+  consistency checks; `ci-consistency` runs beside it and remains part of the
+  summary gate. Formatting and UI quality run directly on the selected runner
+  instead of paying the public backend-image pull cost.
+- `pr_website.yml` is named **PR Website Checks** and owns the public website PR
+  canary. It uses `.github/actions/compute-changes` and runs
+  `website-build` only when `website_changed` is true, or when manually
+  dispatched, so public website validation is separate from Rust/React-console
+  quality checks while still using the central routing signals.
+- `ui_changed` and `website_changed` intentionally describe different products:
+  `ui_changed` is only the embedded React console under `crates/mesh-llm-ui/**`,
+  while `website_changed` is only the public Eleventy/Tailwind/Pagefind website
+  and its passthrough inputs. Website changes do not trigger React console UI
+  quality or UI artifact rebuilds.
+- CLI surface changes in `crates/mesh-llm-cli/src/{parser,models,runtime,benchmark}.rs`
+  set `cli_surface_changed`. When that flag is true, `cli-docs-sync` requires a
+  public website docs/example update under `website/src/docs/pages/` or
+  `website/src/_includes/`, with `website/src/docs/pages/CLI.md` as the primary
+  command reference.
+- Changes to `compute-changes` or the central PR/main/release workflow callers
+  fail open to the SDK producer and smoke graph. Caller-owned mode, timeout,
+  artifact, and trust-policy edits therefore cannot skip the reusable SDK
+  contracts they modify.
+- `pr_builds.yml` is named **PR Builds** and owns PR target jobs plus integration
+  and smoke validation. Linux and macOS CPU artifact jobs upload the binaries
+  that downstream smoke jobs consume before long validation groups finish.
+  Every affected Rust workspace crate is assigned to a generated
+  `rust_crate_tests` matrix and runs its complete `cargo test -p <crate>` suite;
+  the shard containing `skippy-runtime` downloads the public Qwen3 correctness
+  fixture and sets `SKIPPY_CORRECTNESS_MODEL`, so the model-backed grammar
+  equivalence test runs instead of being skipped; protocol compatibility and
+  Skippy smoke remain separate integration rows.
+  Linux host/CPU-runtime and macOS host/Metal-runtime producers run
+  independently, and their product composers never compile. Linux backend rows
+  are split into one independent CUDA, ROCm, or Vulkan runtime producer plus
+  one matching `runner_4` composition-only product job. They consume the same
+  immutable host without a matrix-wide fan-in barrier. Windows follows the
+  same graph: one debug neutral host, independent CPU/CUDA/ROCm/Vulkan runtime
+  inputs, and composition-only products. Unsupported macOS CUDA, ROCm, and
+  Vulkan rows are omitted. The PR Swift `host-only` XCFramework producer starts
+  directly from change routing, in parallel with the macOS product and unit
+  tests; Swift smoke waits only for the macOS product and XCFramework inputs.
+  `sdk_smoke_required` makes the shared static CPU ABI producer eligible; the PR
+  Kotlin debug native-SDK producer restores that immutable ABI, validates its
+  complete link closure, pinned build-image epoch, and build stamp through the
+  verification-only `--require-prebuilt-llama` path, and compiles only the Rust
+  FFI while the Linux product proceeds independently. Both build-script and
+  Cargo auto-build fallbacks are disabled for that reuse path. Kotlin smoke
+  waits only for the product and native-SDK inputs and performs no native
+  compilation.
+- **PR Builds Summary** is the stable, non-matrix branch-protection check for
+  this workflow. `changes` runs `scripts/plan-pr-build-jobs.py` once and exports
+  `required_jobs_json`; every conditional top-level job uses membership in
+  that plan as its route, while normal `needs` success semantics keep consumers
+  behind their producers. The summary directly depends on every other
+  top-level job and consumes the same plan. A skipped job is accepted only when
+  the planner did not require it, so a required producer or dependency chain
+  cannot disappear behind propagated skips. Any failure, cancellation, unknown
+  result, duplicate plan entry, or required ID outside the summary graph fails
+  the gate. The job uses `if: ${{ !cancelled() }}` so ordinary upstream
+  failures are still summarized without using `always()`.
+- Product readiness starts a local mDNS client and never depends on the mutable
+  public mesh. The public `client --auto` admission probe is manual-only, so an
+  external peer outage cannot block a pull request or release.
+- Pull requests test affected crates plus their reverse dependents. Main pushes
+  and manual dispatches assign every Cargo workspace member to the matrix, so a
+  targeted-routing mistake cannot permanently hide a crate suite.
+- The executable-provider artifact contract in `mesh-llm-provider-runtime` is
+  an SDK-smoke input. It remains separate from the Skippy-native runtime crate,
+  but changes to either contract exercise SDK consumers.
+- `rust_changed` is not an artifact-build signal. Rust tooling changes such as
+  `tools/xtask/**` still run PR Quality formatting/clippy, but PR Builds only
+  builds `mesh-llm` artifacts when `inference_artifact_required` is true: a
+  runtime-facing crate, SDK smoke input, React console UI artifact input,
+  backend/native input, all-rust fail-open/escalation, or manual dispatch.
+- `Justfile` is routed by changed hunks, not by path alone. Website/dev recipe
+  edits stay light, while native build, ABI, release, bundle, and package
+  recipe edits set `backend_recipe_changed`, which feeds backend artifacts and
+  Windows CPU/GPU build eligibility.
+- Workflow/orchestration-only PR edits validate the PR routing graph without
+  becoming Rust crate changes. They must not fan out into Linux/macOS artifact
+  producers, native backend, Windows GPU, benchmark, or SDK-smoke lanes unless a
+  changed file also affects Rust crates, React console UI assets, public website
+  inputs, SDK inputs, or backend products. Backend lanes are reserved for files
+  that can affect native ABI/backend products, such as `third_party/llama.cpp/**`,
+  `crates/skippy-ffi/**`, backend build scripts, backend-relevant Justfile
+  hunks, and `.github/cache-version.txt`.
+- Windows broad-Rust changes run lightweight Cargo checks. The immutable debug
+  host, CPU runtime, and CPU product run only when
+  `windows_cpu_build_required` is true or the workflow is manually dispatched.
+  CUDA/ROCm/Vulkan runtime producers and composition-only product jobs run only
+  when `windows_gpu_build_required` is true, backend-relevant Justfile hunks
+  changed, or the workflow is manually dispatched. All products consume the
+  same host artifact and use the release composer contract.
+- `pr_cleanup.yml` deletes PR merge-ref caches and artifacts from positively
+  matched PR workflow runs when a pull request closes. Cache cleanup first plans
+  deterministic shards, then fans deletion out across
+  `vars.PR_CACHE_CLEANUP_WORKERS` workers (default `5`) while keeping each worker
+  serial and rate-limited; a final summary aggregates cache shard results plus
+  artifact cleanup. Cleanup-only workflow edits do not fan out into
+  Rust/build/smoke jobs.
+- Docker image and npm publishing are intentionally not part of pull request
+  CI. `docker.yml` is a manual, non-publishing client Dockerfile validation
+  workflow. `release.yml` owns backend-neutral host artifacts per
+  OS/architecture, manifested native runtimes per backend lane, and product
+  composition that records both immutable digests while retaining
+  compatibility archive names. Host producers attest and import-check the host;
+  consumers verify and copy those exact bytes rather than rebuilding or
+  re-stamping them. The Windows host input includes a checksum-protected
+  producer-built attestation verifier so Windows composers do not compile
+  workspace code. Product consumers never rebuild a missing producer. It
+  dispatches a completed stable release with the full GPU matrix to
+  `Mesh-LLM/mesh-packaging`, which owns package, GHCR, and npm publication.
+  Prereleases publish immutable GitHub Release inputs but never dispatch
+  downstream publication.
+- Merged
+  [`mesh-packaging#16`](https://github.com/Mesh-LLM/mesh-packaging/pull/16)
+  makes that downstream graph artifact-only and build-once. Its complete
+  `v0.75.0-rc1` dry rehearsal
+  [30593548823](https://github.com/Mesh-LLM/mesh-packaging/actions/runs/30593548823)
+  passed 41 jobs with 15 intentional publication-only skips, exercising all
+  11 native package rows, exact final-image QA, Homebrew, all five upstream
+  Node addon lanes, npm assembly, host invariants, and immutable evidence.
+  Merge commit `76c619bcdd82773e159248a2282187b0b2973daa` then passed
+  default-branch Packaging Precheck
+  [30595367445](https://github.com/Mesh-LLM/mesh-packaging/actions/runs/30595367445).
+- `fly-deploy-console.yml` is a manual (`workflow_dispatch`) deploy of the
+  `mesh-llm-console` Fly app. It builds the image on Fly's remote builders from
+  `fly/Dockerfile` and authenticates with the app-scoped `FLY_API_TOKEN` repo
+  secret. It carries no pull request trigger and does not run release or smoke
+  jobs.
+
 Control-plane changes fail open through the selected profile. When they
 require the `web` slice, both console and website rows execute even without a
 content-specific change signal, so the stable gate receives a successful

--- a/crates/mesh-llm-provider-runtime/Cargo.toml
+++ b/crates/mesh-llm-provider-runtime/Cargo.toml
@@ -1,0 +1,28 @@
+[package]
+name = "mesh-llm-provider-runtime"
+edition.workspace = true
+license.workspace = true
+version.workspace = true
+description = "Executable provider runtime artifact, resolution, and installation contract for MeshLLM"
+repository = "https://github.com/Mesh-LLM/mesh-llm"
+homepage = "https://github.com/Mesh-LLM/mesh-llm"
+readme = "README.md"
+
+[lints]
+workspace = true
+
+[dependencies]
+anyhow.workspace = true
+dirs = "6.0.0"
+futures-util = "0.3"
+reqwest = { version = "0.12", features = ["stream"] }
+semver = "1"
+serde.workspace = true
+serde_json.workspace = true
+sha2.workspace = true
+tempfile = "3"
+tokio = { version = "1", features = ["fs", "io-util"] }
+zip = { version = "2", default-features = false, features = ["deflate"] }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt"] }

--- a/crates/mesh-llm-provider-runtime/README.md
+++ b/crates/mesh-llm-provider-runtime/README.md
@@ -1,0 +1,28 @@
+# mesh-llm-provider-runtime
+
+This crate defines MeshLLM's package boundary for executable model providers.
+It is deliberately separate from `mesh-llm-native-runtime`: native runtimes
+contain backend libraries selected by the Skippy ABI, while provider runtimes
+are independently signed processes with their own protocol and model surface.
+
+The crate owns:
+
+- the versioned `provider-runtime.json` bundle manifest;
+- the `provider-runtimes.json` release index;
+- platform, provider, protocol, and model selection;
+- file and archive checksum validation;
+- safe ZIP extraction and immutable cache installation;
+- bundled, cached, and downloadable runtime resolution.
+
+It does not launch provider processes or expose SDK-specific lifecycle APIs.
+Those belong to the host supervisor and language SDK layers built on this
+contract.
+
+Provider bundles are installed beneath:
+
+```text
+<cache>/<artifact-id>/<version>/<os>-<arch>/
+```
+
+Artifact coordinates are immutable. Installing different bytes at an existing
+coordinate is rejected rather than overwriting a previously verified runtime.

--- a/crates/mesh-llm-provider-runtime/examples/inspect.rs
+++ b/crates/mesh-llm-provider-runtime/examples/inspect.rs
@@ -1,0 +1,24 @@
+use mesh_llm_provider_runtime::ProviderRuntimeManifest;
+use serde_json::json;
+use std::path::PathBuf;
+
+fn main() -> anyhow::Result<()> {
+    let bundle = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("usage: inspect <provider-runtime-directory>"))?;
+    let manifest = ProviderRuntimeManifest::read_from_dir(&bundle)?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "status": "valid",
+            "id": manifest.runtime.id,
+            "version": manifest.runtime.version,
+            "provider_kind": manifest.runtime.provider_kind,
+            "protocol_version": manifest.runtime.protocol_version,
+            "entrypoint": bundle.join(manifest.runtime.entrypoint),
+            "models": manifest.runtime.models,
+        }))?
+    );
+    Ok(())
+}

--- a/crates/mesh-llm-provider-runtime/examples/inspect_archive.rs
+++ b/crates/mesh-llm-provider-runtime/examples/inspect_archive.rs
@@ -1,0 +1,39 @@
+use mesh_llm_provider_runtime::{
+    ProviderRuntimeCache, ProviderRuntimeReleaseManifest, install_provider_runtime_archive,
+};
+use serde_json::json;
+use std::path::PathBuf;
+
+fn main() -> anyhow::Result<()> {
+    let mut arguments = std::env::args_os().skip(1).map(PathBuf::from);
+    let release_manifest_path = arguments.next().ok_or_else(|| {
+        anyhow::anyhow!("usage: inspect_archive <provider-runtimes.json> <runtime.zip>")
+    })?;
+    let archive_path = arguments.next().ok_or_else(|| {
+        anyhow::anyhow!("usage: inspect_archive <provider-runtimes.json> <runtime.zip>")
+    })?;
+    let release_manifest = ProviderRuntimeReleaseManifest::read_from_path(&release_manifest_path)?;
+    let artifact = release_manifest
+        .artifacts
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("provider runtime release manifest has no artifacts"))?;
+    let archive_sha256 = artifact
+        .archive_sha256
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("provider runtime artifact has no archive checksum"))?;
+    let workspace = tempfile::tempdir()?;
+    let cache = ProviderRuntimeCache::new(workspace.path().join("cache"));
+    let (status, installed) =
+        install_provider_runtime_archive(&cache, artifact, &archive_path, archive_sha256)?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "status": "valid",
+            "install_status": status,
+            "id": installed.manifest.runtime.id,
+            "version": installed.manifest.runtime.version,
+            "entrypoint_exists": installed.entrypoint().is_file(),
+        }))?
+    );
+    Ok(())
+}

--- a/crates/mesh-llm-provider-runtime/examples/inspect_release.rs
+++ b/crates/mesh-llm-provider-runtime/examples/inspect_release.rs
@@ -1,0 +1,25 @@
+use mesh_llm_provider_runtime::ProviderRuntimeReleaseManifest;
+use serde_json::json;
+use std::path::PathBuf;
+
+fn main() -> anyhow::Result<()> {
+    let path = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .ok_or_else(|| anyhow::anyhow!("usage: inspect_release <provider-runtimes.json>"))?;
+    let manifest = ProviderRuntimeReleaseManifest::read_from_path(&path)?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "status": "valid",
+            "schema_version": manifest.schema_version,
+            "artifacts": manifest.artifacts.iter().map(|artifact| json!({
+                "id": artifact.id,
+                "version": artifact.version,
+                "platform": artifact.platform,
+                "downloadable": artifact.url.is_some(),
+            })).collect::<Vec<_>>(),
+        }))?
+    );
+    Ok(())
+}

--- a/crates/mesh-llm-provider-runtime/src/cache.rs
+++ b/crates/mesh-llm-provider-runtime/src/cache.rs
@@ -1,0 +1,288 @@
+use crate::{PROVIDER_RUNTIME_MANIFEST_FILE, ProviderRuntimeManifest};
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+};
+
+#[derive(Clone, Debug)]
+pub struct ProviderRuntimeCache {
+    root: PathBuf,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct InstalledProviderRuntime {
+    pub path: PathBuf,
+    pub manifest: ProviderRuntimeManifest,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderRuntimeInstallStatus {
+    AlreadyInstalled,
+    Installed,
+}
+
+impl ProviderRuntimeCache {
+    pub fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
+    pub fn install_from_dir(
+        &self,
+        bundle: &Path,
+    ) -> Result<(ProviderRuntimeInstallStatus, InstalledProviderRuntime)> {
+        let manifest = ProviderRuntimeManifest::read_from_dir(bundle)?;
+        let destination = self.artifact_path(&manifest);
+        if destination.exists() {
+            return existing_install(&destination, &manifest);
+        }
+        let parent = destination
+            .parent()
+            .context("provider runtime cache destination has no parent")?;
+        fs::create_dir_all(parent)
+            .with_context(|| format!("create provider runtime cache {}", parent.display()))?;
+        let temporary = tempfile::Builder::new()
+            .prefix(".install-")
+            .tempdir_in(parent)
+            .with_context(|| format!("create provider runtime staging in {}", parent.display()))?;
+        copy_verified_bundle(bundle, temporary.path(), &manifest)
+            .and_then(|()| ProviderRuntimeManifest::read_from_dir(temporary.path()))
+            .and_then(|installed_manifest| {
+                if installed_manifest != manifest {
+                    bail!("installed provider runtime manifest changed during copy");
+                }
+                publish_install(temporary.path(), &destination, &manifest)
+            })
+    }
+
+    pub fn find(
+        &self,
+        artifact_id: &str,
+        version: &str,
+        platform_key: &str,
+    ) -> Result<Option<InstalledProviderRuntime>> {
+        let path = self.root.join(artifact_id).join(version).join(platform_key);
+        if !path.is_dir() {
+            return Ok(None);
+        }
+        let manifest = ProviderRuntimeManifest::read_from_dir(&path)?;
+        Ok(Some(InstalledProviderRuntime { path, manifest }))
+    }
+
+    pub fn list(&self) -> Result<Vec<InstalledProviderRuntime>> {
+        if !self.root.is_dir() {
+            return Ok(Vec::new());
+        }
+        let mut installed = Vec::new();
+        for artifact_dir in child_directories(&self.root)? {
+            for version_dir in child_directories(&artifact_dir)? {
+                for platform_dir in child_directories(&version_dir)? {
+                    if platform_dir.join(PROVIDER_RUNTIME_MANIFEST_FILE).is_file() {
+                        let manifest = ProviderRuntimeManifest::read_from_dir(&platform_dir)?;
+                        installed.push(InstalledProviderRuntime {
+                            path: platform_dir,
+                            manifest,
+                        });
+                    }
+                }
+            }
+        }
+        Ok(installed)
+    }
+
+    fn artifact_path(&self, manifest: &ProviderRuntimeManifest) -> PathBuf {
+        self.root
+            .join(&manifest.runtime.id)
+            .join(&manifest.runtime.version)
+            .join(manifest.runtime.platform_key())
+    }
+}
+
+impl InstalledProviderRuntime {
+    pub fn entrypoint(&self) -> PathBuf {
+        self.path.join(&self.manifest.runtime.entrypoint)
+    }
+}
+
+fn existing_install(
+    destination: &Path,
+    expected: &ProviderRuntimeManifest,
+) -> Result<(ProviderRuntimeInstallStatus, InstalledProviderRuntime)> {
+    let actual = ProviderRuntimeManifest::read_from_dir(destination)?;
+    if &actual != expected {
+        bail!(
+            "provider runtime coordinate {}/{} already contains different metadata",
+            expected.runtime.id,
+            expected.runtime.version
+        );
+    }
+    Ok((
+        ProviderRuntimeInstallStatus::AlreadyInstalled,
+        InstalledProviderRuntime {
+            path: destination.to_path_buf(),
+            manifest: actual,
+        },
+    ))
+}
+
+fn copy_verified_bundle(
+    source: &Path,
+    destination: &Path,
+    manifest: &ProviderRuntimeManifest,
+) -> Result<()> {
+    for relative in manifest.runtime.files.keys() {
+        let source_file = source.join(relative);
+        let destination_file = destination.join(relative);
+        if let Some(parent) = destination_file.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::copy(&source_file, &destination_file).with_context(|| {
+            format!(
+                "copy provider runtime file {} to {}",
+                source_file.display(),
+                destination_file.display()
+            )
+        })?;
+        fs::set_permissions(&destination_file, fs::metadata(&source_file)?.permissions())?;
+    }
+    fs::copy(
+        source.join(PROVIDER_RUNTIME_MANIFEST_FILE),
+        destination.join(PROVIDER_RUNTIME_MANIFEST_FILE),
+    )?;
+    Ok(())
+}
+
+fn publish_install(
+    temporary: &Path,
+    destination: &Path,
+    manifest: &ProviderRuntimeManifest,
+) -> Result<(ProviderRuntimeInstallStatus, InstalledProviderRuntime)> {
+    match fs::rename(temporary, destination) {
+        Ok(()) => Ok((
+            ProviderRuntimeInstallStatus::Installed,
+            InstalledProviderRuntime {
+                path: destination.to_path_buf(),
+                manifest: manifest.clone(),
+            },
+        )),
+        Err(_error) if destination.exists() => {
+            let _ = fs::remove_dir_all(temporary);
+            existing_install(destination, manifest)
+        }
+        Err(error) => Err(error).with_context(|| {
+            format!(
+                "publish provider runtime cache install {}",
+                destination.display()
+            )
+        }),
+    }
+}
+
+fn child_directories(root: &Path) -> Result<Vec<PathBuf>> {
+    let mut directories = Vec::new();
+    for entry in fs::read_dir(root).with_context(|| format!("read {}", root.display()))? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() && !entry.file_name().to_string_lossy().starts_with('.') {
+            directories.push(entry.path());
+        }
+    }
+    directories.sort();
+    Ok(directories)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{
+        PROVIDER_RUNTIME_SCHEMA_VERSION, ProviderRuntimeArtifact, ProviderRuntimeModel,
+        ProviderRuntimePlatform,
+    };
+    use sha2::{Digest, Sha256};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn bundle(root: &Path, contents: &[u8]) -> ProviderRuntimeManifest {
+        let binary = root.join("bin/provider");
+        fs::create_dir_all(binary.parent().unwrap()).unwrap();
+        fs::write(&binary, contents).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&binary, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let digest = format!("{:x}", Sha256::digest(contents));
+        let manifest = ProviderRuntimeManifest {
+            schema_version: PROVIDER_RUNTIME_SCHEMA_VERSION,
+            runtime: ProviderRuntimeArtifact {
+                id: "fixture-provider".to_string(),
+                version: "1.0.0".to_string(),
+                provider_kind: "fixture".to_string(),
+                protocol_version: "1.0".to_string(),
+                platform: ProviderRuntimePlatform {
+                    os: std::env::consts::OS.to_string(),
+                    arch: std::env::consts::ARCH.to_string(),
+                    target: None,
+                    minimum_os_version: None,
+                },
+                entrypoint: "bin/provider".to_string(),
+                models: vec![ProviderRuntimeModel {
+                    id: "fixture/model".to_string(),
+                    kind: "fixture".to_string(),
+                }],
+                features: BTreeSet::new(),
+                files: BTreeMap::from([("bin/provider".to_string(), digest)]),
+                build: BTreeMap::new(),
+                signature: None,
+                url: None,
+                archive_sha256: None,
+            },
+        };
+        manifest.write_to_dir(root).unwrap();
+        manifest
+    }
+
+    #[test]
+    fn installs_immutably_and_reuses_identical_coordinates() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle_dir = temp.path().join("bundle");
+        fs::create_dir(&bundle_dir).unwrap();
+        let manifest = bundle(&bundle_dir, b"runtime");
+        let cache = ProviderRuntimeCache::new(temp.path().join("cache"));
+
+        let (first_status, first) = cache.install_from_dir(&bundle_dir).unwrap();
+        let (second_status, second) = cache.install_from_dir(&bundle_dir).unwrap();
+
+        assert_eq!(first_status, ProviderRuntimeInstallStatus::Installed);
+        assert_eq!(
+            second_status,
+            ProviderRuntimeInstallStatus::AlreadyInstalled
+        );
+        assert_eq!(first, second);
+        assert_eq!(first.manifest, manifest);
+        assert!(first.entrypoint().is_file());
+    }
+
+    #[test]
+    fn rejects_different_bytes_at_an_existing_coordinate() {
+        let temp = tempfile::tempdir().unwrap();
+        let first_bundle = temp.path().join("first");
+        let second_bundle = temp.path().join("second");
+        fs::create_dir(&first_bundle).unwrap();
+        fs::create_dir(&second_bundle).unwrap();
+        bundle(&first_bundle, b"first");
+        bundle(&second_bundle, b"second");
+        let cache = ProviderRuntimeCache::new(temp.path().join("cache"));
+        cache.install_from_dir(&first_bundle).unwrap();
+
+        let error = cache.install_from_dir(&second_bundle).unwrap_err();
+        assert!(
+            error.to_string().contains("different metadata"),
+            "{error:?}"
+        );
+    }
+}

--- a/crates/mesh-llm-provider-runtime/src/install.rs
+++ b/crates/mesh-llm-provider-runtime/src/install.rs
@@ -1,0 +1,518 @@
+use crate::{
+    InstalledProviderRuntime, ProviderRuntimeArtifact, ProviderRuntimeCache,
+    ProviderRuntimeInstallStatus, ProviderRuntimeManifest, ProviderRuntimeReleaseManifest,
+    ProviderRuntimeRequest, ProviderRuntimeResolution, ProviderRuntimeResolver,
+    ProviderRuntimeSource,
+};
+use anyhow::{Context, Result, bail};
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    fs,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+    time::Duration,
+};
+use tokio::io::AsyncWriteExt;
+
+const MAX_ARCHIVE_BYTES: u64 = 1024 * 1024 * 1024;
+const MAX_ARCHIVE_ENTRIES: usize = 4096;
+const MAX_EXPANDED_BYTES: u64 = 2 * MAX_ARCHIVE_BYTES;
+
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ProviderRuntimeBundlePolicy {
+    #[default]
+    UseInPlace,
+    InstallIntoCache,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProviderRuntimeInstallOptions {
+    pub host: crate::ProviderRuntimeHost,
+    pub request: ProviderRuntimeRequest,
+    pub release_manifest: ProviderRuntimeReleaseManifest,
+    pub bundle_dirs: Vec<PathBuf>,
+    pub cache_dir: Option<PathBuf>,
+    pub bundle_policy: ProviderRuntimeBundlePolicy,
+    pub allow_download: bool,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRuntimeInstallOutcome {
+    pub status: ProviderRuntimeInstallStatus,
+    pub runtime: InstalledProviderRuntime,
+    pub resolution: ProviderRuntimeResolution,
+}
+
+impl Default for ProviderRuntimeInstallOptions {
+    fn default() -> Self {
+        Self {
+            host: crate::ProviderRuntimeHost::current(),
+            request: ProviderRuntimeRequest::default(),
+            release_manifest: ProviderRuntimeReleaseManifest {
+                schema_version: crate::PROVIDER_RUNTIME_SCHEMA_VERSION,
+                artifacts: Vec::new(),
+            },
+            bundle_dirs: Vec::new(),
+            cache_dir: None,
+            bundle_policy: ProviderRuntimeBundlePolicy::UseInPlace,
+            allow_download: false,
+        }
+    }
+}
+
+pub async fn install_provider_runtime(
+    options: ProviderRuntimeInstallOptions,
+) -> Result<ProviderRuntimeInstallOutcome> {
+    options.release_manifest.validate()?;
+    let cache = provider_runtime_cache(options.cache_dir.as_deref())?;
+    let resolution = ProviderRuntimeResolver::new(
+        options.host.clone(),
+        options.release_manifest.clone(),
+        cache.clone(),
+    )
+    .with_bundle_dirs(options.bundle_dirs.clone())
+    .resolve(&options.request)?;
+    let (status, runtime) = match &resolution.source {
+        ProviderRuntimeSource::Bundle { path }
+            if options.bundle_policy == ProviderRuntimeBundlePolicy::UseInPlace =>
+        {
+            in_place_runtime(path)?
+        }
+        ProviderRuntimeSource::Bundle { path } => cache.install_from_dir(path)?,
+        ProviderRuntimeSource::Installed { path } => (
+            ProviderRuntimeInstallStatus::AlreadyInstalled,
+            installed_runtime(path)?,
+        ),
+        ProviderRuntimeSource::Download { url, sha256 } if options.allow_download => {
+            download_and_install(&cache, &resolution.selected, url, sha256).await?
+        }
+        ProviderRuntimeSource::Download { .. } => {
+            bail!("selected provider runtime requires a download, but downloads are disabled")
+        }
+        ProviderRuntimeSource::Missing => {
+            bail!(
+                "selected provider runtime {} is not bundled, installed, or downloadable",
+                resolution.selected.id
+            )
+        }
+    };
+    Ok(ProviderRuntimeInstallOutcome {
+        status,
+        runtime,
+        resolution,
+    })
+}
+
+fn provider_runtime_cache(cache_dir: Option<&Path>) -> Result<ProviderRuntimeCache> {
+    let root = match cache_dir {
+        Some(path) => path.to_path_buf(),
+        None => dirs::cache_dir()
+            .or_else(|| dirs::home_dir().map(|home| home.join(".cache")))
+            .context("cannot determine provider runtime cache directory")?
+            .join("mesh-llm")
+            .join("provider-runtimes"),
+    };
+    Ok(ProviderRuntimeCache::new(root))
+}
+
+fn in_place_runtime(
+    path: &Path,
+) -> Result<(ProviderRuntimeInstallStatus, InstalledProviderRuntime)> {
+    Ok((
+        ProviderRuntimeInstallStatus::AlreadyInstalled,
+        installed_runtime(path)?,
+    ))
+}
+
+fn installed_runtime(path: &Path) -> Result<InstalledProviderRuntime> {
+    let manifest = ProviderRuntimeManifest::read_from_dir(path)?;
+    Ok(InstalledProviderRuntime {
+        path: path.to_path_buf(),
+        manifest,
+    })
+}
+
+async fn download_and_install(
+    cache: &ProviderRuntimeCache,
+    selected: &ProviderRuntimeArtifact,
+    url: &str,
+    expected_sha256: &str,
+) -> Result<(ProviderRuntimeInstallStatus, InstalledProviderRuntime)> {
+    let workspace = tempfile::Builder::new()
+        .prefix("mesh-provider-runtime-")
+        .tempdir()
+        .context("create provider runtime download workspace")?;
+    let archive_path = workspace.path().join("provider-runtime.zip");
+    download_archive(url, &archive_path, expected_sha256).await?;
+    install_provider_runtime_archive(cache, selected, &archive_path, expected_sha256)
+}
+
+pub fn install_provider_runtime_archive(
+    cache: &ProviderRuntimeCache,
+    selected: &ProviderRuntimeArtifact,
+    archive_path: &Path,
+    expected_sha256: &str,
+) -> Result<(ProviderRuntimeInstallStatus, InstalledProviderRuntime)> {
+    verify_archive_file(archive_path, expected_sha256)?;
+    let workspace = tempfile::Builder::new()
+        .prefix("mesh-provider-runtime-extract-")
+        .tempdir()
+        .context("create provider runtime extraction workspace")?;
+    let extracted = workspace.path().join("extracted");
+    fs::create_dir(&extracted)?;
+    extract_archive(archive_path, &extracted)?;
+    let bundle = find_provider_bundle(&extracted)?;
+    let manifest = ProviderRuntimeManifest::read_from_dir(&bundle)?;
+    if !manifest.runtime.payload_matches(selected) {
+        bail!(
+            "downloaded provider runtime payload does not match selected artifact {} {}",
+            selected.id,
+            selected.version
+        );
+    }
+    cache.install_from_dir(&bundle)
+}
+
+async fn download_archive(url: &str, path: &Path, expected_sha256: &str) -> Result<()> {
+    let diagnostic_url = url.split_once('?').map_or(url, |(base, _)| base);
+    let response = reqwest::Client::builder()
+        .timeout(Duration::from_secs(600))
+        .build()
+        .context("build provider runtime download client")?
+        .get(url)
+        .header("User-Agent", "mesh-llm")
+        .send()
+        .await
+        .map_err(reqwest::Error::without_url)
+        .with_context(|| format!("download provider runtime {diagnostic_url}"))?
+        .error_for_status()
+        .map_err(reqwest::Error::without_url)
+        .with_context(|| format!("provider runtime request failed for {diagnostic_url}"))?;
+    if response
+        .content_length()
+        .is_some_and(|size| size > MAX_ARCHIVE_BYTES)
+    {
+        bail!("provider runtime archive exceeds the download size limit");
+    }
+    let mut stream = response.bytes_stream();
+    let mut file = tokio::fs::File::create(path)
+        .await
+        .with_context(|| format!("create provider runtime archive {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut downloaded = 0_u64;
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk
+            .map_err(reqwest::Error::without_url)
+            .with_context(|| format!("read provider runtime response {diagnostic_url}"))?;
+        downloaded = downloaded.saturating_add(chunk.len() as u64);
+        if downloaded > MAX_ARCHIVE_BYTES {
+            bail!("provider runtime archive exceeds the download size limit");
+        }
+        file.write_all(&chunk)
+            .await
+            .with_context(|| format!("write provider runtime archive {}", path.display()))?;
+        hasher.update(&chunk);
+    }
+    file.flush().await?;
+    let digest = hasher.finalize();
+    verify_digest(&digest, expected_sha256, "archive")
+}
+
+fn extract_archive(archive_path: &Path, destination: &Path) -> Result<()> {
+    let file = fs::File::open(archive_path)
+        .with_context(|| format!("open provider runtime archive {}", archive_path.display()))?;
+    let mut archive = zip::ZipArchive::new(file).context("open provider runtime ZIP")?;
+    if archive.len() > MAX_ARCHIVE_ENTRIES {
+        bail!("provider runtime archive contains too many entries");
+    }
+    let expanded_bytes = (0..archive.len()).try_fold(0_u64, |total, index| {
+        let entry = archive.by_index(index)?;
+        Ok::<_, zip::result::ZipError>(total.saturating_add(entry.size()))
+    })?;
+    if expanded_bytes > MAX_EXPANDED_BYTES {
+        bail!("provider runtime archive exceeds the expanded size limit");
+    }
+    for index in 0..archive.len() {
+        extract_entry(&mut archive, index, destination)?;
+    }
+    Ok(())
+}
+
+fn extract_entry(
+    archive: &mut zip::ZipArchive<fs::File>,
+    index: usize,
+    destination: &Path,
+) -> Result<()> {
+    let mut entry = archive.by_index(index)?;
+    let relative = entry
+        .enclosed_name()
+        .with_context(|| format!("unsafe provider runtime ZIP entry {}", entry.name()))?;
+    if zip_entry_is_symlink(&entry) {
+        bail!("provider runtime ZIP contains a symlink: {}", entry.name());
+    }
+    let output = destination.join(relative);
+    if entry.is_dir() {
+        fs::create_dir_all(&output)?;
+        return Ok(());
+    }
+    if let Some(parent) = output.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&output)
+        .with_context(|| {
+            format!(
+                "create extracted provider runtime file {}",
+                output.display()
+            )
+        })?;
+    std::io::copy(&mut entry, &mut file)?;
+    file.flush()?;
+    apply_zip_permissions(&output, entry.unix_mode())?;
+    Ok(())
+}
+
+fn zip_entry_is_symlink(entry: &zip::read::ZipFile<'_>) -> bool {
+    entry
+        .unix_mode()
+        .is_some_and(|mode| mode & 0o170000 == 0o120000)
+}
+
+#[cfg(unix)]
+fn apply_zip_permissions(path: &Path, mode: Option<u32>) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    if let Some(mode) = mode {
+        fs::set_permissions(path, fs::Permissions::from_mode(mode & 0o777))?;
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn apply_zip_permissions(_path: &Path, _mode: Option<u32>) -> Result<()> {
+    Ok(())
+}
+
+fn find_provider_bundle(extracted: &Path) -> Result<PathBuf> {
+    let mut matches = Vec::new();
+    collect_provider_bundles(extracted, &mut matches)?;
+    match matches.len() {
+        1 => Ok(matches.remove(0)),
+        0 => bail!("provider runtime archive contains no provider-runtime.json"),
+        count => bail!("provider runtime archive contains {count} provider manifests"),
+    }
+}
+
+fn collect_provider_bundles(directory: &Path, matches: &mut Vec<PathBuf>) -> Result<()> {
+    if directory
+        .join(crate::PROVIDER_RUNTIME_MANIFEST_FILE)
+        .is_file()
+    {
+        matches.push(directory.to_path_buf());
+        return Ok(());
+    }
+    for entry in fs::read_dir(directory)? {
+        let entry = entry?;
+        if entry.file_type()?.is_dir() {
+            collect_provider_bundles(&entry.path(), matches)?;
+        }
+    }
+    Ok(())
+}
+
+fn verify_digest(actual: &[u8], expected: &str, label: &str) -> Result<()> {
+    let actual = actual
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    let expected = crate::manifest::normalize_sha256(expected)?;
+    if actual != expected {
+        bail!("provider runtime {label} checksum mismatch: expected {expected}, got {actual}");
+    }
+    Ok(())
+}
+
+fn verify_archive_file(path: &Path, expected: &str) -> Result<()> {
+    let mut file = fs::File::open(path)
+        .with_context(|| format!("open provider runtime archive {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let count = file.read(&mut buffer)?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    let digest = hasher.finalize();
+    verify_digest(&digest, expected, "archive")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{PROVIDER_RUNTIME_SCHEMA_VERSION, ProviderRuntimeModel, ProviderRuntimePlatform};
+    use std::collections::{BTreeMap, BTreeSet};
+    use std::net::TcpListener;
+
+    fn create_bundle(root: &Path) -> ProviderRuntimeManifest {
+        let binary = root.join("bin/provider");
+        fs::create_dir_all(binary.parent().unwrap()).unwrap();
+        fs::write(&binary, b"runtime").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&binary, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let manifest = ProviderRuntimeManifest {
+            schema_version: PROVIDER_RUNTIME_SCHEMA_VERSION,
+            runtime: ProviderRuntimeArtifact {
+                id: "fixture-provider".to_string(),
+                version: "1.0.0".to_string(),
+                provider_kind: "fixture".to_string(),
+                protocol_version: "1.0".to_string(),
+                platform: ProviderRuntimePlatform {
+                    os: std::env::consts::OS.to_string(),
+                    arch: std::env::consts::ARCH.to_string(),
+                    target: None,
+                    minimum_os_version: None,
+                },
+                entrypoint: "bin/provider".to_string(),
+                models: vec![ProviderRuntimeModel {
+                    id: "fixture/model".to_string(),
+                    kind: "fixture".to_string(),
+                }],
+                features: BTreeSet::new(),
+                files: BTreeMap::from([(
+                    "bin/provider".to_string(),
+                    format!("{:x}", Sha256::digest(b"runtime")),
+                )]),
+                build: BTreeMap::new(),
+                signature: None,
+                url: None,
+                archive_sha256: None,
+            },
+        };
+        manifest.write_to_dir(root).unwrap();
+        manifest
+    }
+
+    fn zip_bundle(bundle: &Path, output: &Path, symlink: bool) {
+        use zip::write::SimpleFileOptions;
+        let file = fs::File::create(output).unwrap();
+        let mut writer = zip::ZipWriter::new(file);
+        let options = SimpleFileOptions::default().unix_permissions(0o755);
+        if symlink {
+            writer
+                .add_symlink(
+                    "bundle/bin/provider",
+                    "outside",
+                    SimpleFileOptions::default(),
+                )
+                .unwrap();
+        } else {
+            writer.start_file("bundle/bin/provider", options).unwrap();
+            writer
+                .write_all(&fs::read(bundle.join("bin/provider")).unwrap())
+                .unwrap();
+        }
+        writer
+            .start_file(
+                "bundle/provider-runtime.json",
+                SimpleFileOptions::default().unix_permissions(0o644),
+            )
+            .unwrap();
+        writer
+            .write_all(&fs::read(bundle.join("provider-runtime.json")).unwrap())
+            .unwrap();
+        writer.finish().unwrap();
+    }
+
+    #[test]
+    fn extracts_and_installs_a_verified_archive() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("bundle-source");
+        fs::create_dir(&bundle).unwrap();
+        let expected = create_bundle(&bundle);
+        let archive = temp.path().join("runtime.zip");
+        zip_bundle(&bundle, &archive, false);
+        let extracted = temp.path().join("extracted");
+        fs::create_dir(&extracted).unwrap();
+
+        extract_archive(&archive, &extracted).unwrap();
+        let found = find_provider_bundle(&extracted).unwrap();
+        let actual = ProviderRuntimeManifest::read_from_dir(&found).unwrap();
+
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn rejects_symlink_entries_before_installation() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("bundle-source");
+        fs::create_dir(&bundle).unwrap();
+        create_bundle(&bundle);
+        let archive = temp.path().join("runtime.zip");
+        zip_bundle(&bundle, &archive, true);
+        let extracted = temp.path().join("extracted");
+        fs::create_dir(&extracted).unwrap();
+
+        let error = extract_archive(&archive, &extracted).unwrap_err();
+        assert!(error.to_string().contains("symlink"), "{error:?}");
+    }
+
+    #[tokio::test]
+    async fn downloads_verifies_and_installs_a_release_artifact() {
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("bundle-source");
+        fs::create_dir(&bundle).unwrap();
+        let manifest = create_bundle(&bundle);
+        let archive = temp.path().join("runtime.zip");
+        zip_bundle(&bundle, &archive, false);
+        let archive_bytes = fs::read(&archive).unwrap();
+        let archive_sha256 = format!("{:x}", Sha256::digest(&archive_bytes));
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut request = [0_u8; 1024];
+            let _ = stream.read(&mut request).unwrap();
+            write!(
+                stream,
+                "HTTP/1.1 200 OK\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                archive_bytes.len()
+            )
+            .unwrap();
+            stream.write_all(&archive_bytes).unwrap();
+        });
+        let mut release_artifact = manifest.runtime.clone();
+        release_artifact.url = Some(format!("http://{address}/runtime.zip?token=redacted"));
+        release_artifact.archive_sha256 = Some(archive_sha256);
+
+        let outcome = install_provider_runtime(ProviderRuntimeInstallOptions {
+            host: crate::ProviderRuntimeHost::current(),
+            request: ProviderRuntimeRequest {
+                artifact_id: Some(release_artifact.id.clone()),
+                ..Default::default()
+            },
+            release_manifest: ProviderRuntimeReleaseManifest {
+                schema_version: PROVIDER_RUNTIME_SCHEMA_VERSION,
+                artifacts: vec![release_artifact],
+            },
+            cache_dir: Some(temp.path().join("cache")),
+            allow_download: true,
+            ..Default::default()
+        })
+        .await
+        .unwrap();
+        server.join().unwrap();
+
+        assert_eq!(outcome.status, ProviderRuntimeInstallStatus::Installed);
+        assert!(outcome.runtime.entrypoint().is_file());
+        assert_eq!(outcome.runtime.manifest.runtime, manifest.runtime);
+    }
+}

--- a/crates/mesh-llm-provider-runtime/src/lib.rs
+++ b/crates/mesh-llm-provider-runtime/src/lib.rs
@@ -1,0 +1,20 @@
+mod cache;
+mod install;
+mod manifest;
+mod resolver;
+
+pub use cache::{InstalledProviderRuntime, ProviderRuntimeCache, ProviderRuntimeInstallStatus};
+pub use install::{
+    ProviderRuntimeBundlePolicy, ProviderRuntimeInstallOptions, ProviderRuntimeInstallOutcome,
+    install_provider_runtime, install_provider_runtime_archive,
+};
+pub use manifest::{
+    PROVIDER_RUNTIME_MANIFEST_FILE, PROVIDER_RUNTIME_RELEASE_MANIFEST_FILE,
+    PROVIDER_RUNTIME_SCHEMA_VERSION, ProviderRuntimeArtifact, ProviderRuntimeManifest,
+    ProviderRuntimeModel, ProviderRuntimePlatform, ProviderRuntimeReleaseManifest,
+    ProviderRuntimeSignature,
+};
+pub use resolver::{
+    ProviderRuntimeHost, ProviderRuntimeRequest, ProviderRuntimeResolution,
+    ProviderRuntimeResolver, ProviderRuntimeSource,
+};

--- a/crates/mesh-llm-provider-runtime/src/manifest.rs
+++ b/crates/mesh-llm-provider-runtime/src/manifest.rs
@@ -1,0 +1,487 @@
+use anyhow::{Context, Result, bail};
+use semver::Version;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use std::{
+    collections::{BTreeMap, BTreeSet},
+    fs,
+    io::Read,
+    path::{Component, Path, PathBuf},
+};
+
+pub const PROVIDER_RUNTIME_SCHEMA_VERSION: u32 = 1;
+pub const PROVIDER_RUNTIME_MANIFEST_FILE: &str = "provider-runtime.json";
+pub const PROVIDER_RUNTIME_RELEASE_MANIFEST_FILE: &str = "provider-runtimes.json";
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRuntimePlatform {
+    pub os: String,
+    pub arch: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub minimum_os_version: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRuntimeModel {
+    pub id: String,
+    pub kind: String,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRuntimeSignature {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub identity: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub team_identifier: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signing_identifier: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub entitlements: Vec<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub notarized: Option<bool>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRuntimeArtifact {
+    pub id: String,
+    pub version: String,
+    pub provider_kind: String,
+    pub protocol_version: String,
+    pub platform: ProviderRuntimePlatform,
+    pub entrypoint: String,
+    pub models: Vec<ProviderRuntimeModel>,
+    #[serde(default, skip_serializing_if = "BTreeSet::is_empty")]
+    pub features: BTreeSet<String>,
+    pub files: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub build: BTreeMap<String, String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<ProviderRuntimeSignature>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub archive_sha256: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRuntimeManifest {
+    pub schema_version: u32,
+    pub runtime: ProviderRuntimeArtifact,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRuntimeReleaseManifest {
+    pub schema_version: u32,
+    #[serde(default)]
+    pub artifacts: Vec<ProviderRuntimeArtifact>,
+}
+
+impl ProviderRuntimeArtifact {
+    pub fn validate(&self) -> Result<()> {
+        validate_coordinate("provider runtime id", &self.id)?;
+        Version::parse(&self.version)
+            .with_context(|| format!("provider runtime {} has invalid version", self.id))?;
+        validate_coordinate("provider kind", &self.provider_kind)?;
+        validate_protocol_version(&self.protocol_version)?;
+        self.platform.validate()?;
+        validate_runtime_path(&self.entrypoint)?;
+        if self.models.is_empty() {
+            bail!(
+                "provider runtime {} must declare at least one model",
+                self.id
+            );
+        }
+        let mut model_ids = BTreeSet::new();
+        for model in &self.models {
+            validate_model(model)?;
+            if !model_ids.insert(&model.id) {
+                bail!("provider runtime {} repeats model {}", self.id, model.id);
+            }
+        }
+        for feature in &self.features {
+            validate_coordinate("provider runtime feature", feature)?;
+        }
+        if self.files.is_empty() {
+            bail!("provider runtime {} must declare checked files", self.id);
+        }
+        if !self.files.contains_key(&self.entrypoint) {
+            bail!(
+                "provider runtime {} entrypoint {} is missing from files",
+                self.id,
+                self.entrypoint
+            );
+        }
+        for (path, checksum) in &self.files {
+            validate_runtime_path(path)?;
+            normalize_sha256(checksum).with_context(|| {
+                format!(
+                    "provider runtime {} has invalid checksum for {path}",
+                    self.id
+                )
+            })?;
+        }
+        if self.url.is_some() && self.archive_sha256.is_none() {
+            bail!(
+                "downloadable provider runtime {} is missing archive_sha256",
+                self.id
+            );
+        }
+        if let Some(checksum) = &self.archive_sha256 {
+            normalize_sha256(checksum).with_context(|| {
+                format!("provider runtime {} has invalid archive checksum", self.id)
+            })?;
+        }
+        Ok(())
+    }
+
+    pub fn payload_matches(&self, other: &Self) -> bool {
+        let mut left = self.clone();
+        let mut right = other.clone();
+        left.url = None;
+        left.archive_sha256 = None;
+        right.url = None;
+        right.archive_sha256 = None;
+        left == right
+    }
+
+    pub fn platform_key(&self) -> String {
+        format!("{}-{}", self.platform.os, self.platform.arch)
+    }
+}
+
+impl ProviderRuntimePlatform {
+    fn validate(&self) -> Result<()> {
+        validate_coordinate("provider runtime platform os", &self.os)?;
+        validate_coordinate("provider runtime platform arch", &self.arch)?;
+        if let Some(target) = &self.target {
+            validate_coordinate("provider runtime platform target", target)?;
+        }
+        if let Some(version) = &self.minimum_os_version {
+            parse_dotted_version(version).with_context(|| {
+                format!("invalid minimum OS version for {}/{}", self.os, self.arch)
+            })?;
+        }
+        Ok(())
+    }
+}
+
+impl ProviderRuntimeManifest {
+    pub fn read_from_dir(dir: &Path) -> Result<Self> {
+        let path = dir.join(PROVIDER_RUNTIME_MANIFEST_FILE);
+        let text = fs::read_to_string(&path)
+            .with_context(|| format!("read provider runtime manifest {}", path.display()))?;
+        let manifest = Self::from_json_str(&text)
+            .with_context(|| format!("parse provider runtime manifest {}", path.display()))?;
+        manifest.verify_contents(dir)?;
+        Ok(manifest)
+    }
+
+    pub fn from_json_str(text: &str) -> Result<Self> {
+        let manifest: Self = serde_json::from_str(text)?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    pub fn write_to_dir(&self, dir: &Path) -> Result<()> {
+        self.validate()?;
+        fs::create_dir_all(dir)
+            .with_context(|| format!("create provider runtime directory {}", dir.display()))?;
+        let path = dir.join(PROVIDER_RUNTIME_MANIFEST_FILE);
+        let text = serde_json::to_string_pretty(self)?;
+        fs::write(&path, format!("{text}\n"))
+            .with_context(|| format!("write provider runtime manifest {}", path.display()))
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        validate_schema_version(self.schema_version)?;
+        self.runtime.validate()
+    }
+
+    pub fn verify_contents(&self, dir: &Path) -> Result<()> {
+        self.validate()?;
+        let root = dir
+            .canonicalize()
+            .with_context(|| format!("canonicalize provider runtime root {}", dir.display()))?;
+        for (relative, expected) in &self.runtime.files {
+            let path = checked_runtime_file(&root, relative)?;
+            let actual = sha256_file(&path)?;
+            let expected = normalize_sha256(expected)?;
+            if actual != expected {
+                bail!(
+                    "provider runtime checksum mismatch for {relative}: expected {expected}, got {actual}"
+                );
+            }
+        }
+        verify_entrypoint_executable(&root.join(&self.runtime.entrypoint))
+    }
+}
+
+impl ProviderRuntimeReleaseManifest {
+    pub fn read_from_path(path: &Path) -> Result<Self> {
+        let text = fs::read_to_string(path).with_context(|| {
+            format!("read provider runtime release manifest {}", path.display())
+        })?;
+        Self::from_json_str(&text)
+    }
+
+    pub fn from_json_str(text: &str) -> Result<Self> {
+        let manifest: Self = serde_json::from_str(text)?;
+        manifest.validate()?;
+        Ok(manifest)
+    }
+
+    pub fn validate(&self) -> Result<()> {
+        validate_schema_version(self.schema_version)?;
+        let mut coordinates = BTreeSet::new();
+        for artifact in &self.artifacts {
+            artifact.validate()?;
+            let coordinate = (
+                &artifact.id,
+                &artifact.version,
+                &artifact.platform.os,
+                &artifact.platform.arch,
+            );
+            if !coordinates.insert(coordinate) {
+                bail!(
+                    "provider runtime release manifest repeats {} {} for {}/{}",
+                    artifact.id,
+                    artifact.version,
+                    artifact.platform.os,
+                    artifact.platform.arch
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+pub(crate) fn normalize_sha256(value: &str) -> Result<String> {
+    let trimmed = value.trim().strip_prefix("sha256:").unwrap_or(value.trim());
+    let digest = trimmed
+        .split_whitespace()
+        .next()
+        .unwrap_or_default()
+        .to_ascii_lowercase();
+    if digest.len() == 64 && digest.chars().all(|ch| ch.is_ascii_hexdigit()) {
+        Ok(digest)
+    } else {
+        bail!("invalid SHA-256 digest: {value}")
+    }
+}
+
+pub(crate) fn sha256_file(path: &Path) -> Result<String> {
+    let mut file = fs::File::open(path)
+        .with_context(|| format!("open provider runtime file {}", path.display()))?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    loop {
+        let count = file
+            .read(&mut buffer)
+            .with_context(|| format!("hash provider runtime file {}", path.display()))?;
+        if count == 0 {
+            break;
+        }
+        hasher.update(&buffer[..count]);
+    }
+    Ok(format!("{:x}", hasher.finalize()))
+}
+
+pub(crate) fn validate_runtime_path(relative: &str) -> Result<()> {
+    let path = Path::new(relative);
+    if relative.trim().is_empty()
+        || path.is_absolute()
+        || path
+            .components()
+            .any(|component| !matches!(component, Component::Normal(_)))
+    {
+        bail!("provider runtime path must be a safe relative path: {relative}");
+    }
+    Ok(())
+}
+
+pub(crate) fn parse_dotted_version(value: &str) -> Result<Vec<u64>> {
+    let components = value
+        .split('.')
+        .map(|part| {
+            part.parse::<u64>()
+                .with_context(|| format!("invalid version component {part}"))
+        })
+        .collect::<Result<Vec<_>>>()?;
+    if components.is_empty() {
+        bail!("version must not be empty");
+    }
+    Ok(components)
+}
+
+fn validate_schema_version(version: u32) -> Result<()> {
+    if version != PROVIDER_RUNTIME_SCHEMA_VERSION {
+        bail!(
+            "unsupported provider runtime schema version {version}; expected {PROVIDER_RUNTIME_SCHEMA_VERSION}"
+        );
+    }
+    Ok(())
+}
+
+fn validate_coordinate(label: &str, value: &str) -> Result<()> {
+    if value.is_empty()
+        || value.len() > 128
+        || !value
+            .chars()
+            .all(|ch| ch.is_ascii_alphanumeric() || matches!(ch, '.' | '_' | '-'))
+    {
+        bail!("{label} contains unsupported characters: {value}");
+    }
+    Ok(())
+}
+
+fn validate_protocol_version(value: &str) -> Result<()> {
+    let components = parse_dotted_version(value)?;
+    if components.len() != 2 {
+        bail!("provider runtime protocol version must use major.minor: {value}");
+    }
+    Ok(())
+}
+
+fn validate_model(model: &ProviderRuntimeModel) -> Result<()> {
+    if model.id.trim().is_empty()
+        || model.id.trim() != model.id
+        || model.id.len() > 256
+        || model.id.chars().any(char::is_control)
+    {
+        bail!("provider runtime model id is invalid: {}", model.id);
+    }
+    validate_coordinate("provider runtime model kind", &model.kind)
+}
+
+fn checked_runtime_file(root: &Path, relative: &str) -> Result<PathBuf> {
+    validate_runtime_path(relative)?;
+    let path = root.join(relative);
+    let metadata = fs::symlink_metadata(&path)
+        .with_context(|| format!("inspect provider runtime file {}", path.display()))?;
+    if metadata.file_type().is_symlink() {
+        bail!("provider runtime file must not be a symlink: {relative}");
+    }
+    if !metadata.is_file() {
+        bail!("provider runtime path is not a file: {relative}");
+    }
+    let canonical = path
+        .canonicalize()
+        .with_context(|| format!("canonicalize provider runtime file {}", path.display()))?;
+    if !canonical.starts_with(root) {
+        bail!("provider runtime path escapes its bundle: {relative}");
+    }
+    Ok(canonical)
+}
+
+#[cfg(unix)]
+fn verify_entrypoint_executable(path: &Path) -> Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mode = fs::metadata(path)?.permissions().mode();
+    if mode & 0o111 == 0 {
+        bail!(
+            "provider runtime entrypoint is not executable: {}",
+            path.display()
+        );
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn verify_entrypoint_executable(_path: &Path) -> Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn fixture_artifact(checksum: String) -> ProviderRuntimeArtifact {
+        ProviderRuntimeArtifact {
+            id: "meshllm-apple-runtime-darwin-arm64".to_string(),
+            version: "0.1.0".to_string(),
+            provider_kind: "apple".to_string(),
+            protocol_version: "0.1".to_string(),
+            platform: ProviderRuntimePlatform {
+                os: "macos".to_string(),
+                arch: "arm64".to_string(),
+                target: Some("aarch64-apple-darwin".to_string()),
+                minimum_os_version: Some("27.0".to_string()),
+            },
+            entrypoint: "bin/mesh-apple-runtime".to_string(),
+            models: vec![ProviderRuntimeModel {
+                id: "apple/system".to_string(),
+                kind: "system".to_string(),
+            }],
+            features: BTreeSet::from(["streaming".to_string()]),
+            files: BTreeMap::from([("bin/mesh-apple-runtime".to_string(), checksum)]),
+            build: BTreeMap::new(),
+            signature: None,
+            url: None,
+            archive_sha256: None,
+        }
+    }
+
+    fn fixture_bundle() -> (tempfile::TempDir, ProviderRuntimeManifest) {
+        let temp = tempfile::tempdir().unwrap();
+        let binary = temp.path().join("bin/mesh-apple-runtime");
+        fs::create_dir_all(binary.parent().unwrap()).unwrap();
+        fs::write(&binary, b"provider runtime").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            fs::set_permissions(&binary, fs::Permissions::from_mode(0o755)).unwrap();
+        }
+        let manifest = ProviderRuntimeManifest {
+            schema_version: PROVIDER_RUNTIME_SCHEMA_VERSION,
+            runtime: fixture_artifact(sha256_file(&binary).unwrap()),
+        };
+        manifest.write_to_dir(temp.path()).unwrap();
+        (temp, manifest)
+    }
+
+    #[test]
+    fn verifies_a_complete_bundle() {
+        let (temp, expected) = fixture_bundle();
+        let actual = ProviderRuntimeManifest::read_from_dir(temp.path()).unwrap();
+        assert_eq!(actual, expected);
+    }
+
+    #[test]
+    fn rejects_unsafe_entrypoint_paths() {
+        let mut artifact = fixture_artifact("a".repeat(64));
+        artifact.entrypoint = "../mesh-apple-runtime".to_string();
+        let error = artifact.validate().unwrap_err();
+        assert!(
+            error.to_string().contains("safe relative path"),
+            "{error:?}"
+        );
+    }
+
+    #[test]
+    fn rejects_tampered_files() {
+        let (temp, _) = fixture_bundle();
+        fs::write(temp.path().join("bin/mesh-apple-runtime"), b"tampered").unwrap();
+        let error = ProviderRuntimeManifest::read_from_dir(temp.path()).unwrap_err();
+        assert!(error.to_string().contains("checksum mismatch"), "{error:?}");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn rejects_symlinked_payloads() {
+        use std::os::unix::fs::symlink;
+        let (temp, manifest) = fixture_bundle();
+        let external = temp.path().join("external");
+        fs::write(&external, b"provider runtime").unwrap();
+        let binary = temp.path().join("bin/mesh-apple-runtime");
+        fs::remove_file(&binary).unwrap();
+        symlink(&external, &binary).unwrap();
+        manifest.write_to_dir(temp.path()).unwrap();
+        let error = ProviderRuntimeManifest::read_from_dir(temp.path()).unwrap_err();
+        assert!(
+            error.to_string().contains("must not be a symlink"),
+            "{error:?}"
+        );
+    }
+}

--- a/crates/mesh-llm-provider-runtime/src/resolver.rs
+++ b/crates/mesh-llm-provider-runtime/src/resolver.rs
@@ -1,0 +1,341 @@
+use crate::{
+    InstalledProviderRuntime, ProviderRuntimeArtifact, ProviderRuntimeCache,
+    ProviderRuntimeManifest, ProviderRuntimeReleaseManifest,
+};
+use anyhow::{Result, bail};
+use semver::Version;
+use serde::{Deserialize, Serialize};
+#[cfg(target_os = "macos")]
+use std::process::Command;
+use std::{cmp::Ordering, path::PathBuf};
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRuntimeHost {
+    pub os: String,
+    pub arch: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub os_version: Option<String>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRuntimeRequest {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub artifact_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub provider_kind: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub model_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol_version: Option<String>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum ProviderRuntimeSource {
+    Bundle { path: PathBuf },
+    Installed { path: PathBuf },
+    Download { url: String, sha256: String },
+    Missing,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct ProviderRuntimeResolution {
+    pub selected: ProviderRuntimeArtifact,
+    pub source: ProviderRuntimeSource,
+}
+
+#[derive(Clone, Debug)]
+pub struct ProviderRuntimeResolver {
+    host: ProviderRuntimeHost,
+    release_manifest: ProviderRuntimeReleaseManifest,
+    cache: ProviderRuntimeCache,
+    bundle_dirs: Vec<PathBuf>,
+}
+
+#[derive(Clone)]
+struct Candidate {
+    artifact: ProviderRuntimeArtifact,
+    source: ProviderRuntimeSource,
+}
+
+impl ProviderRuntimeHost {
+    pub fn current() -> Self {
+        Self {
+            os: canonical_os(std::env::consts::OS).to_string(),
+            arch: canonical_arch(std::env::consts::ARCH).to_string(),
+            os_version: current_os_version(),
+        }
+    }
+}
+
+impl ProviderRuntimeResolver {
+    pub fn new(
+        host: ProviderRuntimeHost,
+        release_manifest: ProviderRuntimeReleaseManifest,
+        cache: ProviderRuntimeCache,
+    ) -> Self {
+        Self {
+            host,
+            release_manifest,
+            cache,
+            bundle_dirs: Vec::new(),
+        }
+    }
+
+    pub fn with_bundle_dirs(mut self, bundle_dirs: Vec<PathBuf>) -> Self {
+        self.bundle_dirs = bundle_dirs;
+        self
+    }
+
+    pub fn resolve(&self, request: &ProviderRuntimeRequest) -> Result<ProviderRuntimeResolution> {
+        if request.artifact_id.is_none()
+            && request.provider_kind.is_none()
+            && request.model_id.is_none()
+        {
+            bail!("provider runtime resolution requires an artifact, provider, or model selector");
+        }
+        let mut candidates = self.collect_candidates()?;
+        candidates.retain(|candidate| self.matches(&candidate.artifact, request));
+        candidates.sort_by(compare_candidates);
+        let Some(selected) = candidates.into_iter().next() else {
+            bail!(
+                "no compatible executable provider runtime found for {}/{}",
+                self.host.os,
+                self.host.arch
+            );
+        };
+        Ok(ProviderRuntimeResolution {
+            selected: selected.artifact,
+            source: selected.source,
+        })
+    }
+
+    fn collect_candidates(&self) -> Result<Vec<Candidate>> {
+        let mut candidates = Vec::new();
+        for path in &self.bundle_dirs {
+            let manifest = ProviderRuntimeManifest::read_from_dir(path)?;
+            candidates.push(Candidate {
+                artifact: manifest.runtime,
+                source: ProviderRuntimeSource::Bundle { path: path.clone() },
+            });
+        }
+        for installed in self.cache.list()? {
+            candidates.push(installed_candidate(installed));
+        }
+        for artifact in &self.release_manifest.artifacts {
+            let source = match (&artifact.url, &artifact.archive_sha256) {
+                (Some(url), Some(sha256)) => ProviderRuntimeSource::Download {
+                    url: url.clone(),
+                    sha256: sha256.clone(),
+                },
+                _ => ProviderRuntimeSource::Missing,
+            };
+            candidates.push(Candidate {
+                artifact: artifact.clone(),
+                source,
+            });
+        }
+        Ok(candidates)
+    }
+
+    fn matches(
+        &self,
+        artifact: &ProviderRuntimeArtifact,
+        request: &ProviderRuntimeRequest,
+    ) -> bool {
+        canonical_os(&artifact.platform.os) == canonical_os(&self.host.os)
+            && canonical_arch(&artifact.platform.arch) == canonical_arch(&self.host.arch)
+            && minimum_os_matches(artifact, &self.host)
+            && request
+                .artifact_id
+                .as_ref()
+                .is_none_or(|expected| expected == &artifact.id)
+            && request
+                .provider_kind
+                .as_ref()
+                .is_none_or(|expected| expected == &artifact.provider_kind)
+            && request
+                .protocol_version
+                .as_ref()
+                .is_none_or(|expected| expected == &artifact.protocol_version)
+            && request
+                .model_id
+                .as_ref()
+                .is_none_or(|expected| artifact.models.iter().any(|model| &model.id == expected))
+    }
+}
+
+fn installed_candidate(installed: InstalledProviderRuntime) -> Candidate {
+    Candidate {
+        artifact: installed.manifest.runtime,
+        source: ProviderRuntimeSource::Installed {
+            path: installed.path,
+        },
+    }
+}
+
+fn compare_candidates(left: &Candidate, right: &Candidate) -> Ordering {
+    let left_version = Version::parse(&left.artifact.version).expect("validated runtime version");
+    let right_version = Version::parse(&right.artifact.version).expect("validated runtime version");
+    right_version
+        .cmp(&left_version)
+        .then_with(|| source_rank(&left.source).cmp(&source_rank(&right.source)))
+        .then_with(|| left.artifact.id.cmp(&right.artifact.id))
+}
+
+fn source_rank(source: &ProviderRuntimeSource) -> u8 {
+    match source {
+        ProviderRuntimeSource::Bundle { .. } => 0,
+        ProviderRuntimeSource::Installed { .. } => 1,
+        ProviderRuntimeSource::Download { .. } => 2,
+        ProviderRuntimeSource::Missing => 3,
+    }
+}
+
+fn minimum_os_matches(artifact: &ProviderRuntimeArtifact, host: &ProviderRuntimeHost) -> bool {
+    let Some(minimum) = &artifact.platform.minimum_os_version else {
+        return true;
+    };
+    let Some(host_version) = &host.os_version else {
+        return false;
+    };
+    dotted_version_at_least(host_version, minimum)
+}
+
+fn dotted_version_at_least(actual: &str, minimum: &str) -> bool {
+    let Ok(mut actual) = crate::manifest::parse_dotted_version(actual) else {
+        return false;
+    };
+    let Ok(mut minimum) = crate::manifest::parse_dotted_version(minimum) else {
+        return false;
+    };
+    let width = actual.len().max(minimum.len());
+    actual.resize(width, 0);
+    minimum.resize(width, 0);
+    actual >= minimum
+}
+
+fn canonical_os(value: &str) -> &str {
+    match value {
+        "darwin" => "macos",
+        other => other,
+    }
+}
+
+fn canonical_arch(value: &str) -> &str {
+    match value {
+        "aarch64" => "arm64",
+        "amd64" => "x86_64",
+        other => other,
+    }
+}
+
+#[cfg(target_os = "macos")]
+fn current_os_version() -> Option<String> {
+    let output = Command::new("sw_vers")
+        .arg("-productVersion")
+        .output()
+        .ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+#[cfg(not(target_os = "macos"))]
+fn current_os_version() -> Option<String> {
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{PROVIDER_RUNTIME_SCHEMA_VERSION, ProviderRuntimeModel, ProviderRuntimePlatform};
+    use std::collections::{BTreeMap, BTreeSet};
+
+    fn artifact(version: &str, url: Option<&str>) -> ProviderRuntimeArtifact {
+        ProviderRuntimeArtifact {
+            id: "apple-runtime".to_string(),
+            version: version.to_string(),
+            provider_kind: "apple".to_string(),
+            protocol_version: "0.1".to_string(),
+            platform: ProviderRuntimePlatform {
+                os: "macos".to_string(),
+                arch: "aarch64".to_string(),
+                target: None,
+                minimum_os_version: Some("27.0".to_string()),
+            },
+            entrypoint: "bin/provider".to_string(),
+            models: vec![ProviderRuntimeModel {
+                id: "apple/system".to_string(),
+                kind: "system".to_string(),
+            }],
+            features: BTreeSet::new(),
+            files: BTreeMap::from([("bin/provider".to_string(), "a".repeat(64))]),
+            build: BTreeMap::new(),
+            signature: None,
+            url: url.map(str::to_string),
+            archive_sha256: url.map(|_| "b".repeat(64)),
+        }
+    }
+
+    #[test]
+    fn selects_the_newest_compatible_download() {
+        let temp = tempfile::tempdir().unwrap();
+        let resolver = ProviderRuntimeResolver::new(
+            ProviderRuntimeHost {
+                os: "macos".to_string(),
+                arch: "aarch64".to_string(),
+                os_version: Some("27.1".to_string()),
+            },
+            ProviderRuntimeReleaseManifest {
+                schema_version: PROVIDER_RUNTIME_SCHEMA_VERSION,
+                artifacts: vec![
+                    artifact("0.1.0", Some("https://example.invalid/old.zip")),
+                    artifact("0.2.0", Some("https://example.invalid/new.zip")),
+                ],
+            },
+            ProviderRuntimeCache::new(temp.path().join("cache")),
+        );
+
+        let resolution = resolver
+            .resolve(&ProviderRuntimeRequest {
+                provider_kind: Some("apple".to_string()),
+                model_id: Some("apple/system".to_string()),
+                ..Default::default()
+            })
+            .unwrap();
+
+        assert_eq!(resolution.selected.version, "0.2.0");
+        assert!(matches!(
+            resolution.source,
+            ProviderRuntimeSource::Download { .. }
+        ));
+    }
+
+    #[test]
+    fn rejects_a_runtime_above_the_host_os_version() {
+        let temp = tempfile::tempdir().unwrap();
+        let resolver = ProviderRuntimeResolver::new(
+            ProviderRuntimeHost {
+                os: "macos".to_string(),
+                arch: "aarch64".to_string(),
+                os_version: Some("26.6".to_string()),
+            },
+            ProviderRuntimeReleaseManifest {
+                schema_version: PROVIDER_RUNTIME_SCHEMA_VERSION,
+                artifacts: vec![artifact("0.1.0", None)],
+            },
+            ProviderRuntimeCache::new(temp.path().join("cache")),
+        );
+
+        assert!(
+            resolver
+                .resolve(&ProviderRuntimeRequest {
+                    provider_kind: Some("apple".to_string()),
+                    ..Default::default()
+                })
+                .is_err()
+        );
+    }
+}

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -50,6 +50,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates/mesh-llm-ui/ crates/mesh-llm-ui/
 COPY crates/mesh-llm-identity/ crates/mesh-llm-identity/
 COPY crates/mesh-llm-native-runtime/ crates/mesh-llm-native-runtime/
+COPY crates/mesh-llm-provider-runtime/ crates/mesh-llm-provider-runtime/
 COPY crates/mesh-llm-protocol/ crates/mesh-llm-protocol/
 COPY crates/mesh-llm-release-footer/ crates/mesh-llm-release-footer/
 COPY crates/mesh-llm-routing/ crates/mesh-llm-routing/
@@ -128,6 +129,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates/mesh-llm-ui/ crates/mesh-llm-ui/
 COPY crates/mesh-llm-identity/ crates/mesh-llm-identity/
 COPY crates/mesh-llm-native-runtime/ crates/mesh-llm-native-runtime/
+COPY crates/mesh-llm-provider-runtime/ crates/mesh-llm-provider-runtime/
 COPY crates/mesh-llm-protocol/ crates/mesh-llm-protocol/
 COPY crates/mesh-llm-release-footer/ crates/mesh-llm-release-footer/
 COPY crates/mesh-llm-routing/ crates/mesh-llm-routing/

--- a/docs/README.md
+++ b/docs/README.md
@@ -46,6 +46,7 @@ Use [SKIPPY_SPLITS.md](SKIPPY_SPLITS.md) for Skippy split-serving workflows.
 | [SWARM_CAPTURE.md](SWARM_CAPTURE.md) | Opt-in local debug capture for mesh membership and connection diagnostics |
 | [design/](design/) | Architecture notes, protocol design, testing playbooks, carried llama.cpp patch documentation |
 | [design/NATIVE_RUNTIMES.md](design/NATIVE_RUNTIMES.md) | Native runtime artifact packaging, exact version matching, resolver behavior, and SDK/autoupdater ownership |
+| [design/PROVIDER_RUNTIMES.md](design/PROVIDER_RUNTIMES.md) | Signed executable-provider manifests, resolution, download verification, and immutable cache installation |
 | [design/APPLE_RUNTIME.md](design/APPLE_RUNTIME.md) | Experimental Apple sidecar architecture, Milestone 0 evidence, packaging boundary, and rollout gates |
 | [design/NODE_OWNER_IDENTITY.md](design/NODE_OWNER_IDENTITY.md) | Owner identity, trust policy, and how owner trust stays separate from release attestation |
 | [design/EMITTER_HOOKS.md](design/EMITTER_HOOKS.md) | Inventory of hook, callback, and emitter surfaces plus readiness ownership. |

--- a/docs/design/APPLE_RUNTIME.md
+++ b/docs/design/APPLE_RUNTIME.md
@@ -118,7 +118,7 @@ The package output is a carrier-neutral directory:
 
 ```text
 meshllm-apple-runtime-darwin-arm64/
-├── manifest.json
+├── provider-runtime.json
 ├── README.md
 ├── Resources/background-inference.entitlements
 └── bin/mesh-apple-runtime
@@ -283,7 +283,9 @@ supervisor and conformance mapping into MeshLLM's public OpenAI frontend.
 
 ### 2. All host-capable macOS SDKs
 
-Publish one signed macOS arm64 runtime artifact; teach CLI/Swift/npm/JVM
+The shared executable-provider manifest, resolver, verified downloader, and
+immutable cache contract now live in `mesh-llm-provider-runtime`. Next, publish
+one signed macOS arm64 runtime artifact and teach CLI/Swift/npm/JVM
 resolvers to install, locate, launch, monitor, upgrade, and terminate it; add
 checksum policy; validate Swift app embedding, sandboxing, notarization,
 quarantine, and launchd/service lifecycles; then certify all SDKs against one

--- a/docs/design/PROVIDER_RUNTIMES.md
+++ b/docs/design/PROVIDER_RUNTIMES.md
@@ -1,0 +1,128 @@
+# Executable provider runtimes
+
+MeshLLM provider runtimes are signed executable processes that expose models
+through a versioned host protocol. They are different from native runtimes:
+
+- a native runtime supplies backend libraries selected against the Skippy ABI;
+- a provider runtime supplies an executable, its own protocol version, and one
+  or more whole-model provider identities.
+
+Apple's `mesh-apple-runtime` is the first provider runtime. The contract is
+provider-neutral so future process-hosted integrations can reuse installation
+and lifecycle infrastructure without inheriting Apple or Foundation Models
+semantics.
+
+## Bundle contract
+
+Every bundle contains `provider-runtime.json` at its root. Schema version 1
+binds these fields:
+
+- immutable artifact ID and semantic version;
+- provider kind and host protocol version;
+- OS, architecture, optional target triple, and minimum OS version;
+- relative executable entrypoint;
+- logical model IDs and provider-specific model kinds;
+- feature declarations;
+- SHA-256 for every installed payload file;
+- optional build and code-signing metadata.
+
+Example:
+
+```json
+{
+  "schema_version": 1,
+  "runtime": {
+    "id": "meshllm-apple-runtime-darwin-arm64",
+    "version": "0.1.0",
+    "provider_kind": "apple",
+    "protocol_version": "0.1",
+    "platform": {
+      "os": "macos",
+      "arch": "arm64",
+      "target": "aarch64-apple-darwin",
+      "minimum_os_version": "27.0"
+    },
+    "entrypoint": "bin/mesh-apple-runtime",
+    "models": [{"id": "apple/system", "kind": "system"}],
+    "features": ["availability", "streaming", "cancellation"],
+    "files": {
+      "bin/mesh-apple-runtime": "sha256:..."
+    }
+  }
+}
+```
+
+Artifact IDs, versions, provider kinds, protocol versions, and platform names
+are data used for selection, not live capability claims. Availability and
+observed model capabilities must still come from the running provider.
+
+## Release index and resolution
+
+`provider-runtimes.json` is the carrier-neutral release index. It contains the
+same artifact record plus an archive URL and mandatory archive SHA-256 when a
+download is offered.
+
+Resolution filters candidates by:
+
+1. host OS, architecture, and minimum OS;
+2. requested artifact, provider, protocol, and model identity;
+3. newest semantic version;
+4. source preference: explicit bundle, installed cache, verified download,
+   then an unavailable metadata-only entry.
+
+An SDK may carry the bundle in its own resource layout, but it must hand that
+directory to the shared resolver. It must not reinterpret or recreate the
+manifest in language-specific code.
+
+## Installation and cache
+
+The shared cache layout is:
+
+```text
+<cache>/<artifact-id>/<version>/<os>-<arch>/
+```
+
+Installation is staged and then renamed into place. Coordinates are immutable:
+installing different metadata or bytes over an existing coordinate fails. An
+upgrade installs a new semantic version beside the old version; the resolver
+selects the newest compatible version. Pruning old versions is deliberately
+outside the version-1 contract so an SDK cannot destroy a runtime that another
+host process is still using.
+
+Bundled runtimes can be used in place or copied into the shared cache. Remote
+archives are downloaded with a bounded size, checked against the release-index
+digest, safely extracted, compared with the selected payload contract, and
+then installed through the same cache path.
+
+## Security invariants
+
+The implementation fails closed on:
+
+- absolute paths, `..`, or other unsafe manifest paths;
+- payload symlinks or ZIP symlink entries;
+- missing, malformed, or mismatched SHA-256 values;
+- entrypoints absent from the checked file set;
+- non-executable Unix entrypoints;
+- duplicate artifact coordinates or model IDs;
+- unsupported schema versions;
+- downloads without an archive digest;
+- ZIP entry-count, compressed-size, or expanded-size limits;
+- archives containing zero or multiple provider manifests;
+- a downloaded bundle that differs from its release-index artifact;
+- attempts to overwrite an installed coordinate with different metadata.
+
+File checksums prove artifact integrity. Platform signature, notarization,
+quarantine, and entitlement verification remain additional policy gates owned
+by the host supervisor and release packaging. Manifest signature metadata is
+descriptive and is never treated as proof by itself.
+
+## Ownership and next layer
+
+`mesh-llm-provider-runtime` owns this data and installation contract. It does
+not launch processes, bind ports, route inference, or expose language-specific
+APIs.
+
+The next stacked layer will add a Rust host supervisor that resolves one of
+these artifacts, validates platform signing policy, launches its entrypoint,
+tracks health and availability, forwards OpenAI requests, drains it, and
+terminates it with the owning MeshLLM instance.

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -100,6 +100,7 @@ COPY crates/mesh-llm-events/ crates/mesh-llm-events/
 COPY crates/mesh-llm-build-info/ crates/mesh-llm-build-info/
 COPY crates/mesh-llm-hardware-profile/ crates/mesh-llm-hardware-profile/
 COPY crates/mesh-llm-native-runtime/ crates/mesh-llm-native-runtime/
+COPY crates/mesh-llm-provider-runtime/ crates/mesh-llm-provider-runtime/
 COPY crates/mesh-llm-runtime-install/ crates/mesh-llm-runtime-install/
 COPY crates/mesh-llm-sdk/ crates/mesh-llm-sdk/
 COPY crates/mesh-llm-tui/ crates/mesh-llm-tui/

--- a/providers/apple/Justfile
+++ b/providers/apple/Justfile
@@ -20,6 +20,11 @@ live: build
 package:
     @"{{ apple_root }}/Packaging/package.sh"
 
+# Validate the packaged executable-provider manifest with the shared Rust contract.
+contract: package
+    @just with-lld cargo run --quiet -p mesh-llm-provider-runtime --example inspect -- \
+      "{{ apple_root }}/../../target/apple-runtime/package/meshllm-apple-runtime-darwin-arm64"
+
 # Exercise models, completion, streaming, tools, and disconnect cancellation over REST.
 rest: package
     @"{{ apple_root }}/QA/rest.sh"

--- a/providers/apple/Packaging/package.sh
+++ b/providers/apple/Packaging/package.sh
@@ -10,6 +10,8 @@ BUNDLE_DIR="$OUTPUT_ROOT/$BUNDLE_ID"
 IDENTITY="${MESH_APPLE_RUNTIME_CODESIGN_IDENTITY:--}"
 ENTITLEMENTS="${MESH_APPLE_RUNTIME_ENTITLEMENTS:-}"
 ENTITLEMENT_PROVISIONING_VALIDATED="${MESH_APPLE_RUNTIME_ENTITLEMENT_PROVISIONING_VALIDATED:-0}"
+RUNTIME_VERSION="${MESH_APPLE_RUNTIME_VERSION:-0.1.0}"
+ARCHIVE_URL="${MESH_APPLE_RUNTIME_ARCHIVE_URL:-}"
 
 if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
     echo "Apple runtime packaging requires Apple silicon macOS" >&2
@@ -54,53 +56,78 @@ codesign "${codesign_args[@]}" "$BUNDLE_DIR/bin/mesh-apple-runtime"
 codesign --verify --strict --verbose=2 "$BUNDLE_DIR/bin/mesh-apple-runtime"
 
 BINARY_SHA="$(shasum -a 256 "$BUNDLE_DIR/bin/mesh-apple-runtime" | awk '{print $1}')"
+README_SHA="$(shasum -a 256 "$BUNDLE_DIR/README.md" | awk '{print $1}')"
+ENTITLEMENT_SHA="$(shasum -a 256 "$BUNDLE_DIR/Resources/background-inference.entitlements" | awk '{print $1}')"
 OS_VERSION="$(sw_vers -productVersion)"
 OS_BUILD="$(sw_vers -buildVersion)"
 XCODE_VERSION="$(xcodebuild -version | awk 'NR == 1 { print $2 }')"
 SDK_VERSION="$(xcrun --sdk macosx --show-sdk-version)"
-SIGNING_IDENTITY="$(codesign -dv --verbose=2 "$BUNDLE_DIR/bin/mesh-apple-runtime" 2>&1 | awk -F= '/^Authority=/ && !found {print $2; found=1}')"
+CODESIGN_DETAILS="$(codesign -dv --verbose=4 "$BUNDLE_DIR/bin/mesh-apple-runtime" 2>&1)"
+SIGNING_IDENTITY="$(printf '%s\n' "$CODESIGN_DETAILS" | awk -F= '/^Authority=/ && !found {print $2; found=1}')"
 if [[ -z "$SIGNING_IDENTITY" ]]; then
     SIGNING_IDENTITY="ad-hoc"
 fi
+TEAM_IDENTIFIER="$(printf '%s\n' "$CODESIGN_DETAILS" | awk -F= '/^TeamIdentifier=/ {print $2; exit}')"
+SIGNING_IDENTIFIER="$(printf '%s\n' "$CODESIGN_DETAILS" | awk -F= '/^Identifier=/ {print $2; exit}')"
+if [[ "$TEAM_IDENTIFIER" == "not set" ]]; then
+    TEAM_IDENTIFIER=""
+fi
+ENTITLEMENT_KEYS_JSON="[]"
+if [[ -n "$ENTITLEMENTS" ]]; then
+    ENTITLEMENT_KEYS_JSON="$(plutil -convert json -o - "$ENTITLEMENTS" | python3 -c \
+        'import json, sys; print(json.dumps(sorted(json.load(sys.stdin).keys())))')"
+fi
 
 python3 - \
-    "$BUNDLE_DIR/manifest.json" \
+    "$BUNDLE_DIR/provider-runtime.json" \
     "$BUNDLE_ID" \
+    "$RUNTIME_VERSION" \
     "$BINARY_SHA" \
+    "$README_SHA" \
+    "$ENTITLEMENT_SHA" \
     "$OS_VERSION" \
     "$OS_BUILD" \
     "$XCODE_VERSION" \
     "$SDK_VERSION" \
     "$SIGNING_IDENTITY" \
-    "$ENTITLEMENTS" <<'PY'
+    "$TEAM_IDENTIFIER" \
+    "$SIGNING_IDENTIFIER" \
+    "$ENTITLEMENT_KEYS_JSON" <<'PY'
 import json
 import sys
 
 (
     output,
     bundle_id,
+    runtime_version,
     binary_sha,
+    readme_sha,
+    entitlement_sha,
     os_version,
     os_build,
     xcode_version,
     sdk_version,
     signing_identity,
-    entitlements,
+    team_identifier,
+    signing_identifier,
+    entitlement_keys_json,
 ) = sys.argv[1:]
 
 manifest = {
+    "schema_version": 1,
     "runtime": {
         "id": bundle_id,
-        "kind": "apple",
-        "runtime_protocol": "0.1",
+        "version": runtime_version,
+        "provider_kind": "apple",
+        "protocol_version": "0.1",
         "platform": {
             "os": "macos",
             "arch": "arm64",
-            "minimum_os": "27.0",
+            "target": "aarch64-apple-darwin",
+            "minimum_os_version": "27.0",
         },
-        "hosting_modes": ["process"],
         "entrypoint": "bin/mesh-apple-runtime",
-        "model_ids": ["apple/system"],
+        "models": [{"id": "apple/system", "kind": "system"}],
         "features": [
             "availability",
             "streaming",
@@ -112,6 +139,8 @@ manifest = {
         ],
         "files": {
             "bin/mesh-apple-runtime": f"sha256:{binary_sha}",
+            "README.md": f"sha256:{readme_sha}",
+            "Resources/background-inference.entitlements": f"sha256:{entitlement_sha}",
         },
         "build": {
             "macos": os_version,
@@ -119,9 +148,12 @@ manifest = {
             "xcode": xcode_version,
             "sdk": sdk_version,
         },
-        "signing": {
+        "signature": {
             "identity": signing_identity,
-            "entitlements_source": entitlements or None,
+            "team_identifier": team_identifier or None,
+            "signing_identifier": signing_identifier or None,
+            "entitlements": json.loads(entitlement_keys_json),
+            "notarized": False,
         },
     }
 }
@@ -131,11 +163,49 @@ with open(output, "w", encoding="utf-8") as handle:
     handle.write("\n")
 PY
 
+just --justfile "$REPO_ROOT/Justfile" with-lld \
+    cargo run --quiet -p mesh-llm-provider-runtime --example inspect -- "$BUNDLE_DIR"
+
 ARCHIVE="$OUTPUT_ROOT/$BUNDLE_ID.zip"
 ditto -c -k --keepParent "$BUNDLE_DIR" "$ARCHIVE"
-(cd "$OUTPUT_ROOT" && shasum -a 256 "$BUNDLE_ID.zip" > "$BUNDLE_ID.zip.sha256")
+ARCHIVE_SHA="$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')"
+printf '%s  %s\n' "$ARCHIVE_SHA" "$(basename "$ARCHIVE")" > "$ARCHIVE.sha256"
+
+python3 - \
+    "$BUNDLE_DIR/provider-runtime.json" \
+    "$OUTPUT_ROOT/provider-runtimes.json" \
+    "$ARCHIVE_SHA" \
+    "$ARCHIVE_URL" <<'PY'
+import json
+import sys
+
+bundle_manifest_path, release_manifest_path, archive_sha, archive_url = sys.argv[1:]
+with open(bundle_manifest_path, encoding="utf-8") as handle:
+    artifact = json.load(handle)["runtime"]
+artifact["archive_sha256"] = f"sha256:{archive_sha}"
+if archive_url:
+    artifact["url"] = archive_url
+
+release_manifest = {"schema_version": 1, "artifacts": [artifact]}
+with open(release_manifest_path, "w", encoding="utf-8") as handle:
+    json.dump(release_manifest, handle, indent=2, sort_keys=True)
+    handle.write("\n")
+PY
+
+RELEASE_MANIFEST="$OUTPUT_ROOT/provider-runtimes.json"
+RELEASE_MANIFEST_SHA="$(shasum -a 256 "$RELEASE_MANIFEST" | awk '{print $1}')"
+printf '%s  %s\n' "$RELEASE_MANIFEST_SHA" "$(basename "$RELEASE_MANIFEST")" \
+    > "$RELEASE_MANIFEST.sha256"
+
+just --justfile "$REPO_ROOT/Justfile" with-lld \
+    cargo run --quiet -p mesh-llm-provider-runtime --example inspect_release -- \
+    "$RELEASE_MANIFEST"
+just --justfile "$REPO_ROOT/Justfile" with-lld \
+    cargo run --quiet -p mesh-llm-provider-runtime --example inspect_archive -- \
+    "$RELEASE_MANIFEST" "$ARCHIVE"
 
 echo "packaged experimental Apple runtime:"
 echo "  bundle: $BUNDLE_DIR"
 echo "  archive: $ARCHIVE"
+echo "  release manifest: $RELEASE_MANIFEST"
 echo "  signing: $SIGNING_IDENTITY"

--- a/providers/apple/QA/carriers.sh
+++ b/providers/apple/QA/carriers.sh
@@ -12,7 +12,7 @@ cleanup() {
 }
 trap cleanup EXIT
 
-[[ -f "$PACKAGE_ROOT/manifest.json" ]] || {
+[[ -f "$PACKAGE_ROOT/provider-runtime.json" ]] || {
     echo "missing Apple runtime package; run just apple::package" >&2
     exit 2
 }
@@ -38,7 +38,7 @@ for layout in "${layouts[@]}"; do
     "$binary" status > "$OUTPUT_DIR/$name.json"
 done
 
-python3 - "$PACKAGE_ROOT/manifest.json" "$OUTPUT_DIR" <<'PY'
+python3 - "$PACKAGE_ROOT/provider-runtime.json" "$OUTPUT_DIR" <<'PY'
 import hashlib
 import json
 import pathlib

--- a/providers/apple/README.md
+++ b/providers/apple/README.md
@@ -238,6 +238,7 @@ tool, client-disconnect cancellation, and slot reuse after cancellation.
 
 ```bash
 just apple::live
+just apple::contract
 just apple::carriers
 just apple::launchd
 just apple::instruments
@@ -247,6 +248,9 @@ just apple::orphan
 `just apple::instruments` writes unencrypted prompts and responses into ignored
 files under `target/apple-runtime/instruments/`. Only its aggregate
 `summary.json` is suitable for sharing.
+
+`just apple::contract` verifies `provider-runtime.json`, every declared file
+digest, and the executable bit through the shared Rust provider-runtime crate.
 
 ## Packaging and signing
 
@@ -272,7 +276,7 @@ caveats, and rollout gates.
 |---|---|---|
 | 0 | Policy, entitlement, packaging, signing, launchd, and accelerator spike | complete |
 | 1 | Local `apple/system` REST vertical slice | experimental implementation complete |
-| 2 | All host-capable macOS SDKs drive the same runtime lifecycle | not implemented |
+| 2 | All host-capable macOS SDKs drive the same runtime lifecycle | provider artifact contract implemented; supervisor and SDK lifecycle pending |
 | 3 | Private-mesh routing, load, failover, affinity, and withdrawal | not implemented |
 
 This runtime does not alter the Skippy ABI or use Skippy stage execution.

--- a/scripts/affected-crates.sh
+++ b/scripts/affected-crates.sh
@@ -20,6 +20,7 @@ WORKSPACE_MEMBERS=(
   "mesh-llm-identity"
   "mesh-llm-log-store"
   "mesh-llm-native-runtime"
+  "mesh-llm-provider-runtime"
   "mesh-llm-protocol"
   "mesh-llm-release-footer"
   "mesh-llm-routing"

--- a/scripts/plan-clippy-batches.sh
+++ b/scripts/plan-clippy-batches.sh
@@ -23,6 +23,7 @@ WORKSPACE_MEMBERS=(
   "mesh-llm-identity"
   "mesh-llm-log-store"
   "mesh-llm-native-runtime"
+  "mesh-llm-provider-runtime"
   "mesh-llm-protocol"
   "mesh-llm-release-footer"
   "mesh-llm-routing"
@@ -166,6 +167,7 @@ weights = {
     "mesh-llm-system": 3,
     "mesh-llm-runtime-install": 2,
     "mesh-llm-native-runtime": 2,
+    "mesh-llm-provider-runtime": 1,
     "mesh-llm-hardware-profile": 1,
     "mesh-llm-routing": 2,
     "mesh-llm-sdk": 2,

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -393,6 +393,7 @@ publish_crates=(
     mesh-llm-node
     mesh-llm-api-server
     mesh-llm-native-runtime
+    mesh-llm-provider-runtime
     mesh-llm-hardware-profile
     skippy-runtime
     skippy-scheduler


### PR DESCRIPTION
## Experimental stacked change

This is the **2A provider artifact** layer of the experimental Apple runtime roadmap in #1246.

- Stacked on #1249; review and merge that PR first.
- Base branch: `jd/experimental-apple-runtime`
- This is experimental and is not connected to production model gossip, mesh routing, or the public OpenAI frontend.
- Trying the Apple runtime requires Apple silicon, **macOS Golden Gate (macOS 27)**, full Xcode 27 selected with `xcode-select`, Apple Intelligence enabled, and the system model downloaded.

## Why this layer exists

MeshLLM already has native runtime artifacts for backend libraries selected against the Skippy ABI. An Apple system-model integration is a different shape: it is a signed executable provider with its own process boundary, protocol version, model identities, platform requirements, entitlements, and lifecycle.

This PR gives executable providers a provider-neutral package, resolution, verification, download, and immutable-cache contract before the host supervisor and SDK bindings are added. Apple is the first consumer, but the contract does not embed Foundation Models semantics.

## What changes

- Adds the publishable `mesh-llm-provider-runtime` crate.
- Defines schema-v1 `provider-runtime.json` bundle manifests and `provider-runtimes.json` release indexes.
- Selects artifacts by OS/architecture/minimum OS, artifact/provider/protocol/model selector, semantic version, and source priority.
- Supports in-place bundles, immutable cache installs, and verified HTTP ZIP downloads.
- Enforces safe relative paths, payload and ZIP symlink rejection, SHA-256 verification, executable entrypoints, bounded archives, unique coordinates/model IDs, and exact release-index/payload agreement.
- Keeps cache coordinates immutable at `<cache>/<artifact-id>/<version>/<os>-<arch>/`.
- Updates Apple packaging to emit and validate the shared contract, ZIP/checksum sidecars, a release index, and descriptive signing metadata.
- Proves that the same artifact survives CLI, Swift bundle, Node package, and JVM resource carrier layouts.
- Routes the new crate through affected-crate, Clippy, SDK-smoke, publication, Docker/Fly, and CI consistency inventories.
- Documents the contract in `docs/design/PROVIDER_RUNTIMES.md`.

This layer deliberately does **not** launch or supervise the provider, bind it into SDK lifecycle APIs, or advertise it across a mesh. Those are the next stacked changes.

## Try it

From the repository root:

1. Confirm the Golden Gate developer environment:

   ```bash
   xcode-select -p
   xcodebuild -version
   xcrun --sdk macosx --show-sdk-version
   ```

   The selected path must be full Xcode/Xcode beta and the SDK must be 27.x.

2. Build the carrier-neutral Apple provider artifact:

   ```bash
   just apple::package
   ```

3. Validate `provider-runtime.json`, every declared file digest, and the executable bit using the shared Rust contract:

   ```bash
   just apple::contract
   ```

4. Exercise the same artifact in every planned SDK carrier layout:

   ```bash
   just apple::carriers
   ```

   Expected summary:

   ```json
   {
     "carriers": [
       "cli_runtimes_apple",
       "jvm_ai_meshllm_apple-runtime_macos-arm64_runtime",
       "node_node_modules__mesh-llm_apple-runtime-darwin-arm64_runtime",
       "swift_MeshLLMAppleRuntime.bundle_Contents_Resources_runtime"
     ],
     "status": "pass"
   }
   ```

5. To exercise the experimental parent runtime itself:

   ```bash
   just apple::run status
   just apple::run serve --port 11435
   ```

   In another terminal:

   ```bash
   curl -s http://127.0.0.1:11435/v1/models | jq
   just apple::rest
   ```

   The parent PR's `providers/apple/README.md` includes captured Golden Gate output for a buffered completion, SSE streaming, usage accounting, and a REST tool execution.

Generated artifacts are under `target/apple-runtime/package/`, including the bundle, ZIP, SHA-256 sidecars, and `provider-runtimes.json`.

## Validation

- `just build`
- `just with-lld cargo fmt --all -- --check`
- `just with-lld cargo test -p mesh-llm-provider-runtime` — 11 passed
- `just with-lld cargo clippy -p mesh-llm-provider-runtime --all-targets -- -D warnings`
- `just with-lld cargo package -p mesh-llm-provider-runtime --allow-dirty --no-verify`
- `just apple::carriers` — CLI, Swift, Node, and JVM carrier layouts passed
- `actionlint -config-file .github/actionlint.yaml`
- `shellcheck providers/apple/Packaging/package.sh providers/apple/QA/carriers.sh`
- repo-consistency: `ci-crate-lists`, `publish-crates`, and `release-targets`
- `python3 scripts/tests/test_publish_crates.py` — 9 passed

## Next stack

2B will add the Rust host supervisor: resolve the artifact, enforce platform signing policy, launch and health-check the sidecar, forward requests, drain it, and terminate it with the owning MeshLLM instance. Later changes will bind that lifecycle into Rust, Swift, Node/Electron, and Kotlin/JVM before private-mesh routing is enabled.

Closes no issue; advances #1246.
