### PR TITLE
Fix install one-liner 404 on NVIDIA hosts without a CUDA toolkit

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -336,11 +336,12 @@ recommended_flavor() {
 detect_cuda_major() {
     local ver=""
     if command -v nvcc >/dev/null 2>&1; then
-        ver="$(nvcc --version 2>/dev/null | grep -oE 'release [0-9]+' | awk '{print $2}' | head -n 1)"
+        ver="$(nvcc --version 2>/dev/null | grep -oE 'release [0-9]+' | awk '{print $2}' | head -n 1 || true)"
     fi
     if [[ -z "$ver" ]]; then
         local lib
-        for lib in /usr/local/cuda*/targets/*/lib/libcudart.so.* /usr/local/cuda*/targets/*/lib/stubs/libcudart.so.*; do
+        local probe_root="${MESH_LLM_TEST_CUDA_PROBE_ROOT:-}"
+        for lib in "$probe_root"/usr/local/cuda*/targets/*/lib/libcudart.so.* "$probe_root"/usr/local/cuda*/targets/*/lib/stubs/libcudart.so.*; do
             if [[ -f "$lib" ]]; then
                 ver="$(basename "$lib" | grep -oE 'libcudart\.so\.[0-9]+' | awk -F. '{print $3}' | head -n 1)"
                 break
@@ -348,7 +349,17 @@ detect_cuda_major() {
         done
     fi
     if [[ -z "$ver" ]]; then
-        ver="$(ldconfig -p 2>/dev/null | grep -oE 'libcudart\.so\.[0-9]+' | awk -F. '{print $3}' | sort -rn | head -n 1)"
+        ver="$(ldconfig -p 2>/dev/null | grep -oE 'libcudart\.so\.[0-9]+' | awk -F. '{print $3}' | sort -rn | head -n 1 || true)"
+    fi
+    # Inference-only hosts carry an NVIDIA driver but no CUDA toolkit, so none of
+    # the probes above find anything. The driver still advertises the highest CUDA
+    # it supports in the nvidia-smi header ("CUDA Version: 13.0"); use that as an
+    # upper bound and clamp it to a CUDA lane we actually publish.
+    if [[ -z "$ver" ]] && command -v nvidia-smi >/dev/null 2>&1; then
+        ver="$(nvidia-smi 2>/dev/null | grep -oE 'CUDA Version: *[0-9]+' | grep -oE '[0-9]+' | head -n 1 || true)"
+        if [[ -n "$ver" ]] && (( ver > 13 )); then
+            ver=13
+        fi
     fi
     case "$ver" in
         12|13) printf '%s\n' "$ver" ;;
@@ -368,11 +379,12 @@ asset_name() {
                         cuda)
                             local cuda_major
                             cuda_major="$(detect_cuda_major)"
-                            if [[ -n "$cuda_major" ]]; then
-                                printf 'mesh-llm-aarch64-unknown-linux-gnu-cuda-%s.tar.gz\n' "$cuda_major"
-                            else
-                                printf 'mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz\n'
+                            if [[ -z "$cuda_major" ]]; then
+                                echo "error: detected an NVIDIA GPU but could not determine a supported CUDA major version (expected 12 or 13)." >&2
+                                echo "       install a CUDA toolkit, or re-run with --flavor cpu to use a non-CUDA build." >&2
+                                return 1
                             fi
+                            printf 'mesh-llm-aarch64-unknown-linux-gnu-cuda-%s.tar.gz\n' "$cuda_major"
                             ;;
                         *) echo "error: unsupported aarch64 flavor '$flavor'" >&2; return 1 ;;
                     esac
@@ -383,11 +395,12 @@ asset_name() {
                         cuda)
                             local cuda_major
                             cuda_major="$(detect_cuda_major)"
-                            if [[ -n "$cuda_major" ]]; then
-                                printf 'mesh-llm-x86_64-unknown-linux-gnu-cuda-%s.tar.gz\n' "$cuda_major"
-                            else
-                                printf 'mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz\n'
+                            if [[ -z "$cuda_major" ]]; then
+                                echo "error: detected an NVIDIA GPU but could not determine a supported CUDA major version (expected 12 or 13)." >&2
+                                echo "       install a CUDA toolkit, or re-run with --flavor cpu (or --flavor vulkan) to use a non-CUDA build." >&2
+                                return 1
                             fi
+                            printf 'mesh-llm-x86_64-unknown-linux-gnu-cuda-%s.tar.gz\n' "$cuda_major"
                             ;;
                         rocm) printf 'mesh-llm-x86_64-unknown-linux-gnu-rocm.tar.gz\n' ;;
                         vulkan) printf 'mesh-llm-x86_64-unknown-linux-gnu-vulkan.tar.gz\n' ;;

--- a/scripts/tests/test_install_sh.py
+++ b/scripts/tests/test_install_sh.py
@@ -78,11 +78,13 @@ class InstallScriptTests(unittest.TestCase):
                 """
                 export MESH_LLM_TEST_UNAME_S=Linux
                 export MESH_LLM_TEST_UNAME_M=aarch64
+                # No CUDA evidence of any kind on this host.
+                detect_cuda_major() { printf '\\n'; }
                 printf 'support=%s\\n' "$(platform_support_status)"
                 printf 'flavors=%s\\n' "$(supported_flavors)"
                 printf 'recommended=%s\\n' "$(recommended_flavor)"
                 printf 'cpu=%s\\n' "$(asset_name cpu)"
-                printf 'cuda=%s\\n' "$(asset_name cuda)"
+                printf 'cuda=%s\\n' "$(asset_name cuda || true)"
                 """,
             )
 
@@ -91,7 +93,86 @@ class InstallScriptTests(unittest.TestCase):
             self.assertIn("flavors=cuda cpu", result.stdout)
             self.assertIn("recommended=cpu", result.stdout)
             self.assertIn("cpu=mesh-llm-aarch64-unknown-linux-gnu.tar.gz", result.stdout)
-            self.assertIn("cuda=mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz", result.stdout)
+            # With no CUDA evidence at all there is no publishable cuda asset name.
+            # Releases stopped publishing the legacy bare -cuda archive when the
+            # lanes split into -cuda-12/-cuda-13, so asset_name must refuse rather
+            # than emit a name that always 404s.
+            self.assertIn("cuda=\n", result.stdout)
+            self.assertNotIn("mesh-llm-aarch64-unknown-linux-gnu-cuda.tar.gz", result.stdout)
+            self.assertIn("could not determine a supported CUDA major version", result.stderr)
+            self.assertIn("--flavor cpu", result.stderr)
+            self.assertNotIn("--flavor vulkan", result.stderr)
+
+    def test_asset_name_uses_detected_cuda_major_lane(self) -> None:
+        for arch in ("aarch64", "x86_64"):
+            with self.subTest(arch=arch):
+                with tempfile.TemporaryDirectory() as tmp:
+                    tmp_path = Path(tmp)
+                    install_dir = tmp_path / "bin"
+                    install_dir.mkdir()
+
+                    result = self._run_helper(
+                        tmp_path,
+                        install_dir,
+                        f"""
+                        export MESH_LLM_TEST_UNAME_S=Linux
+                        export MESH_LLM_TEST_UNAME_M={arch}
+                        detect_cuda_major() {{ printf '13\\n'; }}
+                        asset_name cuda
+                        """,
+                    )
+
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(
+                        result.stdout.strip(),
+                        f"mesh-llm-{arch}-unknown-linux-gnu-cuda-13.tar.gz",
+                    )
+
+    def test_detect_cuda_major_falls_back_to_nvidia_smi_driver_version(self) -> None:
+        # Inference-only hosts have a driver but no toolkit, so every toolkit
+        # probe comes up empty and only the nvidia-smi header carries a version.
+        cases = (
+            ("CUDA Version: 13.0", "13"),
+            ("CUDA Version: 12.4", "12"),
+            # A driver newer than any lane we publish clamps to the newest lane.
+            ("CUDA Version: 14.2", "13"),
+            # A driver too old for any published lane yields nothing.
+            ("CUDA Version: 11.8", ""),
+        )
+        for header, expected in cases:
+            with self.subTest(header=header):
+                with tempfile.TemporaryDirectory() as tmp:
+                    tmp_path = Path(tmp)
+                    install_dir = tmp_path / "bin"
+                    install_dir.mkdir()
+                    probe_root = tmp_path / "cuda-probe-root"
+                    probe_root.mkdir()
+                    wrappers = tmp_path / "wrappers"
+                    wrappers.mkdir()
+                    for absent in ("nvcc", "ldconfig"):
+                        stub = wrappers / absent
+                        stub.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+                        stub.chmod(0o755)
+                    nvidia_smi = wrappers / "nvidia-smi"
+                    nvidia_smi.write_text(
+                        "#!/usr/bin/env bash\n"
+                        f"printf '%s\\n' '| NVIDIA-SMI 595.84  Driver Version: 595.84  {header} |'\n",
+                        encoding="utf-8",
+                    )
+                    nvidia_smi.chmod(0o755)
+
+                    result = self._run_helper(
+                        tmp_path,
+                        install_dir,
+                        f"""
+                        export PATH={shlex_quote(str(wrappers))}:$PATH
+                        export MESH_LLM_TEST_CUDA_PROBE_ROOT={shlex_quote(str(probe_root))}
+                        detect_cuda_major
+                        """,
+                    )
+
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    self.assertEqual(result.stdout.strip(), expected)
 
     def test_release_target_helpers_recommend_cuda_on_jetson_orin(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
@@ -151,6 +232,8 @@ class InstallScriptTests(unittest.TestCase):
             install_dir.mkdir()
             wrappers = tmp_path / "wrappers"
             wrappers.mkdir()
+            probe_root = tmp_path / "cuda-probe-root"
+            probe_root.mkdir()
             ldconfig = wrappers / "ldconfig"
             ldconfig.write_text(
                 "#!/usr/bin/env bash\n"
@@ -164,6 +247,7 @@ class InstallScriptTests(unittest.TestCase):
                 install_dir,
                 f"""
                 export PATH={shlex_quote(str(wrappers))}:$PATH
+                export MESH_LLM_TEST_CUDA_PROBE_ROOT={shlex_quote(str(probe_root))}
                 detect_cuda_major
                 """,
             )


### PR DESCRIPTION
## What this fixes

The documented install one-liner now works on Linux hosts that have an NVIDIA driver but no CUDA toolkit — the normal shape for an inference-only GPU box.

Before, it failed with a 404:

```
$ curl -fsSL https://meshllm.cloud/install.sh | bash -s -- --no-setup
curl: (22) The requested URL returned error: 404
error: could not download release archive for mesh-llm-x86_64-unknown-linux-gnu-cuda.tar.gz or mesh-bundle.tar.gz
```

After, it selects the right lane and installs.

## Why it happened

`detect_cuda_major` probed three things — `nvcc --version`, `/usr/local/cuda*/.../libcudart.so.*`, and `libcudart` in `ldconfig -p`. All three are *toolkit* artifacts, so a driver-only host returned empty. `asset_name` then fell back to the legacy bare name `mesh-llm-<arch>-unknown-linux-gnu-cuda.tar.gz`, which releases stopped publishing when the CUDA lanes were split into `-cuda-12` / `-cuda-13`. The v0.75.1 release publishes only the split names, so that fallback could never resolve — on x86_64 or aarch64.

This is the installer-side counterpart to #1195, which separated driver bound from installed toolkit in host runtime selection. Same underlying confusion (driver ≠ toolkit), different code path: #1195 fixed picking the native runtime after install, this fixes picking the archive to download in the first place. It is not a platform-support limitation — the correct archive exists and is published, the installer just asked for a name that does not.

## What changed

- When toolkit probes find nothing but `nvidia-smi` is present, take the CUDA major from its header (`CUDA Version: 13.0`). That is the driver's maximum supported CUDA, which is the correct upper bound for choosing a lane, and clamp it to the newest published lane.
- Remove the bare-`-cuda` fallback on both the x86_64 and aarch64 branches. If no supported major can be determined, fail with an actionable message instead of fabricating an archive name that cannot exist:

```
error: detected an NVIDIA GPU but could not determine a supported CUDA major version (expected 12 or 13).
       install a CUDA toolkit, or re-run with --flavor cpu (or --flavor vulkan) to use a non-CUDA build.
```

## Validation

`bash -n install.sh` passes. `detect_cuda_major` exercised against a stubbed `nvidia-smi` on a machine with no CUDA toolkit at all, covering every branch of the new path:

| stub `nvidia-smi` output | result |
|---|---|
| `CUDA Version: 13.0` | `13` |
| `CUDA Version: 14.2` (future driver) | `13` (clamped to newest published lane) |
| `CUDA Version: 11.8` (too old) | empty → actionable error |
| no `nvidia-smi` on PATH | empty → actionable error |

Release-asset names confirmed against v0.75.1 with `gh release view`: only `-cuda-12` and `-cuda-13` are published for both `x86_64` and `aarch64`, no bare `-cuda`.

Partially addresses #1220 — the installer half. Deliberately not using a closing keyword: #1220 also reports a runtime-linkage failure that this does not fix, so the issue should stay open until that half is tracked separately.

Not covered here: the reporter also hit a *second*, separate problem — after installing, the Linux cuda13 native runtime links `libcudart.so.13`/`libcublas.so.13` without bundling them, while the Windows runtime ships its own CUDA DLLs. That needs its own issue and fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA version detection by using the installed NVIDIA driver when toolkit information is unavailable.
  * Limited detected CUDA versions to supported releases.
  * Installation now reports an error when no supported CUDA version can be identified instead of selecting an incompatible archive.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Update after first CI run

CI caught something my local checks did not, and it was a real bug rather than a stale assertion.

`scripts/tests/test_install_sh.py` asserted the legacy bare `-cuda` name that this PR removes, so that assertion is updated to require the refusal instead. But running the suite locally then exposed a genuine defect in my own change: `install.sh` runs under `set -euo pipefail`, and a non-matching `grep` inside `$(...)` aborts the whole script. On a host where the new `nvidia-smi` probe found no version, the installer would have died mid-detection instead of reaching the actionable error. Every `detect_cuda_major` probe pipeline now ends in `|| true`, which also hardens the two pre-existing `nvcc` and `ldconfig` probes that had the same latent exposure.

Test coverage added:

- `test_detect_cuda_major_falls_back_to_nvidia_smi_driver_version` — stubs a driver-only host (no `nvcc`, no `ldconfig`) across `13.0` → `13`, `12.4` → `12`, `14.2` → `13` (clamped), `11.8` → empty.
- `test_asset_name_uses_detected_cuda_major_lane` — the `-cuda-12`/`-cuda-13` lane name is built correctly on both `x86_64` and `aarch64`.
- `test_release_target_helpers_keep_linux_aarch64_flavor_surface` — now asserts refusal plus the actionable stderr, and asserts the legacy name is never emitted.

`python3 -m unittest scripts.tests.test_install_sh` → 26 passed.
