### PR TITLE
ci: validate protected lane activation

### DIFF
--- a/ci/slices.yml
+++ b/ci/slices.yml
@@ -1,4 +1,5 @@
 {
+
   "schema_version": 1,
   "profiles": {
     "pr-draft": {


### PR DESCRIPTION
Temporary activation probe for the protected central-dispatch topology.

This PR contains only a behavior-neutral blank line in `ci/slices.yml`, intentionally selecting the CI control-plane fail-open profile. It must not be merged and will be closed after validating separate Quality, Website, Linux, macOS, and Windows graphs plus the aggregate required check.

Depot remains disabled for PR execution.