### PR TITLE
Package Apple provider in macOS products

### DIFF
--- a/docs/design/APPLE_RUNTIME.md
+++ b/docs/design/APPLE_RUNTIME.md
@@ -194,9 +194,14 @@ This establishes the intended SDK contract:
 - the Swift SDK may additionally embed the provider library in an app, but its
   behavior must remain protocol-conformant with the process form.
 
-The current QA proves the carrier layouts, not final npm/JAR/XCFramework
-publication. Those release jobs should consume one already-signed runtime artifact rather
-than rebuild it independently.
+The CLI release composer now embeds that artifact at
+`provider-runtimes/apple/<runtime-id>`, records its tree and manifest digests in
+`product-manifest.json`, and preserves it through Unix installation. The host's
+adjacent-product discovery requires no provider bundle or index override.
+
+The current QA proves the CLI product and representative carrier layouts, not
+final npm/JAR/XCFramework publication. Those release jobs should consume one
+already-signed runtime artifact rather than rebuild it independently.
 
 ## Validation evidence
 
@@ -207,6 +212,8 @@ just apple::build
 just apple::test
 just apple::live
 just apple::mesh
+just apple::product 0.72.1 target/apple-runtime/product
+just apple::product-qa 0.72.1 target/apple-runtime/product
 MESH_APPLE_RUNTIME_CODESIGN_IDENTITY="Mesh-LLM Local Codesign" \
   just apple::rest
 MESH_APPLE_RUNTIME_CODESIGN_IDENTITY="Mesh-LLM Local Codesign" \
@@ -244,6 +251,7 @@ Observed live results:
 | Foundation Models Instruments trace | pass |
 | Core AI Instruments accelerator trace | pass; ANE load/prediction observed |
 | Supervisor SIGKILL/orphan prevention | pass; provider child exited |
+| Release-shaped CLI product auto-discovery | pass; no bundle/index override |
 
 A representative deterministic text request completed in 2.30 seconds with a
 1.81-second time to first token, 73 input tokens, and 25 output tokens. A
@@ -337,12 +345,14 @@ MeshLLM's normal local OpenAI frontend and runtime-process management surface.
 ### 2. All host-capable macOS SDKs
 
 The shared executable-provider manifest, resolver, verified downloader,
-immutable cache contract, and Rust host supervisor are implemented. Next,
-publish one signed macOS arm64 runtime artifact and bind the Rust, Swift,
-Node/Electron, and Kotlin/JVM SDK surfaces to the same installation and host
-lifecycle contract. Validate Swift app embedding, sandboxing, notarization,
-quarantine, and launchd/service lifecycles, then certify every SDK against one
-protocol test suite.
+immutable cache contract, Rust host supervisor, CLI product composition, and
+adjacent-product auto-discovery are implemented. The release lane requires a
+Developer ID Application signature, secure timestamp, accepted notarization,
+and `spctl` assessment before composition. Next, publish that one signed macOS
+arm64 artifact and bind the Rust, Swift, Node/Electron, and Kotlin/JVM SDK
+surfaces to the same installation and host lifecycle contract. Validate Swift
+app embedding, sandboxing, quarantine, and launchd/service lifecycles, then
+certify every SDK against one protocol test suite.
 
 ### 3. Private-mesh system-model routing
 

--- a/docs/design/PROVIDER_RUNTIMES.md
+++ b/docs/design/PROVIDER_RUNTIMES.md
@@ -74,6 +74,37 @@ An SDK may carry the bundle in its own resource layout, but it must hand that
 directory to the shared resolver. It must not reinterpret or recreate the
 manifest in language-specific code.
 
+## Composed product contract
+
+A macOS arm64 MeshLLM product can carry provider runtimes beside the neutral
+host and native runtime:
+
+```text
+mesh-bundle/
+├── mesh-llm
+├── product-manifest.json
+├── native-runtimes/<native-runtime-id>/
+└── provider-runtimes/
+    └── apple/<provider-runtime-id>/
+```
+
+`product-manifest.json` attests every embedded provider runtime by ID, semantic
+version, provider kind, protocol version, canonical relative path, complete
+tree SHA-256, and provider-manifest SHA-256. The Unix installer moves the whole
+`provider-runtimes/` tree atomically with the host and native runtime. Because
+the Apple supervisor searches `provider-runtimes/apple` adjacent to its own
+executable, both an unpacked release and an installed release discover the
+provider without `MESH_LLM_PROVIDER_RUNTIME_BUNDLE_DIR` or
+`MESH_LLM_PROVIDER_RUNTIME_INDEX`.
+
+Embedding is explicit at product-composition time. Other platforms and normal
+MeshLLM products remain unchanged when no provider runtime root is supplied.
+An Apple provider may enter a public product only when its executable passes
+strict code-signature verification, its manifest declares a real team and
+successful notarization, and `spctl` accepts the executable. The local Golden
+Gate QA lane has a deliberately named unnotarized exception; that exception is
+not release eligible.
+
 ## Installation and cache
 
 The shared cache layout is:

--- a/providers/apple/Justfile
+++ b/providers/apple/Justfile
@@ -20,6 +20,32 @@ live: build
 package:
     @"{{ apple_root }}/Packaging/package.sh"
 
+# Build a Developer ID signed and notarized provider artifact. The caller must
+# supply MESH_APPLE_RUNTIME_CODESIGN_IDENTITY and MESH_APPLE_RUNTIME_NOTARY_PROFILE.
+release-package runtime_version archive_url:
+    @MESH_APPLE_RUNTIME_RELEASE=1 \
+      MESH_APPLE_RUNTIME_VERSION="{{ runtime_version }}" \
+      MESH_APPLE_RUNTIME_ARCHIVE_URL="{{ archive_url }}" \
+      "{{ apple_root }}/Packaging/package.sh"
+
+# Compose a local release-shaped product with the ad-hoc provider for Golden Gate QA.
+product mesh_version output="target/apple-runtime/product":
+    @just --justfile "{{ apple_root }}/../../Justfile" release-build
+    @just --justfile "{{ apple_root }}/../../Justfile" apple::package
+    @MESH_LLM_PROVIDER_RUNTIME_ROOT="{{ apple_root }}/../../target/apple-runtime/package" \
+      MESH_RELEASE_ALLOW_UNNOTARIZED_PROVIDER_RUNTIME=1 \
+      "{{ apple_root }}/../../scripts/package-release.sh" \
+      "{{ mesh_version }}" "{{ apple_root }}/../../{{ output }}"
+
+# Compose a public-release product from one notarized Apple provider artifact.
+release-product mesh_version runtime_version archive_url output="dist":
+    @just --justfile "{{ apple_root }}/../../Justfile" release-build
+    @just --justfile "{{ apple_root }}/../../Justfile" \
+      apple::release-package "{{ runtime_version }}" "{{ archive_url }}"
+    @MESH_LLM_PROVIDER_RUNTIME_ROOT="{{ apple_root }}/../../target/apple-runtime/package" \
+      "{{ apple_root }}/../../scripts/package-release.sh" \
+      "{{ mesh_version }}" "{{ apple_root }}/../../{{ output }}"
+
 # Validate the packaged executable-provider manifest with the shared Rust contract.
 contract: package
     @just with-lld cargo run --quiet -p mesh-llm-provider-runtime --example inspect -- \
@@ -33,6 +59,19 @@ rest: package
 mesh: package
     @just --justfile "{{ apple_root }}/../../Justfile" build
     @"{{ apple_root }}/QA/mesh.sh"
+
+# Prove packaged-product auto-discovery with no provider bundle/index override.
+product-smoke mesh_version output="target/apple-runtime/product":
+    @MESH_APPLE_RUNTIME_PRODUCT_VERSION="{{ mesh_version }}" \
+      MESH_APPLE_RUNTIME_PRODUCT_OUTPUT="{{ apple_root }}/../../{{ output }}" \
+      "{{ apple_root }}/QA/product.sh"
+
+# Build the release-shaped product and then run its auto-discovery smoke.
+product-qa mesh_version output="target/apple-runtime/product":
+    @just --justfile "{{ apple_root }}/../../Justfile" \
+      apple::product "{{ mesh_version }}" "{{ output }}"
+    @just --justfile "{{ apple_root }}/../../Justfile" \
+      apple::product-smoke "{{ mesh_version }}" "{{ output }}"
 
 # Verify one signed runtime from CLI, Swift, Node, and JVM carrier layouts.
 carriers: package

--- a/providers/apple/Packaging/package.sh
+++ b/providers/apple/Packaging/package.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 APPLE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPO_ROOT="$(cd "$APPLE_ROOT/../.." && pwd)"
 PACKAGE_PATH="$APPLE_ROOT"
-OUTPUT_ROOT="$REPO_ROOT/target/apple-runtime/package"
+OUTPUT_ROOT="${MESH_APPLE_RUNTIME_OUTPUT_ROOT:-$REPO_ROOT/target/apple-runtime/package}"
 BUNDLE_ID="meshllm-apple-runtime-darwin-arm64"
 BUNDLE_DIR="$OUTPUT_ROOT/$BUNDLE_ID"
 IDENTITY="${MESH_APPLE_RUNTIME_CODESIGN_IDENTITY:--}"
@@ -12,6 +12,27 @@ ENTITLEMENTS="${MESH_APPLE_RUNTIME_ENTITLEMENTS:-}"
 ENTITLEMENT_PROVISIONING_VALIDATED="${MESH_APPLE_RUNTIME_ENTITLEMENT_PROVISIONING_VALIDATED:-0}"
 RUNTIME_VERSION="${MESH_APPLE_RUNTIME_VERSION:-0.1.0}"
 ARCHIVE_URL="${MESH_APPLE_RUNTIME_ARCHIVE_URL:-}"
+RELEASE_MODE="${MESH_APPLE_RUNTIME_RELEASE:-0}"
+NOTARY_PROFILE="${MESH_APPLE_RUNTIME_NOTARY_PROFILE:-}"
+
+if [[ "$RELEASE_MODE" != "0" && "$RELEASE_MODE" != "1" ]]; then
+    echo "MESH_APPLE_RUNTIME_RELEASE must be 0 or 1" >&2
+    exit 2
+fi
+if [[ "$RELEASE_MODE" == "1" ]]; then
+    [[ "$IDENTITY" != "-" ]] || {
+        echo "release packaging requires a Developer ID Application signing identity" >&2
+        exit 2
+    }
+    [[ -n "$NOTARY_PROFILE" ]] || {
+        echo "release packaging requires MESH_APPLE_RUNTIME_NOTARY_PROFILE" >&2
+        exit 2
+    }
+    [[ -n "$ARCHIVE_URL" ]] || {
+        echo "release packaging requires MESH_APPLE_RUNTIME_ARCHIVE_URL" >&2
+        exit 2
+    }
+fi
 
 if [[ "$(uname -s)" != "Darwin" || "$(uname -m)" != "arm64" ]]; then
     echo "Apple runtime packaging requires Apple silicon macOS" >&2
@@ -38,7 +59,14 @@ SOURCE_BINARY="$BIN_DIR/mesh-apple-runtime"
     exit 2
 }
 
-rm -rf "$OUTPUT_ROOT"
+mkdir -p "$OUTPUT_ROOT"
+rm -rf "$BUNDLE_DIR"
+rm -f \
+    "$OUTPUT_ROOT/$BUNDLE_ID.zip" \
+    "$OUTPUT_ROOT/$BUNDLE_ID.zip.sha256" \
+    "$OUTPUT_ROOT/provider-runtimes.json" \
+    "$OUTPUT_ROOT/provider-runtimes.json.sha256" \
+    "$OUTPUT_ROOT/notarization.json"
 mkdir -p "$BUNDLE_DIR/bin" "$BUNDLE_DIR/Resources"
 cp "$SOURCE_BINARY" "$BUNDLE_DIR/bin/mesh-apple-runtime"
 cp "$PACKAGE_PATH/README.md" "$BUNDLE_DIR/README.md"
@@ -46,7 +74,9 @@ cp "$PACKAGE_PATH/Packaging/Entitlements/background-inference.entitlements" \
     "$BUNDLE_DIR/Resources/background-inference.entitlements"
 
 codesign_args=(--force --sign "$IDENTITY")
-if [[ "$IDENTITY" != "-" ]]; then
+if [[ "$RELEASE_MODE" == "1" ]]; then
+    codesign_args+=(--options runtime --timestamp)
+elif [[ "$IDENTITY" != "-" ]]; then
     codesign_args+=(--options runtime --timestamp=none)
 fi
 if [[ -n "$ENTITLEMENTS" ]]; then
@@ -72,6 +102,12 @@ SIGNING_IDENTIFIER="$(printf '%s\n' "$CODESIGN_DETAILS" | awk -F= '/^Identifier=
 if [[ "$TEAM_IDENTIFIER" == "not set" ]]; then
     TEAM_IDENTIFIER=""
 fi
+if [[ "$RELEASE_MODE" == "1" ]]; then
+    [[ "$SIGNING_IDENTITY" == "Developer ID Application:"* && -n "$TEAM_IDENTIFIER" ]] || {
+        echo "release signature is not a Developer ID Application signature" >&2
+        exit 2
+    }
+fi
 ENTITLEMENT_KEYS_JSON="[]"
 if [[ -n "$ENTITLEMENTS" ]]; then
     ENTITLEMENT_KEYS_JSON="$(plutil -convert json -o - "$ENTITLEMENTS" | python3 -c \
@@ -92,7 +128,8 @@ python3 - \
     "$SIGNING_IDENTITY" \
     "$TEAM_IDENTIFIER" \
     "$SIGNING_IDENTIFIER" \
-    "$ENTITLEMENT_KEYS_JSON" <<'PY'
+    "$ENTITLEMENT_KEYS_JSON" \
+    "$RELEASE_MODE" <<'PY'
 import json
 import sys
 
@@ -111,6 +148,7 @@ import sys
     team_identifier,
     signing_identifier,
     entitlement_keys_json,
+    release_mode,
 ) = sys.argv[1:]
 
 manifest = {
@@ -153,7 +191,7 @@ manifest = {
             "team_identifier": team_identifier or None,
             "signing_identifier": signing_identifier or None,
             "entitlements": json.loads(entitlement_keys_json),
-            "notarized": False,
+            "notarized": release_mode == "1",
         },
     }
 }
@@ -168,6 +206,26 @@ just --justfile "$REPO_ROOT/Justfile" with-lld \
 
 ARCHIVE="$OUTPUT_ROOT/$BUNDLE_ID.zip"
 ditto -c -k --keepParent "$BUNDLE_DIR" "$ARCHIVE"
+
+if [[ "$RELEASE_MODE" == "1" ]]; then
+    xcrun notarytool submit "$ARCHIVE" \
+        --keychain-profile "$NOTARY_PROFILE" \
+        --wait \
+        --output-format json \
+        >"$OUTPUT_ROOT/notarization.json"
+    python3 - "$OUTPUT_ROOT/notarization.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    result = json.load(handle)
+if result.get("status") != "Accepted":
+    raise SystemExit(f"notarization failed: {result.get('status', 'unknown status')}")
+print(f"notarization accepted: {result.get('id', 'submission id unavailable')}")
+PY
+    spctl --assess --type execute --verbose=2 "$BUNDLE_DIR/bin/mesh-apple-runtime"
+fi
+
 ARCHIVE_SHA="$(shasum -a 256 "$ARCHIVE" | awk '{print $1}')"
 printf '%s  %s\n' "$ARCHIVE_SHA" "$(basename "$ARCHIVE")" > "$ARCHIVE.sha256"
 
@@ -209,3 +267,4 @@ echo "  bundle: $BUNDLE_DIR"
 echo "  archive: $ARCHIVE"
 echo "  release manifest: $RELEASE_MANIFEST"
 echo "  signing: $SIGNING_IDENTITY"
+echo "  release eligible: $RELEASE_MODE"

--- a/providers/apple/QA/mesh.sh
+++ b/providers/apple/QA/mesh.sh
@@ -4,8 +4,9 @@ set -euo pipefail
 APPLE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REPO_ROOT="$(cd "$APPLE_ROOT/../.." && pwd)"
 PACKAGE_ROOT="$REPO_ROOT/target/apple-runtime/package/meshllm-apple-runtime-darwin-arm64"
-HOST_BINARY="$REPO_ROOT/target/debug/mesh-llm"
-OUTPUT_DIR="$REPO_ROOT/target/apple-runtime/mesh"
+HOST_BINARY="${MESH_APPLE_RUNTIME_MESH_HOST_BINARY:-$REPO_ROOT/target/debug/mesh-llm}"
+OUTPUT_DIR="${MESH_APPLE_RUNTIME_MESH_OUTPUT_DIR:-$REPO_ROOT/target/apple-runtime/mesh}"
+AUTO_DISCOVERY="${MESH_APPLE_RUNTIME_MESH_AUTO_DISCOVERY:-0}"
 HOST_LOG="$OUTPUT_DIR/host.jsonl"
 HOST_ERR="$OUTPUT_DIR/host.stderr"
 HOST_PID=""
@@ -15,10 +16,14 @@ PROVIDER_PID=""
     echo "missing MeshLLM debug product; run just build" >&2
     exit 2
 }
-[[ -f "$PACKAGE_ROOT/provider-runtime.json" ]] || {
+if [[ "$AUTO_DISCOVERY" != "0" && "$AUTO_DISCOVERY" != "1" ]]; then
+    echo "MESH_APPLE_RUNTIME_MESH_AUTO_DISCOVERY must be 0 or 1" >&2
+    exit 2
+fi
+if [[ "$AUTO_DISCOVERY" == "0" && ! -f "$PACKAGE_ROOT/provider-runtime.json" ]]; then
     echo "missing packaged Apple provider; run just apple::package" >&2
     exit 2
-}
+fi
 
 cleanup() {
     if [[ "$HOST_PID" =~ ^[0-9]+$ ]] && kill -0 "$HOST_PID" 2>/dev/null; then
@@ -44,10 +49,17 @@ print(*ports)
 PY
 )
 
-MESH_LLM_CONFIG="$OUTPUT_DIR/empty-config.toml" \
-MESH_LLM_PROVIDER_RUNTIME_BUNDLE_DIR="$PACKAGE_ROOT" \
-MESH_LLM_PROVIDER_RUNTIME_CACHE_DIR="$OUTPUT_DIR/provider-cache" \
-MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC=1 \
+provider_discovery_env=()
+if [[ "$AUTO_DISCOVERY" == "0" ]]; then
+    provider_discovery_env+=(MESH_LLM_PROVIDER_RUNTIME_BUNDLE_DIR="$PACKAGE_ROOT")
+fi
+env \
+    -u MESH_LLM_PROVIDER_RUNTIME_INDEX \
+    -u MESH_LLM_PROVIDER_RUNTIME_BUNDLE_DIR \
+    ${provider_discovery_env[@]+"${provider_discovery_env[@]}"} \
+    MESH_LLM_CONFIG="$OUTPUT_DIR/empty-config.toml" \
+    MESH_LLM_PROVIDER_RUNTIME_CACHE_DIR="$OUTPUT_DIR/provider-cache" \
+    MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC=1 \
     "$HOST_BINARY" --log-format json serve \
         --port "$API_PORT" \
         --console "$CONSOLE_PORT" \

--- a/providers/apple/QA/product.sh
+++ b/providers/apple/QA/product.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APPLE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$APPLE_ROOT/../.." && pwd)"
+PRODUCT_VERSION="${MESH_APPLE_RUNTIME_PRODUCT_VERSION:?set the composed MeshLLM product version}"
+PRODUCT_OUTPUT="${MESH_APPLE_RUNTIME_PRODUCT_OUTPUT:-$REPO_ROOT/target/apple-runtime/product}"
+ARCHIVE="$PRODUCT_OUTPUT/mesh-llm-${PRODUCT_VERSION#v}-aarch64-apple-darwin.tar.gz"
+QA_OUTPUT="$REPO_ROOT/target/apple-runtime/product-qa"
+TEMP_ROOT="$(mktemp -d "${TMPDIR:-/tmp}/mesh-apple-product.XXXXXX")"
+
+cleanup() {
+    rm -rf "$TEMP_ROOT"
+}
+trap cleanup EXIT
+
+[[ -f "$ARCHIVE" ]] || {
+    echo "missing composed Apple product: $ARCHIVE" >&2
+    echo "run just apple::product $PRODUCT_VERSION" >&2
+    exit 2
+}
+
+tar -xzf "$ARCHIVE" -C "$TEMP_ROOT"
+BUNDLE="$TEMP_ROOT/mesh-bundle"
+HOST_BINARY="$BUNDLE/mesh-llm"
+PROVIDER_BUNDLE="$BUNDLE/provider-runtimes/apple/meshllm-apple-runtime-darwin-arm64"
+
+[[ -x "$HOST_BINARY" ]] || {
+    echo "composed product has no executable MeshLLM host" >&2
+    exit 2
+}
+[[ -f "$PROVIDER_BUNDLE/provider-runtime.json" ]] || {
+    echo "composed product has no adjacent Apple provider runtime" >&2
+    exit 2
+}
+
+python3 - "$BUNDLE/product-manifest.json" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    manifest = json.load(handle)
+providers = manifest.get("provider_runtimes", [])
+assert len(providers) == 1, manifest
+provider = providers[0]
+assert provider["id"] == "meshllm-apple-runtime-darwin-arm64", provider
+assert provider["provider_kind"] == "apple", provider
+assert provider["path"] == (
+    "provider-runtimes/apple/meshllm-apple-runtime-darwin-arm64"
+), provider
+PY
+
+MESH_APPLE_RUNTIME_MESH_HOST_BINARY="$HOST_BINARY" \
+MESH_APPLE_RUNTIME_MESH_OUTPUT_DIR="$QA_OUTPUT" \
+MESH_APPLE_RUNTIME_MESH_AUTO_DISCOVERY=1 \
+    "$APPLE_ROOT/QA/mesh.sh"
+
+python3 - "$QA_OUTPUT/summary.json" "$ARCHIVE" <<'PY'
+import json
+import pathlib
+import sys
+
+summary_path = pathlib.Path(sys.argv[1])
+summary = json.loads(summary_path.read_text(encoding="utf-8"))
+summary["product_archive"] = sys.argv[2]
+summary["provider_discovery"] = "adjacent_product_bundle"
+summary["provider_bundle_override_used"] = False
+summary["provider_index_override_used"] = False
+summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+print(json.dumps({
+    "status": summary["status"],
+    "model": summary["model"],
+    "versioned_model": summary["versioned_model"],
+    "provider_discovery": summary["provider_discovery"],
+    "provider_bundle_override_used": summary["provider_bundle_override_used"],
+    "completion_content": summary["completion"]["choices"][0]["message"]["content"],
+    "tool_executions": summary["tool"]["mesh_tool_executions"],
+}, indent=2, sort_keys=True))
+PY

--- a/providers/apple/README.md
+++ b/providers/apple/README.md
@@ -6,10 +6,11 @@ exposed as `apple/system`. Named Core AI models will be added to the same
 runtime and protocol rather than shipped as a second sidecar.
 
 This work is **experimental**. A macOS `mesh-llm serve` host can supervise the
-runtime and expose `apple/system` through its normal local OpenAI frontend. The
-provider is not included in release products, model gossip, or private-mesh
+runtime and expose `apple/system` through its normal local OpenAI frontend. A
+release-shaped macOS product can now embed and auto-discover the provider; the
+provider is not enabled in published releases, model gossip, or private-mesh
 routing yet. It implements the Milestone 0 evidence, local REST vertical slice,
-and Rust host-supervision layer from
+Rust host-supervision layer, and CLI product-packaging layer from
 [issue #1246](https://github.com/Mesh-LLM/mesh-llm/issues/1246).
 
 ## Requirements
@@ -327,6 +328,45 @@ MESH_APPLE_RUNTIME_CODESIGN_IDENTITY="Mesh-LLM Local Codesign" \
   just apple::package
 ```
 
+Build and exercise a release-shaped CLI product on Golden Gate:
+
+```bash
+just apple::product-qa 0.72.1 target/apple-runtime/product
+```
+
+Use `just apple::product 0.72.1 target/apple-runtime/product` when only the
+composed archives are needed; `product-qa` already performs that build before
+running the smoke.
+
+The product contains the host, one native Metal runtime, and the same Apple
+sidecar under
+`provider-runtimes/apple/meshllm-apple-runtime-darwin-arm64`. Product QA runs
+the host from that layout with both provider bundle and provider index
+overrides unset, then repeats the completion, streaming, tool, cancellation,
+restart, and shutdown checks. The resulting
+`target/apple-runtime/product-qa/summary.json` records
+`provider_discovery=adjacent_product_bundle` and
+`provider_bundle_override_used=false`.
+
+The public release lane is intentionally stricter:
+
+```bash
+MESH_APPLE_RUNTIME_CODESIGN_IDENTITY="Developer ID Application: Example (TEAMID)" \
+MESH_APPLE_RUNTIME_NOTARY_PROFILE=mesh-llm-notary \
+  just apple::release-product \
+    v0.72.1 0.1.0 \
+    https://github.com/Mesh-LLM/mesh-llm/releases/download/v0.72.1/meshllm-apple-runtime-darwin-arm64.zip \
+    dist
+```
+
+This signs with hardened runtime and a secure timestamp, submits the exact ZIP
+to Apple's notary service, requires an `Accepted` result, checks it with
+`spctl`, and only then composes the provider into the product. It requires a
+Developer ID Application certificate and a `notarytool` keychain profile. The
+notarization submission ID/status are written to
+`target/apple-runtime/package/notarization.json`; credentials are never written
+to the artifact.
+
 The background continued-processing inference entitlement is included as a
 review artifact. Packaging refuses to apply it unless provisioning has been
 independently validated. A locally created certificate is not sufficient:
@@ -342,7 +382,7 @@ caveats, and rollout gates.
 |---|---|---|
 | 0 | Policy, entitlement, packaging, signing, launchd, and accelerator spike | complete |
 | 1 | Local `apple/system` REST vertical slice | experimental implementation complete |
-| 2 | All host-capable macOS SDKs drive the same runtime lifecycle | provider artifact and Rust host supervisor implemented; SDK packaging and bindings pending |
+| 2 | All host-capable macOS SDKs drive the same runtime lifecycle | CLI release packaging and auto-discovery implemented; SDK carrier publication and bindings pending |
 | 3 | Private-mesh routing, load, failover, affinity, and withdrawal | not implemented |
 
 This runtime does not alter the Skippy ABI or use Skippy stage execution.

--- a/scripts/compose-product-bundle.py
+++ b/scripts/compose-product-bundle.py
@@ -30,6 +30,18 @@ class RuntimeManifest(TypedDict):
     build: NotRequired[BuildData]
 
 
+class ProviderRuntimeData(TypedDict):
+    id: str
+    version: str
+    provider_kind: str
+    protocol_version: str
+
+
+class ProviderRuntimeManifest(TypedDict):
+    schema_version: int
+    runtime: ProviderRuntimeData
+
+
 def expected_backend_kind(backend: str) -> str:
     return BACKEND_KIND_ALIASES.get(backend, backend)
 
@@ -82,6 +94,7 @@ def compose_manifest(
     runtime: Path,
     version: str,
     backend: str,
+    provider_runtimes: list[Path],
 ) -> dict[str, object]:
     version = version.removeprefix("v")
     runtime_manifest_path = runtime / "manifest.json"
@@ -97,7 +110,7 @@ def compose_manifest(
             f"expected {version}"
         )
     validate_runtime_backend(runtime_id, runtime_manifest, runtime_data, backend)
-    return {
+    manifest: dict[str, object] = {
         "schema_version": 2,
         "contract": "mesh-llm-product-v2",
         "mesh_version": version,
@@ -113,6 +126,56 @@ def compose_manifest(
             "manifest_sha256": file_sha256(runtime_manifest_path),
         },
     }
+    if provider_runtimes:
+        manifest["provider_runtimes"] = compose_provider_runtimes(
+            bundle, provider_runtimes
+        )
+    return manifest
+
+
+def compose_provider_runtimes(
+    bundle: Path, provider_runtimes: list[Path]
+) -> list[dict[str, str]]:
+    composed: list[dict[str, str]] = []
+    coordinates: set[tuple[str, str]] = set()
+    for provider_runtime in sorted(provider_runtimes):
+        manifest_path = provider_runtime / "provider-runtime.json"
+        provider_manifest: ProviderRuntimeManifest = json.loads(
+            manifest_path.read_text(encoding="utf-8")
+        )
+        if provider_manifest["schema_version"] != 1:
+            raise ValueError(
+                f"unsupported provider runtime schema in {manifest_path}: "
+                f"{provider_manifest['schema_version']}"
+            )
+        runtime_data = provider_manifest["runtime"]
+        runtime_id = runtime_data["id"]
+        provider_kind = runtime_data["provider_kind"]
+        coordinate = (runtime_id, runtime_data["version"])
+        if coordinate in coordinates:
+            raise ValueError(
+                f"duplicate provider runtime coordinate {runtime_id}@{runtime_data['version']}"
+            )
+        coordinates.add(coordinate)
+        expected_path = Path("provider-runtimes") / provider_kind / runtime_id
+        actual_path = provider_runtime.relative_to(bundle)
+        if actual_path != expected_path:
+            raise ValueError(
+                f"provider runtime {runtime_id} path mismatch: found "
+                f"{actual_path.as_posix()}, expected {expected_path.as_posix()}"
+            )
+        composed.append(
+            {
+                "id": runtime_id,
+                "version": runtime_data["version"],
+                "provider_kind": provider_kind,
+                "protocol_version": runtime_data["protocol_version"],
+                "path": actual_path.as_posix(),
+                "sha256": tree_sha256(provider_runtime),
+                "manifest_sha256": file_sha256(manifest_path),
+            }
+        )
+    return composed
 
 
 def parse_args() -> argparse.Namespace:
@@ -122,6 +185,13 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--runtime", type=Path, required=True)
     parser.add_argument("--version", required=True)
     parser.add_argument("--backend", required=True)
+    parser.add_argument(
+        "--provider-runtime",
+        action="append",
+        default=[],
+        type=Path,
+        help="Provider runtime bundle embedded in the composed product (repeatable).",
+    )
     parser.add_argument(
         "--check",
         action="store_true",
@@ -133,7 +203,12 @@ def parse_args() -> argparse.Namespace:
 def main() -> int:
     args = parse_args()
     manifest = compose_manifest(
-        args.bundle, args.host, args.runtime, args.version, args.backend
+        args.bundle,
+        args.host,
+        args.runtime,
+        args.version,
+        args.backend,
+        args.provider_runtime,
     )
     manifest_path = args.bundle / "product-manifest.json"
     if args.check:

--- a/scripts/package-release.sh
+++ b/scripts/package-release.sh
@@ -10,10 +10,13 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 RELEASE_BIN_DIR="${MESH_LLM_RELEASE_BIN_DIR:-$REPO_ROOT/target/release}"
 NATIVE_RUNTIME_ROOT="${MESH_LLM_NATIVE_RUNTIME_ROOT:-$REPO_ROOT/dist/native-runtimes}"
+PROVIDER_RUNTIME_ROOT="${MESH_LLM_PROVIDER_RUNTIME_ROOT:-}"
+ALLOW_UNNOTARIZED_PROVIDER_RUNTIME="${MESH_RELEASE_ALLOW_UNNOTARIZED_PROVIDER_RUNTIME:-0}"
 ATTESTATION_SIGNING_KEY_FILE="${MESH_RELEASE_ATTESTATION_SIGNING_KEY_FILE:-}"
 ATTESTATION_PUBLIC_KEY_FILE="${MESH_RELEASE_ATTESTATION_PUBLIC_KEY_FILE:-}"
 PRECOMPOSED_PRODUCT_DIR="${MESH_LLM_PRECOMPOSED_PRODUCT_DIR:-}"
 ATTESTATION_PREVERIFIED="${MESH_RELEASE_ATTESTATION_PREVERIFIED:-0}"
+PROVIDER_RUNTIME_BUNDLES=()
 
 python_bin() {
     if command -v python3 >/dev/null 2>&1; then
@@ -187,12 +190,158 @@ write_product_manifest() {
     local version="$4"
     local flavor="$5"
 
+    local provider_args=()
+    local provider_runtime
+    for provider_runtime in "${PROVIDER_RUNTIME_BUNDLES[@]}"; do
+        provider_args+=(--provider-runtime "$provider_runtime")
+    done
+
     "$(python_bin)" "$SCRIPT_DIR/compose-product-bundle.py" \
         --bundle "$bundle_dir" \
         --host "$host_path" \
         --runtime "$runtime_path" \
         --version "$version" \
-        --backend "$flavor"
+        --backend "$flavor" \
+        "${provider_args[@]}"
+}
+
+provider_runtime_coordinates() {
+    local manifest="$1"
+    "$(python_bin)" - "$manifest" <<'PY'
+import json
+import re
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    document = json.load(handle)
+runtime = document["runtime"]
+values = (runtime["provider_kind"], runtime["id"])
+if any(not re.fullmatch(r"[a-z0-9][a-z0-9._-]*", value) for value in values):
+    raise SystemExit("provider kind and runtime id must be safe package path components")
+print("\t".join(values))
+PY
+}
+
+verify_provider_runtime_contract() {
+    local bundle="$1"
+    just --justfile "$REPO_ROOT/Justfile" with-lld \
+        cargo run --quiet -p mesh-llm-provider-runtime --example inspect -- "$bundle"
+}
+
+verify_apple_provider_release_policy() {
+    local bundle="$1"
+    local manifest="$bundle/provider-runtime.json"
+    local entrypoint
+    local declared_notarized
+    local declared_team
+    local declared_identifier
+    local codesign_details
+    local actual_team
+    local actual_identifier
+
+    read -r entrypoint declared_notarized declared_team declared_identifier < <(
+        "$(python_bin)" - "$manifest" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    runtime = json.load(handle)["runtime"]
+signature = runtime.get("signature") or {}
+print(
+    runtime["entrypoint"],
+    str(signature.get("notarized") is True).lower(),
+    signature.get("team_identifier") or "-",
+    signature.get("signing_identifier") or "-",
+)
+PY
+    )
+    local executable="$bundle/$entrypoint"
+    codesign --verify --strict --verbose=2 "$executable"
+    codesign_details="$(codesign -dv --verbose=4 "$executable" 2>&1)"
+    actual_team="$(printf '%s\n' "$codesign_details" | awk -F= '/^TeamIdentifier=/ {print $2; exit}')"
+    actual_identifier="$(printf '%s\n' "$codesign_details" | awk -F= '/^Identifier=/ {print $2; exit}')"
+
+    if [[ "$ALLOW_UNNOTARIZED_PROVIDER_RUNTIME" == "1" ]]; then
+        echo "Apple provider release policy: local-development exception (not release eligible)"
+        return 0
+    fi
+    if [[ "$ALLOW_UNNOTARIZED_PROVIDER_RUNTIME" != "0" ]]; then
+        echo "MESH_RELEASE_ALLOW_UNNOTARIZED_PROVIDER_RUNTIME must be 0 or 1" >&2
+        exit 1
+    fi
+    if [[ "$declared_notarized" != "true" || "$declared_team" == "-" ]]; then
+        echo "release products require a Developer ID signed and notarized Apple provider runtime" >&2
+        exit 1
+    fi
+    if [[ "$declared_team" != "$actual_team" || "$declared_identifier" != "$actual_identifier" ]]; then
+        echo "Apple provider manifest signing identity does not match the executable" >&2
+        exit 1
+    fi
+    spctl --assess --type execute --verbose=2 "$executable"
+}
+
+verify_provider_runtime_release_policy() {
+    local bundle="$1"
+    local provider_kind="$2"
+    case "$provider_kind" in
+        apple)
+            if [[ "$(normalized_release_platform)" != "macos/aarch64" ]]; then
+                echo "Apple provider runtimes may only be composed into macOS arm64 products" >&2
+                exit 1
+            fi
+            verify_apple_provider_release_policy "$bundle"
+            ;;
+    esac
+}
+
+copy_provider_runtimes() {
+    local source_root="$1"
+    local bundle_dir="$2"
+    local manifest
+    local source_bundle
+    local coordinates
+    local provider_kind
+    local runtime_id
+    local destination
+    local found=0
+
+    [[ -d "$source_root" ]] || {
+        echo "Provider runtime root does not exist: $source_root" >&2
+        exit 1
+    }
+    while IFS= read -r manifest; do
+        found=$((found + 1))
+        source_bundle="$(dirname "$manifest")"
+        verify_provider_runtime_contract "$source_bundle"
+        coordinates="$(provider_runtime_coordinates "$manifest")"
+        IFS=$'\t' read -r provider_kind runtime_id <<<"$coordinates"
+        verify_provider_runtime_release_policy "$source_bundle" "$provider_kind"
+        destination="$bundle_dir/provider-runtimes/$provider_kind/$runtime_id"
+        [[ ! -e "$destination" ]] || {
+            echo "Duplicate provider runtime destination: $destination" >&2
+            exit 1
+        }
+        mkdir -p "$(dirname "$destination")"
+        cp -R "$source_bundle" "$destination"
+        PROVIDER_RUNTIME_BUNDLES+=("$destination")
+    done < <(find "$source_root" -maxdepth 2 -type f -name provider-runtime.json -print | sort)
+    if [[ "$found" -eq 0 ]]; then
+        echo "Provider runtime root contains no provider-runtime.json: $source_root" >&2
+        exit 1
+    fi
+}
+
+discover_bundled_provider_runtimes() {
+    local bundle_dir="$1"
+    local manifest
+    PROVIDER_RUNTIME_BUNDLES=()
+    [[ -d "$bundle_dir/provider-runtimes" ]] || return 0
+    while IFS= read -r manifest; do
+        PROVIDER_RUNTIME_BUNDLES+=("$(dirname "$manifest")")
+    done < <(
+        find "$bundle_dir/provider-runtimes" \
+            -mindepth 3 -maxdepth 3 -type f -name provider-runtime.json -print | sort
+    )
 }
 
 validate_attestation_env() {
@@ -528,12 +677,25 @@ copy_and_verify_precomposed_product() {
         exit 1
     fi
     "$SCRIPT_DIR/verify-native-runtime-package.sh" "$runtime_dir"
+    discover_bundled_provider_runtimes "$bundle_dir"
+    local provider_runtime
+    local provider_kind
+    for provider_runtime in "${PROVIDER_RUNTIME_BUNDLES[@]}"; do
+        verify_provider_runtime_contract "$provider_runtime"
+        provider_kind="$(provider_runtime_coordinates "$provider_runtime/provider-runtime.json" | cut -f1)"
+        verify_provider_runtime_release_policy "$provider_runtime" "$provider_kind"
+    done
+    local provider_args=()
+    for provider_runtime in "${PROVIDER_RUNTIME_BUNDLES[@]}"; do
+        provider_args+=(--provider-runtime "$provider_runtime")
+    done
     "$(python_bin)" "$SCRIPT_DIR/compose-product-bundle.py" \
         --bundle "$bundle_dir" \
         --host "$bundle_binary" \
         --runtime "$runtime_dir" \
         --version "$version" \
         --backend "$flavor" \
+        "${provider_args[@]}" \
         --check
 }
 
@@ -592,6 +754,9 @@ main() {
         bundled_runtime="$bundle_dir/native-runtimes/$(basename "$runtime_dir")"
         mkdir -p "$(dirname "$bundled_runtime")"
         cp -R "$runtime_dir" "$bundled_runtime"
+        if [[ -n "$PROVIDER_RUNTIME_ROOT" ]]; then
+            copy_provider_runtimes "$PROVIDER_RUNTIME_ROOT" "$bundle_dir"
+        fi
         write_product_manifest \
             "$bundle_dir" \
             "$bundle_binary" \

--- a/scripts/tests/test_install_sh.py
+++ b/scripts/tests/test_install_sh.py
@@ -494,6 +494,41 @@ class InstallScriptTests(unittest.TestCase):
             )
             self.assertFalse(existing_runtime.exists())
 
+    def test_install_bundle_preserves_adjacent_provider_runtime_layout(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            install_dir = tmp_path / "bin"
+            bundle_dir = self._write_installable_bundle(tmp_path, "new")
+            provider = (
+                bundle_dir
+                / "provider-runtimes"
+                / "apple"
+                / "meshllm-apple-runtime-darwin-arm64"
+            )
+            (provider / "bin").mkdir(parents=True)
+            (provider / "provider-runtime.json").write_text(
+                '{"schema_version":1}\n', encoding="utf-8"
+            )
+            executable = provider / "bin" / "mesh-apple-runtime"
+            executable.write_text("provider\n", encoding="utf-8")
+            executable.chmod(0o755)
+
+            result = self._run_helper(
+                tmp_path,
+                install_dir,
+                f"install_bundle {shlex_quote(str(bundle_dir))}",
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            installed = (
+                install_dir
+                / "provider-runtimes"
+                / "apple"
+                / "meshllm-apple-runtime-darwin-arm64"
+            )
+            self.assertTrue((installed / "provider-runtime.json").is_file())
+            self.assertTrue((installed / "bin" / "mesh-apple-runtime").is_file())
+
     def test_install_bundle_rolls_back_when_a_staged_move_fails(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)

--- a/scripts/tests/test_package_release.py
+++ b/scripts/tests/test_package_release.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import pathlib
@@ -64,6 +65,34 @@ class PackageReleaseTests(unittest.TestCase):
         )
         return runtime
 
+    def provider_runtime(
+        self,
+        bundle: pathlib.Path,
+        runtime_id: str = "meshllm-apple-runtime-darwin-arm64",
+    ) -> pathlib.Path:
+        provider = bundle / "provider-runtimes" / "apple" / runtime_id
+        (provider / "bin").mkdir(parents=True)
+        executable = provider / "bin" / "mesh-apple-runtime"
+        executable.write_bytes(b"provider")
+        executable.chmod(0o755)
+        (provider / "provider-runtime.json").write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "runtime": {
+                        "id": runtime_id,
+                        "version": "0.1.0",
+                        "provider_kind": "apple",
+                        "protocol_version": "0.1",
+                        "entrypoint": "bin/mesh-apple-runtime",
+                    },
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return provider
+
     def test_selects_exact_platform_and_backend(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = pathlib.Path(directory)
@@ -123,6 +152,69 @@ class PackageReleaseTests(unittest.TestCase):
             self.assertEqual(
                 manifest["runtime"]["path"], "native-runtimes/linux-cpu"
             )
+
+    def test_product_manifest_attests_embedded_provider_runtime(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bundle = pathlib.Path(directory) / "mesh-bundle"
+            runtime_root = bundle / "native-runtimes"
+            host = bundle / "mesh-llm"
+            bundle.mkdir()
+            host.write_bytes(b"host")
+            runtime = self.runtime(runtime_root, "linux-cpu", "cpu")
+            provider = self.provider_runtime(bundle)
+            result = run_bash(
+                (
+                    f'PROVIDER_RUNTIME_BUNDLES=("{provider}"); '
+                    f'write_product_manifest "{bundle}" "{host}" "{runtime}" '
+                    '"v0.73.1" "cpu"'
+                ),
+                {},
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+            manifest = json.loads(
+                (bundle / "product-manifest.json").read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                manifest["provider_runtimes"],
+                [
+                    {
+                        "id": "meshllm-apple-runtime-darwin-arm64",
+                        "manifest_sha256": hashlib.sha256(
+                            (provider / "provider-runtime.json").read_bytes()
+                        ).hexdigest(),
+                        "path": (
+                            "provider-runtimes/apple/"
+                            "meshllm-apple-runtime-darwin-arm64"
+                        ),
+                        "protocol_version": "0.1",
+                        "provider_kind": "apple",
+                        "sha256": manifest["provider_runtimes"][0]["sha256"],
+                        "version": "0.1.0",
+                    }
+                ],
+            )
+
+    def test_product_manifest_rejects_provider_outside_canonical_path(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            bundle = pathlib.Path(directory) / "mesh-bundle"
+            runtime_root = bundle / "native-runtimes"
+            host = bundle / "mesh-llm"
+            bundle.mkdir()
+            host.write_bytes(b"host")
+            runtime = self.runtime(runtime_root, "linux-cpu", "cpu")
+            provider = self.provider_runtime(bundle)
+            wrong_path = bundle / "provider-runtimes" / "wrong"
+            provider.rename(wrong_path)
+            result = run_bash(
+                (
+                    f'PROVIDER_RUNTIME_BUNDLES=("{wrong_path}"); '
+                    f'write_product_manifest "{bundle}" "{host}" "{runtime}" '
+                    '"v0.73.1" "cpu"'
+                ),
+                {},
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("path mismatch", result.stderr)
 
     def test_rejects_product_runtime_backend_mismatch_before_manifest_write(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
> [!IMPORTANT]
> **Experimental: you must have macOS Golden Gate (macOS 27) on Apple silicon to run this.** This does not enable `apple/system` in published releases or advertise it to mesh peers.

## Stack

- Builds on #1252, which adds host-owned Apple provider supervision and versioned `apple/system@27.0` routing.
- Tracks #1246.
- This is the Phase 2C1 CLI product-packaging and automatic-discovery layer. Swift, Node/Electron, and Kotlin/JVM distribution work remains in the next stack.

## Why

The supervisor in #1252 can already drive Apple's on-device system model, but a user must point it at a development bundle manually. That is not a product: installers and unpacked releases need to carry one verified sidecar in a stable location, the host must find it without SDK-specific environment variables, and public artifacts must fail closed unless the executable has a real Developer ID signature and accepted Apple notarization.

For eligible Apple silicon users, this moves `apple/system` toward a zero-checkpoint-download, private, Apple-accelerated inference option that behaves like the same OpenAI-compatible MeshLLM model from every host-capable SDK. Foundation Models stays isolated in one Swift sidecar; the Rust host and SDKs do not link or reimplement Apple's API, and Skippy pipeline parallelism is not involved.

## What changed

- Embeds the carrier-neutral Apple provider at `provider-runtimes/apple/<runtime-id>` beside the release host and native Metal runtime.
- Extends `product-manifest.json` with provider ID, version, kind, protocol, canonical path, complete tree SHA-256, and provider-manifest SHA-256.
- Validates the shared executable-provider contract again during product composition, including all declared payload hashes and the executable bit.
- Preserves `provider-runtimes/` through the existing atomic Unix installer transaction.
- Uses the host's adjacent-product discovery so installed and unpacked products need neither `MESH_LLM_PROVIDER_RUNTIME_BUNDLE_DIR` nor `MESH_LLM_PROVIDER_RUNTIME_INDEX`.
- Adds an explicit local Golden Gate product lane for ad-hoc QA and keeps that exception visibly non-release-eligible.
- Adds a public lane that requires Developer ID Application signing, hardened runtime, a secure timestamp, an accepted `notarytool` submission, matching manifest/signature identity, and passing `spctl` assessment before product composition.
- Adds release-product QA that extracts the real tarball and repeats completion, streaming, tools, cancellation, process restart, route withdrawal, and shutdown checks from the packaged layout.
- Documents the composed product and the next SDK-carrier boundary.

There is no Apple backward-compatibility path here: the provider uses the mandatory protocol and version metadata introduced by #1252.

## Requirements

You must have:

1. Apple silicon.
2. **macOS Golden Gate (macOS 27).**
3. Full Xcode 27 selected with `xcode-select`; Command Line Tools alone are insufficient.
4. Apple Intelligence enabled.
5. The system model downloaded and reported as available.

Confirm the environment:

```bash
xcode-select -p
xcodebuild -version
xcrun --sdk macosx --show-sdk-version
just apple::run status
```

The developer path should end in `Xcode.app/Contents/Developer` or the beta equivalent, the SDK should be 27.x, and status should report `apple/system@27.0` as available.

## Try the packaged product

From the repository root:

1. Build the release host, native Metal runtime, ad-hoc Apple provider, and composed tarball, then run the full product smoke:

   ```bash
   just apple::product-qa 0.72.1 target/apple-runtime/product
   ```

2. Inspect the retained result:

   ```bash
   jq . target/apple-runtime/product-qa/summary.json
   ```

   The important discovery evidence is:

   ```json
   {
     "provider_discovery": "adjacent_product_bundle",
     "provider_bundle_override_used": false,
     "provider_index_override_used": false
   }
   ```

3. To run the composed product manually, extract it:

   ```bash
   mkdir -p target/apple-runtime/manual-product
   tar -xzf \
     target/apple-runtime/product/mesh-llm-0.72.1-aarch64-apple-darwin.tar.gz \
     -C target/apple-runtime/manual-product
   ```

4. Start the packaged host. The ad-hoc allowance is only for this local experimental artifact; there is deliberately no provider discovery override:

   ```bash
   MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC=1 \
     ./target/apple-runtime/manual-product/mesh-bundle/mesh-llm \
       --log-format json serve \
       --port 9337 --console 3131 --headless
   ```

5. Send a completion over MeshLLM REST:

   ```bash
   curl -s http://127.0.0.1:9337/v1/chat/completions \
     -H 'content-type: application/json' \
     -d '{
       "model": "apple/system@27.0",
       "messages": [{
         "role": "user",
         "content": "Reply with exactly: apple runtime REST ready"
       }],
       "temperature": 0,
       "max_tokens": 32
     }' | jq
   ```

6. Exercise the deterministic tool path:

   ```bash
   curl -s http://127.0.0.1:9337/v1/chat/completions \
     -H 'content-type: application/json' \
     -d '{
       "model": "apple/system",
       "messages": [{"role":"user","content":"Use the tool with key: rest-demo"}],
       "tools": [{
         "type": "function",
         "function": {
           "name": "mesh_fixture_lookup",
           "description": "Look up a fixture",
           "parameters": {
             "type": "object",
             "properties": {"key": {"type": "string"}},
             "required": ["key"]
           }
         }
       }]
     }' | jq
   ```

## Captured Golden Gate output

This output came from the extracted release product, not the direct Swift development server:

```json
{
  "status": "pass",
  "model": "apple/system",
  "versioned_model": "apple/system@27.0",
  "provider_discovery": "adjacent_product_bundle",
  "provider_bundle_override_used": false,
  "completion_content": "apple runtime REST ready",
  "tool_executions": [{
    "name": "mesh_fixture_lookup",
    "arguments": {"key": "rest-demo"},
    "result": "mesh-fixture-value-for-rest-demo"
  }],
  "stream_done": true,
  "client_disconnect_cancelled": true,
  "provider_reported_in_management_api": true,
  "provider_restarted_after_crash": true,
  "provider_exited_with_meshllm": true
}
```

## Public signing and notarization

A release operator first stores notarization credentials in Keychain using Apple's `notarytool`, then runs:

```bash
MESH_APPLE_RUNTIME_CODESIGN_IDENTITY="Developer ID Application: Example (TEAMID)" \
MESH_APPLE_RUNTIME_NOTARY_PROFILE=mesh-llm-notary \
  just apple::release-product \
    v0.72.1 0.1.0 \
    https://github.com/Mesh-LLM/mesh-llm/releases/download/v0.72.1/meshllm-apple-runtime-darwin-arm64.zip \
    dist
```

The exact provider ZIP is submitted with `--wait`; only `Accepted` proceeds. Composition then independently validates the provider contract, strict code signature, declared/actual team and signing identifiers, and `spctl` assessment. `notarization.json` records the submission result but never credentials.

This machine has only the local `Mesh-LLM Local Codesign` identity, so the public lane was correctly exercised as a fail-closed credential gate rather than falsely marked notarized. Producing the public artifact requires the release team's Developer ID Application certificate and notary profile.

## Validation

- `just apple::package`
- `just apple::product 0.72.1 target/apple-runtime/product`
- `just apple::product-smoke 0.72.1 target/apple-runtime/product-recheck`
- extracted-product completion/SSE/tool/cancellation/restart/shutdown smoke — pass
- adjacent discovery with bundle/index overrides unset — pass
- `just with-lld python3 -m unittest scripts.tests.test_package_release scripts.tests.test_install_sh` — 34 passed
- `just with-lld cargo fmt --all -- --check`
- `bash -n scripts/package-release.sh providers/apple/Packaging/package.sh providers/apple/QA/mesh.sh providers/apple/QA/product.sh`
- `shellcheck scripts/package-release.sh providers/apple/Packaging/package.sh providers/apple/QA/mesh.sh providers/apple/QA/product.sh`
- `git diff --check`
- public release packaging without Developer ID identity — rejected as required

## Next stack

Package this same signed artifact into every host-capable macOS SDK carrier: Rust bundle/resource discovery, Swift Bundle/XCFramework resources and sandbox lifecycle, Node/Electron optional platform package, and Kotlin/JVM resource extraction. All carriers should invoke the same host lifecycle and pass one protocol/product test suite; none should bind Foundation Models independently.
