### PR TITLE
fix(cache): certify Muse-Glimmer family for the resident-KV prefix cache

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/family_policy.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/family_policy.rs
@@ -267,7 +267,7 @@ fn family_policy_for_normalized_family_id(
         | "gptneox" | "bloom" | "stablelm" | "starcoder2" | "mpt" | "phi" | "phi2" | "phimoe"
         | "gpt2" | "mistral" | "internlm2" | "baichuan" | "exaone" | "exaone4" | "cohere2"
         | "command_r" | "falcon" | "qwen2vl" | "qwen3vl" | "deepseek2ocr" | "qwen3vlmoe"
-        | "openai_moe" | "ernie4_5_moe" | "llama4" | "mistral4" | "seed_oss" => {
+        | "openai_moe" | "ernie4_5_moe" | "llama4" | "mistral4" | "seed_oss" | "muse_glimmer" => {
             resident_kv_policy(activation_wire_dtype)
         }
         "qwen3next" | "falcon_h1" | "jamba" | "lfm2" | "mamba" | "mamba2" | "rwkv6" | "rwkv7"
@@ -578,6 +578,40 @@ mod tests {
                 max_entries: 16,
             }
         );
+    }
+
+    /// Regression: Muse-Glimmer must get the resident-KV prefix cache.
+    ///
+    /// The arch is supported by the pinned llama.cpp, but the family was
+    /// missing from the cache certification list, so every agent turn
+    /// re-prefilled the full context (`cached_tokens=0`, ~10x turn latency
+    /// on long agent transcripts).
+    #[test]
+    fn muse_glimmer_policy_comes_from_gguf_architecture() {
+        let policy = family_policy_for_gguf_meta(&meta("muse-glimmer"), None);
+
+        assert_eq!(policy.activation_wire_dtype, StageWireDType::F16);
+        assert_eq!(
+            policy.prefix_cache,
+            FamilyPrefixCachePolicy::Auto {
+                payload: FamilyPrefixCachePayload::ResidentKv,
+                min_tokens: 256,
+                max_entries: 16,
+            }
+        );
+    }
+
+    #[test]
+    fn muse_glimmer_policy_comes_from_model_id() {
+        let policy = family_policy_for_model_id("meta-models/Muse-Glimmer-30B-GGUF:Q4_K_M");
+
+        assert!(matches!(
+            policy.prefix_cache,
+            FamilyPrefixCachePolicy::Auto {
+                payload: FamilyPrefixCachePayload::ResidentKv,
+                ..
+            }
+        ));
     }
 
     #[test]

--- a/crates/skippy-topology/src/family_capability.rs
+++ b/crates/skippy-topology/src/family_capability.rs
@@ -1369,6 +1369,15 @@ fn infer_mid_remaining_capability(
     layer_count: u32,
     activation_width: u32,
 ) -> Option<FamilyCapabilityRecord> {
+    if compact.contains("museglimmer") {
+        return Some(dense_family_capability(
+            "muse_glimmer",
+            layer_count,
+            activation_width,
+            WireValidation::Untested,
+            ExactStateMobility::Untested,
+        ));
+    }
     if compact.contains("mpt") {
         return Some(dense_family_capability(
             "mpt",


### PR DESCRIPTION
## Problem

Muse-Glimmer's architecture is supported by the pinned llama.cpp, but the family was never added to the cache certification list. Family inference fell through to `unknown_family_policy` ("family cache policy is not certified"), so the prefix cache stayed disabled and **every request re-prefilled the full context** — `cached_tokens=0` on all turns.

For agent workloads (buzz-agent, goose, pi) this is catastrophic: a 15k-token agent transcript re-prefills every round, ~110s per LLM call on Muse-Glimmer-30B Q4_K_M where a warm prefix costs well under a second. A 4-round tool task took ~8 minutes wall clock, ~80% of it redundant prefill.

Config overrides couldn't rescue it either: `[defaults.model_fit.prefix_cache] enabled = true` alone still resolved payload `Auto` → `infer_cache_payload` → `Disabled` for the unrecognized identity.

## Fix

- Add `muse_glimmer` to family capability inference in `skippy-topology` (dense, standard attention — same shape as the certified `qwen3vl` family; `WireValidation::Untested` / `ExactStateMobility::Untested` like other newly-certified dense families).
- Add `muse_glimmer` to the resident-KV policy list in the host runtime.
- Regression tests: policy via GGUF architecture (`muse-glimmer`) and via model id (`meta-models/Muse-Glimmer-30B-GGUF:Q4_K_M`).

## Measured

Muse-Glimmer-30B Q4_K_M (M4 64GB, Metal), 2.4k-token prompt, second identical request, default config (no env vars, no config.toml):

| | cached_tokens | prompt_ms |
|---|---|---|
| before | 0 | 11002 |
| after | **2304** | **601** |

For reference, certified Qwen3.5-4B on the same box: cached=2416, prompt_ms=11 — same mechanism now working for Glimmer.

`cargo test -p mesh-llm-host-runtime --lib muse_glimmer` passes; clippy clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Muse-Glimmer models.
  * Muse-Glimmer models now use resident-KV caching and are recognized with the appropriate dense capability and mobility behavior.
* **Bug Fixes**
  * Improved model detection across architecture metadata and model identifiers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->