### PR TITLE
Fix split serving: stages above layer 0 fail to load

### DIFF
--- a/.agents/skills/llama-stage-patch-changes/SKILL.md
+++ b/.agents/skills/llama-stage-patch-changes/SKILL.md
@@ -163,6 +163,28 @@ LLAMA_WORKDIR="$tmp_root/llama.cpp" \
   scripts/build-llama.sh
 ```
 
+### Re-pinning upstream
+
+Advancing `third_party/llama.cpp/upstream.txt` can silently invalidate a patch
+that depends on upstream's *ordering*, not just its symbols. The queue still
+applies, everything compiles, and the behavior is broken. This happened with
+upstream `1269cb1`, which moved `check_tensor_dims` ahead of `buft_for_tensor`
+and left the stage tensor filter running too late; split serving was broken on
+main because no test opened a real mid-stage artifact.
+
+So on every re-pin, in addition to the checks above:
+
+- Read `git log <old-pin>..<new-pin> -- src/llama-model-loader.* src/llama-model.*`
+  for changes to load order, not just to signatures the patches touch.
+- Prove the staged load path with a real artifact whose first block is not
+  block 0. `cargo test -p skippy-model-package` covers this via
+  `mid_stage_artifact_opens_with_the_stage_filter_applied`.
+- Confirm that test actually ran rather than skipped. It is gated on
+  `SKIPPY_CORRECTNESS_MODEL`; without it the test prints
+  `skipping mid-stage: SKIPPY_CORRECTNESS_MODEL is not set` and passes. Grep the
+  CI log for `mid_stage_artifact_opens_with_the_stage_filter_applied ... ok`, or
+  set the variable locally. A skipped gate reads identically to a pass.
+
 Compile each new public header once as C11 and once as C++17 with warnings
 treated as errors. For implementation moves, run the tests owned by the moved
 capability in addition to the Rust fallout checks below.

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -86,7 +86,7 @@ jobs:
       - name: Prepare UI placeholder
         run: mkdir -p crates/mesh-llm-ui/dist && printf '<html></html>' > crates/mesh-llm-ui/dist/index.html
       - name: Prepare patched llama.cpp when required
-        if: ${{ contains(toJson(matrix.batch.crates), 'skippy-quantize') || contains(toJson(matrix.batch.crates), 'skippy-runtime') || contains(toJson(matrix.batch.crates), 'skippy-ffi') }}
+        if: ${{ contains(toJson(matrix.batch.crates), 'skippy-quantize') || contains(toJson(matrix.batch.crates), 'skippy-runtime') || contains(toJson(matrix.batch.crates), 'skippy-model-package') || contains(toJson(matrix.batch.crates), 'skippy-ffi') }}
         run: scripts/prepare-llama.sh pinned
       - name: Download immutable static ABI input
         uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
@@ -96,7 +96,7 @@ jobs:
       - name: Restore immutable static ABI input
         run: scripts/restore-static-abi-input.sh "$RUNNER_TEMP/static-abi-input" "$LLAMA_STAGE_BUILD_DIR" x86_64-unknown-linux-gnu cpu
       - name: Download Skippy correctness model when required
-        if: ${{ contains(toJson(matrix.batch.crates), 'skippy-runtime') }}
+        if: ${{ contains(toJson(matrix.batch.crates), 'skippy-runtime') || contains(toJson(matrix.batch.crates), 'skippy-model-package') }}
         run: |
           set -euo pipefail
           mkdir -p "$RUNNER_TEMP/skippy-correctness-model"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7452,6 +7452,7 @@ dependencies = [
  "skippy-ffi",
  "skippy-protocol",
  "skippy-runtime",
+ "tempfile",
  "tokio",
 ]
 

--- a/crates/skippy-model-package/Cargo.toml
+++ b/crates/skippy-model-package/Cargo.toml
@@ -18,3 +18,6 @@ serde.workspace = true
 serde_json.workspace = true
 sha2 = "0.10"
 tokio = { version = "1", features = ["rt"] }
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/skippy-model-package/src/tests.rs
+++ b/crates/skippy-model-package/src/tests.rs
@@ -423,8 +423,9 @@ fn mid_stage_artifact_opens_with_the_stage_filter_applied() -> anyhow::Result<()
     }
     let layer_start = layer_count / 2;
 
-    let dir = unique_test_dir("mid-stage-load");
-    let artifact = dir.join("stage-mid.gguf");
+    // RAII: the directory is removed when `dir` drops, on every exit path.
+    let dir = tempfile::tempdir()?;
+    let artifact = dir.path().join("stage-mid.gguf");
     let stage = crate::plan::stage_plan_from_tensors(
         1,
         layer_start,
@@ -433,10 +434,7 @@ fn mid_stage_artifact_opens_with_the_stage_filter_applied() -> anyhow::Result<()
         true,
         &source.tensors,
     );
-    if let Err(error) = crate::write::write_stage_artifact(&source, &stage, &artifact) {
-        let _ = std::fs::remove_dir_all(&dir);
-        return Err(error);
-    }
+    crate::write::write_stage_artifact(&source, &stage, &artifact)?;
 
     let config = RuntimeConfig {
         stage_index: 1,
@@ -454,10 +452,12 @@ fn mid_stage_artifact_opens_with_the_stage_filter_applied() -> anyhow::Result<()
         ..RuntimeConfig::default()
     };
 
-    let result = StageModel::open(&artifact, &config);
-    let _ = std::fs::remove_dir_all(&dir);
-    result.map_err(|error| {
+    let model = StageModel::open(&artifact, &config).map_err(|error| {
         anyhow::anyhow!("mid-stage load of layers {layer_start}..{layer_count} failed: {error}")
     })?;
+    // Close the model before the temp dir is removed: on Windows a mapped file
+    // cannot be deleted while it is still open.
+    drop(model);
+    dir.close()?;
     Ok(())
 }

--- a/crates/skippy-model-package/src/tests.rs
+++ b/crates/skippy-model-package/src/tests.rs
@@ -393,3 +393,68 @@ fn unique_test_dir(name: &str) -> PathBuf {
         std::process::id()
     ))
 }
+
+/// Regression cover for loading a stage that does not start at layer 0.
+///
+/// A mid-stage artifact legitimately contains no `blk.0.*` tensors. The native
+/// loader must consult the skippy stage filter *before* looking a tensor up;
+/// when the filter runs after the lookup instead, opening this artifact fails
+/// with `check_tensor_dims: tensor 'blk.0.attn_norm.weight' not found`.
+///
+/// Writing a real mid-stage artifact and opening it through the runtime is what
+/// makes this catch the bug: a full GGUF still contains block 0, so a filtered
+/// config over an unfiltered file exercises none of this.
+#[test]
+fn mid_stage_artifact_opens_with_the_stage_filter_applied() -> anyhow::Result<()> {
+    use skippy_runtime::{
+        FlashAttentionType, GGML_TYPE_F16, RuntimeConfig, RuntimeLoadMode, StageModel,
+    };
+
+    let Some(model_path) = std::env::var_os("SKIPPY_CORRECTNESS_MODEL").map(PathBuf::from) else {
+        eprintln!("skipping mid-stage load: SKIPPY_CORRECTNESS_MODEL is not set");
+        return Ok(());
+    };
+
+    let source = crate::write::ModelSource::open(&model_path)?;
+    let layer_count = crate::plan::layer_count(&source.tensors)?;
+    if layer_count < 2 {
+        eprintln!("skipping mid-stage load: model has fewer than 2 layers");
+        return Ok(());
+    }
+    let layer_start = layer_count / 2;
+
+    let dir = unique_test_dir("mid-stage-load");
+    let artifact = dir.join("stage-mid.gguf");
+    let stage = crate::plan::stage_plan_from_tensors(
+        1,
+        layer_start,
+        layer_count,
+        true,
+        true,
+        &source.tensors,
+    );
+    crate::write::write_stage_artifact(&source, &stage, &artifact)?;
+
+    let config = RuntimeConfig {
+        stage_index: 1,
+        layer_start,
+        layer_end: layer_count,
+        ctx_size: 256,
+        n_gpu_layers: 0,
+        cache_type_k: GGML_TYPE_F16,
+        cache_type_v: GGML_TYPE_F16,
+        flash_attn_type: FlashAttentionType::Auto,
+        load_mode: RuntimeLoadMode::RuntimeSlice,
+        include_embeddings: true,
+        include_output: true,
+        filter_tensors_on_load: true,
+        ..RuntimeConfig::default()
+    };
+
+    let result = StageModel::open(&artifact, &config);
+    let _ = std::fs::remove_dir_all(&dir);
+    result.map_err(|error| {
+        anyhow::anyhow!("mid-stage load of layers {layer_start}..{layer_count} failed: {error}")
+    })?;
+    Ok(())
+}

--- a/crates/skippy-model-package/src/tests.rs
+++ b/crates/skippy-model-package/src/tests.rs
@@ -433,7 +433,10 @@ fn mid_stage_artifact_opens_with_the_stage_filter_applied() -> anyhow::Result<()
         true,
         &source.tensors,
     );
-    crate::write::write_stage_artifact(&source, &stage, &artifact)?;
+    if let Err(error) = crate::write::write_stage_artifact(&source, &stage, &artifact) {
+        let _ = std::fs::remove_dir_all(&dir);
+        return Err(error);
+    }
 
     let config = RuntimeConfig {
         stage_index: 1,

--- a/third_party/llama.cpp/patches/0001-Add-staged-model-graph-and-family-support.patch
+++ b/third_party/llama.cpp/patches/0001-Add-staged-model-graph-and-family-support.patch
@@ -1,4 +1,4 @@
-From e6999a73cb1ecd85fe8ad89b14bd164b28a9ed58 Mon Sep 17 00:00:00 2001
+From d05c14f28310cbed10527f4fb1a1b2f32bad1a6c Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 8 Aug 2026 16:02:19 +1000
 Subject: [PATCH 01/15] Add staged model graph and family support
@@ -3279,7 +3279,7 @@ index ef82eb976..4f1f1df8d 100644
      }
      if (cell_count > size) {
 diff --git a/src/llama-model-loader.cpp b/src/llama-model-loader.cpp
-index 3d50f8a1c..4aa1d7e56 100644
+index 3d50f8a1c..1086cad36 100644
 --- a/src/llama-model-loader.cpp
 +++ b/src/llama-model-loader.cpp
 @@ -18,6 +18,25 @@ static const size_t kiB = 1024;
@@ -3368,7 +3368,7 @@ index 3d50f8a1c..4aa1d7e56 100644
              // make sure the main file is loaded first
              uint16_t idx = 0;
              const std::string kv_split_no = llm_kv(LLM_KV_SPLIT_NO);
-@@ -1090,14 +1149,20 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1090,14 +1149,101 @@ struct ggml_tensor * llama_model_loader::create_tensor(
          return it->second.get();
      };
  
@@ -3386,78 +3386,101 @@ index 3d50f8a1c..4aa1d7e56 100644
 +                return false;
              }
 -            throw std::runtime_error(format("missing tensor '%s'", tn.str().c_str()));
-         }
++        }
 +        return true;
 +    };
++
++    auto stage_filter_excludes = [&](ggml_tensor * t_meta) -> bool {
++        if (!g_skippy_filter.enabled) {
++            return false;
++        }
++
++        llm_tensor tn_tensor = tn.tensor;
++        if (tn.tensor == LLM_TENSOR_TOKEN_EMBD && (flags & TENSOR_DUPLICATED)) {
++            tn_tensor = LLM_TENSOR_OUTPUT;
+         }
  
++        llm_tensor_info info;
++        try {
++            info = llm_tensor_info_for(tn_tensor);
++        } catch (const std::out_of_range & e) {
++            // Leave the diagnostic to buft_for_tensor, which reports it with context.
++            return false;
++        }
++
++        bool keep = true;
++        switch (info.layer) {
++            case LLM_TENSOR_LAYER_INPUT:
++                keep = g_skippy_filter.include_embeddings;
++                break;
++            case LLM_TENSOR_LAYER_OUTPUT:
++                keep = g_skippy_filter.include_output;
++                break;
++            case LLM_TENSOR_LAYER_REPEATING:
++                keep = tn.bid >= g_skippy_filter.layer_start &&
++                       tn.bid <  g_skippy_filter.layer_end;
++                break;
++            default:
++                keep = true;
++                break;
++        }
++
++        if (!keep && llm_kv.arch == LLM_ARCH_GEMMA4 && hparams.n_embd_per_layer > 0) {
++            keep = tn.tensor == LLM_TENSOR_TOKEN_EMBD ||
++                   tn.tensor == LLM_TENSOR_PER_LAYER_TOKEN_EMBD ||
++                   tn.tensor == LLM_TENSOR_PER_LAYER_MODEL_PROJ ||
++                   tn.tensor == LLM_TENSOR_PER_LAYER_PROJ_NORM;
++        }
++        if (!keep && llm_kv.arch == LLM_ARCH_GEMMA3N) {
++            keep = tn.tensor == LLM_TENSOR_PER_LAYER_TOKEN_EMBD ||
++                   tn.tensor == LLM_TENSOR_PER_LAYER_MODEL_PROJ ||
++                   tn.tensor == LLM_TENSOR_PER_LAYER_PROJ_NORM ||
++                   (tn.tensor == LLM_TENSOR_ALTUP_PROJ && g_skippy_filter.include_embeddings) ||
++                   (tn.tensor == LLM_TENSOR_ALTUP_UNEMBD_PROJ && g_skippy_filter.include_output);
++        }
++
++        if (!keep) {
++            if (t_meta) {
++                const bool requested_tensor_exists =
++                        !(flags & TENSOR_NOT_REQUIRED) || requested_shape_matches(t_meta);
++                const std::string tensor_name = tn.str();
++                bool first_filtered_request = true;
++                if (requested_tensor_exists && !(flags & TENSOR_DUPLICATED)) {
++                    first_filtered_request = skippy_counted_filtered_tensors.insert(tensor_name).second;
++                }
++                const size_t nbytes = ggml_nbytes(t_meta);
++                LLAMA_LOG_DEBUG(
++                        "llama_model_loader: stage filter skipping tensor %s (size = %zu bytes)\n",
++                        tensor_name.c_str(),
++                        nbytes);
++
++                if (requested_tensor_exists && first_filtered_request) {
++                    size_data -= nbytes;
++                    if (!(flags & TENSOR_DUPLICATED)) {
++                        n_created++;
++                    }
++                }
++                g_skippy_last_tensor_filtered = true;
++            } else {
++                g_skippy_last_tensor_filtered = false;
++            }
++
++            return true;
++        }
++
++        return false;
++    };
++
 +    auto buft_for_tensor = [&](ggml_tensor * t_meta) -> ggml_backend_buffer_type_t {
          // some models use the token embedding tensor as the output, but since these are used in different layers and with different ops
          // the tensor is duplicated
          // to handle this, we check if the tensor is duplicated, and if so, we assume that it is being loaded as the output tensor
-@@ -1113,6 +1178,78 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1113,6 +1259,20 @@ struct ggml_tensor * llama_model_loader::create_tensor(
              throw std::runtime_error(format("missing tensor info mapping for %s", tn.str().c_str()));
          }
  
-+        if (g_skippy_filter.enabled) {
-+            bool keep = true;
-+            switch (info.layer) {
-+                case LLM_TENSOR_LAYER_INPUT:
-+                    keep = g_skippy_filter.include_embeddings;
-+                    break;
-+                case LLM_TENSOR_LAYER_OUTPUT:
-+                    keep = g_skippy_filter.include_output;
-+                    break;
-+                case LLM_TENSOR_LAYER_REPEATING:
-+                    keep = tn.bid >= g_skippy_filter.layer_start &&
-+                           tn.bid <  g_skippy_filter.layer_end;
-+                    break;
-+                default:
-+                    keep = true;
-+                    break;
-+            }
-+
-+            if (!keep && llm_kv.arch == LLM_ARCH_GEMMA4 && hparams.n_embd_per_layer > 0) {
-+                keep = tn.tensor == LLM_TENSOR_TOKEN_EMBD ||
-+                       tn.tensor == LLM_TENSOR_PER_LAYER_TOKEN_EMBD ||
-+                       tn.tensor == LLM_TENSOR_PER_LAYER_MODEL_PROJ ||
-+                       tn.tensor == LLM_TENSOR_PER_LAYER_PROJ_NORM;
-+            }
-+            if (!keep && llm_kv.arch == LLM_ARCH_GEMMA3N) {
-+                keep = tn.tensor == LLM_TENSOR_PER_LAYER_TOKEN_EMBD ||
-+                       tn.tensor == LLM_TENSOR_PER_LAYER_MODEL_PROJ ||
-+                       tn.tensor == LLM_TENSOR_PER_LAYER_PROJ_NORM ||
-+                       (tn.tensor == LLM_TENSOR_ALTUP_PROJ && g_skippy_filter.include_embeddings) ||
-+                       (tn.tensor == LLM_TENSOR_ALTUP_UNEMBD_PROJ && g_skippy_filter.include_output);
-+            }
-+
-+            if (!keep) {
-+                if (t_meta) {
-+                    const bool requested_tensor_exists =
-+                            !(flags & TENSOR_NOT_REQUIRED) || requested_shape_matches(t_meta);
-+                    const std::string tensor_name = tn.str();
-+                    bool first_filtered_request = true;
-+                    if (requested_tensor_exists && !(flags & TENSOR_DUPLICATED)) {
-+                        first_filtered_request = skippy_counted_filtered_tensors.insert(tensor_name).second;
-+                    }
-+                    const size_t nbytes = ggml_nbytes(t_meta);
-+                    LLAMA_LOG_DEBUG(
-+                            "llama_model_loader: stage filter skipping tensor %s (size = %zu bytes)\n",
-+                            tensor_name.c_str(),
-+                            nbytes);
-+
-+                    if (requested_tensor_exists && first_filtered_request) {
-+                        size_data -= nbytes;
-+                        if (!(flags & TENSOR_DUPLICATED)) {
-+                            n_created++;
-+                        }
-+                    }
-+                    g_skippy_last_tensor_filtered = true;
-+                } else {
-+                    g_skippy_last_tensor_filtered = false;
-+                }
-+
-+                return nullptr;
-+            }
++        if (stage_filter_excludes(t_meta)) {
++            return nullptr;
 +        }
 +
 +        if (!t_meta) {
@@ -3473,6 +3496,23 @@ index 3d50f8a1c..4aa1d7e56 100644
          // skip unused tensors
          if (info.op == GGML_OP_NONE || (flags & TENSOR_SKIP)) {
              const size_t nbytes = ggml_nbytes(t_meta);
+@@ -1269,6 +1429,16 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+     }
+ 
+     LLAMA_LOG_DEBUG("%s: loading tensor %s\n", __func__, tn.str().c_str());
++
++    // The stage filter must be consulted BEFORE the tensor is looked up: a filtered
++    // stage package legitimately does not contain tensors outside its layer range, so
++    // check_tensor_dims would throw "tensor 'blk.0.attn_norm.weight' not found" for a
++    // stage that starts above layer 0. buft_for_tensor also applies the filter, but it
++    // runs after this lookup on the file-backed path.
++    if (g_skippy_filter.enabled && stage_filter_excludes(get_tensor_meta(tn.str().c_str()))) {
++        return nullptr;
++    }
++
+     const struct ggml_tensor * cur = check_tensor_dims(tn.str(), ne, !(flags & TENSOR_NOT_REQUIRED), flags & TENSOR_ALLOW_RESHAPE);
+     if (cur == NULL) {
+         return NULL;
 diff --git a/src/llama-model-loader.h b/src/llama-model-loader.h
 index d6b31c231..74fc6c093 100644
 --- a/src/llama-model-loader.h


### PR DESCRIPTION
Split serving works again. A worker assigned a layer range that does not start at layer 0 currently fails to load its stage on `main` and never comes up, so no split can serve inference at all:

```text
llama_model_load: error loading model: check_tensor_dims: tensor 'blk.0.attn_norm.weight' not found
mesh-llm: skippy_model_open_from_parts returned status=ModelError
```

Fixes #1288.

## What broke

Correction to an earlier version of this description: **#1216 did not introduce the broken ordering.** Its pinned llama.cpp still called `buft_for_tensor` before `check_tensor_dims`, so the skippy filter ran early enough. The regression came from #1232 advancing the pin past upstream llama.cpp [`1269cb1`](https://github.com/ggml-org/llama.cpp/commit/1269cb1ff1598751f846241be90083ae9ad036fb) ("allow reshape of tensors during load"), which moved `check_tensor_dims` ahead of `buft_for_tensor`, without reconciling the skippy filter ordering that #1216 had placed inside the `buft_for_tensor` lambda.

On the file-backed load path that lambda is now not called until *after*:

```cpp
const struct ggml_tensor * cur = check_tensor_dims(tn.str(), ne, !(flags & TENSOR_NOT_REQUIRED), ...);
```

So a stage assigned layers 18..36 still walks blocks from 0, `blk.0.attn_norm.weight` is looked up before the filter can skip it, `get_tensor_meta` returns NULL because a filtered stage package legitimately has no block 0, and it throws.

The fix extracts the filter decision into a `stage_filter_excludes` helper and consults it ahead of `check_tensor_dims`, preserving the `size_data` / `n_created` / `g_skippy_last_tensor_filtered` bookkeeping from #1216. `buft_for_tensor` calls the same helper, so behavior on the virtual path is unchanged.

## Why tests didn't catch it

The `files.empty()` virtual path calls `buft_for_tensor` before any tensor lookup, so it kept working — every build and every existing test passed while real split serving was dead.

Nothing in the suite ever opened a genuine mid-stage artifact. `skippy-runtime`'s CI tests load a full Qwen3-0.6B GGUF at `layer_start: 0`, and `skippy-correctness`'s filtered-stage coverage is `#[ignore]`d behind model downloads. A filtered *config* over an unfiltered GGUF does not reproduce this, because a full GGUF still contains block 0 — the artifact has to actually be missing those tensors.

This PR adds that missing shape: a test that writes a real mid-stage artifact via `write_stage_artifact` and opens it through `StageModel`. It runs in CI wherever `SKIPPY_CORRECTNESS_MODEL` is already set.

## Validation

Patch-queue change only (patch 0001) — no Rust source changes outside the new test.

- Fresh `scripts/prepare-llama.sh pinned` replay of the full 15-patch queue applies cleanly and produces the intended tree.
- `scripts/build-llama.sh` clean.
- **With the fix:** `cargo test -p skippy-model-package` → 53 passed, 0 failed.
- **Without the fix** (same tree, filter hoist reverted, native rebuilt): the new test fails with the exact production error, `check_tensor_dims: tensor 'blk.0.attn_norm.weight' not found`.
- `cargo fmt --all --check` and `cargo clippy -p skippy-model-package --all-targets -- -D warnings` clean.

Two-machine split validation on real hardware is next; I'll post the result here. Filing now because `main` is broken.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for loading and running staged, multi-part model artifacts.
  - Added stage-aware execution with filtered tensor loading, activation support, and stage-boundary outputs.
  - Expanded support for Inkling models and improved compatibility with DeepSeek-based models.
  - Improved KV-cache management, including compaction, persistence, staged transfer, and indexer-key support.

- **Tests**
  - Added regression coverage for loading mid-stage artifacts with runtime tensor filtering enabled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
