### PR TITLE
Fix/windows skippy package large gguf

### DIFF
--- a/crates/skippy-model-package/src/main.rs
+++ b/crates/skippy-model-package/src/main.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Parser;
 
 mod cli;
@@ -38,9 +38,26 @@ fn prepare_model_download_directories() {
     unsafe { prepared.apply_to_process_environment() };
 }
 
+// ponytail: main runs on a child thread because the Windows main thread has a
+// 1 MB stack. sha256 over a multi-GB GGUF plus FFI slice writing blows that
+// stack in debug builds. 8 MB matches the mesh-llm runtime default. If a real
+// recursion sink appears, raise this or fix the recursion — don't go lower.
+const MAIN_STACK_SIZE: usize = 8 * 1024 * 1024;
+
 fn main() -> Result<()> {
     prepare_model_download_directories();
     let args = Args::parse();
+
+    let handle = std::thread::Builder::new()
+        .stack_size(MAIN_STACK_SIZE)
+        .spawn(move || run(args))
+        .context("spawn skippy-model-package worker thread")?;
+    handle.join().unwrap_or_else(|panic| {
+        std::panic::resume_unwind(panic);
+    })
+}
+
+fn run(args: Args) -> Result<()> {
     match args.command {
         Command::Inspect { model } => inspect::inspect(model),
         Command::Plan { model, stages } => plan::build_plan(&model, stages).and_then(|output| {

--- a/third_party/llama.cpp/patches/0005-Add-Skippy-model-lifecycle-and-package-support.patch
+++ b/third_party/llama.cpp/patches/0005-Add-Skippy-model-lifecycle-and-package-support.patch
@@ -1445,10 +1445,10 @@ index 000000000..ee1e43035
 +} // extern "C"
 diff --git a/src/skippy/model_package.cpp b/src/skippy/model_package.cpp
 new file mode 100644
-index 000000000..3d199add8
+index 000000000..65d15b717
 --- /dev/null
 +++ b/src/skippy/model_package.cpp
-@@ -0,0 +1,705 @@
+@@ -0,0 +1,727 @@
 +#include "skippy/model_package.h"
 +#include "skippy/errors.h"
 +
@@ -1812,8 +1812,30 @@ index 000000000..3d199add8
 +            break;
 +        }
 +
-+        const size_t source_data_offset = gguf_get_data_offset(item.source->ctx);
-+        if (std::fseek(input, static_cast<long>(source_data_offset + item.tensor->offset), SEEK_SET) != 0) {
++        // std::fseek takes a long, which is 32-bit on Win32 MSVC, so GGUF files
++        // over 4 GB wrap and tensor reads land at the wrong offset. Seek with a
++        // 64-bit API where available, and validate the absolute offset first so
++        // an out-of-range value fails loudly instead of wrapping.
++        static_assert(std::numeric_limits<size_t>::digits <= std::numeric_limits<uint64_t>::digits,
++                      "size_t wider than uint64_t is not supported here");
++        const uint64_t source_data_offset =
++            static_cast<uint64_t>(gguf_get_data_offset(item.source->ctx));
++        const uint64_t tensor_offset = static_cast<uint64_t>(item.tensor->offset);
++        bool seek_ok = false;
++        if (tensor_offset <= (std::numeric_limits<uint64_t>::max)() - source_data_offset) {
++            const uint64_t absolute_offset = source_data_offset + tensor_offset;
++#if defined(_MSC_VER)
++            seek_ok = absolute_offset <= static_cast<uint64_t>((std::numeric_limits<__int64>::max)()) &&
++                      _fseeki64(input, static_cast<__int64>(absolute_offset), SEEK_SET) == 0;
++#elif defined(_FILE_OFFSET_BITS) && _FILE_OFFSET_BITS == 64
++            seek_ok = absolute_offset <= static_cast<uint64_t>((std::numeric_limits<off_t>::max)()) &&
++                      fseeko(input, static_cast<off_t>(absolute_offset), SEEK_SET) == 0;
++#else
++            seek_ok = absolute_offset <= static_cast<uint64_t>((std::numeric_limits<long>::max)()) &&
++                      std::fseek(input, static_cast<long>(absolute_offset), SEEK_SET) == 0;
++#endif
++        }
++        if (!seek_ok) {
 +            std::fclose(input);
 +            ok = false;
 +            break;


### PR DESCRIPTION
Title

  fix(windows): skippy-model-package crashes on GGUF files larger than 4 GB

  Original problem

  On Windows, skippy-model-package fails on any GGUF larger than 4 GB. Two independent root causes, both triggered by
  the same workload:

  1. Stack overflow on startup. The Windows main thread has a 1 MB stack (PE default). For a ~5 GB model, the combined
  cost of sha256-hashing the source plus FFI slice writing overflows the stack before any output is produced:
  thread 'main' (15404) has overflowed its stack
  1. The sibling mesh-llm binary already runs its workers on an 8 MB stack (crates/mesh-llm/src/main.rs:14) for the same
   reason, but that fix never propagated to skippy-model-package, which runs all the heavy work directly on the main
  thread.
  2. 32-bit seek wraparound past 4 GB. skippy_copy_source_tensors called std::fseek(input, static_cast<long>(...),
  SEEK_SET). On Win32 MSVC, long is 32-bit even on 64-bit Windows, so tensor offsets past 4 GB wrap and reads land at
  the wrong file position. Result: an opaque failed to copy selected GGUF tensor data partway through write-package,
  always at the first tensor past 4 GB.

  Diagnostics

  Reproduced on Windows (MSVC build) with Qwen/Qwen3-8B:Q4_K_M (~5.0 GB gguf):

  - Symptom 1 — process dies with thread 'main' has overflowed its stack during the source-model hashing phase.
  - Symptom 2 — once the stack issue is bypassed, write-package writes layers 0–10 successfully, then fails every run at
   layer-011 (the first one whose source tensor offset crosses 4 GB):
  failed to copy selected GGUF tensor data

  Confirmed the 4 GB boundary by checking the failing tensor's absolute_offset in a debugger — it was just above
  0x1_0000_0000, and the wrapped 32-bit value matched the byte the reader actually landed on.

  Fix

  Two minimal changes, one per root cause:

  1. crates/skippy-model-package/src/main.rs — Move the body into a spawned thread with an 8 MB stack, matching the
  mesh-llm runtime default. Panics are re-raised with resume_unwind so the original payload reaches the main thread
  instead of a generic JoinError.
  2. third_party/llama.cpp/patches/0001-Add-Skippy-ABI-and-package-writer-foundation.patch — Use a 64-bit seek:
    - _fseeki64 on MSVC
    - fseeko when _FILE_OFFSET_BITS=64 on POSIX
    - std::fseek fallback otherwise (unchanged)

  The GGUF header KV-skip helper is left alone — single KV values do not approach 4 GB in practice.

  After both fixes, the same repro completes all 36 layers of Qwen3-8B:Q4_K_M.

  Compatibility / migration: none. Both changes are platform-specific internal fixes — no CLI, protocol, or on-disk
  format change. Existing packages are byte-identical; only Windows builds larger than 4 GB start succeeding.

  Validation

  - Local checks: Ran cargo build and cargo test -p skippy-model-package on Windows/MSVC — pass. The changed paths are
  Windows-only at runtime; POSIX builds exercise the unchanged fallback.
  - Manual repro: skippy-model-package write-package Qwen3-8B-Q4_K_M.gguf now completes all 36 layers on Windows;
  previously failed at layer-011.
  - Regression: A small (<4 GB) GGUF still packages identically on Windows and Linux — confirms the fallback path is
  untouched.
  - UI: No UI changes — this is a CLI/packaging tool. No screenshots needed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for opening and managing models from single files or multipart packages.
  - Added backend device discovery and configurable model loading options.
  - Added package inspection, tensor filtering, progress and failure reporting, and optional draft-model support.
  - Added improved handling for large model files across platforms.

- **Bug Fixes**
  - Improved command execution reliability and error reporting.
  - Worker failures are now surfaced correctly instead of being silently lost.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->