### PR TITLE
ci: fail fast on topic lane projections

### DIFF
--- a/.github/actions/plan-ci/action.yml
+++ b/.github/actions/plan-ci/action.yml
@@ -193,6 +193,30 @@ runs:
         plan_json=$(jq -c . ci-plan.json)
         plan_digest=$(printf '%s' "$plan_json" | sha256sum | awk '{print $1}')
         jq -e '.schema_version == 1' ci-plan.json >/dev/null
+        quality_lane_plan=$(jq -ce '
+          {
+            lane: "quality",
+            required: (([.required_slices[] | select(. == "quality" or . == "runner-contract")] | length) > 0),
+            profile,
+            domains,
+            required_slices,
+            signals,
+            budgets,
+            matrices: {clippy: .matrices.clippy}
+          }
+        ' ci-plan.json)
+        website_lane_plan=$(jq -ce '
+          {
+            lane: "website",
+            required: ((.required_slices | index("web")) != null),
+            profile,
+            domains,
+            required_slices,
+            signals,
+            budgets,
+            matrices: {}
+          }
+        ' ci-plan.json)
         {
           echo "plan_path=ci-plan.json"
           echo "plan_json=$plan_json"
@@ -221,30 +245,8 @@ runs:
           echo "macos_max_parallel=$(jq -r '.budgets.macos_max_parallel' ci-plan.json)"
           echo "windows_max_parallel=$(jq -r '.budgets.windows_max_parallel' ci-plan.json)"
           echo "total_max_workers=$(jq -r '.budgets.total_max_workers' ci-plan.json)"
-          echo "quality_lane_plan=$(jq -c '
-            {
-              lane: "quality",
-              required: ([.required_slices[] | select(. == "quality" or . == "runner-contract")] | length) > 0,
-              profile,
-              domains,
-              required_slices,
-              signals,
-              budgets,
-              matrices: {clippy: .matrices.clippy}
-            }
-          ' ci-plan.json)"
-          echo "website_lane_plan=$(jq -c '
-            {
-              lane: "website",
-              required: (.required_slices | index("web")) != null,
-              profile,
-              domains,
-              required_slices,
-              signals,
-              budgets,
-              matrices: {}
-            }
-          ' ci-plan.json)"
+          echo "quality_lane_plan=$quality_lane_plan"
+          echo "website_lane_plan=$website_lane_plan"
           echo "linux_lane_plan=$(jq -c '
             {
               lane: "linux",

--- a/scripts/tests/test_ci_lane_workflows.py
+++ b/scripts/tests/test_ci_lane_workflows.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import json
 from pathlib import Path
+import re
+import subprocess
 import unittest
 
 
@@ -131,9 +134,65 @@ class CiLaneWorkflowTests(unittest.TestCase):
             "windows_lane_plan",
         ):
             self.assertIn(f"{output}:", action)
-            self.assertIn(f'echo "{output}=$(jq -c', action)
+            self.assertIn(f'echo "{output}=$', action)
         for platform in ("linux", "macos", "windows"):
             self.assertIn(f'select(.platform == "{platform}")', action)
+
+    def test_topic_lane_projections_are_valid_jq(self) -> None:
+        action = (ROOT / ".github/actions/plan-ci/action.yml").read_text(
+            encoding="utf-8"
+        )
+        plans = (
+            {
+                "profile": "pr-ready",
+                "domains": ["ci-control"],
+                "required_slices": ["quality", "runner-contract", "web"],
+                "signals": {"rust_changed": True},
+                "budgets": {"total_max_workers": 10},
+                "matrices": {"clippy": [{"id": "batch-0"}]},
+            },
+            {
+                "profile": "pr-ready",
+                "domains": ["docs"],
+                "required_slices": [],
+                "signals": {"rust_changed": False},
+                "budgets": {"total_max_workers": 2},
+                "matrices": {"clippy": []},
+            },
+        )
+        for output, lane in (
+            ("quality_lane_plan", "quality"),
+            ("website_lane_plan", "website"),
+        ):
+            match = re.search(
+                rf"{output}=\$\(jq -ce '(.*?)' ci-plan\.json\)",
+                action,
+                re.DOTALL,
+            )
+            self.assertIsNotNone(match)
+            for required, plan in zip((True, False), plans, strict=True):
+                with self.subTest(output=output, required=required):
+                    result = subprocess.run(
+                        ["jq", "-ce", match.group(1)],
+                        input=json.dumps(plan),
+                        text=True,
+                        capture_output=True,
+                        check=True,
+                    )
+                    projection = json.loads(result.stdout)
+                    self.assertEqual(lane, projection["lane"])
+                    self.assertIs(required, projection["required"])
+                    self.assertEqual(
+                        plan["required_slices"], projection["required_slices"]
+                    )
+                    self.assertEqual(plan["signals"], projection["signals"])
+                    self.assertEqual(plan["budgets"], projection["budgets"])
+                    expected_matrices = (
+                        {"clippy": plan["matrices"]["clippy"]}
+                        if lane == "quality"
+                        else {}
+                    )
+                    self.assertEqual(expected_matrices, projection["matrices"])
 
     def test_dispatched_pr_lanes_receive_no_hugging_face_credential(self) -> None:
         controller = self.workflow("ci-control.yml")


### PR DESCRIPTION
## Summary

- fix the quality and website jq projections so they emit valid JSON
- evaluate those projections before writing action outputs so jq failures stop planning
- execute the exact projection programs in regression coverage

## Activation evidence

Temporary PR #1273 exposed this on protected controller run 31656893304: both topic projections failed jq compilation inside command substitutions, leaving empty outputs while the planner step reported success.

## Validation

- `python3 -m unittest scripts.tests.test_ci_lane_workflows`
- `just ci-validate` (413 tests, 7 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation and generation of automated quality and website check plans.
  * Ensured lane-specific requirements, signals, budgets, and matrices are preserved consistently in CI results.

* **Tests**
  * Added coverage to verify that generated quality and website plans are valid and contain the expected lane and requirement details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->