### PR TITLE
Expose Apple system provider through macOS SDKs

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,12 @@ let hasRemoteFFIXCFramework =
     !remoteFFIXCFrameworkURL.contains("__MESH_SWIFT_RELEASE_TAG__")
     && !remoteFFIXCFrameworkChecksum.contains("__MESH_SWIFT_RELEASE_CHECKSUM__")
 
-var meshLLMDependencies: [Target.Dependency] = []
+var meshLLMDependencies: [Target.Dependency] = [
+    .target(
+        name: "MeshLLMAppleProviderResources",
+        condition: .when(platforms: [.macOS])
+    ),
+]
 var packageTargets: [Target] = []
 
 if hasLocalFFIXCFramework {
@@ -62,6 +67,7 @@ let package = Package(
                 .linkedFramework("Accelerate"),
                 .linkedFramework("AppKit", .when(platforms: [.macOS])),
                 .linkedFramework("CoreGraphics"),
+                .linkedFramework("CoreWLAN", .when(platforms: [.macOS])),
                 .linkedFramework("Foundation"),
                 .linkedFramework("Metal"),
                 .linkedFramework("MetalKit"),
@@ -73,6 +79,11 @@ let package = Package(
             name: "MeshLLMTests",
             dependencies: ["MeshLLM"],
             path: "sdk/swift/Tests/MeshLLMTests"
+        ),
+        .target(
+            name: "MeshLLMAppleProviderResources",
+            path: "sdk/swift/Sources/MeshLLMAppleProviderResources",
+            resources: [.copy("Resources/apple")]
         ),
     ] + packageTargets
 )

--- a/crates/mesh-llm-ffi/src/lib.rs
+++ b/crates/mesh-llm-ffi/src/lib.rs
@@ -571,9 +571,9 @@ pub fn start_provider_host(
     #[cfg(not(feature = "embedded-runtime"))]
     {
         let _ = options;
-        return Err(FfiError::ServingUnsupported(
+        Err(FfiError::ServingUnsupported(
             "this native library was built without embedded-runtime support".to_string(),
-        ));
+        ))
     }
     #[cfg(feature = "embedded-runtime")]
     {

--- a/crates/mesh-llm-ffi/src/lib.rs
+++ b/crates/mesh-llm-ffi/src/lib.rs
@@ -8,6 +8,8 @@ use mesh_llm_sdk::node::{
     UnloadModelOptions as ApiUnloadModelOptions, UnloadTarget as ApiUnloadTarget,
     create_auto_node as sdk_create_auto_node,
 };
+#[cfg(feature = "embedded-runtime")]
+use mesh_llm_sdk::provider_host::{ProviderHost, ProviderHostConfig};
 use mesh_llm_sdk::{
     ChatMessage, ChatRequest, ClientBuilder, InviteToken, MeshApiError, MeshClient, OwnerKeypair,
     PublicMeshQuery as ApiPublicMeshQuery, RequestId, ResponsesRequest,
@@ -89,6 +91,15 @@ pub struct ConsoleOptionsNative {
     pub asset_dir: String,
     pub port: Option<u16>,
     pub listen_all: bool,
+}
+
+#[derive(uniffi::Record)]
+pub struct ProviderRuntimeOptionsNative {
+    pub bundle_roots: Vec<String>,
+    pub release_manifest: Option<String>,
+    pub cache_dir: Option<String>,
+    pub allow_download: bool,
+    pub startup_timeout_ms: u64,
 }
 
 #[derive(uniffi::Record)]
@@ -433,6 +444,13 @@ pub struct ConsoleHandle {
     url: String,
 }
 
+#[derive(uniffi::Object)]
+pub struct ProviderHostHandle {
+    #[cfg(feature = "embedded-runtime")]
+    host: tokio::sync::Mutex<Option<ProviderHost>>,
+    api_base_url: String,
+}
+
 /// Generate a fresh owner keypair, returning its hex-encoded form.
 ///
 /// Callers should persist this value on first run and pass it back to
@@ -544,6 +562,71 @@ pub fn create_auto_node(
             })
         })
         .map_err(map_mesh_api_error)
+}
+
+#[uniffi::export]
+pub fn start_provider_host(
+    options: ProviderRuntimeOptionsNative,
+) -> Result<Arc<ProviderHostHandle>, FfiError> {
+    #[cfg(not(feature = "embedded-runtime"))]
+    {
+        let _ = options;
+        return Err(FfiError::ServingUnsupported(
+            "this native library was built without embedded-runtime support".to_string(),
+        ));
+    }
+    #[cfg(feature = "embedded-runtime")]
+    {
+        let host = block_on(ProviderHost::start(provider_host_config(options)))
+            .map_err(|error| FfiError::HostUnavailable(error.to_string()))?;
+        let api_base_url = host.api_base_url().to_string();
+        Ok(Arc::new(ProviderHostHandle {
+            host: tokio::sync::Mutex::new(Some(host)),
+            api_base_url,
+        }))
+    }
+}
+
+#[uniffi::export]
+impl ProviderHostHandle {
+    pub fn api_base_url(&self) -> String {
+        self.api_base_url.clone()
+    }
+
+    pub fn status_json(&self) -> Result<String, FfiError> {
+        #[cfg(not(feature = "embedded-runtime"))]
+        return Err(FfiError::ServingUnsupported(
+            "this native library was built without embedded-runtime support".to_string(),
+        ));
+        #[cfg(feature = "embedded-runtime")]
+        block_on(async {
+            let host = self.host.lock().await;
+            let host = host
+                .as_ref()
+                .ok_or_else(|| FfiError::HostUnavailable("provider host is stopped".to_string()))?;
+            host.status()
+                .await
+                .map(|status| status.to_string())
+                .map_err(|error| FfiError::HostUnavailable(error.to_string()))
+        })
+    }
+
+    pub fn stop(&self) -> Result<(), FfiError> {
+        #[cfg(not(feature = "embedded-runtime"))]
+        return Err(FfiError::ServingUnsupported(
+            "this native library was built without embedded-runtime support".to_string(),
+        ));
+        #[cfg(feature = "embedded-runtime")]
+        block_on(async {
+            let host = self.host.lock().await.take();
+            if let Some(host) = host {
+                host.stop()
+                    .await
+                    .map_err(|error| FfiError::HostUnavailable(error.to_string()))?;
+            }
+            Ok(())
+        })
+    }
 }
 
 #[uniffi::export]
@@ -1008,6 +1091,22 @@ fn non_empty_path(value: Option<String>) -> Option<String> {
         let trimmed = path.trim();
         (!trimmed.is_empty()).then(|| trimmed.to_string())
     })
+}
+
+#[cfg(feature = "embedded-runtime")]
+fn provider_host_config(options: ProviderRuntimeOptionsNative) -> ProviderHostConfig {
+    ProviderHostConfig {
+        bundle_roots: options
+            .bundle_roots
+            .into_iter()
+            .filter_map(|path| non_empty_path(Some(path)))
+            .map(PathBuf::from)
+            .collect(),
+        release_manifest: non_empty_path(options.release_manifest).map(PathBuf::from),
+        cache_dir: non_empty_path(options.cache_dir).map(PathBuf::from),
+        allow_download: options.allow_download,
+        startup_timeout: Duration::from_millis(options.startup_timeout_ms.max(1)),
+    }
 }
 
 fn runtime_install_options(

--- a/crates/mesh-llm-ffi/src/mesh_ffi.udl
+++ b/crates/mesh-llm-ffi/src/mesh_ffi.udl
@@ -21,6 +21,9 @@ namespace mesh_ffi {
     MeshNodeHandle create_auto_node(string owner_keypair_bytes_hex, PublicMeshQuery query);
 
     [Throws=FfiError]
+    ProviderHostHandle start_provider_host(ProviderRuntimeOptionsNative options);
+
+    [Throws=FfiError]
     sequence<PublicMesh> discover_public_meshes(PublicMeshQuery query);
 
     string generate_owner_keypair_hex();
@@ -51,6 +54,24 @@ namespace mesh_ffi {
         string? active_mesh_version,
         NativeRuntimePruneModeNative mode
     );
+};
+
+dictionary ProviderRuntimeOptionsNative {
+    sequence<string> bundle_roots;
+    string? release_manifest;
+    string? cache_dir;
+    boolean allow_download;
+    u64 startup_timeout_ms;
+};
+
+interface ProviderHostHandle {
+    string api_base_url();
+
+    [Throws=FfiError]
+    string status_json();
+
+    [Throws=FfiError]
+    void stop();
 };
 
 [Error]

--- a/crates/mesh-llm-nodejs/src/lib.rs
+++ b/crates/mesh-llm-nodejs/src/lib.rs
@@ -8,6 +8,7 @@ use mesh_llm_sdk::node::{
     ChatMessage, ChatRequest, DevicePolicy, DownloadOptions, InviteToken, LoadModelOptions,
     MeshNode, OwnerKeypair, ResponsesRequest, UnloadModelOptions, UnloadTarget,
 };
+use mesh_llm_sdk::provider_host::{ProviderHost as SdkProviderHost, ProviderHostConfig};
 use napi::bindgen_prelude::*;
 use napi::threadsafe_function::{ThreadsafeFunction, ThreadsafeFunctionCallMode};
 use napi_derive::napi;
@@ -101,6 +102,54 @@ pub struct Node {
 pub struct ConsoleHandle {
     inner: Arc<Mutex<Option<mesh_llm_sdk::console::ConsoleServerHandle>>>,
     url: String,
+}
+
+#[napi]
+pub struct ProviderHost {
+    host: tokio::sync::Mutex<Option<SdkProviderHost>>,
+    api_base_url: String,
+}
+
+#[napi]
+impl ProviderHost {
+    #[napi(factory)]
+    pub async fn start(options_json: String) -> Result<Self> {
+        let config = parse_provider_host_config(&options_json)?;
+        let host = SdkProviderHost::start(config)
+            .await
+            .map_err(to_napi_error)?;
+        let api_base_url = host.api_base_url().to_string();
+        Ok(Self {
+            host: tokio::sync::Mutex::new(Some(host)),
+            api_base_url,
+        })
+    }
+
+    #[napi(getter)]
+    pub fn api_base_url(&self) -> String {
+        self.api_base_url.clone()
+    }
+
+    #[napi(js_name = "statusJson")]
+    pub async fn status_json(&self) -> Result<String> {
+        let host = self.host.lock().await;
+        let host = host
+            .as_ref()
+            .ok_or_else(|| Error::from_reason("provider host is stopped"))?;
+        host.status()
+            .await
+            .map(|status| status.to_string())
+            .map_err(to_napi_error)
+    }
+
+    #[napi]
+    pub async fn stop(&self) -> Result<()> {
+        let host = self.host.lock().await.take();
+        if let Some(host) = host {
+            host.stop().await.map_err(to_napi_error)?;
+        }
+        Ok(())
+    }
 }
 
 #[napi]
@@ -736,6 +785,29 @@ fn parse_native_runtime_install_options(
     })
 }
 
+fn parse_provider_host_config(source: &str) -> Result<ProviderHostConfig> {
+    let value = parse_json(source)?;
+    Ok(ProviderHostConfig {
+        bundle_roots: string_array(&value, "bundleRoots")
+            .into_iter()
+            .map(PathBuf::from)
+            .collect(),
+        release_manifest: optional_string(&value, "releaseManifest").map(PathBuf::from),
+        cache_dir: optional_string(&value, "cacheDir").map(PathBuf::from),
+        allow_download: value
+            .get("allowDownload")
+            .and_then(Value::as_bool)
+            .unwrap_or(false),
+        startup_timeout: Duration::from_millis(
+            value
+                .get("startupTimeoutMs")
+                .and_then(Value::as_u64)
+                .unwrap_or(30_000)
+                .max(1),
+        ),
+    })
+}
+
 fn optional_string(value: &Value, key: &str) -> Option<String> {
     value
         .get(key)
@@ -923,4 +995,35 @@ fn new_request_id() -> String {
         "node-local-{}",
         NEXT_REQUEST_ID.fetch_add(1, Ordering::Relaxed)
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn provider_host_json_maps_typed_carrier_configuration() {
+        let config = parse_provider_host_config(
+            r#"{
+                "bundleRoots":["/app/provider-runtimes/apple"],
+                "releaseManifest":"/app/provider-runtimes.json",
+                "cacheDir":"/cache/providers",
+                "allowDownload":true,
+                "startupTimeoutMs":45000
+            }"#,
+        )
+        .expect("provider host config");
+
+        assert_eq!(
+            config.bundle_roots,
+            vec![PathBuf::from("/app/provider-runtimes/apple")]
+        );
+        assert_eq!(
+            config.release_manifest,
+            Some(PathBuf::from("/app/provider-runtimes.json"))
+        );
+        assert_eq!(config.cache_dir, Some(PathBuf::from("/cache/providers")));
+        assert!(config.allow_download);
+        assert_eq!(config.startup_timeout, Duration::from_secs(45));
+    }
 }

--- a/crates/mesh-llm-sdk/src/lib.rs
+++ b/crates/mesh-llm-sdk/src/lib.rs
@@ -28,6 +28,9 @@ pub mod node {
 pub mod embedded_node;
 
 #[cfg(feature = "serving")]
+pub mod provider_host;
+
+#[cfg(feature = "serving")]
 pub use embedded_node::{MeshNode, MeshNodeBuilder, MeshNodeStatus, OpenAiClient};
 
 #[cfg(feature = "serving")]

--- a/crates/mesh-llm-sdk/src/provider_host.rs
+++ b/crates/mesh-llm-sdk/src/provider_host.rs
@@ -1,0 +1,112 @@
+//! Shared executable-provider host lifecycle for language SDK carriers.
+
+use crate::embedded_node::MeshNode;
+use anyhow::{Context, Result};
+use serde_json::Value;
+use std::net::TcpListener;
+use std::path::PathBuf;
+use std::time::Duration;
+
+/// Typed provider-runtime resources supplied by a host-capable SDK package.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ProviderHostConfig {
+    pub bundle_roots: Vec<PathBuf>,
+    pub release_manifest: Option<PathBuf>,
+    pub cache_dir: Option<PathBuf>,
+    pub allow_download: bool,
+    pub startup_timeout: Duration,
+}
+
+impl ProviderHostConfig {
+    pub fn new(bundle_roots: impl IntoIterator<Item = impl Into<PathBuf>>) -> Self {
+        Self {
+            bundle_roots: bundle_roots.into_iter().map(Into::into).collect(),
+            startup_timeout: Duration::from_secs(30),
+            ..Self::default()
+        }
+    }
+}
+
+/// A provider-only embedded host exposing the normal OpenAI-compatible REST API.
+pub struct ProviderHost {
+    node: MeshNode,
+}
+
+impl ProviderHost {
+    pub async fn start(config: ProviderHostConfig) -> Result<Self> {
+        anyhow::ensure!(
+            !config.bundle_roots.is_empty() || config.release_manifest.is_some(),
+            "provider host requires a bundle root or release manifest"
+        );
+        let api_port = free_loopback_port().context("reserve provider host API port")?;
+        let console_port = free_loopback_port().context("reserve provider host console port")?;
+        let mut builder = MeshNode::builder()
+            .serve()
+            .provider_runtime_roots(config.bundle_roots)
+            .allow_provider_runtime_downloads(config.allow_download)
+            .api_port(api_port)
+            .console_port(console_port)
+            .console_ui(false)
+            .startup_timeout(config.startup_timeout);
+        if let Some(path) = config.release_manifest {
+            builder = builder.provider_runtime_release_manifest(path);
+        }
+        if let Some(path) = config.cache_dir {
+            builder = builder.provider_runtime_cache_dir(path);
+        }
+        Ok(Self {
+            node: builder.start().await?,
+        })
+    }
+
+    pub fn api_base_url(&self) -> &str {
+        self.node.api_base_url()
+    }
+
+    pub async fn status(&self) -> Result<Value> {
+        Ok(self.node.status().await?.payload)
+    }
+
+    pub async fn stop(self) -> Result<()> {
+        self.node.stop().await
+    }
+}
+
+impl Default for ProviderHostConfig {
+    fn default() -> Self {
+        Self {
+            bundle_roots: Vec::new(),
+            release_manifest: None,
+            cache_dir: None,
+            allow_download: false,
+            startup_timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+fn free_loopback_port() -> Result<u16> {
+    Ok(TcpListener::bind(("127.0.0.1", 0))?.local_addr()?.port())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_owns_carrier_paths_and_download_policy() {
+        let config = ProviderHostConfig {
+            bundle_roots: vec![PathBuf::from("/app/provider-runtimes/apple")],
+            release_manifest: Some(PathBuf::from("/app/provider-runtimes.json")),
+            cache_dir: Some(PathBuf::from("/cache/providers")),
+            allow_download: true,
+            startup_timeout: Duration::from_secs(45),
+        };
+
+        assert_eq!(
+            config.bundle_roots,
+            vec![PathBuf::from("/app/provider-runtimes/apple")]
+        );
+        assert!(config.allow_download);
+        assert_eq!(config.startup_timeout, Duration::from_secs(45));
+    }
+}

--- a/docs/SDK.md
+++ b/docs/SDK.md
@@ -208,6 +208,37 @@ path-based native boundary exists so SwiftPM resources, Node package files, JVM
 resources, and Rust app resources can all pass the packaged console directory
 to the same console server.
 
+## Apple system provider carriers
+
+On Apple silicon running macOS Golden Gate, every host-capable SDK can expose
+the system model through the same provider-only lifecycle:
+
+| SDK | Entry point |
+|---|---|
+| Rust | `ProviderHost::start(ProviderHostConfig)` |
+| Swift | `ProviderHost.start(.packagedAppleSystem())` |
+| Node/Electron | `ProviderHost.start(packagedAppleSystemProvider())` |
+| Kotlin/JVM | `ProviderHost.start(ProviderRuntimeOptions.packagedAppleSystem())` |
+
+All four return an OpenAI-compatible loopback base URL. The language process
+supervises one shared `mesh-apple-runtime` sidecar; it does not embed separate
+Foundation Models logic or use Skippy pipeline parallelism. Release packaging
+copies the exact signed and notarized artifact with
+`scripts/package-sdk-provider-runtime.sh --sdk all`. Electron must unpack the
+optional Darwin-arm64 provider package from ASAR, while Kotlin/JVM extracts the
+separate macOS-arm64 resource JAR before launch. Swift uses a macOS-only
+resource target. Non-macOS SDK artifacts do not carry the executable.
+
+Golden Gate conformance is one command:
+
+```bash
+just apple::sdk-carriers
+```
+
+It runs the Swift, Node/Electron, and Kotlin/JVM wrappers through identical
+model listing, completion, streaming, tool, usage, cancellation, and error
+assertions. Rust has the companion `just apple::rust-sdk` typed-carrier test.
+
 ## Native Runtime Artifacts
 
 The accepted packaging direction is documented in

--- a/docs/design/APPLE_RUNTIME.md
+++ b/docs/design/APPLE_RUNTIME.md
@@ -180,9 +180,9 @@ identity in these representative layouts:
 | Carrier | Representative location | Result |
 |---|---|---|
 | CLI | `runtimes/apple/` | pass |
-| Swift | `MeshLLMAppleRuntime.bundle/Contents/Resources/runtime/` | pass |
-| Node.js | `@mesh-llm/apple-runtime-darwin-arm64/runtime/` | pass |
-| JVM | `ai/meshllm/apple-runtime/macos-arm64/runtime/` | pass |
+| Swift | macOS-only SwiftPM resource target | pass |
+| Node.js | `@mesh-llm/apple-runtime-darwin-arm64` outside Electron ASAR | pass |
+| JVM | `meshllm-apple-runtime-macos-arm64` resource JAR | pass |
 
 This establishes the intended SDK contract:
 
@@ -199,9 +199,21 @@ The CLI release composer now embeds that artifact at
 `product-manifest.json`, and preserves it through Unix installation. The host's
 adjacent-product discovery requires no provider bundle or index override.
 
-The current QA proves the CLI product and representative carrier layouts, not
-final npm/JAR/XCFramework publication. Those release jobs should consume one
-already-signed runtime artifact rather than rebuild it independently.
+`scripts/package-sdk-provider-runtime.sh` copies one already-signed artifact
+into all three platform-gated package-resource layouts. It never rebuilds the
+sidecar per SDK, and non-macOS npm, Maven, iOS, and Android artifacts do not
+carry the macOS executable.
+Swift, Node/Electron, and Kotlin/JVM then enter the same Rust `ProviderHost`
+lifecycle through the UniFFI or N-API boundary and expose the same loopback
+OpenAI-compatible URL. The accelerator-entitled process remains
+`mesh-apple-runtime`; the host-language process supervises it but does not call
+Foundation Models directly.
+
+`just apple::sdk-carriers` starts each real language carrier and runs the same
+REST assertions for model listing, the rolling and versioned IDs, buffered and
+streaming completions, tools, usage, disconnect cancellation, slot release,
+and structured errors. Final npm/JAR/XCFramework release publication must
+consume the same notarized artifact used by CLI product composition.
 
 ## Validation evidence
 
@@ -215,6 +227,7 @@ just apple::mesh
 just apple::product 0.72.1 target/apple-runtime/product
 just apple::product-qa 0.72.1 target/apple-runtime/product
 just apple::rust-sdk
+just apple::sdk-carriers
 MESH_APPLE_RUNTIME_CODESIGN_IDENTITY="Mesh-LLM Local Codesign" \
   just apple::rest
 MESH_APPLE_RUNTIME_CODESIGN_IDENTITY="Mesh-LLM Local Codesign" \
@@ -349,13 +362,13 @@ MeshLLM's normal local OpenAI frontend and runtime-process management surface.
 The shared executable-provider manifest, resolver, verified downloader,
 immutable cache contract, Rust host supervisor, CLI product composition,
 adjacent-product auto-discovery, and typed Rust SDK carrier configuration are
-implemented. Provider-only Rust SDK hosts do not load Skippy. The release lane requires a
-Developer ID Application signature, secure timestamp, accepted notarization,
-and `spctl` assessment before composition. Next, publish that one signed macOS
-arm64 artifact and bind the Swift, Node/Electron, and Kotlin/JVM SDK surfaces
-to the same installation and host lifecycle contract. Validate Swift
-app embedding, sandboxing, quarantine, and launchd/service lifecycles, then
-certify every SDK against one protocol test suite.
+implemented. Swift, Node/Electron, and Kotlin/JVM now bind the same provider-only
+host and are certified by one live protocol suite. Provider-only SDK hosts do
+not load Skippy. The release lane requires a Developer ID Application
+signature, secure timestamp, accepted notarization, and `spctl` assessment
+before composition. Remaining promotion work is release-channel publication
+of the one signed artifact plus app-sandbox and quarantine validation in a
+signed Swift app and packaged Electron app.
 
 ### 3. Private-mesh system-model routing
 

--- a/docs/design/PROVIDER_RUNTIMES.md
+++ b/docs/design/PROVIDER_RUNTIMES.md
@@ -155,12 +155,25 @@ APIs. The host runtime now consumes the contract through its experimental Apple
 provider supervisor, which owns platform policy, process lifecycle, health, and
 local route registration.
 
-The next stacked layer packages that same artifact and lifecycle for every
-host-capable macOS SDK. The Rust SDK now accepts carrier bundle roots, an
-optional release index/cache, and explicit download permission through its
-embedded-node builder. The typed configuration flows into the same resolver
-without mutating or inheriting process-global provider discovery environment.
-Provider-only Rust hosts also skip the unrelated Skippy native-runtime load.
-Swift, Node/Electron, and Kotlin/JVM should map their resource locations into
-this contract rather than reimplement Foundation Models semantics or create
-divergent sidecars.
+Every host-capable macOS SDK packages that same artifact and lifecycle. The
+Rust SDK accepts carrier bundle roots, an optional release index/cache, and
+explicit download permission through `ProviderHostConfig`. Swift and
+Kotlin/JVM call it through UniFFI; Node/Electron calls it through N-API. The
+typed configuration flows into the same resolver without mutating or
+inheriting process-global provider-discovery environment. Provider-only hosts
+also skip the unrelated Skippy native-runtime load.
+
+Carrier resources are deliberately mechanical:
+
+| SDK | Packaged location | Runtime handling |
+|---|---|---|
+| SwiftPM | macOS-only `MeshLLMAppleProviderResources` target | use the resource directory in place |
+| npm / Electron | optional `@mesh-llm/apple-runtime-darwin-arm64` package | ship outside ASAR so the executable remains a file |
+| Kotlin/JVM | `meshllm-apple-runtime-macos-arm64` resource JAR | extract the manifest-listed files to an empty private directory and restore the executable bit |
+
+`scripts/package-sdk-provider-runtime.sh` copies the exact signed bytes into
+these layouts. `just apple::sdk-carriers` then certifies every wrapper with one
+REST suite. SDKs must not reinterpret Foundation Models semantics, fork the
+sidecar, or silently fall back to a different model. Platform resource packages
+remain separate so Linux/Windows npm installs and iOS/Android artifacts never
+carry a macOS executable.

--- a/providers/apple/Justfile
+++ b/providers/apple/Justfile
@@ -77,6 +77,14 @@ product-qa mesh_version output="target/apple-runtime/product":
 rust-sdk: package
     @"{{ apple_root }}/QA/rust-sdk.sh"
 
+# Copy the exact signed sidecar into SwiftPM, npm, and JVM package resources.
+sdk-package: package
+    @"{{ apple_root }}/../../scripts/package-sdk-provider-runtime.sh" --sdk all
+
+# Run Swift, Node/Electron, and Kotlin/JVM through one REST conformance suite.
+sdk-carriers: package
+    @"{{ apple_root }}/QA/sdk-carriers.sh"
+
 # Verify one signed runtime from CLI, Swift, Node, and JVM carrier layouts.
 carriers: package
     @"{{ apple_root }}/QA/carriers.sh"
@@ -94,4 +102,4 @@ orphan: package
     @"{{ apple_root }}/QA/orphan.sh"
 
 # Run the complete experimental Apple runtime validation suite.
-qa: test live rest mesh carriers launchd instruments orphan
+qa: test live rest mesh carriers sdk-carriers launchd instruments orphan

--- a/providers/apple/QA/sdk-carriers.sh
+++ b/providers/apple/QA/sdk-carriers.sh
@@ -1,0 +1,214 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APPLE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$APPLE_ROOT/../.." && pwd)"
+PACKAGE_ROOT="$REPO_ROOT/target/apple-runtime/package/meshllm-apple-runtime-darwin-arm64"
+OUTPUT_DIR="$REPO_ROOT/target/apple-runtime/sdk-carriers"
+SWIFT_TARGET_DIR="$REPO_ROOT/target/swift-provider-host-debug"
+SWIFT_EXAMPLE_DIR="$REPO_ROOT/sdk/swift/example/MeshExampleApp"
+KOTLIN_EXAMPLE_DIR="$REPO_ROOT/sdk/kotlin/example/example-jvm"
+ACTIVE_PID=""
+ACTIVE_STOP_FILE=""
+
+cleanup() {
+    if [[ -n "$ACTIVE_STOP_FILE" ]]; then
+        : > "$ACTIVE_STOP_FILE"
+    fi
+    if [[ "$ACTIVE_PID" =~ ^[0-9]+$ ]] && kill -0 "$ACTIVE_PID" 2>/dev/null; then
+        kill -TERM "$ACTIVE_PID" 2>/dev/null || true
+        wait "$ACTIVE_PID" 2>/dev/null || true
+    fi
+}
+trap cleanup EXIT
+
+[[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]] || {
+    echo "Apple SDK carrier conformance requires Apple silicon macOS" >&2
+    exit 2
+}
+[[ -f "$PACKAGE_ROOT/provider-runtime.json" ]] || {
+    echo "missing Apple runtime package; run just apple::package" >&2
+    exit 2
+}
+
+if [[ -n "${JAVA_HOME:-}" && -x "$JAVA_HOME/bin/java" ]]; then
+    JDK_HOME="$JAVA_HOME"
+elif [[ -x "/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home/bin/java" ]]; then
+    JDK_HOME="/Library/Java/JavaVirtualMachines/jdk-21.jdk/Contents/Home"
+else
+    JDK_HOME="$(/usr/libexec/java_home -v 21 2>/dev/null || true)"
+fi
+[[ -x "$JDK_HOME/bin/java" ]] || {
+    echo "Kotlin/JVM carrier conformance requires JDK 21" >&2
+    exit 2
+}
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR"
+
+echo "Building Node/Electron provider carrier..."
+just --justfile "$REPO_ROOT/Justfile" with-lld \
+    cargo build -p mesh-llm-nodejs
+
+echo "Building Kotlin/JVM provider carrier..."
+just --justfile "$REPO_ROOT/Justfile" with-lld \
+    cargo build -p mesh-llm-ffi --no-default-features --features host,embedded-runtime
+JAVA_HOME="$JDK_HOME" \
+    "$KOTLIN_EXAMPLE_DIR/gradlew" --no-daemon -p "$KOTLIN_EXAMPLE_DIR" classes
+
+echo "Building Swift provider carrier..."
+just --justfile "$REPO_ROOT/Justfile" with-lld \
+    env -u RUSTFLAGS \
+    CARGO_TARGET_DIR="$SWIFT_TARGET_DIR" \
+    MESH_SWIFT_FFI_PROFILE=debug \
+    bash "$REPO_ROOT/sdk/swift/scripts/build-host-macos-xcframework.sh"
+xattr -cr "$REPO_ROOT/sdk/swift/Generated/MeshLLMFFI.xcframework"
+swift build --package-path "$SWIFT_EXAMPLE_DIR" --product AppleSystemHost
+
+SWIFT_BIN="$(swift build --package-path "$SWIFT_EXAMPLE_DIR" --show-bin-path)/AppleSystemHost"
+NODE_ADDON="$REPO_ROOT/target/debug/libmesh_llm_nodejs.dylib"
+KOTLIN_FFI_DIR="$OUTPUT_DIR/kotlin-native"
+mkdir -p "$KOTLIN_FFI_DIR"
+cp "$REPO_ROOT/target/debug/libmeshllm_ffi.dylib" \
+    "$KOTLIN_FFI_DIR/libuniffi_mesh_ffi.dylib"
+
+wait_until_ready() {
+    local ready_file="$1"
+    local stderr_file="$2"
+    for _ in $(seq 1 600); do
+        [[ -s "$ready_file" ]] && return 0
+        if ! kill -0 "$ACTIVE_PID" 2>/dev/null; then
+            echo "SDK carrier exited before its REST host became ready" >&2
+            cat "$stderr_file" >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+    echo "timed out waiting for SDK carrier REST host" >&2
+    cat "$stderr_file" >&2
+    return 1
+}
+
+wait_for_apple_model() {
+    local rest_base_url="$1"
+    local models_file="$2"
+    local stderr_file="$3"
+    for _ in $(seq 1 300); do
+        if curl --silent --show-error "$rest_base_url/v1/models" >"$models_file" \
+            && python3 - "$models_file" <<'PY'
+import json
+import pathlib
+import sys
+
+models = json.loads(pathlib.Path(sys.argv[1]).read_text())
+raise SystemExit(0 if any(
+    model.get("id", "").startswith("apple/system@")
+    for model in models.get("data", [])
+) else 1)
+PY
+        then
+            return 0
+        fi
+        if ! kill -0 "$ACTIVE_PID" 2>/dev/null; then
+            echo "SDK carrier exited before apple/system became available" >&2
+            cat "$stderr_file" >&2
+            return 1
+        fi
+        sleep 0.1
+    done
+    echo "timed out waiting for apple/system through SDK carrier" >&2
+    cat "$stderr_file" >&2
+    return 1
+}
+
+run_carrier() {
+    local carrier="$1"
+    shift
+    local carrier_dir="$OUTPUT_DIR/$carrier"
+    local ready_file="$carrier_dir/ready.json"
+    local stop_file="$carrier_dir/stop"
+    local stdout_file="$carrier_dir/carrier.stdout"
+    local stderr_file="$carrier_dir/carrier.stderr"
+    mkdir -p "$carrier_dir"
+
+    echo "Running $carrier carrier through shared REST conformance..."
+    MESH_LLM_PROVIDER_RUNTIME_BUNDLE_DIR=/invalid/sdk-carrier-must-ignore-environment \
+    MESH_LLM_PROVIDER_RUNTIME_INDEX=/invalid/sdk-carrier-must-ignore-environment.json \
+    MESH_LLM_PROVIDER_RUNTIME_CACHE_DIR="$carrier_dir/provider-cache" \
+    MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC=1 \
+        "$@" >"$stdout_file" 2>"$stderr_file" &
+    ACTIVE_PID=$!
+    ACTIVE_STOP_FILE="$stop_file"
+    wait_until_ready "$ready_file" "$stderr_file"
+
+    local api_base_url
+    api_base_url="$(python3 - "$ready_file" "$carrier" <<'PY'
+import json
+import pathlib
+import sys
+
+ready = json.loads(pathlib.Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert ready["carrier"] == sys.argv[2], ready
+assert ready["apiBaseUrl"].startswith("http://127.0.0.1:"), ready
+print(ready["apiBaseUrl"])
+PY
+    )"
+    local rest_base_url="${api_base_url%/v1}"
+    wait_for_apple_model "$rest_base_url" "$carrier_dir/models-ready.json" "$stderr_file"
+    MESH_APPLE_RUNTIME_BASE_URL="$rest_base_url" \
+    MESH_APPLE_RUNTIME_REST_OUTPUT_DIR="$carrier_dir/rest" \
+        "$APPLE_ROOT/QA/rest.sh" >"$carrier_dir/rest-output.json"
+
+    : > "$stop_file"
+    wait "$ACTIVE_PID"
+    ACTIVE_PID=""
+    ACTIVE_STOP_FILE=""
+}
+
+run_carrier swift \
+    "$SWIFT_BIN" "$PACKAGE_ROOT" "$OUTPUT_DIR/swift/ready.json" "$OUTPUT_DIR/swift/stop"
+
+run_carrier node-electron \
+    env MESHLLM_NODE_NATIVE_PATH="$NODE_ADDON" \
+    node "$REPO_ROOT/sdk/node/example/apple-system-host.js" \
+    "$PACKAGE_ROOT" "$OUTPUT_DIR/node-electron/ready.json" "$OUTPUT_DIR/node-electron/stop"
+
+run_carrier kotlin-jvm \
+    env JAVA_HOME="$JDK_HOME" \
+    JAVA_TOOL_OPTIONS="-Djna.library.path=$KOTLIN_FFI_DIR" \
+    MESH_APPLE_PROVIDER_ROOT="$PACKAGE_ROOT" \
+    MESH_APPLE_SDK_READY_FILE="$OUTPUT_DIR/kotlin-jvm/ready.json" \
+    MESH_APPLE_SDK_STOP_FILE="$OUTPUT_DIR/kotlin-jvm/stop" \
+    "$KOTLIN_EXAMPLE_DIR/gradlew" --no-daemon -q -p "$KOTLIN_EXAMPLE_DIR" run
+
+python3 - "$OUTPUT_DIR" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+carriers = []
+for carrier in ("swift", "node-electron", "kotlin-jvm"):
+    summary = json.loads((root / carrier / "rest" / "summary.json").read_text())
+    assert summary["status"] == "pass", summary
+    carriers.append({
+        "carrier": carrier,
+        "api_base_url": json.loads((root / carrier / "ready.json").read_text())["apiBaseUrl"],
+        "model": summary["model"],
+        "versioned_model": summary["versioned_model"],
+        "completion": summary["completion"]["choices"][0]["message"]["content"],
+        "tool_executions": summary["tool"]["mesh_tool_executions"],
+        "stream_done": summary["stream_done"],
+        "client_disconnect_cancelled": summary["client_disconnect_cancelled"],
+        "typed_model_error": summary["typed_model_error"],
+    })
+
+result = {
+    "status": "pass",
+    "provider_process": "mesh-apple-runtime",
+    "provider_artifact_shared_by_all_carriers": True,
+    "carriers": carriers,
+}
+(root / "summary.json").write_text(json.dumps(result, indent=2, sort_keys=True) + "\n")
+print(json.dumps(result, indent=2, sort_keys=True))
+PY

--- a/providers/apple/README.md
+++ b/providers/apple/README.md
@@ -389,7 +389,34 @@ caveats, and rollout gates.
 |---|---|---|
 | 0 | Policy, entitlement, packaging, signing, launchd, and accelerator spike | complete |
 | 1 | Local `apple/system` REST vertical slice | experimental implementation complete |
-| 2 | All host-capable macOS SDKs drive the same runtime lifecycle | CLI and Rust SDK carriers implemented; Swift, Node/Electron, and Kotlin/JVM pending |
+| 2 | All host-capable macOS SDKs drive the same runtime lifecycle | implemented experimentally for Rust, Swift, Node/Electron, and Kotlin/JVM; release publication and signed-app sandbox certification remain |
 | 3 | Private-mesh routing, load, failover, affinity, and withdrawal | not implemented |
 
 This runtime does not alter the Skippy ABI or use Skippy stage execution.
+
+## SDK carrier conformance
+
+Every macOS carrier supervises the same `mesh-apple-runtime` executable and
+receives an OpenAI-compatible loopback base URL. No language SDK implements
+Foundation Models prompts, tools, model identity, or cancellation itself.
+
+On Apple silicon running macOS Golden Gate with Xcode and JDK 21 installed:
+
+```bash
+just apple::sdk-carriers
+```
+
+The command builds the Swift, Node/Electron, and Kotlin/JVM native bridges,
+starts each carrier in turn, and runs the shared REST suite. Evidence is written
+to `target/apple-runtime/sdk-carriers/summary.json`, including completion text
+and tool executions for every carrier.
+
+To prepare publishable SDK source trees from an already signed provider bundle:
+
+```bash
+just apple::sdk-package
+```
+
+Release automation must run that packaging step with the already notarized
+artifact. It must not rebuild or re-sign the sidecar independently for npm,
+SwiftPM, or Maven.

--- a/scripts/package-sdk-provider-runtime.sh
+++ b/scripts/package-sdk-provider-runtime.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: scripts/package-sdk-provider-runtime.sh [options]
+
+Copy one already-built Apple provider runtime into host-capable macOS SDK
+resource layouts. The exact signed executable is reused by every carrier.
+
+Options:
+  --sdk node|swift|kotlin|all  SDK package to update. Defaults to all.
+  --runtime-dir DIR            Bundle root containing provider-runtime.json.
+                               Defaults to the Golden Gate QA package output.
+  -h, --help                   Show this help.
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+SDK="all"
+RUNTIME_DIR="$REPO_ROOT/target/apple-runtime/package/meshllm-apple-runtime-darwin-arm64"
+
+while [[ "$#" -gt 0 ]]; do
+    case "$1" in
+        --sdk)
+            SDK="${2:?missing SDK name}"
+            shift 2
+            ;;
+        --runtime-dir)
+            RUNTIME_DIR="${2:?missing runtime directory}"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        *)
+            usage
+            exit 1
+            ;;
+    esac
+done
+
+case "$SDK" in
+    node|swift|kotlin|all) ;;
+    *)
+        echo "unsupported SDK: $SDK" >&2
+        usage
+        exit 1
+        ;;
+esac
+
+[[ "$(uname -s)" == "Darwin" && "$(uname -m)" == "arm64" ]] || {
+    echo "Apple provider SDK packaging requires Apple silicon macOS" >&2
+    exit 2
+}
+[[ -f "$RUNTIME_DIR/provider-runtime.json" ]] || {
+    echo "provider runtime is missing provider-runtime.json: $RUNTIME_DIR" >&2
+    exit 2
+}
+[[ -x "$RUNTIME_DIR/bin/mesh-apple-runtime" ]] || {
+    echo "provider runtime entrypoint is missing or not executable: $RUNTIME_DIR/bin/mesh-apple-runtime" >&2
+    exit 2
+}
+
+codesign --verify --strict --verbose=2 "$RUNTIME_DIR/bin/mesh-apple-runtime"
+
+write_resource_manifest() {
+    local destination="$1"
+    python3 - "$destination" <<'PY'
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+entries = [
+    path.relative_to(root).as_posix()
+    for path in root.rglob("*")
+    if path.is_file() and path.name not in {".gitkeep", "manifest.txt"}
+]
+(root / "manifest.txt").write_text("\n".join(sorted(entries)) + "\n", encoding="utf-8")
+PY
+}
+
+copy_runtime() {
+    local destination="$1"
+    local include_resource_manifest="$2"
+    rm -rf "$destination"
+    mkdir -p "$destination"
+    ditto "$RUNTIME_DIR" "$destination"
+    : > "$destination/.gitkeep"
+    if [[ "$include_resource_manifest" == "1" ]]; then
+        write_resource_manifest "$destination"
+    fi
+    cmp "$RUNTIME_DIR/bin/mesh-apple-runtime" "$destination/bin/mesh-apple-runtime"
+    codesign --verify --strict --verbose=2 "$destination/bin/mesh-apple-runtime"
+}
+
+package_node() {
+    copy_runtime "$REPO_ROOT/sdk/node/apple-runtime-darwin-arm64/runtime" 0
+}
+
+package_swift() {
+    copy_runtime "$REPO_ROOT/sdk/swift/Sources/MeshLLMAppleProviderResources/Resources/apple" 0
+}
+
+package_kotlin() {
+    copy_runtime "$REPO_ROOT/sdk/kotlin/apple-runtime-macos-arm64/src/main/resources/mesh-llm/provider-runtimes/apple" 1
+}
+
+case "$SDK" in
+    node) package_node ;;
+    swift) package_swift ;;
+    kotlin) package_kotlin ;;
+    all)
+        package_node
+        package_swift
+        package_kotlin
+        ;;
+esac
+
+echo "Packaged the same signed Apple provider runtime for SDK carrier: $SDK"

--- a/scripts/verify-swift-release-artifact.sh
+++ b/scripts/verify-swift-release-artifact.sh
@@ -91,6 +91,8 @@ CONSUMER_DIR="$TMP_ROOT/consumer"
 mkdir -p "$CONSUMER_DIR/Sources" "$CONSUMER_DIR/Sources/Consumer"
 cp "$ARTIFACT_ZIP" "$CONSUMER_DIR/MeshLLMFFI.xcframework.zip"
 ln -s "$REPO_ROOT/sdk/swift/Sources/MeshLLM" "$CONSUMER_DIR/Sources/MeshLLM"
+ln -s "$REPO_ROOT/sdk/swift/Sources/MeshLLMAppleProviderResources" \
+  "$CONSUMER_DIR/Sources/MeshLLMAppleProviderResources"
 
 cat > "$CONSUMER_DIR/Package.swift" <<'EOF'
 // swift-tools-version: 5.9
@@ -108,7 +110,10 @@ let package = Package(
         ),
         .target(
             name: "MeshLLM",
-            dependencies: ["MeshLLMFFI"],
+            dependencies: [
+                "MeshLLMFFI",
+                "MeshLLMAppleProviderResources",
+            ],
             path: "Sources/MeshLLM",
             resources: [
                 .copy("Resources/Console"),
@@ -123,6 +128,11 @@ let package = Package(
                 .linkedFramework("SystemConfiguration"),
                 .linkedLibrary("c++"),
             ]
+        ),
+        .target(
+            name: "MeshLLMAppleProviderResources",
+            path: "Sources/MeshLLMAppleProviderResources",
+            resources: [.copy("Resources/apple")]
         ),
         .executableTarget(
             name: "Consumer",

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -53,5 +53,11 @@ Generated UniFFI source bindings are refreshed from
 `crates/mesh-llm-ffi/src/mesh_ffi.udl`. Apple binary artifacts such as
 `MeshLLMFFI.xcframework` are build outputs and should not be checked in.
 
+The experimental Golden Gate provider is one signed Swift sidecar shared by
+Rust, Swift, Node/Electron, and Kotlin/JVM. Language SDKs only package its path
+and bind the shared Rust `ProviderHost` lifecycle. Prepare carrier resources
+with `scripts/package-sdk-provider-runtime.sh`; certify all macOS wrappers with
+`just apple::sdk-carriers`.
+
 If you add another top-level SDK here, include a `README.md` in that SDK
 directory explaining its packaging and public surface.

--- a/sdk/kotlin/README.md
+++ b/sdk/kotlin/README.md
@@ -135,6 +135,32 @@ MESH_SDK_MODEL_REF=Qwen2.5-3B-Instruct-Q4_K_M \
 ./gradlew --no-daemon run -p sdk/kotlin/example/example-jvm
 ```
 
+## Apple system model on macOS Golden Gate
+
+Add the platform resource JAR beside the normal Kotlin/JVM SDK:
+
+```kotlin
+runtimeOnly("ai.meshllm:meshllm-apple-runtime-macos-arm64:0.72.1")
+```
+
+Release preparation copies the shared sidecar into that JAR's resources:
+
+```bash
+scripts/package-sdk-provider-runtime.sh --sdk kotlin
+```
+
+```kotlin
+val host = ProviderHost.start(ProviderRuntimeOptions.packagedAppleSystem())
+println(host.apiBaseUrl) // http://127.0.0.1:<port>/v1
+println(host.statusJson())
+host.stop()
+```
+
+The wrapper extracts only manifest-listed files to an empty private directory,
+restores the sidecar executable bit, and removes its transient extraction after
+the host stops. Android packages do not depend on or advertise this macOS-only
+runtime.
+
 ## Optional Console Assets
 
 Published Kotlin/JVM and Android packages include the built console resources

--- a/sdk/kotlin/apple-runtime-macos-arm64/README.md
+++ b/sdk/kotlin/apple-runtime-macos-arm64/README.md
@@ -1,0 +1,5 @@
+# MeshLLM Apple runtime for macOS arm64
+
+Platform resource JAR for the MeshLLM Kotlin/JVM SDK. It carries the signed
+`mesh-apple-runtime` sidecar used to expose `apple/system` on macOS Golden Gate.
+It contains no Kotlin-specific provider implementation.

--- a/sdk/kotlin/apple-runtime-macos-arm64/build.gradle.kts
+++ b/sdk/kotlin/apple-runtime-macos-arm64/build.gradle.kts
@@ -1,0 +1,21 @@
+plugins {
+    `java-library`
+    `maven-publish`
+}
+
+group = "ai.meshllm"
+version = "0.72.1"
+
+publishing {
+    publications {
+        create<MavenPublication>("runtimeJar") {
+            artifactId = "meshllm-apple-runtime-macos-arm64"
+            from(components["java"])
+            pom {
+                name.set("MeshLLM Apple runtime for macOS arm64")
+                description.set("Signed Apple provider sidecar resources for the MeshLLM Kotlin/JVM SDK.")
+                url.set("https://github.com/Mesh-LLM/mesh-llm")
+            }
+        }
+    }
+}

--- a/sdk/kotlin/example/example-jvm/src/main/kotlin/ai/meshllm/example/ExampleMain.kt
+++ b/sdk/kotlin/example/example-jvm/src/main/kotlin/ai/meshllm/example/ExampleMain.kt
@@ -7,6 +7,8 @@ import ai.meshllm.InviteToken
 import ai.meshllm.LoadModelOptions
 import ai.meshllm.NativeRuntime
 import ai.meshllm.Node
+import ai.meshllm.ProviderHost
+import ai.meshllm.ProviderRuntimeOptions
 import ai.meshllm.UnloadModelOptions
 import kotlinx.coroutines.runBlocking
 import uniffi.mesh_ffi.DevicePolicy
@@ -16,6 +18,11 @@ import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
 fun main(args: Array<String>) = runBlocking {
+    val providerRoot = System.getenv("MESH_APPLE_PROVIDER_ROOT")
+    if (providerRoot != null) {
+        runProviderHost(providerRoot)
+        return@runBlocking
+    }
     val modelRef = System.getenv("MESH_SDK_MODEL_REF")
     val inviteToken = args.firstOrNull { !it.startsWith("--") } ?: modelRef?.let { "local-kotlin-example" } ?: run {
         System.err.println("Usage: ExampleMain <invite_token>")
@@ -74,6 +81,26 @@ fun main(args: Array<String>) = runBlocking {
     } finally {
         node.stop()
         println("[disconnect] ok")
+    }
+}
+
+private suspend fun runProviderHost(providerRoot: String) {
+    val readyFile = System.getenv("MESH_APPLE_SDK_READY_FILE")?.let(::File)
+        ?: error("MESH_APPLE_SDK_READY_FILE is required")
+    val stopFile = System.getenv("MESH_APPLE_SDK_STOP_FILE")?.let(::File)
+        ?: error("MESH_APPLE_SDK_STOP_FILE is required")
+    val host = ProviderHost.start(
+        ProviderRuntimeOptions(bundleRoots = listOf(File(providerRoot)))
+    )
+    readyFile.writeText(
+        "{\"carrier\":\"kotlin-jvm\",\"apiBaseUrl\":\"${host.apiBaseUrl}\"}\n"
+    )
+    try {
+        while (!stopFile.exists()) {
+            kotlinx.coroutines.delay(100)
+        }
+    } finally {
+        host.stop()
     }
 }
 

--- a/sdk/kotlin/settings.gradle.kts
+++ b/sdk/kotlin/settings.gradle.kts
@@ -1,1 +1,3 @@
 rootProject.name = "MeshLLM"
+
+include(":apple-runtime-macos-arm64")

--- a/sdk/kotlin/src/main/kotlin/ai/meshllm/Node.kt
+++ b/sdk/kotlin/src/main/kotlin/ai/meshllm/Node.kt
@@ -14,12 +14,15 @@ import uniffi.mesh_ffi.EventListener as FfiEventListener
 import uniffi.mesh_ffi.MeshClientHandleInterface
 import uniffi.mesh_ffi.MeshNodeHandleInterface
 import uniffi.mesh_ffi.ModelNative
+import uniffi.mesh_ffi.ProviderHostHandleInterface
+import uniffi.mesh_ffi.ProviderRuntimeOptionsNative
 import uniffi.mesh_ffi.ResponsesRequestNative
 import uniffi.mesh_ffi.createAutoClient as ffiCreateAutoClient
 import uniffi.mesh_ffi.createAutoNode as ffiCreateAutoNode
 import uniffi.mesh_ffi.createClient as ffiCreateClient
 import uniffi.mesh_ffi.createNode as ffiCreateNode
 import uniffi.mesh_ffi.discoverPublicMeshes as ffiDiscoverPublicMeshes
+import uniffi.mesh_ffi.startProviderHost as ffiStartProviderHost
 import java.io.File
 import java.nio.file.Files
 
@@ -72,6 +75,115 @@ data class ConsoleOptions(
     val port: UShort? = null,
     val listenAll: Boolean = false,
 )
+
+data class ProviderRuntimeOptions(
+    val bundleRoots: List<File>,
+    val releaseManifest: File? = null,
+    val cacheDir: File? = null,
+    val allowDownload: Boolean = false,
+    val startupTimeoutMs: ULong = 30_000UL,
+    internal val cleanupBundleRoots: List<File> = emptyList(),
+) {
+    companion object {
+        fun packagedAppleSystem(
+            destination: File? = null,
+            cacheDir: File? = null,
+            allowDownload: Boolean = false,
+        ): ProviderRuntimeOptions {
+            val root = ProviderRuntimeAssets.extractPackagedApple(destination)
+            return ProviderRuntimeOptions(
+                bundleRoots = listOf(root),
+                cacheDir = cacheDir,
+                allowDownload = allowDownload,
+                cleanupBundleRoots = if (destination == null) listOf(root) else emptyList(),
+            )
+        }
+    }
+}
+
+object ProviderRuntimeAssets {
+    private const val RESOURCE_ROOT = "mesh-llm/provider-runtimes/apple"
+    private const val MANIFEST = "$RESOURCE_ROOT/manifest.txt"
+
+    fun extractPackagedApple(destination: File? = null): File {
+        val target = destination ?: Files.createTempDirectory("mesh-llm-apple-provider-").toFile()
+        val loader = Thread.currentThread().contextClassLoader
+            ?: ProviderRuntimeAssets::class.java.classLoader
+        val entries = loader.getResourceAsStream(MANIFEST)?.bufferedReader()?.use { reader ->
+            reader.readLines().map(String::trim).filter(String::isNotEmpty)
+        } ?: error("Packaged Apple provider runtime is missing from the MeshLLM JVM resources.")
+
+        check(!target.exists() || target.listFiles().isNullOrEmpty()) {
+            "Provider runtime extraction destination must be empty: ${target.absolutePath}"
+        }
+        target.mkdirs()
+        entries.forEach { relativePath ->
+            requireSafeProviderRuntimePath(relativePath)
+            val output = target.resolve(relativePath)
+            output.parentFile?.mkdirs()
+            loader.getResourceAsStream("$RESOURCE_ROOT/$relativePath")?.use { input ->
+                output.outputStream().use { destinationStream ->
+                    input.copyTo(destinationStream)
+                }
+            } ?: error("Packaged Apple provider runtime file is missing: $relativePath")
+        }
+        check(target.resolve("provider-runtime.json").isFile) {
+            "Packaged Apple provider runtime did not include provider-runtime.json"
+        }
+        target.resolve("bin/mesh-apple-runtime").setExecutable(true, true)
+        return target
+    }
+
+    private fun requireSafeProviderRuntimePath(relativePath: String) {
+        require(relativePath.isNotBlank()) { "Provider runtime path must not be blank" }
+        require(!relativePath.startsWith("/") && !relativePath.contains("\\")) {
+            "Provider runtime path must be relative: $relativePath"
+        }
+        require(relativePath.split('/').none { it == ".." || it.isBlank() }) {
+            "Provider runtime path must stay inside the carrier resource: $relativePath"
+        }
+    }
+}
+
+class ProviderHost private constructor(
+    private val handle: ProviderHostHandleInterface,
+    private val cleanupBundleRoots: List<File>,
+) {
+    val apiBaseUrl: String get() = handle.apiBaseUrl()
+
+    suspend fun statusJson(): String = withContext(Dispatchers.IO) { handle.statusJson() }
+
+    suspend fun stop(): Unit = withContext(Dispatchers.IO) {
+        try {
+            handle.stop()
+        } finally {
+            cleanupBundleRoots.forEach(File::deleteRecursively)
+        }
+    }
+
+    companion object {
+        suspend fun start(options: ProviderRuntimeOptions): ProviderHost =
+            withContext(Dispatchers.IO) {
+                try {
+                    ProviderHost(
+                        ffiStartProviderHost(
+                            ProviderRuntimeOptionsNative(
+                                bundleRoots = options.bundleRoots.map { it.absolutePath },
+                                releaseManifest = options.releaseManifest?.absolutePath,
+                                cacheDir = options.cacheDir?.absolutePath,
+                                allowDownload = options.allowDownload,
+                                startupTimeoutMs = options.startupTimeoutMs,
+                            )
+                        ),
+                        options.cleanupBundleRoots,
+                    )
+                } catch (error: Throwable) {
+                    options.cleanupBundleRoots.forEach(File::deleteRecursively)
+                    throw error
+                }
+            }
+    }
+}
 
 object ConsoleAssets {
     private const val RESOURCE_ROOT = "mesh-llm/console"

--- a/sdk/kotlin/src/test/kotlin/ai/meshllm/ProviderHostTest.kt
+++ b/sdk/kotlin/src/test/kotlin/ai/meshllm/ProviderHostTest.kt
@@ -1,0 +1,27 @@
+package ai.meshllm
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import java.io.File
+
+class ProviderHostTest {
+    @Test
+    fun explicitProviderOptionsOwnCarrierPathsAndPolicy() {
+        val options = ProviderRuntimeOptions(
+            bundleRoots = listOf(File("/app/provider-runtimes/apple")),
+            releaseManifest = File("/app/provider-runtimes.json"),
+            cacheDir = File("/cache/providers"),
+            allowDownload = true,
+            startupTimeoutMs = 45_000UL,
+        )
+
+        assertEquals(listOf(File("/app/provider-runtimes/apple")), options.bundleRoots)
+        assertEquals(File("/app/provider-runtimes.json"), options.releaseManifest)
+        assertEquals(File("/cache/providers"), options.cacheDir)
+        assertTrue(options.allowDownload)
+        assertEquals(45_000UL, options.startupTimeoutMs)
+        assertFalse(options.cleanupBundleRoots.isNotEmpty())
+    }
+}

--- a/sdk/node/README.md
+++ b/sdk/node/README.md
@@ -87,9 +87,35 @@ In an Electron app, package both:
 - `native/<platform>-<arch>/mesh_llm_nodejs.node`
 - the selected `meshllm-native-runtime-*` runtime artifact directory
 - optional `console/` assets when using `node.startConsole()`
+- the optional `@mesh-llm/apple-runtime-darwin-arm64` package when exposing
+  `apple/system` on Golden Gate
 
 Then pass the packaged artifact directory to `resolveNativeRuntime()` before
 creating a serving-enabled node.
+
+## Apple system model on macOS Golden Gate
+
+The experimental provider host starts the packaged Apple sidecar and returns
+the normal OpenAI-compatible loopback URL:
+
+```js
+const {
+  ProviderHost,
+  packagedAppleSystemProvider
+} = require('@mesh-llm/sdk')
+
+const host = await ProviderHost.start(packagedAppleSystemProvider())
+console.log(host.apiBaseUrl) // http://127.0.0.1:<port>/v1
+console.log(await host.status())
+await host.stop()
+```
+
+Run `scripts/package-sdk-provider-runtime.sh --sdk node` before publishing the
+platform package. It is an optional dependency of `@mesh-llm/sdk` and is
+installed only on Darwin arm64. Electron packagers must keep the package's
+`runtime/**` outside ASAR (for example with `asarUnpack`) because macOS must
+execute and verify the real signed file. The Node process owns lifecycle;
+`mesh-apple-runtime` is the one process that receives Apple accelerator access.
 
 ## Optional Console
 

--- a/sdk/node/apple-runtime-darwin-arm64/README.md
+++ b/sdk/node/apple-runtime-darwin-arm64/README.md
@@ -1,0 +1,5 @@
+# MeshLLM Apple runtime for Darwin arm64
+
+Platform resource package for `@mesh-llm/sdk`. It carries the signed
+`mesh-apple-runtime` sidecar used to expose `apple/system` on macOS Golden Gate.
+It contains no language-specific provider implementation.

--- a/sdk/node/apple-runtime-darwin-arm64/index.js
+++ b/sdk/node/apple-runtime-darwin-arm64/index.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const path = require('node:path')
+
+module.exports = {
+  runtimeRoot: path.join(__dirname, 'runtime')
+}

--- a/sdk/node/apple-runtime-darwin-arm64/package.json
+++ b/sdk/node/apple-runtime-darwin-arm64/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@mesh-llm/apple-runtime-darwin-arm64",
+  "version": "0.72.1",
+  "description": "Signed MeshLLM Apple provider sidecar for Apple silicon macOS",
+  "main": "index.js",
+  "files": [
+    "index.js",
+    "runtime/",
+    "README.md"
+  ],
+  "os": [
+    "darwin"
+  ],
+  "cpu": [
+    "arm64"
+  ],
+  "license": "MIT OR Apache-2.0",
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org/",
+    "provenance": true
+  }
+}

--- a/sdk/node/example/apple-system-host.js
+++ b/sdk/node/example/apple-system-host.js
@@ -1,0 +1,32 @@
+'use strict'
+
+const fs = require('node:fs')
+const {
+  ProviderHost,
+  packagedAppleSystemProvider
+} = require('..')
+
+async function main() {
+  const rootDir = process.argv[2]
+  const readyFile = process.argv[3]
+  const stopFile = process.argv[4]
+  if (!rootDir || !readyFile || !stopFile) {
+    throw new Error('usage: apple-system-host <provider-root> <ready-file> <stop-file>')
+  }
+
+  const host = await ProviderHost.start(packagedAppleSystemProvider({ rootDir }))
+  fs.writeFileSync(readyFile, JSON.stringify({
+    carrier: 'node-electron',
+    apiBaseUrl: host.apiBaseUrl
+  }))
+
+  while (!fs.existsSync(stopFile)) {
+    await new Promise((resolve) => setTimeout(resolve, 100))
+  }
+  await host.stop()
+}
+
+main().catch((error) => {
+  console.error(error)
+  process.exit(1)
+})

--- a/sdk/node/index.d.ts
+++ b/sdk/node/index.d.ts
@@ -154,6 +154,29 @@ export type NodeOptions = {
   servingEnabled?: boolean
 }
 
+export type ProviderRuntimeOptions = {
+  bundleRoots: string[]
+  releaseManifest?: string
+  cacheDir?: string
+  allowDownload?: boolean
+  startupTimeoutMs?: number
+}
+
+export declare class ProviderHost {
+  static start(options: ProviderRuntimeOptions): Promise<ProviderHost>
+  readonly apiBaseUrl: string
+  status(): Promise<unknown>
+  stop(): Promise<void>
+}
+
+export declare function packagedAppleSystemProvider(options?: {
+  rootDir?: string
+  releaseManifest?: string
+  cacheDir?: string
+  allowDownload?: boolean
+  startupTimeoutMs?: number
+}): ProviderRuntimeOptions
+
 export type ConsoleOptions = {
   assetDir?: string
   port?: number

--- a/sdk/node/index.js
+++ b/sdk/node/index.js
@@ -102,6 +102,69 @@ class Console {
   }
 }
 
+class ProviderHost {
+  constructor(handle) {
+    this._handle = handle
+  }
+
+  static async start(options) {
+    if (!options || !Array.isArray(options.bundleRoots)) {
+      throw new Error('ProviderHost.start requires ProviderRuntimeOptions.bundleRoots')
+    }
+    const handle = await native.ProviderHost.start(JSON.stringify({
+      bundleRoots: options.bundleRoots,
+      releaseManifest: options.releaseManifest || null,
+      cacheDir: options.cacheDir || null,
+      allowDownload: options.allowDownload === true,
+      startupTimeoutMs: options.startupTimeoutMs || 30000
+    }))
+    return new ProviderHost(handle)
+  }
+
+  get apiBaseUrl() {
+    return this._handle.apiBaseUrl
+  }
+
+  async status() {
+    return parse(await this._handle.statusJson())
+  }
+
+  stop() {
+    return this._handle.stop()
+  }
+}
+
+function packagedAppleSystemProvider(options = {}) {
+  return {
+    bundleRoots: [options.rootDir || packagedAppleRuntimeRoot()],
+    releaseManifest: options.releaseManifest,
+    cacheDir: options.cacheDir,
+    allowDownload: options.allowDownload === true,
+    startupTimeoutMs: options.startupTimeoutMs || 30000
+  }
+}
+
+function packagedAppleRuntimeRoot() {
+  if (process.platform !== 'darwin' || process.arch !== 'arm64') {
+    throw new Error('apple/system requires Apple silicon running macOS Golden Gate')
+  }
+  try {
+    return require('@mesh-llm/apple-runtime-darwin-arm64').runtimeRoot
+  } catch (error) {
+    const developmentRoot = path.join(__dirname, 'apple-runtime-darwin-arm64', 'runtime')
+    try {
+      require.resolve(path.join(developmentRoot, 'provider-runtime.json'))
+      return developmentRoot
+    } catch (_) {
+      throw new Error(
+        'Packaged Apple provider runtime is missing. Install ' +
+        '@mesh-llm/apple-runtime-darwin-arm64 or pass rootDir explicitly.',
+        { cause: error }
+      )
+    }
+  }
+}
+
 class Node {
   constructor(handle) {
     this._handle = handle
@@ -234,6 +297,8 @@ module.exports = {
   Client,
   Console,
   Node,
+  ProviderHost,
+  packagedAppleSystemProvider,
   generateOwnerKeypairHex: native.generateOwnerKeypairHex,
   currentMeshVersion: nativeRuntime.currentMeshVersion,
   currentSkippyAbiVersion: nativeRuntime.currentSkippyAbiVersion,

--- a/sdk/node/package.json
+++ b/sdk/node/package.json
@@ -38,6 +38,9 @@
     "x64"
   ],
   "license": "MIT OR Apache-2.0",
+  "optionalDependencies": {
+    "@mesh-llm/apple-runtime-darwin-arm64": "0.72.1"
+  },
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org/",

--- a/sdk/swift/README.md
+++ b/sdk/swift/README.md
@@ -151,6 +151,27 @@ The generated XCFramework is built with embedded serving support for Apple
 targets. `build-host-macos-xcframework.sh` remains as a faster macOS-only smoke
 artifact for local development; it is not the platform SDK contract.
 
+## Apple system model on macOS Golden Gate
+
+Package the one signed provider sidecar into the macOS-only
+`MeshLLMAppleProviderResources` SwiftPM target, then start its provider-only
+host:
+
+```bash
+scripts/package-sdk-provider-runtime.sh --sdk swift
+```
+
+```swift
+let host = try await ProviderHost.start(.packagedAppleSystem())
+print(host.apiBaseURL) // http://127.0.0.1:<port>/v1
+print(try await host.statusJSON())
+try await host.stop()
+```
+
+This is an experimental macOS Golden Gate surface. Swift owns the host
+lifecycle and resource URL; the shared signed `mesh-apple-runtime` process owns
+Foundation Models and accelerator access.
+
 ## Optional Console Assets
 
 Published Swift packages include the built console as SwiftPM resources under

--- a/sdk/swift/Sources/MeshLLM/Generated/mesh_ffi.swift
+++ b/sdk/swift/Sources/MeshLLM/Generated/mesh_ffi.swift
@@ -1234,6 +1234,141 @@ public func FfiConverterTypeMeshNodeHandle_lower(_ value: MeshNodeHandle) -> UIn
 
 
 
+
+
+public protocol ProviderHostHandleProtocol: AnyObject, Sendable {
+
+    func apiBaseUrl()  -> String
+
+    func statusJson() throws  -> String
+
+    func stop() throws
+
+}
+open class ProviderHostHandle: ProviderHostHandleProtocol, @unchecked Sendable {
+    fileprivate let handle: UInt64
+
+    /// Used to instantiate a [FFIObject] without an actual handle, for fakes in tests, mostly.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public struct NoHandle {
+        public init() {}
+    }
+
+    // TODO: We'd like this to be `private` but for Swifty reasons,
+    // we can't implement `FfiConverter` without making this `required` and we can't
+    // make it `required` without making it `public`.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    required public init(unsafeFromHandle handle: UInt64) {
+        self.handle = handle
+    }
+
+    // This constructor can be used to instantiate a fake object.
+    // - Parameter noHandle: Placeholder value so we can have a constructor separate from the default empty one that may be implemented for classes extending [FFIObject].
+    //
+    // - Warning:
+    //     Any object instantiated with this constructor cannot be passed to an actual Rust-backed object. Since there isn't a backing handle the FFI lower functions will crash.
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public init(noHandle: NoHandle) {
+        self.handle = 0
+    }
+
+#if swift(>=5.8)
+    @_documentation(visibility: private)
+#endif
+    public func uniffiCloneHandle() -> UInt64 {
+        return try! rustCall { uniffi_meshllm_ffi_fn_clone_providerhosthandle(self.handle, $0) }
+    }
+    // No primary constructor declared for this class.
+
+    deinit {
+        if handle == 0 {
+            // Mock objects have handle=0 don't try to free them
+            return
+        }
+
+        try! rustCall { uniffi_meshllm_ffi_fn_free_providerhosthandle(handle, $0) }
+    }
+
+
+
+
+open func apiBaseUrl() -> String  {
+    return try!  FfiConverterString.lift(try! rustCall() {
+    uniffi_meshllm_ffi_fn_method_providerhosthandle_api_base_url(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+
+open func statusJson()throws  -> String  {
+    return try  FfiConverterString.lift(try rustCallWithError(FfiConverterTypeFfiError_lift) {
+    uniffi_meshllm_ffi_fn_method_providerhosthandle_status_json(
+            self.uniffiCloneHandle(),$0
+    )
+})
+}
+
+open func stop()throws   {try rustCallWithError(FfiConverterTypeFfiError_lift) {
+    uniffi_meshllm_ffi_fn_method_providerhosthandle_stop(
+            self.uniffiCloneHandle(),$0
+    )
+}
+}
+
+
+
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeProviderHostHandle: FfiConverter {
+    typealias FfiType = UInt64
+    typealias SwiftType = ProviderHostHandle
+
+    public static func lift(_ handle: UInt64) throws -> ProviderHostHandle {
+        return ProviderHostHandle(unsafeFromHandle: handle)
+    }
+
+    public static func lower(_ value: ProviderHostHandle) -> UInt64 {
+        return value.uniffiCloneHandle()
+    }
+
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ProviderHostHandle {
+        let handle: UInt64 = try readInt(&buf)
+        return try lift(handle)
+    }
+
+    public static func write(_ value: ProviderHostHandle, into buf: inout [UInt8]) {
+        writeInt(&buf, lower(value))
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeProviderHostHandle_lift(_ handle: UInt64) throws -> ProviderHostHandle {
+    return try FfiConverterTypeProviderHostHandle.lift(handle)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeProviderHostHandle_lower(_ value: ProviderHostHandle) -> UInt64 {
+    return FfiConverterTypeProviderHostHandle.lower(value)
+}
+
+
+
+
 public struct ChatMessageNative: Equatable, Hashable {
     public var role: String
     public var content: String
@@ -2555,6 +2690,72 @@ public func FfiConverterTypeNativeRuntimePruneResultNative_lift(_ buf: RustBuffe
 #endif
 public func FfiConverterTypeNativeRuntimePruneResultNative_lower(_ value: NativeRuntimePruneResultNative) -> RustBuffer {
     return FfiConverterTypeNativeRuntimePruneResultNative.lower(value)
+}
+
+
+public struct ProviderRuntimeOptionsNative: Equatable, Hashable {
+    public var bundleRoots: [String]
+    public var releaseManifest: String?
+    public var cacheDir: String?
+    public var allowDownload: Bool
+    public var startupTimeoutMs: UInt64
+
+    // Default memberwise initializers are never public by default, so we
+    // declare one manually.
+    public init(bundleRoots: [String], releaseManifest: String?, cacheDir: String?, allowDownload: Bool, startupTimeoutMs: UInt64) {
+        self.bundleRoots = bundleRoots
+        self.releaseManifest = releaseManifest
+        self.cacheDir = cacheDir
+        self.allowDownload = allowDownload
+        self.startupTimeoutMs = startupTimeoutMs
+    }
+
+
+
+
+}
+
+#if compiler(>=6)
+extension ProviderRuntimeOptionsNative: Sendable {}
+#endif
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public struct FfiConverterTypeProviderRuntimeOptionsNative: FfiConverterRustBuffer {
+    public static func read(from buf: inout (data: Data, offset: Data.Index)) throws -> ProviderRuntimeOptionsNative {
+        return
+            try ProviderRuntimeOptionsNative(
+                bundleRoots: FfiConverterSequenceString.read(from: &buf),
+                releaseManifest: FfiConverterOptionString.read(from: &buf),
+                cacheDir: FfiConverterOptionString.read(from: &buf),
+                allowDownload: FfiConverterBool.read(from: &buf),
+                startupTimeoutMs: FfiConverterUInt64.read(from: &buf)
+        )
+    }
+
+    public static func write(_ value: ProviderRuntimeOptionsNative, into buf: inout [UInt8]) {
+        FfiConverterSequenceString.write(value.bundleRoots, into: &buf)
+        FfiConverterOptionString.write(value.releaseManifest, into: &buf)
+        FfiConverterOptionString.write(value.cacheDir, into: &buf)
+        FfiConverterBool.write(value.allowDownload, into: &buf)
+        FfiConverterUInt64.write(value.startupTimeoutMs, into: &buf)
+    }
+}
+
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeProviderRuntimeOptionsNative_lift(_ buf: RustBuffer) throws -> ProviderRuntimeOptionsNative {
+    return try FfiConverterTypeProviderRuntimeOptionsNative.lift(buf)
+}
+
+#if swift(>=5.8)
+@_documentation(visibility: private)
+#endif
+public func FfiConverterTypeProviderRuntimeOptionsNative_lower(_ value: ProviderRuntimeOptionsNative) -> RustBuffer {
+    return FfiConverterTypeProviderRuntimeOptionsNative.lower(value)
 }
 
 
@@ -4688,6 +4889,13 @@ public func removeNativeRuntime(cacheDir: String?, meshVersion: String, nativeRu
     )
 })
 }
+public func startProviderHost(options: ProviderRuntimeOptionsNative)throws  -> ProviderHostHandle  {
+    return try  FfiConverterTypeProviderHostHandle_lift(try rustCallWithError(FfiConverterTypeFfiError_lift) {
+    uniffi_meshllm_ffi_fn_func_start_provider_host(
+        FfiConverterTypeProviderRuntimeOptionsNative_lower(options),$0
+    )
+})
+}
 
 private enum InitializationResult {
     case ok
@@ -4738,6 +4946,9 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_meshllm_ffi_checksum_func_remove_native_runtime() != 48639) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_meshllm_ffi_checksum_func_start_provider_host() != 55013) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_meshllm_ffi_checksum_method_consolehandle_stop() != 13931) {
@@ -4843,6 +5054,15 @@ private let initializationResult: InitializationResult = {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_model_by_id() != 21862) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_meshllm_ffi_checksum_method_providerhosthandle_api_base_url() != 2817) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_meshllm_ffi_checksum_method_providerhosthandle_status_json() != 3874) {
+        return InitializationResult.apiChecksumMismatch
+    }
+    if (uniffi_meshllm_ffi_checksum_method_providerhosthandle_stop() != 23768) {
         return InitializationResult.apiChecksumMismatch
     }
     if (uniffi_meshllm_ffi_checksum_method_eventlistener_on_event() != 56769) {

--- a/sdk/swift/Sources/MeshLLM/ProviderHost.swift
+++ b/sdk/swift/Sources/MeshLLM/ProviderHost.swift
@@ -1,0 +1,115 @@
+import Foundation
+#if os(macOS)
+import MeshLLMAppleProviderResources
+#endif
+
+public struct ProviderRuntimeOptions: Sendable {
+    public let bundleRoots: [URL]
+    public let releaseManifest: URL?
+    public let cacheDirectory: URL?
+    public let allowDownload: Bool
+    public let startupTimeout: Duration
+
+    public init(
+        bundleRoots: [URL],
+        releaseManifest: URL? = nil,
+        cacheDirectory: URL? = nil,
+        allowDownload: Bool = false,
+        startupTimeout: Duration = .seconds(30)
+    ) {
+        self.bundleRoots = bundleRoots
+        self.releaseManifest = releaseManifest
+        self.cacheDirectory = cacheDirectory
+        self.allowDownload = allowDownload
+        self.startupTimeout = startupTimeout
+    }
+
+    public static func packagedAppleSystem(
+        cacheDirectory: URL? = nil,
+        allowDownload: Bool = false
+    ) throws -> ProviderRuntimeOptions {
+        #if os(macOS)
+        guard let root = MeshLLMAppleProviderResources.appleRuntimeRoot else {
+            throw ProviderRuntimeAssetError.packagedAppleRuntimeMissing
+        }
+        return ProviderRuntimeOptions(
+            bundleRoots: [root],
+            cacheDirectory: cacheDirectory,
+            allowDownload: allowDownload
+        )
+        #else
+        throw ProviderRuntimeAssetError.packagedAppleRuntimeMissing
+        #endif
+    }
+}
+
+public enum ProviderRuntimeAssetError: Error, CustomStringConvertible {
+    case packagedAppleRuntimeMissing
+
+    public var description: String {
+        switch self {
+        case .packagedAppleRuntimeMissing:
+            return "Packaged Apple provider runtime is missing from the MeshLLM SwiftPM resources."
+        }
+    }
+}
+
+#if canImport(MeshLLMFFI)
+public final class ProviderHost: @unchecked Sendable {
+    private let handle: ProviderHostHandle
+
+    public var apiBaseURL: URL {
+        URL(string: handle.apiBaseUrl())!
+    }
+
+    private init(handle: ProviderHostHandle) {
+        self.handle = handle
+    }
+
+    public static func start(_ options: ProviderRuntimeOptions) async throws -> ProviderHost {
+        let timeout = options.startupTimeout.components
+        let timeoutMilliseconds = UInt64(max(1, timeout.seconds * 1_000
+            + Int64(timeout.attoseconds / 1_000_000_000_000_000)))
+        let handle = try await runProviderBlocking {
+            try startProviderHost(
+                options: ProviderRuntimeOptionsNative(
+                    bundleRoots: options.bundleRoots.map(\.path),
+                    releaseManifest: options.releaseManifest?.path,
+                    cacheDir: options.cacheDirectory?.path,
+                    allowDownload: options.allowDownload,
+                    startupTimeoutMs: timeoutMilliseconds
+                )
+            )
+        }
+        return ProviderHost(handle: handle)
+    }
+
+    public func statusJSON() async throws -> String {
+        let handle = self.handle
+        return try await runProviderBlocking {
+            try handle.statusJson()
+        }
+    }
+
+    public func stop() async throws {
+        let handle = self.handle
+        try await runProviderBlocking {
+            try handle.stop()
+        }
+    }
+}
+
+private func runProviderBlocking<T>(_ work: @escaping () throws -> T) async throws -> T {
+    try await withCheckedThrowingContinuation { continuation in
+        DispatchQueue.global().async(flags: .inheritQoS) {
+            do {
+                continuation.resume(returning: try work())
+            } catch {
+                continuation.resume(throwing: error)
+            }
+        }
+    }
+}
+#else
+#error("MeshLLM Swift SDK requires MeshLLMFFI.xcframework. Build it before using provider hosts.")
+#endif

--- a/sdk/swift/Sources/MeshLLMAppleProviderResources/ProviderResources.swift
+++ b/sdk/swift/Sources/MeshLLMAppleProviderResources/ProviderResources.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+public enum MeshLLMAppleProviderResources {
+    public static var appleRuntimeRoot: URL? {
+        Bundle.module.url(forResource: "apple", withExtension: nil)
+    }
+}

--- a/sdk/swift/Tests/MeshLLMTests/ProviderHostTests.swift
+++ b/sdk/swift/Tests/MeshLLMTests/ProviderHostTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+@testable import MeshLLM
+
+final class ProviderHostTests: XCTestCase {
+    func testExplicitCarrierConfigurationUsesURLs() {
+        let root = URL(fileURLWithPath: "/app/Resources/provider-runtimes/apple")
+        let options = ProviderRuntimeOptions(
+            bundleRoots: [root],
+            releaseManifest: URL(fileURLWithPath: "/app/Resources/provider-runtimes.json"),
+            cacheDirectory: URL(fileURLWithPath: "/cache/providers"),
+            allowDownload: true,
+            startupTimeout: .seconds(45)
+        )
+
+        XCTAssertEqual(options.bundleRoots, [root])
+        XCTAssertTrue(options.allowDownload)
+        XCTAssertEqual(options.startupTimeout, .seconds(45))
+    }
+}

--- a/sdk/swift/example/MeshExampleApp/Package.swift
+++ b/sdk/swift/example/MeshExampleApp/Package.swift
@@ -20,6 +20,23 @@ let package = Package(
                 .linkedFramework("Accelerate"),
                 .linkedFramework("AppKit"),
                 .linkedFramework("CoreGraphics"),
+                .linkedFramework("CoreWLAN"),
+                .linkedFramework("Metal"),
+                .linkedFramework("SystemConfiguration"),
+                .linkedLibrary("c++"),
+            ]
+        ),
+        .executableTarget(
+            name: "AppleSystemHost",
+            dependencies: [
+                .product(name: "MeshLLM", package: "mesh-llm"),
+            ],
+            path: "Sources/AppleSystemHost",
+            linkerSettings: [
+                .linkedFramework("Accelerate"),
+                .linkedFramework("AppKit"),
+                .linkedFramework("CoreGraphics"),
+                .linkedFramework("CoreWLAN"),
                 .linkedFramework("Metal"),
                 .linkedFramework("SystemConfiguration"),
                 .linkedLibrary("c++"),

--- a/sdk/swift/example/MeshExampleApp/Sources/AppleSystemHost/main.swift
+++ b/sdk/swift/example/MeshExampleApp/Sources/AppleSystemHost/main.swift
@@ -1,0 +1,37 @@
+import Foundation
+import MeshLLM
+
+let arguments = Array(CommandLine.arguments.dropFirst())
+guard arguments.count == 3 else {
+    FileHandle.standardError.write(
+        Data("usage: AppleSystemHost <provider-root> <ready-file> <stop-file>\n".utf8)
+    )
+    exit(2)
+}
+
+let providerRoot = URL(fileURLWithPath: arguments[0], isDirectory: true)
+let readyFile = URL(fileURLWithPath: arguments[1])
+let stopFile = URL(fileURLWithPath: arguments[2])
+
+Task {
+    do {
+        let host = try await ProviderHost.start(
+            ProviderRuntimeOptions(bundleRoots: [providerRoot])
+        )
+        let ready = try JSONSerialization.data(withJSONObject: [
+            "carrier": "swift",
+            "apiBaseUrl": host.apiBaseURL.absoluteString,
+        ])
+        try ready.write(to: readyFile, options: .atomic)
+        while !FileManager.default.fileExists(atPath: stopFile.path) {
+            try await Task.sleep(for: .milliseconds(100))
+        }
+        try await host.stop()
+        exit(0)
+    } catch {
+        FileHandle.standardError.write(Data("\(error)\n".utf8))
+        exit(1)
+    }
+}
+
+RunLoop.main.run()

--- a/sdk/swift/scripts/build-host-macos-xcframework.sh
+++ b/sdk/swift/scripts/build-host-macos-xcframework.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 SWIFT_DIR="$REPO_ROOT/sdk/swift"
 FFI_DIR="$SWIFT_DIR/Generated/FFI"
-TARGET_DIR="$REPO_ROOT/target"
+TARGET_DIR="${CARGO_TARGET_DIR:-$REPO_ROOT/target}"
+if [[ "$TARGET_DIR" != /* ]]; then
+  TARGET_DIR="$REPO_ROOT/$TARGET_DIR"
+fi
 XCFRAMEWORK_DIR="$SWIFT_DIR/Generated"
 FRAMEWORK_NAME="MeshLLMFFI"
 GENERATED_SWIFT="$SWIFT_DIR/Sources/MeshLLM/Generated/mesh_ffi.swift"
@@ -43,16 +46,34 @@ echo "Preparing embedded llama.cpp ABI libraries..."
 "$REPO_ROOT/scripts/prepare-llama.sh" "${MESH_LLM_LLAMA_PIN_SHA:-pinned}"
 LLAMA_BUILD_DIR="$LLAMA_STAGE_BUILD_DIR" "$REPO_ROOT/scripts/build-llama.sh"
 
-RUSTUP_RUSTC="$(rustup run stable which rustc)"
+RUSTUP_RUSTC="$(rustup which --toolchain stable rustc)"
+RUSTUP_CARGO="$(rustup which --toolchain stable cargo)"
 echo "Using rustc: $RUSTUP_RUSTC"
+echo "Using cargo: $RUSTUP_CARGO"
 echo "Building for $RUST_TARGET..."
 echo "macOS deployment target: $MACOSX_DEPLOYMENT_TARGET"
 echo "llama.cpp backend: $LLAMA_STAGE_BACKEND"
 echo "llama.cpp build dir: $LLAMA_STAGE_BUILD_DIR"
+FFI_PROFILE="${MESH_SWIFT_FFI_PROFILE:-release}"
+case "$FFI_PROFILE" in
+  release)
+    PROFILE_ARGS=(--release)
+    PROFILE_DIR=release
+    ;;
+  debug)
+    PROFILE_ARGS=()
+    PROFILE_DIR=debug
+    ;;
+  *)
+    echo "Unsupported MESH_SWIFT_FFI_PROFILE: $FFI_PROFILE" >&2
+    exit 2
+    ;;
+esac
+echo "Rust profile: $FFI_PROFILE"
 RUSTC="$RUSTUP_RUSTC" \
-  cargo build --release -p mesh-llm-ffi --target "$RUST_TARGET" --no-default-features --features host,embedded-runtime
+  "$RUSTUP_CARGO" build "${PROFILE_ARGS[@]}" -p mesh-llm-ffi --no-default-features --features host,embedded-runtime
 
-LIB_PATH="$TARGET_DIR/$RUST_TARGET/release/libmeshllm_ffi.a"
+LIB_PATH="$TARGET_DIR/$PROFILE_DIR/libmeshllm_ffi.a"
 
 echo "Syncing UniFFI API checksums into generated Swift bindings..."
 python3 - "$LIB_PATH" "$GENERATED_SWIFT" <<'PY'

--- a/sdk/swift/scripts/build-xcframework.sh
+++ b/sdk/swift/scripts/build-xcframework.sh
@@ -39,9 +39,11 @@ RUSTUP_RUSTC="$HOME/.rustup/toolchains/stable-aarch64-apple-darwin/bin/rustc"
 if [ ! -x "$RUSTUP_RUSTC" ]; then
   # Fallback: find any stable toolchain
   STABLE_TOOLCHAIN=$(rustup toolchain list | grep stable | head -1 | awk '{print $1}')
-  RUSTUP_RUSTC="$(rustup run "$STABLE_TOOLCHAIN" which rustc)"
+  RUSTUP_RUSTC="$(rustup which --toolchain "$STABLE_TOOLCHAIN" rustc)"
 fi
 echo "Using rustc: $RUSTUP_RUSTC"
+RUSTUP_CARGO="$(dirname "$RUSTUP_RUSTC")/cargo"
+echo "Using cargo: $RUSTUP_CARGO"
 
 build_llama_for_target() {
   local RUST_TARGET="$1"
@@ -83,7 +85,7 @@ build_rust_target() {
   esac
 
   env "${CARGO_ENV[@]}" \
-    cargo build --release -p mesh-llm-ffi --target "$RUST_TARGET" --no-default-features --features "$RUST_FEATURES"
+    "$RUSTUP_CARGO" build --release -p mesh-llm-ffi --target "$RUST_TARGET" --no-default-features --features "$RUST_FEATURES"
 }
 
 build_apple_target() {


### PR DESCRIPTION
> [!WARNING]
> Experimental. This requires Apple silicon running **macOS Golden Gate (macOS 27)**. It is not a public/default routing path and the ad-hoc-signed QA artifact is not release eligible.

Stacked on #1256. Tracks the Phase 2 SDK-carrier work in #1246.

## Why

Apple Silicon users should be able to use the model already supplied and updated by macOS through the same OpenAI-compatible MeshLLM surface as every other model. That gives Mac applications private on-device inference, no model download, low setup cost, accelerator-backed execution, low network latency, and offline availability.

This complements Skippy rather than adding pipeline parallelism: `apple/system` is a whole-model local provider. MeshLLM routes the complete request to the capable Mac and the one shared Swift sidecar calls Foundation Models.

## What changed

- adds a shared typed Rust `ProviderHost` lifecycle that starts a provider-only embedded host and returns its loopback `/v1` base URL;
- exposes that lifecycle through UniFFI to Swift and Kotlin/JVM and through N-API to Node/Electron;
- keeps Foundation Models behavior, tool semantics, cancellation, usage, model identity, and accelerator access in the single `mesh-apple-runtime` Swift sidecar;
- packages the exact same signed sidecar bytes in platform-gated carriers:
  - macOS-only `MeshLLMAppleProviderResources` SwiftPM target;
  - optional Darwin-arm64 `@mesh-llm/apple-runtime-darwin-arm64` npm package;
  - `meshllm-apple-runtime-macos-arm64` JVM resource JAR;
- avoids shipping a macOS executable in Linux/Windows npm, iOS, or Android artifacts;
- adds one live conformance runner for Swift, Node/Electron, and Kotlin/JVM;
- updates the Apple runtime and SDK documentation with packaging, lifecycle, and release constraints.

The SDKs supply typed bundle roots and deliberately ignore process-global provider discovery variables. The signed sidecar process receives Apple accelerator access; the language process only owns supervision and the REST endpoint lifecycle.

## Try it

Prerequisites:

1. Apple silicon Mac running macOS Golden Gate (macOS 27).
2. Full Xcode installed and selected with `sudo xcode-select -s /Applications/Xcode.app/Contents/Developer`.
3. Xcode licence accepted, Swift 6.4 available, Node.js 20+, Rust, and JDK 21 installed.
4. This branch checked out on top of #1256.

Run all three real language carriers through the same REST suite:

```bash
just apple::sdk-carriers
```

That command:

1. builds and ad-hoc signs the experimental `mesh-apple-runtime` package;
2. builds the Node N-API, Kotlin UniFFI/JNA, and Swift XCFramework carriers;
3. starts Swift, Node/Electron, and Kotlin/JVM one at a time;
4. waits for `apple/system@27.0`;
5. exercises model listing, buffered completion, versioned completion, SSE, tools, usage, disconnect cancellation, slot recovery, and typed errors;
6. writes the aggregate result to `target/apple-runtime/sdk-carriers/summary.json`.

To prepare the three platform resource packages from the already-built sidecar:

```bash
just apple::sdk-package
```

Release automation must feed that step the already Developer-ID-signed and notarized provider artifact. It must not rebuild or re-sign a different sidecar per SDK. Electron packages must unpack the provider runtime from ASAR.

## SDK shape

Swift:

```swift
let host = try await ProviderHost.start(.packagedAppleSystem())
print(host.apiBaseURL)
try await host.stop()
```

Node/Electron:

```js
const host = await ProviderHost.start(packagedAppleSystemProvider())
console.log(host.apiBaseUrl)
await host.stop()
```

Kotlin/JVM:

```kotlin
val host = ProviderHost.start(ProviderRuntimeOptions.packagedAppleSystem())
println(host.apiBaseUrl)
host.stop()
```

Each URL is an ordinary loopback OpenAI-compatible endpoint such as `http://127.0.0.1:53771/v1`.

## Golden Gate REST evidence

Completion captured through the Swift carrier's REST endpoint:

```json
{
  "model": "apple/system",
  "object": "chat.completion",
  "choices": [{
    "index": 0,
    "finish_reason": "stop",
    "message": {
      "role": "assistant",
      "content": "apple runtime REST ready"
    }
  }],
  "usage": {
    "prompt_tokens": 65,
    "completion_tokens": 9,
    "total_tokens": 74
  },
  "mesh_timing": {
    "time_to_first_token_ms": 1664,
    "elapsed_ms": 1749
  }
}
```

Tool execution captured over the same REST surface:

```json
{
  "model": "apple/system",
  "choices": [{
    "finish_reason": "stop",
    "message": {
      "role": "assistant",
      "content": "mesh-fixture-value-for-rest-demo"
    }
  }],
  "mesh_tool_executions": [{
    "name": "mesh_fixture_lookup",
    "arguments": {"key": "rest-demo"},
    "result": "mesh-fixture-value-for-rest-demo"
  }],
  "usage": {
    "prompt_tokens": 327,
    "completion_tokens": 13,
    "total_tokens": 340
  }
}
```

The final shared result was `pass` for `swift`, `node-electron`, and `kotlin-jvm`; all three resolved `apple/system@27.0`, completed SSE, cancelled on client disconnect, released the slot, and returned structured model errors.

## Validation

- `just apple::sdk-carriers`
- `just build`
- `cargo test -p mesh-llm-sdk --features serving` (through `just with-lld`)
- `cargo test -p mesh-llm-ffi --features host,embedded-runtime --lib` (through `just with-lld`)
- `cargo test -p mesh-llm-nodejs --lib` (through `just with-lld`)
- touched-crate Clippy pass
- `swift test --package-path .` — 14 tests
- Kotlin/JVM Gradle tests on JDK 21
- Node tests and syntax checks
- ShellCheck and `git diff --check`
- platform-package dry run proved the same sidecar SHA-256 in SwiftPM, npm, and JVM resources

## Remaining promotion gates

- publish the notarized provider and platform resource packages through the real release channels;
- validate quarantine and App Sandbox behavior in signed Swift and packaged Electron applications;
- complete Apple policy/licensing review before enabling a public/default route;
- Phase 3 private-mesh availability, load routing, failover, affinity, and withdrawal remains separate.
