### PR TITLE
ci: probe protected split-lane activation

### DIFF
--- a/ci/slices.yml
+++ b/ci/slices.yml
@@ -1,4 +1,5 @@
 {
+
   "schema_version": 1,
   "profiles": {
     "pr-draft": {


### PR DESCRIPTION
## Purpose

Temporary activation probe for the protected central-dispatch CI design landed in #1244 and the skipped-bootstrap correction in #1272.

The only change is behavior-neutral JSON whitespace in `ci/slices.yml`. Because that manifest belongs to `ci-control`, the ready-PR planner must fail open and dispatch all five independently readable workflow graphs.

## Acceptance

- `PR CI` contains only routing.
- `CI Control` computes one canonical plan.
- Separate `CI / Quality`, `CI / Website`, `CI / Linux`, `CI / macOS`, and `CI / Windows` runs appear.
- Every lane is correlated by source SHA and plan digest.
- Aggregate `CI Required` completes successfully.
- PR-origin work remains GitHub-hosted with Depot placement and Depot remote-cache authority disabled.

Do not merge this temporary PR; close it after evidence is collected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved formatting in the CI configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->