### PR TITLE
Expose provider runtimes through Rust SDK

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4254,6 +4254,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/mesh-llm-embedded-runtime/README.md
+++ b/crates/mesh-llm-embedded-runtime/README.md
@@ -34,3 +34,8 @@ async fn main() -> anyhow::Result<()> {
 }
 ```
 
+Provider-only hosts can omit `.model(...)` and supply one or more packaged
+provider roots with `.provider_runtime_root(...)`. This path does not require a
+Skippy native runtime. Provider roots are SDK-owned resource locations; bundle
+validation, selection, launch, health, restart, routing, and shutdown remain
+owned by the shared host runtime.

--- a/crates/mesh-llm-embedded-runtime/src/lib.rs
+++ b/crates/mesh-llm-embedded-runtime/src/lib.rs
@@ -6,9 +6,10 @@ pub use mesh_llm_host_runtime::sdk::{
     EmbeddedMeshHttpConfig, EmbeddedMeshLogFormat, EmbeddedMeshNetworkConfig,
     EmbeddedMeshNodeBuilder, EmbeddedMeshNodeConfig, EmbeddedMeshNodeHandle, EmbeddedMeshNodeMode,
     EmbeddedMeshNodeStatus, EmbeddedMeshRequirementsConfig, EmbeddedMeshServingConfig,
-    EmbeddedMeshStorageConfig, EmbeddedServeConfig, EmbeddedServeHandle, EmbeddedServeMode,
-    EmbeddedServeStatus, EmbeddedServingController, EmbeddedTrustPolicy,
-    SIGNED_JOIN_TOKEN_MIN_PROTOCOL_VERSION, start_embedded_node, start_embedded_serve,
+    EmbeddedMeshStorageConfig, EmbeddedProviderRuntimeConfig, EmbeddedServeConfig,
+    EmbeddedServeHandle, EmbeddedServeMode, EmbeddedServeStatus, EmbeddedServingController,
+    EmbeddedTrustPolicy, SIGNED_JOIN_TOKEN_MIN_PROTOCOL_VERSION, start_embedded_node,
+    start_embedded_serve,
 };
 
 pub mod config {

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -88,7 +88,10 @@ pub(crate) use self::operational_logging::{
     NativeSkippyOperationalEvent, RuntimeOperationalEvent, record_native_skippy_operational_event,
     record_runtime_operational_event, record_runtime_operational_event_with_context,
 };
-use self::provider_supervisor::*;
+pub(crate) use self::provider_supervisor::ProviderRuntimeDiscoveryOptions;
+use self::provider_supervisor::{
+    ProviderSupervisorContext, ProviderSupervisorHandle, start_apple_provider_supervisor,
+};
 use self::publication::*;
 pub use self::run_auto::load_resolved_plugins;
 use self::run_auto::*;

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -89,7 +89,7 @@ pub(crate) use self::operational_logging::{
     record_runtime_operational_event, record_runtime_operational_event_with_context,
 };
 pub(crate) use self::provider_supervisor::ProviderRuntimeDiscoveryOptions;
-use self::provider_supervisor::{
+pub(crate) use self::provider_supervisor::{
     ProviderSupervisorContext, ProviderSupervisorHandle, start_apple_provider_supervisor,
 };
 use self::publication::*;

--- a/crates/mesh-llm-host-runtime/src/runtime/provider_supervisor.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/provider_supervisor.rs
@@ -40,6 +40,15 @@ pub(super) struct ProviderSupervisorContext {
     pub(super) console_state: Option<api::MeshApi>,
 }
 
+#[derive(Clone, Debug, Default)]
+pub(crate) struct ProviderRuntimeDiscoveryOptions {
+    pub(crate) bundle_roots: Vec<PathBuf>,
+    pub(crate) release_manifest: Option<PathBuf>,
+    pub(crate) cache_dir: Option<PathBuf>,
+    pub(crate) allow_download: bool,
+    pub(crate) inherit_environment: bool,
+}
+
 pub(super) struct ProviderSupervisorHandle {
     shutdown_tx: watch::Sender<bool>,
     task: JoinHandle<()>,
@@ -98,8 +107,9 @@ impl ProviderSupervisorHandle {
 
 pub(super) async fn start_apple_provider_supervisor(
     context: ProviderSupervisorContext,
+    discovery_options: Option<&ProviderRuntimeDiscoveryOptions>,
 ) -> Option<ProviderSupervisorHandle> {
-    let resolved = match resolve_apple_provider_runtime().await {
+    let resolved = match resolve_apple_provider_runtime(discovery_options).await {
         Ok(Some(runtime)) => runtime,
         Ok(None) => return None,
         Err(error) => {
@@ -123,8 +133,10 @@ pub(super) async fn start_apple_provider_supervisor(
     Some(ProviderSupervisorHandle { shutdown_tx, task })
 }
 
-async fn resolve_apple_provider_runtime() -> Result<Option<InstalledProviderRuntime>> {
-    let discovery = ProviderDiscovery::from_environment()?;
+async fn resolve_apple_provider_runtime(
+    options: Option<&ProviderRuntimeDiscoveryOptions>,
+) -> Result<Option<InstalledProviderRuntime>> {
+    let discovery = ProviderDiscovery::from_options(options)?;
     if !discovery.has_candidates()? {
         return Ok(None);
     }
@@ -154,17 +166,31 @@ struct ProviderDiscovery {
 }
 
 impl ProviderDiscovery {
-    fn from_environment() -> Result<Self> {
-        let cache_dir = provider_cache_dir()?;
-        let mut roots = configured_bundle_roots();
-        roots.extend(default_bundle_roots());
+    fn from_options(options: Option<&ProviderRuntimeDiscoveryOptions>) -> Result<Self> {
+        let inherit_environment = options.is_none_or(|options| options.inherit_environment);
+        let cache_dir = provider_cache_dir(
+            options.and_then(|options| options.cache_dir.clone()),
+            inherit_environment,
+        )?;
+        let roots = discovery_roots(
+            options
+                .map(|options| options.bundle_roots.clone())
+                .unwrap_or_default(),
+            inherit_environment.then(configured_bundle_roots),
+            default_bundle_roots(),
+            inherit_environment,
+        );
         let bundle_dirs = discover_bundle_dirs(&roots)?;
-        let release_manifest = configured_release_manifest()?;
+        let release_manifest = provider_release_manifest(
+            options.and_then(|options| options.release_manifest.as_deref()),
+            inherit_environment,
+        )?;
         Ok(Self {
             bundle_dirs,
             release_manifest,
             cache_dir,
-            allow_download: environment_flag("MESH_LLM_PROVIDER_RUNTIME_DOWNLOAD"),
+            allow_download: options.is_some_and(|options| options.allow_download)
+                || (inherit_environment && environment_flag("MESH_LLM_PROVIDER_RUNTIME_DOWNLOAD")),
         })
     }
 
@@ -176,6 +202,19 @@ impl ProviderDiscovery {
             .list()?
             .is_empty())
     }
+}
+
+fn discovery_roots(
+    mut explicit: Vec<PathBuf>,
+    environment: Option<Vec<PathBuf>>,
+    defaults: Vec<PathBuf>,
+    inherit_environment: bool,
+) -> Vec<PathBuf> {
+    if inherit_environment {
+        explicit.extend(environment.unwrap_or_default());
+    }
+    explicit.extend(defaults);
+    explicit
 }
 
 fn configured_bundle_roots() -> Vec<PathBuf> {
@@ -227,11 +266,20 @@ fn discover_bundle_dirs(roots: &[PathBuf]) -> Result<Vec<PathBuf>> {
     Ok(bundles)
 }
 
-fn configured_release_manifest() -> Result<ProviderRuntimeReleaseManifest> {
-    let Some(path) = std::env::var_os("MESH_LLM_PROVIDER_RUNTIME_INDEX") else {
+fn provider_release_manifest(
+    configured: Option<&Path>,
+    inherit_environment: bool,
+) -> Result<ProviderRuntimeReleaseManifest> {
+    let path = configured.map(Path::to_path_buf).or_else(|| {
+        inherit_environment
+            .then(|| std::env::var_os("MESH_LLM_PROVIDER_RUNTIME_INDEX"))
+            .flatten()
+            .map(PathBuf::from)
+    });
+    let Some(path) = path else {
         return Ok(empty_release_manifest());
     };
-    ProviderRuntimeReleaseManifest::read_from_path(Path::new(&path))
+    ProviderRuntimeReleaseManifest::read_from_path(&path)
 }
 
 fn empty_release_manifest() -> ProviderRuntimeReleaseManifest {
@@ -241,9 +289,14 @@ fn empty_release_manifest() -> ProviderRuntimeReleaseManifest {
     }
 }
 
-fn provider_cache_dir() -> Result<PathBuf> {
-    if let Some(path) = std::env::var_os("MESH_LLM_PROVIDER_RUNTIME_CACHE_DIR") {
-        return Ok(PathBuf::from(path));
+fn provider_cache_dir(configured: Option<PathBuf>, inherit_environment: bool) -> Result<PathBuf> {
+    if let Some(path) = configured {
+        return Ok(path);
+    }
+    if inherit_environment
+        && let Some(path) = std::env::var_os("MESH_LLM_PROVIDER_RUNTIME_CACHE_DIR")
+    {
+        return Ok(path.into());
     }
     dirs::cache_dir()
         .or_else(|| dirs::home_dir().map(|home| home.join(".cache")))
@@ -922,6 +975,38 @@ mod tests {
 
         let discovered = discover_bundle_dirs(&[direct.clone(), parent]).unwrap();
         assert_eq!(discovered, vec![direct, nested]);
+    }
+
+    #[test]
+    fn embedded_discovery_roots_do_not_inherit_process_environment() {
+        let explicit = PathBuf::from("/sdk/resources/provider-runtimes/apple");
+        let environment = PathBuf::from("/process/provider-runtimes");
+        let adjacent = PathBuf::from("/app/Resources/provider-runtimes/apple");
+
+        let roots = discovery_roots(
+            vec![explicit.clone()],
+            Some(vec![environment]),
+            vec![adjacent.clone()],
+            false,
+        );
+
+        assert_eq!(roots, vec![explicit, adjacent]);
+    }
+
+    #[test]
+    fn cli_discovery_roots_retain_environment_and_adjacent_defaults() {
+        let explicit = PathBuf::from("/configured/provider-runtimes");
+        let environment = PathBuf::from("/process/provider-runtimes");
+        let adjacent = PathBuf::from("/bin/provider-runtimes/apple");
+
+        let roots = discovery_roots(
+            vec![explicit.clone()],
+            Some(vec![environment.clone()]),
+            vec![adjacent.clone()],
+            true,
+        );
+
+        assert_eq!(roots, vec![explicit, environment, adjacent]);
     }
 
     #[tokio::test]

--- a/crates/mesh-llm-host-runtime/src/runtime/provider_supervisor.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/provider_supervisor.rs
@@ -34,7 +34,7 @@ const PROVIDER_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
 const PROVIDER_MAX_HEALTH_FAILURES: u8 = 3;
 const PROVIDER_MAX_RESTART_BACKOFF_SECS: u64 = 30;
 
-pub(super) struct ProviderSupervisorContext {
+pub(crate) struct ProviderSupervisorContext {
     pub(super) target_tx: Arc<watch::Sender<election::ModelTargets>>,
     pub(super) dashboard_processes: Arc<tokio::sync::Mutex<Vec<api::RuntimeProcessPayload>>>,
     pub(super) console_state: Option<api::MeshApi>,
@@ -49,7 +49,7 @@ pub(crate) struct ProviderRuntimeDiscoveryOptions {
     pub(crate) inherit_environment: bool,
 }
 
-pub(super) struct ProviderSupervisorHandle {
+pub(crate) struct ProviderSupervisorHandle {
     shutdown_tx: watch::Sender<bool>,
     task: JoinHandle<()>,
 }
@@ -105,7 +105,7 @@ impl ProviderSupervisorHandle {
     }
 }
 
-pub(super) async fn start_apple_provider_supervisor(
+pub(crate) async fn start_apple_provider_supervisor(
     context: ProviderSupervisorContext,
     discovery_options: Option<&ProviderRuntimeDiscoveryOptions>,
 ) -> Option<ProviderSupervisorHandle> {

--- a/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
@@ -5,10 +5,10 @@ use super::status::mesh_guardrail_mode_to_openai;
 use super::{
     AutoRuntimeNodeSetup, BootstrapProxyStopTx, DashboardContextUsage, ManagedModelController,
     ModelTargetReconciliationPolicy, ModelTargetReconciliationState, OpenAiGuardrailPolicyHandle,
-    PreparedRuntimeStartup, ProviderSupervisorContext, ProviderSupervisorHandle,
-    RunAutoAdditionalModelsContext, RunAutoConsoleStateContext, RunAutoRuntimeLifecycleContext,
-    RunAutoServingSurface, RunAutoServingSurfaceContext, RuntimeCapacityLedger,
-    RuntimeDashboardSnapshotProvider, RuntimeEvent, RuntimeInstanceRegistry,
+    PreparedRuntimeStartup, ProviderRuntimeDiscoveryOptions, ProviderSupervisorContext,
+    ProviderSupervisorHandle, RunAutoAdditionalModelsContext, RunAutoConsoleStateContext,
+    RunAutoRuntimeLifecycleContext, RunAutoServingSurface, RunAutoServingSurfaceContext,
+    RuntimeCapacityLedger, RuntimeDashboardSnapshotProvider, RuntimeEvent, RuntimeInstanceRegistry,
     RuntimeModelHandleEntry, RuntimeOperationalEvent, RuntimeOptions,
     RuntimeResourcePlanningProfile, RuntimeSurface, SkippyNativeLogForwardingGuard,
     StartupLocalModelTask, StartupMeshCreationState, StartupModelPlan, StartupModelSpec,
@@ -119,6 +119,7 @@ pub(crate) struct EmbeddedRuntimeOptions {
     pub(crate) config_path: Option<PathBuf>,
     pub(crate) log_format: LogFormat,
     pub(crate) headless: bool,
+    pub(crate) provider_runtimes: ProviderRuntimeDiscoveryOptions,
     pub(crate) control_rx: Option<tokio::sync::mpsc::UnboundedReceiver<api::RuntimeControlRequest>>,
 }
 
@@ -174,7 +175,7 @@ pub(super) fn write_runtime_owner_metadata(
 
 pub(crate) async fn run() -> Result<()> {
     initialize_runtime_entrypoint()?;
-    run_runtime_cli(RuntimeOptions::default(), None, None, None).await
+    run_runtime_cli(RuntimeOptions::default(), None, None, None, None).await
 }
 
 pub(crate) async fn run_cli(
@@ -183,7 +184,7 @@ pub(crate) async fn run_cli(
     legacy_warning: Option<String>,
 ) -> Result<()> {
     initialize_runtime_entrypoint()?;
-    run_runtime_cli(options, explicit_surface, legacy_warning, None).await
+    run_runtime_cli(options, explicit_surface, legacy_warning, None, None).await
 }
 
 pub(crate) async fn run_embedded_runtime(mut options: EmbeddedRuntimeOptions) -> Result<()> {
@@ -193,8 +194,16 @@ pub(crate) async fn run_embedded_runtime(mut options: EmbeddedRuntimeOptions) ->
 
     let surface = options.runtime_surface();
     let control_rx = options.control_rx.take();
+    let provider_runtimes = options.provider_runtimes.clone();
     let options = options_from_embedded_options(options);
-    run_runtime_cli(options, Some(surface), None, control_rx).await
+    run_runtime_cli(
+        options,
+        Some(surface),
+        None,
+        control_rx,
+        Some(provider_runtimes),
+    )
+    .await
 }
 
 pub(super) fn options_from_embedded_options(embedded: EmbeddedRuntimeOptions) -> RuntimeOptions {
@@ -245,6 +254,7 @@ pub(super) async fn run_runtime_cli(
     explicit_surface: Option<RuntimeSurface>,
     legacy_warning: Option<String>,
     embedded_control_rx: Option<tokio::sync::mpsc::UnboundedReceiver<api::RuntimeControlRequest>>,
+    provider_runtime_discovery: Option<ProviderRuntimeDiscoveryOptions>,
 ) -> Result<()> {
     options.validate_discovery_mode_args()?;
 
@@ -344,6 +354,7 @@ pub(super) async fn run_runtime_cli(
         runtime,
         auto_join_candidates,
         embedded_control_rx,
+        provider_runtime_discovery,
     })
     .await
 }
@@ -1322,6 +1333,7 @@ pub(super) struct RunAutoContext {
     pub(super) auto_join_candidates: Vec<(String, Option<String>)>,
     pub(super) embedded_control_rx:
         Option<tokio::sync::mpsc::UnboundedReceiver<api::RuntimeControlRequest>>,
+    pub(super) provider_runtime_discovery: Option<ProviderRuntimeDiscoveryOptions>,
 }
 
 #[expect(
@@ -1339,6 +1351,7 @@ pub(super) async fn run_auto(ctx: RunAutoContext) -> Result<()> {
         runtime,
         auto_join_candidates,
         mut embedded_control_rx,
+        provider_runtime_discovery,
     } = ctx;
     let resolved_plugins = resolve_plugins_from_config(&config, &options)?;
     let swarm_capture = configure_swarm_capture(&options)?;

--- a/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
@@ -254,7 +254,7 @@ pub(super) async fn run_runtime_cli(
     explicit_surface: Option<RuntimeSurface>,
     legacy_warning: Option<String>,
     embedded_control_rx: Option<tokio::sync::mpsc::UnboundedReceiver<api::RuntimeControlRequest>>,
-    provider_runtime_discovery: Option<ProviderRuntimeDiscoveryOptions>,
+    provider_runtimes: Option<ProviderRuntimeDiscoveryOptions>,
 ) -> Result<()> {
     options.validate_discovery_mode_args()?;
 
@@ -354,7 +354,7 @@ pub(super) async fn run_runtime_cli(
         runtime,
         auto_join_candidates,
         embedded_control_rx,
-        provider_runtime_discovery,
+        provider_runtimes,
     })
     .await
 }
@@ -1333,7 +1333,7 @@ pub(super) struct RunAutoContext {
     pub(super) auto_join_candidates: Vec<(String, Option<String>)>,
     pub(super) embedded_control_rx:
         Option<tokio::sync::mpsc::UnboundedReceiver<api::RuntimeControlRequest>>,
-    pub(super) provider_runtime_discovery: Option<ProviderRuntimeDiscoveryOptions>,
+    pub(super) provider_runtimes: Option<ProviderRuntimeDiscoveryOptions>,
 }
 
 #[expect(
@@ -1351,7 +1351,7 @@ pub(super) async fn run_auto(ctx: RunAutoContext) -> Result<()> {
         runtime,
         auto_join_candidates,
         mut embedded_control_rx,
-        provider_runtime_discovery,
+        provider_runtimes,
     } = ctx;
     let resolved_plugins = resolve_plugins_from_config(&config, &options)?;
     let swarm_capture = configure_swarm_capture(&options)?;
@@ -1523,6 +1523,7 @@ pub(super) async fn run_auto(ctx: RunAutoContext) -> Result<()> {
         target_tx.clone(),
         runtime_state.dashboard_processes.clone(),
         console_state.clone(),
+        provider_runtimes.as_ref(),
     )
     .await;
     let startup_ready_reporter = StartupReadyReporter::new_with_failure_policy(
@@ -1596,15 +1597,19 @@ async fn start_run_auto_provider_supervisor(
     target_tx: Arc<tokio::sync::watch::Sender<election::ModelTargets>>,
     dashboard_processes: Arc<tokio::sync::Mutex<Vec<api::RuntimeProcessPayload>>>,
     console_state: Option<api::MeshApi>,
+    discovery_options: Option<&ProviderRuntimeDiscoveryOptions>,
 ) -> Option<ProviderSupervisorHandle> {
     if is_client {
         return None;
     }
-    start_apple_provider_supervisor(ProviderSupervisorContext {
-        target_tx,
-        dashboard_processes,
-        console_state,
-    })
+    start_apple_provider_supervisor(
+        ProviderSupervisorContext {
+            target_tx,
+            dashboard_processes,
+            console_state,
+        },
+        discovery_options,
+    )
     .await
 }
 

--- a/crates/mesh-llm-host-runtime/src/sdk.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk.rs
@@ -140,7 +140,10 @@ impl Drop for EmbeddedServeHandle {
 pub async fn start_embedded_node(
     mut config: EmbeddedMeshNodeConfig,
 ) -> Result<EmbeddedServeHandle> {
-    embedded_startup::prepare_embedded_native_runtime(&config.mode)?;
+    embedded_startup::prepare_embedded_native_runtime(
+        &config.mode,
+        !config.serving.models.is_empty(),
+    )?;
     let isolated_config = prepare_isolated_config(&mut config)?;
     embedded_logging::validate_embedded_config(config.storage.config_path.as_deref())?;
     let (control_tx, control_rx) = tokio::sync::mpsc::unbounded_channel();
@@ -261,6 +264,13 @@ fn embedded_runtime_options(
         config_path: config.storage.config_path.clone(),
         log_format: config.log_format.into(),
         headless: !config.http.console_ui,
+        provider_runtimes: crate::runtime::ProviderRuntimeDiscoveryOptions {
+            bundle_roots: config.provider_runtimes.bundle_roots.clone(),
+            release_manifest: config.provider_runtimes.release_manifest.clone(),
+            cache_dir: config.provider_runtimes.cache_dir.clone(),
+            allow_download: config.provider_runtimes.allow_download,
+            inherit_environment: false,
+        },
         control_rx,
     }
 }
@@ -810,6 +820,10 @@ mod tests {
             .trust_owner("owner-b")
             .min_node_version("0.65.0")
             .signed_join_tokens(true)
+            .provider_runtime_root("/app/Resources/provider-runtimes/apple")
+            .provider_runtime_release_manifest("/app/Resources/provider-runtimes.json")
+            .provider_runtime_cache_dir("/tmp/mesh-provider-cache")
+            .allow_provider_runtime_downloads(true)
             .build();
         let options = embedded_runtime_options(&config, None);
 
@@ -823,6 +837,20 @@ mod tests {
         assert_embedded_runtime_admission_options(&options);
         assert_eq!(options.log_format, mesh_llm_events::LogFormat::Json);
         assert!(options.headless);
+        assert_eq!(
+            options.provider_runtimes.bundle_roots,
+            vec![PathBuf::from("/app/Resources/provider-runtimes/apple")]
+        );
+        assert_eq!(
+            options.provider_runtimes.release_manifest.as_deref(),
+            Some(Path::new("/app/Resources/provider-runtimes.json"))
+        );
+        assert_eq!(
+            options.provider_runtimes.cache_dir.as_deref(),
+            Some(Path::new("/tmp/mesh-provider-cache"))
+        );
+        assert!(options.provider_runtimes.allow_download);
+        assert!(!options.provider_runtimes.inherit_environment);
     }
 
     fn assert_embedded_runtime_network_options(options: &crate::runtime::EmbeddedRuntimeOptions) {

--- a/crates/mesh-llm-host-runtime/src/sdk/embedded_config.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk/embedded_config.rs
@@ -147,6 +147,20 @@ pub struct EmbeddedMeshStorageConfig {
     pub isolated_config: bool,
 }
 
+/// Executable provider runtimes carried by an embedded host application.
+///
+/// Bundle roots may point at either a provider bundle containing
+/// `provider-runtime.json` or a directory whose direct children are bundles.
+/// Embedded hosts use this typed configuration instead of process-global
+/// provider discovery environment variables.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct EmbeddedProviderRuntimeConfig {
+    pub bundle_roots: Vec<PathBuf>,
+    pub release_manifest: Option<PathBuf>,
+    pub cache_dir: Option<PathBuf>,
+    pub allow_download: bool,
+}
+
 impl Default for EmbeddedMeshStorageConfig {
     fn default() -> Self {
         Self {
@@ -164,6 +178,7 @@ pub struct EmbeddedMeshNodeConfig {
     pub network: EmbeddedMeshNetworkConfig,
     pub admission: EmbeddedMeshAdmissionConfig,
     pub storage: EmbeddedMeshStorageConfig,
+    pub provider_runtimes: EmbeddedProviderRuntimeConfig,
     pub log_format: EmbeddedMeshLogFormat,
     pub startup_timeout: Duration,
 }
@@ -177,6 +192,7 @@ impl Default for EmbeddedMeshNodeConfig {
             network: EmbeddedMeshNetworkConfig::default(),
             admission: EmbeddedMeshAdmissionConfig::default(),
             storage: EmbeddedMeshStorageConfig::default(),
+            provider_runtimes: EmbeddedProviderRuntimeConfig::default(),
             log_format: EmbeddedMeshLogFormat::default(),
             startup_timeout: Duration::from_secs(30),
         }
@@ -463,6 +479,35 @@ impl EmbeddedMeshNodeBuilder {
         self
     }
 
+    pub fn provider_runtime_root(mut self, path: impl Into<PathBuf>) -> Self {
+        self.config.provider_runtimes.bundle_roots.push(path.into());
+        self
+    }
+
+    pub fn provider_runtime_roots<I, P>(mut self, paths: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        self.config.provider_runtimes.bundle_roots = paths.into_iter().map(Into::into).collect();
+        self
+    }
+
+    pub fn provider_runtime_release_manifest(mut self, path: impl Into<PathBuf>) -> Self {
+        self.config.provider_runtimes.release_manifest = Some(path.into());
+        self
+    }
+
+    pub fn provider_runtime_cache_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.config.provider_runtimes.cache_dir = Some(path.into());
+        self
+    }
+
+    pub fn allow_provider_runtime_downloads(mut self, allowed: bool) -> Self {
+        self.config.provider_runtimes.allow_download = allowed;
+        self
+    }
+
     pub fn log_format(mut self, format: EmbeddedMeshLogFormat) -> Self {
         self.config.log_format = format;
         self
@@ -504,6 +549,7 @@ pub struct EmbeddedServeConfig {
     pub admission: EmbeddedMeshAdmissionConfig,
     pub config_path: Option<PathBuf>,
     pub isolated_config: bool,
+    pub provider_runtimes: EmbeddedProviderRuntimeConfig,
     pub log_format: EmbeddedMeshLogFormat,
     pub startup_timeout: Duration,
 }
@@ -535,6 +581,7 @@ impl Default for EmbeddedServeConfig {
             admission: EmbeddedMeshAdmissionConfig::default(),
             config_path: None,
             isolated_config: true,
+            provider_runtimes: EmbeddedProviderRuntimeConfig::default(),
             log_format: EmbeddedMeshLogFormat::default(),
             startup_timeout: Duration::from_secs(30),
         }
@@ -576,6 +623,7 @@ impl From<EmbeddedServeConfig> for EmbeddedMeshNodeConfig {
                 config_path: config.config_path,
                 isolated_config: config.isolated_config,
             },
+            provider_runtimes: config.provider_runtimes,
             log_format: config.log_format,
             startup_timeout: config.startup_timeout,
         }
@@ -609,6 +657,7 @@ impl From<EmbeddedMeshNodeConfig> for EmbeddedServeConfig {
             admission: config.admission,
             config_path: config.storage.config_path,
             isolated_config: config.storage.isolated_config,
+            provider_runtimes: config.provider_runtimes,
             log_format: config.log_format,
             startup_timeout: config.startup_timeout,
         }

--- a/crates/mesh-llm-host-runtime/src/sdk/embedded_startup.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk/embedded_startup.rs
@@ -3,10 +3,16 @@ use anyhow::Result;
 #[cfg(any(feature = "dynamic-native-runtime", test))]
 use std::path::Path;
 
-pub(super) fn prepare_embedded_native_runtime(mode: &EmbeddedMeshNodeMode) -> Result<()> {
+pub(super) fn prepare_embedded_native_runtime(
+    mode: &EmbeddedMeshNodeMode,
+    has_native_models: bool,
+) -> Result<()> {
     #[cfg(feature = "dynamic-native-runtime")]
     {
-        if *mode == EmbeddedMeshNodeMode::Client || skippy_runtime::native_runtime_loaded() {
+        if *mode == EmbeddedMeshNodeMode::Client
+            || !has_native_models
+            || skippy_runtime::native_runtime_loaded()
+        {
             return Ok(());
         }
         let cache = crate::system::native_runtime_install::default_native_runtime_cache()?;
@@ -20,11 +26,11 @@ pub(super) fn prepare_embedded_native_runtime(mode: &EmbeddedMeshNodeMode) -> Re
             crate::system::native_runtime::load_local_native_runtime_for_embedded_serving()?
                 .is_some()
                 || skippy_runtime::native_runtime_loaded();
-        ensure_embedded_native_runtime_ready(mode, loaded, requirement)?;
+        ensure_embedded_native_runtime_ready(mode, has_native_models, loaded, requirement)?;
     }
     #[cfg(not(feature = "dynamic-native-runtime"))]
     {
-        let _ = mode;
+        let _ = (mode, has_native_models);
     }
     Ok(())
 }
@@ -39,10 +45,11 @@ struct EmbeddedNativeRuntimeRequirement<'a> {
 #[cfg(any(feature = "dynamic-native-runtime", test))]
 fn ensure_embedded_native_runtime_ready(
     mode: &EmbeddedMeshNodeMode,
+    has_native_models: bool,
     loaded: bool,
     requirement: EmbeddedNativeRuntimeRequirement<'_>,
 ) -> Result<()> {
-    if *mode == EmbeddedMeshNodeMode::Client || loaded {
+    if *mode == EmbeddedMeshNodeMode::Client || !has_native_models || loaded {
         return Ok(());
     }
     anyhow::bail!(missing_native_runtime_message(requirement));
@@ -74,6 +81,7 @@ mod tests {
     fn missing_embedded_serve_runtime_error_names_versions_cache_and_fix() {
         let error = ensure_embedded_native_runtime_ready(
             &EmbeddedMeshNodeMode::Serve,
+            true,
             false,
             requirement(),
         )
@@ -89,13 +97,34 @@ mod tests {
 
     #[test]
     fn embedded_client_does_not_require_native_serving_runtime() {
-        ensure_embedded_native_runtime_ready(&EmbeddedMeshNodeMode::Client, false, requirement())
-            .expect("client-only embedding should not require a serving runtime");
+        ensure_embedded_native_runtime_ready(
+            &EmbeddedMeshNodeMode::Client,
+            true,
+            false,
+            requirement(),
+        )
+        .expect("client-only embedding should not require a serving runtime");
+    }
+
+    #[test]
+    fn provider_only_serve_does_not_require_native_serving_runtime() {
+        ensure_embedded_native_runtime_ready(
+            &EmbeddedMeshNodeMode::Serve,
+            false,
+            false,
+            requirement(),
+        )
+        .expect("provider-only embedded serving should not require Skippy");
     }
 
     #[test]
     fn loaded_native_runtime_allows_embedded_serve() {
-        ensure_embedded_native_runtime_ready(&EmbeddedMeshNodeMode::Serve, true, requirement())
-            .expect("loaded runtime should allow embedded serving");
+        ensure_embedded_native_runtime_ready(
+            &EmbeddedMeshNodeMode::Serve,
+            true,
+            true,
+            requirement(),
+        )
+        .expect("loaded runtime should allow embedded serving");
     }
 }

--- a/crates/mesh-llm-sdk/Cargo.toml
+++ b/crates/mesh-llm-sdk/Cargo.toml
@@ -10,6 +10,10 @@ readme = "README.md"
 keywords = ["llm", "mesh", "sdk", "inference"]
 categories = ["api-bindings", "network-programming"]
 
+[[example]]
+name = "apple_system"
+required-features = ["serving"]
+
 [features]
 default = ["client"]
 client = ["dep:mesh-llm-api-client"]
@@ -39,3 +43,6 @@ mesh-llm-runtime-install = { path = "../mesh-llm-runtime-install", version = "0.
 reqwest = { version = "0.12", features = ["json"], optional = true }
 serde = { workspace = true, optional = true }
 serde_json = { workspace = true, optional = true }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread", "time"] }

--- a/crates/mesh-llm-sdk/README.md
+++ b/crates/mesh-llm-sdk/README.md
@@ -69,6 +69,47 @@ let status = node.status().await?;
 node.shutdown().await?;
 ```
 
+## Packaged Provider Runtimes
+
+Host-capable SDK applications can carry executable provider runtimes in their
+own resources and pass those resource paths through typed configuration. The
+shared host resolver still verifies the manifest, payload hashes, platform,
+protocol, signature policy, and lifecycle; the SDK does not interpret an Apple
+bundle or bind Foundation Models itself.
+
+On Apple silicon with macOS Golden Gate, package the experimental sidecar and
+point the embedded host at either the bundle itself or its parent directory:
+
+```rust,no_run
+use mesh_llm_sdk::MeshNode;
+
+let node = MeshNode::builder()
+    .serve()
+    .provider_runtime_root(
+        "/Applications/MyApp.app/Contents/Resources/provider-runtimes/apple",
+    )
+    .start()
+    .await?;
+
+let models = node.openai_client().models().await?;
+node.shutdown().await?;
+```
+
+Provider-only embedded serving does not require a Skippy native runtime. Add a
+native runtime only when the same embedded host also loads GGUF models through
+`.model(...)`. Embedded provider discovery deliberately ignores
+`MESH_LLM_PROVIDER_RUNTIME_BUNDLE_DIR`,
+`MESH_LLM_PROVIDER_RUNTIME_INDEX`, and the provider download flag: SDK carriers
+must supply roots, an optional release manifest/cache, and download permission
+through the builder. This avoids process-global discovery collisions when more
+than one SDK host exists in an application.
+
+The complete Golden Gate example includes a versioned completion and tool call:
+
+```bash
+just apple::rust-sdk
+```
+
 ## Check and Install the Required Native Runtime
 
 Embedded serving requires a native runtime matching both the exact

--- a/crates/mesh-llm-sdk/examples/apple_system.rs
+++ b/crates/mesh-llm-sdk/examples/apple_system.rs
@@ -1,0 +1,103 @@
+use anyhow::{Context, Result, bail};
+use mesh_llm_sdk::MeshNode;
+use serde_json::{Value, json};
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::time::Duration;
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    let provider_root = std::env::args_os()
+        .nth(1)
+        .map(PathBuf::from)
+        .context("usage: apple_system <provider-runtime-bundle-or-parent>")?;
+    let api_port = free_local_port()?;
+    let console_port = free_local_port()?;
+    let node = MeshNode::builder()
+        .serve()
+        .provider_runtime_root(provider_root)
+        .api_port(api_port)
+        .console_port(console_port)
+        .startup_timeout(Duration::from_secs(30))
+        .start()
+        .await?;
+    let openai = node.openai_client();
+    let versioned_model = wait_for_apple_model(&openai).await?;
+    let completion = openai
+        .chat_completions(json!({
+            "model": versioned_model,
+            "messages": [{
+                "role": "user",
+                "content": "Reply with exactly: rust sdk apple ready"
+            }],
+            "temperature": 0,
+            "max_tokens": 32
+        }))
+        .await?;
+    let tool = openai
+        .chat_completions(json!({
+            "model": "apple/system",
+            "messages": [{
+                "role": "user",
+                "content": "Use the tool with key: rust-sdk"
+            }],
+            "tools": [{
+                "type": "function",
+                "function": {
+                    "name": "mesh_fixture_lookup",
+                    "description": "Look up a fixture",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {"key": {"type": "string"}},
+                        "required": ["key"]
+                    }
+                }
+            }],
+            "temperature": 0
+        }))
+        .await?;
+    println!(
+        "{}",
+        serde_json::to_string_pretty(&json!({
+            "status": "pass",
+            "model": "apple/system",
+            "versioned_model": versioned_model,
+            "provider_discovery": "rust_sdk_typed_config",
+            "completion_content": completion_content(&completion),
+            "tool_executions": tool.get("mesh_tool_executions"),
+        }))?
+    );
+    node.shutdown().await
+}
+
+async fn wait_for_apple_model(client: &mesh_llm_sdk::OpenAiClient) -> Result<String> {
+    for _ in 0..300 {
+        if let Ok(models) = client.models().await
+            && let Some(model) = versioned_apple_model(&models)
+        {
+            return Ok(model);
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    bail!("apple/system did not become available through the embedded Rust SDK host")
+}
+
+fn versioned_apple_model(models: &Value) -> Option<String> {
+    models.get("data")?.as_array()?.iter().find_map(|model| {
+        model
+            .get("id")?
+            .as_str()
+            .filter(|id| id.starts_with("apple/system@"))
+            .map(str::to_string)
+    })
+}
+
+fn completion_content(completion: &Value) -> Option<&str> {
+    completion
+        .pointer("/choices/0/message/content")
+        .and_then(Value::as_str)
+}
+
+fn free_local_port() -> Result<u16> {
+    Ok(TcpListener::bind(("127.0.0.1", 0))?.local_addr()?.port())
+}

--- a/crates/mesh-llm-sdk/src/embedded_node.rs
+++ b/crates/mesh-llm-sdk/src/embedded_node.rs
@@ -6,7 +6,7 @@ pub use mesh_llm_embedded_runtime::{
     EmbeddedMeshAdmissionConfig, EmbeddedMeshDiscoveryMode, EmbeddedMeshHttpConfig,
     EmbeddedMeshLogFormat, EmbeddedMeshNetworkConfig, EmbeddedMeshNodeConfig, EmbeddedMeshNodeMode,
     EmbeddedMeshRequirementsConfig, EmbeddedMeshServingConfig, EmbeddedMeshStorageConfig,
-    EmbeddedTrustPolicy, SIGNED_JOIN_TOKEN_MIN_PROTOCOL_VERSION,
+    EmbeddedProviderRuntimeConfig, EmbeddedTrustPolicy, SIGNED_JOIN_TOKEN_MIN_PROTOCOL_VERSION,
 };
 
 pub type MeshNodeStatus = mesh_llm_embedded_runtime::EmbeddedMeshNodeStatus;
@@ -305,6 +305,35 @@ impl MeshNodeBuilder {
         self
     }
 
+    pub fn provider_runtime_root(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.provider_runtime_root(path);
+        self
+    }
+
+    pub fn provider_runtime_roots<I, P>(mut self, paths: I) -> Self
+    where
+        I: IntoIterator<Item = P>,
+        P: Into<PathBuf>,
+    {
+        self.inner = self.inner.provider_runtime_roots(paths);
+        self
+    }
+
+    pub fn provider_runtime_release_manifest(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.provider_runtime_release_manifest(path);
+        self
+    }
+
+    pub fn provider_runtime_cache_dir(mut self, path: impl Into<PathBuf>) -> Self {
+        self.inner = self.inner.provider_runtime_cache_dir(path);
+        self
+    }
+
+    pub fn allow_provider_runtime_downloads(mut self, allowed: bool) -> Self {
+        self.inner = self.inner.allow_provider_runtime_downloads(allowed);
+        self
+    }
+
     pub fn log_format(mut self, format: EmbeddedMeshLogFormat) -> Self {
         self.inner = self.inner.log_format(format);
         self
@@ -414,6 +443,7 @@ mod tests {
             .serve()
             .model("unsloth/Qwen3-0.6B-GGUF:Q4_K_M")
             .auto_join_public_mesh()
+            .provider_runtime_root("/app/Resources/provider-runtimes/apple")
             .api_port(19447)
             .console_port(13141)
             .build();
@@ -430,6 +460,10 @@ mod tests {
         );
         assert_eq!(config.http.api_port, 19447);
         assert_eq!(config.http.console_port, 13141);
+        assert_eq!(
+            config.provider_runtimes.bundle_roots,
+            vec![PathBuf::from("/app/Resources/provider-runtimes/apple")]
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-sdk/src/lib.rs
+++ b/crates/mesh-llm-sdk/src/lib.rs
@@ -40,10 +40,10 @@ pub mod embedded_runtime {
         EmbeddedMeshHttpConfig, EmbeddedMeshLogFormat, EmbeddedMeshNetworkConfig,
         EmbeddedMeshNodeBuilder, EmbeddedMeshNodeConfig, EmbeddedMeshNodeHandle,
         EmbeddedMeshNodeMode, EmbeddedMeshNodeStatus, EmbeddedMeshRequirementsConfig,
-        EmbeddedMeshServingConfig, EmbeddedMeshStorageConfig, EmbeddedServeConfig,
-        EmbeddedServeHandle, EmbeddedServeMode, EmbeddedServeStatus, EmbeddedServingController,
-        EmbeddedTrustPolicy, SIGNED_JOIN_TOKEN_MIN_PROTOCOL_VERSION, initialize_host_runtime,
-        start_embedded_node, start_embedded_serve,
+        EmbeddedMeshServingConfig, EmbeddedMeshStorageConfig, EmbeddedProviderRuntimeConfig,
+        EmbeddedServeConfig, EmbeddedServeHandle, EmbeddedServeMode, EmbeddedServeStatus,
+        EmbeddedServingController, EmbeddedTrustPolicy, SIGNED_JOIN_TOKEN_MIN_PROTOCOL_VERSION,
+        initialize_host_runtime, start_embedded_node, start_embedded_serve,
     };
 }
 
@@ -172,6 +172,14 @@ pub struct AdmissionConfig {
 pub struct ServingConfig {
     pub models: Vec<String>,
     pub max_vram_gb: Option<f64>,
+}
+
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct ProviderRuntimeConfig {
+    pub bundle_roots: Vec<PathBuf>,
+    pub release_manifest: Option<PathBuf>,
+    pub cache_dir: Option<PathBuf>,
+    pub allow_download: bool,
 }
 
 #[cfg(feature = "serving")]
@@ -411,6 +419,36 @@ macro_rules! impl_common_builder_methods {
             self
         }
 
+        pub fn provider_runtime_root(mut self, path: impl Into<PathBuf>) -> Self {
+            self.config.provider_runtimes.bundle_roots.push(path.into());
+            self
+        }
+
+        pub fn provider_runtime_roots<I, P>(mut self, paths: I) -> Self
+        where
+            I: IntoIterator<Item = P>,
+            P: Into<PathBuf>,
+        {
+            self.config.provider_runtimes.bundle_roots =
+                paths.into_iter().map(Into::into).collect();
+            self
+        }
+
+        pub fn provider_runtime_release_manifest(mut self, path: impl Into<PathBuf>) -> Self {
+            self.config.provider_runtimes.release_manifest = Some(path.into());
+            self
+        }
+
+        pub fn provider_runtime_cache_dir(mut self, path: impl Into<PathBuf>) -> Self {
+            self.config.provider_runtimes.cache_dir = Some(path.into());
+            self
+        }
+
+        pub fn allow_provider_runtime_downloads(mut self, allowed: bool) -> Self {
+            self.config.provider_runtimes.allow_download = allowed;
+            self
+        }
+
         pub fn log_format(mut self, format: LogFormat) -> Self {
             self.config.log_format = format;
             self
@@ -486,6 +524,7 @@ pub mod client {
         pub network: NetworkConfig,
         pub admission: AdmissionConfig,
         pub storage: StorageConfig,
+        pub provider_runtimes: ProviderRuntimeConfig,
         pub log_format: LogFormat,
         pub startup_timeout: Duration,
     }
@@ -497,6 +536,7 @@ pub mod client {
                 network: NetworkConfig::default(),
                 admission: AdmissionConfig::default(),
                 storage: StorageConfig::default(),
+                provider_runtimes: ProviderRuntimeConfig::default(),
                 log_format: LogFormat::default(),
                 startup_timeout: Duration::from_secs(30),
             }
@@ -529,6 +569,7 @@ pub mod client {
             network: config.network,
             admission: config.admission,
             storage: config.storage,
+            provider_runtimes: config.provider_runtimes,
             serving: ServingConfig::default(),
             log_format: config.log_format,
             startup_timeout: config.startup_timeout,
@@ -547,6 +588,7 @@ pub mod serve {
         pub network: NetworkConfig,
         pub admission: AdmissionConfig,
         pub storage: StorageConfig,
+        pub provider_runtimes: ProviderRuntimeConfig,
         pub serving: ServingConfig,
         pub log_format: LogFormat,
         pub startup_timeout: Duration,
@@ -559,6 +601,7 @@ pub mod serve {
                 network: NetworkConfig::default(),
                 admission: AdmissionConfig::default(),
                 storage: StorageConfig::default(),
+                provider_runtimes: ProviderRuntimeConfig::default(),
                 serving: ServingConfig::default(),
                 log_format: LogFormat::default(),
                 startup_timeout: Duration::from_secs(30),
@@ -611,6 +654,7 @@ pub mod serve {
             network: config.network,
             admission: config.admission,
             storage: config.storage,
+            provider_runtimes: config.provider_runtimes,
             serving: config.serving,
             log_format: config.log_format,
             startup_timeout: config.startup_timeout,
@@ -634,6 +678,7 @@ struct EmbeddedNodeParts {
     network: NetworkConfig,
     admission: AdmissionConfig,
     storage: StorageConfig,
+    provider_runtimes: ProviderRuntimeConfig,
     serving: ServingConfig,
     log_format: LogFormat,
     startup_timeout: Duration,
@@ -716,6 +761,12 @@ fn host_config(parts: EmbeddedNodeParts) -> mesh_llm_embedded_runtime::EmbeddedM
             config_path: parts.storage.config_path,
             isolated_config: parts.storage.isolated_config,
         },
+        provider_runtimes: mesh_llm_embedded_runtime::EmbeddedProviderRuntimeConfig {
+            bundle_roots: parts.provider_runtimes.bundle_roots,
+            release_manifest: parts.provider_runtimes.release_manifest,
+            cache_dir: parts.provider_runtimes.cache_dir,
+            allow_download: parts.provider_runtimes.allow_download,
+        },
         log_format: match parts.log_format {
             LogFormat::Pretty => mesh_llm_embedded_runtime::EmbeddedMeshLogFormat::Pretty,
             LogFormat::Json => mesh_llm_embedded_runtime::EmbeddedMeshLogFormat::Json,
@@ -758,6 +809,7 @@ mod tests {
             .model("unsloth/Qwen3-0.6B-GGUF:Q4_K_M")
             .max_vram_gb(6.0)
             .mesh_name("sprout")
+            .provider_runtime_root("/app/Resources/provider-runtimes/apple")
             .build();
 
         assert_eq!(
@@ -766,6 +818,10 @@ mod tests {
         );
         assert_eq!(config.serving.max_vram_gb, Some(6.0));
         assert_eq!(config.network.mesh_name.as_deref(), Some("sprout"));
+        assert_eq!(
+            config.provider_runtimes.bundle_roots,
+            vec![PathBuf::from("/app/Resources/provider-runtimes/apple")]
+        );
     }
 
     #[test]

--- a/docs/design/APPLE_RUNTIME.md
+++ b/docs/design/APPLE_RUNTIME.md
@@ -214,6 +214,7 @@ just apple::live
 just apple::mesh
 just apple::product 0.72.1 target/apple-runtime/product
 just apple::product-qa 0.72.1 target/apple-runtime/product
+just apple::rust-sdk
 MESH_APPLE_RUNTIME_CODESIGN_IDENTITY="Mesh-LLM Local Codesign" \
   just apple::rest
 MESH_APPLE_RUNTIME_CODESIGN_IDENTITY="Mesh-LLM Local Codesign" \
@@ -252,6 +253,7 @@ Observed live results:
 | Core AI Instruments accelerator trace | pass; ANE load/prediction observed |
 | Supervisor SIGKILL/orphan prevention | pass; provider child exited |
 | Release-shaped CLI product auto-discovery | pass; no bundle/index override |
+| Rust SDK typed provider carrier | pass; completion and tool call |
 
 A representative deterministic text request completed in 2.30 seconds with a
 1.81-second time to first token, 73 input tokens, and 25 output tokens. A
@@ -345,12 +347,13 @@ MeshLLM's normal local OpenAI frontend and runtime-process management surface.
 ### 2. All host-capable macOS SDKs
 
 The shared executable-provider manifest, resolver, verified downloader,
-immutable cache contract, Rust host supervisor, CLI product composition, and
-adjacent-product auto-discovery are implemented. The release lane requires a
+immutable cache contract, Rust host supervisor, CLI product composition,
+adjacent-product auto-discovery, and typed Rust SDK carrier configuration are
+implemented. Provider-only Rust SDK hosts do not load Skippy. The release lane requires a
 Developer ID Application signature, secure timestamp, accepted notarization,
 and `spctl` assessment before composition. Next, publish that one signed macOS
-arm64 artifact and bind the Rust, Swift, Node/Electron, and Kotlin/JVM SDK
-surfaces to the same installation and host lifecycle contract. Validate Swift
+arm64 artifact and bind the Swift, Node/Electron, and Kotlin/JVM SDK surfaces
+to the same installation and host lifecycle contract. Validate Swift
 app embedding, sandboxing, quarantine, and launchd/service lifecycles, then
 certify every SDK against one protocol test suite.
 

--- a/docs/design/PROVIDER_RUNTIMES.md
+++ b/docs/design/PROVIDER_RUNTIMES.md
@@ -156,5 +156,11 @@ provider supervisor, which owns platform policy, process lifecycle, health, and
 local route registration.
 
 The next stacked layer packages that same artifact and lifecycle for every
-host-capable macOS SDK. SDKs remain thin carriers or clients: they must not
-reimplement Foundation Models semantics or create divergent sidecars.
+host-capable macOS SDK. The Rust SDK now accepts carrier bundle roots, an
+optional release index/cache, and explicit download permission through its
+embedded-node builder. The typed configuration flows into the same resolver
+without mutating or inheriting process-global provider discovery environment.
+Provider-only Rust hosts also skip the unrelated Skippy native-runtime load.
+Swift, Node/Electron, and Kotlin/JVM should map their resource locations into
+this contract rather than reimplement Foundation Models semantics or create
+divergent sidecars.

--- a/providers/apple/Justfile
+++ b/providers/apple/Justfile
@@ -73,6 +73,10 @@ product-qa mesh_version output="target/apple-runtime/product":
     @just --justfile "{{ apple_root }}/../../Justfile" \
       apple::product-smoke "{{ mesh_version }}" "{{ output }}"
 
+# Drive the Apple provider through typed Rust SDK carrier configuration.
+rust-sdk: package
+    @"{{ apple_root }}/QA/rust-sdk.sh"
+
 # Verify one signed runtime from CLI, Swift, Node, and JVM carrier layouts.
 carriers: package
     @"{{ apple_root }}/QA/carriers.sh"

--- a/providers/apple/QA/rust-sdk.sh
+++ b/providers/apple/QA/rust-sdk.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APPLE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$APPLE_ROOT/../.." && pwd)"
+PACKAGE_ROOT="$REPO_ROOT/target/apple-runtime/package/meshllm-apple-runtime-darwin-arm64"
+OUTPUT_DIR="$REPO_ROOT/target/apple-runtime/rust-sdk"
+SUMMARY="$OUTPUT_DIR/summary.json"
+
+[[ -f "$PACKAGE_ROOT/provider-runtime.json" ]] || {
+    echo "missing packaged Apple provider; run just apple::package" >&2
+    exit 2
+}
+
+mkdir -p "$OUTPUT_DIR"
+MESH_LLM_PROVIDER_RUNTIME_BUNDLE_DIR=/invalid/embedded-sdk-must-ignore-environment \
+MESH_LLM_PROVIDER_RUNTIME_INDEX=/invalid/embedded-sdk-must-ignore-environment.json \
+MESH_LLM_PROVIDER_RUNTIME_CACHE_DIR="$OUTPUT_DIR/provider-cache" \
+MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC=1 \
+    just --justfile "$REPO_ROOT/Justfile" with-lld \
+        cargo run --quiet -p mesh-llm-sdk --features serving \
+        --example apple_system -- "$PACKAGE_ROOT" \
+        >"$SUMMARY"
+
+python3 - "$SUMMARY" <<'PY'
+import json
+import pathlib
+import sys
+
+summary = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert summary["status"] == "pass", summary
+assert summary["provider_discovery"] == "rust_sdk_typed_config", summary
+assert summary["versioned_model"] == "apple/system@27.0", summary
+assert summary["completion_content"] == "rust sdk apple ready", summary
+executions = summary["tool_executions"]
+assert executions == [{
+    "name": "mesh_fixture_lookup",
+    "arguments": {"key": "rust-sdk"},
+    "result": "mesh-fixture-value-for-rust-sdk",
+}], summary
+print(json.dumps(summary, indent=2, sort_keys=True))
+PY

--- a/providers/apple/README.md
+++ b/providers/apple/README.md
@@ -306,6 +306,7 @@ select artifacts and policy with:
 just apple::live
 just apple::contract
 just apple::mesh
+just apple::rust-sdk
 just apple::carriers
 just apple::launchd
 just apple::instruments
@@ -318,6 +319,12 @@ files under `target/apple-runtime/instruments/`. Only its aggregate
 
 `just apple::contract` verifies `provider-runtime.json`, every declared file
 digest, and the executable bit through the shared Rust provider-runtime crate.
+
+`just apple::rust-sdk` starts a provider-only embedded MeshLLM node through the
+public Rust SDK builder. It supplies the carrier root through typed
+configuration while setting invalid process discovery variables, then proves
+`apple/system@27.0`, completion, and tool execution. This path intentionally
+does not install or load a Skippy runtime.
 
 ## Packaging and signing
 
@@ -382,7 +389,7 @@ caveats, and rollout gates.
 |---|---|---|
 | 0 | Policy, entitlement, packaging, signing, launchd, and accelerator spike | complete |
 | 1 | Local `apple/system` REST vertical slice | experimental implementation complete |
-| 2 | All host-capable macOS SDKs drive the same runtime lifecycle | CLI release packaging and auto-discovery implemented; SDK carrier publication and bindings pending |
+| 2 | All host-capable macOS SDKs drive the same runtime lifecycle | CLI and Rust SDK carriers implemented; Swift, Node/Electron, and Kotlin/JVM pending |
 | 3 | Private-mesh routing, load, failover, affinity, and withdrawal | not implemented |
 
 This runtime does not alter the Skippy ABI or use Skippy stage execution.


### PR DESCRIPTION
## Experimental: Rust SDK carrier for Apple system models

> This is an experimental stacked PR. Trying the live Apple path requires Apple silicon running macOS Golden Gate with Foundation Models availability.

Tracks #1246. This PR stacks on #1255 (release packaging and adjacent discovery), which stacks on #1252 (host supervisor and versioned `apple/system`).

## Why

Host-capable SDKs should carry one signed Apple sidecar as an application resource and hand its location to the shared MeshLLM host. They should not mutate process-global environment variables, interpret provider manifests themselves, or reimplement Foundation Models behavior.

For Rust applications this makes the system model a normal embedded MeshLLM serving resource: private on-device inference, no model download, no model weights in application memory, the same OpenAI-compatible REST surface, and the same provider validation, supervision, routing, cancellation, usage, error, and shutdown behavior as the CLI product. A provider-only application also has no reason to install or load Skippy.

## What changed

- adds typed provider-runtime carrier configuration to `mesh-llm-sdk` and `mesh-llm-embedded-runtime`
- accepts bundle roots, an optional signed release manifest, an optional cache directory, and explicit download permission
- passes those values into the existing shared provider resolver without mutating or inheriting provider discovery environment variables
- keeps adjacent product discovery available for conventionally packaged applications
- lets provider-only embedded hosts start without a Skippy native runtime; a Skippy runtime remains required when `.model(...)` loads a GGUF model
- adds a public Rust example and Golden Gate QA lane that proves versioned model discovery, a completion, tool execution, and clean shutdown over the SDK-owned REST endpoint

This does not add an Apple compatibility alias or legacy provider path. The Apple surface remains the canonical `apple/system` alias plus the runtime-reported versioned ID, currently `apple/system@27.0` on Golden Gate.

## Try it on macOS Golden Gate

1. Install and select the current Golden Gate Xcode toolchain.
2. Confirm Foundation Models is available for the signed process on an Apple-silicon Mac.
3. From the repository root, run:

   ```bash
   just apple::rust-sdk
   ```

   This packages the experimental Apple provider, starts a provider-only embedded node through the public Rust SDK, deliberately sets invalid process discovery variables to prove the typed carrier path owns discovery, calls `/v1/models` and `/v1/chat/completions`, and shuts the node down.

4. To embed the same path in a Rust application:

   ```rust
   use mesh_llm_sdk::MeshNode;

   let node = MeshNode::builder()
       .serve()
       .provider_runtime_root(
           "/Applications/MyApp.app/Contents/Resources/provider-runtimes/apple",
       )
       .start()
       .await?;

   let models = node.openai_client().models().await?;
   node.shutdown().await?;
   ```

The resource path may name the provider bundle itself or a parent directory whose direct children are provider bundles.

## Captured Golden Gate output

```json
{
  "completion_content": "rust sdk apple ready",
  "model": "apple/system",
  "provider_discovery": "rust_sdk_typed_config",
  "status": "pass",
  "tool_executions": [
    {
      "arguments": {
        "key": "rust-sdk"
      },
      "name": "mesh_fixture_lookup",
      "result": "mesh-fixture-value-for-rust-sdk"
    }
  ],
  "versioned_model": "apple/system@27.0"
}
```

## Validation

- `just build`
- `just with-lld cargo test -p mesh-llm-sdk --features serving --lib`
- `just with-lld cargo test -p mesh-llm-sdk --features serving`
- `just with-lld cargo test -p mesh-llm-host-runtime provider_supervisor --lib`
- `just with-lld cargo clippy -p mesh-llm-host-runtime --lib -- -A unfulfilled-lint-expectations -D warnings`
- `just with-lld cargo clippy -p mesh-llm-sdk --features serving --all-targets -- -A unfulfilled-lint-expectations -D warnings`
- `bash -n providers/apple/QA/rust-sdk.sh`
- `shellcheck providers/apple/QA/rust-sdk.sh`
- `just apple::rust-sdk` on macOS Golden Gate

## Stack roadmap

This is the Rust SDK carrier slice of Phase 2. Follow-up stacked PRs can map Swift application resources, Node/Electron resources, and Kotlin/JVM resources into this same typed host contract. Private-mesh advertisement, routing, load balancing, failover, affinity, and withdrawal remain Phase 3.
