### PR TITLE
fix: cross-platform product bundle tree hashes

### DIFF
--- a/scripts/compose-product-bundle.py
+++ b/scripts/compose-product-bundle.py
@@ -44,7 +44,8 @@ def file_sha256(path: Path) -> str:
 
 def tree_sha256(path: Path) -> str:
     digest = hashlib.sha256()
-    for item in sorted(candidate for candidate in path.rglob("*") if candidate.is_file()):
+    files = (candidate for candidate in path.rglob("*") if candidate.is_file())
+    for item in sorted(files, key=lambda candidate: candidate.relative_to(path).as_posix()):
         relative = item.relative_to(path).as_posix().encode()
         digest.update(len(relative).to_bytes(8, "big"))
         digest.update(relative)

--- a/scripts/tests/test_compose_product_bundle.py
+++ b/scripts/tests/test_compose_product_bundle.py
@@ -1,0 +1,43 @@
+import importlib.util
+import pathlib
+import unittest
+
+
+ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "compose-product-bundle.py"
+SPEC = importlib.util.spec_from_file_location("compose_product_bundle", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+COMPOSE_PRODUCT_BUNDLE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(COMPOSE_PRODUCT_BUNDLE)
+
+
+class ComposeProductBundleTests(unittest.TestCase):
+    def test_tree_hash_uses_ordinal_relative_path_order(self) -> None:
+        class CaseInsensitivePath(type(pathlib.Path())):
+            def __lt__(self, other: object) -> bool:
+                if not isinstance(other, pathlib.PurePath):
+                    return NotImplemented
+                return str(self).lower() < str(other).lower()
+
+        fixture = CaseInsensitivePath(ROOT / "scripts" / "tests" / "fixtures" / "tree-hash")
+        files = {
+            fixture / "README.md": b"upper sorts first ordinally\n",
+            fixture / "lib" / "runtime.dll": b"lower sorts second ordinally\n",
+        }
+        for path, contents in files.items():
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_bytes(contents)
+        try:
+            self.assertEqual(
+                COMPOSE_PRODUCT_BUNDLE.tree_sha256(fixture),
+                "01df8a658501c6798530548aa7ca5a15ce02059d66b8ab87df4150811b55c7e1",
+            )
+        finally:
+            for path in files:
+                path.unlink()
+            (fixture / "lib").rmdir()
+            fixture.rmdir()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- make product bundle runtime tree hashing sort normalized relative POSIX paths explicitly
- match the installer's ordinal path ordering on every build host
- add a regression test that simulates case-insensitive host path ordering

## Root cause

`compose-product-bundle.py` sorted `Path` objects. `Path` ordering follows the host filesystem/path flavour, so a bundle composed on a case-insensitive host could hash files in a different order from `install.ps1`, which explicitly uses `[StringComparer]::Ordinal`. The archived bytes and individual file hashes were valid, but the embedded aggregate `runtime.sha256` was produced with a different traversal order.

The composer now normalizes each relative path with `as_posix()` and sorts by that string, matching the verifier contract.

## Validation

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 409 passed, 7 skipped
- `python3 -m py_compile scripts/compose-product-bundle.py scripts/tests/test_compose_product_bundle.py`
- `git diff --check`

Fixes #1219


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved product bundle hashing consistency by applying stable, ordinal ordering to file paths, including paths that differ by letter case.

* **Tests**
  * Added coverage to verify consistent hash results across varying file-path case and ordering scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->