### PR TITLE
fix: move model lifecycle controls off peer-reachable ingress

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/tests/runtime_lifecycle_routes.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests/runtime_lifecycle_routes.rs
@@ -40,6 +40,77 @@ async fn runtime_status_and_activity_routes_are_dispatched() {
 }
 
 #[tokio::test]
+async fn local_runtime_model_routes_remain_the_lifecycle_api() {
+    let state = build_test_mesh_api().await;
+    let (control_tx, mut control_rx) = mpsc::unbounded_channel();
+    state.set_runtime_control(control_tx).await;
+
+    let load_task = tokio::spawn(async move {
+        match control_rx.recv().await {
+            Some(RuntimeControlRequest::Load {
+                spec,
+                profile,
+                resp,
+            }) => {
+                assert_eq!(spec, "org/model:Q4_K_M");
+                assert_eq!(profile, "low-ctx");
+                let _ = resp.send(Ok(RuntimeLoadResponse {
+                    model_ref: spec.clone(),
+                    model: spec,
+                    instance_id: "runtime-load-1".to_string(),
+                    profile,
+                    backend: None,
+                    context_length: None,
+                }));
+            }
+            _ => panic!("expected local load request"),
+        }
+    });
+
+    let loaded = send_runtime_lifecycle_request(
+        state.clone(),
+        lifecycle_post(
+            "/api/runtime/models",
+            r#"{"model":"org/model:Q4_K_M#low-ctx"}"#,
+        ),
+    )
+    .await;
+    load_task.await.unwrap();
+    assert!(loaded.starts_with("HTTP/1.1 201 Created"), "response: {loaded}");
+    assert_eq!(json_body(&loaded)["loaded"], "org/model:Q4_K_M");
+
+    let (control_tx, mut control_rx) = mpsc::unbounded_channel();
+    state.set_runtime_control(control_tx).await;
+    let unload_task = tokio::spawn(async move {
+        match control_rx.recv().await {
+            Some(RuntimeControlRequest::Unload {
+                target: mesh_llm_node::serving::UnloadTarget::Model(model),
+                options: _,
+                resp,
+            }) => {
+                assert_eq!(model, "org/model:Q4_K_M");
+                let _ = resp.send(Ok(RuntimeUnloadResponse {
+                    model,
+                    instance_id: "runtime-load-1".to_string(),
+                    unloaded: true,
+                }));
+            }
+            _ => panic!("expected local unload request"),
+        }
+    });
+
+    let unloaded = send_runtime_lifecycle_request(
+        state,
+        "DELETE /api/runtime/models/org%2Fmodel%3AQ4_K_M HTTP/1.1\r\nHost: localhost\r\n\r\n"
+            .into(),
+    )
+    .await;
+    unload_task.await.unwrap();
+    assert!(unloaded.starts_with("HTTP/1.1 200 OK"), "response: {unloaded}");
+    assert_eq!(json_body(&unloaded)["dropped"], "org/model:Q4_K_M");
+}
+
+#[tokio::test]
 async fn runtime_activity_override_uses_put_and_delete() {
     let state = build_test_mesh_api().await;
     let body = r#""active""#;

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -1,4 +1,3 @@
-use crate::api;
 use crate::inference::{election, pipeline};
 use crate::logging::{OpenAiLifecycleAttachment, OpenAiRouteObserver};
 use crate::mesh;
@@ -8,7 +7,6 @@ use crate::network::openai::transport as proxy;
 use crate::network::router;
 use mesh_llm_events::audit::{audit_events, emit_audit};
 use mesh_llm_events::{OutputEvent, emit_event};
-use mesh_llm_node::serving::{UnloadOptions, UnloadTarget};
 use mesh_mixture_of_agents as moa;
 
 enum AutoRouteResolution {
@@ -28,7 +26,6 @@ struct IngressRouteContext<'a> {
 
 struct ProxyConnectionContext<'a> {
     route: IngressRouteContext<'a>,
-    control_tx: &'a tokio::sync::mpsc::UnboundedSender<api::RuntimeControlRequest>,
 }
 
 struct AutoRouteDecision {
@@ -126,105 +123,6 @@ async fn bind_api_proxy_listener(
                 }
             }
         }
-    }
-}
-
-async fn send_runtime_control_response<T, F>(
-    tcp_stream: tokio::net::TcpStream,
-    response: Result<Result<T, anyhow::Error>, tokio::sync::oneshot::error::RecvError>,
-    closed_reason: &str,
-    route_observer: OpenAiRouteObserver<'_>,
-    ok_response: F,
-) -> proxy::RouteDispatchOutcome
-where
-    F: FnOnce(T) -> serde_json::Value,
-{
-    match response {
-        Ok(Ok(value)) => response_outcome(
-            200,
-            proxy::send_json_ok(tcp_stream, &ok_response(value)).await,
-        ),
-        Ok(Err(error)) => {
-            let message = error.to_string();
-            let code = api::classify_runtime_error(&message);
-            response_outcome(
-                code,
-                proxy::send_error_observed(tcp_stream, code, &message, route_observer).await,
-            )
-        }
-        Err(_) => response_outcome(
-            503,
-            proxy::send_503_observed(tcp_stream, closed_reason, route_observer).await,
-        ),
-    }
-}
-
-async fn handle_mesh_load_request(
-    tcp_stream: tokio::net::TcpStream,
-    request: &proxy::BufferedHttpRequest,
-    control_tx: &tokio::sync::mpsc::UnboundedSender<api::RuntimeControlRequest>,
-    route_observer: OpenAiRouteObserver<'_>,
-) -> proxy::RouteDispatchOutcome {
-    if let Some(spec) = request.model_name.as_ref() {
-        let (model_ref, profile) = parse_model_with_profile(spec);
-        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
-        let _ = control_tx.send(api::RuntimeControlRequest::Load {
-            spec: model_ref.to_string(),
-            profile: profile.to_string(),
-            resp: resp_tx,
-        });
-        send_runtime_control_response(
-            tcp_stream,
-            resp_rx.await,
-            "runtime load channel closed",
-            route_observer,
-            |loaded| {
-                serde_json::json!({
-                    "loaded": loaded.model,
-                    "instance_id": loaded.instance_id,
-                })
-            },
-        )
-        .await
-    } else {
-        response_outcome(
-            400,
-            proxy::send_400_observed(tcp_stream, "missing 'model' field", route_observer).await,
-        )
-    }
-}
-
-async fn handle_mesh_unload_request(
-    tcp_stream: tokio::net::TcpStream,
-    request: &proxy::BufferedHttpRequest,
-    control_tx: &tokio::sync::mpsc::UnboundedSender<api::RuntimeControlRequest>,
-    route_observer: OpenAiRouteObserver<'_>,
-) -> proxy::RouteDispatchOutcome {
-    if let Some(name) = request.model_name.as_ref() {
-        let (resp_tx, resp_rx) = tokio::sync::oneshot::channel();
-        let _ = control_tx.send(api::RuntimeControlRequest::Unload {
-            target: UnloadTarget::Model(name.clone()),
-            options: UnloadOptions::default(),
-            resp: resp_tx,
-        });
-        send_runtime_control_response(
-            tcp_stream,
-            resp_rx.await,
-            "runtime unload channel closed",
-            route_observer,
-            |dropped| {
-                serde_json::json!({
-                    "dropped": dropped.model,
-                    "instance_id": dropped.instance_id,
-                })
-            },
-        )
-        .await
-    } else {
-        response_outcome(
-            400,
-            proxy::send_400_observed(tcp_stream, "missing 'model' field", route_observer).await,
-        )
     }
 }
 
@@ -829,6 +727,10 @@ async fn maybe_handle_control_request(
     ctx: &ProxyConnectionContext<'_>,
     route_observer: OpenAiRouteObserver<'_>,
 ) -> Result<proxy::RouteDispatchOutcome, tokio::net::TcpStream> {
+    if proxy::is_legacy_lifecycle_path(&request.path) {
+        return Ok(proxy::reject_legacy_lifecycle_request(tcp_stream, route_observer).await);
+    }
+
     if proxy::is_models_list_request(&request.method, &request.path) {
         let outcome = handle_models_list_request(
             tcp_stream,
@@ -837,13 +739,6 @@ async fn maybe_handle_control_request(
             ctx.route.plugin_manager,
         )
         .await;
-        return Ok(outcome);
-    }
-
-    let path = request.path.split('?').next().unwrap_or(&request.path);
-    if request.method == "POST" && path == "/mesh/load" {
-        let outcome =
-            handle_mesh_load_request(tcp_stream, request, ctx.control_tx, route_observer).await;
         return Ok(outcome);
     }
 
@@ -998,20 +893,7 @@ async fn handle_buffered_api_request(
     let descriptors = ctx.route.node.all_served_model_descriptors().await;
     proxy::rewrite_public_model_alias(&mut request, &callable, &descriptors);
 
-    if proxy::is_drop_request(&request.method, &request.path) {
-        let outcome = handle_mesh_unload_request(
-            tcp_stream,
-            &request,
-            ctx.control_tx,
-            lifecycle.route_observer(),
-        )
-        .await;
-        lifecycle.terminal(terminal_outcome_for_dispatch(outcome));
-        return;
-    }
-
-    // Admission applies only to new inference work. Control and unload requests
-    // remain available while host activity pauses inference.
+    // Admission applies to inference work after control-path rejection.
     let tcp_stream = match check_activity_admission(
         tcp_stream,
         &ctx.route.node.activity_policy_guard,
@@ -1101,7 +983,6 @@ async fn handle_api_proxy_connection(
     node: mesh::Node,
     mut tcp_stream: tokio::net::TcpStream,
     targets: election::ModelTargets,
-    control_tx: tokio::sync::mpsc::UnboundedSender<api::RuntimeControlRequest>,
     affinity: affinity::AffinityRouter,
 ) {
     let plugin_manager = node.plugin_manager().await;
@@ -1118,15 +999,8 @@ async fn handle_api_proxy_connection(
                 affinity: &affinity,
                 plugin_manager: plugin_manager.as_ref(),
             };
-            handle_buffered_api_request(
-                tcp_stream,
-                request,
-                ProxyConnectionContext {
-                    route,
-                    control_tx: &control_tx,
-                },
-            )
-            .await;
+            handle_buffered_api_request(tcp_stream, request, ProxyConnectionContext { route })
+                .await;
         }
         Err(error) => {
             let _ = super::parse_failure::send_read_failure(tcp_stream, &error).await;
@@ -1141,7 +1015,6 @@ pub(crate) async fn api_proxy(
     node: mesh::Node,
     port: u16,
     target_rx: tokio::sync::watch::Receiver<election::ModelTargets>,
-    control_tx: tokio::sync::mpsc::UnboundedSender<api::RuntimeControlRequest>,
     existing_listener: Option<tokio::net::TcpListener>,
     listen_all: bool,
     affinity: affinity::AffinityRouter,
@@ -1160,9 +1033,8 @@ pub(crate) async fn api_proxy(
         let targets = target_rx.borrow().clone();
         let node = node.clone();
         let affinity = affinity.clone();
-        let control_tx = control_tx.clone();
         tokio::spawn(async move {
-            handle_api_proxy_connection(node, tcp_stream, targets, control_tx, affinity).await;
+            handle_api_proxy_connection(node, tcp_stream, targets, affinity).await;
         });
     }
 }

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -1335,7 +1335,6 @@ mod tests {
             vec![election::InferenceTarget::Local(1)],
         );
         let affinity = affinity::AffinityRouter::new();
-        let (control_tx, _control_rx) = tokio::sync::mpsc::unbounded_channel();
 
         // Real connected TcpStream pair; the degrade path hands it back unused.
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
@@ -1385,7 +1384,6 @@ mod tests {
                 affinity: &affinity,
                 plugin_manager: None,
             },
-            control_tx: &control_tx,
         };
         let lifecycle = OpenAiLifecycleAttachment::unowned();
 

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress_tests/durable_artifacts.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress_tests/durable_artifacts.rs
@@ -23,14 +23,12 @@ async fn parsed_missing_model_error_persists_the_client_visible_response_artifac
     let node = mesh::Node::new_for_tests(crate::mesh::NodeRole::Worker)
         .await
         .expect("test node");
-    let (control_tx, _control_rx) = tokio::sync::mpsc::unbounded_channel();
     let server = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.expect("accept ingress client");
         handle_api_proxy_connection(
             node,
             stream,
             election::ModelTargets::default(),
-            control_tx,
             affinity::AffinityRouter::new(),
         )
         .await;
@@ -119,14 +117,12 @@ async fn ingress_body_parse_error_persists_a_response_only_after_complete_header
     let node = mesh::Node::new_for_tests(crate::mesh::NodeRole::Worker)
         .await
         .expect("test node");
-    let (control_tx, _control_rx) = tokio::sync::mpsc::unbounded_channel();
     let server = tokio::spawn(async move {
         let (stream, _) = listener.accept().await.expect("accept ingress client");
         handle_api_proxy_connection(
             node,
             stream,
             election::ModelTargets::default(),
-            control_tx,
             affinity::AffinityRouter::new(),
         )
         .await;

--- a/crates/mesh-llm-host-runtime/src/network/openai/request_parse.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/request_parse.rs
@@ -889,9 +889,12 @@ pub fn is_models_list_request(method: &str, path: &str) -> bool {
     method == "GET" && (path == "/v1/models" || path == "/models")
 }
 
-pub fn is_drop_request(method: &str, path: &str) -> bool {
+/// Legacy lifecycle paths formerly handled by the peer-reachable OpenAI
+/// ingress. They remain recognizable only so callers can return an explicit
+/// compatibility response instead of routing them as inference.
+pub fn is_legacy_lifecycle_path(path: &str) -> bool {
     let path = path.split('?').next().unwrap_or(path);
-    method == "POST" && path == "/mesh/drop"
+    matches!(path, "/mesh/load" | "/mesh/drop")
 }
 
 fn is_tokenize_request(method: &str, path: &str) -> bool {
@@ -1498,6 +1501,24 @@ mod tests {
         let body = serde_json::json!({"input":"hi"});
         assert!(!pipeline_request_supported("/v1/chat/completions", &body));
     }
+
+    #[test]
+    fn legacy_lifecycle_paths_are_rejected_even_with_query_strings() {
+        for path in [
+            "/mesh/load",
+            "/mesh/load?model=ignored",
+            "/mesh/drop",
+            "/mesh/drop?model=ignored",
+        ] {
+            assert!(
+                is_legacy_lifecycle_path(path),
+                "expected legacy path: {path}"
+            );
+        }
+        assert!(!is_legacy_lifecycle_path("/v1/chat/completions"));
+        assert!(!is_legacy_lifecycle_path("/mesh/load/"));
+    }
+
     #[tokio::test]
     async fn test_read_http_request_fragmented_post_body() {
         let body =

--- a/crates/mesh-llm-host-runtime/src/network/openai/response.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response.rs
@@ -22,6 +22,5 @@ pub use pipeline::{PipelineProxyResult, pipeline_proxy_local};
 pub(super) use routing::{route_local_attempt, route_remote_attempt};
 pub(crate) use send::{
     append_safe_header, is_valid_header_name, send_400, send_400_observed, send_503_observed,
-    send_error_observed, send_json_ok, send_json_ok_with_headers,
-    send_json_with_status_and_headers_observed,
+    send_error_observed, send_json_ok_with_headers, send_json_with_status_and_headers_observed,
 };

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/send.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/send.rs
@@ -2,18 +2,6 @@ use crate::logging::OpenAiRouteObserver;
 use tokio::io::AsyncWriteExt;
 use tokio::net::TcpStream;
 
-pub async fn send_json_ok(mut stream: TcpStream, data: &serde_json::Value) -> std::io::Result<()> {
-    let body = data.to_string();
-    let resp = format!(
-        "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{}",
-        body.len(),
-        body
-    );
-    stream.write_all(resp.as_bytes()).await?;
-    stream.shutdown().await?;
-    Ok(())
-}
-
 /// RFC 7230 tchar set for header field names: ASCII alphanumeric plus
 /// `!#$%&'*+-.^_`|~`. We additionally forbid `:` because it terminates
 /// the field-name in the wire grammar. Used to reject caller-provided
@@ -106,6 +94,7 @@ async fn send_json_with_status_and_headers_inner(
     let status = match code {
         400 => "Bad Request",
         404 => "Not Found",
+        410 => "Gone",
         409 => "Conflict",
         422 => "Unprocessable Content",
         429 => "Too Many Requests",
@@ -178,6 +167,7 @@ async fn send_openai_error(
         401 => "Unauthorized",
         403 => "Forbidden",
         404 => "Not Found",
+        410 => "Gone",
         409 => "Conflict",
         413 => "Payload Too Large",
         422 => "Unprocessable Content",
@@ -226,7 +216,7 @@ const fn openai_error_kind_for_status(status_code: u16) -> openai_frontend::Open
     match status_code {
         401 => openai_frontend::OpenAiErrorKind::Authentication,
         403 => openai_frontend::OpenAiErrorKind::Permission,
-        404 => openai_frontend::OpenAiErrorKind::NotFound,
+        404 | 410 => openai_frontend::OpenAiErrorKind::NotFound,
         413 => openai_frontend::OpenAiErrorKind::PayloadTooLarge,
         429 => openai_frontend::OpenAiErrorKind::RateLimit,
         500 => openai_frontend::OpenAiErrorKind::Internal,
@@ -243,6 +233,7 @@ const fn openai_error_code_for_status(status_code: u16) -> &'static str {
         401 => "invalid_api_key",
         403 => "permission_denied",
         404 => "model_not_found",
+        410 => "legacy_route_gone",
         409 => "conflict",
         413 => "payload_too_large",
         422 => "unprocessable_content",

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -20,12 +20,12 @@ use tokio::net::TcpStream;
 pub use super::request_normalize::{ResponseAdapter, release_request_objects};
 pub(crate) use super::request_parse::read_http_request_with_plugin_manager_with_context;
 pub use super::request_parse::{
-    BufferedHttpRequest, inject_mesh_hooks_flag, is_drop_request, is_models_list_request,
+    BufferedHttpRequest, inject_mesh_hooks_flag, is_legacy_lifecycle_path, is_models_list_request,
     read_http_request, rewrite_model_field, rewrite_public_model_alias,
 };
 pub(crate) use super::response::{
     PipelineProxyResult, append_safe_header, pipeline_proxy_local, send_400_observed,
-    send_503_observed, send_error_observed, send_json_ok, send_json_ok_with_headers,
+    send_503_observed, send_error_observed, send_json_ok_with_headers,
     send_json_with_status_and_headers_observed, send_models_list_with_descriptors,
 };
 pub(crate) use super::routing_rank::{
@@ -144,6 +144,25 @@ fn response_outcome(status_code: u16, result: std::io::Result<()>) -> RouteDispa
     }
 }
 
+const LEGACY_LIFECYCLE_ROUTE_MESSAGE: &str =
+    "model lifecycle routes moved to the trusted local management API at :3131/api/runtime/models";
+
+pub(crate) async fn reject_legacy_lifecycle_request(
+    tcp_stream: TcpStream,
+    route_observer: OpenAiRouteObserver<'_>,
+) -> RouteDispatchOutcome {
+    response_outcome(
+        410,
+        send_error_observed(
+            tcp_stream,
+            410,
+            LEGACY_LIFECYCLE_ROUTE_MESSAGE,
+            route_observer,
+        )
+        .await,
+    )
+}
+
 /// Generation context is a property of decode requests, not capability RPCs.
 /// A tokenizer request may carry a megabyte of source text while using no
 /// target KV context at all.
@@ -225,6 +244,34 @@ fn attach_request_logging(request: &mut BufferedHttpRequest) -> OpenAiLifecycleA
     lifecycle
 }
 
+async fn handle_mesh_control_request(
+    node: &mesh::Node,
+    tcp_stream: TcpStream,
+    request: &BufferedHttpRequest,
+    lifecycle: &mut OpenAiLifecycleAttachment,
+) -> Option<TcpStream> {
+    if is_legacy_lifecycle_path(&request.path) {
+        let outcome = reject_legacy_lifecycle_request(tcp_stream, lifecycle.route_observer()).await;
+        lifecycle.terminal(outcome.terminal_outcome());
+        release_request_objects(node, &request.request_object_request_ids).await;
+        return None;
+    }
+
+    if is_models_list_request(&request.method, &request.path) {
+        let served = node.models_being_served().await;
+        let descriptors = node.all_served_model_descriptors().await;
+        let runtimes = node.all_model_runtime_descriptors().await;
+        let outcome = response_outcome(
+            200,
+            send_models_list_with_descriptors(tcp_stream, &served, &descriptors, &runtimes).await,
+        );
+        lifecycle.terminal(outcome.terminal_outcome());
+        return None;
+    }
+
+    Some(tcp_stream)
+}
+
 // ── Model-aware tunnel routing ──
 
 /// The common request-handling path used by idle proxy, passive proxy, and bootstrap proxy.
@@ -270,18 +317,11 @@ pub async fn handle_mesh_request(
         });
     }
 
-    // Handle /v1/models
-    if is_models_list_request(&request.method, &request.path) {
-        let served = node.models_being_served().await;
-        let descriptors = node.all_served_model_descriptors().await;
-        let runtimes = node.all_model_runtime_descriptors().await;
-        let outcome = response_outcome(
-            200,
-            send_models_list_with_descriptors(tcp_stream, &served, &descriptors, &runtimes).await,
-        );
-        lifecycle.terminal(outcome.terminal_outcome());
+    let Some(tcp_stream) =
+        handle_mesh_control_request(&node, tcp_stream, &request, &mut lifecycle).await
+    else {
         return;
-    }
+    };
 
     // MoA routing directive: `model: "mesh"` triggers mixture-of-agents
     // fan-out. Orchestration happens here, regardless of whether this node

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport_tests/durable_artifacts.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport_tests/durable_artifacts.rs
@@ -1,41 +1,130 @@
 use super::{AffinityRouter, RequestId, handle_mesh_request};
+use crate::inference::election;
+use crate::mesh;
+use crate::network::openai::ingress::api_proxy;
+use crate::network::tunnel::Manager as TunnelManager;
+use std::collections::HashMap;
+use std::net::{IpAddr, Ipv4Addr};
+use std::time::Duration;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::{oneshot, watch};
 
-async fn assert_passive_legacy_lifecycle_path_is_rejected(path: &str) {
-    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+async fn start_http_tunnel_test_node() -> (mesh::Node, mesh::TunnelChannels) {
+    let relay_urls = Vec::new();
+    let relay_auths = HashMap::new();
+    mesh::Node::start(
+        mesh::NodeRole::Client,
+        mesh::RelayConfig {
+            urls: &relay_urls,
+            auths: &relay_auths,
+            policy: mesh::RelayPolicy::Disabled,
+        },
+        mesh::QuicBindSelection {
+            ip: Some(IpAddr::V4(Ipv4Addr::LOCALHOST)),
+            port: Some(0),
+        },
+        Some(0.0),
+        false,
+        None,
+        None,
+        crate::MeshRequirements::unrestricted(),
+    )
+    .await
+    .expect("start HTTP tunnel test node")
+}
 
+async fn spawn_tunnel_capture() -> (u16, oneshot::Receiver<Vec<u8>>, tokio::task::JoinHandle<()>) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
         .await
-        .expect("bind passive lifecycle test listener");
-    let address = listener
+        .expect("bind tunnel capture listener");
+    let port = listener
         .local_addr()
-        .expect("passive lifecycle listener address");
-    let node = crate::mesh::Node::new_for_tests(crate::mesh::NodeRole::Client)
-        .await
-        .expect("test node");
-    let server = tokio::spawn(async move {
-        let (stream, _) = listener.accept().await.expect("accept passive client");
-        handle_mesh_request(node, stream, true, AffinityRouter::new()).await;
+        .expect("tunnel capture listener address")
+        .port();
+    let (capture_tx, capture_rx) = oneshot::channel();
+    let handle = tokio::spawn(async move {
+        let Ok((mut stream, _)) = listener.accept().await else {
+            return;
+        };
+        let mut request = vec![0; 8192];
+        let bytes_read = stream.read(&mut request).await.unwrap_or_default();
+        request.truncate(bytes_read);
+        let _ = capture_tx.send(request);
+        let _ = stream
+            .write_all(b"HTTP/1.1 200 OK\r\nContent-Length: 0\r\nConnection: close\r\n\r\n")
+            .await;
     });
+    (port, capture_rx, handle)
+}
 
+async fn send_tunneled_request(
+    node: &mesh::Node,
+    peer_id: iroh::EndpointId,
+    path: &str,
+) -> Vec<u8> {
     let body = r#"{"model":"test"}"#;
     let request = format!(
         "POST {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
         body.len(),
     );
-    let mut client = tokio::net::TcpStream::connect(address)
+    let (mut send, mut recv) = node
+        .open_http_tunnel(peer_id)
         .await
-        .expect("connect passive client");
-    client
-        .write_all(request.as_bytes())
+        .expect("open HTTP tunnel");
+    send.write_all(request.as_bytes())
         .await
-        .expect("write passive lifecycle request");
-    let mut wire = Vec::new();
-    client
-        .read_to_end(&mut wire)
+        .expect("write tunneled lifecycle request");
+    send.finish().expect("finish tunneled lifecycle request");
+    recv.read_to_end(4 * 1024 * 1024)
         .await
-        .expect("read passive lifecycle response");
-    server.await.expect("passive handler joins");
+        .expect("read tunneled lifecycle response")
+}
 
+async fn assert_passive_legacy_lifecycle_path_is_rejected(path: &str) {
+    let (sender, sender_channels) = start_http_tunnel_test_node().await;
+    let (receiver, receiver_channels) = start_http_tunnel_test_node().await;
+    let (upstream_port, upstream_rx, upstream_handle) = spawn_tunnel_capture().await;
+    let api_listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind receiving API proxy listener");
+    let api_port = api_listener
+        .local_addr()
+        .expect("receiving API proxy listener address")
+        .port();
+    let mut targets = election::ModelTargets::default();
+    targets.targets.insert(
+        "test".to_string(),
+        vec![election::InferenceTarget::Local(upstream_port)],
+    );
+    let (_target_tx, target_rx) = watch::channel(targets);
+    let api_proxy_handle = tokio::spawn(api_proxy(
+        receiver.clone(),
+        api_port,
+        target_rx,
+        Some(api_listener),
+        false,
+        AffinityRouter::new(),
+    ));
+    let tunnel_manager = TunnelManager::start(
+        receiver.clone(),
+        receiver_channels.rpc,
+        receiver_channels.http,
+        receiver_channels.stage,
+    )
+    .await
+    .expect("start receiving tunnel manager");
+    tunnel_manager.set_http_port(api_port);
+    sender.start_accepting();
+    receiver.start_accepting();
+    sender
+        .connect_to_peer(receiver.endpoint_addr_for_advertisement())
+        .await
+        .expect("connect HTTP tunnel test nodes");
+
+    let before_models = receiver.models.lock().await.clone();
+    let before_requested_models = receiver.requested_models.lock().await.clone();
+    let before_runtime_intents = receiver.runtime_intents.lock().unwrap().len();
+    let wire = send_tunneled_request(&sender, receiver.id(), path).await;
     let response = String::from_utf8(wire).expect("HTTP response should be UTF-8");
     assert!(
         response.starts_with("HTTP/1.1 410 Gone"),
@@ -45,6 +134,24 @@ async fn assert_passive_legacy_lifecycle_path_is_rejected(path: &str) {
         response.contains("legacy_route_gone"),
         "response: {response}"
     );
+    assert_eq!(receiver.models.lock().await.clone(), before_models);
+    assert_eq!(
+        receiver.requested_models.lock().await.clone(),
+        before_requested_models
+    );
+    assert_eq!(
+        receiver.runtime_intents.lock().unwrap().len(),
+        before_runtime_intents
+    );
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), upstream_rx)
+            .await
+            .is_err(),
+        "legacy lifecycle paths must not reach an inference target"
+    );
+    api_proxy_handle.abort();
+    upstream_handle.abort();
+    drop(sender_channels);
 }
 
 #[tokio::test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport_tests/durable_artifacts.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport_tests/durable_artifacts.rs
@@ -1,5 +1,59 @@
 use super::{AffinityRouter, RequestId, handle_mesh_request};
 
+async fn assert_passive_legacy_lifecycle_path_is_rejected(path: &str) {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind passive lifecycle test listener");
+    let address = listener
+        .local_addr()
+        .expect("passive lifecycle listener address");
+    let node = crate::mesh::Node::new_for_tests(crate::mesh::NodeRole::Client)
+        .await
+        .expect("test node");
+    let server = tokio::spawn(async move {
+        let (stream, _) = listener.accept().await.expect("accept passive client");
+        handle_mesh_request(node, stream, true, AffinityRouter::new()).await;
+    });
+
+    let body = r#"{"model":"test"}"#;
+    let request = format!(
+        "POST {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len(),
+    );
+    let mut client = tokio::net::TcpStream::connect(address)
+        .await
+        .expect("connect passive client");
+    client
+        .write_all(request.as_bytes())
+        .await
+        .expect("write passive lifecycle request");
+    let mut wire = Vec::new();
+    client
+        .read_to_end(&mut wire)
+        .await
+        .expect("read passive lifecycle response");
+    server.await.expect("passive handler joins");
+
+    let response = String::from_utf8(wire).expect("HTTP response should be UTF-8");
+    assert!(
+        response.starts_with("HTTP/1.1 410 Gone"),
+        "response: {response}"
+    );
+    assert!(
+        response.contains("legacy_route_gone"),
+        "response: {response}"
+    );
+}
+
+#[tokio::test]
+async fn passive_legacy_lifecycle_paths_are_rejected_before_mesh_routing() {
+    for path in ["/mesh/load", "/mesh/drop?model=test"] {
+        assert_passive_legacy_lifecycle_path_is_rejected(path).await;
+    }
+}
+
 #[tokio::test]
 #[serial_test::serial]
 async fn passive_missing_model_error_persists_the_client_visible_response_artifact() {

--- a/crates/mesh-llm-host-runtime/src/runtime/proxy.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/proxy.rs
@@ -1,4 +1,3 @@
-use crate::api;
 use crate::inference::election;
 use crate::mesh;
 use crate::network::affinity;
@@ -7,7 +6,6 @@ pub(super) async fn api_proxy(
     node: mesh::Node,
     port: u16,
     target_rx: tokio::sync::watch::Receiver<election::ModelTargets>,
-    control_tx: tokio::sync::mpsc::UnboundedSender<api::RuntimeControlRequest>,
     existing_listener: Option<tokio::net::TcpListener>,
     listen_all: bool,
     affinity: affinity::AffinityRouter,
@@ -16,7 +14,6 @@ pub(super) async fn api_proxy(
         node,
         port,
         target_rx,
-        control_tx,
         existing_listener,
         listen_all,
         affinity,

--- a/crates/mesh-llm-host-runtime/src/runtime/proxy/tests/basic.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/proxy/tests/basic.rs
@@ -1,4 +1,34 @@
 #[tokio::test]
+async fn legacy_lifecycle_paths_are_gone_from_openai_ingress() {
+    let (upstream_port, upstream_rx, upstream_handle) =
+        spawn_capturing_upstream(r#"{"unexpected":true}"#).await;
+    let (proxy_addr, proxy_handle) =
+        spawn_api_proxy_test_harness(local_targets(&[("test", upstream_port)])).await;
+
+    for (path, body) in [
+        ("/mesh/load", r#"{"model":"test"}"#),
+        ("/mesh/drop?model=test", r#"{"model":"test"}"#),
+    ] {
+        let request = format!(
+            "POST {path} HTTP/1.1\r\nHost: localhost\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let response = send_request_and_read_response(proxy_addr, vec![request.into_bytes()]).await;
+        assert!(response.starts_with("HTTP/1.1 410 Gone"), "response: {response}");
+        assert!(response.contains("legacy_route_gone"), "response: {response}");
+    }
+
+    assert!(
+        tokio::time::timeout(Duration::from_millis(100), upstream_rx)
+            .await
+            .is_err(),
+        "legacy lifecycle paths must not reach an inference target"
+    );
+    proxy_handle.abort();
+    upstream_handle.abort();
+}
+
+#[tokio::test]
 async fn test_api_proxy_integration_fragmented_post_body() {
     let (upstream_port, upstream_rx, upstream_handle) =
         spawn_capturing_upstream(r#"{"ok":true}"#).await;

--- a/crates/mesh-llm-host-runtime/src/runtime/proxy/tests/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/proxy/tests/mod.rs
@@ -12,7 +12,7 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{mpsc, oneshot, watch};
+use tokio::sync::{oneshot, watch};
 
 async fn spawn_api_proxy_test_harness(
     targets: election::ModelTargets,
@@ -23,12 +23,10 @@ async fn spawn_api_proxy_test_harness(
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let (_target_tx, target_rx) = watch::channel(targets);
-    let (drop_tx, _drop_rx) = mpsc::unbounded_channel();
     let handle = tokio::spawn(api_proxy(
         node,
         addr.port(),
         target_rx,
-        drop_tx,
         Some(listener),
         false,
         affinity::AffinityRouter::default(),
@@ -50,12 +48,10 @@ async fn spawn_api_proxy_test_harness_with_contexts(
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let (_target_tx, target_rx) = watch::channel(targets);
-    let (drop_tx, _drop_rx) = mpsc::unbounded_channel();
     let handle = tokio::spawn(api_proxy(
         node,
         addr.port(),
         target_rx,
-        drop_tx,
         Some(listener),
         false,
         affinity::AffinityRouter::default(),
@@ -74,12 +70,10 @@ async fn spawn_api_proxy_test_harness_with_plugin_manager(
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
     let (_target_tx, target_rx) = watch::channel(targets);
-    let (drop_tx, _drop_rx) = mpsc::unbounded_channel();
     let handle = tokio::spawn(api_proxy(
         node,
         addr.port(),
         target_rx,
-        drop_tx,
         Some(listener),
         false,
         affinity::AffinityRouter::default(),

--- a/crates/mesh-llm-host-runtime/src/runtime/serving_surface.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/serving_surface.rs
@@ -1218,7 +1218,6 @@ pub(super) async fn setup_run_auto_serving_surface(
         ctx.api_port,
         api_listener,
         ctx.target_rx,
-        ctx.control_tx,
         ctx.affinity_router,
     );
     let console_server_handle = spawn_run_auto_console_server(
@@ -1325,14 +1324,12 @@ pub(super) fn spawn_run_auto_api_proxy(
     api_port: u16,
     api_listener: tokio::net::TcpListener,
     target_rx: &tokio::sync::watch::Receiver<election::ModelTargets>,
-    control_tx: &tokio::sync::mpsc::UnboundedSender<api::RuntimeControlRequest>,
     affinity_router: &affinity::AffinityRouter,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(Box::pin(api_proxy(
         node.clone(),
         api_port,
         target_rx.clone(),
-        control_tx.clone(),
         Some(api_listener),
         options.listen_all,
         affinity_router.clone(),

--- a/docs/plugins/plugin-hosted-mesh-serving-design.md
+++ b/docs/plugins/plugin-hosted-mesh-serving-design.md
@@ -125,10 +125,14 @@ the local proxy, find no local model, and route back out to another peer
 through `hosts_for_model()` — making the client a mesh-internal request relay.
 Nothing would *select* a client that way (clients never advertise `Host`), but
 any peer that deliberately dialed one could use it, which on a public mesh
-means any member. The same ingress also carries the `/mesh/load` and
-`/mesh/drop` control paths, which are dispatched ahead of the inference
-admission check; `/mesh/load` is refused for clients by the runtime control
-loop, and `/mesh/drop` is inert only because a client has nothing loaded.
+means any member. The OpenAI ingress is inference/discovery-only. The former
+`/mesh/load` and `/mesh/drop` paths are rejected with `410 Gone` before model
+routing, including when they arrive through an inbound HTTP tunnel, so they
+cannot mutate local runtime state or fall through as inference. Local lifecycle
+administration uses the trusted management API on `:3131`; remote lifecycle
+administration uses the authenticated owner-control plane. Topology-scoped
+Skippy stage control remains available on its separate cooperative-inference
+transport.
 
 Gating keeps a client exactly as reachable as it was before this change — not
 at all — and avoids widening a surface that issue #1190 exists to narrow.

--- a/website/src/docs/pages/runtime-lifecycle.md
+++ b/website/src/docs/pages/runtime-lifecycle.md
@@ -97,6 +97,11 @@ curl -s -X DELETE \
   localhost:3131/api/runtime/instances/<instance-id>
 ```
 
+The legacy `/mesh/load` and `/mesh/drop` paths on the peer-reachable `:9337`
+OpenAI ingress return `410 Gone` and never mutate or route runtime state. Use
+the `:3131` management API for local lifecycle changes and the authenticated
+owner-control endpoints for remote administration.
+
 Model-targeted unload applies to the resolved model. Instance-targeted unload
 selects one exact running instance.
 


### PR DESCRIPTION
## Original problem

`POST /mesh/load` and `POST /mesh/drop` were handled by the model-aware OpenAI ingress on `:9337`. Because inbound `STREAM_TUNNEL_HTTP` traffic is relayed to the loopback API port, an admitted peer could reach model lifecycle controls through the same channel intended for inference and discovery.

## Diagnostics

The request path was traced through the OpenAI ingress, the runtime proxy, and the inbound HTTP tunnel relay. Regression tests cover both direct ingress requests and the passive/bootstrap path used for tunneled peer HTTP requests.

## Fix

- Removed model load/drop runtime-control handlers and control-channel plumbing from the peer-reachable OpenAI ingress.
- Recognize the legacy `/mesh/load` and `/mesh/drop` paths before any inference or model routing, including query-string variants.
- Return HTTP `410 Gone` with the `legacy_route_gone` error code for those legacy paths. They do not reach an inference upstream and cannot mutate runtime state.
- Kept inference, model discovery, normal peer HTTP tunneling, and Skippy stage control/transport behavior unchanged.
- Retained the trusted local lifecycle API as the canonical path:
  - `POST :3131/api/runtime/models`
  - `DELETE :3131/api/runtime/models/{model}`
- Retained authenticated owner-control lifecycle commands for remote administration.
- Added tests proving the canonical management routes still load/unload models and the legacy ingress paths are rejected without routing or mutation.
- Updated hosted-mesh and runtime lifecycle documentation, including the compatibility behavior for older callers.

This is an HTTP-surface compatibility change only; the mesh wire protocol is unchanged, and mixed-version inference/split serving remains supported.

## Validation

- `just with-lld cargo test -p mesh-llm-host-runtime -- --test-threads=1` — 2,455 passed, 8 ignored.
- `just with-lld cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings` — passed.
- `just build` — passed.
- `just website-build` — passed.
- `git diff --check` — passed.
- No UI changes; screenshots are not applicable.

Closes #1190


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Legacy `/mesh/load` and `/mesh/drop` endpoints now return `410 Gone` without changing runtime state, including through inbound tunnels.
  * OpenAI interfaces remain available for inference and model discovery.

* **New Features**
  * Local lifecycle operations use the management API.
  * Remote administration uses authenticated owner-control endpoints.

* **Documentation**
  * Updated lifecycle and hosted mesh serving guidance.

* **Tests**
  * Added coverage confirming rejected lifecycle requests are not forwarded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->