### PR TITLE
fix(ci): keep main planning exhaustive

### DIFF
--- a/.github/workflows/ci-runner-contract-slice.yml
+++ b/.github/workflows/ci-runner-contract-slice.yml
@@ -69,7 +69,11 @@ jobs:
           workflow_targets=(
             .github/workflows/ci.yml
             .github/workflows/main_*.yml
-            .github/workflows/pr_*.yml
+            .github/workflows/pr_quality.yml
+            .github/workflows/pr_website.yml
+            .github/workflows/pr_linux.yml
+            .github/workflows/pr_macos.yml
+            .github/workflows/pr_windows.yml
             .github/workflows/ci-control.yml
             .github/workflows/ci-*-lane.yml
             .github/workflows/ci-*-slice.yml

--- a/scripts/plan-ci.py
+++ b/scripts/plan-ci.py
@@ -352,10 +352,10 @@ def _affected_crates(
     raw: object,
 ) -> list[str]:
     workspace_names = [package["name"] for package in packages]
-    if raw is not None and raw != []:
-        affected = _string_list(raw, "affected_crates")
-    elif profile in {"main", "manual-full"}:
+    if profile in {"main", "manual-full"}:
         affected = workspace_names
+    elif raw is not None and raw != []:
+        affected = _string_list(raw, "affected_crates")
     else:
         script = root / "scripts" / "affected-crates.sh"
         result = subprocess.run(

--- a/scripts/tests/test_plan_ci.py
+++ b/scripts/tests/test_plan_ci.py
@@ -207,20 +207,31 @@ class PlanCiTests(unittest.TestCase):
             "trusted-readwrite",
         )
 
-    def test_main_ignores_partial_affected_crate_input(self) -> None:
-        payload = fixture("main.json")
-        payload["affected_crates"] = ["mesh-llm"]
-
-        plan = PLANNER.build_plan(payload, root=ROOT)
-
+    def test_full_profiles_ignore_partial_affected_crate_input(self) -> None:
         workspace = {"mesh-llm", "mesh-llm-host-runtime", "mesh-llm-config"}
-        tested = {
-            crate
-            for batch in plan["matrices"]["rust_tests"]
-            for crate in batch["crates"]
-        }
-        self.assertEqual(set(plan["affected_crates"]), workspace)
-        self.assertEqual(tested, workspace)
+        for profile, event_name in (
+            ("main", "push"),
+            ("manual-full", "workflow_dispatch"),
+        ):
+            with self.subTest(profile=profile):
+                payload = fixture("main.json")
+                payload.update(
+                    {
+                        "profile": profile,
+                        "event_name": event_name,
+                        "affected_crates": ["mesh-llm"],
+                    }
+                )
+
+                plan = PLANNER.build_plan(payload, root=ROOT)
+
+                tested = {
+                    crate
+                    for batch in plan["matrices"]["rust_tests"]
+                    for crate in batch["crates"]
+                }
+                self.assertEqual(set(plan["affected_crates"]), workspace)
+                self.assertEqual(tested, workspace)
 
     def test_control_plane_changes_fail_open_to_the_profile_rows(self) -> None:
         payload = fixture("runtime.json")

--- a/scripts/tests/test_plan_ci.py
+++ b/scripts/tests/test_plan_ci.py
@@ -207,6 +207,21 @@ class PlanCiTests(unittest.TestCase):
             "trusted-readwrite",
         )
 
+    def test_main_ignores_partial_affected_crate_input(self) -> None:
+        payload = fixture("main.json")
+        payload["affected_crates"] = ["mesh-llm"]
+
+        plan = PLANNER.build_plan(payload, root=ROOT)
+
+        workspace = {"mesh-llm", "mesh-llm-host-runtime", "mesh-llm-config"}
+        tested = {
+            crate
+            for batch in plan["matrices"]["rust_tests"]
+            for crate in batch["crates"]
+        }
+        self.assertEqual(set(plan["affected_crates"]), workspace)
+        self.assertEqual(tested, workspace)
+
     def test_control_plane_changes_fail_open_to_the_profile_rows(self) -> None:
         payload = fixture("runtime.json")
         payload["changed_files"] = [".github/workflows/pr_linux.yml"]

--- a/scripts/tests/test_reusable_workflow_runner_trust.py
+++ b/scripts/tests/test_reusable_workflow_runner_trust.py
@@ -107,6 +107,20 @@ class ReusableWorkflowRunnerTrustTests(unittest.TestCase):
         )
         self.assertNotIn("2>/dev/null", workflow)
 
+    def test_runner_contract_scans_only_pr_validation_entrypoints(self) -> None:
+        workflow = self.workflow("ci-runner-contract-slice.yml")
+        for name in (
+            "pr_quality.yml",
+            "pr_website.yml",
+            "pr_linux.yml",
+            "pr_macos.yml",
+            "pr_windows.yml",
+        ):
+            self.assertIn(f".github/workflows/{name}", workflow)
+        self.assertNotIn(".github/workflows/pr_*.yml", workflow)
+        self.assertNotIn(".github/workflows/pr_auto_assign.yml", workflow)
+        self.assertNotIn(".github/workflows/pr_cleanup.yml", workflow)
+
     def test_sdk_slice_matches_parsed_row_ids(self) -> None:
         linux = self.workflow("ci-linux-sdk-slice.yml")
         macos = self.workflow("ci-macos-sdk-slice.yml")


### PR DESCRIPTION
## Summary

- make main/manual-full planning ignore partial diff-scoped affected-crate input
- preserve the exhaustive workspace Rust matrix required by trusted main builds
- scope the PR runner-policy scan to the five validation entrypoints, excluding metadata-only cleanup/assignment workflows
- add regressions for both integration failures observed after #1282

## Validation

- targeted planner/runner-contract tests: 35 passed
- `just ci-validate`: 430 passed, 7 skipped; actionlint and all consistency checks passed

## Incident

The first direct five-workflow main run after #1282 passed a diff-scoped `affected_crates` list into the main profile. The planner honored that partial list before applying the main profile policy, then correctly rejected its own non-exhaustive Rust-test matrix. The merged base also broadened the runner-contract glob to metadata-only `pull_request_target` workflows, contradicting the documented five-entrypoint validation boundary. This change makes the exhaustive profile authoritative and keeps the runner scan aligned with that boundary.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Full CI validation now runs for main and manual full-check profiles, even when only a partial set of changed components is provided.
  * CI workflow checks now target the intended pull request validation workflows explicitly, improving scan reliability.

* **Tests**
  * Added coverage for complete affected-component detection, Rust test execution, and precise workflow selection in full CI plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->