### PR TITLE
Prevent stale native runtime reuse across branch builds

### DIFF
--- a/crates/mesh-llm-commands/src/runtime_native.rs
+++ b/crates/mesh-llm-commands/src/runtime_native.rs
@@ -420,6 +420,7 @@ mod tests {
         std::fs::write(path.join("lib/libllama.so"), b"native runtime").unwrap();
         NativeRuntimeManifest {
             runtime: NativeRuntimeArtifact {
+                build_id: None,
                 id: runtime_id.to_string(),
                 mesh_version: Some(CURRENT_MESH_VERSION.to_string()),
                 skippy_abi: "0.1.25".to_string(),

--- a/crates/mesh-llm-commands/src/runtime_native/setup_helpers.rs
+++ b/crates/mesh-llm-commands/src/runtime_native/setup_helpers.rs
@@ -302,6 +302,7 @@ mod tests {
 
     fn fake_install_outcome(mesh_version: &str) -> NativeRuntimeInstallOutcome {
         let artifact = NativeRuntimeArtifact {
+            build_id: None,
             id: "meshllm-runtime-linux-x86_64-cpu".to_string(),
             mesh_version: Some(mesh_version.to_string()),
             skippy_abi: "0.1.25".to_string(),

--- a/crates/mesh-llm-hardware-profile/src/lib.rs
+++ b/crates/mesh-llm-hardware-profile/src/lib.rs
@@ -984,6 +984,7 @@ mod tests {
             vulkan: None,
         };
         let artifact = |id: &str, backend: NativeRuntimeBackend| NativeRuntimeArtifact {
+            build_id: None,
             id: id.to_string(),
             mesh_version: Some("test".to_string()),
             skippy_abi: "test-abi".to_string(),

--- a/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
@@ -455,6 +455,7 @@ mod dynamic {
             fs::write(dir.join(&library_rel_path), b"native runtime").unwrap();
             let manifest = NativeRuntimeManifest {
                 runtime: NativeRuntimeArtifact {
+                    build_id: None,
                     id: id.to_string(),
                     mesh_version: version.map(ToString::to_string),
                     skippy_abi: "0.1.25".to_string(),
@@ -728,6 +729,7 @@ mod dynamic {
                 artifacts: Vec::new(),
             };
             let artifact = NativeRuntimeArtifact {
+                build_id: None,
                 id: runtime_id.to_string(),
                 mesh_version: Some(release_version.to_string()),
                 skippy_abi: "0.1.25".to_string(),

--- a/crates/mesh-llm-native-runtime/src/cache.rs
+++ b/crates/mesh-llm-native-runtime/src/cache.rs
@@ -421,6 +421,7 @@ mod tests {
         let manifest = NativeRuntimeManifest {
             runtime: NativeRuntimeArtifact {
                 id: id.to_string(),
+                build_id: None,
                 mesh_version: Some(version.to_string()),
                 skippy_abi: "0.1.25".to_string(),
                 platform: NativeRuntimePlatform {

--- a/crates/mesh-llm-native-runtime/src/manifest.rs
+++ b/crates/mesh-llm-native-runtime/src/manifest.rs
@@ -23,6 +23,8 @@ pub struct NativeRuntimePlatform {
 pub struct NativeRuntimeArtifact {
     pub id: String,
     #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub build_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub mesh_version: Option<String>,
     pub skippy_abi: String,
     pub platform: NativeRuntimePlatform,
@@ -163,6 +165,14 @@ fn validate_artifact(artifact: &NativeRuntimeArtifact) -> Result<()> {
     if artifact.id.trim().is_empty() {
         bail!("native runtime artifact id is empty");
     }
+    if let Some(build_id) = &artifact.build_id {
+        validate_build_id(build_id).with_context(|| {
+            format!(
+                "native runtime artifact {} has invalid build_id",
+                artifact.id
+            )
+        })?;
+    }
     if artifact.skippy_abi.trim().is_empty() {
         bail!(
             "native runtime artifact {} skippy_abi is empty",
@@ -242,6 +252,20 @@ fn validate_runtime_path(relative: &str) -> Result<()> {
     Ok(())
 }
 
+fn validate_build_id(value: &str) -> Result<()> {
+    let Some(digest) = value.strip_prefix("sha256:") else {
+        bail!("expected sha256:<64 lowercase hex>");
+    };
+    if digest.len() != 64
+        || !digest
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+    {
+        bail!("expected sha256:<64 lowercase hex>");
+    }
+    Ok(())
+}
+
 fn normalize_sha256(value: &str) -> Result<String> {
     let value = value
         .trim()
@@ -292,6 +316,7 @@ mod tests {
             r#"{
   "runtime": {
     "id": "meshllm-runtime-linux-x86_64-cuda12",
+    "build_id": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
     "mesh_version": "0.68.0",
     "skippy_abi": "0.1.25",
     "platform": {
@@ -319,6 +344,10 @@ mod tests {
         let manifest = NativeRuntimeManifest::read_from_dir(temp.path()).unwrap();
 
         assert_eq!(manifest.runtime.id, "meshllm-runtime-linux-x86_64-cuda12");
+        assert_eq!(
+            manifest.runtime.build_id.as_deref(),
+            Some("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        );
         assert_eq!(manifest.runtime.skippy_abi, "0.1.25");
         assert_eq!(manifest.runtime.backend.kind.as_str(), "cuda");
     }
@@ -345,7 +374,37 @@ mod tests {
         .unwrap();
 
         assert_eq!(manifest.artifacts.len(), 1);
+        assert_eq!(manifest.artifacts[0].build_id, None);
         assert_eq!(manifest.artifacts[0].backend, NativeRuntimeBackend::cpu());
+    }
+
+    #[test]
+    fn rejects_invalid_runtime_build_ids() {
+        for build_id in [
+            "",
+            &"a".repeat(64),
+            &format!("sha256:{}", "a".repeat(63)),
+            &format!("sha256:{}", "A".repeat(64)),
+            &format!("sha256:{}g", "a".repeat(63)),
+        ] {
+            let json = format!(
+                r#"{{
+  "mesh_version": "0.68.0",
+  "skippy_abi": "0.1.25",
+  "artifacts": [{{
+    "id": "runtime",
+    "build_id": "{build_id}",
+    "skippy_abi": "0.1.25",
+    "platform": {{"os": "linux", "arch": "x86_64"}},
+    "backend": {{"kind": "cpu"}},
+    "libraries": ["lib/runtime.so"]
+  }}]
+}}"#
+            );
+
+            let error = NativeRuntimeReleaseManifest::from_json_str(&json).unwrap_err();
+            assert!(error.to_string().contains("invalid build_id"), "{build_id}");
+        }
     }
 
     #[test]
@@ -357,6 +416,7 @@ mod tests {
         let manifest = NativeRuntimeManifest {
             runtime: NativeRuntimeArtifact {
                 id: "meshllm-runtime-linux-x86_64-cpu".to_string(),
+                build_id: None,
                 mesh_version: Some("0.68.0".to_string()),
                 skippy_abi: "0.1.25".to_string(),
                 platform: NativeRuntimePlatform {
@@ -395,6 +455,7 @@ mod tests {
         let manifest = NativeRuntimeManifest {
             runtime: NativeRuntimeArtifact {
                 id: "meshllm-runtime-linux-x86_64-cuda12".to_string(),
+                build_id: None,
                 mesh_version: Some("0.68.0".to_string()),
                 skippy_abi: "0.1.25".to_string(),
                 platform: NativeRuntimePlatform {
@@ -478,6 +539,7 @@ mod tests {
     fn rejects_runtime_checksum_path_traversal() {
         let artifact = NativeRuntimeArtifact {
             id: "meshllm-runtime-linux-x86_64-cpu".to_string(),
+            build_id: None,
             mesh_version: Some("0.68.0".to_string()),
             skippy_abi: "0.1.25".to_string(),
             platform: NativeRuntimePlatform {

--- a/crates/mesh-llm-native-runtime/src/resolver.rs
+++ b/crates/mesh-llm-native-runtime/src/resolver.rs
@@ -205,7 +205,9 @@ impl NativeRuntimeResolver {
             artifact.mesh_version_or(&self.mesh_version),
             artifact.native_runtime_id(),
         )?;
-        if let Some(installed) = installed {
+        if let Some(installed) = installed
+            && artifact_identity_matches(&installed.manifest.runtime, artifact)
+        {
             return Ok(NativeRuntimeSource::Installed {
                 path: installed.path,
             });
@@ -223,6 +225,10 @@ fn parse_cuda_major(value: &str) -> Option<u32> {
 }
 
 fn artifact_key(artifact: &NativeRuntimeArtifact) -> String {
+    // Candidate evaluation is lane-based: the selected release/bundle artifact
+    // must replace any installed candidate for the same lane. Build identity is
+    // enforced later by source_for_artifact when deciding whether cached bytes
+    // satisfy that selected artifact.
     format!(
         "{}\0{}\0{}",
         artifact.id,
@@ -376,6 +382,10 @@ fn artifact_identity_matches(
     candidate.id == selected.id
         && candidate.mesh_version.as_deref() == selected.mesh_version.as_deref()
         && candidate.skippy_abi == selected.skippy_abi
+        && selected
+            .build_id
+            .as_ref()
+            .is_none_or(|build_id| candidate.build_id.as_ref() == Some(build_id))
 }
 
 fn evaluate_backend_requirements(
@@ -577,6 +587,7 @@ mod tests {
     fn artifact(id: &str, backend: NativeRuntimeBackend) -> NativeRuntimeArtifact {
         NativeRuntimeArtifact {
             id: id.to_string(),
+            build_id: None,
             mesh_version: Some("0.68.0".to_string()),
             skippy_abi: "0.1.25".to_string(),
             platform: NativeRuntimePlatform {
@@ -1008,6 +1019,7 @@ mod tests {
             mesh_version: "0.67.0".to_string(),
             skippy_abi: "0.1.25".to_string(),
             artifacts: vec![NativeRuntimeArtifact {
+                build_id: None,
                 mesh_version: Some("0.67.0".to_string()),
                 ..cuda_runtime("meshllm-runtime-linux-x86_64-cuda12", 12, &["sm_90"])
             }],
@@ -1030,6 +1042,7 @@ mod tests {
             mesh_version: "0.67.0".to_string(),
             skippy_abi: "0.1.25".to_string(),
             artifacts: vec![NativeRuntimeArtifact {
+                build_id: None,
                 mesh_version: Some("0.67.0".to_string()),
                 ..cuda_runtime("meshllm-runtime-linux-x86_64-cuda12", 12, &["sm_90"])
             }],
@@ -1121,12 +1134,101 @@ mod tests {
         );
     }
 
+    fn resolve_with_cached_and_selected_build(
+        cached_build_id: Option<&str>,
+        selected_build_id: Option<&str>,
+    ) -> NativeRuntimeResolution {
+        let bundle = tempfile::tempdir().unwrap();
+        let cache_root = tempfile::tempdir().unwrap();
+        let runtime_id = "meshllm-runtime-linux-x86_64-cpu";
+        let mut cached = artifact(runtime_id, NativeRuntimeBackend::cpu());
+        cached.build_id = cached_build_id.map(str::to_string);
+        write_bundle_runtime(bundle.path(), cached);
+        let cache = NativeRuntimeCache::new(cache_root.path());
+        let installed = cache.install_from_dir(bundle.path()).unwrap();
+
+        let mut selected = artifact(runtime_id, NativeRuntimeBackend::cpu());
+        selected.build_id = selected_build_id.map(str::to_string);
+        selected.url = Some("https://example.invalid/runtime.tar.gz".to_string());
+        let resolution = NativeRuntimeResolver::new(
+            "0.68.0",
+            HostRuntimeProfile {
+                available_flavors: BTreeSet::from([NativeRuntimeBackendKind::Cpu]),
+                cuda: None,
+                ..profile()
+            },
+            NativeRuntimeReleaseManifest {
+                mesh_version: "0.68.0".to_string(),
+                skippy_abi: "0.1.25".to_string(),
+                artifacts: vec![selected],
+            },
+            cache,
+        )
+        .with_skippy_abi_version("0.1.25")
+        .resolve(&RuntimeSelection::Recommended)
+        .unwrap();
+        assert_eq!(
+            installed.path,
+            cache_root.path().join("0.68.0").join(runtime_id)
+        );
+        resolution
+    }
+
+    #[test]
+    fn selected_build_does_not_reuse_cached_runtime_without_build_id() {
+        let resolution = resolve_with_cached_and_selected_build(
+            None,
+            Some("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        );
+        assert!(matches!(
+            resolution.source,
+            NativeRuntimeSource::Download { .. }
+        ));
+    }
+
+    #[test]
+    fn selected_build_does_not_reuse_cached_runtime_with_different_build_id() {
+        let resolution = resolve_with_cached_and_selected_build(
+            Some("sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+            Some("sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+        );
+        assert!(matches!(
+            resolution.source,
+            NativeRuntimeSource::Download { .. }
+        ));
+    }
+
+    #[test]
+    fn selected_build_reuses_cached_runtime_with_matching_build_id() {
+        let resolution = resolve_with_cached_and_selected_build(
+            Some("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+            Some("sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+        );
+        assert!(matches!(
+            resolution.source,
+            NativeRuntimeSource::Installed { .. }
+        ));
+    }
+
+    #[test]
+    fn legacy_selected_artifact_reuses_cached_runtime_regardless_of_build_id() {
+        let resolution = resolve_with_cached_and_selected_build(
+            Some("sha256:dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd"),
+            None,
+        );
+        assert!(matches!(
+            resolution.source,
+            NativeRuntimeSource::Installed { .. }
+        ));
+    }
+
     #[test]
     fn stale_bundle_with_same_id_does_not_satisfy_selected_artifact() {
         let bundle = tempfile::tempdir().unwrap();
         let cache_root = tempfile::tempdir().unwrap();
         let runtime_id = "meshllm-runtime-linux-x86_64-cpu";
         let stale_bundle_artifact = NativeRuntimeArtifact {
+            build_id: None,
             mesh_version: Some("0.67.0".to_string()),
             ..artifact(runtime_id, NativeRuntimeBackend::cpu())
         };

--- a/crates/mesh-llm-runtime-install/src/discovery.rs
+++ b/crates/mesh-llm-runtime-install/src/discovery.rs
@@ -294,6 +294,7 @@ mod tests {
         fs::write(path.join("lib/libllama.so"), b"runtime").unwrap();
         NativeRuntimeManifest {
             runtime: NativeRuntimeArtifact {
+                build_id: None,
                 id: id.to_string(),
                 mesh_version: Some("0.75.0".to_string()),
                 skippy_abi: "0.1.25".to_string(),

--- a/crates/mesh-llm-system/src/benchmark/tests.rs
+++ b/crates/mesh-llm-system/src/benchmark/tests.rs
@@ -342,6 +342,7 @@ fn test_runtime_tool_selection_excludes_preferred_legacy_runtime_without_tool() 
         path: PathBuf::from(format!("/test/{id}")),
         manifest: NativeRuntimeManifest {
             runtime: NativeRuntimeArtifact {
+                build_id: None,
                 id: id.to_string(),
                 mesh_version: Some("0.74.0".to_string()),
                 skippy_abi: "0.1.0".to_string(),

--- a/scripts/package-native-runtime.sh
+++ b/scripts/package-native-runtime.sh
@@ -656,6 +656,22 @@ manifest = {
         "llama_patch_digest": "$patch_digest" or None,
     },
 }
+canonical_runtime = {
+    key: value
+    for key, value in manifest["runtime"].items()
+    if key not in {"url", "sha256", "signature"}
+}
+build_identity = {
+    "runtime": canonical_runtime,
+    "build": manifest["build"],
+}
+canonical_bytes = json.dumps(
+    build_identity,
+    sort_keys=True,
+    separators=(",", ":"),
+    ensure_ascii=False,
+).encode("utf-8")
+manifest["runtime"]["build_id"] = "sha256:" + hashlib.sha256(canonical_bytes).hexdigest()
 with open(manifest_path, "w", encoding="utf-8") as fh:
     json.dump(manifest, fh, indent=2, sort_keys=True)
     fh.write("\\n")

--- a/scripts/tests/test_package_native_runtime.py
+++ b/scripts/tests/test_package_native_runtime.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -13,6 +14,44 @@ SCRIPT = ROOT / "scripts" / "package-native-runtime.sh"
 
 
 class PackageNativeRuntimeTests(unittest.TestCase):
+    def test_build_id_is_deterministic_and_preserves_runtime_identity(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            build_dir = root / "build"
+            build_dir.mkdir()
+            (build_dir / "libggml.so").write_bytes(b"dependency")
+            (build_dir / "libllama.so").write_bytes(b"primary")
+            env = self.package_environment(root, build_dir)
+
+            first = self.package_cpu(root / "first", env)
+            second = self.package_cpu(root / "second", env)
+
+            runtime = first["runtime"]
+            self.assertEqual(runtime["id"], "meshllm-native-runtime-linux-x86_64-cpu")
+            self.assertRegex(runtime["build_id"], r"^sha256:[0-9a-f]{64}$")
+            self.assertEqual(runtime["build_id"], second["runtime"]["build_id"])
+            self.assertEqual(runtime["build_id"], self.expected_build_id(first))
+            self.assertTrue(
+                (root / "first" / f'{runtime["id"]}.tar.gz').is_file()
+            )
+
+    def test_build_id_changes_when_canonical_runtime_content_changes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            build_dir = root / "build"
+            build_dir.mkdir()
+            library = build_dir / "libllama.so"
+            library.write_bytes(b"first content")
+            env = self.package_environment(root, build_dir)
+            first = self.package_cpu(root / "first", env)
+
+            library.write_bytes(b"second content")
+            second = self.package_cpu(root / "second", env)
+
+            self.assertNotEqual(
+                first["runtime"]["build_id"], second["runtime"]["build_id"]
+            )
+
     def test_cpu_package_with_no_tools_is_safe_under_macos_bash(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -137,6 +176,13 @@ class PackageNativeRuntimeTests(unittest.TestCase):
                 manifest["runtime"]["backend"]["rocm"]["gpu_arches"],
                 ["gfx90a", "gfx942", "gfx1151"],
             )
+            self.assertEqual(
+                manifest["runtime"]["build_id"], self.expected_build_id(manifest)
+            )
+            self.assertEqual(
+                list(manifest["runtime"]["tools"]),
+                ["tools/mesh-llm-gpu-benchmark"],
+            )
 
     def test_cuda_flavor_uses_mesh_cuda_version_major(self) -> None:
         self.assertEqual(
@@ -172,6 +218,56 @@ class PackageNativeRuntimeTests(unittest.TestCase):
                     "MESH_LLM_CUDA_TOOLKIT_MAJOR must be digits-only",
                     result.stderr,
                 )
+
+    def expected_build_id(self, manifest: dict) -> str:
+        runtime = {
+            key: value
+            for key, value in manifest["runtime"].items()
+            if key not in {"build_id", "url", "sha256", "signature"}
+        }
+        canonical = json.dumps(
+            {"runtime": runtime, "build": manifest["build"]},
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=False,
+        ).encode("utf-8")
+        return f"sha256:{hashlib.sha256(canonical).hexdigest()}"
+
+    def package_environment(self, root: Path, build_dir: Path) -> dict[str, str]:
+        tool_dir = root / "tools"
+        tool_dir.mkdir(exist_ok=True)
+        patchelf = tool_dir / "patchelf"
+        patchelf.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+        patchelf.chmod(0o755)
+        env = os.environ.copy()
+        env["LLAMA_STAGE_BUILD_DIR"] = str(build_dir)
+        env["PATH"] = f"{tool_dir}{os.pathsep}{env['PATH']}"
+        return env
+
+    def package_cpu(self, output: Path, env: dict[str, str]) -> dict:
+        result = subprocess.run(
+            [
+                "/bin/bash",
+                str(SCRIPT),
+                "--backend",
+                "cpu",
+                "--target",
+                "x86_64-unknown-linux-gnu",
+                "--out",
+                str(output),
+            ],
+            env=env,
+            text=True,
+            capture_output=True,
+        )
+        result.check_returncode()
+        return json.loads(
+            (
+                output
+                / "meshllm-native-runtime-linux-x86_64-cpu"
+                / "manifest.json"
+            ).read_text(encoding="utf-8")
+        )
 
     def backend_flavor(
         self,


### PR DESCRIPTION
🤖 Branch and release builds that share a MeshLLM version and runtime lane no longer reuse stale native-runtime bytes from the cache.

Native runtime manifests now carry an optional content-derived `runtime.build_id`. The resolver requires a matching build ID whenever the selected artifact supplies one, while preserving legacy matching for older manifests without build identity.

## Compatibility

- Stable `runtime.id` values are unchanged.
- Runtime directory names inside archives are unchanged.
- Release archive filenames and download URLs are unchanged.
- Existing manifests without `build_id` continue to deserialize and resolve under legacy behavior.
- The cache layout remains `<version>/<runtime.id>`; a mismatched selected build bypasses stale installed bytes and resolves the explicit bundle/download, which then replaces the lane normally.

## Build identity

`build_id` is `sha256:<64 lowercase hex>` over canonical runtime metadata, backend architecture requirements, sorted library/tool checksums, and native build provenance. Mutable distribution fields (`url`, archive checksum, signature) are excluded so repackaging identical runtime contents does not change identity.

## Validation

At `9ab9ca30`:

- `cargo fmt --all --check`
- `cargo test -p mesh-llm-native-runtime --lib` — 39 passed
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `python3 -m unittest discover -s scripts/tests -p 'test_package_native_runtime.py'` — 9 passed
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Runtime packages now include deterministic build identifiers based on their contents and build metadata.
  - Build identifiers are validated to ensure they use the expected SHA-256 format.

- **Bug Fixes**
  - Cached runtimes are reused only when their build identifier matches the selected runtime, helping prevent stale or incompatible bundles.
  - Older runtime manifests without build identifiers remain compatible.

- **Tests**
  - Added coverage for deterministic identifiers, content changes, matching behavior, missing identifiers, and invalid values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Cache behavior

This change **detects and refuses stale build reuse; it does not retain multiple builds for one lane**. The cache remains one directory per `<version>/<runtime.id>`, and installing another build replaces that lane as before. A selected local artifact with no bundle/download source and mismatched cached bytes resolves as missing rather than silently loading the wrong build. Multi-build retention would require a separate cache-layout and prune-semantics change.
