### PR TITLE
fix: emit usage in Apple streaming completions

### DIFF
--- a/providers/apple/QA/rest.sh
+++ b/providers/apple/QA/rest.sh
@@ -111,7 +111,7 @@ curl --fail --silent --show-error \
 
 curl --fail --silent --show-error --no-buffer \
     -H 'content-type: application/json' \
-    --data-binary "{\"model\":\"$MODEL_ID\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: streaming REST ready\"}],\"temperature\":0,\"max_tokens\":32,\"stream\":true}" \
+    --data-binary "{\"model\":\"$MODEL_ID\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: streaming REST ready\"}],\"temperature\":0,\"max_tokens\":32,\"stream\":true,\"stream_options\":{\"include_usage\":true}}" \
     "$BASE_URL/v1/chat/completions" >"$OUTPUT_DIR/stream.txt"
 
 curl --fail --silent --show-error \
@@ -178,6 +178,12 @@ assert versioned_completion["model"] == versioned_models[0]["id"], versioned_com
 assert versioned_completion["choices"][0]["message"]["content"], versioned_completion
 assert "data: [DONE]" in stream, stream
 assert "chat.completion.chunk" in stream, stream
+stream_chunks = [
+    json.loads(line.removeprefix("data: ").strip())
+    for line in stream.splitlines()
+    if line.startswith("data: {")
+]
+assert any(chunk.get("usage", {}).get("completion_tokens", 0) > 0 for chunk in stream_chunks), stream
 assert tool["mesh_tool_executions"] == [{
     "name": "mesh_fixture_lookup",
     "arguments": {"key": "rest-demo"},

--- a/providers/apple/Sources/MeshAppleRuntime/Transport/LoopbackHTTPServer.swift
+++ b/providers/apple/Sources/MeshAppleRuntime/Transport/LoopbackHTTPServer.swift
@@ -182,7 +182,7 @@ public final class LoopbackHTTPServer: @unchecked Sendable {
       temperature: request.temperature
     )
     if request.stream == true {
-      try await stream(generation, connection: connection)
+      try await stream(generation, includeUsage: request.includeUsage, connection: connection)
       return
     }
     let result = try await runtime.generate(request: generation) { _ in }
@@ -239,6 +239,7 @@ public final class LoopbackHTTPServer: @unchecked Sendable {
 
   private func stream(
     _ request: AppleGenerationRequest,
+    includeUsage: Bool,
     connection: NWConnection
   ) async throws {
     sendHeaders(
@@ -250,7 +251,7 @@ public final class LoopbackHTTPServer: @unchecked Sendable {
     )
     let completionID = "chatcmpl-\(UUID().uuidString)"
     do {
-      _ = try await runtime.generate(request: request) { event in
+      let result = try await runtime.generate(request: request) { event in
         guard event.type == "delta", let delta = event.delta else { return }
         let payload: [String: Any] = [
           "id": completionID,
@@ -270,35 +271,52 @@ public final class LoopbackHTTPServer: @unchecked Sendable {
         else { return }
         connection.send(content: Data("data: \(json)\n\n".utf8), completion: .idempotent)
       }
+      let finalPayload: [String: Any] = [
+        "id": completionID,
+        "object": "chat.completion.chunk",
+        "created": Int(Date().timeIntervalSince1970),
+        "model": request.modelID,
+        "choices": [
+          [
+            "index": 0,
+            "delta": [:],
+            "finish_reason": "stop",
+          ]
+        ],
+      ]
+      let finalData = try JSONSerialization.data(withJSONObject: finalPayload)
+      let finalJSON = String(decoding: finalData, as: UTF8.self)
+      var trailer = "data: \(finalJSON)\n\n"
+      if includeUsage {
+        let usagePayload: [String: Any] = [
+          "id": completionID,
+          "object": "chat.completion.chunk",
+          "created": Int(Date().timeIntervalSince1970),
+          "model": request.modelID,
+          "choices": [],
+          "usage": usageObject(result.usage),
+        ]
+        let usageData = try JSONSerialization.data(withJSONObject: usagePayload)
+        trailer += "data: \(String(decoding: usageData, as: UTF8.self))\n\n"
+      }
+      trailer += "data: [DONE]\n\n"
+      connection.send(
+        content: Data(trailer.utf8), contentContext: .finalMessage, isComplete: true,
+        completion: .idempotent)
     } catch {
       let failure = (error as? AppleRuntimeFailure)
-        ?? AppleRuntimeFailure(code: "internal_error", message: String(describing: error), retryable: false)
+        ?? AppleRuntimeFailure(
+          code: "internal_error", message: String(describing: error), retryable: false)
       let payload: [String: Any] = [
         "error": ["code": failure.code, "message": failure.message, "retryable": failure.retryable]
       ]
       if let data = try? JSONSerialization.data(withJSONObject: payload),
-        let json = String(data: data, encoding: .utf8) {
+        let json = String(data: data, encoding: .utf8)
+      {
         connection.send(content: Data("data: \(json)\n\n".utf8), completion: .idempotent)
       }
+      return
     }
-    let finalPayload: [String: Any] = [
-      "id": completionID,
-      "object": "chat.completion.chunk",
-      "created": Int(Date().timeIntervalSince1970),
-      "model": request.modelID,
-      "choices": [
-        [
-          "index": 0,
-          "delta": [:],
-          "finish_reason": "stop",
-        ]
-      ],
-    ]
-    let finalData = try JSONSerialization.data(withJSONObject: finalPayload)
-    guard let finalJSON = String(data: finalData, encoding: .utf8) else { return }
-    let trailer = Data("data: \(finalJSON)\n\ndata: [DONE]\n\n".utf8)
-    connection.send(
-      content: trailer, contentContext: .finalMessage, isComplete: true, completion: .idempotent)
   }
 
   private func chatResponse(_ result: AppleGenerationResult) -> [String: Any] {
@@ -500,6 +518,14 @@ private struct HTTPRequest: Sendable {
 }
 
 private struct OpenAIChatRequest: Decodable, Sendable {
+  struct StreamOptions: Decodable, Sendable {
+    let includeUsage: Bool?
+
+    enum CodingKeys: String, CodingKey {
+      case includeUsage = "include_usage"
+    }
+  }
+
   struct Message: Decodable, Sendable {
     let role: String
     let content: String?
@@ -517,6 +543,7 @@ private struct OpenAIChatRequest: Decodable, Sendable {
   let model: String
   let messages: [Message]
   let stream: Bool?
+  let streamOptions: StreamOptions?
   let temperature: Double?
   let maxTokens: Int?
   let maxCompletionTokens: Int?
@@ -524,12 +551,17 @@ private struct OpenAIChatRequest: Decodable, Sendable {
 
   enum CodingKeys: String, CodingKey {
     case model, messages, stream, temperature, tools
+    case streamOptions = "stream_options"
     case maxTokens = "max_tokens"
     case maxCompletionTokens = "max_completion_tokens"
   }
 
   var responseTokenLimit: Int? {
     maxCompletionTokens ?? maxTokens
+  }
+
+  var includeUsage: Bool {
+    streamOptions?.includeUsage == true
   }
 
   var instructions: String? {


### PR DESCRIPTION
## Summary

The Apple runtime's non-streaming completions reported Foundation Models usage, but streaming completions ended with a stop chunk and `[DONE]` without a usage trailer. The console uses the streaming `/api/responses` path, so it received no `output_tokens` and could not render the tok/s counter for `apple/system` or Core AI models.

This stacked follow-up:

- honors `stream_options.include_usage` on the Apple REST carrier;
- emits the measured Apple completion usage on the final streaming chunk;
- keeps the existing OpenAI-compatible stream shape for callers that did not request usage;
- adds a REST QA assertion that streamed usage contains a positive completion-token count.

The console already measures the stream wall-clock interval, so once the usage trailer reaches the Responses adapter it can render tok/s without estimating tokens in the browser.

Stacked on #1261.

## Validation

- `just apple::test` (17 tests passed)
- `bash -n providers/apple/QA/rest.sh`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Streaming chat completions can now request usage statistics.
  * When enabled, usage data is returned in a final usage-only streaming chunk before completion.

* **Bug Fixes**
  * Improved streaming response handling to preserve the final completion data.
  * Added validation to confirm streamed completion-token usage is reported correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->