### PR TITLE
ci: distinguish skipped bootstrap routes

### DIFF
--- a/.github/workflows/ci-control.yml
+++ b/.github/workflows/ci-control.yml
@@ -49,10 +49,12 @@ jobs:
               per_page: 100,
             });
             const bootstrapped = jobs.some((job) =>
-              job.name === 'Bootstrap PR CI' ||
-              job.name === 'Bootstrap main CI' ||
-              job.name.startsWith('Bootstrap PR CI / ') ||
-              job.name.startsWith('Bootstrap main CI / ')
+              job.conclusion !== 'skipped' && (
+                job.name === 'Bootstrap PR CI' ||
+                job.name === 'Bootstrap main CI' ||
+                job.name.startsWith('Bootstrap PR CI / ') ||
+                job.name.startsWith('Bootstrap main CI / ')
+              )
             );
             core.setOutput('should_dispatch', String(!bootstrapped));
             if (bootstrapped) return;

--- a/scripts/tests/test_ci_lane_workflows.py
+++ b/scripts/tests/test_ci_lane_workflows.py
@@ -37,6 +37,7 @@ class CiLaneWorkflowTests(unittest.TestCase):
         self.assertIn("job.name === 'Bootstrap PR CI'", workflow)
         self.assertIn("job.name.startsWith('Bootstrap PR CI / ')", workflow)
         self.assertIn("job.name.startsWith('Bootstrap main CI / ')", workflow)
+        self.assertIn("job.conclusion !== 'skipped'", workflow)
         self.assertIn("head_repository.full_name == github.repository", workflow)
         self.assertIn("should_dispatch", workflow)
 


### PR DESCRIPTION
## Problem

The first post-#1244 activation probe showed that GitHub includes the unselected bootstrap caller in the entry run's job list with `conclusion=skipped`. The protected controller matched the bootstrap job name without checking its conclusion, so it suppressed lane dispatch for every thin PR/main route.

## Fix

Treat exact and reusable-workflow-prefixed bootstrap job names as evidence only when the matching job was not skipped. Actual bootstrap executions still suppress protected redispatch; an unselected bootstrap caller no longer does.

## Validation

- `just ci-validate`
- 412 Python tests passed (7 expected skips)
- actionlint and repository-consistency checks passed

This prerequisite must merge before the temporary split-lane activation probe. Depot remains trusted-main only; no provider, variable, runner-group, or cache setting changes are included.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved workflow dispatch decisions by ignoring bootstrap jobs that were skipped.
  - Dispatch is now suppressed only when a matching bootstrap job completed without being skipped.

- **Tests**
  - Added coverage to verify skipped bootstrap jobs do not block dispatch.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->