### PR TITLE
ci: add bounded Depot PR canary gate

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -168,9 +168,9 @@ Relevant repository variable names include `DEPOT_RUNNERS_ENABLED`,
 `refs/pull/<number>/merge` ref only). The latter is a bounded selector
 canary, not a cache-isolation proof or a replacement for the global PR gate.
 Native Actions-cache consumers remain a documented unresolved boundary for
-any future Depot PR run. `CUDA_VERSION`, `VULKAN_SDK_VERSION`, smoke
-configuration variables, and release/deployment variables. Secret values
-never belong in this inventory;
+any future Depot PR run. Other variables include `CUDA_VERSION`,
+`VULKAN_SDK_VERSION`, smoke configuration variables, and release/deployment
+variables. Secret values never belong in this inventory;
 known names include `HF_TOKEN`, release-attestation keys, `CARGO_REGISTRY_TOKEN`
 and deployment tokens.
 

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -163,9 +163,14 @@ comparison, and rollback run are still pending; `DEPOT_RUNNERS_ENABLED` or a
 successful manual canary does not prove PR isolation.
 
 Relevant repository variable names include `DEPOT_RUNNERS_ENABLED`,
-`DEPOT_PR_RUNNERS_ENABLED` (absent/false until protected PR activation),
-`CUDA_VERSION`, `VULKAN_SDK_VERSION`, smoke configuration variables, and
-release/deployment variables. Secret values never belong in this inventory;
+`DEPOT_PR_RUNNERS_ENABLED` (absent/false until protected PR activation), and
+`DEPOT_PR_CANARY_REF` (absent by default; one exact
+`refs/pull/<number>/merge` ref only). The latter is a bounded selector
+canary, not a cache-isolation proof or a replacement for the global PR gate.
+Native Actions-cache consumers remain a documented unresolved boundary for
+any future Depot PR run. `CUDA_VERSION`, `VULKAN_SDK_VERSION`, smoke
+configuration variables, and release/deployment variables. Secret values
+never belong in this inventory;
 known names include `HF_TOKEN`, release-attestation keys, `CARGO_REGISTRY_TOKEN`
 and deployment tokens.
 

--- a/.github/actions/audit-depot-pr-isolation/action.yml
+++ b/.github/actions/audit-depot-pr-isolation/action.yml
@@ -49,6 +49,9 @@ runs:
 
         for endpoint_name in ACTIONS_CACHE_URL ACTIONS_RESULTS_URL; do
           endpoint="${!endpoint_name:-}"
+          if [[ -z "$endpoint" ]]; then
+            continue
+          fi
           endpoint_lower="$(printf '%s' "$endpoint" | tr '[:upper:]' '[:lower:]')"
           if [[ ! "$endpoint_lower" =~ ^https://([a-z0-9-]+\.)*actions\.githubusercontent\.com(:[0-9]+)?([/?#]|$) ]]; then
             echo "PR runner received a non-GitHub Actions endpoint: $endpoint_name" >&2

--- a/.github/actions/audit-depot-pr-isolation/action.yml
+++ b/.github/actions/audit-depot-pr-isolation/action.yml
@@ -6,6 +6,9 @@ inputs:
     description: Original event used to derive the trust boundary.
     required: false
     default: ''
+  depot_selected:
+    description: Whether the centralized runner policy selected a Depot executor.
+    required: true
 
 runs:
   using: composite
@@ -14,12 +17,19 @@ runs:
       shell: bash
       env:
         INPUT_ORIGINAL_EVENT_NAME: ${{ inputs.original_event_name }}
+        INPUT_DEPOT_SELECTED: ${{ inputs.depot_selected }}
       run: |
         set -euo pipefail
         original_event="${INPUT_ORIGINAL_EVENT_NAME:-${GITHUB_EVENT_NAME:-}}"
         if [[ "$original_event" != "pull_request" &&
               "$original_event" != "pull_request_target" ]]; then
           exit 0
+        fi
+
+        depot_selected="${INPUT_DEPOT_SELECTED:-}"
+        if [[ "$depot_selected" != "true" && "$depot_selected" != "false" ]]; then
+          echo "depot_selected must be true or false, got: $depot_selected" >&2
+          exit 1
         fi
 
         forbidden_names=(
@@ -53,6 +63,17 @@ runs:
             continue
           fi
           endpoint_lower="$(printf '%s' "$endpoint" | tr '[:upper:]' '[:lower:]')"
+          if [[ "$endpoint_lower" == *depot.dev* ]]; then
+            echo "PR runner received a Depot Actions endpoint: $endpoint_name" >&2
+            exit 1
+          fi
+          if [[ "$endpoint_lower" =~ ^https?://[^/]*@ ]]; then
+            echo "PR runner received an Actions endpoint with URL userinfo: $endpoint_name" >&2
+            exit 1
+          fi
+          if [[ "$depot_selected" != "true" ]]; then
+            continue
+          fi
           if [[ ! "$endpoint_lower" =~ ^https://([a-z0-9-]+\.)*actions\.githubusercontent\.com(:[0-9]+)?([/?#]|$) ]]; then
             echo "PR runner received a non-GitHub Actions endpoint: $endpoint_name" >&2
             exit 1

--- a/.github/actions/select-ci-runners/action.yml
+++ b/.github/actions/select-ci-runners/action.yml
@@ -26,6 +26,10 @@ inputs:
     description: Exact-string repository gate for direct pull-request Depot placement.
     required: false
     default: "false"
+  pr_canary_ref:
+    description: Optional exact pull-request merge ref selected for a protected canary.
+    required: false
+    default: ""
   force_hosted:
     description: Fail-closed planner signal for CI-control or runner-policy changes.
     required: false
@@ -88,6 +92,7 @@ runs:
         INPUT_REF: ${{ inputs.ref }}
         INPUT_DEPOT_MAIN_ENABLED: ${{ inputs.depot_main_enabled }}
         INPUT_DEPOT_PR_ENABLED: ${{ inputs.depot_pr_enabled }}
+        INPUT_PR_CANARY_REF: ${{ inputs.pr_canary_ref }}
         INPUT_FORCE_HOSTED: ${{ inputs.force_hosted }}
         INPUT_MANUAL_USE_DEPOT: ${{ inputs.manual_use_depot }}
       run: |
@@ -106,10 +111,18 @@ runs:
           fi
         done
 
+        pr_canary_ref="${INPUT_PR_CANARY_REF:-}"
+        if [[ -n "$pr_canary_ref" &&
+          ! "$pr_canary_ref" =~ ^refs/pull/[0-9]+/merge$ ]]; then
+          echo "INPUT_PR_CANARY_REF must be an exact pull-request merge ref" >&2
+          exit 1
+        fi
+
         # A direct PR may opt into Depot only when this protected repository
-        # explicitly enables the feature. Both the base and PR-head repository
-        # comparisons remain exact so a fork, mirror, or similarly named
-        # repository cannot opt in.
+        # explicitly enables the feature, or when one exact merge ref is
+        # selected for the protected canary. Both the base and PR-head
+        # repository comparisons remain exact so a fork, mirror, or similarly
+        # named repository cannot opt in.
         trusted_repository="Mesh-LLM/mesh-llm"
         depot_enabled=false
         allow_depot_remote_cache=false
@@ -128,7 +141,8 @@ runs:
               "$INPUT_HEAD_REPOSITORY" == "$trusted_repository" && \
               "$INPUT_REF" =~ ^refs/pull/[0-9]+/merge$ && \
               "$INPUT_FORCE_HOSTED" == "false" && \
-              "$INPUT_DEPOT_PR_ENABLED" == "true" ]]; then
+              ( "$INPUT_DEPOT_PR_ENABLED" == "true" ||
+                ( -n "$pr_canary_ref" && "$INPUT_REF" == "$pr_canary_ref" ) ) ]]; then
               is_direct_pull_request=true
               depot_enabled=true
             fi

--- a/.github/workflows/ci-linux-host-slice.yml
+++ b/.github/workflows/ci-linux-host-slice.yml
@@ -105,7 +105,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-linux-host-slice.yml
+++ b/.github/workflows/ci-linux-host-slice.yml
@@ -79,6 +79,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: ${{ vars.DEPOT_RUNNERS_ENABLED == 'true' }}
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
           manual_use_depot: ${{ inputs.use_depot }}
 

--- a/.github/workflows/ci-linux-host-slice.yml
+++ b/.github/workflows/ci-linux-host-slice.yml
@@ -105,7 +105,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_8, 'depot-') }}

--- a/.github/workflows/ci-linux-host-slice.yml
+++ b/.github/workflows/ci-linux-host-slice.yml
@@ -108,6 +108,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_8, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-linux-product-slice.yml
+++ b/.github/workflows/ci-linux-product-slice.yml
@@ -85,6 +85,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-linux-product-slice.yml
+++ b/.github/workflows/ci-linux-product-slice.yml
@@ -62,6 +62,7 @@ jobs:
           # Product composition is not in the trusted-main Depot allowlist.
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
 
   linux_product:

--- a/.github/workflows/ci-linux-product-slice.yml
+++ b/.github/workflows/ci-linux-product-slice.yml
@@ -82,7 +82,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-linux-product-slice.yml
+++ b/.github/workflows/ci-linux-product-slice.yml
@@ -82,7 +82,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/ci-linux-runtime-slice.yml
+++ b/.github/workflows/ci-linux-runtime-slice.yml
@@ -103,7 +103,7 @@ jobs:
       LLAMA_STAGE_SKIP_NCCL: "1"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-linux-runtime-slice.yml
+++ b/.github/workflows/ci-linux-runtime-slice.yml
@@ -72,6 +72,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: ${{ vars.DEPOT_RUNNERS_ENABLED == 'true' }}
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
           manual_use_depot: ${{ inputs.use_depot }}
 

--- a/.github/workflows/ci-linux-runtime-slice.yml
+++ b/.github/workflows/ci-linux-runtime-slice.yml
@@ -103,7 +103,7 @@ jobs:
       LLAMA_STAGE_SKIP_NCCL: "1"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_16, 'depot-') }}

--- a/.github/workflows/ci-linux-runtime-slice.yml
+++ b/.github/workflows/ci-linux-runtime-slice.yml
@@ -106,6 +106,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_16, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-macos-host-slice.yml
+++ b/.github/workflows/ci-macos-host-slice.yml
@@ -89,7 +89,7 @@ jobs:
       matrix:
         host: ${{ fromJson(inputs.hosts_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-macos-host-slice.yml
+++ b/.github/workflows/ci-macos-host-slice.yml
@@ -89,7 +89,7 @@ jobs:
       matrix:
         host: ${{ fromJson(inputs.hosts_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-host-slice.yml
+++ b/.github/workflows/ci-macos-host-slice.yml
@@ -74,6 +74,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
 
   macos_host:

--- a/.github/workflows/ci-macos-host-slice.yml
+++ b/.github/workflows/ci-macos-host-slice.yml
@@ -92,6 +92,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-macos-product-slice.yml
+++ b/.github/workflows/ci-macos-product-slice.yml
@@ -75,7 +75,7 @@ jobs:
       matrix:
         runtime: ${{ fromJson(inputs.runtime_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-product-slice.yml
+++ b/.github/workflows/ci-macos-product-slice.yml
@@ -75,7 +75,7 @@ jobs:
       matrix:
         runtime: ${{ fromJson(inputs.runtime_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-macos-product-slice.yml
+++ b/.github/workflows/ci-macos-product-slice.yml
@@ -60,6 +60,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
 
   macos_product:

--- a/.github/workflows/ci-macos-product-slice.yml
+++ b/.github/workflows/ci-macos-product-slice.yml
@@ -78,6 +78,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-macos-runtime-slice.yml
+++ b/.github/workflows/ci-macos-runtime-slice.yml
@@ -65,6 +65,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
 
   macos_runtime:

--- a/.github/workflows/ci-macos-runtime-slice.yml
+++ b/.github/workflows/ci-macos-runtime-slice.yml
@@ -86,6 +86,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-macos-runtime-slice.yml
+++ b/.github/workflows/ci-macos-runtime-slice.yml
@@ -83,7 +83,7 @@ jobs:
       LLAMA_STAGE_BACKEND: ${{ matrix.runtime.backend }}
       LLAMA_STAGE_BUILD_DIR: ${{ matrix.runtime.build_dir }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-runtime-slice.yml
+++ b/.github/workflows/ci-macos-runtime-slice.yml
@@ -83,7 +83,7 @@ jobs:
       LLAMA_STAGE_BACKEND: ${{ matrix.runtime.backend }}
       LLAMA_STAGE_BUILD_DIR: ${{ matrix.runtime.build_dir }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-platform-checks-slice.yml
+++ b/.github/workflows/ci-platform-checks-slice.yml
@@ -99,6 +99,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(fromJSON(needs.runner_policy.outputs.runner_by_platform)[matrix.check.platform], 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-platform-checks-slice.yml
+++ b/.github/workflows/ci-platform-checks-slice.yml
@@ -72,6 +72,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
       - name: Map platform runners explicitly
         id: platform_runners

--- a/.github/workflows/ci-platform-checks-slice.yml
+++ b/.github/workflows/ci-platform-checks-slice.yml
@@ -96,7 +96,7 @@ jobs:
       matrix:
         check: ${{ fromJson(inputs.platform_checks_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-platform-checks-slice.yml
+++ b/.github/workflows/ci-platform-checks-slice.yml
@@ -96,7 +96,7 @@ jobs:
       matrix:
         check: ${{ fromJson(inputs.platform_checks_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(fromJSON(needs.runner_policy.outputs.runner_by_platform)[matrix.check.platform], 'depot-') }}

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 20
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -126,7 +126,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 15
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -160,7 +160,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_8, 'depot-') }}
@@ -210,7 +210,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 5
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -81,6 +81,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: ${{ vars.DEPOT_RUNNERS_ENABLED == 'true' }}
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
           manual_use_depot: ${{ inputs.use_depot }}
 

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -94,6 +94,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}
@@ -128,6 +129,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}
@@ -161,6 +163,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_8, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}
@@ -210,6 +213,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -91,7 +91,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 20
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -125,7 +125,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 15
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -158,7 +158,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -207,7 +207,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 5
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -106,6 +106,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -103,7 +103,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -76,6 +76,7 @@ jobs:
           # Rust tests are not in the existing trusted-main Depot allowlist.
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
 
   rust_tests:

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -103,7 +103,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -72,7 +72,7 @@ jobs:
       run:
         working-directory: crates/mesh-llm-ui
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -72,7 +72,7 @@ jobs:
       run:
         working-directory: crates/mesh-llm-ui
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -75,6 +75,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -60,6 +60,7 @@ jobs:
           # producer. PR placement is independently gated and cache-isolated.
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
 
   ui_artifact:

--- a/.github/workflows/ci-web-slice.yml
+++ b/.github/workflows/ci-web-slice.yml
@@ -58,6 +58,7 @@ jobs:
           # Website is not in the existing trusted-main Depot allowlist.
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
 
   ui_quality:

--- a/.github/workflows/ci-web-slice.yml
+++ b/.github/workflows/ci-web-slice.yml
@@ -74,6 +74,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}
@@ -119,6 +120,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-web-slice.yml
+++ b/.github/workflows/ci-web-slice.yml
@@ -71,7 +71,7 @@ jobs:
       run:
         working-directory: crates/mesh-llm-ui
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -116,7 +116,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 20
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-web-slice.yml
+++ b/.github/workflows/ci-web-slice.yml
@@ -71,7 +71,7 @@ jobs:
       run:
         working-directory: crates/mesh-llm-ui
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -117,7 +117,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 20
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-windows-host-slice.yml
+++ b/.github/workflows/ci-windows-host-slice.yml
@@ -95,6 +95,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-windows-host-slice.yml
+++ b/.github/workflows/ci-windows-host-slice.yml
@@ -74,6 +74,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
 
   windows_host:

--- a/.github/workflows/ci-windows-host-slice.yml
+++ b/.github/workflows/ci-windows-host-slice.yml
@@ -92,7 +92,7 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/ci-windows-host-slice.yml
+++ b/.github/workflows/ci-windows-host-slice.yml
@@ -92,7 +92,7 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-windows-product-slice.yml
+++ b/.github/workflows/ci-windows-product-slice.yml
@@ -78,6 +78,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/ci-windows-product-slice.yml
+++ b/.github/workflows/ci-windows-product-slice.yml
@@ -75,7 +75,7 @@ jobs:
       matrix:
         runtime: ${{ fromJson(inputs.runtime_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/ci-windows-product-slice.yml
+++ b/.github/workflows/ci-windows-product-slice.yml
@@ -75,7 +75,7 @@ jobs:
       matrix:
         runtime: ${{ fromJson(inputs.runtime_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/ci-windows-product-slice.yml
+++ b/.github/workflows/ci-windows-product-slice.yml
@@ -60,6 +60,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
 
   windows_product:

--- a/.github/workflows/ci-windows-runtime-slice.yml
+++ b/.github/workflows/ci-windows-runtime-slice.yml
@@ -86,7 +86,7 @@ jobs:
       WINDOWS_VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION || '1.4.328.1' }}
       ROCM_HIP_SDK_FILENAME: AMD-Software-PRO-Edition-25.Q3-WinSvr2022-For-HIP.exe
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - name: Validate immutable source SHA

--- a/.github/workflows/ci-windows-runtime-slice.yml
+++ b/.github/workflows/ci-windows-runtime-slice.yml
@@ -89,6 +89,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}
       - name: Validate immutable source SHA
         shell: pwsh
         env:

--- a/.github/workflows/ci-windows-runtime-slice.yml
+++ b/.github/workflows/ci-windows-runtime-slice.yml
@@ -64,6 +64,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
 
   windows_runtime:

--- a/.github/workflows/ci-windows-runtime-slice.yml
+++ b/.github/workflows/ci-windows-runtime-slice.yml
@@ -86,7 +86,7 @@ jobs:
       WINDOWS_VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION || '1.4.328.1' }}
       ROCM_HIP_SDK_FILENAME: AMD-Software-PRO-Edition-25.Q3-WinSvr2022-For-HIP.exe
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/depot-canary.yml
+++ b/.github/workflows/depot-canary.yml
@@ -83,9 +83,12 @@ jobs:
           fi
           for endpoint_name in ACTIONS_CACHE_URL ACTIONS_RESULTS_URL; do
             endpoint="${!endpoint_name:-}"
+            if [[ -z "$endpoint" ]]; then
+              continue
+            fi
             endpoint_lower="${endpoint,,}"
             if [[ ! "$endpoint_lower" =~ ^https://([a-z0-9-]+\.)*actions\.githubusercontent\.com(:[0-9]+)?([/?#]|$) ]]; then
-              echo "GitHub Actions endpoint is missing or not GitHub-owned: $endpoint_name" >&2
+              echo "GitHub Actions endpoint is not GitHub-owned: $endpoint_name" >&2
               exit 1
             fi
           done

--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -208,7 +208,7 @@ jobs:
     env:
       LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-static
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}
@@ -313,7 +313,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -208,7 +208,7 @@ jobs:
     env:
       LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-static
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
@@ -312,7 +312,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -118,6 +118,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: ${{ vars.DEPOT_RUNNERS_ENABLED == 'true' }}
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
           manual_use_depot: ${{ inputs.use_depot }}
       - name: Resolve runner size and target

--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -211,6 +211,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}
@@ -315,6 +316,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/static-abi-artifact.yml
+++ b/.github/workflows/static-abi-artifact.yml
@@ -145,7 +145,7 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       SCCACHE_GHA_ENABLED: "true"
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/static-abi-artifact.yml
+++ b/.github/workflows/static-abi-artifact.yml
@@ -84,6 +84,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: ${{ vars.DEPOT_RUNNERS_ENABLED == 'true' }}
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
           manual_use_depot: ${{ inputs.use_depot }}
       - name: Resolve runner size and target

--- a/.github/workflows/static-abi-artifact.yml
+++ b/.github/workflows/static-abi-artifact.yml
@@ -148,6 +148,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/static-abi-artifact.yml
+++ b/.github/workflows/static-abi-artifact.yml
@@ -145,7 +145,7 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       SCCACHE_GHA_ENABLED: "true"
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -104,6 +104,7 @@ jobs:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ inputs.source_sha || github.sha }}

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -81,6 +81,7 @@ jobs:
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
+          pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
 
   swift_sdk_artifact:

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -101,7 +101,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_RW_MODE: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event.inputs.original_event_name == 'pull_request' || github.event.inputs.original_event_name == 'pull_request_target') && 'READ_ONLY' || 'READ_WRITE' }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
         with:
           original_event_name: ${{ inputs.original_event_name }}
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -101,7 +101,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_RW_MODE: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event.inputs.original_event_name == 'pull_request' || github.event.inputs.original_event_name == 'pull_request_target') && 'READ_ONLY' || 'READ_WRITE' }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -228,10 +228,17 @@ stay on their approved placement. Trusted main Linux work may use Depot only
 when DEPOT_RUNNERS_ENABLED is exactly true, with a GitHub-hosted fallback.
 Callers never provide raw labels or independent remote-cache permission.
 
-Depot PR execution is not implemented. Depot's documented GitHub cache path is
+Depot PR execution is not enabled. The selector has a bounded
+`DEPOT_PR_CANARY_REF` hook for one exact same-repository merge ref, while the
+global `DEPOT_PR_RUNNERS_ENABLED` gate remains absent/false. Fork heads,
+`pull_request_target`, dispatches and planner-forced hosted paths remain on
+GitHub-hosted runners. Depot's documented GitHub cache path is
 repository-scoped and not branch-isolated; automatic cache redirection can
 expose repository-wide cache authority to PR code. Cache-key prefixes are not
-isolation.
+isolation. Native `actions/cache` consumers remain an unresolved boundary for
+the canary hook, so the hook is not itself an isolation proof and must not be
+enabled until the actual Depot/WebDAV authority is tested or those consumers
+are explicitly disabled.
 
 Before a PR Depot path is enabled, an administrator must prove:
 

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -40,6 +40,10 @@ Depot is a placement provider, not a different CI graph.
   remains hosted.
 - Callers never provide a raw Depot label or a separate remote-cache
   permission. Runner and cache policy come from one event-derived decision.
+- The PR isolation audit receives that selected-provider decision. Depot-selected
+  PR jobs require GitHub-owned Actions endpoints; hosted PR jobs allow the
+  runner's approved local transport while still rejecting Depot credentials,
+  `depot.dev` redirects, and URL userinfo.
 
 Disabling Depot must change placement only. It must not change plan membership,
 commands, artifacts, smoke coverage or required checks.

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -25,6 +25,12 @@ Depot is a placement provider, not a different CI graph.
   placement gate. It must remain absent or `false` until the branch/main
   provider-parity, same-repository, and fork sentinel canaries below pass; a
   missing value fails closed.
+- `DEPOT_PR_CANARY_REF` is an optional, exact
+  `refs/pull/<number>/merge` selector for one protected same-repository canary
+  ref. It does not enable the global PR gate, does not grant remote cache
+  permission, and fails closed for forks, target/dispatch events, malformed or
+  non-matching refs, and planner-forced hosted paths. It remains unset until
+  the external isolation gates pass.
 - Pull requests, feature refs, tags, credential-bearing smokes and
   hardware-qualified GPU work retain their approved non-Depot placement until
   the protected PR executor is separately activated. The intended executor may
@@ -200,6 +206,13 @@ The remaining runtime questions are:
 5. Does the restricted runner group continue to allow only the exact protected
    workflow refs after the PR canary is enabled?
 
+The checked-in selector and negative audit do not prove this boundary. Native
+`actions/cache` consumers on a Depot runner can still read repository/base
+caches, so a canary ref must either target the actual Depot/WebDAV authority
+with an approved non-secret marker protocol or explicitly disable every
+relevant cache consumer before any PR code is placed on Depot. This repository
+does neither yet; the canary remains an external runtime/admin prerequisite.
+
 Do not introduce a long-lived Depot organization token without a separate
 security review and explicit authorization.
 
@@ -234,9 +247,12 @@ grants its own Depot placement.
 
 ## Isolation acceptance canary
 
-Use a non-secret sentinel protocol:
+Use a non-secret sentinel protocol, keeping trusted-main creation separate from
+the untrusted PR probe:
 
-1. Trusted main writes a random sentinel cache entry.
+1. Trusted main creates a random non-secret marker through the actual approved
+   Depot/WebDAV authority (never a repository secret and never a native
+   GitHub-cache claim).
 2. A same-repository PR and a fork PR run through the proposed Depot path.
 3. Both probe `actions/cache`, Depot/WebDAV variables, automatic tool
    configuration, and direct cache access.

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -282,6 +282,17 @@ smokes and other hardware-qualified work retain explicit approved placement.
 Provider choice never changes plan membership, commands, artifacts, tests or
 summaries.
 
+The selector also accepts the optional repository variable
+`DEPOT_PR_CANARY_REF`. When it is absent (the default), no canary PR is
+selected and the normal global `DEPOT_PR_RUNNERS_ENABLED` gate is unchanged.
+When it contains one exact `refs/pull/<number>/merge` ref, that same-
+repository PR merge ref is an additive canary path; fork heads,
+`pull_request_target`, dispatches and planner-forced hosted paths still remain
+hosted. The canary gate never grants remote Depot cache permission and does not
+replace the global PR gate. Maintainers must not set it until the external
+isolation protocol proves the actual Depot/WebDAV and Actions-cache authority
+boundary.
+
 The intended PR-Depot end state preserves the same five entry workflows and
 matching protected lane calls. After the external cache and runner-group gates
 in `ci/DEPOT_MIGRATION.md` are proven, provider policy may select ephemeral
@@ -321,10 +332,15 @@ caches have substantially better reuse-to-storage value. Cache hits are always
 an optimization: native stamps/manifests/checksums are verified, and every job
 must still regenerate successfully after a miss.
 
-Depot PR execution is not implemented. Cache isolation, protected
-default-branch runner-owning workflow refs, no-secret/no-token execution and a
-sentinel canary are prerequisites in `ci/DEPOT_MIGRATION.md`. Do not change
-Depot settings or runner groups in a workflow refactor.
+Depot PR execution is not enabled. The bounded `DEPOT_PR_CANARY_REF` selector
+hook exists only to exercise a single protected same-repository ref after the
+external gates are ready. Native `actions/cache` consumers on a Depot runner
+may still read repository/base caches; a selector result, cache-key prefix or
+negative credential audit is not proof of cache isolation. Cache isolation,
+protected default-branch runner-owning workflow refs, no-secret/no-token
+execution and a sentinel canary are prerequisites in
+`ci/DEPOT_MIGRATION.md`. Do not change Depot settings or runner groups in a
+workflow refactor.
 
 The external administrative posture now has automatic Depot Cache and Registry
 Actions connectivity disabled and the Depot runner group restricted to this

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -315,6 +315,7 @@ class CiArtifactActionTests(unittest.TestCase):
         repository: str = "Mesh-LLM/mesh-llm",
         head_repository: str | None = None,
         pr_enabled: str = "false",
+        pr_canary_ref: str = "",
         force_hosted: str = "false",
     ) -> dict[str, str]:
         action = self.read_action("select-ci-runners")
@@ -341,6 +342,7 @@ class CiArtifactActionTests(unittest.TestCase):
                     "GITHUB_REF": ref,
                     "INPUT_DEPOT_MAIN_ENABLED": main_enabled,
                     "INPUT_DEPOT_PR_ENABLED": pr_enabled,
+                    "INPUT_PR_CANARY_REF": pr_canary_ref,
                     "INPUT_FORCE_HOSTED": force_hosted,
                     "INPUT_MANUAL_USE_DEPOT": manual_enabled,
                     "DISPATCH_ORIGINAL_EVENT_NAME": original_event_name,
@@ -2027,6 +2029,105 @@ class CiArtifactActionTests(unittest.TestCase):
             untrusted_dispatch["allow_depot_remote_cache"],
             "false",
         )
+
+        canary_pr = self.run_runner_selector(
+            event_name="pull_request",
+            ref="refs/pull/12/merge",
+            main_enabled="false",
+            manual_enabled="false",
+            pr_enabled="false",
+            pr_canary_ref="refs/pull/12/merge",
+        )
+        self.assertEqual(canary_pr["depot_enabled"], "true")
+        self.assertEqual(canary_pr["runner"], "depot-ubuntu-24.04")
+        self.assertEqual(canary_pr["allow_depot_remote_cache"], "false")
+
+        for name, kwargs in (
+            (
+                "empty canary ref",
+                {"pr_canary_ref": ""},
+            ),
+            (
+                "different pull-request ref",
+                {"pr_canary_ref": "refs/pull/13/merge"},
+            ),
+            (
+                "fork head",
+                {
+                    "pr_canary_ref": "refs/pull/12/merge",
+                    "head_repository": "attacker/mesh-llm",
+                },
+            ),
+            (
+                "pull_request_target",
+                {
+                    "pr_canary_ref": "refs/pull/12/merge",
+                    "event_name": "pull_request_target",
+                },
+            ),
+            (
+                "forced hosted",
+                {
+                    "pr_canary_ref": "refs/pull/12/merge",
+                    "force_hosted": "true",
+                },
+            ),
+            (
+                "dispatch source",
+                {
+                    "pr_canary_ref": "refs/pull/12/merge",
+                    "event_name": "workflow_dispatch",
+                    "ref": "refs/heads/main",
+                },
+            ),
+        ):
+            with self.subTest(canary_case=name):
+                case = {
+                    "event_name": "pull_request",
+                    "ref": "refs/pull/12/merge",
+                    "main_enabled": "false",
+                    "manual_enabled": "false",
+                    "pr_enabled": "false",
+                    **kwargs,
+                }
+                selected = self.run_runner_selector(**case)
+                self.assertEqual(selected["depot_enabled"], "false")
+                self.assertEqual(selected["runner"], "ubuntu-24.04")
+                self.assertEqual(
+                    selected["allow_depot_remote_cache"],
+                    "false",
+                )
+
+        action = self.read_action("select-ci-runners")
+        run_block = action.split("      run: |\n", maxsplit=1)[1]
+        script = "\n".join(
+            line[8:] if line.startswith("        ") else line
+            for line in run_block.splitlines()
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "github-output"
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=ROOT,
+                env={
+                    **os.environ,
+                    "GITHUB_OUTPUT": str(output),
+                    "INPUT_EVENT_NAME": "pull_request",
+                    "INPUT_REPOSITORY": "Mesh-LLM/mesh-llm",
+                    "INPUT_HEAD_REPOSITORY": "Mesh-LLM/mesh-llm",
+                    "INPUT_REF": "refs/pull/12/merge",
+                    "INPUT_DEPOT_MAIN_ENABLED": "false",
+                    "INPUT_DEPOT_PR_ENABLED": "false",
+                    "INPUT_PR_CANARY_REF": "refs/heads/main",
+                    "INPUT_FORCE_HOSTED": "false",
+                    "INPUT_MANUAL_USE_DEPOT": "false",
+                },
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("exact pull-request merge ref", result.stderr)
 
     def test_dispatched_pr_cache_writes_remain_blocked_with_depot(
         self,

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -38,7 +38,7 @@ class CiArtifactActionTests(unittest.TestCase):
         }
         protected_pre_checkout_action = (
             "Mesh-LLM/mesh-llm/.github/actions/"
-            "audit-depot-pr-isolation@4f9899c0c381b8cc225c9be73980ffa8db525c57"
+            "audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3"
         )
 
         for path in (*action_files, *workflow_files):

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -38,7 +38,7 @@ class CiArtifactActionTests(unittest.TestCase):
         }
         protected_pre_checkout_action = (
             "Mesh-LLM/mesh-llm/.github/actions/"
-            "audit-depot-pr-isolation@69bb127ee3bc28feee89ceef9a5f8bb9381a02e3"
+            "audit-depot-pr-isolation@98909c0909a947944dd3215ff4ef2c7f431e4ea8"
         )
 
         for path in (*action_files, *workflow_files):

--- a/scripts/tests/test_depot_canary_workflow.py
+++ b/scripts/tests/test_depot_canary_workflow.py
@@ -92,11 +92,31 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
             "'[:upper:]' '[:lower:]')\"",
             action,
         )
+        self.assertIn("depot_selected", action)
+        self.assertIn("INPUT_DEPOT_SELECTED", action)
+        self.assertIn('if [[ "$endpoint_lower" == *depot.dev* ]]', action)
+        self.assertIn("URL userinfo", action)
         self.assertIn(
             'docker_config="${DOCKER_CONFIG:-${HOME:-}/.docker}/config.json"',
             action,
         )
         self.assertIn("grep -Eiq 'depot\\.dev'", action)
+
+    def test_pr_audit_receives_central_runner_provider_selection(self) -> None:
+        workflow_root = ROOT / ".github" / "workflows"
+        audit_calls = 0
+        for path in sorted(workflow_root.glob("*.yml")):
+            lines = path.read_text(encoding="utf-8").splitlines()
+            for line_number, line in enumerate(lines):
+                if "audit-depot-pr-isolation@" not in line:
+                    continue
+                audit_calls += 1
+                block = "\n".join(lines[line_number : line_number + 5])
+                with self.subTest(path=path.name, line=line_number + 1):
+                    self.assertIn("depot_selected:", block)
+                    self.assertIn("startsWith(", block)
+                    self.assertIn("needs.runner_policy.outputs.", block)
+        self.assertEqual(audit_calls, 22)
 
     def test_endpoint_and_docker_auth_probes_fail_closed(self) -> None:
         action = (
@@ -126,6 +146,8 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
             results_url: str,
             docker_auth_config: str | None = None,
             docker_config_content: str | None = None,
+            depot_selected: str = "true",
+            **extra_environment: str,
         ) -> subprocess.CompletedProcess[str]:
             with (
                 tempfile.TemporaryDirectory() as home,
@@ -142,8 +164,10 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                     "DOCKER_CONFIG": docker_config,
                     "GITHUB_EVENT_NAME": "pull_request",
                     "INPUT_ORIGINAL_EVENT_NAME": "pull_request",
+                    "INPUT_DEPOT_SELECTED": depot_selected,
                     "ACTIONS_CACHE_URL": cache_url,
                     "ACTIONS_RESULTS_URL": results_url,
+                    **extra_environment,
                 }
                 if docker_auth_config is not None:
                     environment["DOCKER_AUTH_CONFIG"] = docker_auth_config
@@ -167,6 +191,12 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
             (
                 "HTTPS://ACTIONS.GITHUBUSERCONTENT.COM?cache=1",
                 "https://results-receiver.actions.githubusercontent.com#results",
+            ),
+        )
+        hosted_endpoints = (
+            (
+                "http://127.0.0.1:12345/_apis/artifactcache/",
+                "http://localhost:12346/",
             ),
         )
         invalid_endpoints = (
@@ -200,6 +230,25 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                 with self.subTest(script=script_name, endpoints=endpoints):
                     result = run_probe(script, *endpoints)
                     self.assertEqual(result.returncode, 0, result.stderr)
+            if script_name == "audit action":
+                with self.subTest(script=script_name, provider="malformed"):
+                    result = run_probe(
+                        script,
+                        *valid_endpoints[0],
+                        depot_selected="maybe",
+                    )
+                    self.assertNotEqual(result.returncode, 0)
+                for endpoints in hosted_endpoints:
+                    with self.subTest(
+                        script=script_name,
+                        hosted_endpoints=endpoints,
+                    ):
+                        result = run_probe(
+                            script,
+                            *endpoints,
+                            depot_selected="false",
+                        )
+                        self.assertEqual(result.returncode, 0, result.stderr)
             for endpoints in absent_endpoints:
                 with self.subTest(script=script_name, absent_endpoints=endpoints):
                     result = run_probe(script, *endpoints)
@@ -207,6 +256,34 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
             for endpoints in invalid_endpoints:
                 with self.subTest(script=script_name, endpoints=endpoints):
                     result = run_probe(script, *endpoints)
+                    self.assertNotEqual(result.returncode, 0)
+            if script_name == "audit action":
+                for endpoints in (
+                    (
+                        "https://cache.depot.dev/cache",
+                        hosted_endpoints[0][1],
+                    ),
+                    (
+                        hosted_endpoints[0][0],
+                        "https://results.depot.dev/results",
+                    ),
+                ):
+                    with self.subTest(
+                        script=script_name,
+                        depot_endpoint=endpoints,
+                    ):
+                        result = run_probe(
+                            script,
+                            *endpoints,
+                            depot_selected="false",
+                        )
+                        self.assertNotEqual(result.returncode, 0)
+                with self.subTest(script=script_name, userinfo="hosted"):
+                    result = run_probe(
+                        script,
+                        *invalid_endpoints[0],
+                        depot_selected="false",
+                    )
                     self.assertNotEqual(result.returncode, 0)
 
         depot_auth = '{"auths":{"REGISTRY.DEPOT.DEV":{"auth":"secret"}}}'
@@ -240,6 +317,15 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
             with self.subTest(script=script_name, auth="unset"):
                 result = run_probe(script, *valid_endpoints[0])
                 self.assertEqual(result.returncode, 0, result.stderr)
+
+            if script_name == "audit action":
+                with self.subTest(script=script_name, auth="DEPOT_CACHE_TOKEN"):
+                    result = run_probe(
+                        script,
+                        *valid_endpoints[0],
+                        DEPOT_CACHE_TOKEN="redacted-test-token",
+                    )
+                    self.assertNotEqual(result.returncode, 0)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_depot_canary_workflow.py
+++ b/scripts/tests/test_depot_canary_workflow.py
@@ -175,6 +175,10 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                 valid_endpoints[0][1],
             ),
             (
+                "https://actions.githubusercontent.com@depot.dev/cache",
+                valid_endpoints[0][1],
+            ),
+            (
                 "http://actions.githubusercontent.com/cache",
                 valid_endpoints[0][1],
             ),
@@ -182,6 +186,10 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                 "https://actions.githubusercontent.com.evil/cache",
                 valid_endpoints[0][1],
             ),
+        )
+        absent_endpoints = (
+            ("", ""),
+            (valid_endpoints[0][0], ""),
             ("", valid_endpoints[0][1]),
         )
         for script_name, script in (
@@ -190,6 +198,10 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
         ):
             for endpoints in valid_endpoints:
                 with self.subTest(script=script_name, endpoints=endpoints):
+                    result = run_probe(script, *endpoints)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+            for endpoints in absent_endpoints:
+                with self.subTest(script=script_name, absent_endpoints=endpoints):
                     result = run_probe(script, *endpoints)
                     self.assertEqual(result.returncode, 0, result.stderr)
             for endpoints in invalid_endpoints:


### PR DESCRIPTION
## Summary

- allow absent GitHub cache endpoints in the negative Depot audit while rejecting every non-empty non-GitHub endpoint
- add a fail-closed `DEPOT_PR_CANARY_REF` selector gate for one exact same-repository pull-request merge ref
- wire the protected canary ref through every runner-policy owner and keep forks, PR-target, dispatch provenance, invalid refs, and planner-forced hosted lanes off Depot
- document that native Actions-cache base-branch readability is not proven by this gate and remains an external isolation prerequisite
- pin the updated audit action to immutable commit `69bb127ee3bc28feee89ceef9a5f8bb9381a02e3`

## Validation

- `just ci-validate` (442 tests passed, 7 skipped)
- focused selector/canary/lane/trust suite (76 passed)
- `actionlint -config-file .github/actionlint.yaml`
- `git diff --check`

## Rollout evidence

Merged-main negative canary run `31756929689` started all six Depot labels with ~1s runner queue and peak concurrency 6. It failed uniformly because `ACTIONS_CACHE_URL` was absent, which is the expected safe posture after automatic Depot cache connectivity was disabled; this PR makes absence valid while preserving fail-closed validation for any injected endpoint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an optional, narrowly scoped canary for routing a specific trusted pull request through Depot.
  - Added validation for canary references and fail-closed behavior for untrusted or malformed values.
- **Bug Fixes**
  - CI no longer rejects runs when cache or results endpoints are unset.
  - Configured endpoints continue to require GitHub-owned HTTPS hosts and reject unsafe URLs or credentials.
- **Documentation**
  - Clarified canary limitations, cache-isolation requirements, and that general pull-request Depot execution remains disabled.
- **Tests**
  - Expanded coverage for canary routing, invalid references, endpoint configurations, and isolation safeguards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->