### PR TITLE
chore(deps): pin iroh to 1.0.3 explicitly

### DIFF
--- a/crates/mesh-client/Cargo.toml
+++ b/crates/mesh-client/Cargo.toml
@@ -22,7 +22,7 @@ host-io = ["mesh-llm-identity/host-io"]
 # model-artifact, iroh, tokio, prost, bytes, rustls, quinn, serde, serde_json, thiserror, anyhow,
 # tracing, sha2, ed25519-dalek, hex, uuid, url, http, base64, async-trait, httparse
 # (httparse is a transitive dep of iroh; not in forbidden list)
-iroh = { version = "1.0.0", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
+iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
 mesh-llm-identity = { path = "../mesh-llm-identity", version = "0.72.1", default-features = false }
 mesh-llm-protocol = { path = "../mesh-llm-protocol", version = "0.72.1" }
 mesh-llm-routing = { path = "../mesh-llm-routing", version = "0.72.1" }

--- a/crates/mesh-llm-commands/Cargo.toml
+++ b/crates/mesh-llm-commands/Cargo.toml
@@ -20,7 +20,7 @@ chrono = { version = "0.4", features = ["serde"] }
 dirs = "6.0.0"
 hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.2", default-features = false, features = ["blocking"] }
 hex = "0.4.3"
-iroh = { version = "1.0.0", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
+iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
 json5 = "1.3.1"
 nix = { version = "0.29.0", default-features = false, features = ["signal"] }
 mesh-llm-build-info.workspace = true

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -56,7 +56,7 @@ skippy-runtime = { path = "../skippy-runtime", version = "0.72.1"  }
 skippy-ffi = { path = "../skippy-ffi", version = "0.72.1", default-features = false }
 skippy-server = { path = "../skippy-server", version = "0.72.1"  }
 skippy-topology = { path = "../skippy-topology", version = "0.72.1"  }
-iroh = { version = "1.0.0", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
+iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"
@@ -119,5 +119,5 @@ mesh-client = { package = "mesh-llm-client", path = "../mesh-client", version = 
 # with AccessConfig::Restricted, then build a real iroh::Endpoint from our
 # relay_map_from_urls output and verify --relay-auth tokens reach the relay
 # on the WebSocket upgrade (and that the wrong token is rejected).
-iroh = { version = "1.0.0", features = ["test-utils"] }
-iroh-relay = { version = "1.0.0", features = ["server", "test-utils"] }
+iroh = { version = "1.0.3", features = ["test-utils"] }
+iroh-relay = { version = "1.0.3", features = ["server", "test-utils"] }

--- a/crates/mesh-llm-protocol/Cargo.toml
+++ b/crates/mesh-llm-protocol/Cargo.toml
@@ -11,7 +11,7 @@ readme = "README.md"
 [dependencies]
 anyhow.workspace = true
 hex = "0.4"
-iroh = { version = "1.0.0", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
+iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
 prost = "0.14"
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/mesh-llm-routing/Cargo.toml
+++ b/crates/mesh-llm-routing/Cargo.toml
@@ -11,4 +11,4 @@ keywords = ["llm", "mesh", "routing", "inference"]
 categories = ["network-programming"]
 
 [dependencies]
-iroh = { version = "1.0.0", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
+iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }


### PR DESCRIPTION
Follow-up from mesh-dev: we are already **on** iroh 1.0.3 in `Cargo.lock`, but every manifest asked for `"1.0.0"`. Caret semver means a fresh lockfile could legitimately resolve back to 1.0.0-1.0.2 and silently drop fixes we depend on:

- 1.0.0: correct path abandonment when a new path has worse RTT; don't kill the endpoint on the first transport recv error; happy-eyeballs v4/v6 relay connect
- 1.0.2: receive-transport lane fairness counter fix
- 1.0.3: error on connecting with an empty ALPN; pkarr resolver in the n0 preset

This raises the floor to 1.0.3 in mesh-llm-routing, -commands, -protocol, -host-runtime (incl. the `iroh-relay` dev-dep) and mesh-client.

**No lockfile change** — `cargo update -p iroh` locks 0 packages.

Verification:
- `cargo check --all-targets` on all five affected crates: clean
- `cargo test -p mesh-llm-routing -p mesh-llm-protocol`: 16 passed, 0 failed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the networking components to a newer compatible version.
  - Preserved existing feature settings and configuration.
  - Includes updates for runtime, client, protocol, routing, and command functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->