### PR TITLE
Retry transient model route misses in console chat

### DIFF
--- a/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.test.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.test.ts
@@ -447,6 +447,36 @@ describe('createMeshConnectionAdapter', () => {
     })
   })
 
+  it('retries a transient model-not-found response while public routing converges', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: "model 'apple/system' not found" } }), {
+          status: 404,
+          headers: { 'Content-Type': 'application/json' }
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(
+          createSSEStream([
+            'data: {"type":"response.output_text.delta","delta":"Recovered"}\n',
+            'data: [DONE]\n'
+          ]),
+          { status: 200 }
+        )
+      )
+    vi.stubGlobal('fetch', fetchMock)
+
+    const adapter = createMeshConnectionAdapter('apple/system')
+    const chunks: StreamChunk[] = []
+    for await (const chunk of adapter.connect(createMessages(), undefined, undefined)) {
+      chunks.push(chunk)
+    }
+
+    expect(fetchMock).toHaveBeenCalledTimes(2)
+    expect(chunks.map((chunk) => chunk.type)).toContain(EventType.TEXT_MESSAGE_CONTENT)
+  })
+
   it('stops before /api/responses when attachment upload fails', async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       new Response(JSON.stringify({ error: { message: 'Upload failed: 503' } }), {

--- a/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.test.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.test.ts
@@ -448,6 +448,7 @@ describe('createMeshConnectionAdapter', () => {
   })
 
   it('retries a transient model-not-found response while public routing converges', async () => {
+    vi.useFakeTimers()
     const fetchMock = vi
       .fn()
       .mockResolvedValueOnce(
@@ -458,23 +459,45 @@ describe('createMeshConnectionAdapter', () => {
       )
       .mockResolvedValueOnce(
         new Response(
-          createSSEStream([
-            'data: {"type":"response.output_text.delta","delta":"Recovered"}\n',
-            'data: [DONE]\n'
-          ]),
+          createSSEStream(['data: {"type":"response.output_text.delta","delta":"Recovered"}\n', 'data: [DONE]\n']),
           { status: 200 }
         )
       )
     vi.stubGlobal('fetch', fetchMock)
 
     const adapter = createMeshConnectionAdapter('apple/system')
+    const iterator = adapter.connect(createMessages(), undefined, undefined)[Symbol.asyncIterator]()
     const chunks: StreamChunk[] = []
-    for await (const chunk of adapter.connect(createMessages(), undefined, undefined)) {
-      chunks.push(chunk)
+    try {
+      const first = await iterator.next()
+      if (!first.done) chunks.push(first.value)
+
+      const pendingNext = iterator.next()
+      await vi.advanceTimersByTimeAsync(0)
+      expect(vi.getTimerCount()).toBe(1)
+      await vi.advanceTimersByTimeAsync(500)
+
+      while (true) {
+        const next = await pendingNext
+        if (!next.done) chunks.push(next.value)
+        break
+      }
+      while (true) {
+        const next = await iterator.next()
+        if (next.done) break
+        chunks.push(next.value)
+      }
+    } finally {
+      vi.useRealTimers()
     }
 
     expect(fetchMock).toHaveBeenCalledTimes(2)
-    expect(chunks.map((chunk) => chunk.type)).toContain(EventType.TEXT_MESSAGE_CONTENT)
+    expect(
+      chunks
+        .filter((chunk) => chunk.type === EventType.TEXT_MESSAGE_CONTENT)
+        .map((chunk) => (chunk.type === EventType.TEXT_MESSAGE_CONTENT ? chunk.delta : ''))
+        .join('')
+    ).toContain('Recovered')
   })
 
   it('stops before /api/responses when attachment upload fails', async () => {

--- a/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.ts
@@ -222,7 +222,13 @@ async function* runConnect(
 
       const errorBody = await parseApiErrorBody(response)
       const shouldRetry = attempt === 0 && isModelRouteNotFound(response.status, errorBody)
-      if (!shouldRetry || !(await waitForModelRouteRetry(abortSignal))) {
+      if (!shouldRetry) {
+        throw new ApiError(response.status, errorBody, `Chat request failed: ${response.status}`)
+      }
+
+      const retryAllowed = await waitForModelRouteRetry(abortSignal)
+      if (abortSignal?.aborted) return
+      if (!retryAllowed) {
         throw new ApiError(response.status, errorBody, `Chat request failed: ${response.status}`)
       }
     }

--- a/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.ts
+++ b/crates/mesh-llm-ui/src/features/chat/api/mesh-connection.ts
@@ -81,6 +81,33 @@ function isAbortError(error: unknown) {
   return error instanceof Error && error.name === 'AbortError'
 }
 
+const MODEL_ROUTE_RETRY_DELAY_MS = 500
+
+function isModelRouteNotFound(status: number, body: string): boolean {
+  if (status !== 404) return false
+  const normalized = body.toLowerCase()
+  return normalized.includes('model') && (normalized.includes('not found') || normalized.includes('missing'))
+}
+
+async function waitForModelRouteRetry(abortSignal?: AbortSignal): Promise<boolean> {
+  if (abortSignal?.aborted) return false
+
+  return new Promise((resolve) => {
+    let timerId: ReturnType<typeof setTimeout> | undefined
+    let abortHandler: (() => void) | undefined
+
+    const finish = (shouldRetry: boolean) => {
+      if (timerId !== undefined) clearTimeout(timerId)
+      if (abortHandler) abortSignal?.removeEventListener('abort', abortHandler)
+      resolve(shouldRetry)
+    }
+
+    abortHandler = () => finish(false)
+    abortSignal?.addEventListener('abort', abortHandler, { once: true })
+    timerId = setTimeout(() => finish(true), MODEL_ROUTE_RETRY_DELAY_MS)
+  })
+}
+
 async function* parseSSEStream(
   body: ReadableStream<Uint8Array>,
   abortSignal?: AbortSignal
@@ -183,20 +210,25 @@ async function* runConnect(
   let response: Response
   try {
     const requestBody = await buildResponsesInput(messages, model, clientId, requestId, systemPrompt)
-    response = await fetch(`${env.managementApiUrl}/api/responses`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(requestBody),
-      signal: abortSignal
-    })
+    for (let attempt = 0; ; attempt += 1) {
+      response = await fetch(`${env.managementApiUrl}/api/responses`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(requestBody),
+        signal: abortSignal
+      })
+
+      if (response.ok) break
+
+      const errorBody = await parseApiErrorBody(response)
+      const shouldRetry = attempt === 0 && isModelRouteNotFound(response.status, errorBody)
+      if (!shouldRetry || !(await waitForModelRouteRetry(abortSignal))) {
+        throw new ApiError(response.status, errorBody, `Chat request failed: ${response.status}`)
+      }
+    }
   } catch (err) {
     if (err instanceof Error && err.name === 'AbortError') return
     throw err
-  }
-
-  if (!response.ok) {
-    const errorBody = await parseApiErrorBody(response)
-    throw new ApiError(response.status, errorBody, `Chat request failed: ${response.status}`)
   }
 
   if (!response.body) {


### PR DESCRIPTION
## Summary

- retry one transient model-route 404 in console chat
- keep the selected model and request body unchanged while public gossip/routing converges
- add coverage for recovery from an `apple/system` model-not-found response

## Why

The console can receive a model from `/api/models` before the public gateway has an eligible route for it. The first `/api/responses` request then returns 404 even though the model is valid and becomes routable moments later. Previously this surfaced as “Message failed to send” and required a manual refresh or model re-selection.

The adapter now waits 500 ms and retries once only for a 404 whose error body identifies a missing model. Other errors are still surfaced immediately, and aborts cancel the retry wait.

## Validation

- `just build` passes.
- Added a focused adapter test covering the transient 404 and successful streamed retry.
- Full UI suite: the new test passes; one unrelated pre-existing `DataModeContext` localStorage test remains failing in this checkout.

Fixes the console-side portion of the public model catalog/routing convergence issue.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Chat requests now automatically retry once after a brief delay when the selected model is temporarily unavailable.
  - Successful retries continue streaming responses normally without requiring user action.
  - Requests canceled during the retry stop cleanly.
  - Existing error handling is preserved when the model cannot be recovered or the retry conditions are not met.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->