### PR TITLE
Route Apple system models across private meshes

### DIFF
--- a/crates/mesh-client/tests/mesh_types.rs
+++ b/crates/mesh-client/tests/mesh_types.rs
@@ -34,6 +34,11 @@ fn model_runtime_descriptor_not_ready_by_default() {
         identity_hash: None,
         context_length: None,
         ready: false,
+        provider_kind: None,
+        model_version: None,
+        max_concurrent_requests: None,
+        active_requests: None,
+        queued_requests: None,
     };
     assert!(d.advertised_context_length().is_none());
 }
@@ -45,6 +50,11 @@ fn model_runtime_descriptor_ready_returns_context_length() {
         identity_hash: None,
         context_length: Some(4096),
         ready: true,
+        provider_kind: None,
+        model_version: None,
+        max_concurrent_requests: None,
+        active_requests: None,
+        queued_requests: None,
     };
     assert_eq!(d.advertised_context_length(), Some(4096));
 }

--- a/crates/mesh-llm-host-runtime/src/api/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/mod.rs
@@ -71,8 +71,7 @@ use self::status::{
     OpenAiGuardrailsPayload, RuntimeCapabilityFlags, RuntimeLlamaPayload, RuntimeProcessesPayload,
     RuntimeStatusPayload, StatusPayload, build_runtime_processes_payload,
     build_runtime_stage_payloads, build_runtime_status_payload, derive_daemon_state,
-    enrich_provider_runtime_models,
-    runtime_stage_state_label, runtime_stage_wire_dtype_label,
+    enrich_provider_runtime_models, runtime_stage_state_label, runtime_stage_wire_dtype_label,
 };
 use crate::mesh;
 use crate::models::append_external_inference_models;

--- a/crates/mesh-llm-host-runtime/src/api/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/mod.rs
@@ -71,6 +71,7 @@ use self::status::{
     OpenAiGuardrailsPayload, RuntimeCapabilityFlags, RuntimeLlamaPayload, RuntimeProcessesPayload,
     RuntimeStatusPayload, StatusPayload, build_runtime_processes_payload,
     build_runtime_stage_payloads, build_runtime_status_payload, derive_daemon_state,
+    enrich_provider_runtime_models,
     runtime_stage_state_label, runtime_stage_wire_dtype_label,
 };
 use crate::mesh;
@@ -555,14 +556,15 @@ impl MeshApi {
     }
 
     async fn runtime_status(&self) -> RuntimeStatusPayload {
-        let (runtime_status, openai_guardrails) = {
+        let (runtime_status, openai_guardrails, node) = {
             let inner = self.inner.lock().await;
             (
                 inner.runtime_data_collector.runtime_status_snapshot(),
                 inner.openai_guardrails.clone(),
+                inner.node.clone(),
             )
         };
-        build_runtime_status_payload(
+        let mut payload = build_runtime_status_payload(
             runtime_status.primary_model.as_deref().unwrap_or_default(),
             runtime_status.primary_backend,
             openai_guardrails,
@@ -570,7 +572,10 @@ impl MeshApi {
             runtime_status.llama_ready,
             runtime_status.llama_port,
             runtime_data::runtime_process_payloads(&runtime_status.local_processes),
-        )
+        );
+        let provider_runtimes = node.local_model_runtime_descriptors().await;
+        enrich_provider_runtime_models(&mut payload.models, &provider_runtimes);
+        payload
     }
 
     async fn runtime_processes(&self) -> RuntimeProcessesPayload {
@@ -902,9 +907,7 @@ impl MeshApi {
             runtime_status.llama_port,
             local_processes.clone(),
         );
-        node.refresh_stage_runtime_statuses(std::time::Duration::from_secs(2))
-            .await;
-        runtime.stages = build_runtime_stage_payloads(node.stage_runtime_statuses().await);
+        enrich_runtime_observations(&node, &mut runtime).await;
 
         let wakeable_nodes = wakeable_inventory.status_snapshot().await;
         let hardware = runtime_data_collector
@@ -919,14 +922,8 @@ impl MeshApi {
         append_external_inference_models(&mut hosted_models, &plugin_models);
         let peers = node.peers().await;
 
-        let local_serving = local_processes
-            .iter()
-            .any(|process| matches!(process.status.as_str(), "serving" | "ready"));
-        let plugin_ingress = !plugin_models.is_empty();
-        let proxying = plugin_ingress
-            || peers
-                .iter()
-                .any(|peer| !peer.http_routable_models().is_empty());
+        let (local_serving, plugin_ingress, proxying) =
+            runtime_serving_activity(&local_processes, &plugin_models, &peers);
         let lifecycle_instances = build_lifecycle_instances(&local_processes);
         let has_terminal_failure = lifecycle_instances
             .iter()
@@ -1012,6 +1009,30 @@ impl MeshApi {
         inner.runtime_data_producer.mark_status_dirty();
         inner.sse_clients.retain(|tx| !tx.is_closed());
     }
+}
+
+async fn enrich_runtime_observations(node: &mesh::Node, runtime: &mut RuntimeStatusPayload) {
+    let provider_runtimes = node.local_model_runtime_descriptors().await;
+    enrich_provider_runtime_models(&mut runtime.models, &provider_runtimes);
+    node.refresh_stage_runtime_statuses(std::time::Duration::from_secs(2))
+        .await;
+    runtime.stages = build_runtime_stage_payloads(node.stage_runtime_statuses().await);
+}
+
+fn runtime_serving_activity(
+    local_processes: &[RuntimeProcessPayload],
+    plugin_models: &[String],
+    peers: &[mesh::PeerInfo],
+) -> (bool, bool, bool) {
+    let local_serving = local_processes
+        .iter()
+        .any(|process| matches!(process.status.as_str(), "serving" | "ready"));
+    let plugin_ingress = !plugin_models.is_empty();
+    let proxying = plugin_ingress
+        || peers
+            .iter()
+            .any(|peer| !peer.http_routable_models().is_empty());
+    (local_serving, plugin_ingress, proxying)
 }
 
 fn build_lifecycle_instances(

--- a/crates/mesh-llm-host-runtime/src/api/state.rs
+++ b/crates/mesh-llm-host-runtime/src/api/state.rs
@@ -107,6 +107,16 @@ pub struct RuntimeModelPayload {
     pub port: Option<u16>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_length: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_concurrent_requests: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_requests: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub queued_requests: Option<u32>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, Serialize)]

--- a/crates/mesh-llm-host-runtime/src/api/status.rs
+++ b/crates/mesh-llm-host-runtime/src/api/status.rs
@@ -10,6 +10,7 @@ use crate::runtime_data;
 use crate::system::hardware::expand_gpu_names;
 mod runtime;
 
+use mesh_llm_types::mesh::ModelRuntimeDescriptor;
 pub(crate) use runtime::*;
 use serde::Serialize;
 use skippy_server::OpenAiGuardrailsStatus;
@@ -512,6 +513,8 @@ pub(crate) struct PeerPayload {
     pub(crate) hosted_models_known: bool,
     #[serde(skip_serializing_if = "Vec::is_empty", default)]
     pub(crate) advertised_model_throughput: Vec<metrics::ModelThroughputHint>,
+    #[serde(skip_serializing_if = "Vec::is_empty", default)]
+    pub(crate) provider_runtimes: Vec<ModelRuntimeDescriptor>,
     pub(crate) version: Option<String>,
     pub(crate) rtt_ms: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -743,6 +746,11 @@ pub(crate) fn build_runtime_status_payload(
             status: process.status,
             port: Some(process.port),
             context_length: process.context_length,
+            provider_kind: None,
+            model_version: None,
+            max_concurrent_requests: None,
+            active_requests: None,
+            queued_requests: None,
         })
         .collect();
 
@@ -758,6 +766,11 @@ pub(crate) fn build_runtime_status_payload(
                 status: "starting".into(),
                 port: llama_port,
                 context_length: None,
+                provider_kind: None,
+                model_version: None,
+                max_concurrent_requests: None,
+                active_requests: None,
+                queued_requests: None,
             },
         );
     }
@@ -771,6 +784,24 @@ pub(crate) fn build_runtime_status_payload(
         capabilities: None,
         lifecycle_instances: vec![],
         intent_summary: None,
+    }
+}
+
+pub(crate) fn enrich_provider_runtime_models(
+    models: &mut [RuntimeModelPayload],
+    descriptors: &[ModelRuntimeDescriptor],
+) {
+    for model in models {
+        let Some(descriptor) = descriptors.iter().find(|descriptor| {
+            descriptor.model_name == model.name && descriptor.provider_kind.is_some()
+        }) else {
+            continue;
+        };
+        model.provider_kind.clone_from(&descriptor.provider_kind);
+        model.model_version.clone_from(&descriptor.model_version);
+        model.max_concurrent_requests = descriptor.max_concurrent_requests;
+        model.active_requests = descriptor.active_requests;
+        model.queued_requests = descriptor.queued_requests;
     }
 }
 
@@ -1098,6 +1129,7 @@ mod tests {
             hosted_models: vec![],
             hosted_models_known: false,
             advertised_model_throughput: vec![],
+            provider_runtimes: vec![],
             version: Some("0.56.0".to_string()),
             rtt_ms: None,
             latency_ms: None,
@@ -1131,6 +1163,7 @@ mod tests {
             hosted_models: vec![],
             hosted_models_known: false,
             advertised_model_throughput: vec![],
+            provider_runtimes: vec![],
             version: None,
             rtt_ms: None,
             latency_ms: None,
@@ -1442,6 +1475,7 @@ mod tests {
             hosted_models: vec!["Qwen".to_string()],
             hosted_models_known: true,
             advertised_model_throughput: vec![],
+            provider_runtimes: vec![],
             version: Some("0.60.2".to_string()),
             rtt_ms: Some(12),
             latency_ms: None,

--- a/crates/mesh-llm-host-runtime/src/api/tests/node_state.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests/node_state.rs
@@ -152,6 +152,7 @@ fn derive_peer_state_prefers_client_role() {
         identity_hash: None,
         context_length: Some(8192),
         ready: true,
+        ..Default::default()
     }];
 
     assert_eq!(MeshApi::derive_peer_state(&peer), NodeState::Client);
@@ -168,6 +169,7 @@ fn derive_peer_state_returns_serving_for_ready_runtime() {
         identity_hash: None,
         context_length: Some(8192),
         ready: true,
+        ..Default::default()
     }];
 
     assert_eq!(MeshApi::derive_peer_state(&peer), NodeState::Serving);
@@ -182,6 +184,7 @@ fn derive_peer_state_returns_loading_for_assigned_but_unready_peer() {
         identity_hash: None,
         context_length: None,
         ready: false,
+        ..Default::default()
     }];
 
     assert_eq!(MeshApi::derive_peer_state(&peer), NodeState::Loading);

--- a/crates/mesh-llm-host-runtime/src/mesh/node.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node.rs
@@ -1213,15 +1213,17 @@ impl Node {
         }
     }
 
-    pub async fn remove_served_model_descriptor(&self, model_name: &str) {
-        self.served_model_descriptors
-            .lock()
-            .await
-            .retain(|descriptor| descriptor.identity.model_name != model_name);
+    pub async fn remove_served_model_descriptor(&self, model_name: &str) -> bool {
+        let mut descriptors = self.served_model_descriptors.lock().await;
+        let old_len = descriptors.len();
+        descriptors.retain(|descriptor| descriptor.identity.model_name != model_name);
+        let removed = descriptors.len() != old_len;
+        drop(descriptors);
         self.model_runtime_descriptors
             .lock()
             .await
             .retain(|runtime| runtime.model_name != model_name);
+        removed
     }
 
     pub async fn set_model_runtime_context_length(
@@ -1251,11 +1253,42 @@ impl Node {
                     identity_hash,
                     context_length: Some(context_length),
                     ready: true,
+                    provider_kind: None,
+                    model_version: None,
+                    max_concurrent_requests: None,
+                    active_requests: None,
+                    queued_requests: None,
                 });
             }
         } else {
             runtimes.retain(|runtime| runtime.model_name != model_name);
         }
+    }
+
+    pub(crate) async fn upsert_model_runtime_descriptor(
+        &self,
+        descriptor: ModelRuntimeDescriptor,
+    ) -> bool {
+        let mut runtimes = self.model_runtime_descriptors.lock().await;
+        if let Some(existing) = runtimes
+            .iter_mut()
+            .find(|runtime| runtime.model_name == descriptor.model_name)
+        {
+            if *existing == descriptor {
+                return false;
+            }
+            *existing = descriptor;
+        } else {
+            runtimes.push(descriptor);
+        }
+        true
+    }
+
+    pub(crate) async fn remove_model_runtime_descriptor(&self, model_name: &str) -> bool {
+        let mut runtimes = self.model_runtime_descriptors.lock().await;
+        let old_len = runtimes.len();
+        runtimes.retain(|runtime| runtime.model_name != model_name);
+        runtimes.len() != old_len
     }
 
     pub async fn local_model_context_length(&self, model_name: &str) -> Option<u32> {
@@ -1278,6 +1311,36 @@ impl Node {
             .peers
             .get(&peer_id)
             .and_then(|peer| peer.advertised_context_length(model_name))
+    }
+
+    pub(crate) async fn local_model_runtime_load(
+        &self,
+        model_name: &str,
+    ) -> Option<mesh_llm_types::mesh::ModelRuntimeLoad> {
+        self.model_runtime_descriptors
+            .lock()
+            .await
+            .iter()
+            .find(|runtime| runtime.model_name == model_name)
+            .and_then(ModelRuntimeDescriptor::provider_load)
+    }
+
+    pub(crate) async fn peer_model_runtime_load(
+        &self,
+        peer_id: EndpointId,
+        model_name: &str,
+    ) -> Option<mesh_llm_types::mesh::ModelRuntimeLoad> {
+        self.state
+            .lock()
+            .await
+            .peers
+            .get(&peer_id)
+            .and_then(|peer| {
+                peer.served_model_runtime
+                    .iter()
+                    .find(|runtime| runtime.model_name == model_name)
+            })
+            .and_then(ModelRuntimeDescriptor::provider_load)
     }
 
     pub(crate) async fn peer_model_throughput_hint(
@@ -1324,6 +1387,10 @@ impl Node {
         };
         runtimes.extend(peer_runtimes);
         runtimes
+    }
+
+    pub(crate) async fn local_model_runtime_descriptors(&self) -> Vec<ModelRuntimeDescriptor> {
+        self.model_runtime_descriptors.lock().await.clone()
     }
 
     pub async fn serving_models(&self) -> Vec<String> {

--- a/crates/mesh-llm-host-runtime/src/mesh/peer_state.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/peer_state.rs
@@ -430,6 +430,10 @@ impl PeerInfo {
 
     pub fn accepts_http_inference(&self) -> bool {
         matches!(self.role, NodeRole::Host { .. })
+            || self
+                .served_model_runtime
+                .iter()
+                .any(|runtime| runtime.ready && runtime.provider_kind.is_some())
     }
 
     pub fn http_routable_models(&self) -> Vec<String> {

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/owner_control.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/owner_control.rs
@@ -41,6 +41,7 @@ fn make_test_peer_info(peer_id: EndpointId) -> PeerInfo {
             identity_hash: Some("sha256:abc123".into()),
             context_length: Some(32768),
             ready: true,
+            ..Default::default()
         }],
         owner_attestation: None,
         release_attestation_summary: crate::ReleaseAttestationSummary::default(),

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/peer_state.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/peer_state.rs
@@ -954,6 +954,7 @@ fn gossip_frame_roundtrip_preserves_scanned_model_metadata() {
             identity_hash: Some("identity-hash".to_string()),
             context_length: Some(32768),
             ready: true,
+            ..Default::default()
         }],
         owner_attestation: None,
         genesis_policy: None,

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/protocol_frames.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/protocol_frames.rs
@@ -720,6 +720,29 @@ fn worker_only_legacy_models_are_excluded_from_http_routes() {
 }
 
 #[test]
+fn provider_runtime_makes_zero_model_worker_http_routable() {
+    let provider_id = EndpointId::from(iroh::SecretKey::from_bytes(&[0xD4; 32]).public());
+    let mut provider = make_test_peer_info(provider_id);
+    provider.role = super::NodeRole::Worker;
+    provider.serving_models = vec!["apple/system".to_string()];
+    provider.hosted_models = vec!["apple/system".to_string()];
+    provider.hosted_models_known = true;
+    provider.served_model_runtime = vec![mesh_llm_types::mesh::ModelRuntimeDescriptor {
+        model_name: "apple/system".to_string(),
+        ready: true,
+        provider_kind: Some("apple".to_string()),
+        ..Default::default()
+    }];
+
+    assert!(provider.accepts_http_inference());
+    assert_eq!(
+        provider.http_routable_models(),
+        vec!["apple/system".to_string()]
+    );
+    assert!(provider.routes_http_model("apple/system"));
+}
+
+#[test]
 #[serial_test::serial]
 fn canonical_demand_model_ref_uses_loaded_catalog_without_refreshing() {
     use crate::models::remote_catalog::{

--- a/crates/mesh-llm-host-runtime/src/network/affinity.rs
+++ b/crates/mesh-llm-host-runtime/src/network/affinity.rs
@@ -304,6 +304,8 @@ pub struct TargetSelection {
     pub target: election::InferenceTarget,
     pub learn_prefix_hash: Option<u64>,
     pub cached_target: Option<election::InferenceTarget>,
+    /// True when an explicit/stored affinity decision must outrank live load.
+    pub affinity_selected: bool,
 }
 
 pub struct PreparedTargets {
@@ -525,6 +527,7 @@ pub fn select_model_target_from_candidates(
             target: election::ModelTargets::pick_sticky_from(candidates, session_hash),
             learn_prefix_hash: None,
             cached_target: None,
+            affinity_selected: true,
         };
     }
 
@@ -534,6 +537,7 @@ pub fn select_model_target_from_candidates(
                 target: target.clone(),
                 learn_prefix_hash: Some(prefix_hash),
                 cached_target: Some(target),
+                affinity_selected: true,
             };
         }
 
@@ -542,6 +546,7 @@ pub fn select_model_target_from_candidates(
                 target: election::ModelTargets::pick_sticky_from(candidates, prefix_hash),
                 learn_prefix_hash: Some(prefix_hash),
                 cached_target: None,
+                affinity_selected: true,
             };
         }
 
@@ -551,6 +556,7 @@ pub fn select_model_target_from_candidates(
                 target: election::ModelTargets::pick_sticky_from(candidates, sticky_hash),
                 learn_prefix_hash: Some(prefix_hash),
                 cached_target: None,
+                affinity_selected: true,
             };
         }
 
@@ -558,6 +564,7 @@ pub fn select_model_target_from_candidates(
             target: targets.pick_from(candidates),
             learn_prefix_hash: Some(prefix_hash),
             cached_target: None,
+            affinity_selected: false,
         };
     }
 
@@ -567,6 +574,7 @@ pub fn select_model_target_from_candidates(
             target: election::ModelTargets::pick_sticky_from(candidates, sticky_hash),
             learn_prefix_hash: None,
             cached_target: None,
+            affinity_selected: true,
         };
     }
 
@@ -574,6 +582,7 @@ pub fn select_model_target_from_candidates(
         target: targets.pick_from(candidates),
         learn_prefix_hash: None,
         cached_target: None,
+        affinity_selected: false,
     }
 }
 

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -676,12 +676,14 @@ async fn route_request(
                 &provider_targets,
                 model_name,
                 request,
-                required_tokens,
-                ctx.affinity,
+                proxy::RouteModelRequestContext {
+                    required_tokens,
+                    affinity: ctx.affinity,
+                    route_observer,
+                },
             )
             .await;
-            debug_assert!(routed);
-            return;
+            return routed;
         }
 
         // Model explicitly requested. Check local candidates first.

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -666,6 +666,24 @@ async fn route_request(
     route_observer: OpenAiRouteObserver<'_>,
 ) -> proxy::RouteDispatchOutcome {
     if let Some(model_name) = effective_model {
+        if let Some(provider_targets) = provider_mesh_targets(ctx, model_name).await {
+            if !request.is_tokenize_request() && provider_targets.candidates(model_name).len() > 1 {
+                request.ensure_body_json();
+            }
+            let routed = proxy::route_model_request(
+                ctx.node.clone(),
+                tcp_stream,
+                &provider_targets,
+                model_name,
+                request,
+                required_tokens,
+                ctx.affinity,
+            )
+            .await;
+            debug_assert!(routed);
+            return;
+        }
+
         // Model explicitly requested. Check local candidates first.
         if !has_available_candidates(ctx.targets, model_name) {
             return route_missing_local_model(
@@ -713,6 +731,60 @@ async fn route_request(
         )
         .await
     }
+}
+
+async fn provider_mesh_targets(
+    ctx: &IngressRouteContext<'_>,
+    model_name: &str,
+) -> Option<election::ModelTargets> {
+    let local_candidates = ctx.targets.candidates(model_name);
+    let remote_hosts = ctx.node.hosts_for_model(model_name).await;
+    let local_provider = ctx
+        .node
+        .local_model_runtime_load(model_name)
+        .await
+        .is_some();
+    let mut remote_provider = false;
+    for peer_id in &remote_hosts {
+        if ctx
+            .node
+            .peer_model_runtime_load(*peer_id, model_name)
+            .await
+            .is_some()
+        {
+            remote_provider = true;
+            break;
+        }
+    }
+    if !local_provider && !remote_provider {
+        return None;
+    }
+
+    let candidates = merge_provider_candidates(&local_candidates, &remote_hosts);
+    if candidates.is_empty() {
+        return None;
+    }
+    let mut targets = ctx.targets.clone();
+    targets.targets.insert(model_name.to_string(), candidates);
+    Some(targets)
+}
+
+fn merge_provider_candidates(
+    local_candidates: &[election::InferenceTarget],
+    remote_hosts: &[iroh::EndpointId],
+) -> Vec<election::InferenceTarget> {
+    let mut candidates = local_candidates
+        .iter()
+        .filter(|target| !matches!(target, election::InferenceTarget::None))
+        .cloned()
+        .collect::<Vec<_>>();
+    for peer_id in remote_hosts {
+        let target = election::InferenceTarget::Remote(*peer_id);
+        if !candidates.contains(&target) {
+            candidates.push(target);
+        }
+    }
+    candidates
 }
 
 async fn prepare_auto_route_decision(
@@ -1552,6 +1624,26 @@ mod tests {
             ],
         );
         assert!(has_local_unavailable_candidates(&targets, "loading-model"));
+    }
+
+    #[test]
+    fn provider_candidates_combine_local_runtime_and_remote_replicas() {
+        let peer_id = iroh::EndpointId::from(iroh::SecretKey::generate().public());
+        let candidates = merge_provider_candidates(
+            &[
+                election::InferenceTarget::None,
+                election::InferenceTarget::Local(41_001),
+            ],
+            &[peer_id, peer_id],
+        );
+
+        assert_eq!(
+            candidates,
+            vec![
+                election::InferenceTarget::Local(41_001),
+                election::InferenceTarget::Remote(peer_id),
+            ]
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_selection.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_selection.rs
@@ -54,7 +54,9 @@ pub(in crate::network::openai) fn virtual_mesh_capabilities(
         ..Default::default()
     };
     for model in models {
-        if model == mesh_mixture_of_agents::VIRTUAL_MODEL_NAME {
+        if model == mesh_mixture_of_agents::VIRTUAL_MODEL_NAME
+            || crate::network::openai::provider_policy::is_explicit_only_model(model)
+        {
             continue;
         }
         let (base_model, _) = crate::network::openai::ingress::parse_model_with_profile(model);
@@ -101,12 +103,10 @@ pub(in crate::network::openai) fn should_advertise_virtual_mesh(models: &[String
     // can", which a single-model node does by serving that model — so hiding
     // the name would remove the one name clients are told to send, and break
     // any client that validates against `/v1/models`.
-    models
-        .iter()
-        .any(|model| {
-            model.as_str() != mesh_mixture_of_agents::VIRTUAL_MODEL_NAME
-                && !crate::network::openai::provider_policy::is_explicit_only_model(model)
-        })
+    models.iter().any(|model| {
+        model.as_str() != mesh_mixture_of_agents::VIRTUAL_MODEL_NAME
+            && !crate::network::openai::provider_policy::is_explicit_only_model(model)
+    })
 }
 
 #[cfg(test)]

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_selection.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/context_selection.rs
@@ -78,6 +78,9 @@ pub(in crate::network::openai) fn virtual_mesh_context_length(
         if model == mesh_mixture_of_agents::VIRTUAL_MODEL_NAME {
             continue;
         }
+        if crate::network::openai::provider_policy::is_explicit_only_model(model) {
+            continue;
+        }
         let context = runtimes
             .iter()
             .filter(|runtime| runtime.model_name == *model)
@@ -100,7 +103,10 @@ pub(in crate::network::openai) fn should_advertise_virtual_mesh(models: &[String
     // any client that validates against `/v1/models`.
     models
         .iter()
-        .any(|model| model.as_str() != mesh_mixture_of_agents::VIRTUAL_MODEL_NAME)
+        .any(|model| {
+            model.as_str() != mesh_mixture_of_agents::VIRTUAL_MODEL_NAME
+                && !crate::network::openai::provider_policy::is_explicit_only_model(model)
+        })
 }
 
 #[cfg(test)]
@@ -113,6 +119,7 @@ mod tests {
             identity_hash: None,
             context_length,
             ready: true,
+            ..Default::default()
         }
     }
 

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/mod.rs
@@ -67,10 +67,10 @@ async fn degrade_to_single_model(
     if candidates.is_empty() {
         candidates = node.serving_models().await;
     }
-    let Some(target) = candidates
-        .into_iter()
-        .find(|m| m != moa::VIRTUAL_MODEL_NAME)
-    else {
+    let Some(target) = candidates.into_iter().find(|m| {
+        m != moa::VIRTUAL_MODEL_NAME
+            && !crate::network::openai::provider_policy::is_explicit_only_model(m)
+    }) else {
         return match proxy::send_503_observed(
             tcp_stream,
             "no models available in the mesh",

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/pool.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/pool.rs
@@ -275,7 +275,10 @@ pub(super) async fn assemble_worker_pool(
         .models_being_served()
         .await
         .into_iter()
-        .filter(|n| n != moa::VIRTUAL_MODEL_NAME)
+        .filter(|n| {
+            n != moa::VIRTUAL_MODEL_NAME
+                && !crate::network::openai::provider_policy::is_explicit_only_model(n)
+        })
         .collect();
 
     // Verified sizes gossiped by peers (metadata.parameter_count_b). The

--- a/crates/mesh-llm-host-runtime/src/network/openai/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/mod.rs
@@ -4,6 +4,7 @@ mod forwarded_request;
 pub(crate) mod ingress;
 pub(crate) mod moa_gateway;
 mod parse_failure;
+mod provider_policy;
 mod request_normalize;
 pub(crate) mod request_parse;
 mod response;

--- a/crates/mesh-llm-host-runtime/src/network/openai/provider_policy.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/provider_policy.rs
@@ -1,0 +1,17 @@
+/// Provider models that require an explicit model id and must never be selected
+/// by `auto` or the virtual `mesh` model.
+pub(crate) fn is_explicit_only_model(model: &str) -> bool {
+    model == "apple/system" || model.starts_with("apple/system@")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apple_system_aliases_are_explicit_only() {
+        assert!(is_explicit_only_model("apple/system"));
+        assert!(is_explicit_only_model("apple/system@27.0"));
+        assert!(!is_explicit_only_model("org/apple-system-7b:q4_k_m"));
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/models.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/models.rs
@@ -166,6 +166,30 @@ fn model_metadata_json(
             );
         }
     }
+    if let Some(provider) = provider_runtime_metadata_for_model(model_name, runtimes) {
+        metadata.insert("provider".to_string(), serde_json::json!(provider.kind));
+        metadata.insert(
+            "provider_model_versions".to_string(),
+            serde_json::json!(provider.model_versions),
+        );
+        metadata.insert("replicas".to_string(), serde_json::json!(provider.replicas));
+        metadata.insert(
+            "max_concurrent_requests".to_string(),
+            serde_json::json!(provider.max_concurrent_requests),
+        );
+        metadata.insert(
+            "active_requests".to_string(),
+            serde_json::json!(provider.active_requests),
+        );
+        metadata.insert(
+            "queued_requests".to_string(),
+            serde_json::json!(provider.queued_requests),
+        );
+        metadata.insert(
+            "available_slots".to_string(),
+            serde_json::json!(provider.available_slots),
+        );
+    }
     if let Some(value) = descriptor_metadata.and_then(|metadata| metadata.native_context_length) {
         metadata.insert(
             "native_context_length".to_string(),
@@ -199,6 +223,55 @@ fn model_metadata_json(
 struct RuntimeContextLengths {
     min: u32,
     max: u32,
+}
+
+struct ProviderRuntimeMetadata {
+    kind: String,
+    model_versions: Vec<String>,
+    replicas: usize,
+    max_concurrent_requests: u32,
+    active_requests: u32,
+    queued_requests: u32,
+    available_slots: u32,
+}
+
+fn provider_runtime_metadata_for_model(
+    model_name: &str,
+    runtimes: &[mesh::ModelRuntimeDescriptor],
+) -> Option<ProviderRuntimeMetadata> {
+    let provider_runtimes = runtimes
+        .iter()
+        .filter(|runtime| runtime.model_name == model_name && runtime.ready)
+        .filter_map(|runtime| runtime.provider_kind.as_deref().map(|kind| (kind, runtime)))
+        .collect::<Vec<_>>();
+    let (kind, _) = provider_runtimes.first()?;
+    let mut model_versions = provider_runtimes
+        .iter()
+        .filter_map(|(_, runtime)| runtime.model_version.clone())
+        .collect::<Vec<_>>();
+    model_versions.sort();
+    model_versions.dedup();
+    let max_concurrent_requests = provider_runtimes
+        .iter()
+        .filter_map(|(_, runtime)| runtime.max_concurrent_requests)
+        .sum();
+    let active_requests = provider_runtimes
+        .iter()
+        .filter_map(|(_, runtime)| runtime.active_requests)
+        .sum();
+    let queued_requests = provider_runtimes
+        .iter()
+        .filter_map(|(_, runtime)| runtime.queued_requests)
+        .sum();
+    Some(ProviderRuntimeMetadata {
+        kind: (*kind).to_string(),
+        model_versions,
+        replicas: provider_runtimes.len(),
+        max_concurrent_requests,
+        active_requests,
+        queued_requests,
+        available_slots: max_concurrent_requests.saturating_sub(active_requests),
+    })
 }
 
 fn runtime_context_lengths_for_model(
@@ -393,6 +466,7 @@ mod tests {
             identity_hash: None,
             context_length: Some(65_536),
             ready: true,
+            ..Default::default()
         }];
 
         let body = models_list_json(&models, &[descriptor], &runtimes);
@@ -422,12 +496,14 @@ mod tests {
                 identity_hash: None,
                 context_length: Some(32_768),
                 ready: true,
+                ..Default::default()
             },
             mesh::ModelRuntimeDescriptor {
                 model_name: models[0].clone(),
                 identity_hash: None,
                 context_length: Some(131_072),
                 ready: true,
+                ..Default::default()
             },
         ];
 
@@ -439,6 +515,49 @@ mod tests {
     }
 
     #[test]
+    fn models_list_reports_aggregate_provider_capacity() {
+        let models = vec!["apple/system".to_string()];
+        let runtimes = vec![
+            mesh::ModelRuntimeDescriptor {
+                model_name: models[0].clone(),
+                context_length: Some(4096),
+                ready: true,
+                provider_kind: Some("apple".to_string()),
+                model_version: Some("27.0".to_string()),
+                max_concurrent_requests: Some(1),
+                active_requests: Some(0),
+                queued_requests: Some(0),
+                ..Default::default()
+            },
+            mesh::ModelRuntimeDescriptor {
+                model_name: models[0].clone(),
+                context_length: Some(4096),
+                ready: true,
+                provider_kind: Some("apple".to_string()),
+                model_version: Some("27.0".to_string()),
+                max_concurrent_requests: Some(1),
+                active_requests: Some(1),
+                queued_requests: Some(2),
+                ..Default::default()
+            },
+        ];
+
+        let body = models_list_json(&models, &[], &runtimes);
+        let metadata = &body["data"][0]["metadata"];
+
+        assert_eq!(metadata["provider"], "apple");
+        assert_eq!(
+            metadata["provider_model_versions"],
+            serde_json::json!(["27.0"])
+        );
+        assert_eq!(metadata["replicas"], 2);
+        assert_eq!(metadata["max_concurrent_requests"], 2);
+        assert_eq!(metadata["active_requests"], 1);
+        assert_eq!(metadata["queued_requests"], 2);
+        assert_eq!(metadata["available_slots"], 1);
+    }
+
+    #[test]
     fn models_list_advertises_virtual_mesh_when_moa_has_two_models() {
         let models = vec!["fast-8b".to_string(), "strong-32b".to_string()];
         let runtimes = vec![
@@ -447,12 +566,14 @@ mod tests {
                 identity_hash: None,
                 context_length: Some(16_384),
                 ready: true,
+                ..Default::default()
             },
             mesh::ModelRuntimeDescriptor {
                 model_name: "strong-32b".to_string(),
                 identity_hash: None,
                 context_length: Some(65_536),
                 ready: true,
+                ..Default::default()
             },
         ];
 

--- a/crates/mesh-llm-host-runtime/src/network/openai/routing_rank.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/routing_rank.rs
@@ -78,7 +78,15 @@ struct RankedTarget<T> {
     candidate: T,
     context_length: Option<u32>,
     throughput: Option<TargetThroughputRank>,
+    load: Option<mesh_llm_types::mesh::ModelRuntimeLoad>,
 }
+
+type ProviderRankCandidate<T> = (
+    T,
+    Option<u32>,
+    Option<TargetThroughputRank>,
+    Option<mesh_llm_types::mesh::ModelRuntimeLoad>,
+);
 
 const LOCAL_THROUGHPUT_PRECEDENCE_SAMPLES: u64 = 3;
 const TARGET_THROUGHPUT_MAX_SCORE_SAMPLES: u64 = 32;
@@ -103,12 +111,25 @@ fn target_throughput_rank_key(throughput: Option<TargetThroughputRank>) -> (bool
 
 fn sort_ranked_targets<T>(targets: &mut [RankedTarget<T>]) {
     targets.sort_by(|a, b| {
-        target_throughput_rank_key(b.throughput)
-            .cmp(&target_throughput_rank_key(a.throughput))
+        target_load_rank_key(a.load)
+            .cmp(&target_load_rank_key(b.load))
+            .then_with(|| {
+                target_throughput_rank_key(b.throughput)
+                    .cmp(&target_throughput_rank_key(a.throughput))
+            })
             .then_with(|| a.index.cmp(&b.index))
     });
 }
 
+fn target_load_rank_key(load: Option<mesh_llm_types::mesh::ModelRuntimeLoad>) -> (u8, u32, u32) {
+    match load {
+        Some(load) if !load.saturated() => (0, load.queued_requests, load.active_requests),
+        None => (1, 0, 0),
+        Some(load) => (2, load.queued_requests, load.active_requests),
+    }
+}
+
+#[cfg(test)]
 pub(super) fn reorder_candidates_by_context_and_throughput<T: Clone>(
     candidates: &[(T, Option<u32>, Option<TargetThroughputRank>)],
     required_tokens: Option<u32>,
@@ -122,6 +143,7 @@ pub(super) fn reorder_candidates_by_context_and_throughput<T: Clone>(
                 candidate: candidate.clone(),
                 context_length: *context_length,
                 throughput: *throughput,
+                load: None,
             },
         )
         .collect::<Vec<_>>();
@@ -146,6 +168,54 @@ pub(super) fn reorder_candidates_by_context_and_throughput<T: Clone>(
         return Vec::new();
     }
 
+    sort_ranked_targets(&mut adequate);
+    sort_ranked_targets(&mut unknown);
+    adequate
+        .into_iter()
+        .chain(unknown)
+        .map(|ranked| ranked.candidate)
+        .collect()
+}
+
+fn reorder_candidates_by_context_load_and_throughput<T: Clone>(
+    candidates: &[ProviderRankCandidate<T>],
+    required_tokens: Option<u32>,
+) -> Vec<T> {
+    let ranked = candidates
+        .iter()
+        .enumerate()
+        .map(
+            |(index, (candidate, context_length, throughput, load))| RankedTarget {
+                index,
+                candidate: candidate.clone(),
+                context_length: *context_length,
+                throughput: *throughput,
+                load: *load,
+            },
+        )
+        .collect::<Vec<_>>();
+    reorder_ranked_candidates(ranked, required_tokens)
+}
+
+fn reorder_ranked_candidates<T: Clone>(
+    ranked: Vec<RankedTarget<T>>,
+    required_tokens: Option<u32>,
+) -> Vec<T> {
+    let Some(required_tokens) = required_tokens else {
+        let mut ranked = ranked;
+        sort_ranked_targets(&mut ranked);
+        return ranked.into_iter().map(|ranked| ranked.candidate).collect();
+    };
+
+    let mut adequate = Vec::new();
+    let mut unknown = Vec::new();
+    for ranked in ranked {
+        match ranked.context_length {
+            Some(value) if value >= required_tokens => adequate.push(ranked),
+            Some(_) => {}
+            None => unknown.push(ranked),
+        }
+    }
     sort_ranked_targets(&mut adequate);
     sort_ranked_targets(&mut unknown);
     adequate
@@ -215,9 +285,10 @@ pub(super) async fn order_remote_hosts_by_context(
             *host,
             node.peer_model_context_length(*host, model).await,
             remote_target_throughput_rank(node, model, *host).await,
+            node.peer_model_runtime_load(*host, model).await,
         ));
     }
-    reorder_candidates_by_context_and_throughput(&candidates, required_tokens)
+    reorder_candidates_by_context_load_and_throughput(&candidates, required_tokens)
 }
 
 pub(super) async fn order_targets_by_context(
@@ -241,9 +312,36 @@ pub(super) async fn order_targets_by_context(
             }
             _ => local_target_throughput_rank(node, model, target),
         };
-        candidates.push((target.clone(), context_length, throughput));
+        let load = match target {
+            election::InferenceTarget::Local(_) => node.local_model_runtime_load(model).await,
+            election::InferenceTarget::Remote(peer_id) => {
+                node.peer_model_runtime_load(*peer_id, model).await
+            }
+            election::InferenceTarget::None => None,
+        };
+        candidates.push((target.clone(), context_length, throughput, load));
     }
-    reorder_candidates_by_context_and_throughput(&candidates, required_tokens)
+    reorder_candidates_by_context_load_and_throughput(&candidates, required_tokens)
+}
+
+pub(super) async fn preferred_provider_target(
+    node: &mesh::Node,
+    model: &str,
+    ordered_candidates: &[election::InferenceTarget],
+) -> Option<election::InferenceTarget> {
+    for candidate in ordered_candidates {
+        let load = match candidate {
+            election::InferenceTarget::Local(_) => node.local_model_runtime_load(model).await,
+            election::InferenceTarget::Remote(peer_id) => {
+                node.peer_model_runtime_load(*peer_id, model).await
+            }
+            election::InferenceTarget::None => None,
+        };
+        if load.is_some() {
+            return ordered_candidates.first().cloned();
+        }
+    }
+    None
 }
 
 pub(super) fn move_target_first<T: PartialEq>(targets: &mut [T], target: &T) -> bool {
@@ -564,6 +662,26 @@ mod tests {
         );
 
         assert_eq!(ordered, vec![2, 1]);
+    }
+
+    #[test]
+    fn provider_load_prefers_idle_then_unknown_then_saturated() {
+        let load = |active, queued| mesh_llm_types::mesh::ModelRuntimeLoad {
+            max_concurrent_requests: 1,
+            active_requests: active,
+            queued_requests: queued,
+        };
+        let ordered = reorder_candidates_by_context_load_and_throughput(
+            &[
+                (1u8, Some(4096), None, Some(load(1, 2))),
+                (2u8, Some(4096), None, None),
+                (3u8, Some(4096), None, Some(load(0, 0))),
+                (4u8, Some(4096), None, Some(load(1, 0))),
+            ],
+            Some(2048),
+        );
+
+        assert_eq!(ordered, vec![3, 2, 4, 1]);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -40,7 +40,7 @@ use super::response::{
 };
 use super::routing_rank::{
     cached_auto_model_satisfies_media_requirements, move_target_first,
-    order_remote_hosts_by_context, order_targets_by_context,
+    order_remote_hosts_by_context, order_targets_by_context, preferred_provider_target,
 };
 use mesh_llm_events::logging::events::TokenUsage;
 use mesh_llm_events::logging::identifiers::RequestId;
@@ -1094,6 +1094,7 @@ async fn resolve_auto_model_request(args: AutoModelRequestArgs<'_>) -> AutoModel
     let routing_metrics = node.routing_metrics();
     let with_caps: Vec<router::RoutingCandidate<'_>> = served
         .iter()
+        .filter(|name| !super::provider_policy::is_explicit_only_model(name))
         .map(|name| {
             let caps = capabilities_for_model(name, descriptors);
             let (tps_hint, throughput_samples) = routing_metrics
@@ -1487,13 +1488,18 @@ async fn route_model_request_inner(args: RouteModelRequestArgs<'_>) -> RouteDisp
     }
     route_observer.route_selected(Some(model));
 
-    let selection = crate::network::affinity::select_model_target_from_candidates(
+    let mut selection = crate::network::affinity::select_model_target_from_candidates(
         targets,
         &ordered_candidates,
         model,
         request.body_json.as_ref(),
         affinity,
     );
+    if !selection.affinity_selected
+        && let Some(preferred) = preferred_provider_target(&node, model, &ordered_candidates).await
+    {
+        selection.target = preferred;
+    }
     if matches!(selection.target, election::InferenceTarget::None) {
         return send_route_model_none_target(&node, tcp_stream, model, route_observer).await;
     }

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport_tests/routing.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport_tests/routing.rs
@@ -153,6 +153,7 @@ async fn remote_tokenizer_plan_routes_identity_model_without_context_rejection()
         identity_hash: None,
         context_length: Some(32_768),
         ready: true,
+        ..Default::default()
     }];
     node.insert_test_peer(peer).await;
     let affinity = AffinityRouter::new();

--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -332,6 +332,11 @@ fn runtime_descriptor_to_proto(
         identity_hash: descriptor.identity_hash.clone(),
         context_length: descriptor.context_length,
         ready: descriptor.ready,
+        provider_kind: descriptor.provider_kind.clone(),
+        model_version: descriptor.model_version.clone(),
+        max_concurrent_requests: descriptor.max_concurrent_requests,
+        active_requests: descriptor.active_requests,
+        queued_requests: descriptor.queued_requests,
     }
 }
 
@@ -343,6 +348,11 @@ fn proto_runtime_descriptor_to_local(
         identity_hash: descriptor.identity_hash.clone(),
         context_length: descriptor.context_length,
         ready: descriptor.ready,
+        provider_kind: descriptor.provider_kind.clone(),
+        model_version: descriptor.model_version.clone(),
+        max_concurrent_requests: descriptor.max_concurrent_requests,
+        active_requests: descriptor.active_requests,
+        queued_requests: descriptor.queued_requests,
     }
 }
 

--- a/crates/mesh-llm-host-runtime/src/protocol/tests/announcements.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/tests/announcements.rs
@@ -132,7 +132,7 @@ pub(crate) fn assert_mixed_version_peer_ignores_missing_release_attestation() {
 }
 
 #[test]
-fn advertised_model_throughput_roundtrips_through_proto_announcement() {
+fn advertised_throughput_and_provider_load_roundtrip_through_proto_announcement() {
     let peer_id = EndpointId::from(SecretKey::from_bytes(&[0xAC; 32]).public());
     let expected_hints = vec![crate::network::metrics::ModelThroughputHint {
         model_name: "qwen".to_string(),
@@ -170,7 +170,17 @@ fn advertised_model_throughput_roundtrips_through_proto_announcement() {
         experts_summary: None,
         available_model_sizes: HashMap::new(),
         served_model_descriptors: vec![],
-        served_model_runtime: vec![],
+        served_model_runtime: vec![crate::mesh::ModelRuntimeDescriptor {
+            model_name: "qwen".to_string(),
+            context_length: Some(4_096),
+            ready: true,
+            provider_kind: Some("apple".to_string()),
+            model_version: Some("27.0".to_string()),
+            max_concurrent_requests: Some(1),
+            active_requests: Some(1),
+            queued_requests: Some(2),
+            ..Default::default()
+        }],
         owner_attestation: None,
         genesis_policy: None,
         release_attestation: None,
@@ -195,6 +205,10 @@ fn advertised_model_throughput_roundtrips_through_proto_announcement() {
 
     let mut proto_pa = local_ann_to_proto_ann(&ann);
     assert_eq!(proto_pa.advertised_model_throughput.len(), 1);
+    assert_eq!(
+        proto_pa.served_model_runtime[0].provider_kind.as_deref(),
+        Some("apple")
+    );
     assert_eq!(proto_pa.advertised_model_throughput[0].model_name, "qwen");
     assert_eq!(
         proto_pa.advertised_model_throughput[0].avg_tokens_per_second_milli,
@@ -214,6 +228,14 @@ fn advertised_model_throughput_roundtrips_through_proto_announcement() {
 
     let (_, roundtripped) = proto_ann_to_local(&proto_pa).expect("proto_ann_to_local must succeed");
     assert_eq!(roundtripped.advertised_model_throughput, expected_hints);
+    assert_eq!(
+        roundtripped.served_model_runtime[0].provider_load(),
+        Some(mesh_llm_types::mesh::ModelRuntimeLoad {
+            max_concurrent_requests: 1,
+            active_requests: 1,
+            queued_requests: 2,
+        })
+    );
 }
 
 #[test]

--- a/crates/mesh-llm-host-runtime/src/runtime/provider_supervisor.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/provider_supervisor.rs
@@ -1,5 +1,8 @@
-use super::{add_runtime_local_target, remove_runtime_local_target, upsert_dashboard_process};
-use crate::{api, inference::election};
+mod advertisement;
+mod platform_policy;
+
+use crate::{api, inference::election, mesh};
+use advertisement::*;
 use anyhow::{Context, Result, bail};
 use mesh_llm_events::{OutputEvent, emit_event};
 use mesh_llm_provider_runtime::{
@@ -8,9 +11,8 @@ use mesh_llm_provider_runtime::{
     ProviderRuntimeInstallOptions, ProviderRuntimeReleaseManifest, ProviderRuntimeRequest,
     install_provider_runtime,
 };
+use platform_policy::validate_provider_platform_policy;
 use serde::Deserialize;
-#[cfg(target_os = "macos")]
-use std::ffi::OsString;
 use std::{
     path::{Path, PathBuf},
     process::Stdio,
@@ -28,16 +30,19 @@ const APPLE_MODEL_ID: &str = "apple/system";
 const APPLE_PROVIDER_KIND: &str = "apple";
 const APPLE_PROVIDER_PROTOCOL: &str = "0.1";
 const PROVIDER_INSTANCE_ID: &str = "provider:apple/system";
-const PROVIDER_HEALTH_INTERVAL: Duration = Duration::from_secs(5);
+// Provider load changes at request timescale. Poll fast enough for another Mac
+// to avoid a one-slot runtime while retaining a three-second health grace.
+const PROVIDER_HEALTH_INTERVAL: Duration = Duration::from_millis(250);
 const PROVIDER_READY_TIMEOUT: Duration = Duration::from_secs(30);
 const PROVIDER_SHUTDOWN_GRACE: Duration = Duration::from_secs(5);
-const PROVIDER_MAX_HEALTH_FAILURES: u8 = 3;
+const PROVIDER_MAX_HEALTH_FAILURES: u8 = 12;
 const PROVIDER_MAX_RESTART_BACKOFF_SECS: u64 = 30;
 
 pub(crate) struct ProviderSupervisorContext {
     pub(super) target_tx: Arc<watch::Sender<election::ModelTargets>>,
     pub(super) dashboard_processes: Arc<tokio::sync::Mutex<Vec<api::RuntimeProcessPayload>>>,
     pub(super) console_state: Option<api::MeshApi>,
+    pub(super) node: mesh::Node,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -69,9 +74,14 @@ enum ProviderRunOutcome {
 #[derive(Clone, Debug, Eq, PartialEq)]
 struct ProviderAvailability {
     available: bool,
+    unavailable_reason: Option<String>,
     context_length: Option<u32>,
     model_version: String,
     versioned_model_id: String,
+    capabilities: Vec<String>,
+    max_concurrent_requests: u32,
+    active_requests: u32,
+    queued_requests: u32,
 }
 
 #[derive(Debug, Deserialize)]
@@ -85,10 +95,17 @@ struct ProviderModelEntry {
     #[serde(default)]
     availability: Option<String>,
     #[serde(default)]
+    unavailable_reason: Option<String>,
+    #[serde(default)]
     context_length: Option<u32>,
     model_version: String,
     version_source: String,
     versioned_model_id: String,
+    #[serde(default)]
+    capabilities: Vec<String>,
+    max_concurrent_requests: u32,
+    active_requests: u32,
+    queued_requests: u32,
 }
 
 impl ProviderSupervisorHandle {
@@ -500,20 +517,21 @@ async fn monitor_provider_process(
     };
     let mut health_tick = tokio::time::interval(PROVIDER_HEALTH_INTERVAL);
     health_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-    let mut failures = 0_u8;
-    let mut routed_model_ids = Vec::new();
+    let mut state = ProviderRoutingState::default();
     loop {
         tokio::select! {
             changed = shutdown_rx.changed() => {
                 if changed.is_err() || *shutdown_rx.borrow() {
-                    withdraw_provider_routes(&mut routed_model_ids, port, context);
+                    withdraw_provider_routes(&mut state.routed_model_ids, port, context);
+                    withdraw_provider_advertisement(&mut state.advertised_model_ids, context).await;
                     remove_provider_process(context).await;
                     let _ = terminate_provider_process(child).await;
                     return ProviderRunOutcome::Shutdown;
                 }
             }
             status = child.wait() => {
-                withdraw_provider_routes(&mut routed_model_ids, port, context);
+                withdraw_provider_routes(&mut state.routed_model_ids, port, context);
+                withdraw_provider_advertisement(&mut state.advertised_model_ids, context).await;
                 remove_provider_process(context).await;
                 return ProviderRunOutcome::Restart(match status {
                     Ok(status) => format!("provider process exited with {status}"),
@@ -521,34 +539,71 @@ async fn monitor_provider_process(
                 });
             }
             _ = health_tick.tick() => {
-                match probe_provider(&client, port, &runtime.model_id).await {
-                    Ok(availability) => {
-                        failures = 0;
-                        publish_provider_state(runtime, context, pid, port, &availability).await;
-                        let was_unrouted = routed_model_ids.is_empty();
-                        reconcile_provider_routes(
-                            runtime,
-                            &availability,
-                            &mut routed_model_ids,
-                            port,
-                            context,
-                        );
-                        if was_unrouted && !routed_model_ids.is_empty() {
-                            emit_provider_ready(runtime, &availability, port, pid);
-                        }
-                    }
-                    Err(error) => {
-                        failures = failures.saturating_add(1);
-                        publish_provider_unhealthy(runtime, context, pid, port).await;
-                        withdraw_provider_routes(&mut routed_model_ids, port, context);
-                        if failures >= PROVIDER_MAX_HEALTH_FAILURES {
-                            let _ = terminate_provider_process(child).await;
-                            return ProviderRunOutcome::Restart(format!(
-                                "provider failed {failures} consecutive health checks: {error:#}"
-                            ));
-                        }
-                    }
+                if let Some(outcome) = observe_provider_health(
+                    runtime, context, child, &client, pid, port, &mut state,
+                )
+                .await
+                {
+                    return outcome;
                 }
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct ProviderRoutingState {
+    failures: u8,
+    routed_model_ids: Vec<String>,
+    advertised_model_ids: Vec<String>,
+}
+
+async fn observe_provider_health(
+    runtime: &ProviderRuntimeContext,
+    context: &ProviderSupervisorContext,
+    child: &mut Child,
+    client: &reqwest::Client,
+    pid: u32,
+    port: u16,
+    state: &mut ProviderRoutingState,
+) -> Option<ProviderRunOutcome> {
+    match probe_provider(client, port, &runtime.model_id).await {
+        Ok(availability) => {
+            state.failures = 0;
+            publish_provider_state(runtime, context, pid, port, &availability).await;
+            let was_unrouted = state.routed_model_ids.is_empty();
+            reconcile_provider_routes(
+                runtime,
+                &availability,
+                &mut state.routed_model_ids,
+                port,
+                context,
+            );
+            reconcile_provider_advertisement(
+                &runtime.model_id,
+                &availability,
+                &mut state.advertised_model_ids,
+                context,
+            )
+            .await;
+            if was_unrouted && !state.routed_model_ids.is_empty() {
+                emit_provider_ready(runtime, &availability, port, pid);
+            }
+            None
+        }
+        Err(error) => {
+            state.failures = state.failures.saturating_add(1);
+            publish_provider_unhealthy(runtime, context, pid, port).await;
+            withdraw_provider_routes(&mut state.routed_model_ids, port, context);
+            withdraw_provider_advertisement(&mut state.advertised_model_ids, context).await;
+            if state.failures >= PROVIDER_MAX_HEALTH_FAILURES {
+                let _ = terminate_provider_process(child).await;
+                Some(ProviderRunOutcome::Restart(format!(
+                    "provider failed {} consecutive health checks: {error:#}",
+                    state.failures
+                )))
+            } else {
+                None
             }
         }
     }
@@ -583,14 +638,22 @@ async fn probe_provider(
         .find(|candidate| candidate.id == model_id)
         .with_context(|| format!("provider does not report requested model {model_id}"))?;
     let versioned_model_id = validated_versioned_model_id(&model)?;
+    if model.max_concurrent_requests == 0 {
+        bail!("provider returned zero max_concurrent_requests");
+    }
     Ok(ProviderAvailability {
         available: model
             .availability
             .as_deref()
             .is_none_or(|status| status.eq_ignore_ascii_case("available")),
+        unavailable_reason: model.unavailable_reason,
         context_length: model.context_length,
         model_version: model.model_version,
         versioned_model_id,
+        capabilities: model.capabilities,
+        max_concurrent_requests: model.max_concurrent_requests,
+        active_requests: model.active_requests,
+        queued_requests: model.queued_requests,
     })
 }
 
@@ -606,108 +669,6 @@ fn validated_versioned_model_id(model: &ProviderModelEntry) -> Result<String> {
         );
     }
     Ok(model.versioned_model_id.clone())
-}
-
-fn desired_provider_routes(model_id: &str, availability: &ProviderAvailability) -> Vec<String> {
-    if !availability.available {
-        return Vec::new();
-    }
-    let mut routes = vec![model_id.to_string()];
-    routes.push(availability.versioned_model_id.clone());
-    routes
-}
-
-fn reconcile_provider_routes(
-    runtime: &ProviderRuntimeContext,
-    availability: &ProviderAvailability,
-    routed_model_ids: &mut Vec<String>,
-    port: u16,
-    context: &ProviderSupervisorContext,
-) {
-    let desired = desired_provider_routes(&runtime.model_id, availability);
-    for model_id in routed_model_ids.iter().filter(|id| !desired.contains(id)) {
-        remove_runtime_local_target(&context.target_tx, model_id, port);
-    }
-    for model_id in desired.iter().filter(|id| !routed_model_ids.contains(id)) {
-        add_runtime_local_target(&context.target_tx, model_id, port);
-    }
-    *routed_model_ids = desired;
-}
-
-async fn publish_provider_state(
-    runtime: &ProviderRuntimeContext,
-    context: &ProviderSupervisorContext,
-    pid: u32,
-    port: u16,
-    availability: &ProviderAvailability,
-) {
-    let status = if availability.available {
-        "ready"
-    } else {
-        "unavailable"
-    };
-    upsert_provider_process(
-        runtime,
-        context,
-        pid,
-        port,
-        status,
-        availability.context_length,
-    )
-    .await;
-}
-
-async fn publish_provider_unhealthy(
-    runtime: &ProviderRuntimeContext,
-    context: &ProviderSupervisorContext,
-    pid: u32,
-    port: u16,
-) {
-    upsert_provider_process(runtime, context, pid, port, "unhealthy", None).await;
-}
-
-async fn upsert_provider_process(
-    runtime: &ProviderRuntimeContext,
-    context: &ProviderSupervisorContext,
-    pid: u32,
-    port: u16,
-    status: &str,
-    context_length: Option<u32>,
-) {
-    let process = api::RuntimeProcessPayload {
-        name: runtime.model_id.clone(),
-        instance_id: Some(PROVIDER_INSTANCE_ID.to_string()),
-        profile: String::new(),
-        backend: runtime.runtime.manifest.runtime.provider_kind.clone(),
-        status: status.to_string(),
-        port,
-        pid,
-        slots: 1,
-        context_length,
-    };
-    upsert_dashboard_process(&context.dashboard_processes, process.clone()).await;
-    if let Some(console_state) = &context.console_state {
-        console_state.upsert_local_process(process).await;
-    }
-}
-
-fn withdraw_provider_routes(
-    routed_model_ids: &mut Vec<String>,
-    port: u16,
-    context: &ProviderSupervisorContext,
-) {
-    for model_id in routed_model_ids.drain(..) {
-        remove_runtime_local_target(&context.target_tx, &model_id, port);
-    }
-}
-
-async fn remove_provider_process(context: &ProviderSupervisorContext) {
-    super::remove_dashboard_process(&context.dashboard_processes, PROVIDER_INSTANCE_ID).await;
-    if let Some(console_state) = &context.console_state {
-        console_state
-            .remove_local_process(PROVIDER_INSTANCE_ID)
-            .await;
-    }
 }
 
 fn emit_provider_ready(
@@ -796,139 +757,6 @@ fn request_provider_termination(child: &mut Child) -> Result<()> {
 #[cfg(not(unix))]
 fn request_provider_termination(child: &mut Child) -> Result<()> {
     child.start_kill().context("stop provider process")
-}
-
-#[cfg(target_os = "macos")]
-fn validate_provider_platform_policy(runtime: &InstalledProviderRuntime) -> Result<()> {
-    if runtime.manifest.runtime.provider_kind != APPLE_PROVIDER_KIND {
-        return Ok(());
-    }
-    let executable = runtime.entrypoint();
-    run_policy_command(
-        "codesign",
-        &[
-            OsString::from("--verify"),
-            OsString::from("--strict"),
-            executable.clone().into(),
-        ],
-        "verify Apple provider code signature",
-    )?;
-    let details = run_policy_command(
-        "codesign",
-        &[
-            OsString::from("-dv"),
-            OsString::from("--verbose=4"),
-            executable.clone().into(),
-        ],
-        "inspect Apple provider code signature",
-    )?;
-    let team_identifier = signing_detail(&details, "TeamIdentifier");
-    let signing_identifier = signing_detail(&details, "Identifier");
-    let is_ad_hoc = team_identifier
-        .as_deref()
-        .is_none_or(|team| team == "not set");
-    if is_ad_hoc && !environment_flag("MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC") {
-        bail!(
-            "Apple provider is ad-hoc signed; set MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC=1 only for local experimental builds"
-        );
-    }
-    if let Some(signature) = &runtime.manifest.runtime.signature {
-        compare_signing_detail(
-            "team identifier",
-            signature.team_identifier.as_deref(),
-            team_identifier.as_deref(),
-        )?;
-        compare_signing_detail(
-            "signing identifier",
-            signature.signing_identifier.as_deref(),
-            signing_identifier.as_deref(),
-        )?;
-        validate_declared_entitlements(&executable, &signature.entitlements)?;
-        if signature.notarized == Some(true) {
-            run_policy_command(
-                "spctl",
-                &[
-                    OsString::from("--assess"),
-                    OsString::from("--type"),
-                    OsString::from("execute"),
-                    executable.into(),
-                ],
-                "assess Apple provider notarization",
-            )?;
-        }
-    }
-    Ok(())
-}
-
-#[cfg(not(target_os = "macos"))]
-fn validate_provider_platform_policy(runtime: &InstalledProviderRuntime) -> Result<()> {
-    if runtime.manifest.runtime.provider_kind == APPLE_PROVIDER_KIND {
-        bail!("Apple provider runtimes may only be launched on macOS");
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "macos")]
-fn run_policy_command(program: &str, arguments: &[OsString], label: &str) -> Result<String> {
-    let output = std::process::Command::new(program)
-        .args(arguments)
-        .output()
-        .with_context(|| label.to_string())?;
-    let combined = format!(
-        "{}{}",
-        String::from_utf8_lossy(&output.stdout),
-        String::from_utf8_lossy(&output.stderr)
-    );
-    if !output.status.success() {
-        bail!("{label} failed: {}", combined.trim());
-    }
-    Ok(combined)
-}
-
-#[cfg(target_os = "macos")]
-fn signing_detail(details: &str, name: &str) -> Option<String> {
-    details.lines().find_map(|line| {
-        line.strip_prefix(&format!("{name}="))
-            .map(str::trim)
-            .filter(|value| !value.is_empty())
-            .map(str::to_string)
-    })
-}
-
-#[cfg(target_os = "macos")]
-fn compare_signing_detail(label: &str, expected: Option<&str>, actual: Option<&str>) -> Result<()> {
-    if let Some(expected) = expected
-        && actual != Some(expected)
-    {
-        bail!(
-            "Apple provider {label} mismatch: expected {expected}, got {}",
-            actual.unwrap_or("missing")
-        );
-    }
-    Ok(())
-}
-
-#[cfg(target_os = "macos")]
-fn validate_declared_entitlements(executable: &Path, declared: &[String]) -> Result<()> {
-    if declared.is_empty() {
-        return Ok(());
-    }
-    let output = run_policy_command(
-        "codesign",
-        &[
-            OsString::from("-d"),
-            OsString::from("--entitlements"),
-            OsString::from(":-"),
-            executable.to_path_buf().into(),
-        ],
-        "inspect Apple provider entitlements",
-    )?;
-    for entitlement in declared {
-        if !output.contains(&format!("<key>{entitlement}</key>")) {
-            bail!("Apple provider is missing declared entitlement {entitlement}");
-        }
-    }
-    Ok(())
 }
 
 #[cfg(test)]
@@ -1028,10 +856,14 @@ mod tests {
             vec![election::InferenceTarget::Local(11_435)],
         );
         let (target_tx, _target_rx) = watch::channel(targets);
+        let node = mesh::Node::new_for_tests(mesh::NodeRole::Host { http_port: 9_337 })
+            .await
+            .unwrap();
         let context = ProviderSupervisorContext {
             target_tx: Arc::new(target_tx),
             dashboard_processes: Arc::new(tokio::sync::Mutex::new(Vec::new())),
             console_state: None,
+            node,
         };
 
         let mut routed_model_ids =
@@ -1060,17 +892,27 @@ mod tests {
         let entry = ProviderModelEntry {
             id: APPLE_MODEL_ID.to_string(),
             availability: Some("available".to_string()),
+            unavailable_reason: None,
             context_length: Some(4_096),
             model_version: "27.0".to_string(),
             version_source: "apple_os_release_band".to_string(),
             versioned_model_id: "apple/system@27.0".to_string(),
+            capabilities: vec!["tool_calling".to_string()],
+            max_concurrent_requests: 1,
+            active_requests: 0,
+            queued_requests: 0,
         };
         let versioned_model_id = validated_versioned_model_id(&entry).unwrap();
         let availability = ProviderAvailability {
             available: true,
+            unavailable_reason: None,
             context_length: entry.context_length,
             model_version: entry.model_version,
             versioned_model_id,
+            capabilities: entry.capabilities,
+            max_concurrent_requests: entry.max_concurrent_requests,
+            active_requests: entry.active_requests,
+            queued_requests: entry.queued_requests,
         };
         assert_eq!(
             desired_provider_routes(APPLE_MODEL_ID, &availability),
@@ -1083,10 +925,15 @@ mod tests {
         let unsupported = ProviderModelEntry {
             id: APPLE_MODEL_ID.to_string(),
             availability: Some("available".to_string()),
+            unavailable_reason: None,
             context_length: Some(4_096),
             model_version: "27.0".to_string(),
             version_source: "unknown".to_string(),
             versioned_model_id: "apple/system@27.0".to_string(),
+            capabilities: vec![],
+            max_concurrent_requests: 1,
+            active_requests: 0,
+            queued_requests: 0,
         };
         assert!(validated_versioned_model_id(&unsupported).is_err());
 
@@ -1096,5 +943,88 @@ mod tests {
             ..unsupported
         };
         assert!(validated_versioned_model_id(&mismatched).is_err());
+    }
+
+    fn available_provider() -> ProviderAvailability {
+        ProviderAvailability {
+            available: true,
+            unavailable_reason: None,
+            context_length: Some(4_096),
+            model_version: "27.0".to_string(),
+            versioned_model_id: "apple/system@27.0".to_string(),
+            capabilities: vec!["tool_calling".to_string(), "reasoning".to_string()],
+            max_concurrent_requests: 1,
+            active_requests: 1,
+            queued_requests: 2,
+        }
+    }
+
+    #[tokio::test]
+    async fn private_mesh_advertises_provider_load_and_withdraws_it() {
+        let node = mesh::Node::new_for_tests(mesh::NodeRole::Host { http_port: 9_337 })
+            .await
+            .unwrap();
+        let (target_tx, _target_rx) = watch::channel(election::ModelTargets::default());
+        let context = ProviderSupervisorContext {
+            target_tx: Arc::new(target_tx),
+            dashboard_processes: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            console_state: None,
+            node: node.clone(),
+        };
+        let mut advertised = Vec::new();
+
+        reconcile_provider_advertisement(
+            APPLE_MODEL_ID,
+            &available_provider(),
+            &mut advertised,
+            &context,
+        )
+        .await;
+
+        assert_eq!(
+            advertised,
+            vec!["apple/system".to_string(), "apple/system@27.0".to_string()]
+        );
+        assert_eq!(node.hosted_models().await, advertised);
+        let runtimes = node.all_model_runtime_descriptors().await;
+        assert_eq!(runtimes.len(), 2);
+        assert!(runtimes.iter().all(|runtime| {
+            runtime.provider_kind.as_deref() == Some("apple")
+                && runtime.max_concurrent_requests == Some(1)
+                && runtime.active_requests == Some(1)
+                && runtime.queued_requests == Some(2)
+        }));
+
+        withdraw_provider_advertisement(&mut advertised, &context).await;
+        assert!(advertised.is_empty());
+        assert!(node.hosted_models().await.is_empty());
+        assert!(node.all_model_runtime_descriptors().await.is_empty());
+    }
+
+    #[tokio::test]
+    async fn public_mesh_does_not_advertise_apple_system() {
+        let mut node = mesh::Node::new_for_tests(mesh::NodeRole::Host { http_port: 9_337 })
+            .await
+            .unwrap();
+        node.public_mesh = true;
+        let (target_tx, _target_rx) = watch::channel(election::ModelTargets::default());
+        let context = ProviderSupervisorContext {
+            target_tx: Arc::new(target_tx),
+            dashboard_processes: Arc::new(tokio::sync::Mutex::new(Vec::new())),
+            console_state: None,
+            node: node.clone(),
+        };
+        let mut advertised = Vec::new();
+
+        reconcile_provider_advertisement(
+            APPLE_MODEL_ID,
+            &available_provider(),
+            &mut advertised,
+            &context,
+        )
+        .await;
+
+        assert!(advertised.is_empty());
+        assert!(node.hosted_models().await.is_empty());
     }
 }

--- a/crates/mesh-llm-host-runtime/src/runtime/provider_supervisor/advertisement.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/provider_supervisor/advertisement.rs
@@ -1,0 +1,263 @@
+use super::*;
+use crate::models;
+
+pub(super) fn desired_provider_routes(
+    model_id: &str,
+    availability: &ProviderAvailability,
+) -> Vec<String> {
+    if !availability.available {
+        return Vec::new();
+    }
+    let mut routes = vec![model_id.to_string()];
+    routes.push(availability.versioned_model_id.clone());
+    routes
+}
+
+pub(super) fn reconcile_provider_routes(
+    runtime: &ProviderRuntimeContext,
+    availability: &ProviderAvailability,
+    routed_model_ids: &mut Vec<String>,
+    port: u16,
+    context: &ProviderSupervisorContext,
+) {
+    let desired = desired_provider_routes(&runtime.model_id, availability);
+    for model_id in routed_model_ids.iter().filter(|id| !desired.contains(id)) {
+        super::super::remove_runtime_local_target(&context.target_tx, model_id, port);
+    }
+    for model_id in desired.iter().filter(|id| !routed_model_ids.contains(id)) {
+        super::super::add_runtime_local_target(&context.target_tx, model_id, port);
+    }
+    *routed_model_ids = desired;
+}
+
+pub(super) async fn publish_provider_state(
+    runtime: &ProviderRuntimeContext,
+    context: &ProviderSupervisorContext,
+    pid: u32,
+    port: u16,
+    availability: &ProviderAvailability,
+) {
+    if !availability.available {
+        tracing::debug!(
+            reason = availability
+                .unavailable_reason
+                .as_deref()
+                .unwrap_or("unknown"),
+            "Apple system model is currently unavailable"
+        );
+    }
+    let status = if availability.available {
+        "ready"
+    } else {
+        "unavailable"
+    };
+    upsert_provider_process(
+        runtime,
+        context,
+        pid,
+        port,
+        status,
+        availability.context_length,
+    )
+    .await;
+}
+
+pub(super) async fn publish_provider_unhealthy(
+    runtime: &ProviderRuntimeContext,
+    context: &ProviderSupervisorContext,
+    pid: u32,
+    port: u16,
+) {
+    upsert_provider_process(runtime, context, pid, port, "unhealthy", None).await;
+}
+
+async fn upsert_provider_process(
+    runtime: &ProviderRuntimeContext,
+    context: &ProviderSupervisorContext,
+    pid: u32,
+    port: u16,
+    status: &str,
+    context_length: Option<u32>,
+) {
+    let process = api::RuntimeProcessPayload {
+        name: runtime.model_id.clone(),
+        instance_id: Some(PROVIDER_INSTANCE_ID.to_string()),
+        profile: String::new(),
+        backend: runtime.runtime.manifest.runtime.provider_kind.clone(),
+        status: status.to_string(),
+        port,
+        pid,
+        slots: 1,
+        context_length,
+    };
+    super::super::upsert_dashboard_process(&context.dashboard_processes, process.clone()).await;
+    if let Some(console_state) = &context.console_state {
+        console_state.upsert_local_process(process).await;
+    }
+}
+
+pub(super) fn withdraw_provider_routes(
+    routed_model_ids: &mut Vec<String>,
+    port: u16,
+    context: &ProviderSupervisorContext,
+) {
+    for model_id in routed_model_ids.drain(..) {
+        super::super::remove_runtime_local_target(&context.target_tx, &model_id, port);
+    }
+}
+
+pub(super) async fn reconcile_provider_advertisement(
+    model_id: &str,
+    availability: &ProviderAvailability,
+    advertised_model_ids: &mut Vec<String>,
+    context: &ProviderSupervisorContext,
+) {
+    let desired = if context.node.public_mesh {
+        Vec::new()
+    } else {
+        desired_provider_routes(model_id, availability)
+    };
+    let previous = advertised_model_ids.clone();
+    let mut changed = previous != desired;
+
+    if previous != desired {
+        reconcile_provider_model_names(&context.node, &previous, &desired).await;
+    }
+    for model_id in previous.iter().filter(|model| !desired.contains(model)) {
+        changed |= context.node.remove_served_model_descriptor(model_id).await;
+        changed |= context.node.remove_model_runtime_descriptor(model_id).await;
+    }
+    for model_id in &desired {
+        context
+            .node
+            .upsert_served_model_descriptor(provider_served_model_descriptor(
+                model_id,
+                availability,
+            ))
+            .await;
+        changed |= context
+            .node
+            .upsert_model_runtime_descriptor(provider_runtime_descriptor(model_id, availability))
+            .await;
+    }
+    *advertised_model_ids = desired;
+    if changed {
+        context.node.regossip().await;
+    }
+}
+
+async fn reconcile_provider_model_names(
+    node: &mesh::Node,
+    previous: &[String],
+    desired: &[String],
+) {
+    let mut serving = node.serving_models().await;
+    serving.retain(|model| !previous.contains(model));
+    for model in desired {
+        if !serving.contains(model) {
+            serving.push(model.clone());
+        }
+    }
+    node.set_serving_models(serving).await;
+
+    let mut hosted = node.hosted_models().await;
+    hosted.retain(|model| !previous.contains(model));
+    for model in desired {
+        if !hosted.contains(model) {
+            hosted.push(model.clone());
+        }
+    }
+    node.set_hosted_models(hosted).await;
+}
+
+fn provider_served_model_descriptor(
+    model_id: &str,
+    availability: &ProviderAvailability,
+) -> mesh::ServedModelDescriptor {
+    let capabilities = provider_model_capabilities(&availability.capabilities);
+    mesh::ServedModelDescriptor {
+        identity: mesh::ServedModelIdentity {
+            model_name: model_id.to_string(),
+            canonical_ref: Some(availability.versioned_model_id.clone()),
+            ..Default::default()
+        },
+        capabilities_known: true,
+        capabilities,
+        topology: None,
+        metadata: Some(mesh::ServedModelMetadata {
+            architecture: Some("apple_system".to_string()),
+            native_context_length: availability.context_length,
+            ..Default::default()
+        }),
+    }
+}
+
+fn provider_model_capabilities(capabilities: &[String]) -> models::ModelCapabilities {
+    let supported = |name: &str| capabilities.iter().any(|value| value == name);
+    let vision = supported("vision");
+    models::ModelCapabilities {
+        multimodal: vision,
+        vision: if vision {
+            models::CapabilityLevel::Supported
+        } else {
+            models::CapabilityLevel::None
+        },
+        reasoning: if supported("reasoning") {
+            models::CapabilityLevel::Supported
+        } else {
+            models::CapabilityLevel::None
+        },
+        tool_use: if supported("tool_calling") {
+            models::CapabilityLevel::Supported
+        } else {
+            models::CapabilityLevel::None
+        },
+        ..Default::default()
+    }
+}
+
+fn provider_runtime_descriptor(
+    model_id: &str,
+    availability: &ProviderAvailability,
+) -> mesh::ModelRuntimeDescriptor {
+    mesh::ModelRuntimeDescriptor {
+        model_name: model_id.to_string(),
+        identity_hash: None,
+        context_length: availability.context_length,
+        ready: availability.available,
+        provider_kind: Some(APPLE_PROVIDER_KIND.to_string()),
+        model_version: Some(availability.model_version.clone()),
+        max_concurrent_requests: Some(availability.max_concurrent_requests),
+        active_requests: Some(availability.active_requests),
+        queued_requests: Some(availability.queued_requests),
+    }
+}
+
+pub(super) async fn withdraw_provider_advertisement(
+    advertised_model_ids: &mut Vec<String>,
+    context: &ProviderSupervisorContext,
+) {
+    if advertised_model_ids.is_empty() {
+        return;
+    }
+    let previous = std::mem::take(advertised_model_ids);
+    reconcile_provider_model_names(&context.node, &previous, &[]).await;
+    for model_id in previous {
+        context.node.remove_served_model_descriptor(&model_id).await;
+        context
+            .node
+            .remove_model_runtime_descriptor(&model_id)
+            .await;
+    }
+    context.node.regossip().await;
+}
+
+pub(super) async fn remove_provider_process(context: &ProviderSupervisorContext) {
+    super::super::remove_dashboard_process(&context.dashboard_processes, PROVIDER_INSTANCE_ID)
+        .await;
+    if let Some(console_state) = &context.console_state {
+        console_state
+            .remove_local_process(PROVIDER_INSTANCE_ID)
+            .await;
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/runtime/provider_supervisor/platform_policy.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/provider_supervisor/platform_policy.rs
@@ -1,0 +1,137 @@
+use super::*;
+
+#[cfg(target_os = "macos")]
+use std::ffi::OsString;
+
+#[cfg(target_os = "macos")]
+pub(super) fn validate_provider_platform_policy(runtime: &InstalledProviderRuntime) -> Result<()> {
+    if runtime.manifest.runtime.provider_kind != APPLE_PROVIDER_KIND {
+        return Ok(());
+    }
+    let executable = runtime.entrypoint();
+    run_policy_command(
+        "codesign",
+        &[
+            OsString::from("--verify"),
+            OsString::from("--strict"),
+            executable.clone().into(),
+        ],
+        "verify Apple provider code signature",
+    )?;
+    let details = run_policy_command(
+        "codesign",
+        &[
+            OsString::from("-dv"),
+            OsString::from("--verbose=4"),
+            executable.clone().into(),
+        ],
+        "inspect Apple provider code signature",
+    )?;
+    let team_identifier = signing_detail(&details, "TeamIdentifier");
+    let signing_identifier = signing_detail(&details, "Identifier");
+    let is_ad_hoc = team_identifier
+        .as_deref()
+        .is_none_or(|team| team == "not set");
+    if is_ad_hoc && !environment_flag("MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC") {
+        bail!(
+            "Apple provider is ad-hoc signed; set MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC=1 only for local experimental builds"
+        );
+    }
+    if let Some(signature) = &runtime.manifest.runtime.signature {
+        compare_signing_detail(
+            "team identifier",
+            signature.team_identifier.as_deref(),
+            team_identifier.as_deref(),
+        )?;
+        compare_signing_detail(
+            "signing identifier",
+            signature.signing_identifier.as_deref(),
+            signing_identifier.as_deref(),
+        )?;
+        validate_declared_entitlements(&executable, &signature.entitlements)?;
+        if signature.notarized == Some(true) {
+            run_policy_command(
+                "spctl",
+                &[
+                    OsString::from("--assess"),
+                    OsString::from("--type"),
+                    OsString::from("execute"),
+                    executable.into(),
+                ],
+                "assess Apple provider notarization",
+            )?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(not(target_os = "macos"))]
+pub(super) fn validate_provider_platform_policy(runtime: &InstalledProviderRuntime) -> Result<()> {
+    if runtime.manifest.runtime.provider_kind == APPLE_PROVIDER_KIND {
+        bail!("Apple provider runtimes may only be launched on macOS");
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn run_policy_command(program: &str, arguments: &[OsString], label: &str) -> Result<String> {
+    let output = std::process::Command::new(program)
+        .args(arguments)
+        .output()
+        .with_context(|| label.to_string())?;
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    if !output.status.success() {
+        bail!("{label} failed: {}", combined.trim());
+    }
+    Ok(combined)
+}
+
+#[cfg(target_os = "macos")]
+fn signing_detail(details: &str, name: &str) -> Option<String> {
+    details.lines().find_map(|line| {
+        line.strip_prefix(&format!("{name}="))
+            .map(str::trim)
+            .filter(|value| !value.is_empty())
+            .map(str::to_string)
+    })
+}
+
+#[cfg(target_os = "macos")]
+fn compare_signing_detail(label: &str, expected: Option<&str>, actual: Option<&str>) -> Result<()> {
+    if let Some(expected) = expected
+        && actual != Some(expected)
+    {
+        bail!(
+            "Apple provider {label} mismatch: expected {expected}, got {}",
+            actual.unwrap_or("missing")
+        );
+    }
+    Ok(())
+}
+
+#[cfg(target_os = "macos")]
+fn validate_declared_entitlements(executable: &Path, declared: &[String]) -> Result<()> {
+    if declared.is_empty() {
+        return Ok(());
+    }
+    let output = run_policy_command(
+        "codesign",
+        &[
+            OsString::from("-d"),
+            OsString::from("--entitlements"),
+            OsString::from(":-"),
+            executable.to_path_buf().into(),
+        ],
+        "inspect Apple provider entitlements",
+    )?;
+    for entitlement in declared {
+        if !output.contains(&format!("<key>{entitlement}</key>")) {
+            bail!("Apple provider is missing declared entitlement {entitlement}");
+        }
+    }
+    Ok(())
+}

--- a/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
@@ -359,6 +359,45 @@ pub(super) async fn run_runtime_cli(
     .await
 }
 
+fn initialize_early_topology_audit_logging(options: &mut RuntimeOptions) -> Result<()> {
+    let config_path = options.config.clone();
+    initialize_early_topology_audit_logging_with(
+        options,
+        || plugin::load_config(config_path.as_deref()),
+        initialize_audit_logging_for_options,
+    )
+}
+
+pub(super) fn initialize_early_topology_audit_logging_with(
+    options: &mut RuntimeOptions,
+    load_config: impl FnOnce() -> Result<plugin::MeshConfig>,
+    initialize_audit_logging: impl FnOnce(&RuntimeOptions) -> Result<()>,
+) -> Result<()> {
+    match load_config() {
+        Ok(config) => apply_runtime_config_options(options, &config),
+        Err(error) => {
+            tracing::warn!(
+                error = %error,
+                "failed to load config for early topology audit logging; continuing without config-derived audit settings"
+            );
+        }
+    }
+    initialize_audit_logging(options)
+}
+
+fn initialize_audit_logging_for_options(options: &RuntimeOptions) -> Result<()> {
+    if options.audit_log_path.is_some() {
+        init_audit_logging(
+            options.audit_log_path.clone(),
+            options.audit_log_format,
+            options.audit_log_level,
+            options.audit_max_file_size,
+            options.audit_max_files,
+        )?;
+    }
+    Ok(())
+}
+
 pub(super) fn apply_runtime_config_options(
     options: &mut RuntimeOptions,
     config: &plugin::MeshConfig,
@@ -1536,23 +1575,6 @@ pub(super) async fn run_auto(ctx: RunAutoContext) -> Result<()> {
     })
     .await?;
 
-<<<<<<< HEAD
-=======
-    let provider_supervisor = start_provider_for_openai_surface(
-        is_client,
-        ProviderSupervisorContext {
-            target_tx: target_tx.clone(),
-            dashboard_processes: runtime_state.dashboard_processes.clone(),
-            console_state: console_state.clone(),
-            node: node.clone(),
-        },
-        provider_runtime_discovery.as_ref(),
-        &tunnel_mgr,
-        api_port,
-    )
-    .await;
-
->>>>>>> c667591c (Route Apple system models across private meshes)
     let primary_model_name = requested_model_names.first().cloned().unwrap_or_default();
     let provider_supervisor = start_run_auto_provider_supervisor(
         is_client,

--- a/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
@@ -1336,6 +1336,25 @@ pub(super) struct RunAutoContext {
     pub(super) provider_runtimes: Option<ProviderRuntimeDiscoveryOptions>,
 }
 
+async fn start_provider_for_openai_surface(
+    is_client: bool,
+    context: ProviderSupervisorContext,
+    discovery: Option<&ProviderRuntimeDiscoveryOptions>,
+    tunnel_mgr: &tunnel::Manager,
+    api_port: u16,
+) -> Option<ProviderSupervisorHandle> {
+    if is_client {
+        return None;
+    }
+    let supervisor = start_apple_provider_supervisor(context, discovery).await;
+    if supervisor.is_some() {
+        // Provider-only hosts have no GGUF startup loop to register the API
+        // port. Provider gossip begins only after the sidecar is healthy.
+        tunnel_mgr.set_http_port(api_port);
+    }
+    supervisor
+}
+
 #[expect(
     clippy::cognitive_complexity,
     reason = "run_auto is the top-level runtime orchestration path and preserves startup/shutdown ordering"
@@ -1517,6 +1536,23 @@ pub(super) async fn run_auto(ctx: RunAutoContext) -> Result<()> {
     })
     .await?;
 
+<<<<<<< HEAD
+=======
+    let provider_supervisor = start_provider_for_openai_surface(
+        is_client,
+        ProviderSupervisorContext {
+            target_tx: target_tx.clone(),
+            dashboard_processes: runtime_state.dashboard_processes.clone(),
+            console_state: console_state.clone(),
+            node: node.clone(),
+        },
+        provider_runtime_discovery.as_ref(),
+        &tunnel_mgr,
+        api_port,
+    )
+    .await;
+
+>>>>>>> c667591c (Route Apple system models across private meshes)
     let primary_model_name = requested_model_names.first().cloned().unwrap_or_default();
     let provider_supervisor = start_run_auto_provider_supervisor(
         is_client,

--- a/crates/mesh-llm-host-runtime/src/runtime_data/collector.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/collector.rs
@@ -1107,6 +1107,12 @@ fn build_peer_payload(peer: &mesh::PeerInfo) -> PeerPayload {
         hosted_models: peer.hosted_models.clone(),
         hosted_models_known: peer.hosted_models_known,
         advertised_model_throughput: peer.advertised_model_throughput.clone(),
+        provider_runtimes: peer
+            .served_model_runtime
+            .iter()
+            .filter(|runtime| runtime.provider_kind.is_some())
+            .cloned()
+            .collect(),
         version: peer.version.clone(),
         rtt_ms: peer.rtt_ms,
         latency_ms: display_latency.latency_ms,

--- a/crates/mesh-llm-host-runtime/src/sdk.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk.rs
@@ -146,6 +146,7 @@ pub async fn start_embedded_node(
     )?;
     let isolated_config = prepare_isolated_config(&mut config)?;
     embedded_logging::validate_embedded_config(config.storage.config_path.as_deref())?;
+    embedded_logging::initialize_embedded_logging(config.storage.config_path.as_deref()).await?;
     let (control_tx, control_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime_options = embedded_runtime_options(&config, Some(control_rx));
     let api_base_url = format!("http://127.0.0.1:{}/v1", config.http.api_port);

--- a/crates/mesh-llm-protocol/proto/node.proto
+++ b/crates/mesh-llm-protocol/proto/node.proto
@@ -258,6 +258,11 @@ message ModelRuntimeDescriptor {
   optional string identity_hash = 2;
   optional uint32 context_length = 3;
   bool ready = 4;
+  optional string provider_kind = 5;          // Whole-model provider, e.g. "apple"; absent for native runtimes
+  optional string model_version = 6;          // Provider-defined resolved model generation
+  optional uint32 max_concurrent_requests = 7;
+  optional uint32 active_requests = 8;
+  optional uint32 queued_requests = 9;
 }
 
 message ModelMoeInfo {

--- a/crates/mesh-llm-protocol/src/proto/node.rs
+++ b/crates/mesh-llm-protocol/src/proto/node.rs
@@ -304,6 +304,16 @@ pub struct ModelRuntimeDescriptor {
     pub context_length: ::core::option::Option<u32>,
     #[prost(bool, tag = "4")]
     pub ready: bool,
+    #[prost(string, optional, tag = "5")]
+    pub provider_kind: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(string, optional, tag = "6")]
+    pub model_version: ::core::option::Option<::prost::alloc::string::String>,
+    #[prost(uint32, optional, tag = "7")]
+    pub max_concurrent_requests: ::core::option::Option<u32>,
+    #[prost(uint32, optional, tag = "8")]
+    pub active_requests: ::core::option::Option<u32>,
+    #[prost(uint32, optional, tag = "9")]
+    pub queued_requests: ::core::option::Option<u32>,
 }
 #[derive(Clone, PartialEq, Eq, Hash, ::prost::Message)]
 pub struct ModelMoeInfo {

--- a/crates/mesh-llm-types/src/mesh/mod.rs
+++ b/crates/mesh-llm-types/src/mesh/mod.rs
@@ -103,11 +103,42 @@ pub struct ModelRuntimeDescriptor {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub context_length: Option<u32>,
     pub ready: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub provider_kind: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model_version: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_concurrent_requests: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_requests: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub queued_requests: Option<u32>,
 }
 
 impl ModelRuntimeDescriptor {
     pub fn advertised_context_length(&self) -> Option<u32> {
         self.ready.then_some(self.context_length).flatten()
+    }
+
+    pub fn provider_load(&self) -> Option<ModelRuntimeLoad> {
+        Some(ModelRuntimeLoad {
+            max_concurrent_requests: self.max_concurrent_requests?,
+            active_requests: self.active_requests.unwrap_or_default(),
+            queued_requests: self.queued_requests.unwrap_or_default(),
+        })
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct ModelRuntimeLoad {
+    pub max_concurrent_requests: u32,
+    pub active_requests: u32,
+    pub queued_requests: u32,
+}
+
+impl ModelRuntimeLoad {
+    pub const fn saturated(self) -> bool {
+        self.active_requests >= self.max_concurrent_requests
     }
 }
 

--- a/crates/mesh-llm-ui/src/features/network/api/status-adapter.test.ts
+++ b/crates/mesh-llm-ui/src/features/network/api/status-adapter.test.ts
@@ -125,6 +125,44 @@ describe('adaptStatusToDashboard', () => {
     expect(dashboard.peers[1]).toEqual(expect.objectContaining({ id: 'aeac0d8e53', owner: 'unsigned' }))
   })
 
+  it('derives Apple provider load from additive runtime capacity', () => {
+    const dashboard = adaptStatusToDashboard({
+      ...PUBLIC_STATUS_PAYLOAD,
+      runtime: {
+        models: [
+          {
+            name: 'apple/system',
+            status: 'ready',
+            provider_kind: 'apple',
+            max_concurrent_requests: 1,
+            active_requests: 1,
+            queued_requests: 2
+          }
+        ]
+      },
+      peers: [
+        {
+          id: 'apple-peer',
+          role: 'Host',
+          state: 'serving',
+          models: ['apple/system'],
+          provider_runtimes: [
+            {
+              model_name: 'apple/system',
+              provider_kind: 'apple',
+              max_concurrent_requests: 1,
+              active_requests: 0,
+              queued_requests: 0
+            }
+          ]
+        }
+      ]
+    })
+
+    expect(dashboard.peers.find((peer) => peer.role === 'you')?.loadPct).toBe(100)
+    expect(dashboard.peers.find((peer) => peer.id === 'apple-peer')?.loadPct).toBe(0)
+  })
+
   it('adapts live status into the six-cell dashboard metrics bar', () => {
     const dashboard = adaptStatusToDashboard({
       ...PUBLIC_STATUS_PAYLOAD,

--- a/crates/mesh-llm-ui/src/features/network/api/status-adapter.ts
+++ b/crates/mesh-llm-ui/src/features/network/api/status-adapter.ts
@@ -117,8 +117,7 @@ function finiteMetric(value: number | undefined): number {
 
 function providerLoadPct(
   runtimes:
-    | Array<Pick<ProviderRuntimeInfo, 'max_concurrent_requests' | 'active_requests' | 'queued_requests'>>
-    | undefined
+    Array<Pick<ProviderRuntimeInfo, 'max_concurrent_requests' | 'active_requests' | 'queued_requests'>> | undefined
 ): number | undefined {
   const capacity = runtimes?.reduce((sum, runtime) => sum + finiteMetric(runtime.max_concurrent_requests), 0) ?? 0
   if (capacity <= 0) return undefined

--- a/crates/mesh-llm-ui/src/features/network/api/status-adapter.ts
+++ b/crates/mesh-llm-ui/src/features/network/api/status-adapter.ts
@@ -1,5 +1,5 @@
 import { DASHBOARD_HARNESS } from '@/features/app-tabs/data'
-import type { StatusPayload, PeerInfo, GpuInfo, ServingModelEntry } from '@/lib/api/types'
+import type { StatusPayload, PeerInfo, GpuInfo, ServingModelEntry, ProviderRuntimeInfo } from '@/lib/api/types'
 import { isPublicMesh } from '@/lib/api/mesh-visibility'
 import { gpuRatedVramGB } from '@/lib/vram'
 import type {
@@ -115,6 +115,17 @@ function finiteMetric(value: number | undefined): number {
   return typeof value === 'number' && Number.isFinite(value) ? value : 0
 }
 
+function providerLoadPct(
+  runtimes:
+    | Array<Pick<ProviderRuntimeInfo, 'max_concurrent_requests' | 'active_requests' | 'queued_requests'>>
+    | undefined
+): number | undefined {
+  const capacity = runtimes?.reduce((sum, runtime) => sum + finiteMetric(runtime.max_concurrent_requests), 0) ?? 0
+  if (capacity <= 0) return undefined
+  const active = runtimes?.reduce((sum, runtime) => sum + finiteMetric(runtime.active_requests), 0) ?? 0
+  return Math.min(Math.max(Math.round((active / capacity) * 100), 0), 100)
+}
+
 function gpuTotalVramGb(gpus?: GpuInfo[]): number | null {
   if (!gpus?.length) return null
 
@@ -153,7 +164,7 @@ function adaptPeer(peer: PeerInfo, fallbackIndex: number): Peer {
     latencySource: peer.latency_source ?? null,
     latencyAgeMs: peer.latency_age_ms ?? null,
     latencyObserverId: peer.latency_observer_id ?? null,
-    loadPct: peer.load_pct ?? 0,
+    loadPct: peer.load_pct ?? providerLoadPct(peer.provider_runtimes) ?? 0,
     shortId: id.slice(0, 8),
     version: peer.version,
     vramGB: peerVramGb(peer),
@@ -192,7 +203,7 @@ function adaptSelfPeer(payload: StatusPayload): Peer {
     latencySource: null,
     latencyAgeMs: null,
     latencyObserverId: null,
-    loadPct: payload.load_pct ?? 0,
+    loadPct: payload.load_pct ?? providerLoadPct(payload.runtime?.models) ?? 0,
     shortId: payload.node_id.slice(0, 8),
     role: 'you' as const,
     nodeState: effectiveState,

--- a/crates/mesh-llm-ui/src/features/network/components/ModelCatalog.tsx
+++ b/crates/mesh-llm-ui/src/features/network/components/ModelCatalog.tsx
@@ -32,6 +32,7 @@ type ModelProvider = { label: string; Icon: LucideIcon }
 type ModelIconStyle = CSSProperties & { '--model-card-icon-color': string }
 
 const MODEL_PROVIDERS: ModelProvider[] = [
+  { label: 'Apple', Icon: Cpu },
   { label: 'Cohere', Icon: Sparkles },
   { label: 'Z.ai', Icon: BrainCircuit },
   { label: 'OpenAI', Icon: Sparkles },

--- a/crates/mesh-llm-ui/src/features/network/lib/model-catalog-utils.test.ts
+++ b/crates/mesh-llm-ui/src/features/network/lib/model-catalog-utils.test.ts
@@ -73,6 +73,7 @@ describe('model catalog filter utilities', () => {
   })
 
   it('uses normalized family labels for provider detection', () => {
+    expect(modelProviderLabel(model({ name: 'apple/system' }))).toBe('Apple')
     expect(modelProviderLabel(model({ name: 'Hermes-2-Pro-Mistral-7B-Q4_K_M' }))).toBe('Mistral AI')
     expect(modelProviderLabel(model({ name: 'gpt-oss-120b', fullId: 'openai/gpt-oss-120b' }))).toBe('OpenAI')
     expect(modelProviderLabel(model({ name: 'command-a-03-2025' }))).toBe('Cohere')

--- a/crates/mesh-llm-ui/src/features/network/lib/model-catalog-utils.ts
+++ b/crates/mesh-llm-ui/src/features/network/lib/model-catalog-utils.ts
@@ -8,6 +8,7 @@ type ModelFamilyRule = { label: string; patterns: RegExp[] }
 type ModelLicenseRule = { label: string; patterns: RegExp[] }
 
 const MODEL_PROVIDER_RULES: ModelProviderRule[] = [
+  { label: 'Apple', prefixes: ['apple'] },
   { label: 'Cohere', prefixes: ['command', 'cohere'] },
   { label: 'Z.ai', prefixes: ['glm', 'zai', 'z.ai', 'zhipu'] },
   { label: 'OpenAI', prefixes: ['gpt-oss'] },

--- a/crates/mesh-llm-ui/src/lib/api/types.ts
+++ b/crates/mesh-llm-ui/src/lib/api/types.ts
@@ -115,6 +115,7 @@ export interface PeerInfo {
   release_attestation?: ReleaseAttestationSummary
   gpus?: GpuInfo[]
   first_joined_mesh_ts?: number
+  provider_runtimes?: ProviderRuntimeInfo[]
 }
 
 export type MeshPublicationState = 'private' | 'public' | 'publish_failed'
@@ -130,7 +131,7 @@ export interface RuntimeStageInfo {
 
 export interface RuntimeInfo {
   backend?: string
-  models?: { name: string; status: string; port?: number }[]
+  models?: RuntimeModelInfo[]
   stages?: RuntimeStageInfo[]
 }
 
@@ -140,6 +141,26 @@ export interface LoggingStatus {
   artifact_capture_available: boolean
   artifact_capture_ready: boolean
   artifact_capture_degradation?: string
+}
+
+export interface ProviderRuntimeInfo {
+  model_name: string
+  provider_kind?: string
+  model_version?: string
+  max_concurrent_requests?: number
+  active_requests?: number
+  queued_requests?: number
+}
+
+export interface RuntimeModelInfo {
+  name: string
+  status: string
+  port?: number
+  provider_kind?: string
+  model_version?: string
+  max_concurrent_requests?: number
+  active_requests?: number
+  queued_requests?: number
 }
 
 export interface StatusPayload {

--- a/docs/MESHES.md
+++ b/docs/MESHES.md
@@ -110,6 +110,28 @@ Join from an API-only client:
 mesh-llm client --join <token>
 ```
 
+### Apple system models on a private mesh (experimental)
+
+On an Apple silicon Mac running macOS Golden Gate with the signed Apple
+provider runtime installed, `mesh-llm serve` can advertise `apple/system` and
+its resolved generation, for example `apple/system@27.0`, to peers that joined
+the same private mesh. Requests are sent to one Mac for their entire lifetime;
+the opaque Apple model is never split into Skippy pipeline stages.
+
+The advertisement includes runtime-observed context, capability, generation,
+one-request capacity, active work, and queue depth. MeshLLM prefers an idle Mac,
+preserves normal request affinity, retries another provider only if failure
+happens before streaming begins, and withdraws the route when its sidecar is no
+longer healthy. Missing additive load fields from an older peer are treated as
+unknown capacity, preserving mixed-version operation.
+
+This provider is intentionally explicit-only. Call `apple/system` or an exact
+versioned ID; `auto`, `mesh`, and MoA will not select it. Nodes started with
+`--publish` do not advertise Apple system models. This keeps the experimental
+system-model route inside an invite-gated trust boundary while licensing,
+quality, privacy, signing, and release-distribution gates remain open. See
+[Experimental Apple runtime](design/APPLE_RUNTIME.md) for packaging and setup.
+
 ### Multi-interface Linux and Docker hosts
 
 On Linux hosts with several kernel-visible interfaces, especially

--- a/docs/design/APPLE_RUNTIME.md
+++ b/docs/design/APPLE_RUNTIME.md
@@ -1,8 +1,9 @@
 # Experimental Apple runtime
 
-Status: Milestone 0, the local REST vertical slice, executable-provider
-artifact contract, and experimental Rust host supervisor completed on
-2026-08-12; SDK distribution and mesh routing remain gated. Tracking issue:
+Status: Milestones 0–3 have experimental implementations as of 2026-08-12:
+the system-model spike, local REST vertical slice, shared SDK carrier contract,
+and private-mesh whole-model routing. Release promotion and public-mesh
+advertisement remain gated. Tracking issue:
 [#1246](https://github.com/mesh-llm/mesh-llm/issues/1246).
 
 ## Outcome
@@ -19,8 +20,9 @@ path uses Apple's native accelerator stack; it is not a CPU-only Swift wrapper.
 
 The experimental sidecar exposes a loopback OpenAI-shaped REST surface. The
 Rust host can now resolve and supervise the packaged process and route
-`apple/system` through MeshLLM's normal local OpenAI frontend. It does not yet
-ship in release products or gossip `apple/system` to peers.
+`apple/system` through MeshLLM's normal local OpenAI frontend. Private meshes
+gossip its observed availability, version, context, and one-slot load; the
+provider does not ship in release products or advertise on public meshes.
 
 ## Why this is valuable to Apple silicon users
 
@@ -105,6 +107,8 @@ The provider currently implements:
 
 - availability and explicit unavailability reasons;
 - context size, languages, and capability discovery;
+- exact input token preflight for prompts, instructions, tool definitions, and
+  guided-generation schemas, including requested response-token headroom;
 - session prewarming;
 - snapshot-to-delta streaming;
 - elapsed time and time to first token;
@@ -155,9 +159,18 @@ The supervisor:
   `SIGTERM`, waits up to five seconds, and force-kills a child that does not
   exit.
 
-This phase deliberately advertises no provider state through gossip. The
-supervised model is local-only until the additive Phase 3 capability and
-availability fields, routing semantics, and mixed-version behavior are proven.
+On private meshes, the supervisor advertises both `apple/system` and its
+resolved generation as ordinary whole-model routes. Additive runtime fields
+carry provider kind, generation, maximum concurrency, active requests, and
+queued requests. Health loss or process exit withdraws the routes and triggers
+fresh gossip; public meshes suppress the advertisement entirely.
+
+Routing prefers an idle provider, then peers without load metadata, then busy
+or queued providers. Existing request affinity keeps a session on the selected
+Mac while it remains healthy. Failover is allowed only before response headers
+or the first stream event; MeshLLM never attempts to splice a generation across
+providers. `apple/system` and `apple/system@<generation>` are explicit-only:
+they are excluded from `auto`, the virtual `mesh` model, and MoA worker pools.
 
 ## Runtime packaging and SDK ownership
 
@@ -224,6 +237,7 @@ just apple::build
 just apple::test
 just apple::live
 just apple::mesh
+just apple::private-mesh
 just apple::product 0.72.1 target/apple-runtime/product
 just apple::product-qa 0.72.1 target/apple-runtime/product
 just apple::rust-sdk
@@ -253,6 +267,7 @@ Observed live results:
 | REST tool execution | pass |
 | REST client-disconnect cancellation | pass |
 | MeshLLM `/v1` completion, SSE, tool, and cancellation | pass |
+| Two-node private mesh provider gossip and completion | pass; 2 replicas / 2 total slots |
 | Version-resolved `apple/system@27.0` completion | pass |
 | Management API provider PID, health, port, and context | pass |
 | Unexpected provider exit and supervised restart | pass |
@@ -281,6 +296,24 @@ Public evidence should contain only aggregate timings, token counts, and
 accelerator classification.
 
 ### Quality and context findings
+
+[Apple TN3193](https://developer.apple.com/documentation/technotes/tn3193-managing-the-on-device-foundation-model-s-context-window)
+confirms that each language-model session has a 4,096-token context and that
+instructions, prompts, tool schemas/inputs/outputs, `Generable` schemas,
+transcript entries, and model responses all consume it. The sidecar therefore
+uses Apple's `tokenCount(for:)` APIs before generation. It sums the applicable
+prompt, instruction, tool, and schema counts, reserves an explicitly requested
+response-token limit, and returns `context_exceeded` before starting work when
+the request cannot fit. The framework error remains a final safety net because
+tool outputs and an unconstrained response can grow after preflight.
+
+TN3193 also changes the product guidance for longer tasks: do not imply that
+request routing creates a larger logical context. Use concise instructions,
+small tool schemas (Apple recommends offering at most 3–5 tools), retrieval of
+only relevant snippets, or application-level chunk/summarize/compact flows that
+start a new Apple language-model session. A strict response-token maximum is a
+runaway-generation guard, not a general truncation strategy, because it may
+produce malformed or incomplete output.
 
 The guided-generation API returned a valid `@Generable` value and usage, but it
 misclassified the simple phrase “choose a warm mesh replica” as unrelated with
@@ -370,12 +403,17 @@ before composition. Remaining promotion work is release-channel publication
 of the one signed artifact plus app-sandbox and quarantine validation in a
 signed Swift app and packaged Electron app.
 
-### 3. Private-mesh system-model routing
+### 3. Private-mesh system-model routing — experimental implementation complete
 
-Extend the local supervisor's availability and withdrawal state into additive
-gossip, then add load and queue reporting, whole-model placement, pre-stream
-failover, request affinity, mixed-version behavior, and two-node validation.
-Keep `apple/system` explicit and private-mesh-only.
+Private peers now exchange additive provider runtime descriptors and route the
+rolling or versioned system-model ID as one whole request. The Apple sidecar
+owns a one-request FIFO scheduler and reports capacity, active work, and queue
+depth. Routing is load-aware, honors normal session/prefix affinity, retries a
+different healthy Mac only before streaming begins, and withdraws a provider
+after health or process failure. Older peers safely ignore the new fields; a
+new peer treats an older provider's missing load as unknown. The management API,
+OpenAI model metadata, and console expose the observed provider generation and
+load. Public meshes, `auto`, virtual `mesh`, and MoA do not select this model.
 
 ### 4. Core AI model providers and workload certification
 

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -378,6 +378,70 @@ mesh-llm serve --model Qwen2.5-32B --join <TOKEN>
 - Both nodes run solo (no split) — each is its own host
 - API works from both nodes on `:9337`
 
+### 2a. Two Apple system-model providers on a private mesh (experimental)
+
+This test requires two Apple silicon Macs running macOS Golden Gate with the
+system model available. On each Mac, build the host and an ad-hoc local QA
+provider (release products must use the signed/notarized artifact instead):
+
+```bash
+just build
+just apple::package
+export MESH_LLM_PROVIDER_RUNTIME_BUNDLE_DIR="$PWD/target/apple-runtime/package/meshllm-apple-runtime-darwin-arm64"
+export MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC=1
+```
+
+Start Mac A, copy the private invite token from its structured startup output,
+then join Mac B with distinct local ports:
+
+```bash
+# Mac A
+target/debug/mesh-llm --log-format json serve --headless --port 9337 --console 3131
+
+# Mac B
+target/debug/mesh-llm --log-format json serve --headless --port 9447 --console 3141 --join <TOKEN>
+```
+
+From either Mac, verify the rolling and resolved IDs and their provider load:
+
+```bash
+curl -s http://127.0.0.1:9337/v1/models | jq '.data[] |
+  select(.id | startswith("apple/system")) |
+  {id, metadata}'
+
+curl -s http://127.0.0.1:3131/api/status | jq '{
+  local: [.runtime.models[] | select(.provider_kind == "apple")],
+  peers: [.peers[] | {id, provider_runtimes}]
+}'
+
+curl -s http://127.0.0.1:9337/v1/chat/completions \
+  -H 'content-type: application/json' \
+  -d '{"model":"apple/system","messages":[{"role":"user","content":"Reply with exactly: private mesh ready"}],"max_tokens":32}' | jq .
+```
+
+Required evidence:
+
+- both Macs advertise `apple/system` and the same documented generation;
+- a request whose Apple-counted instructions, prompt, tool/schema material,
+  and requested output exceed 4,096 tokens fails before generation with
+  `context_exceeded` and does not consume the provider slot indefinitely;
+- every provider reports `max_concurrent_requests=1`, with active and queued
+  counts changing under concurrent requests;
+- an idle provider ranks before a saturated provider, while repeated requests
+  with the same affinity key remain on their healthy selected Mac;
+- killing one `mesh-apple-runtime` withdraws both of that Mac's routes; a
+  request that has not started streaming can retry the other Mac, but an
+  interrupted stream fails rather than being spliced;
+- restarting the sidecar restores its advertisement and capacity;
+- requests with `model=auto` or `model=mesh` never choose `apple/system`;
+- repeating Mac A with `--publish` leaves Apple provider descriptors absent
+  from peer gossip and public discovery; and
+- a released older peer can join and route using the model name while safely
+  ignoring the additive provider/load fields.
+
+The single-host `just apple::mesh` recipe remains the fast prerequisite smoke
+for completion, SSE, tools, cancellation, supervisor restart, and cleanup.
+
 ### 3. Two GPU nodes, forced split
 
 ```bash

--- a/providers/apple/Justfile
+++ b/providers/apple/Justfile
@@ -60,6 +60,11 @@ mesh: package
     @just --justfile "{{ apple_root }}/../../Justfile" build
     @"{{ apple_root }}/QA/mesh.sh"
 
+# Route apple/system through two private-mesh nodes and verify additive load gossip.
+private-mesh: package
+    @just --justfile "{{ apple_root }}/../../Justfile" build
+    @"{{ apple_root }}/QA/private-mesh.sh"
+
 # Prove packaged-product auto-discovery with no provider bundle/index override.
 product-smoke mesh_version output="target/apple-runtime/product":
     @MESH_APPLE_RUNTIME_PRODUCT_VERSION="{{ mesh_version }}" \
@@ -102,4 +107,4 @@ orphan: package
     @"{{ apple_root }}/QA/orphan.sh"
 
 # Run the complete experimental Apple runtime validation suite.
-qa: test live rest mesh carriers sdk-carriers launchd instruments orphan
+qa: test live rest mesh private-mesh carriers sdk-carriers launchd instruments orphan

--- a/providers/apple/QA/private-mesh.sh
+++ b/providers/apple/QA/private-mesh.sh
@@ -1,0 +1,273 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+APPLE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REPO_ROOT="$(cd "$APPLE_ROOT/../.." && pwd)"
+PACKAGE_ROOT="$REPO_ROOT/target/apple-runtime/package/meshllm-apple-runtime-darwin-arm64"
+HOST_BINARY="${MESH_APPLE_RUNTIME_MESH_HOST_BINARY:-$REPO_ROOT/target/debug/mesh-llm}"
+OUTPUT_DIR="${MESH_APPLE_RUNTIME_PRIVATE_MESH_OUTPUT_DIR:-$REPO_ROOT/target/apple-runtime/private-mesh}"
+NODE_A_PID=""
+NODE_B_PID=""
+LOAD_A_PID=""
+LOAD_B_PID=""
+
+cleanup() {
+    for pid in "$LOAD_B_PID" "$LOAD_A_PID"; do
+        if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+            kill -TERM "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
+    for pid in "$NODE_B_PID" "$NODE_A_PID"; do
+        if [[ "$pid" =~ ^[0-9]+$ ]] && kill -0 "$pid" 2>/dev/null; then
+            kill -TERM "$pid" 2>/dev/null || true
+            wait "$pid" 2>/dev/null || true
+        fi
+    done
+}
+trap cleanup EXIT
+
+[[ -x "$HOST_BINARY" ]] || {
+    echo "missing MeshLLM debug product; run just build" >&2
+    exit 2
+}
+[[ -f "$PACKAGE_ROOT/provider-runtime.json" ]] || {
+    echo "missing packaged Apple provider; run just apple::package" >&2
+    exit 2
+}
+
+rm -rf "$OUTPUT_DIR"
+mkdir -p "$OUTPUT_DIR/node-a-home" "$OUTPUT_DIR/node-b-home"
+
+read -r API_A CONSOLE_A API_B CONSOLE_B < <(python3 <<'PY'
+import socket
+
+ports = []
+for _ in range(4):
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    ports.append(sock.getsockname()[1])
+    sock.close()
+print(*ports)
+PY
+)
+
+env \
+    -u MESH_LLM_PROVIDER_RUNTIME_INDEX \
+    HOME="$OUTPUT_DIR/node-a-home" \
+    MESH_LLM_CONFIG="$OUTPUT_DIR/node-a-config.toml" \
+    MESH_LLM_PROVIDER_RUNTIME_BUNDLE_DIR="$PACKAGE_ROOT" \
+    MESH_LLM_PROVIDER_RUNTIME_CACHE_DIR="$OUTPUT_DIR/node-a-provider-cache" \
+    MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC=1 \
+    "$HOST_BINARY" --log-format json serve --headless \
+        --port "$API_A" --console "$CONSOLE_A" \
+        >"$OUTPUT_DIR/node-a.jsonl" 2>"$OUTPUT_DIR/node-a.stderr" &
+NODE_A_PID=$!
+
+INVITE_TOKEN=""
+for _ in $(seq 1 300); do
+    INVITE_TOKEN="$(python3 - "$OUTPUT_DIR/node-a.jsonl" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+for line in path.read_text().splitlines() if path.exists() else []:
+    try:
+        event = json.loads(line)
+    except json.JSONDecodeError:
+        continue
+    if event.get("event") == "invite_token":
+        print(event.get("token", ""))
+        break
+PY
+)"
+    if [[ -n "$INVITE_TOKEN" ]] \
+        && curl --silent --show-error "http://127.0.0.1:$API_A/v1/models" \
+            >"$OUTPUT_DIR/node-a-models.json" 2>/dev/null \
+        && grep -q 'apple/system' "$OUTPUT_DIR/node-a-models.json"; then
+        break
+    fi
+    kill -0 "$NODE_A_PID" 2>/dev/null || {
+        cat "$OUTPUT_DIR/node-a.stderr" >&2
+        exit 1
+    }
+    sleep 0.1
+done
+[[ -n "$INVITE_TOKEN" ]] || {
+    echo "node A did not emit an invite token" >&2
+    exit 1
+}
+
+env \
+    -u MESH_LLM_PROVIDER_RUNTIME_INDEX \
+    HOME="$OUTPUT_DIR/node-b-home" \
+    MESH_LLM_CONFIG="$OUTPUT_DIR/node-b-config.toml" \
+    MESH_LLM_PROVIDER_RUNTIME_BUNDLE_DIR="$PACKAGE_ROOT" \
+    MESH_LLM_PROVIDER_RUNTIME_CACHE_DIR="$OUTPUT_DIR/node-b-provider-cache" \
+    MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC=1 \
+    "$HOST_BINARY" --log-format json serve --headless \
+        --port "$API_B" --console "$CONSOLE_B" --join "$INVITE_TOKEN" \
+        >"$OUTPUT_DIR/node-b.jsonl" 2>"$OUTPUT_DIR/node-b.stderr" &
+NODE_B_PID=$!
+
+for _ in $(seq 1 400); do
+    if curl --silent --show-error "http://127.0.0.1:$CONSOLE_A/api/status" \
+        >"$OUTPUT_DIR/node-a-status.json" 2>/dev/null \
+        && curl --silent --show-error "http://127.0.0.1:$CONSOLE_B/api/status" \
+            >"$OUTPUT_DIR/node-b-status.json" 2>/dev/null \
+        && curl --silent --show-error "http://127.0.0.1:$API_A/v1/models" \
+            >"$OUTPUT_DIR/mesh-models.json" 2>/dev/null \
+        && python3 - "$OUTPUT_DIR" 2>/dev/null <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+status_a = json.loads((root / "node-a-status.json").read_text())
+status_b = json.loads((root / "node-b-status.json").read_text())
+models = json.loads((root / "mesh-models.json").read_text())
+
+def peer_has_apple(status):
+    return any(
+        runtime.get("model_name") == "apple/system"
+        and runtime.get("provider_kind") == "apple"
+        and runtime.get("max_concurrent_requests") == 1
+        for peer in status.get("peers", [])
+        for runtime in peer.get("provider_runtimes", [])
+    )
+
+apple = next((model for model in models.get("data", []) if model.get("id") == "apple/system"), None)
+metadata = apple.get("metadata", {}) if apple else {}
+assert peer_has_apple(status_a)
+assert peer_has_apple(status_b)
+assert metadata.get("provider") == "apple"
+assert metadata.get("replicas") == 2
+assert metadata.get("max_concurrent_requests") == 2
+PY
+    then
+        break
+    fi
+    kill -0 "$NODE_A_PID" 2>/dev/null || exit 1
+    kill -0 "$NODE_B_PID" 2>/dev/null || {
+        cat "$OUTPUT_DIR/node-b.stderr" >&2
+        exit 1
+    }
+    sleep 0.1
+done
+
+python3 - "$OUTPUT_DIR" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+models = json.loads((root / "mesh-models.json").read_text())
+apple = next(model for model in models["data"] if model["id"] == "apple/system")
+assert apple["metadata"]["replicas"] == 2, apple
+PY
+
+curl --fail --silent --show-error "http://127.0.0.1:$API_A/v1/chat/completions" \
+    -H 'content-type: application/json' \
+    -d '{"model":"apple/system","messages":[{"role":"user","content":"Reply with exactly: private mesh ready"}],"max_tokens":32}' \
+    >"$OUTPUT_DIR/completion.json"
+
+curl --fail --silent --show-error "http://127.0.0.1:$API_A/v1/chat/completions" \
+    -H 'content-type: application/json' \
+    -d '{"model":"apple/system","messages":[{"role":"user","content":"Write exactly 100 numbered lines, with four words on each line."}],"max_tokens":256}' \
+    >"$OUTPUT_DIR/load-a-completion.json" &
+LOAD_A_PID=$!
+
+LOAD_A_OBSERVED=0
+for _ in $(seq 1 200); do
+    if curl --silent --show-error "http://127.0.0.1:$CONSOLE_A/api/status" \
+        >"$OUTPUT_DIR/node-a-active.json" 2>/dev/null \
+        && python3 - "$OUTPUT_DIR/node-a-active.json" 2>/dev/null <<'PY'
+import json
+import pathlib
+import sys
+
+status = json.loads(pathlib.Path(sys.argv[1]).read_text())
+assert any(
+    model.get("name") == "apple/system" and model.get("active_requests") == 1
+    for model in status.get("runtime", {}).get("models", [])
+    )
+PY
+    then
+        LOAD_A_OBSERVED=1
+        break
+    fi
+    kill -0 "$LOAD_A_PID" 2>/dev/null || {
+        echo "first load probe completed before its active slot was observable" >&2
+        exit 1
+    }
+    sleep 0.05
+done
+[[ "$LOAD_A_OBSERVED" == "1" ]] || {
+    echo "first provider active slot was not observable" >&2
+    exit 1
+}
+
+curl --fail --silent --show-error "http://127.0.0.1:$API_A/v1/chat/completions" \
+    -H 'content-type: application/json' \
+    -d '{"model":"apple/system","messages":[{"role":"user","content":"Write exactly 100 numbered lines, with five words on each line."}],"max_tokens":256}' \
+    >"$OUTPUT_DIR/load-b-completion.json" &
+LOAD_B_PID=$!
+
+LOAD_B_OBSERVED=0
+for _ in $(seq 1 200); do
+    if curl --silent --show-error "http://127.0.0.1:$CONSOLE_B/api/status" \
+        >"$OUTPUT_DIR/node-b-active.json" 2>/dev/null \
+        && python3 - "$OUTPUT_DIR/node-b-active.json" 2>/dev/null <<'PY'
+import json
+import pathlib
+import sys
+
+status = json.loads(pathlib.Path(sys.argv[1]).read_text())
+assert any(
+    model.get("name") == "apple/system" and model.get("active_requests") == 1
+    for model in status.get("runtime", {}).get("models", [])
+    )
+PY
+    then
+        LOAD_B_OBSERVED=1
+        break
+    fi
+    kill -0 "$LOAD_B_PID" 2>/dev/null || {
+        echo "second load probe did not route to the idle peer" >&2
+        exit 1
+    }
+    sleep 0.05
+done
+[[ "$LOAD_B_OBSERVED" == "1" ]] || {
+    echo "second request did not use the idle peer" >&2
+    exit 1
+}
+
+wait "$LOAD_A_PID"
+LOAD_A_PID=""
+wait "$LOAD_B_PID"
+LOAD_B_PID=""
+
+python3 - "$OUTPUT_DIR" <<'PY'
+import json
+import pathlib
+import sys
+
+root = pathlib.Path(sys.argv[1])
+models = json.loads((root / "mesh-models.json").read_text())
+completion = json.loads((root / "completion.json").read_text())
+apple = next(model for model in models["data"] if model["id"] == "apple/system")
+summary = {
+    "status": "pass",
+    "model": "apple/system",
+    "replicas": apple["metadata"]["replicas"],
+    "max_concurrent_requests": apple["metadata"]["max_concurrent_requests"],
+    "provider_model_versions": apple["metadata"]["provider_model_versions"],
+    "completion_content": completion["choices"][0]["message"]["content"],
+    "private_peer_provider_runtime_visible": True,
+    "load_aware_remote_dispatch": True,
+}
+(root / "summary.json").write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+print(json.dumps(summary, indent=2, sort_keys=True))
+PY

--- a/providers/apple/README.md
+++ b/providers/apple/README.md
@@ -300,12 +300,21 @@ select artifacts and policy with:
 - `MESH_LLM_PROVIDER_RUNTIME_CACHE_DIR` for an isolated immutable cache; and
 - `MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC=1` only for local development.
 
+`just apple::private-mesh` starts two identity-isolated MeshLLM nodes on the
+Golden Gate Mac, joins them with a private invite, and verifies that additive
+provider runtime gossip produces two `apple/system` replicas, two aggregate
+request slots, peer-visible provider generation/load, a routed completion, and
+dispatch of concurrent work from a busy local provider to the idle peer.
+Use the two-physical-Mac procedure in `docs/design/TESTING.md` for release
+confidence, withdrawal, affinity, and failover checks.
+
 ## Other validation commands
 
 ```bash
 just apple::live
 just apple::contract
 just apple::mesh
+just apple::private-mesh
 just apple::rust-sdk
 just apple::carriers
 just apple::launchd

--- a/providers/apple/Sources/MeshAppleRuntime/AppleRuntime.swift
+++ b/providers/apple/Sources/MeshAppleRuntime/AppleRuntime.swift
@@ -2,13 +2,16 @@ import Foundation
 
 public actor AppleRuntime {
   private let systemModel: SystemModelProvider
+  private let scheduler: ProviderRequestScheduler
 
   public init() {
     systemModel = SystemModelProvider()
+    scheduler = ProviderRequestScheduler()
   }
 
   public func status() async -> AppleRuntimeStatus {
-    let systemModelStatus = await systemModel.status()
+    let load = await scheduler.snapshot()
+    let systemModelStatus = await systemModel.status(load: load)
     return AppleRuntimeStatus(
       runtimeID: AppleRuntimeIdentifiers.runtimeID,
       protocolVersion: AppleRuntimeIdentifiers.protocolVersion,
@@ -19,7 +22,9 @@ public actor AppleRuntime {
 
   public func prewarm(modelID: String, promptPrefix: String? = nil) async throws {
     try requireSystemModel(modelID)
-    try await systemModel.prewarm(promptPrefix: promptPrefix)
+    try await scheduler.withPermit {
+      try await self.systemModel.prewarm(promptPrefix: promptPrefix)
+    }
   }
 
   public func generate(
@@ -27,7 +32,9 @@ public actor AppleRuntime {
     onEvent: @Sendable (AppleRuntimeEvent) -> Void
   ) async throws -> AppleGenerationResult {
     try requireSystemModel(request.modelID)
-    return try await systemModel.generate(request: request, onEvent: onEvent)
+    return try await scheduler.withPermit {
+      try await self.systemModel.generate(request: request, onEvent: onEvent)
+    }
   }
 
   public func generateStructured(
@@ -35,12 +42,16 @@ public actor AppleRuntime {
     prompt: String
   ) async throws -> AppleStructuredResult {
     try requireSystemModel(modelID)
-    return try await systemModel.generateStructured(prompt: prompt)
+    return try await scheduler.withPermit {
+      try await self.systemModel.generateStructured(prompt: prompt)
+    }
   }
 
   public func exerciseTool(modelID: String, key: String) async throws -> AppleToolResult {
     try requireSystemModel(modelID)
-    return try await systemModel.exerciseTool(key: key)
+    return try await scheduler.withPermit {
+      try await self.systemModel.exerciseTool(key: key)
+    }
   }
 
   private func requireSystemModel(_ modelID: String) throws {

--- a/providers/apple/Sources/MeshAppleRuntime/FoundationModels/SystemModelProvider.swift
+++ b/providers/apple/Sources/MeshAppleRuntime/FoundationModels/SystemModelProvider.swift
@@ -50,7 +50,7 @@ public actor SystemModelProvider {
     model = .default
   }
 
-  public func status() -> AppleModelStatus? {
+  public func status(load: AppleProviderLoad) -> AppleModelStatus? {
     let availability = availabilityFields(model.availability)
     guard let modelVersion = AppleRuntimeIdentifiers.systemModelVersion,
       let versionedModelID = AppleRuntimeIdentifiers.versionedSystemModelID
@@ -83,7 +83,8 @@ public actor SystemModelProvider {
       modelVersion: modelVersion,
       versionSource: AppleRuntimeIdentifiers.systemModelVersionSource,
       versionedModelID: versionedModelID,
-      capabilities: capabilities.sorted()
+      capabilities: capabilities.sorted(),
+      load: load
     )
   }
 
@@ -99,6 +100,11 @@ public actor SystemModelProvider {
     onEvent: @Sendable (AppleRuntimeEvent) -> Void
   ) async throws -> AppleGenerationResult {
     try requireAvailable()
+    try await validateContextBudget(
+      prompt: request.prompt,
+      instructions: request.instructions,
+      maximumResponseTokens: request.maximumResponseTokens
+    )
     let session: LanguageModelSession
     if let preparedSession, request.instructions == nil {
       session = preparedSession
@@ -173,10 +179,17 @@ public actor SystemModelProvider {
 
   public func generateStructured(prompt: String) async throws -> AppleStructuredResult {
     try requireAvailable()
+    let instructions =
+      "Classify the supplied text. Keep the explanation short. Confidence is 0 through 100."
+    try await validateContextBudget(
+      prompt: prompt,
+      instructions: instructions,
+      schema: SpikeClassification.generationSchema,
+      maximumResponseTokens: 128
+    )
     let session = LanguageModelSession(
       model: model,
-      instructions:
-        "Classify the supplied text. Keep the explanation short. Confidence is 0 through 100."
+      instructions: instructions
     )
     do {
       let response = try await session.respond(
@@ -200,14 +213,22 @@ public actor SystemModelProvider {
     try requireAvailable()
     let recorder = FixtureInvocationRecorder()
     let tool = FixtureLookupTool(recorder: recorder)
+    let instructions = "Call mesh_fixture_lookup once. Reply with only its output."
+    let prompt = "Fixture key: \(key)"
+    try await validateContextBudget(
+      prompt: prompt,
+      instructions: instructions,
+      tools: [tool],
+      maximumResponseTokens: 32
+    )
     let session = LanguageModelSession(
       model: model,
       tools: [tool],
-      instructions: "Call mesh_fixture_lookup once. Reply with only its output."
+      instructions: instructions
     )
     do {
       let response = try await session.respond(
-        to: "Fixture key: \(key)",
+        to: prompt,
         options: GenerationOptions(
           temperature: 0,
           maximumResponseTokens: 32,
@@ -234,6 +255,55 @@ public actor SystemModelProvider {
         retryable: fields.reason == "model_not_ready"
       )
     }
+  }
+
+  private func validateContextBudget(
+    prompt: String,
+    instructions: String?,
+    tools: [any Tool] = [],
+    schema: GenerationSchema? = nil,
+    maximumResponseTokens: Int?
+  ) async throws {
+    var inputTokens = try await model.tokenCount(for: Prompt(prompt))
+    if let instructions, !instructions.isEmpty {
+      inputTokens += try await model.tokenCount(for: Instructions(instructions))
+    }
+    if !tools.isEmpty {
+      inputTokens += try await model.tokenCount(for: tools)
+    }
+    if let schema {
+      inputTokens += try await model.tokenCount(for: schema)
+    }
+
+    try validateAppleContextBudget(
+      contextSize: model.contextSize,
+      inputTokens: inputTokens,
+      maximumResponseTokens: maximumResponseTokens
+    )
+  }
+}
+
+func validateAppleContextBudget(
+  contextSize: Int,
+  inputTokens: Int,
+  maximumResponseTokens: Int?
+) throws {
+  let outputTokens = maximumResponseTokens ?? 0
+  guard outputTokens >= 0 else {
+    throw AppleRuntimeFailure(
+      code: "invalid_maximum_response_tokens",
+      message: "maximum response tokens cannot be negative",
+      retryable: false
+    )
+  }
+  guard inputTokens < contextSize, inputTokens + outputTokens <= contextSize else {
+    throw AppleRuntimeFailure(
+      code: "context_exceeded",
+      message:
+        "Apple system model context limit is \(contextSize) tokens; "
+        + "request input uses \(inputTokens) and reserves \(outputTokens) response tokens",
+      retryable: false
+    )
   }
 }
 
@@ -290,6 +360,9 @@ private func milliseconds(
 }
 
 private func mapProviderError(_ error: any Error) -> AppleRuntimeFailure {
+  if let failure = error as? AppleRuntimeFailure {
+    return failure
+  }
   if error is CancellationError {
     return AppleRuntimeFailure(
       code: "cancelled",

--- a/providers/apple/Sources/MeshAppleRuntime/Lifecycle/ProviderRequestScheduler.swift
+++ b/providers/apple/Sources/MeshAppleRuntime/Lifecycle/ProviderRequestScheduler.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+public actor ProviderRequestScheduler {
+  private var occupied = false
+  private var waiterOrder: [UUID] = []
+  private var waiters: [UUID: CheckedContinuation<Void, Never>] = [:]
+
+  public init() {}
+
+  public func snapshot() -> AppleProviderLoad {
+    AppleProviderLoad(
+      maxConcurrentRequests: 1,
+      activeRequests: occupied ? 1 : 0,
+      queuedRequests: waiters.count
+    )
+  }
+
+  public func withPermit<T: Sendable>(
+    _ operation: @Sendable () async throws -> T
+  ) async throws -> T {
+    try await acquire()
+    do {
+      try Task.checkCancellation()
+      let result = try await operation()
+      release()
+      return result
+    } catch {
+      release()
+      throw error
+    }
+  }
+
+  private func acquire() async throws {
+    try Task.checkCancellation()
+    if !occupied {
+      occupied = true
+      return
+    }
+    let id = UUID()
+    try await withTaskCancellationHandler {
+      await withCheckedContinuation { continuation in
+        waiterOrder.append(id)
+        waiters[id] = continuation
+      }
+      try Task.checkCancellation()
+    } onCancel: {
+      Task { await self.cancelWaiter(id) }
+    }
+  }
+
+  private func cancelWaiter(_ id: UUID) {
+    waiterOrder.removeAll { $0 == id }
+    waiters.removeValue(forKey: id)?.resume()
+  }
+
+  private func release() {
+    while let id = waiterOrder.first {
+      waiterOrder.removeFirst()
+      if let continuation = waiters.removeValue(forKey: id) {
+        continuation.resume()
+        return
+      }
+    }
+    occupied = false
+  }
+}

--- a/providers/apple/Sources/MeshAppleRuntime/Protocol/RuntimeTypes.swift
+++ b/providers/apple/Sources/MeshAppleRuntime/Protocol/RuntimeTypes.swift
@@ -66,6 +66,7 @@ public struct AppleModelStatus: Codable, Equatable, Sendable {
   public let versionSource: String
   public let versionedModelID: String
   public let capabilities: [String]
+  public let load: AppleProviderLoad
 
   public init(
     modelID: String,
@@ -78,7 +79,8 @@ public struct AppleModelStatus: Codable, Equatable, Sendable {
     modelVersion: String,
     versionSource: String,
     versionedModelID: String,
-    capabilities: [String]
+    capabilities: [String],
+    load: AppleProviderLoad
   ) {
     self.modelID = modelID
     self.providerKind = providerKind
@@ -91,6 +93,29 @@ public struct AppleModelStatus: Codable, Equatable, Sendable {
     self.versionSource = versionSource
     self.versionedModelID = versionedModelID
     self.capabilities = capabilities
+    self.load = load
+  }
+}
+
+public struct AppleProviderLoad: Codable, Equatable, Sendable {
+  public let maxConcurrentRequests: Int
+  public let activeRequests: Int
+  public let queuedRequests: Int
+
+  public init(
+    maxConcurrentRequests: Int,
+    activeRequests: Int,
+    queuedRequests: Int
+  ) {
+    self.maxConcurrentRequests = maxConcurrentRequests
+    self.activeRequests = activeRequests
+    self.queuedRequests = queuedRequests
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case maxConcurrentRequests = "max_concurrent_requests"
+    case activeRequests = "active_requests"
+    case queuedRequests = "queued_requests"
   }
 }
 

--- a/providers/apple/Sources/MeshAppleRuntime/Transport/LoopbackHTTPServer.swift
+++ b/providers/apple/Sources/MeshAppleRuntime/Transport/LoopbackHTTPServer.swift
@@ -134,7 +134,8 @@ public final class LoopbackHTTPServer: @unchecked Sendable {
   }
 
   private func modelObject(_ model: AppleModelStatus, id: String) -> [String: Any] {
-    var object = [
+    var object =
+      [
         "id": model.modelID,
         "object": "model",
         "owned_by": "apple",
@@ -147,6 +148,10 @@ public final class LoopbackHTTPServer: @unchecked Sendable {
     object["model_version"] = model.modelVersion
     object["version_source"] = model.versionSource
     object["versioned_model_id"] = model.versionedModelID
+    object["unavailable_reason"] = model.unavailableReason
+    object["max_concurrent_requests"] = model.load.maxConcurrentRequests
+    object["active_requests"] = model.load.activeRequests
+    object["queued_requests"] = model.load.queuedRequests
     return object
   }
 

--- a/providers/apple/Tests/MeshAppleRuntimeTests/RuntimeTypesTests.swift
+++ b/providers/apple/Tests/MeshAppleRuntimeTests/RuntimeTypesTests.swift
@@ -23,7 +23,12 @@ import Testing
     modelVersion: "27.0",
     versionSource: "apple_os_release_band",
     versionedModelID: "apple/system@27.0",
-    capabilities: ["tool_calling"]
+    capabilities: ["tool_calling"],
+    load: AppleProviderLoad(
+      maxConcurrentRequests: 1,
+      activeRequests: 0,
+      queuedRequests: 0
+    )
   )
   let status = AppleRuntimeStatus(
     runtimeID: AppleRuntimeIdentifiers.runtimeID,
@@ -34,6 +39,76 @@ import Testing
   let data = try JSONEncoder().encode(status)
   let decoded = try JSONDecoder().decode(AppleRuntimeStatus.self, from: data)
   #expect(decoded == status)
+}
+
+@Test func providerSchedulerAdvertisesOneSlot() async {
+  let load = await ProviderRequestScheduler().snapshot()
+  #expect(load.maxConcurrentRequests == 1)
+  #expect(load.activeRequests == 0)
+  #expect(load.queuedRequests == 0)
+}
+
+private actor SchedulerGate {
+  private var continuation: CheckedContinuation<Void, Never>?
+
+  func wait() async {
+    await withCheckedContinuation { continuation = $0 }
+  }
+
+  func open() {
+    continuation?.resume()
+    continuation = nil
+  }
+}
+
+@Test func providerSchedulerSerializesAndCancelsQueuedWork() async throws {
+  let scheduler = ProviderRequestScheduler()
+  let gate = SchedulerGate()
+  let first = Task {
+    try await scheduler.withPermit {
+      await gate.wait()
+      return 1
+    }
+  }
+  while await scheduler.snapshot().activeRequests == 0 {
+    await Task.yield()
+  }
+  let second = Task { try await scheduler.withPermit { 2 } }
+  while await scheduler.snapshot().queuedRequests == 0 {
+    await Task.yield()
+  }
+
+  second.cancel()
+  do {
+    _ = try await second.value
+    Issue.record("cancelled queued work unexpectedly ran")
+  } catch is CancellationError {
+    // Expected: cancellation removes the waiter without waiting for the active request.
+  }
+  #expect(await scheduler.snapshot().queuedRequests == 0)
+
+  await gate.open()
+  #expect(try await first.value == 1)
+  #expect(await scheduler.snapshot().activeRequests == 0)
+}
+
+@Test func appleContextBudgetReservesRequestedOutputTokens() throws {
+  try validateAppleContextBudget(
+    contextSize: 4_096,
+    inputTokens: 3_584,
+    maximumResponseTokens: 512
+  )
+
+  do {
+    try validateAppleContextBudget(
+      contextSize: 4_096,
+      inputTokens: 3_585,
+      maximumResponseTokens: 512
+    )
+    Issue.record("over-budget request unexpectedly passed")
+  } catch let failure as AppleRuntimeFailure {
+    #expect(failure.code == "context_exceeded")
+  }
 }
 
 @Test func generationDefaultsToSystemModel() {


### PR DESCRIPTION
> [!IMPORTANT]
> **Experimental. Requires Apple silicon running macOS Golden Gate.** This is an early integration with Apple’s on-device Foundation Models framework. It is not yet a signed, notarized release artifact and it is intentionally unavailable on public meshes.

Stacked on [#1259](https://github.com/Mesh-LLM/mesh-llm/pull/1259). Advances [#1246](https://github.com/Mesh-LLM/mesh-llm/issues/1246).

## Why this matters

Apple silicon Macs already contain a power-efficient, privacy-preserving system language model. Mesh should let an Apple user contribute that capability without downloading model weights, converting checkpoints, allocating a second copy of the model, or learning a new API. Existing OpenAI-compatible clients and every macOS-capable Mesh SDK can use the same `apple/system` model name through the normal REST surface.

For the product, this creates a useful new class of Mesh node:

- idle Macs become whole-model inference replicas with no Skippy pipeline split;
- prompts and generation remain on-device, with no cloud inference dependency;
- Apple owns the model delivery and hardware acceleration path, so Mesh owns routing and lifecycle rather than model distribution;
- multiple Macs add availability and request concurrency, even though they do not combine their context windows;
- Rust, Swift, Node/Electron, and Kotlin/JVM clients all reach one signed Swift sidecar through the same provider contract instead of carrying framework-specific logic in every SDK.

## What this PR adds

This is the single Phase 3 private-mesh routing PR. It builds on the provider artifact and all-SDK carrier work in #1259.

- Advertises `apple/system` and the exact OS model generation, for example `apple/system@27.0`, only inside private meshes.
- Routes each request to one capable Mac. Apple system models never enter Skippy split planning, `auto`, virtual `mesh`, or Mixture-of-Agents selection.
- Publishes provider capacity, active requests, and queued requests as additive gossip fields.
- Prefers an idle replica with known load, then a peer with unknown load, then a saturated replica. Existing request affinity wins over live load so a conversation remains stable.
- Retries another replica only before response streaming begins. Mesh never splices two model streams into one response.
- Withdraws the provider after sustained health failures, process exit, or shutdown, and re-advertises it after recovery.
- Makes a provider-only Mac routable even when it is not serving a GGUF model.
- Aggregates model generation, replica count, capacity, active/queued work, and available slots in `/v1/models` and the management API.
- Shows Apple provider identity and load in the web console.
- Adds a deterministic private-mesh QA harness that starts two identity-isolated nodes on one Golden Gate Mac and proves that a second request is sent over QUIC to the idle replica while the first is occupied.

The mesh protocol change is additive. Older peers ignore the new provider/load fields; newer peers interpret missing load as unknown.

## Context-window behavior

The provider follows Apple’s [TN3193 guidance](https://developer.apple.com/documentation/technotes/tn3193-managing-the-on-device-foundation-model-s-context-window) rather than estimating context from strings in Rust. The signed Swift runtime asks `SystemLanguageModel` for the exact token count across the prompt, instructions, tool declarations, and structured-output schema, and reserves the requested output budget before generation.

Apple documents a 4,096-token total context for the on-device model and notes that tool definitions consume that same budget; Apple recommends roughly three to five tools per request. Oversized requests now fail before generation with the structured `context_exceeded` error. Routing across more Macs improves concurrency and resilience, not the context size of an individual request.

## Runtime packaging and SDK shape

All Apple framework code stays in one Swift sidecar under `providers/apple/`. The backend-neutral Rust host discovers and supervises the packaged provider runtime; SDKs drive the same host/provider lifecycle and OpenAI-compatible endpoint. We do not embed a different Apple implementation into each language binding.

The final release process must sign the sidecar that imports Foundation Models, preserve the required entitlement and code-signing identity, package it beside the neutral host, and notarize the composed product. Local QA permits an explicitly enabled ad-hoc build. Production signing/notarization remains a release gate; this PR does not pretend that an ad-hoc executable is shippable.

## Try it

### Prerequisites

1. An Apple silicon Mac running **macOS Golden Gate** with the on-device system model available.
2. Full Xcode selected, not only Command Line Tools:

   ```bash
   sudo xcode-select -s /Applications/Xcode.app/Contents/Developer
   xcodebuild -version
   ```

3. This branch checked out. It is stacked on #1259, so the branch includes the earlier Apple provider and SDK carrier phases.

### Automated path

```bash
just apple::test
just apple::mesh
just apple::private-mesh
```

- `apple::test` runs the Swift provider tests.
- `apple::mesh` packages the sidecar and exercises completions, SSE streaming, tools, cancellation, versioned model IDs, restart, and cleanup through Mesh REST.
- `apple::private-mesh` builds Mesh, starts two isolated private-mesh nodes, verifies gossip and aggregate capacity, occupies node A, and proves the next request is routed over QUIC to idle node B.

### Run a local node manually

```bash
just apple::package
just build

export MESH_LLM_PROVIDER_RUNTIME_BUNDLE_DIR="$PWD/target/apple-runtime/package/meshllm-apple-runtime-darwin-arm64"
export MESH_LLM_APPLE_PROVIDER_ALLOW_AD_HOC=1

target/debug/mesh-llm --log-format json serve \
  --headless \
  --port 9337 \
  --console 3131
```

List the system-model aliases:

```bash
curl -s http://127.0.0.1:9337/v1/models | jq
```

Request a completion:

```bash
curl -s http://127.0.0.1:9337/v1/chat/completions \
  -H 'content-type: application/json' \
  --data-binary '{
    "model": "apple/system",
    "messages": [{"role": "user", "content": "Reply with exactly: apple runtime REST ready"}],
    "temperature": 0,
    "max_tokens": 32
  }' | jq
```

Exercise the QA tool loop:

```bash
curl -s http://127.0.0.1:9337/v1/chat/completions \
  -H 'content-type: application/json' \
  --data-binary '{
    "model": "apple/system",
    "messages": [{"role": "user", "content": "Use the tool with key: rest-demo"}],
    "tools": [{
      "type": "function",
      "function": {
        "name": "mesh_fixture_lookup",
        "description": "Look up a fixture",
        "parameters": {
          "type": "object",
          "properties": {"key": {"type": "string"}},
          "required": ["key"]
        }
      }
    }],
    "temperature": 0
  }' | jq
```

For two physical Macs, start the first private node, obtain its invite token from the JSON log, and start the second with `--join <token>`. The full two-machine checklist is in `docs/design/TESTING.md`.

## Example REST output

Completion:

```json
{
  "model": "apple/system",
  "choices": [{
    "message": {"role": "assistant", "content": "apple runtime REST ready"},
    "finish_reason": "stop"
  }],
  "mesh_timing": {"elapsed_ms": 1083, "time_to_first_token_ms": 1000},
  "usage": {"prompt_tokens": 65, "completion_tokens": 9, "total_tokens": 74}
}
```

Tool execution:

```json
{
  "model": "apple/system",
  "choices": [{
    "message": {"role": "assistant", "content": "mesh-fixture-value-for-rest-demo"},
    "finish_reason": "stop"
  }],
  "mesh_tool_executions": [{
    "name": "mesh_fixture_lookup",
    "arguments": {"key": "rest-demo"},
    "result": "mesh-fixture-value-for-rest-demo"
  }],
  "usage": {"prompt_tokens": 327, "completion_tokens": 13, "total_tokens": 340}
}
```

Private-mesh proof:

```json
{
  "completion_content": "private mesh ready",
  "load_aware_remote_dispatch": true,
  "max_concurrent_requests": 2,
  "model": "apple/system",
  "private_peer_provider_runtime_visible": true,
  "provider_model_versions": ["27.0"],
  "replicas": 2,
  "status": "pass"
}
```

The model’s natural-language wording and timing vary by machine and OS model generation. The model ID and response schema are the stable contract.

## Validation

- `just apple::test` — 9 passed
- `cargo test -p mesh-llm-host-runtime --lib` — 1,950 passed, 8 ignored
- provider-supervisor focused tests — 11 passed
- `just apple::mesh` — completion, versioned completion, SSE, tool execution, cancellation, restart, cleanup passed
- `just apple::private-mesh` — provider gossip, two-replica aggregation, capacity, completion, and load-aware QUIC dispatch passed
- scoped Clippy with warnings denied — passed
- `cargo fmt --all -- --check` — passed
- focused UI tests — 64 passed
- `bash -n providers/apple/QA/private-mesh.sh` — passed

The full UI suite has one existing environment-specific failure in `DataModeContext.test.tsx` when Node’s experimental `localStorage` is unavailable (`969 passed, 3 skipped, 1 failed`). The focused status/model catalog tests touched here pass.

## Deliberate limits and follow-up

- Private meshes only. The provider is suppressed on public meshes.
- Explicit `apple/system` selection only; no implicit `auto` routing.
- One request occupies one Mac. This is replica routing, not pipeline parallelism.
- The exact version is the Apple OS model generation, not a Mesh-owned weight revision.
- The automated two-node test uses one Golden Gate Mac with isolated identities; a two-physical-Mac run remains required before release confidence.
- Core AI / imported SafeTensors conversion and quantization are a later provider phase, after the system-model route is proven.
- Signed, entitled, notarized product packaging is required before this can graduate from experimental status.

## Reviewer focus

- private/public advertisement policy and withdrawal behavior;
- mixed-version handling of additive gossip fields;
- affinity versus load-aware replica choice;
- the pre-stream-only failover boundary;
- provider-only host routability and lifecycle cleanup;
- packaging assumptions for the signed Swift sidecar.
