### PR TITLE
ci: flatten paginated lane checks

### DIFF
--- a/.github/actions/report-ci-lane/action.yml
+++ b/.github/actions/report-ci-lane/action.yml
@@ -115,7 +115,7 @@ runs:
               ref: process.env.SOURCE_SHA,
               per_page: 100,
               filter: 'latest',
-            }, (response) => response.data.check_runs);
+            });
             const lanes = checkRuns.filter((check) =>
               expected.includes(check.name) && check.external_id === process.env.CORRELATION_ID
             );

--- a/scripts/tests/test_ci_lane_workflows.py
+++ b/scripts/tests/test_ci_lane_workflows.py
@@ -222,6 +222,7 @@ class CiLaneWorkflowTests(unittest.TestCase):
         self.assertIn("check.head_sha !== process.env.SOURCE_SHA", action)
         self.assertIn("if (process.env.OVERALL_CHECK_ID)", action)
         self.assertIn("github.paginate(github.rest.checks.listForRef", action)
+        self.assertNotIn("response.data.check_runs", action)
         self.assertIn("lanes.length === expected.length", action)
         self.assertNotIn("correlated lane checks did not converge", action)
 


### PR DESCRIPTION
## Summary

- use Octokit’s flattened `github.paginate` result directly for correlated check runs
- prevent undefined pagination entries from failing otherwise successful lane summaries
- retain full pagination, correlation filtering, and aggregate completion behavior

## Activation evidence

Activation PR #1275 Website run 31658325809 completed both website jobs successfully, then failed in the reporter with `TypeError: Cannot read properties of undefined (reading name)` while filtering the custom pagination mapper result.

## Validation

- `python3 -m unittest scripts.tests.test_ci_lane_workflows`
- `just ci-validate` (413 tests, 7 skipped)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI reporting reliability when retrieving paginated check-run results.

* **Tests**
  * Added coverage to verify check-run data is processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->