### PR TITLE
Fix CI planning failure that blocks every main push

### DIFF
--- a/scripts/plan-ci.py
+++ b/scripts/plan-ci.py
@@ -352,10 +352,18 @@ def _affected_crates(
     raw: object,
 ) -> list[str]:
     workspace_names = [package["name"] for package in packages]
-    if raw is not None and raw != []:
-        affected = _string_list(raw, "affected_crates")
-    elif profile in {"main", "manual-full"}:
+    if profile in {"main", "manual-full"}:
+        # Main and manual-full always validate the whole workspace; a narrower
+        # caller-supplied list would violate the full-coverage invariant that
+        # _validate_plan asserts for these profiles.
+        if raw is not None and raw != []:
+            supplied = _string_list(raw, "affected_crates")
+            unknown = sorted(set(supplied) - set(workspace_names))
+            if unknown:
+                raise PlanError(f"affected_crates contains non-workspace crates: {unknown}")
         affected = workspace_names
+    elif raw is not None and raw != []:
+        affected = _string_list(raw, "affected_crates")
     else:
         script = root / "scripts" / "affected-crates.sh"
         result = subprocess.run(

--- a/scripts/tests/test_plan_ci.py
+++ b/scripts/tests/test_plan_ci.py
@@ -339,6 +339,41 @@ class PlanCiTests(unittest.TestCase):
         ):
             PLANNER._validate_manifests(ownership, slices)
 
+    def test_main_ignores_narrow_caller_supplied_affected_crates(self) -> None:
+        payload = fixture("main.json")
+        payload["affected_crates"] = ["mesh-llm-config"]
+
+        plan = PLANNER.build_plan(payload, root=ROOT)
+
+        workspace = {"mesh-llm", "mesh-llm-host-runtime", "mesh-llm-config"}
+        tested = {
+            crate
+            for batch in plan["matrices"]["rust_tests"]
+            for crate in batch["crates"]
+        }
+        self.assertEqual(tested, workspace)
+        self.assertEqual(set(plan["affected_crates"]), workspace)
+
+    def test_manual_full_ignores_narrow_caller_supplied_affected_crates(self) -> None:
+        payload = fixture("main.json")
+        payload["profile"] = "manual-full"
+        payload["event_name"] = "workflow_dispatch"
+        payload["affected_crates"] = ["mesh-llm-config"]
+
+        plan = PLANNER.build_plan(payload, root=ROOT)
+
+        self.assertEqual(
+            set(plan["affected_crates"]),
+            {"mesh-llm", "mesh-llm-host-runtime", "mesh-llm-config"},
+        )
+
+    def test_main_still_rejects_non_workspace_affected_crates(self) -> None:
+        payload = fixture("main.json")
+        payload["affected_crates"] = ["not-a-crate"]
+
+        with self.assertRaises(PLANNER.PlanError):
+            PLANNER.build_plan(payload, root=ROOT)
+
     def test_manifest_domain_row_mapping_rejects_unknown_ids(self) -> None:
         ownership = json.loads((ROOT / "ci" / "ownership.yml").read_text())
         slices = json.loads((ROOT / "ci" / "slices.yml").read_text())


### PR DESCRIPTION
Every push to `main` since the split entry workflows landed (53b70ad, #1282) fails in its `Plan <lane>` job before any real work starts, so `Main · Quality`, `Main · Website`, `Main · macOS`, `Main · Linux` and `Main · Windows` are all red:

```
ERROR: unable to build CI plan: main rust test matrix does not cover every workspace crate
Process completed with exit code 2
```

After this change main pushes plan normally again and the five lanes run.

## Cause

`scripts/plan-ci.py` asserts that `main` and `manual-full` runs test every workspace crate, but it only derived that full list when the caller supplied no `affected_crates`. A non-empty caller list won, even on main.

The new `main_*.yml` entry workflows always pass the computed list. 53b70ad is a CI-only commit, so `affected-crates.sh` produced `["xtask"]` — the planner built a one-crate test matrix and then tripped its own coverage assertion.

This is a latent bug that #1282 exposed rather than introduced. Under the previous topology main pushes went through `ci-control.yml` on `workflow_run`, whose bootstrap detection set `should_dispatch=false` and gated out the planner entirely, so main was never actually planned. The assertion exists identically before #1282 and fails the same way given the same inputs.

## Fix

Derive the full workspace list for `main` and `manual-full` regardless of what the caller passes, so the guarantee lives in the component that asserts it and a future entry workflow cannot reintroduce this. Non-workspace crate names supplied by a caller are still rejected.

## Validation

Reproduced the production failure and confirmed the fix against 53b70ad's real changed-file list and its logged `AFFECTED_CRATES: ["xtask"]`:

```
before: PlanError: main rust test matrix does not cover every workspace crate
after:  OK, profile=main, 61 crates tested across 4 batches
```

Three regression tests added to `scripts/tests/test_plan_ci.py`:
- main ignores a narrow caller-supplied `affected_crates` and still plans the full matrix
- `manual-full` does the same
- main still rejects a non-workspace crate name

`python3 -m unittest scripts.tests.test_plan_ci` — the new tests pass. Two errors and one failure in that module are pre-existing and unrelated (macOS bash 3.2 has no `local -A`, so `affected-crates.sh` cannot run locally); they are identical with and without this change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - CI plans for the `main` and `manual-full` profiles now consistently include all workspace packages, even when a narrower package list is supplied.
  - Invalid package names are still rejected with a clear planning error.
- **Tests**
  - Added coverage to verify complete workspace planning and validation of unknown packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->