### PR TITLE
Make the optional GitHub star step reliable in setup

### DIFF
--- a/crates/mesh-llm-commands/src/setup/github_runner.rs
+++ b/crates/mesh-llm-commands/src/setup/github_runner.rs
@@ -4,7 +4,6 @@ use std::process::{Command, Stdio};
 use std::thread;
 use std::time::{Duration, Instant};
 
-const GITHUB_REPOSITORY: &str = "Mesh-LLM/mesh-llm";
 const GH_COMMAND_TIMEOUT: Duration = Duration::from_secs(10);
 const GH_POLL_INTERVAL: Duration = Duration::from_millis(25);
 
@@ -99,34 +98,6 @@ impl Default for ProcessGhCommandRunner {
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::GhCommand;
-
-    #[test]
-    fn github_api_commands_are_pinned_to_dot_com() {
-        for command in [
-            GhCommand::CheckAuthentication,
-            GhCommand::CheckViewerHasStarred,
-            GhCommand::StarRepository,
-        ] {
-            assert!(
-                command.args().windows(2).any(|args| args == ["--hostname", "github.com"]),
-                "{} must explicitly target github.com",
-                command.display_name()
-            );
-        }
-    }
-
-    #[test]
-    fn authentication_probe_checks_the_selected_api_credential() {
-        assert_eq!(
-            GhCommand::CheckAuthentication.args(),
-            &["api", "--hostname", "github.com", "/user", "--silent"]
-        );
-    }
-}
-
 impl GhCommandRunner for ProcessGhCommandRunner {
     fn run(&mut self, command: GhCommand) -> Result<GhCommandOutput, GhCommandError> {
         let mut child = Command::new("gh")
@@ -182,5 +153,36 @@ impl GhCommandRunner for ProcessGhCommandRunner {
                 Err(error) => return Err(GhCommandError::WaitFailed(error.to_string())),
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GhCommand;
+
+    #[test]
+    fn github_api_commands_are_pinned_to_dot_com() {
+        for command in [
+            GhCommand::CheckAuthentication,
+            GhCommand::CheckViewerHasStarred,
+            GhCommand::StarRepository,
+        ] {
+            assert!(
+                command
+                    .args()
+                    .windows(2)
+                    .any(|args| args == ["--hostname", "github.com"]),
+                "{} must explicitly target github.com",
+                command.display_name()
+            );
+        }
+    }
+
+    #[test]
+    fn authentication_probe_checks_the_selected_api_credential() {
+        assert_eq!(
+            GhCommand::CheckAuthentication.args(),
+            &["api", "--hostname", "github.com", "/user", "--silent"]
+        );
     }
 }

--- a/crates/mesh-llm-commands/src/setup/github_runner.rs
+++ b/crates/mesh-llm-commands/src/setup/github_runner.rs
@@ -20,20 +20,21 @@ impl GhCommand {
     const fn args(self) -> &'static [&'static str] {
         match self {
             Self::CheckAvailability => &["--version"],
-            Self::CheckAuthentication => {
-                &["auth", "status", "--active", "--hostname", "github.com"]
-            }
+            Self::CheckAuthentication => &["api", "--hostname", "github.com", "/user", "--silent"],
             Self::CheckViewerHasStarred => &[
-                "repo",
-                "view",
-                GITHUB_REPOSITORY,
-                "--json",
-                "viewerHasStarred",
+                "api",
+                "--hostname",
+                "github.com",
+                "graphql",
+                "-f",
+                "query=query { repository(owner: \"Mesh-LLM\", name: \"mesh-llm\") { viewerHasStarred } }",
                 "--jq",
-                ".viewerHasStarred",
+                ".data.repository.viewerHasStarred",
             ],
             Self::StarRepository => &[
                 "api",
+                "--hostname",
+                "github.com",
                 "--method",
                 "PUT",
                 "/user/starred/Mesh-LLM/mesh-llm",
@@ -45,11 +46,11 @@ impl GhCommand {
     pub(crate) const fn display_name(self) -> &'static str {
         match self {
             Self::CheckAvailability => "gh --version",
-            Self::CheckAuthentication => "gh auth status --active --hostname github.com",
-            Self::CheckViewerHasStarred => {
-                "gh repo view Mesh-LLM/mesh-llm --json viewerHasStarred --jq .viewerHasStarred"
+            Self::CheckAuthentication => "gh api --hostname github.com /user --silent",
+            Self::CheckViewerHasStarred => "gh api --hostname github.com graphql <star query>",
+            Self::StarRepository => {
+                "gh api --hostname github.com --method PUT /user/starred/Mesh-LLM/mesh-llm --silent"
             }
-            Self::StarRepository => "gh api --method PUT /user/starred/Mesh-LLM/mesh-llm --silent",
         }
     }
 }
@@ -95,6 +96,34 @@ impl Default for ProcessGhCommandRunner {
         Self {
             timeout: GH_COMMAND_TIMEOUT,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::GhCommand;
+
+    #[test]
+    fn github_api_commands_are_pinned_to_dot_com() {
+        for command in [
+            GhCommand::CheckAuthentication,
+            GhCommand::CheckViewerHasStarred,
+            GhCommand::StarRepository,
+        ] {
+            assert!(
+                command.args().windows(2).any(|args| args == ["--hostname", "github.com"]),
+                "{} must explicitly target github.com",
+                command.display_name()
+            );
+        }
+    }
+
+    #[test]
+    fn authentication_probe_checks_the_selected_api_credential() {
+        assert_eq!(
+            GhCommand::CheckAuthentication.args(),
+            &["api", "--hostname", "github.com", "/user", "--silent"]
+        );
     }
 }
 

--- a/crates/mesh-llm-commands/src/setup/summary.rs
+++ b/crates/mesh-llm-commands/src/setup/summary.rs
@@ -45,7 +45,7 @@ pub(crate) fn print_setup_summary(plan: &SetupPlan, actions: &CliSetupActions<'_
         eprintln!("- Runtime: {}", runtime_summary(plan, actions));
         eprintln!("- Service: {}", service_summary(plan, actions));
         eprintln!(
-            "- GitHub: {}",
+            "- GitHub star: {}",
             super::github::github_summary(plan, &actions.github_outcome)
         );
         return;
@@ -55,7 +55,7 @@ pub(crate) fn print_setup_summary(plan: &SetupPlan, actions: &CliSetupActions<'_
     eprintln!("  Runtime  {}", runtime_brief(plan, actions));
     eprintln!("  Service  {}", service_brief(plan, actions));
     if let Some(github) = github_brief(actions) {
-        eprintln!("  GitHub   {github}");
+        eprintln!("  GitHub star  {github}");
     }
 }
 
@@ -170,8 +170,12 @@ fn github_brief(actions: &CliSetupActions<'_>) -> Option<String> {
         | super::github::SetupGitHubOutcome::EligibilityCheckFailed(_) => {
             Some(style_warn("not starred"))
         }
-        super::github::SetupGitHubOutcome::CliUnavailable => Some(style_muted("gh unavailable")),
-        super::github::SetupGitHubOutcome::NotAuthenticated => Some(style_muted("gh signed out")),
+        super::github::SetupGitHubOutcome::CliUnavailable => {
+            Some(style_muted("skipped; gh unavailable"))
+        }
+        super::github::SetupGitHubOutcome::NotAuthenticated => {
+            Some(style_muted("skipped; gh not authenticated"))
+        }
         super::github::SetupGitHubOutcome::NotEvaluated => Some(style_muted("not recorded")),
         _ => None,
     }
@@ -225,7 +229,7 @@ mod tests {
 
         assert_eq!(
             github_brief(&actions).map(|brief| strip_ansi_styles(&brief)),
-            Some("gh unavailable".to_string())
+            Some("skipped; gh unavailable".to_string())
         );
     }
 
@@ -235,7 +239,7 @@ mod tests {
 
         assert_eq!(
             github_brief(&actions).map(|brief| strip_ansi_styles(&brief)),
-            Some("gh signed out".to_string())
+            Some("skipped; gh not authenticated".to_string())
         );
     }
 }

--- a/docs/specs/mesh-setup-installer.md
+++ b/docs/specs/mesh-setup-installer.md
@@ -112,7 +112,7 @@ After successful core setup, an interactive setup may offer to star
 Eligibility:
 
 - `gh` is on PATH
-- `gh auth status --active --hostname github.com` succeeds
+- `gh api --hostname github.com /user --silent` succeeds using the account selected by `gh`
 - the authenticated viewer has not already starred the repo
 - a visible interactive prompt is shown
 


### PR DESCRIPTION
Setup now verifies the exact GitHub.com API credential it will use for the optional repository-star prompt, so a valid login is no longer reported as signed out because of GitHub CLI account-state semantics. The setup summary also labels this as **GitHub star** and says when it was skipped, making clear that GitHub is not required for Mesh setup.

Closes #1238

## Behavior

Before:
```text
✓ Mesh setup complete
  Runtime  already ready
  Service  running
  GitHub   gh signed out
```

After, when no usable GitHub.com credential is selected:
```text
✓ Mesh setup complete
  Runtime      already ready
  Service      running
  GitHub star  skipped; gh not authenticated
```

The authentication probe, star-status query, and star mutation are all explicitly pinned to `github.com`, even when `GH_HOST` points elsewhere.

## Validation

- `gh api --hostname github.com /user --silent` succeeded with the selected credential.
- The host-pinned GraphQL star query returned successfully.
- `git diff --check` passed.
- Rust tests/checks not run: this Buzz runtime does not have `cargo` installed (`cargo: command not found`).

## Compatibility

No mesh protocol, plugin protocol, or Skippy ABI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub account verification during setup.
  * GitHub star eligibility checks now consistently target GitHub.com.
  * Setup handles unavailable or unauthenticated GitHub CLI states more clearly.

* **User Experience**
  * Setup summaries now explicitly identify GitHub star status.
  * Messages clarify when starring is skipped because GitHub authentication or the CLI is unavailable.
  * GitHub-related setup checks now provide more consistent status reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->