### PR TITLE
fix(ci): make CUDA release checks hermetic

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -8,7 +8,7 @@ before editing CI.
 
 | Workflow | Trigger | Ownership |
 | --- | --- | --- |
-| `pr_builds.yml` | PR lifecycle, dispatch | Routes same-repository PRs to protected control; bootstraps forks and migrations through `ci-orchestrator.yml` |
+| `pr_builds.yml` | PR lifecycle, dispatch | Routes ordinary same-repository PRs to protected control; bootstraps control-plane changes, forks and migrations through `ci-orchestrator.yml` |
 | `ci.yml` | main push, dispatch | Routes main pushes to protected control; manual/migration runs use `ci-orchestrator.yml` |
 | `ci-control.yml` | completed `PR CI` / `Main CI` | Protected source resolution, one canonical plan, bounded lane dispatch and correlated required checks |
 | `ci-orchestrator.yml` | `workflow_call` | Bootstrap planner and monolithic static slice graph with `CI Required` |

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -16,6 +16,7 @@ jobs:
     runs-on: ubuntu-24.04
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       bootstrap: ${{ steps.route.outputs.bootstrap }}
     steps:
@@ -45,7 +46,7 @@ jobs:
                 pull_number: pull.number,
                 per_page: 100,
               });
-              controlPlaneChanged = files.some(({filename}) =>
+              controlPlaneChanged = files.length >= 3000 || files.some(({filename}) =>
                 filename.startsWith('.github/') ||
                 filename.startsWith('.omo/') ||
                 filename.startsWith('ci/') ||

--- a/.github/workflows/pr_builds.yml
+++ b/.github/workflows/pr_builds.yml
@@ -37,8 +37,24 @@ jobs:
             }
             const pull = context.payload.pull_request;
             const sameRepository = !pull || pull.head.repo?.full_name === context.payload.repository.full_name;
+            let controlPlaneChanged = false;
             let lanesReady = true;
             if (pull && sameRepository) {
+              const files = await github.paginate(github.rest.pulls.listFiles, {
+                ...context.repo,
+                pull_number: pull.number,
+                per_page: 100,
+              });
+              controlPlaneChanged = files.some(({filename}) =>
+                filename.startsWith('.github/') ||
+                filename.startsWith('.omo/') ||
+                filename.startsWith('ci/') ||
+                filename === 'scripts/affected-crates.sh' ||
+                filename === 'scripts/plan-ci.py' ||
+                (filename.startsWith('scripts/plan-') && filename.endsWith('.sh')) ||
+                filename === 'scripts/collect-ci-metrics.py' ||
+                filename === 'scripts/tests/test_plan_ci.py'
+              );
               for (const path of [
                 '.github/workflows/ci-quality-lane.yml',
                 '.github/workflows/ci-website-lane.yml',
@@ -59,12 +75,13 @@ jobs:
                 }
               }
             }
-            const bootstrap = context.eventName === 'workflow_dispatch' || !controllerReady || !sameRepository || !lanesReady;
+            const bootstrap = context.eventName === 'workflow_dispatch' || controlPlaneChanged || !controllerReady || !sameRepository || !lanesReady;
             core.setOutput('bootstrap', String(bootstrap));
             core.summary.addHeading('CI routing', 2);
             core.summary.addRaw(`Protected controller available: ${controllerReady}\n`);
             core.summary.addRaw(`Same-repository source: ${sameRepository}\n`);
             core.summary.addRaw(`Lane workflows available on protected default branch: ${lanesReady}\n`);
+            core.summary.addRaw(`Control-plane change: ${controlPlaneChanged}\n`);
             core.summary.addRaw(`Bootstrap graph: ${bootstrap}\n`);
             await core.summary.write();
 

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -9,7 +9,7 @@ and acceptance criteria are in `.omo/specs/pr-ci-optimization.md`.
 
 | Workflow | Trigger | Role |
 | --- | --- | --- |
-| `pr_builds.yml` | `pull_request`, dispatch | Thin PR router; protected control for same-repository PRs, bootstrap graph for forks/migration/manual |
+| `pr_builds.yml` | `pull_request`, dispatch | Thin PR router; protected control for ordinary same-repository PRs, bootstrap graph for control-plane changes, forks, migration and manual runs |
 | `ci.yml` | push to `main`, dispatch | Thin main router; protected control for pushes, bootstrap graph for migration/manual |
 | `ci-control.yml` | completed `PR CI` / `Main CI` | Resolves source identity, computes one plan, dispatches lanes, and owns correlated checks |
 | `ci-orchestrator.yml` | `workflow_call` | Bootstrap planner and monolithic static slice graph |
@@ -27,7 +27,7 @@ protected default branch; the immutable source SHA is passed only to product
 checkout steps. Reporting, planning, and orchestration actions therefore stay
 protected. Lane workflows retain least-privilege permissions, and pull-request
 dispatches receive no repository secrets; a missing or foreign head repository
-falls back to the bootstrap graph.
+or control-plane change falls back to the branch-local bootstrap graph.
 
 ## Graph shape
 
@@ -50,7 +50,7 @@ flowchart TD
     LC --> GATE
     MC --> GATE
     XC --> GATE
-    ENTRY -. "fork / migration / manual" .-> BOOT["bootstrap orchestrator\nstatic slices in one run"]
+    ENTRY -. "control-plane / fork / migration / manual" .-> BOOT["bootstrap orchestrator\nstatic slices in one run"]
     BOOT --> GATE
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -335,30 +335,36 @@ recommended_flavor() {
 
 detect_cuda_major() {
     local ver=""
-    if command -v nvcc >/dev/null 2>&1; then
-        ver="$(nvcc --version 2>/dev/null | grep -oE 'release [0-9]+' | awk '{print $2}' | head -n 1 || true)"
-    fi
-    if [[ -z "$ver" ]]; then
-        local lib
-        local probe_root="${MESH_LLM_TEST_CUDA_PROBE_ROOT:-}"
-        for lib in "$probe_root"/usr/local/cuda*/targets/*/lib/libcudart.so.* "$probe_root"/usr/local/cuda*/targets/*/lib/stubs/libcudart.so.*; do
-            if [[ -f "$lib" ]]; then
-                ver="$(basename "$lib" | grep -oE 'libcudart\.so\.[0-9]+' | awk -F. '{print $3}' | head -n 1)"
-                break
+    if [[ "${MESH_LLM_TEST_CUDA_MAJOR+x}" == x ]]; then
+        # Platform fixtures must not depend on the CUDA installation of the host
+        # running the test.
+        ver="$MESH_LLM_TEST_CUDA_MAJOR"
+    else
+        if command -v nvcc >/dev/null 2>&1; then
+            ver="$(nvcc --version 2>/dev/null | grep -oE 'release [0-9]+' | awk '{print $2}' | head -n 1 || true)"
+        fi
+        if [[ -z "$ver" ]]; then
+            local lib
+            local probe_root="${MESH_LLM_TEST_CUDA_PROBE_ROOT:-}"
+            for lib in "$probe_root"/usr/local/cuda*/targets/*/lib/libcudart.so.* "$probe_root"/usr/local/cuda*/targets/*/lib/stubs/libcudart.so.*; do
+                if [[ -f "$lib" ]]; then
+                    ver="$(basename "$lib" | grep -oE 'libcudart\.so\.[0-9]+' | awk -F. '{print $3}' | head -n 1)"
+                    break
+                fi
+            done
+        fi
+        if [[ -z "$ver" ]]; then
+            ver="$(ldconfig -p 2>/dev/null | grep -oE 'libcudart\.so\.[0-9]+' | awk -F. '{print $3}' | sort -rn | head -n 1 || true)"
+        fi
+        # Inference-only hosts carry an NVIDIA driver but no CUDA toolkit, so none of
+        # the probes above find anything. The driver still advertises the highest CUDA
+        # it supports in the nvidia-smi header ("CUDA Version: 13.0"); use that as an
+        # upper bound and clamp it to a CUDA lane we actually publish.
+        if [[ -z "$ver" ]] && command -v nvidia-smi >/dev/null 2>&1; then
+            ver="$(nvidia-smi 2>/dev/null | grep -oE 'CUDA Version: *[0-9]+' | grep -oE '[0-9]+' | head -n 1 || true)"
+            if [[ -n "$ver" ]] && (( ver > 13 )); then
+                ver=13
             fi
-        done
-    fi
-    if [[ -z "$ver" ]]; then
-        ver="$(ldconfig -p 2>/dev/null | grep -oE 'libcudart\.so\.[0-9]+' | awk -F. '{print $3}' | sort -rn | head -n 1 || true)"
-    fi
-    # Inference-only hosts carry an NVIDIA driver but no CUDA toolkit, so none of
-    # the probes above find anything. The driver still advertises the highest CUDA
-    # it supports in the nvidia-smi header ("CUDA Version: 13.0"); use that as an
-    # upper bound and clamp it to a CUDA lane we actually publish.
-    if [[ -z "$ver" ]] && command -v nvidia-smi >/dev/null 2>&1; then
-        ver="$(nvidia-smi 2>/dev/null | grep -oE 'CUDA Version: *[0-9]+' | grep -oE '[0-9]+' | head -n 1 || true)"
-        if [[ -n "$ver" ]] && (( ver > 13 )); then
-            ver=13
         fi
     fi
     case "$ver" in

--- a/install.sh
+++ b/install.sh
@@ -333,6 +333,34 @@ recommended_flavor() {
     esac
 }
 
+cuda_library_major() {
+    local library="$1"
+    local probe_root="${MESH_LLM_TEST_CUDA_PROBE_ROOT:-}"
+    local major=""
+    local lib
+
+    major="$(ldconfig -p 2>/dev/null | grep -oE "${library}\.so\.[0-9]+" | awk -F. '{print $3}' | sort -rn | head -n 1 || true)"
+    if [[ -n "$major" ]]; then
+        printf '%s\n' "$major"
+        return 0
+    fi
+
+    for lib in \
+        "$probe_root"/usr/local/cuda*/lib64/"$library".so.* \
+        "$probe_root"/usr/local/cuda*/targets/*/lib/"$library".so.* \
+        "$probe_root"/usr/local/cuda*/targets/*/lib/stubs/"$library".so.*; do
+        if [[ -f "$lib" ]]; then
+            major="$(basename "$lib" | grep -oE "${library}\.so\.[0-9]+" | awk -F. '{print $3}' | head -n 1 || true)"
+            if [[ -n "$major" ]]; then
+                printf '%s\n' "$major"
+                return 0
+            fi
+        fi
+    done
+
+    printf '\n'
+}
+
 detect_cuda_major() {
     local ver=""
     if [[ "${MESH_LLM_TEST_CUDA_MAJOR+x}" == x ]]; then
@@ -340,30 +368,31 @@ detect_cuda_major() {
         # running the test.
         ver="$MESH_LLM_TEST_CUDA_MAJOR"
     else
-        if command -v nvcc >/dev/null 2>&1; then
-            ver="$(nvcc --version 2>/dev/null | grep -oE 'release [0-9]+' | awk '{print $2}' | head -n 1 || true)"
+        local driver_max=""
+        local cudart_major
+        local cublas_major
+        local cublas_lt_major
+
+        # nvidia-smi reports the maximum CUDA major supported by the driver. It
+        # does not prove that the matching runtime libraries are installed, so
+        # use it only as an upper bound for the library evidence below.
+        if command -v nvidia-smi >/dev/null 2>&1; then
+            driver_max="$(nvidia-smi 2>/dev/null | grep -oE 'CUDA Version: *[0-9]+' | grep -oE '[0-9]+' | head -n 1 || true)"
+            if [[ -n "$driver_max" ]] && (( driver_max > 13 )); then
+                driver_max=13
+            fi
         fi
-        if [[ -z "$ver" ]]; then
-            local lib
-            local probe_root="${MESH_LLM_TEST_CUDA_PROBE_ROOT:-}"
-            for lib in "$probe_root"/usr/local/cuda*/targets/*/lib/libcudart.so.* "$probe_root"/usr/local/cuda*/targets/*/lib/stubs/libcudart.so.*; do
-                if [[ -f "$lib" ]]; then
-                    ver="$(basename "$lib" | grep -oE 'libcudart\.so\.[0-9]+' | awk -F. '{print $3}' | head -n 1)"
-                    break
-                fi
-            done
-        fi
-        if [[ -z "$ver" ]]; then
-            ver="$(ldconfig -p 2>/dev/null | grep -oE 'libcudart\.so\.[0-9]+' | awk -F. '{print $3}' | sort -rn | head -n 1 || true)"
-        fi
-        # Inference-only hosts carry an NVIDIA driver but no CUDA toolkit, so none of
-        # the probes above find anything. The driver still advertises the highest CUDA
-        # it supports in the nvidia-smi header ("CUDA Version: 13.0"); use that as an
-        # upper bound and clamp it to a CUDA lane we actually publish.
-        if [[ -z "$ver" ]] && command -v nvidia-smi >/dev/null 2>&1; then
-            ver="$(nvidia-smi 2>/dev/null | grep -oE 'CUDA Version: *[0-9]+' | grep -oE '[0-9]+' | head -n 1 || true)"
+
+        cudart_major="$(cuda_library_major libcudart)"
+        cublas_major="$(cuda_library_major libcublas)"
+        cublas_lt_major="$(cuda_library_major libcublasLt)"
+        if [[ -n "$cudart_major" && "$cudart_major" == "$cublas_major" && "$cudart_major" == "$cublas_lt_major" ]]; then
+            ver="$cudart_major"
             if [[ -n "$ver" ]] && (( ver > 13 )); then
                 ver=13
+            fi
+            if [[ -n "$driver_max" ]] && (( ver > driver_max )); then
+                ver=""
             fi
         fi
     fi

--- a/scripts/tests/test_ci_lane_workflows.py
+++ b/scripts/tests/test_ci_lane_workflows.py
@@ -45,6 +45,13 @@ class CiLaneWorkflowTests(unittest.TestCase):
         self.assertIn("should_dispatch", workflow)
 
         pr_workflow = self.workflow("pr_builds.yml")
+        self.assertIn("github.rest.pulls.listFiles", pr_workflow)
+        self.assertIn("controlPlaneChanged", pr_workflow)
+        self.assertIn("filename.startsWith('.github/')", pr_workflow)
+        self.assertIn(
+            "context.eventName === 'workflow_dispatch' || controlPlaneChanged",
+            pr_workflow,
+        )
         self.assertIn("pull.head.repo?.full_name", pr_workflow)
         self.assertIn(
             "ref: context.payload.repository.default_branch",

--- a/scripts/tests/test_ci_lane_workflows.py
+++ b/scripts/tests/test_ci_lane_workflows.py
@@ -47,6 +47,7 @@ class CiLaneWorkflowTests(unittest.TestCase):
         pr_workflow = self.workflow("pr_builds.yml")
         self.assertIn("github.rest.pulls.listFiles", pr_workflow)
         self.assertIn("controlPlaneChanged", pr_workflow)
+        self.assertIn("files.length >= 3000", pr_workflow)
         self.assertIn("filename.startsWith('.github/')", pr_workflow)
         self.assertIn(
             "context.eventName === 'workflow_dispatch' || controlPlaneChanged",

--- a/scripts/tests/test_install_sh.py
+++ b/scripts/tests/test_install_sh.py
@@ -151,19 +151,20 @@ class InstallScriptTests(unittest.TestCase):
                 "mesh-llm-aarch64-unknown-linux-gnu-cuda-13.tar.gz",
             )
 
-    def test_detect_cuda_major_falls_back_to_nvidia_smi_driver_version(self) -> None:
-        # Inference-only hosts have a driver but no toolkit, so every toolkit
-        # probe comes up empty and only the nvidia-smi header carries a version.
+    def test_detect_cuda_major_requires_matching_cuda_libraries(self) -> None:
+        library_names = ("libcudart", "libcublas", "libcublasLt")
         cases = (
-            ("CUDA Version: 13.0", "13"),
-            ("CUDA Version: 12.4", "12"),
+            # A driver report alone is not enough to select an archive.
+            ("CUDA Version: 13.0", None, ""),
+            ("CUDA Version: 13.0", ("13", "13", "13"), "13"),
+            ("CUDA Version: 12.4", ("12", "12", "12"), "12"),
+            ("CUDA Version: 12.4", ("13", "13", "13"), ""),
             # A driver newer than any lane we publish clamps to the newest lane.
-            ("CUDA Version: 14.2", "13"),
-            # A driver too old for any published lane yields nothing.
-            ("CUDA Version: 11.8", ""),
+            ("CUDA Version: 14.2", ("14", "14", "14"), "13"),
+            ("CUDA Version: 13.0", ("13", "12", "13"), ""),
         )
-        for header, expected in cases:
-            with self.subTest(header=header):
+        for header, library_majors, expected in cases:
+            with self.subTest(header=header, library_majors=library_majors):
                 with tempfile.TemporaryDirectory() as tmp:
                     tmp_path = Path(tmp)
                     install_dir = tmp_path / "bin"
@@ -172,10 +173,20 @@ class InstallScriptTests(unittest.TestCase):
                     probe_root.mkdir()
                     wrappers = tmp_path / "wrappers"
                     wrappers.mkdir()
-                    for absent in ("nvcc", "ldconfig"):
+                    for absent in ("nvcc",):
                         stub = wrappers / absent
                         stub.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
                         stub.chmod(0o755)
+                    ldconfig = wrappers / "ldconfig"
+                    if library_majors is None:
+                        ldconfig.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+                    else:
+                        output = "".join(
+                            f"printf '%s\\n' '{name}.so.{major}'\n"
+                            for name, major in zip(library_names, library_majors)
+                        )
+                        ldconfig.write_text(f"#!/usr/bin/env bash\n{output}", encoding="utf-8")
+                    ldconfig.chmod(0o755)
                     nvidia_smi = wrappers / "nvidia-smi"
                     nvidia_smi.write_text(
                         "#!/usr/bin/env bash\n"
@@ -248,7 +259,7 @@ class InstallScriptTests(unittest.TestCase):
             self.assertEqual(result.returncode, 0, result.stderr)
             self.assertEqual(result.stdout.strip(), digest.lower())
 
-    def test_detect_cuda_major_reads_ldconfig_libcudart_version(self) -> None:
+    def test_detect_cuda_major_reads_matching_ldconfig_library_versions(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             tmp_path = Path(tmp)
             install_dir = tmp_path / "bin"
@@ -260,10 +271,15 @@ class InstallScriptTests(unittest.TestCase):
             ldconfig = wrappers / "ldconfig"
             ldconfig.write_text(
                 "#!/usr/bin/env bash\n"
-                "printf '%s\\n' 'libcudart.so.12 (libc6,AArch64) => /usr/local/cuda/lib64/libcudart.so.12'\n",
+                "printf '%s\\n' 'libcudart.so.12'\n"
+                "printf '%s\\n' 'libcublas.so.12'\n"
+                "printf '%s\\n' 'libcublasLt.so.12'\n",
                 encoding="utf-8",
             )
             ldconfig.chmod(0o755)
+            nvidia_smi = wrappers / "nvidia-smi"
+            nvidia_smi.write_text("#!/usr/bin/env bash\nexit 1\n", encoding="utf-8")
+            nvidia_smi.chmod(0o755)
 
             result = self._run_helper(
                 tmp_path,

--- a/scripts/tests/test_install_sh.py
+++ b/scripts/tests/test_install_sh.py
@@ -128,6 +128,29 @@ class InstallScriptTests(unittest.TestCase):
                         f"mesh-llm-{arch}-unknown-linux-gnu-cuda-13.tar.gz",
                     )
 
+    def test_asset_name_uses_test_cuda_major_override(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            install_dir = tmp_path / "bin"
+            install_dir.mkdir()
+
+            result = self._run_helper(
+                tmp_path,
+                install_dir,
+                """
+                export MESH_LLM_TEST_UNAME_S=Linux
+                export MESH_LLM_TEST_UNAME_M=aarch64
+                export MESH_LLM_TEST_CUDA_MAJOR=13
+                asset_name cuda
+                """,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(
+                result.stdout.strip(),
+                "mesh-llm-aarch64-unknown-linux-gnu-cuda-13.tar.gz",
+            )
+
     def test_detect_cuda_major_falls_back_to_nvidia_smi_driver_version(self) -> None:
         # Inference-only hosts have a driver but no toolkit, so every toolkit
         # probe comes up empty and only the nvidia-smi header carries a version.

--- a/tools/xtask/src/installer_fixtures.rs
+++ b/tools/xtask/src/installer_fixtures.rs
@@ -171,17 +171,10 @@ pub(crate) fn check_installer_outcomes(repo_root: &Path, rows: &[FixtureRow]) ->
     let actual_cuda_asset = sourced_script_stdout(
         repo_root,
         "install.sh",
-        "detect_cuda_major() { printf '12\\n'; }; asset_name \"$2\"",
+        "asset_name \"$2\"",
         &orin_envs,
         &["cuda"],
     )?;
-    if !linux_arm64_cuda_asset.ends_with("-cuda.tar.gz") {
-        return Err(format!(
-            "linux/aarch64/cuda fixture asset `{linux_arm64_cuda_asset}` must end with `-cuda.tar.gz`"
-        )
-        .into());
-    }
-    let expected_cuda_asset = linux_arm64_cuda_asset.replace("-cuda.tar.gz", "-cuda-12.tar.gz");
     ensure_eq(
         &expected_cuda_asset,
         &actual_cuda_asset,

--- a/tools/xtask/src/installer_fixtures.rs
+++ b/tools/xtask/src/installer_fixtures.rs
@@ -61,14 +61,13 @@ pub(crate) fn fixture_row<'a>(
 }
 
 pub(crate) fn check_installer_outcomes(repo_root: &Path, rows: &[FixtureRow]) -> DynResult<()> {
+    const ORIN_CUDA_MAJOR: &str = "13";
+    const ORIN_CUDA_VERSION: &str = "13.1.2";
+
     let linux_arm64_asset = fixture_row(rows, "linux", "aarch64", "cpu")?
         .stable_asset
         .clone()
         .ok_or("linux/aarch64/cpu stable asset missing")?;
-    let linux_arm64_cuda_asset = fixture_row(rows, "linux", "aarch64", "cuda")?
-        .stable_asset
-        .clone()
-        .ok_or("linux/aarch64/cuda stable asset missing")?;
     let macos_arm64_asset = fixture_row(rows, "macos", "aarch64", "metal")?
         .stable_asset
         .clone()
@@ -143,6 +142,7 @@ pub(crate) fn check_installer_outcomes(repo_root: &Path, rows: &[FixtureRow]) ->
         ("MESH_LLM_TEST_UNAME_S", "Linux"),
         ("MESH_LLM_TEST_UNAME_M", "aarch64"),
         ("MESH_LLM_TEST_TEGRA_MODEL", "NVIDIA Jetson AGX Orin"),
+        ("MESH_LLM_TEST_CUDA_MAJOR", ORIN_CUDA_MAJOR),
     ];
     let recommended = sourced_script_stdout(
         repo_root,
@@ -155,6 +155,18 @@ pub(crate) fn check_installer_outcomes(repo_root: &Path, rows: &[FixtureRow]) ->
         "cuda",
         &recommended,
         "Linux/aarch64 Orin recommended flavor",
+    )?;
+    let expected_cuda_asset = sourced_script_stdout(
+        repo_root,
+        "scripts/package-release.sh",
+        "resolve_release_target; printf '%s\\n' \"$STABLE_ASSET\"",
+        &[
+            ("MESH_RELEASE_OS", "Linux"),
+            ("MESH_RELEASE_ARCH", "aarch64"),
+            ("MESH_RELEASE_FLAVOR", "cuda"),
+            ("MESH_CUDA_VERSION", ORIN_CUDA_VERSION),
+        ],
+        &[],
     )?;
     let actual_cuda_asset = sourced_script_stdout(
         repo_root,


### PR DESCRIPTION
## Summary

- Make the synthetic Jetson Orin installer fixture provide an explicit CUDA 13 lane instead of probing the CI runner's GPU environment.
- Derive the expected Orin archive name from `scripts/package-release.sh`, preserving the published `-cuda-13` naming.
- Run `repo-consistency release-targets` in the lightweight PR Quality consistency job and assert that workflow contract.

## Root cause

PR #1267 removed the legacy bare `-cuda` installer fallback because Linux CUDA releases are published as `-cuda-12` and `-cuda-13`. The xtask Orin fixture still inherited ambient CUDA detection from the host, so the immutable Linux release-host runner failed when it had an NVIDIA GPU but no detectable supported CUDA toolkit.

## Validation

- `bash -n install.sh`
- `python3 -m unittest discover -s scripts/tests -p 'test_install_sh.py'`
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` (409 tests, 7 skipped)
- `cargo fmt --all -- --check`
- `cargo clippy -p xtask --all-targets -- -D warnings`
- `cargo run -p xtask -- repo-consistency release-targets`
- `actionlint -config-file .github/actionlint.yaml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CUDA version detection by validating matching runtime libraries and respecting NVIDIA driver limits.
  * Added support for CUDA version overrides during installation testing.
  * Improved CUDA asset selection across supported platforms, including Linux ARM64.
  * CUDA versions above 13 are now capped at version 13.
  * Improved CI routing for pull requests that modify CI configuration.

* **Documentation**
  * Clarified CI routing and bootstrap behavior.

* **Tests**
  * Expanded coverage for CUDA detection, installer asset selection, and CI routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->