### PR TITLE
Fix retained tensor accounting in staged model loads

### DIFF
--- a/third_party/llama.cpp/patches/0001-Add-staged-model-graph-and-family-support.patch
+++ b/third_party/llama.cpp/patches/0001-Add-staged-model-graph-and-family-support.patch
@@ -4,14 +4,14 @@ Date: Sat, 8 Aug 2026 16:02:19 +1000
 Subject: [PATCH 01/15] Add staged model graph and family support
 
 
-diff --git a/include/llama.h b/include/llama.h
-index 5a0b66dc2..a7893e5e5 100644
+Index: b/include/llama.h
+===================================================================
 --- a/include/llama.h
 +++ b/include/llama.h
 @@ -517,6 +517,13 @@ extern "C" {
                                   size_t    n_paths,
                struct llama_model_params    params);
- 
+
 +    // Load a model from multiple GGUF parts without requiring native split metadata.
 +    // The first path provides model metadata; tensors are resolved from all paths in order.
 +    LLAMA_API struct llama_model * llama_model_load_from_parts(
@@ -22,11 +22,11 @@ index 5a0b66dc2..a7893e5e5 100644
      LLAMA_API void llama_model_save_to_file(
              const struct llama_model * model,
                          const char * path_model);
-diff --git a/src/llama-arch.cpp b/src/llama-arch.cpp
-index 73fb8b981..0d01f8eb9 100644
+Index: b/src/llama-arch.cpp
+===================================================================
 --- a/src/llama-arch.cpp
 +++ b/src/llama-arch.cpp
-@@ -71,7 +71,6 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
+@@ -71,7 +71,6 @@ static const std::map<llm_arch, const ch
      { LLM_ARCH_OLMO,             "olmo"             },
      { LLM_ARCH_OLMO2,            "olmo2"            },
      { LLM_ARCH_OLMOE,            "olmoe"            },
@@ -34,7 +34,7 @@ index 73fb8b981..0d01f8eb9 100644
      { LLM_ARCH_OPENELM,          "openelm"          },
      { LLM_ARCH_ARCTIC,           "arctic"           },
      { LLM_ARCH_DEEPSEEK,         "deepseek"         },
-@@ -101,7 +100,6 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
+@@ -101,7 +100,6 @@ static const std::map<llm_arch, const ch
      { LLM_ARCH_GRANITE,          "granite"          },
      { LLM_ARCH_GRANITE_MOE,      "granitemoe"       },
      { LLM_ARCH_GRANITE_HYBRID,   "granitehybrid"    },
@@ -42,15 +42,15 @@ index 73fb8b981..0d01f8eb9 100644
      { LLM_ARCH_CHAMELEON,        "chameleon"        },
      { LLM_ARCH_WAVTOKENIZER_DEC, "wavtokenizer-dec" },
      { LLM_ARCH_PLM,              "plm"              },
-@@ -147,6 +145,7 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
+@@ -147,6 +145,7 @@ static const std::map<llm_arch, const ch
      { LLM_ARCH_MELLUM,           "mellum"           },
      { LLM_ARCH_NANBEIGE,         "nanbeige"         },
      { LLM_ARCH_QWEN3TTS,         "qwen3tts"         },
 +    { LLM_ARCH_INKLING,          "inkling"          },
      { LLM_ARCH_UNKNOWN,          "(unknown)"        },
  };
- 
-@@ -222,11 +221,6 @@ static const std::map<llm_kv, const char *> LLM_KV_NAMES = {
+
+@@ -222,11 +221,6 @@ static const std::map<llm_kv, const char
      { LLM_KV_TIME_DECAY_EXTRA_DIM,              "%s.time_decay_extra_dim"              },
      { LLM_KV_RESIDUAL_SCALE,                    "%s.residual_scale"                    },
      { LLM_KV_EMBEDDING_SCALE,                   "%s.embedding_scale"                   },
@@ -62,7 +62,7 @@ index 73fb8b981..0d01f8eb9 100644
      { LLM_KV_TOKEN_SHIFT_COUNT,                 "%s.token_shift_count"                 },
      { LLM_KV_INTERLEAVE_MOE_LAYER_STEP,         "%s.interleave_moe_layer_step"         },
      { LLM_KV_FULL_ATTENTION_INTERVAL,           "%s.full_attention_interval"           },
-@@ -265,6 +259,8 @@ static const std::map<llm_kv, const char *> LLM_KV_NAMES = {
+@@ -265,6 +259,8 @@ static const std::map<llm_kv, const char
      { LLM_KV_ATTENTION_INDEXER_HEAD_COUNT,           "%s.attention.indexer.head_count"           },
      { LLM_KV_ATTENTION_INDEXER_KEY_LENGTH,           "%s.attention.indexer.key_length"           },
      { LLM_KV_ATTENTION_INDEXER_TOP_K,                "%s.attention.indexer.top_k"                },
@@ -71,9 +71,9 @@ index 73fb8b981..0d01f8eb9 100644
      { LLM_KV_ATTENTION_INDEXER_BLOCK_SIZE,           "%s.attention.indexer.block_size"           },
      { LLM_KV_ATTENTION_INDEXER_LOCAL_BLOCKS,         "%s.attention.indexer.local_blocks"         },
      { LLM_KV_ATTENTION_INDEXER_TYPES,                "%s.attention.indexer.types"                },
-@@ -328,6 +324,18 @@ static const std::map<llm_kv, const char *> LLM_KV_NAMES = {
+@@ -328,6 +324,18 @@ static const std::map<llm_kv, const char
      { LLM_KV_NORM_BEFORE_FC,        "%s.norm_before_fc"       },
- 
+
      { LLM_KV_SHORTCONV_L_CACHE, "%s.shortconv.l_cache" },
 +
 +    // inkling (private arch)
@@ -90,7 +90,7 @@ index 73fb8b981..0d01f8eb9 100644
      // sentence-transformers dense modules feature dims
      { LLM_KV_DENSE_2_FEAT_IN,        "%s.dense_2_feat_in"  },
      { LLM_KV_DENSE_2_FEAT_OUT,       "%s.dense_2_feat_out" },
-@@ -600,9 +608,19 @@ static const std::map<llm_tensor, const char *> LLM_TENSOR_NAMES = {
+@@ -600,9 +608,19 @@ static const std::map<llm_tensor, const
      { LLM_TENSOR_SHORTCONV_CONV,                         "blk.%d.shortconv.conv" },
      { LLM_TENSOR_SHORTCONV_INPROJ,                       "blk.%d.shortconv.in_proj" },
      { LLM_TENSOR_SHORTCONV_OUTPROJ,                      "blk.%d.shortconv.out_proj" },
@@ -110,7 +110,7 @@ index 73fb8b981..0d01f8eb9 100644
      { LLM_TENSOR_VISEXP_ATTN_QKV,                        "blk.%d.vis_attn_qkv" },
      { LLM_TENSOR_VISEXP_ATTN_OUT,                        "blk.%d.vis_attn_output" },
      { LLM_TENSOR_VISEXP_FFN_GATE,                        "blk.%d.vis_gate" },
-@@ -803,6 +821,9 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
+@@ -803,6 +821,9 @@ static const std::map<llm_tensor, llm_te
      {LLM_TENSOR_FFN_UP_EXPS,                {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT_ID}},
      {LLM_TENSOR_FFN_GATE_UP_EXPS,           {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT_ID}},
      {LLM_TENSOR_FFN_DOWN_CHEXPS,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT_ID}},
@@ -120,7 +120,7 @@ index 73fb8b981..0d01f8eb9 100644
      {LLM_TENSOR_FFN_GATE_CHEXPS,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT_ID}},
      {LLM_TENSOR_FFN_UP_CHEXPS,              {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT_ID}},
      {LLM_TENSOR_FFN_EXP_PROBS_B,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_ADD}},
-@@ -844,6 +865,13 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
+@@ -844,6 +865,13 @@ static const std::map<llm_tensor, llm_te
      {LLM_TENSOR_SHORTCONV_CONV,             {LLM_TENSOR_LAYER_REPEATING, GGML_OP_SSM_CONV}},
      {LLM_TENSOR_SHORTCONV_INPROJ,           {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
      {LLM_TENSOR_SHORTCONV_OUTPROJ,          {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
@@ -134,7 +134,7 @@ index 73fb8b981..0d01f8eb9 100644
      {LLM_TENSOR_VISEXP_ATTN_QKV,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
      {LLM_TENSOR_VISEXP_ATTN_OUT,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
      {LLM_TENSOR_VISEXP_FFN_GATE,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
-@@ -977,6 +1005,7 @@ bool llm_arch_is_hybrid(const llm_arch & arch) {
+@@ -977,6 +1005,7 @@ bool llm_arch_is_hybrid(const llm_arch &
          case LLM_ARCH_QWEN35:
          case LLM_ARCH_QWEN35MOE:
          case LLM_ARCH_DEEPSEEK4:
@@ -142,7 +142,7 @@ index 73fb8b981..0d01f8eb9 100644
              return true;
          default:
              return false;
-@@ -999,7 +1028,6 @@ bool llm_arch_supports_rs_rollback(const llm_arch & arch) {
+@@ -999,7 +1028,6 @@ bool llm_arch_supports_rs_rollback(const
      switch (arch) {
          case LLM_ARCH_QWEN35:
          case LLM_ARCH_QWEN35MOE:
@@ -150,7 +150,7 @@ index 73fb8b981..0d01f8eb9 100644
              return true;
          default:
              return false;
-@@ -1035,6 +1063,7 @@ bool llm_arch_supports_sm_tensor(const llm_arch & arch) {
+@@ -1035,6 +1063,7 @@ bool llm_arch_supports_sm_tensor(const l
          case LLM_ARCH_MISTRAL4:
          case LLM_ARCH_KIMI_LINEAR:
          case LLM_ARCH_QWEN3TTS:
@@ -158,8 +158,8 @@ index 73fb8b981..0d01f8eb9 100644
              return false;
          default:
              return true;
-diff --git a/src/llama-arch.h b/src/llama-arch.h
-index 51dfd288c..89f2b45fe 100644
+Index: b/src/llama-arch.h
+===================================================================
 --- a/src/llama-arch.h
 +++ b/src/llama-arch.h
 @@ -76,7 +76,6 @@ enum llm_arch {
@@ -185,7 +185,7 @@ index 51dfd288c..89f2b45fe 100644
 +    LLM_ARCH_INKLING,
      LLM_ARCH_UNKNOWN,
  };
- 
+
 @@ -227,11 +226,6 @@ enum llm_kv {
      LLM_KV_TIME_DECAY_EXTRA_DIM,
      LLM_KV_RESIDUAL_SCALE,
@@ -208,9 +208,9 @@ index 51dfd288c..89f2b45fe 100644
      LLM_KV_ATTENTION_INDEXER_LOCAL_BLOCKS,
      LLM_KV_ATTENTION_INDEXER_TYPES,
 @@ -375,6 +371,17 @@ enum llm_kv {
- 
+
      LLM_KV_SHORTCONV_L_CACHE,
- 
+
 +    // inkling (private arch)
 +    LLM_KV_INKLING_D_REL,
 +    LLM_KV_INKLING_REL_EXTENT,
@@ -251,8 +251,8 @@ index 51dfd288c..89f2b45fe 100644
      LLM_TENSOR_VISEXP_ATTN_QKV,
      LLM_TENSOR_VISEXP_ATTN_OUT,
      LLM_TENSOR_VISEXP_FFN_GATE,
-diff --git a/src/llama-context.cpp b/src/llama-context.cpp
-index 0de3a68d1..5e148757a 100644
+Index: b/src/llama-context.cpp
+===================================================================
 --- a/src/llama-context.cpp
 +++ b/src/llama-context.cpp
 @@ -10,7 +10,6 @@
@@ -261,24 +261,24 @@ index 0de3a68d1..5e148757a 100644
  #include "llama-ext.h"
 -#include "llama-sampler.h"
  #include "llama.h"
- 
+
  #include <cinttypes>
 @@ -121,9 +120,8 @@ llama_context::llama_context(
      cparams.no_perf                 = params.no_perf;
      cparams.warmup                  = false;
- 
+
 -    // +1: id n_layer() taps the output of the last layer ("input" of the head)
 -    cparams.embeddings_layer_inp.resize(hparams.n_layer() + 1, false);
 -    embd_layer_inp.resize(hparams.n_layer() + 1);
 +    cparams.embeddings_layer_inp.resize(hparams.n_layer(), false);
 +    embd_layer_inp.resize(hparams.n_layer());
- 
+
      cparams.ctx_type     = params.ctx_type;
      cparams.pooling_type = params.pooling_type;
 @@ -160,6 +158,31 @@ llama_context::llama_context(
          }
      }
- 
+
 +    if (model.arch == LLM_ARCH_INKLING &&
 +            params.ctx_type == LLAMA_CONTEXT_TYPE_MTP &&
 +            params.ctx_other != nullptr) {
@@ -309,7 +309,7 @@ index 0de3a68d1..5e148757a 100644
          rope_scaling_type = hparams.rope_scaling_type_train;
 @@ -247,27 +270,6 @@ llama_context::llama_context(
      cparams.n_ubatch = std::min(cparams.n_batch, params.n_ubatch == 0 ? params.n_batch : params.n_ubatch);
- 
+
      cparams.n_outputs_max = params.n_outputs_max == 0 || llama_model_has_encoder(&model) ? cparams.n_batch : params.n_outputs_max;
 -    cparams.n_outputs_max_per_seq = params.n_outputs_max_per_seq == 0 ?
 -            cparams.n_outputs_max : std::min(params.n_outputs_max_per_seq, cparams.n_outputs_max);
@@ -332,13 +332,13 @@ index 0de3a68d1..5e148757a 100644
 -            }
 -        }
 -    }
- 
+
      cparams.op_offload = params.op_offload;
      cparams.kv_unified = params.kv_unified;
 @@ -303,19 +305,18 @@ llama_context::llama_context(
          }
      }
- 
+
 -    LLAMA_LOG_INFO("%s: n_seq_max             = %u\n",   __func__, cparams.n_seq_max);
 -    LLAMA_LOG_INFO("%s: n_ctx                 = %u\n",   __func__, cparams.n_ctx);
 -    LLAMA_LOG_INFO("%s: n_ctx_seq             = %u\n",   __func__, cparams.n_ctx_seq);
@@ -364,12 +364,12 @@ index 0de3a68d1..5e148757a 100644
 +    LLAMA_LOG_INFO("%s: freq_scale    = %g\n",   __func__, cparams.rope_freq_scale);
 +    LLAMA_LOG_INFO("%s: n_rs_seq      = %u\n",   __func__, cparams.n_rs_seq);
 +    LLAMA_LOG_INFO("%s: n_outputs_max = %u\n",   __func__, cparams.n_outputs_max);
- 
+
      if (cparams.n_ctx_seq < hparams.n_ctx_train) {
          LLAMA_LOG_INFO("%s: n_ctx_seq (%u) < n_ctx_train (%u) -- the full capacity of the model will not be utilized\n",
 @@ -479,9 +480,6 @@ llama_context::llama_context(
  }
- 
+
  llama_context::~llama_context() {
 -    // wait for any pending asynchronous copies into the output buffers before they are freed
 -    synchronize();
@@ -378,7 +378,7 @@ index 0de3a68d1..5e148757a 100644
          for (size_t i = 0; i < backend_ptrs.size(); ++i) {
              ggml_backend_t             backend = backend_ptrs[i];
 @@ -503,6 +501,22 @@ llama_context::~llama_context() {
- 
+
  void llama_context::resolve_fused_ops(const llama_memory_context_i * mctx, uint32_t n_seqs) {
      const char * func = __func__;
 +
@@ -400,28 +400,28 @@ index 0de3a68d1..5e148757a 100644
      auto resolve = [&](const llm_fused_op_probe & probe, bool & enabled) {
          if (!enabled) {
              return;
-@@ -1169,7 +1183,7 @@ void llama_context::set_embeddings_nextn(bool value, bool masked) {
+@@ -1169,7 +1183,7 @@ void llama_context::set_embeddings_nextn
  void llama_context::set_embeddings_layer_inp(uint32_t lid, bool enable) {
      LLAMA_LOG_DEBUG("%s: lid = %d, enable = %d\n", __func__, lid, enable);
- 
+
 -    GGML_ASSERT(lid <= model.hparams.n_layer());
 +    GGML_ASSERT(lid < model.hparams.n_layer());
- 
+
      cparams.embeddings_layer_inp[lid] = enable;
- 
-@@ -1235,7 +1249,7 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
+
+@@ -1235,7 +1249,7 @@ bool llama_context::set_sampler(llama_se
      if (sampler && can_offload) {
          auto * buft = ggml_backend_dev_buffer_type(model.dev_output());
- 
+
 -        sampler->iface->backend_init(sampler, buft, cparams.n_outputs_max_per_seq);
 +        sampler->iface->backend_init(sampler, buft);
- 
+
          sampling.samplers[seq_id] = sampler;
- 
-@@ -1425,17 +1439,13 @@ int llama_context::encode(const llama_batch & batch_inp) {
+
+@@ -1425,17 +1439,13 @@ int llama_context::encode(const llama_ba
      // micro-batching is not possible for non-causal encoding, so we process the batch in a single shot
      GGML_ASSERT(cparams.n_ubatch >= n_tokens && "encoder requires n_ubatch >= n_tokens");
- 
+
 -    // TODO: this clear of the buffer can easily be forgotten - need something better
 -    // sync first so any in-flight async copies into embd_seq complete before it is freed
 -    if (!embd_seq.empty()) {
@@ -432,17 +432,17 @@ index 0de3a68d1..5e148757a 100644
      if (t_compute_start_us == 0) {
          t_compute_start_us = ggml_time_us();
      }
- 
+
 +    // TODO: this clear of the buffer can easily be forgotten - need something better
 +    embd_seq.clear();
 +
      sched_reserve();
- 
+
      n_queued_tokens += n_tokens;
-@@ -1580,38 +1590,108 @@ int llama_context::encode(const llama_batch & batch_inp) {
+@@ -1580,38 +1590,108 @@ int llama_context::encode(const llama_ba
      return 0;
  }
- 
+
 -template<typename T>
 -static void copy_tensor_async_rows(
 -    const std::vector<ggml_tensor *> & tensors,
@@ -503,7 +503,7 @@ index 0de3a68d1..5e148757a 100644
      if (!dst.has_data()) {
          return;
      }
- 
+
 -    for (size_t i = 0; i < tensors.size(); ++i) {
 -        auto * tensor = tensors[i];
 -        if (tensor == nullptr) {
@@ -512,7 +512,7 @@ index 0de3a68d1..5e148757a 100644
 +        if (it == seq_to_row.end()) {
              continue;
          }
- 
+
 -        const uint32_t row = row_offset + i;
 -        const size_t n_elements = ggml_nelements(tensor);
 -        GGML_ASSERT(ggml_is_contiguous(tensor) && "sampling tensor must be contiguous for async copy");
@@ -522,12 +522,12 @@ index 0de3a68d1..5e148757a 100644
 +        GGML_ASSERT(row < counts.size());
 +
 +        GGML_ASSERT(ggml_is_contiguous(tensor) && "logits/probs tensor must be contiguous for async copy");
- 
+
          ggml_backend_t backend = ggml_backend_sched_get_tensor_backend(sched, tensor);
 -        T * row_ptr = dst.data + (size_t) row * stride;
 +        float * row_ptr = dst.data + (size_t) row * stride;
          ggml_backend_tensor_get_async(backend, tensor, row_ptr, 0, ggml_nbytes(tensor));
- 
+
 -        if (counts) {
 -            GGML_ASSERT(row < counts->size());
 -            (*counts)[row] = n_elements;
@@ -566,37 +566,37 @@ index 0de3a68d1..5e148757a 100644
 +        counts[row] = ggml_nelements(tensor);
      }
  }
- 
-@@ -1651,8 +1731,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
+
+@@ -1651,8 +1731,7 @@ int llama_context::decode(const llama_ba
      const auto & hparams = model.hparams;
- 
+
      const int64_t n_vocab = vocab.n_tokens();
 -    const bool    mtp_embd = cparams.ctx_type == LLAMA_CONTEXT_TYPE_MTP && batch_inp.embd;
 -    const int64_t n_embd  = mtp_embd ? hparams.n_embd_out() : hparams.n_embd_inp();
 +    const int64_t n_embd  = hparams.n_embd_inp();
- 
+
      // when computing embeddings, all tokens are output
      const bool output_all   = cparams.embeddings;
-@@ -1660,12 +1739,12 @@ int llama_context::decode(const llama_batch & batch_inp) {
- 
+@@ -1660,12 +1739,12 @@ int llama_context::decode(const llama_ba
+
      const uint32_t n_seq_max = cparams.kv_unified ? LLAMA_MAX_SEQ : cparams.n_seq_max;
- 
+
 -    // embedding contexts output every token even when batch.logits is not set
 -    if (has_samplers && (output_all || batch_inp.logits)) {
 +    // TODO: avoid this workaround in the future
 +    if (has_samplers && batch_inp.logits) {
          std::vector<int32_t> seq_output_count(n_seq_max, 0);
- 
+
          for (int32_t i = 0; i < batch_inp.n_tokens; ++i) {
 -            if (!output_all && batch_inp.logits[i] == 0) {
 +            if (batch_inp.logits[i] == 0) {
                  continue;
              }
- 
-@@ -1674,17 +1753,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
+
+@@ -1674,17 +1753,10 @@ int llama_context::decode(const llama_ba
              for (int32_t s = 0; s < ns; ++s) {
                  const llama_seq_id seq_id = batch_inp.seq_id ? batch_inp.seq_id[i][s] : 0;
- 
+
 -                if (seq_id < 0 || (uint32_t) seq_id >= n_seq_max) {
 -                    continue;
 -                }
@@ -614,10 +614,10 @@ index 0de3a68d1..5e148757a 100644
                      return -1;
                  }
              }
-@@ -1712,18 +1784,13 @@ int llama_context::decode(const llama_batch & batch_inp) {
- 
+@@ -1712,18 +1784,13 @@ int llama_context::decode(const llama_ba
+
      GGML_ASSERT((cparams.causal_attn || cparams.n_ubatch >= n_tokens_all) && "non-causal attention requires n_ubatch >= n_tokens");
- 
+
 -    // TODO: this clear of the buffer can easily be forgotten - need something better
 -    // sync first so any in-flight async copies into embd_seq complete before it is freed
 -    if (!embd_seq.empty()) {
@@ -629,16 +629,16 @@ index 0de3a68d1..5e148757a 100644
          t_compute_start_us = ggml_time_us();
      }
      n_queued_tokens += n_tokens_all;
- 
+
 +    // TODO: this clear of the buffer can easily be forgotten - need something better
 +    embd_seq.clear();
      output_swaps.clear();
- 
+
      sched_reserve();
-@@ -1784,11 +1851,6 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1784,11 +1851,6 @@ int llama_context::decode(const llama_ba
          return -2;
      };
- 
+
 -    // start a new sampling transaction for this logical batch
 -    for (const auto & entry : sampling.samplers) {
 -        llama_sampler_backend_begin(entry.second);
@@ -646,13 +646,13 @@ index 0de3a68d1..5e148757a 100644
 -
      int64_t n_outputs_prev = 0;
      int64_t n_tokens_prev  = 0;
- 
-@@ -1949,20 +2011,36 @@ int llama_context::decode(const llama_batch & batch_inp) {
- 
+
+@@ -1949,20 +2011,36 @@ int llama_context::decode(const llama_ba
+
                  const uint32_t n_embd  = hparams.n_embd_out();
                  float * embd_nextn_out = embd_nextn.data + offset*n_embd;
 +                const size_t n_bytes = (size_t) n_rows*n_embd*sizeof(float);
- 
+
                  GGML_ASSERT((offset + n_rows)*n_embd <= (int64_t) embd_nextn.size);
 -                ggml_backend_tensor_get_async(backend_h, t_h_nextn, embd_nextn_out, 0, n_rows*n_embd*sizeof(float));
 +                if (n_bytes > ggml_nbytes(t_h_nextn)) {
@@ -670,13 +670,13 @@ index 0de3a68d1..5e148757a 100644
 +                ggml_backend_tensor_get_async(backend_h, t_h_nextn, embd_nextn_out, 0, n_bytes);
              }
          }
- 
+
 -        if (has_samplers) {
 +        // Copy backend sampling output if this ubatch produced any sampling tensors.
 +        if (has_samplers && (!res->t_sampled.empty() || !res->t_sampled_probs.empty() || !res->t_sampled_logits.empty())) {
 +            const auto seq_to_output_row = build_seq_to_output_row(ubatch, n_outputs_prev);
              const auto stride = n_vocab;
- 
+
              // async copy the sampling data from the backend to the host
 -            copy_tensor_async_rows(res->t_sampled,        sampling.sampled,    1,      n_outputs_prev, sched.get());
 -            copy_tensor_async_rows(res->t_sampled_logits, sampling.logits,     stride, n_outputs_prev, sched.get(), &sampling.logits_count);
@@ -688,23 +688,23 @@ index 0de3a68d1..5e148757a 100644
 +            copy_tensor_async_floats    (res->t_sampled_probs,  sampling.probs,      stride, sampling.probs_count,      seq_to_output_row, sched.get());
 +            copy_tensor_async_candidates(res->t_candidates,     sampling.candidates, stride, sampling.candidates_count, seq_to_output_row, sched.get());
          }
- 
+
          n_outputs_prev += n_outputs;
-@@ -2220,9 +2298,8 @@ void llama_context::extract_layer_inputs(const llm_graph_result * res, size_t to
+@@ -2220,9 +2298,8 @@ void llama_context::extract_layer_inputs
  }
- 
+
  void llama_context::output_reorder() {
 -    const uint64_t n_vocab     = model.vocab.n_tokens();
 -    const uint64_t n_embd      = model.hparams.n_embd;
 -    const uint64_t n_embd_out  = model.hparams.n_embd_out();
 +    const uint64_t n_vocab = model.vocab.n_tokens();
 +    const uint64_t n_embd  = model.hparams.n_embd;
- 
+
      for (size_t s = 0; s < output_swaps.size(); ++s) {
          const uint64_t i0 = output_swaps[s].i0;
 @@ -2235,14 +2312,14 @@ void llama_context::output_reorder() {
          }
- 
+
          if (embd.size > 0) {
 -            for (uint64_t k = 0; k < n_embd_out; k++) {
 -                std::swap(embd.data[i0*n_embd_out + k], embd.data[i1*n_embd_out + k]);
@@ -712,7 +712,7 @@ index 0de3a68d1..5e148757a 100644
 +                std::swap(embd.data[i0*n_embd + k], embd.data[i1*n_embd + k]);
              }
          }
- 
+
          if (embd_nextn.size > 0) {
 -            for (uint64_t k = 0; k < n_embd_out; k++) {
 -                std::swap(embd_nextn.data[i0*n_embd_out + k], embd_nextn.data[i1*n_embd_out + k]);
@@ -720,10 +720,10 @@ index 0de3a68d1..5e148757a 100644
 +                std::swap(embd_nextn.data[i0*n_embd + k], embd_nextn.data[i1*n_embd + k]);
              }
          }
- 
+
 @@ -2292,40 +2369,18 @@ void llama_context::output_reorder() {
  //
- 
+
  uint32_t llama_context::graph_max_nodes(uint32_t n_tokens) const {
 -    uint32_t res;
      if (model.arch == LLM_ARCH_QWEN3NEXT ||
@@ -769,7 +769,7 @@ index 0de3a68d1..5e148757a 100644
 @@ -2351,7 +2406,6 @@ static void ubatch_prepare_reserve(
          }
      }
- 
+
 -    // sequences with a sampler that fit in this ubatch
      std::vector<uint32_t> sampler_seqs;
      std::vector<bool> has_sampler(n_seqs, false);
@@ -782,7 +782,7 @@ index 0de3a68d1..5e148757a 100644
          sampler_seqs.push_back(seq_id);
          has_sampler[seq_id] = true;
      }
- 
+
      uint32_t n_outputs_set = 0;
 -
      const uint32_t n_outputs_per_seq = std::min(n_seq_tokens, n_outputs_max_per_seq);
@@ -796,7 +796,7 @@ index 0de3a68d1..5e148757a 100644
              ++n_outputs_set;
          }
      }
- 
+
 -    // use sequences without samplers for any remaining outputs
      for (uint32_t t = 0; t < n_seq_tokens && n_outputs_set < n_outputs; ++t) {
          for (uint32_t s = 0; s < n_seqs && n_outputs_set < n_outputs; ++s) {
@@ -809,7 +809,7 @@ index 0de3a68d1..5e148757a 100644
          }
      }
  }
- 
+
 +llm_graph_result * llama_context::get_gf_res_prev() const {
 +    return static_cast<llm_graph_result *>(gf_res_prev.get());
 +}
@@ -817,10 +817,10 @@ index 0de3a68d1..5e148757a 100644
  ggml_cgraph * llama_context::graph_reserve(
          uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx, bool split_only, size_t * sizes) {
      LLAMA_LOG_DEBUG("%s: reserving a graph for ubatch with n_tokens = %4u, n_seqs = %2u, n_outputs = %4u\n", __func__, n_tokens, n_seqs, n_outputs);
-@@ -2415,7 +2468,14 @@ ggml_cgraph * llama_context::graph_reserve(
+@@ -2415,7 +2468,14 @@ ggml_cgraph * llama_context::graph_reser
      llama_batch_allocr balloc(model.hparams.n_pos_per_embd());
      llama_ubatch ubatch = balloc.ubatch_reserve(n_tokens/n_seqs, n_seqs);
- 
+
 -    ubatch_prepare_reserve(ubatch, n_outputs, sampling.samplers, cparams.n_outputs_max_per_seq);
 +    // set one output token per sequence in order to activate all backend samplers
 +    std::vector<llama_seq_id> seq_ids(n_seqs);
@@ -830,10 +830,10 @@ index 0de3a68d1..5e148757a 100644
 +        ubatch.seq_id[i] = &seq_ids[i];
 +        ubatch.output[i] = true;
 +    }
- 
+
      auto * res = gf_res_reserve.get();
- 
-@@ -3502,7 +3562,6 @@ llama_context_params llama_context_default_params() {
+
+@@ -3502,7 +3562,6 @@ llama_context_params llama_context_defau
          /*.n_seq_max                   =*/ 1,
          /*.n_rs_seq                    =*/ 0,
          /*.n_outputs_max               =*/ 0,
@@ -844,7 +844,7 @@ index 0de3a68d1..5e148757a 100644
 @@ -3572,22 +3631,6 @@ llama_context * llama_init_from_model(
          }
      }
- 
+
 -    if ((model->hparams.is_mla() || model->arch == LLM_ARCH_DEEPSEEK4) && params.type_k != params.type_v) {
 -        LLAMA_LOG_ERROR("%s: model does not support different K (%s) and V (%s) cache types\n", __func__, ggml_type_name(params.type_k), ggml_type_name(params.type_v));
 -        return nullptr;
@@ -867,7 +867,7 @@ index 0de3a68d1..5e148757a 100644
 @@ -3610,6 +3653,11 @@ llama_context * llama_init_from_model(
          }
      }
- 
+
 +    if (ggml_is_quantized(params.type_v) && params.flash_attn_type == LLAMA_FLASH_ATTN_TYPE_DISABLED) {
 +        LLAMA_LOG_ERROR("%s: V cache quantization requires flash_attn\n", __func__);
 +        return nullptr;
@@ -879,7 +879,7 @@ index 0de3a68d1..5e148757a 100644
 @@ -3617,9 +3665,8 @@ llama_context * llama_init_from_model(
                         model->hparams.pooling_type, params.pooling_type);
      }
- 
+
 -    // router_layer >= 0 means n_layer_nextn is repurposed for a router layer, not real MTP
      if (params.ctx_type == LLAMA_CONTEXT_TYPE_MTP &&
 -        (model->hparams.n_layer_nextn == 0 || model->hparams.router_layer >= 0)) {
@@ -897,35 +897,35 @@ index 0de3a68d1..5e148757a 100644
      if (ret != 0 && ret != 1) {
          LLAMA_LOG_ERROR("%s: failed to decode, ret = %d\n", __func__, ret);
      }
-diff --git a/src/llama-context.h b/src/llama-context.h
-index bf91daa8b..20c121b24 100644
+Index: b/src/llama-context.h
+===================================================================
 --- a/src/llama-context.h
 +++ b/src/llama-context.h
 @@ -20,6 +20,8 @@ class llama_batch_allocr;
  class llama_io_read_i;
  class llama_io_write_i;
- 
+
 +int skippy_external_decode_observe(llama_context * ctx, const llama_batch & batch);
 +
  // "memory" as in abstract memory for the context
  struct llama_memory_i;
  struct llama_memory_context_i;
 @@ -243,6 +245,7 @@ public:
- 
+
      // can reuse the llm_graph_result instance of the context (for example to update a memory module)
      llm_graph_result * get_gf_res_reserve() const;
 +    llm_graph_result * get_gf_res_prev() const;
- 
+
      // returns the result of ggml_backend_sched_graph_compute_async execution
      ggml_status graph_compute(ggml_cgraph * gf, bool batched);
-diff --git a/src/llama-graph.cpp b/src/llama-graph.cpp
-index 55d858024..ca9bed0c3 100644
+Index: b/src/llama-graph.cpp
+===================================================================
 --- a/src/llama-graph.cpp
 +++ b/src/llama-graph.cpp
 @@ -23,6 +23,85 @@
  #include <string>
  #include <unordered_set>
- 
+
 +static thread_local skippy_graph_filter g_skippy_graph_filter;
 +static thread_local skippy_activation_tokens g_skippy_activation_tokens;
 +static thread_local skippy_activation_rwkv7_v_first g_skippy_rwkv7_v_first;
@@ -1006,24 +1006,24 @@ index 55d858024..ca9bed0c3 100644
 +}
 +
  // dedup helpers
- 
+
  static ggml_tensor * build_attn_inp_kq_mask(
-@@ -84,23 +163,34 @@ void llm_graph_input_embd::set_input(const llama_ubatch * ubatch) {
+@@ -84,23 +163,34 @@ void llm_graph_input_embd::set_input(con
  bool llm_graph_input_embd::can_reuse(const llm_graph_params & params) {
      bool res = true;
- 
+
 -    res &= (!params.ubatch.token) || (tokens && tokens->ne[0] == params.ubatch.n_tokens);
 -    res &= (!params.ubatch.embd)  || (embd   &&   embd->ne[1] == params.ubatch.n_tokens);
 +    res &= (!params.ubatch.token) || (tokens && tokens->buffer && tokens->ne[0] == params.ubatch.n_tokens);
 +    res &= (!params.ubatch.embd)  || (embd   && embd->buffer   && embd->ne[1] == params.ubatch.n_tokens);
- 
+
      return res;
  }
- 
+
  void llm_graph_input_embd_h::set_input(const llama_ubatch * ubatch) {
      const int64_t n_tokens = ubatch->n_tokens;
 +    const skippy_activation_mtp_embeddings & mtp_embeddings = skippy_graph_get_mtp_embeddings();
- 
+
      if (ubatch->token) {
          ggml_backend_tensor_set(tokens, ubatch->token, 0, n_tokens*ggml_element_size(tokens));
      } else {
@@ -1041,26 +1041,26 @@ index 55d858024..ca9bed0c3 100644
 +                    mtp_embeddings.token_count);
 +            values = mtp_embeddings.values + static_cast<size_t>(token_offset)*n_embd;
 +        }
- 
+
 -        ggml_backend_tensor_set(embd, ubatch->embd, 0, n_tokens*n_embd*ggml_element_size(h));
 +        ggml_backend_tensor_set(embd, values, 0, n_tokens*n_embd*ggml_element_size(embd));
      }
- 
+
      // TODO: extend llama_ubatch to differentiate between token embeddings and hidden states
-@@ -116,15 +206,84 @@ void llm_graph_input_embd_h::set_input(const llama_ubatch * ubatch) {
+@@ -116,15 +206,84 @@ void llm_graph_input_embd_h::set_input(c
  bool llm_graph_input_embd_h::can_reuse(const llm_graph_params & params) {
      bool res = true;
- 
+
 -    res &= (!params.ubatch.token) || (tokens && tokens->ne[0] == params.ubatch.n_tokens);
 -    res &= (!params.ubatch.embd)  || (embd   && embd->ne[1]   == params.ubatch.n_tokens);
 -    res &= (!params.ubatch.embd)  || (h      && h->ne[1]      == params.ubatch.n_tokens);
 +    res &= (!params.ubatch.token) || (tokens && tokens->buffer && tokens->ne[0] == params.ubatch.n_tokens);
 +    res &= (params.ubatch.token)  || (embd   && embd->buffer   && embd->ne[1] == params.ubatch.n_tokens);
 +    res &= (!params.ubatch.embd)  || (h      && h->buffer      && h->ne[1] == params.ubatch.n_tokens);
- 
+
      return res;
  }
- 
+
 +void llm_graph_input_stage_tokens::set_input(const llama_ubatch * ubatch) {
 +    const skippy_activation_tokens & stage_tokens = skippy_graph_get_activation_tokens();
 +    GGML_ASSERT(stage_tokens.tokens != nullptr);
@@ -1134,20 +1134,20 @@ index 55d858024..ca9bed0c3 100644
 +    // scheduler leaves this otherwise declared graph input unallocated.
 +    if (ubatch->pos && pos && pos->buffer) {
          const int64_t n_tokens = ubatch->n_tokens;
- 
+
          if (ubatch->token && n_pos_per_embd == 4) {
-@@ -148,7 +307,7 @@ void llm_graph_input_pos::set_input(const llama_ubatch * ubatch) {
+@@ -148,7 +307,7 @@ void llm_graph_input_pos::set_input(cons
  bool llm_graph_input_pos::can_reuse(const llm_graph_params & params) {
      bool res = true;
- 
+
 -    res &= pos->ne[0] == params.ubatch.n_tokens*n_pos_per_embd;
 +    res &= pos && pos->buffer && pos->ne[0] == params.ubatch.n_tokens*n_pos_per_embd;
- 
+
      return res;
  }
-@@ -501,9 +660,15 @@ bool llm_graph_input_attn_kv::can_reuse(const llm_graph_params & params) {
+@@ -501,9 +660,15 @@ bool llm_graph_input_attn_kv::can_reuse(
  }
- 
+
  void llm_graph_input_attn_k::set_input(const llama_ubatch * ubatch) {
 -    mctx->set_input_k_idxs(self_k_idxs, ubatch);
 +    // Filtered stages can omit their attention path, leaving these declared
@@ -1155,66 +1155,66 @@ index 55d858024..ca9bed0c3 100644
 +    if (self_k_idxs && self_k_idxs->buffer) {
 +        mctx->set_input_k_idxs(self_k_idxs, ubatch);
 +    }
- 
+
 -    mctx->set_input_kq_mask(self_kq_mask, ubatch, cparams.causal_attn);
 +    if (self_kq_mask && self_kq_mask->buffer) {
 +        mctx->set_input_kq_mask(self_kq_mask, ubatch, cparams.causal_attn);
 +    }
  }
- 
+
  bool llm_graph_input_attn_k::can_reuse(const llm_graph_params & params) {
-@@ -513,9 +678,10 @@ bool llm_graph_input_attn_k::can_reuse(const llm_graph_params & params) {
- 
+@@ -513,9 +678,10 @@ bool llm_graph_input_attn_k::can_reuse(c
+
      bool res = true;
- 
+
 -    res &= self_k_idxs->ne[0] == params.ubatch.n_tokens;
 +    res &= self_k_idxs && self_k_idxs->buffer && self_k_idxs->ne[0] == params.ubatch.n_tokens;
- 
+
 -    res &= can_reuse_kq_mask(self_kq_mask, mctx, params.ubatch, params.cparams);
 +    res &= self_kq_mask && self_kq_mask->buffer &&
 +        can_reuse_kq_mask(self_kq_mask, mctx, params.ubatch, params.cparams);
- 
+
      return res;
  }
-@@ -555,15 +721,25 @@ bool llm_graph_input_attn_kv_msa::can_reuse(const llm_graph_params & params) {
+@@ -555,15 +721,25 @@ bool llm_graph_input_attn_kv_msa::can_re
  }
- 
+
  void llm_graph_input_attn_k_dsa::set_input(const llama_ubatch * ubatch) {
 -    mctx->get_mla()->set_input_k_idxs(self_k_idxs_mla, ubatch);
 +    if (self_k_idxs_mla && self_k_idxs_mla->buffer) {
 +        mctx->get_mla()->set_input_k_idxs(self_k_idxs_mla, ubatch);
 +    }
- 
+
 -    mctx->get_mla()->set_input_kq_mask(self_kq_mask_mla, ubatch, cparams.causal_attn);
 +    if (self_kq_mask_mla && self_kq_mask_mla->buffer) {
 +        mctx->get_mla()->set_input_kq_mask(self_kq_mask_mla, ubatch, cparams.causal_attn);
 +    }
- 
+
 -    mctx->get_lid()->set_input_k_idxs(self_k_idxs_lid, ubatch);
 +    if (self_k_idxs_lid && self_k_idxs_lid->buffer) {
 +        mctx->get_lid()->set_input_k_idxs(self_k_idxs_lid, ubatch);
 +    }
- 
+
 -    mctx->get_lid()->set_input_kq_mask(self_kq_mask_lid, ubatch, cparams.causal_attn);
 +    if (self_kq_mask_lid && self_kq_mask_lid->buffer) {
 +        mctx->get_lid()->set_input_kq_mask(self_kq_mask_lid, ubatch, cparams.causal_attn);
 +    }
- 
+
 -    mctx->get_lid()->set_input_k_rot(self_k_rot_lid);
 +    if (self_k_rot_lid && self_k_rot_lid->buffer) {
 +        mctx->get_lid()->set_input_k_rot(self_k_rot_lid);
 +    }
  }
- 
+
  bool llm_graph_input_attn_k_dsa::can_reuse(const llm_graph_params & params) {
-@@ -1060,22 +1236,27 @@ void llm_graph_input_attn_cross::set_input(const llama_ubatch * ubatch) {
+@@ -1060,22 +1236,27 @@ void llm_graph_input_attn_cross::set_inp
  }
- 
+
  void llm_graph_input_mem_hybrid::set_input(const llama_ubatch * ubatch) {
 -    mctx->get_attn()->set_input_k_idxs(inp_attn->self_k_idxs, ubatch);
 -    mctx->get_attn()->set_input_v_idxs(inp_attn->self_v_idxs, ubatch);
 +    const auto * attn_ctx = mctx->get_attn();
- 
+
 -    mctx->get_attn()->set_input_kq_mask(inp_attn->self_kq_mask, ubatch, cparams.causal_attn);
 +    // These tensors may not be allocated for staged slices that contain only
 +    // recurrent layers.
@@ -1223,33 +1223,33 @@ index 55d858024..ca9bed0c3 100644
 +        attn_ctx->set_input_v_idxs(inp_attn->self_v_idxs, ubatch);
 +        attn_ctx->set_input_kq_mask(inp_attn->self_kq_mask, ubatch, cparams.causal_attn);
 +    }
- 
+
      if (inp_attn->self_k_rot) {
 -        mctx->get_attn()->set_input_k_rot(inp_attn->self_k_rot);
 +        attn_ctx->set_input_k_rot(inp_attn->self_k_rot);
      }
- 
+
      if (inp_attn->self_v_rot) {
 -        mctx->get_attn()->set_input_v_rot(inp_attn->self_v_rot);
 +        attn_ctx->set_input_v_rot(inp_attn->self_v_rot);
      }
- 
+
      const int64_t n_rs = mctx->get_recr()->get_n_rs();
- 
+
 -    if (inp_rs->s_copy) {
 +    if (inp_rs->s_copy && inp_rs->s_copy->buffer) {
          GGML_ASSERT(ggml_backend_buffer_is_host(inp_rs->s_copy->buffer));
          int32_t * data = (int32_t *) inp_rs->s_copy->data;
- 
-@@ -1098,10 +1279,16 @@ bool llm_graph_input_mem_hybrid::can_reuse(const llm_graph_params & params) {
- 
+
+@@ -1098,10 +1279,16 @@ bool llm_graph_input_mem_hybrid::can_reu
+
      res &= can_reuse_kq_mask(inp_attn->self_kq_mask, mctx->get_attn(), params.ubatch, params.cparams);
- 
+
 -    res &= inp_rs->s_copy->ne[0] == mctx->get_recr()->get_n_rs();
 +    if (inp_rs->s_copy && inp_rs->s_copy->buffer) {
 +        res &= inp_rs->s_copy->ne[0] == mctx->get_recr()->get_n_rs();
 +    }
- 
+
 -    res &= inp_rs->s_copy_main->ne[0]  == params.ubatch.n_seqs;
 -    res &= inp_rs->s_copy_extra->ne[0] == mctx->get_recr()->get_n_rs() - params.ubatch.n_seqs;
 +    if (inp_rs->s_copy_main && inp_rs->s_copy_main->buffer) {
@@ -1258,16 +1258,16 @@ index 55d858024..ca9bed0c3 100644
 +    if (inp_rs->s_copy_extra && inp_rs->s_copy_extra->buffer) {
 +        res &= inp_rs->s_copy_extra->ne[0] == mctx->get_recr()->get_n_rs() - params.ubatch.n_seqs;
 +    }
- 
+
      res &= inp_rs->head == mctx->get_recr()->get_head();
      res &= inp_rs->rs_z == mctx->get_recr()->get_rs_z();
-@@ -1113,13 +1300,18 @@ bool llm_graph_input_mem_hybrid::can_reuse(const llm_graph_params & params) {
+@@ -1113,13 +1300,18 @@ bool llm_graph_input_mem_hybrid::can_reu
  // Instead of creating a hybrid input, the graph can simply create 2 separate inputs.
  // Refactoring is required in the future.
  void llm_graph_input_mem_hybrid_k::set_input(const llama_ubatch * ubatch) {
 -    mctx->get_attn()->set_input_k_idxs(inp_attn->self_k_idxs, ubatch);
 +    const auto * attn_ctx = mctx->get_attn();
- 
+
 -    mctx->get_attn()->set_input_kq_mask(inp_attn->self_kq_mask, ubatch, cparams.causal_attn);
 +    // These tensors may not be allocated for staged slices that contain only
 +    // recurrent layers.
@@ -1275,23 +1275,23 @@ index 55d858024..ca9bed0c3 100644
 +        attn_ctx->set_input_k_idxs(inp_attn->self_k_idxs, ubatch);
 +        attn_ctx->set_input_kq_mask(inp_attn->self_kq_mask, ubatch, cparams.causal_attn);
 +    }
- 
+
      const int64_t n_rs = mctx->get_recr()->get_n_rs();
- 
+
 -    if (inp_rs->s_copy) {
 +    if (inp_rs->s_copy && inp_rs->s_copy->buffer) {
          GGML_ASSERT(ggml_backend_buffer_is_host(inp_rs->s_copy->buffer));
          int32_t * data = (int32_t *) inp_rs->s_copy->data;
- 
-@@ -1141,10 +1333,16 @@ bool llm_graph_input_mem_hybrid_k::can_reuse(const llm_graph_params & params) {
- 
+
+@@ -1141,10 +1333,16 @@ bool llm_graph_input_mem_hybrid_k::can_r
+
      res &= can_reuse_kq_mask(inp_attn->self_kq_mask, mctx->get_attn(), params.ubatch, params.cparams);
- 
+
 -    res &= inp_rs->s_copy->ne[0] == mctx->get_recr()->get_n_rs();
 +    if (inp_rs->s_copy && inp_rs->s_copy->buffer) {
 +        res &= inp_rs->s_copy->ne[0] == mctx->get_recr()->get_n_rs();
 +    }
- 
+
 -    res &= inp_rs->s_copy_main->ne[0]  == params.ubatch.n_seqs;
 -    res &= inp_rs->s_copy_extra->ne[0] == mctx->get_recr()->get_n_rs() - params.ubatch.n_seqs;
 +    if (inp_rs->s_copy_main && inp_rs->s_copy_main->buffer) {
@@ -1300,27 +1300,27 @@ index 55d858024..ca9bed0c3 100644
 +    if (inp_rs->s_copy_extra && inp_rs->s_copy_extra->buffer) {
 +        res &= inp_rs->s_copy_extra->ne[0] == mctx->get_recr()->get_n_rs() - params.ubatch.n_seqs;
 +    }
- 
+
      res &= inp_rs->head == mctx->get_recr()->get_head();
      res &= inp_rs->rs_z == mctx->get_recr()->get_rs_z();
-@@ -1193,7 +1391,7 @@ void llm_graph_input_mem_hybrid_iswa::set_input(const llama_ubatch * ubatch) {
- 
+@@ -1193,7 +1391,7 @@ void llm_graph_input_mem_hybrid_iswa::se
+
      const int64_t n_rs = mctx->get_recr()->get_n_rs();
- 
+
 -    if (inp_rs->s_copy) {
 +    if (inp_rs->s_copy && inp_rs->s_copy->buffer) {
          GGML_ASSERT(ggml_backend_buffer_is_host(inp_rs->s_copy->buffer));
          int32_t * data = (int32_t *) inp_rs->s_copy->data;
- 
-@@ -1229,10 +1427,16 @@ bool llm_graph_input_mem_hybrid_iswa::can_reuse(const llm_graph_params & params)
- 
+
+@@ -1229,10 +1427,16 @@ bool llm_graph_input_mem_hybrid_iswa::ca
+
      res &= can_reuse_kq_mask(inp_attn->self_kq_mask_swa, attn_ctx->get_swa(), params.ubatch, params.cparams);
- 
+
 -    res &= inp_rs->s_copy->ne[0] == mctx->get_recr()->get_n_rs();
 +    if (inp_rs->s_copy && inp_rs->s_copy->buffer) {
 +        res &= inp_rs->s_copy->ne[0] == mctx->get_recr()->get_n_rs();
 +    }
- 
+
 -    res &= inp_rs->s_copy_main->ne[0]  == params.ubatch.n_seqs;
 -    res &= inp_rs->s_copy_extra->ne[0] == mctx->get_recr()->get_n_rs() - params.ubatch.n_seqs;
 +    if (inp_rs->s_copy_main && inp_rs->s_copy_main->buffer) {
@@ -1329,7 +1329,7 @@ index 55d858024..ca9bed0c3 100644
 +    if (inp_rs->s_copy_extra && inp_rs->s_copy_extra->buffer) {
 +        res &= inp_rs->s_copy_extra->ne[0] == mctx->get_recr()->get_n_rs() - params.ubatch.n_seqs;
 +    }
- 
+
      res &= inp_rs->head == mctx->get_recr()->get_head();
      res &= inp_rs->rs_z == mctx->get_recr()->get_rs_z();
 @@ -1299,6 +1503,9 @@ void llm_graph_result::reset() {
@@ -1339,10 +1339,10 @@ index 55d858024..ca9bed0c3 100644
 +    t_skippy_rwkv7_v_first = nullptr;
 +    t_skippy_gemma3n_altup = nullptr;
 +    t_skippy_glm_dsa_top_k = nullptr;
- 
+
      t_layer_inp.resize(LLAMA_MAX_LAYERS + 1);
      std::fill(t_layer_inp.begin(), t_layer_inp.end(), nullptr);
-@@ -1345,6 +1552,15 @@ void llm_graph_result::set_outputs(const llm_graph_params & params) {
+@@ -1345,6 +1552,15 @@ void llm_graph_result::set_outputs(const
      if (t_h_nextn != nullptr) {
          ggml_set_output(t_h_nextn);
      }
@@ -1358,7 +1358,7 @@ index 55d858024..ca9bed0c3 100644
      {
          const auto & embeddings_layer_inp = params.cparams.embeddings_layer_inp;
          for (size_t il = 0; il < embeddings_layer_inp.size(); ++il) {
-@@ -1487,9 +1703,15 @@ ggml_tensor * llm_graph_context::build_cvec(
+@@ -1487,9 +1703,15 @@ ggml_tensor * llm_graph_context::build_c
  ggml_tensor * llm_graph_context::build_lora_mm(
            ggml_tensor * w,
            ggml_tensor * cur,
@@ -1366,7 +1366,7 @@ index 55d858024..ca9bed0c3 100644
 +          ggml_tensor * w_s,
 +        enum ggml_prec   prec) const {
      ggml_tensor * res = ggml_mul_mat(ctx0, w, cur);
- 
+
 +    if (prec != GGML_PREC_DEFAULT) {
 +        // Set precision on the base MUL_MAT before an optional scale/LoRA attachment changes the root op.
 +        ggml_mul_mat_set_prec(res, prec);
@@ -1375,14 +1375,14 @@ index 55d858024..ca9bed0c3 100644
      if (w_s) {
          res = ggml_mul(ctx0, res, w_s);
      }
-@@ -2289,28 +2511,32 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
+@@ -2289,28 +2511,32 @@ ggml_tensor * llm_graph_context::build_i
      {
          auto & cur = inps[0];
- 
+
 -        cur = ggml_get_rows(ctx0, tok_embd, inp->tokens);
 +        if (tok_embd) {
 +            cur = ggml_get_rows(ctx0, tok_embd, inp->tokens);
- 
+
 -        // apply lora for embedding tokens if needed
 -        for (const auto & lora : *loras) {
 -            llama_adapter_lora_weight * lw = lora.first->get_weight(tok_embd);
@@ -1395,12 +1395,12 @@ index 55d858024..ca9bed0c3 100644
 +                if (lw == nullptr) {
 +                    continue;
 +                }
- 
+
 -            const float adapter_scale = lora.second;
 -            const float scale = lw->get_scale(lora.first->alpha, adapter_scale);
 +                const float adapter_scale = lora.second;
 +                const float scale = lw->get_scale(lora.first->alpha, adapter_scale);
- 
+
 -            ggml_tensor * inpL_delta = ggml_scale(ctx0, ggml_mul_mat(
 -                        ctx0, lw->b, // non-transposed lora_b
 -                        ggml_get_rows(ctx0, lw->a, inp->tokens)
@@ -1409,12 +1409,12 @@ index 55d858024..ca9bed0c3 100644
 +                            ctx0, lw->b, // non-transposed lora_b
 +                            ggml_get_rows(ctx0, lw->a, inp->tokens)
 +                            ), scale);
- 
+
 -            cur = ggml_add(ctx0, cur, inpL_delta);
 -        }
 +                cur = ggml_add(ctx0, cur, inpL_delta);
 +            }
- 
+
 -        if (n_embd_inp != n_embd) {
 -            cur = ggml_pad(ctx0, cur, hparams.n_embd_inp() - n_embd, 0, 0, 0);
 +            if (n_embd_inp != n_embd) {
@@ -1424,11 +1424,11 @@ index 55d858024..ca9bed0c3 100644
 +            cur = inp->embd;
          }
      }
- 
-@@ -2324,7 +2550,13 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
+
+@@ -2324,7 +2550,13 @@ ggml_tensor * llm_graph_context::build_i
      assert(ggml_are_same_shape (inps[0], inps[1]));
      assert(ggml_are_same_stride(inps[0], inps[1]));
- 
+
 -    ggml_tensor * cur = ggml_build_forward_select(gf, inps.data(), inps.size(), ubatch.token ? 0 : 1);
 +    // A mid-stage Skippy slice has no token embedding table, so both branches
 +    // above refer to `inp->embd`. Feeding the same tensor through
@@ -1437,13 +1437,13 @@ index 55d858024..ca9bed0c3 100644
 +    ggml_tensor * cur = tok_embd
 +        ? ggml_build_forward_select(gf, inps.data(), inps.size(), ubatch.token ? 0 : 1)
 +        : inp->embd;
- 
+
      if (n_embd_inp != n_embd) {
          cur = ggml_view_2d(ctx0, cur, n_embd, n_tokens, cur->nb[1], 0);
-@@ -2332,10 +2564,15 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
- 
+@@ -2332,10 +2564,15 @@ ggml_tensor * llm_graph_context::build_i
+
      res->t_inp_embd = cur;
- 
+
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool skippy_mid_stage_input = stage_filter.enabled && stage_filter.layer_start > 0;
 +
@@ -1457,10 +1457,10 @@ index 55d858024..ca9bed0c3 100644
          if (!ggml_is_contiguous(cur)) {
              cur = ggml_cont(ctx0, cur);
          }
-@@ -2520,9 +2757,26 @@ ggml_tensor * llm_graph_context::build_attn_mha(
- 
+@@ -2520,9 +2757,26 @@ ggml_tensor * llm_graph_context::build_a
+
      ggml_tensor * cur;
- 
+
 -    const bool use_flash_attn = cparams.flash_attn && kq_b == nullptr;
 +    // backends without a fused-bias flash-attention kernel (e.g. Metal for the
 +    // banded op) can still run FA by folding the additive KQ bias into the mask
@@ -1483,35 +1483,35 @@ index 55d858024..ca9bed0c3 100644
 +            fa_mask = ggml_cast(ctx0, ggml_add(ctx0, bias, mask_f32), GGML_TYPE_F16);
 +            cb(fa_mask, "kq_mask_biased", il);
 +        }
- 
+
          if (v_trans) {
              v = ggml_transpose(ctx0, v);
-@@ -2537,7 +2791,7 @@ ggml_tensor * llm_graph_context::build_attn_mha(
+@@ -2537,7 +2791,7 @@ ggml_tensor * llm_graph_context::build_a
              v = ggml_cast(ctx0, v, GGML_TYPE_F16);
          }
- 
+
 -        cur = ggml_flash_attn_ext(ctx0, q, k, v, kq_mask, kq_scale, hparams.f_max_alibi_bias,
 +        cur = ggml_flash_attn_ext(ctx0, q, k, v, fa_mask, kq_scale, hparams.f_max_alibi_bias,
                                    hparams.attn_soft_cap ? hparams.f_attn_logit_softcapping : 0.0f);
          res->add_fused_node({LLM_FUSED_OP_FLASH_ATTN, cur, il});
- 
-@@ -2936,6 +3190,8 @@ ggml_tensor * llm_graph_context::build_attn(
- 
+
+@@ -2936,6 +3190,8 @@ ggml_tensor * llm_graph_context::build_a
+
      const auto & kq_mask = inp->get_kq_mask_mla();
- 
+
 +    GGML_ASSERT(top_k != nullptr);
 +
      // prepare new kq mask - starts filled with -INFINITY
      ggml_tensor * kq_mask_all = ggml_fill(ctx0, kq_mask, -INFINITY);
- 
-diff --git a/src/llama-graph.h b/src/llama-graph.h
-index 75bc0fe80..71874c700 100644
+
+Index: b/src/llama-graph.h
+===================================================================
 --- a/src/llama-graph.h
 +++ b/src/llama-graph.h
 @@ -31,6 +31,80 @@ class llama_memory_recurrent_context;
  class llama_memory_hybrid_context;
  class llama_memory_hybrid_iswa_context;
- 
+
 +enum skippy_glm_dsa_phase_hint : int32_t {
 +    SKIPPY_GLM_DSA_PHASE_HINT_AUTO = 0,
 +    SKIPPY_GLM_DSA_PHASE_HINT_PREFILL = 1,
@@ -1592,7 +1592,7 @@ index 75bc0fe80..71874c700 100644
 @@ -153,6 +227,65 @@ public:
      const int64_t n_embd = 0;
  };
- 
+
 +class llm_graph_input_stage_tokens : public llm_graph_input_i {
 +public:
 +    llm_graph_input_stage_tokens() = default;
@@ -1662,9 +1662,9 @@ index 75bc0fe80..71874c700 100644
 +    ggml_tensor * get_skippy_rwkv7_v_first() const { return t_skippy_rwkv7_v_first; }
 +    ggml_tensor * get_skippy_gemma3n_altup() const { return t_skippy_gemma3n_altup; }
 +    ggml_tensor * get_skippy_glm_dsa_top_k() const { return t_skippy_glm_dsa_top_k; }
- 
+
      ggml_tensor * get_layer_inp(int il) const { return t_layer_inp[il]; }
- 
+
 @@ -901,6 +1037,9 @@ public:
      ggml_tensor * t_embd        = nullptr;
      ggml_tensor * t_embd_pooled = nullptr;
@@ -1672,9 +1672,9 @@ index 75bc0fe80..71874c700 100644
 +    ggml_tensor * t_skippy_rwkv7_v_first = nullptr;
 +    ggml_tensor * t_skippy_gemma3n_altup = nullptr;
 +    ggml_tensor * t_skippy_glm_dsa_top_k = nullptr;
- 
+
      std::vector<ggml_tensor *> t_layer_inp;
- 
+
 @@ -1018,7 +1157,8 @@ struct llm_graph_context {
      ggml_tensor * build_lora_mm(
                ggml_tensor * w,
@@ -1682,16 +1682,16 @@ index 75bc0fe80..71874c700 100644
 -              ggml_tensor * w_s = nullptr) const;
 +              ggml_tensor * w_s = nullptr,
 +            enum ggml_prec   prec = GGML_PREC_DEFAULT) const;
- 
+
      // do mat_mul_id, while optionally apply lora and per-expert scale
      ggml_tensor * build_lora_mm_id(
-diff --git a/src/llama-hparams.cpp b/src/llama-hparams.cpp
-index 781277f3f..b53ea27d4 100644
+Index: b/src/llama-hparams.cpp
+===================================================================
 --- a/src/llama-hparams.cpp
 +++ b/src/llama-hparams.cpp
-@@ -181,6 +181,11 @@ uint32_t llama_hparams::n_embd_v_gqa_max() const {
+@@ -181,6 +181,11 @@ uint32_t llama_hparams::n_embd_v_gqa_max
  }
- 
+
  uint32_t llama_hparams::n_embd_r() const {
 +    if (n_embd_r_impl != 0) {
 +        // explicit override (e.g. inkling: 4 packed shortconv streams per layer)
@@ -1701,8 +1701,8 @@ index 781277f3f..b53ea27d4 100644
      if (wkv_head_size != 0) {
          // for RWKV models
          return token_shift_count * n_embd;
-diff --git a/src/llama-hparams.h b/src/llama-hparams.h
-index 57de80824..4d74e3527 100644
+Index: b/src/llama-hparams.h
+===================================================================
 --- a/src/llama-hparams.h
 +++ b/src/llama-hparams.h
 @@ -53,10 +53,6 @@ struct llama_hparams {
@@ -1717,9 +1717,9 @@ index 57de80824..4d74e3527 100644
      uint32_t n_expert_used = 0;
      uint32_t n_rel_attn_bkts = 0;
 @@ -84,6 +80,17 @@ struct llama_hparams {
- 
+
      uint32_t n_shortconv_l_cache  = 0;
- 
+
 +    // explicit override for the rolling state size per layer (see n_embd_r())
 +    uint32_t n_embd_r_impl = 0;
 +
@@ -1748,13 +1748,13 @@ index 57de80824..4d74e3527 100644
 +        types.fill(-1);
 +        return types;
 +    }(); // -1 unknown, 0 shared, 1 full
- 
+
      // Indexer is "full" (1) or "shared" (0)
      // Shared indexers reuse top-k from previous full layer
 @@ -358,6 +375,9 @@ struct llama_hparams {
      uint32_t n_embd_k_gqa_max() const;
      uint32_t n_embd_v_gqa_max() const;
- 
+
 +    // dimension of the single-head MSA indexer key stream
 +    uint32_t n_embd_k_idx(uint32_t il = 0) const;
 +
@@ -1762,16 +1762,16 @@ index 57de80824..4d74e3527 100644
      // corresponds to Mamba's conv_states size or RWKV's token_shift states size
      uint32_t n_embd_r() const;
 @@ -375,8 +395,6 @@ struct llama_hparams {
- 
+
      bool has_kv(uint32_t il) const;
- 
+
 -    bool has_rope(uint32_t il) const;
 -
      // number of effective layers (excludes nextn layers)
      uint32_t n_layer() const;
- 
-diff --git a/src/llama-kv-cache.cpp b/src/llama-kv-cache.cpp
-index 5382cd726..138a7c63b 100644
+
+Index: b/src/llama-kv-cache.cpp
+===================================================================
 --- a/src/llama-kv-cache.cpp
 +++ b/src/llama-kv-cache.cpp
 @@ -4,6 +4,7 @@
@@ -1779,7 +1779,7 @@ index 5382cd726..138a7c63b 100644
  #include "llama-model.h"
  #include "llama-context.h"
 +#include "skippy.h"
- 
+
  #include <algorithm>
  #include <cassert>
 @@ -112,7 +113,7 @@ llama_kv_cache::llama_kv_cache(
@@ -1794,7 +1794,7 @@ index 5382cd726..138a7c63b 100644
 @@ -195,12 +196,10 @@ llama_kv_cache::llama_kv_cache(
              n_embd_head_k_all = -1;
          }
- 
+
 -        if (!is_mla) {
 -            if (n_embd_head_v_all == 0) {
 -                n_embd_head_v_all = (int32_t) hparams.n_embd_head_v(il);
@@ -1806,12 +1806,12 @@ index 5382cd726..138a7c63b 100644
 +        } else if (n_embd_head_v_all > 0 && n_embd_head_v_all != (int32_t) hparams.n_embd_head_v(il)) {
 +            n_embd_head_v_all = -1;
          }
- 
+
          // [TAG_V_CACHE_VARIABLE]
 @@ -242,9 +241,25 @@ llama_kv_cache::llama_kv_cache(
              v_stream.push_back(has_v ? ggml_view_2d(ctx, v, n_embd_v_gqa, kv_size, v->nb[1], s*v->nb[2]) : nullptr);
          }
- 
+
 +        const uint32_t n_embd_k_idx = hparams.n_embd_k_idx(il);
 +        ggml_tensor * k_idx = n_embd_k_idx > 0
 +            ? ggml_new_tensor_3d(ctx, GGML_TYPE_F32, n_embd_k_idx, kv_size, n_stream)
@@ -1829,15 +1829,15 @@ index 5382cd726..138a7c63b 100644
 +        }
 +
          map_layer_ids[il] = layers.size();
- 
+
 -        layers.push_back({ il, k, v, k_stream, v_stream, });
 +        layers.push_back({ il, k, v, k_idx, k_stream, v_stream, k_idx_stream });
      }
- 
+
      if (reuse) {
 @@ -293,13 +308,24 @@ llama_kv_cache::llama_kv_cache(
      }
- 
+
      {
 -        const size_t memory_size_k = size_k_bytes();
 -        const size_t memory_size_v = size_v_bytes();
@@ -1845,7 +1845,7 @@ index 5382cd726..138a7c63b 100644
 +        const size_t memory_size_v     = size_v_bytes();
 +        const size_t memory_size_k_idx = size_k_idx_bytes();
 +        const size_t memory_size_total = memory_size_k + memory_size_v + memory_size_k_idx;
- 
+
 -        LLAMA_LOG_INFO("%s: size = %7.2f MiB (%6u cells, %3d layers, %2u/%u seqs), K (%s): %7.2f MiB, V (%s): %7.2f MiB\n", __func__,
 -                (float)(memory_size_k + memory_size_v) / (1024.0f * 1024.0f), kv_size, (int) layers.size(), n_seq_max, n_stream,
 -                ggml_type_name(type_k), (float)memory_size_k / (1024.0f * 1024.0f),
@@ -1864,12 +1864,12 @@ index 5382cd726..138a7c63b 100644
 +                (float) memory_size_total / mib, kv_size, (int) layers.size(), n_seq_max, n_stream,
 +                k_log.c_str(), v_log.c_str(), k_idx_log.c_str());
      }
- 
+
      // TODO: refactor [TAG_KV_CACHE_SHARE_CELLS]
-@@ -392,6 +418,39 @@ bool llama_kv_cache::seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos p1) {
+@@ -392,6 +418,39 @@ bool llama_kv_cache::seq_rm(llama_seq_id
          p1 = std::numeric_limits<llama_pos>::max();
      }
- 
+
 +    // empty range - nothing to remove
 +    if (p0 >= p1) {
 +        return true;
@@ -1906,9 +1906,9 @@ index 5382cd726..138a7c63b 100644
      if (seq_id >= 0) {
          auto & cells = v_cells[seq_to_stream[seq_id]];
          auto & head  = v_heads[seq_to_stream[seq_id]];
-@@ -737,11 +796,28 @@ llama_memory_context_ptr llama_kv_cache::init_full() {
+@@ -737,11 +796,28 @@ llama_memory_context_ptr llama_kv_cache:
  }
- 
+
  llama_memory_context_ptr llama_kv_cache::init_update(llama_context * lctx, bool optimize) {
 -    GGML_UNUSED(optimize);
 -
@@ -1919,7 +1919,7 @@ index 5382cd726..138a7c63b 100644
 +        if (lctx != nullptr) {
 +            lctx->synchronize();
 +        }
- 
+
 -    return std::make_unique<llama_kv_cache_context>(this, lctx, do_shift, std::move(sc_info));
 +        const auto moves = compact_cells();
 +        did_compact = !moves.empty();
@@ -1936,9 +1936,9 @@ index 5382cd726..138a7c63b 100644
 +            std::move(sc_info),
 +            did_compact);
  }
- 
+
  llama_kv_cache::slot_info_vec_t llama_kv_cache::prepare(const std::vector<llama_ubatch> & ubatches) {
-@@ -846,6 +922,10 @@ bool llama_kv_cache::update(llama_context * lctx, bool do_shift, const stream_co
+@@ -846,6 +922,10 @@ bool llama_kv_cache::update(llama_contex
                  if (layer.v_stream[ssrc]) {
                      ggml_backend_tensor_copy(layer.v_stream[ssrc], layer.v_stream[sdst]);
                  }
@@ -1949,10 +1949,10 @@ index 5382cd726..138a7c63b 100644
              }
          }
      }
-@@ -994,6 +1074,44 @@ llama_kv_cache::slot_info llama_kv_cache::find_slot(const llama_ubatch & ubatch,
- 
+@@ -994,6 +1074,44 @@ llama_kv_cache::slot_info llama_kv_cache
+
          const auto & cells = v_cells[seq_to_stream[seq_id]];
- 
+
 +        if (n_tokens > cells.size()) {
 +            LLAMA_LOG_ERROR("%s: n_tokens = %d > size = %u\n", __func__, n_tokens, cells.size());
 +            return { };
@@ -1992,24 +1992,24 @@ index 5382cd726..138a7c63b 100644
 +        }
 +
          uint32_t head_cur = v_heads[seq_to_stream[seq_id]];
- 
+
          // if we have enough unused cells before the current head ->
-@@ -1002,11 +1120,6 @@ llama_kv_cache::slot_info llama_kv_cache::find_slot(const llama_ubatch & ubatch,
+@@ -1002,11 +1120,6 @@ llama_kv_cache::slot_info llama_kv_cache
              head_cur = 0;
          }
- 
+
 -        if (n_tokens > cells.size()) {
 -            LLAMA_LOG_ERROR("%s: n_tokens = %d > size = %u\n", __func__, n_tokens, cells.size());
 -            return { };
 -        }
 -
          uint32_t n_tested = 0;
- 
+
          // for continuous slots, we test that all tokens in the ubatch fit, starting from the current head
-@@ -1113,6 +1226,15 @@ void llama_kv_cache::apply_ubatch(const slot_info & sinfo, const llama_ubatch &
- 
+@@ -1113,6 +1226,15 @@ void llama_kv_cache::apply_ubatch(const
+
              const auto idx = sinfo.idxs[s][ii];
- 
+
 +            if (msa_strict_slots && (llama_pos) idx != ubatch.pos[i]) {
 +                LLAMA_LOG_ERROR("%s: MSA slot/position invariant violated: "
 +                        "writing pos %d into cell %u (stream %u). The indexer cache "
@@ -2021,21 +2021,21 @@ index 5382cd726..138a7c63b 100644
 +
              if (!cells.is_empty(idx)) {
                  assert(cells.seq_count(idx) == 1);
- 
-@@ -1156,7 +1278,8 @@ void llama_kv_cache::apply_ubatch(const slot_info & sinfo, const llama_ubatch &
+
+@@ -1156,7 +1278,8 @@ void llama_kv_cache::apply_ubatch(const
              LLAMA_LOG_DEBUG("%s: purging positions [%d, %d] of sequence %d from KV cache\n",
                      __func__, cells.seq_pos_min(s), seq_pos_max_rm[s], s);
- 
+
 -            seq_rm(s, cells.seq_pos_min(s), seq_pos_max_rm[s] + 1);
 +            // under MSA strict slots this path should be unreachable, since strict MSA placement never selects occupied cells
 +            GGML_ASSERT(seq_rm(s, cells.seq_pos_min(s), seq_pos_max_rm[s] + 1));
          }
      }
- 
-@@ -1168,6 +1291,93 @@ void llama_kv_cache::apply_ubatch(const slot_info & sinfo, const llama_ubatch &
+
+@@ -1168,6 +1291,93 @@ void llama_kv_cache::apply_ubatch(const
      }
  }
- 
+
 +std::vector<llama_kv_cache::compaction_move> llama_kv_cache::compact_cells() {
 +    std::vector<compaction_move> moves;
 +
@@ -2126,7 +2126,7 @@ index 5382cd726..138a7c63b 100644
  bool llama_kv_cache::get_can_shift() const {
      // Step35 uses per-layer RoPE dims; K-shift assumes a single global n_rot.
      if (model.arch == LLM_ARCH_STEP35) {
-@@ -1176,6 +1386,12 @@ bool llama_kv_cache::get_can_shift() const {
+@@ -1176,6 +1386,12 @@ bool llama_kv_cache::get_can_shift() con
      if (hparams.n_pos_per_embd() > 1) {
          return false;
      }
@@ -2138,11 +2138,11 @@ index 5382cd726..138a7c63b 100644
 +    }
      return true;
  }
- 
-@@ -1230,6 +1446,413 @@ const llama_kv_cells & llama_kv_cache::get_cells(llama_seq_id seq_id) const {
+
+@@ -1230,6 +1446,413 @@ const llama_kv_cells & llama_kv_cache::g
      return v_cells[seq_to_stream[seq_id]];
  }
- 
+
 +bool llama_kv_cache::stage_export_kv_page(
 +        llama_seq_id seq_id,
 +        int32_t layer_start,
@@ -2552,11 +2552,11 @@ index 5382cd726..138a7c63b 100644
 +
  uint32_t llama_kv_cache::get_n_kv(const slot_info & sinfo) const {
      uint32_t result = 0;
- 
-@@ -1246,6 +1869,49 @@ uint32_t llama_kv_cache::get_n_kv(const slot_info & sinfo) const {
+
+@@ -1246,6 +1869,49 @@ uint32_t llama_kv_cache::get_n_kv(const
      return result;
  }
- 
+
 +uint32_t llama_kv_cache::get_n_kv_pos_contiguous(const slot_info & sinfo, const llama_ubatch & ubatch) const {
 +    if (sinfo.n_stream() != 1 || ubatch.n_seqs_unq != 1 || ubatch.n_tokens == 0 ||
 +        ubatch.pos == nullptr || ubatch.n_seq_id == nullptr ||
@@ -2602,11 +2602,11 @@ index 5382cd726..138a7c63b 100644
 +
  ggml_tensor * llama_kv_cache::get_k(ggml_context * ctx, int32_t il, uint32_t n_kv, const slot_info & sinfo) const {
      const int32_t ikv = map_layer_ids.at(il);
- 
-@@ -1298,6 +1964,23 @@ ggml_tensor * llama_kv_cache::get_v(ggml_context * ctx, int32_t il, uint32_t n_k
+
+@@ -1298,6 +1964,23 @@ ggml_tensor * llama_kv_cache::get_v(ggml
              ggml_row_size(v->type, kv_size*n_embd_v_gqa)*sinfo.s0);
  }
- 
+
 +ggml_tensor * llama_kv_cache::get_k_idx(ggml_context * ctx, int32_t il, uint32_t n_kv, const slot_info & sinfo) const {
 +    const int32_t ikv = map_layer_ids.at(il);
 +    auto * k_idx = layers[ikv].k_idx;
@@ -2626,11 +2626,11 @@ index 5382cd726..138a7c63b 100644
 +
  ggml_tensor * llama_kv_cache::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il, const slot_info & sinfo) const {
      GGML_UNUSED(sinfo);
- 
-@@ -1399,6 +2082,28 @@ ggml_tensor * llama_kv_cache::build_input_k_idxs(ggml_context * ctx, const llama
+
+@@ -1399,6 +2082,28 @@ ggml_tensor * llama_kv_cache::build_inpu
      return k_idxs;
  }
- 
+
 +ggml_tensor * llama_kv_cache::cpy_k_idx(ggml_context * ctx, ggml_tensor * k_idx_cur, ggml_tensor * k_idxs, int32_t il, const slot_info & sinfo) const {
 +    GGML_UNUSED(sinfo);
 +    const int32_t ikv = map_layer_ids.at(il);
@@ -2655,11 +2655,11 @@ index 5382cd726..138a7c63b 100644
 +
  ggml_tensor * llama_kv_cache::build_input_v_idxs(ggml_context * ctx, const llama_ubatch & ubatch) const {
      const uint32_t n_tokens = ubatch.n_tokens;
- 
-@@ -1785,6 +2490,39 @@ void llama_kv_cache::set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch
+
+@@ -1785,6 +2490,39 @@ void llama_kv_cache::set_input_pos_bucke
      }
  }
- 
+
 +void llama_kv_cache::set_input_pos_rel_flat(ggml_tensor * dst, const llama_ubatch * ubatch, uint32_t extent) const {
 +    const int64_t n_tokens = ubatch->n_tokens;
 +
@@ -2695,11 +2695,11 @@ index 5382cd726..138a7c63b 100644
 +
  void llama_kv_cache::set_input_k_rot(ggml_tensor * dst) const {
      GGML_ASSERT(ggml_backend_buffer_is_host(dst->buffer));
- 
-@@ -1833,6 +2571,18 @@ size_t llama_kv_cache::size_v_bytes() const {
+
+@@ -1833,6 +2571,18 @@ size_t llama_kv_cache::size_v_bytes() co
      return size_v_bytes;
  }
- 
+
 +size_t llama_kv_cache::size_k_idx_bytes() const {
 +    size_t size_k_idx_bytes = 0;
 +
@@ -2715,21 +2715,21 @@ index 5382cd726..138a7c63b 100644
  ggml_tensor * llama_kv_cache::build_rope_shift(
          const llama_cparams & cparams,
                 ggml_context * ctx,
-@@ -1931,10 +2681,6 @@ ggml_cgraph * llama_kv_cache::build_graph_shift(llm_graph_result * res, llama_co
+@@ -1931,10 +2681,6 @@ ggml_cgraph * llama_kv_cache::build_grap
      for (const auto & layer : layers) {
          const uint32_t il = layer.il;
- 
+
 -        if (!hparams.has_rope(il)) {
 -            continue;
 -        }
 -
          const int64_t n_head_kv    = hparams.n_head_kv(il);
          const int64_t n_embd_k_gqa = hparams.n_embd_k_gqa(il);
- 
-@@ -2149,6 +2895,36 @@ void llama_kv_cache::state_write_data(llama_io_write_i & io, const cell_ranges_t
+
+@@ -2149,6 +2895,36 @@ void llama_kv_cache::state_write_data(ll
          }
      }
- 
+
 +    if (size_k_idx_bytes() > 0) {
 +        const uint32_t has_k_idx_u32 = 1;
 +        io.write(&has_k_idx_u32, sizeof(has_k_idx_u32));
@@ -2763,10 +2763,10 @@ index 5382cd726..138a7c63b 100644
      if (!v_trans) {
          for (const auto & layer : layers) {
              const uint32_t il = layer.il;
-@@ -2397,6 +3173,68 @@ bool llama_kv_cache::state_read_data(llama_io_read_i & io, uint32_t strm, uint32
+@@ -2397,6 +3173,68 @@ bool llama_kv_cache::state_read_data(lla
          }
      }
- 
+
 +    if (size_k_idx_bytes() > 0) {
 +        uint32_t has_k_idx_u32 = 0;
 +        io.read(&has_k_idx_u32, sizeof(has_k_idx_u32));
@@ -2832,7 +2832,7 @@ index 5382cd726..138a7c63b 100644
      if (!this->v_trans) {
          for (const auto & layer : layers) {
              const uint32_t il = layer.il;
-@@ -2528,8 +3366,9 @@ llama_kv_cache_context::llama_kv_cache_context(
+@@ -2528,8 +3366,9 @@ llama_kv_cache_context::llama_kv_cache_c
          llama_kv_cache * kv,
          llama_context * lctx,
          bool do_shift,
@@ -2844,10 +2844,10 @@ index 5382cd726..138a7c63b 100644
          status = LLAMA_MEMORY_STATUS_NO_UPDATE;
      }
  }
-@@ -2582,6 +3421,21 @@ uint32_t llama_kv_cache_context::get_n_kv() const {
+@@ -2582,6 +3421,21 @@ uint32_t llama_kv_cache_context::get_n_k
      return n_kv;
  }
- 
+
 +uint32_t llama_kv_cache_context::get_n_kv_pos_contiguous() const {
 +    // Full-cache and update contexts do not carry a concrete ubatch/slot pair.
 +    if (ubatches.empty() || sinfos.empty() || i_cur >= ubatches.size() || i_cur >= sinfos.size()) {
@@ -2866,10 +2866,10 @@ index 5382cd726..138a7c63b 100644
  ggml_type llama_kv_cache_context::type_k() const {
      return kv->type_k();
  }
-@@ -2598,6 +3452,10 @@ ggml_tensor * llama_kv_cache_context::get_v(ggml_context * ctx, int32_t il) cons
+@@ -2598,6 +3452,10 @@ ggml_tensor * llama_kv_cache_context::ge
      return kv->get_v(ctx, il, n_kv, sinfos[i_cur]);
  }
- 
+
 +ggml_tensor * llama_kv_cache_context::get_k_idx(ggml_context * ctx, int32_t il) const {
 +    return kv->get_k_idx(ctx, il, n_kv, sinfos[i_cur]);
 +}
@@ -2877,10 +2877,10 @@ index 5382cd726..138a7c63b 100644
  ggml_tensor * llama_kv_cache_context::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il) const {
      return kv->cpy_k(ctx, k_cur, k_idxs, il, sinfos[i_cur]);
  }
-@@ -2606,6 +3464,10 @@ ggml_tensor * llama_kv_cache_context::cpy_v(ggml_context * ctx, ggml_tensor * v_
+@@ -2606,6 +3464,10 @@ ggml_tensor * llama_kv_cache_context::cp
      return kv->cpy_v(ctx, v_cur, v_idxs, il, sinfos[i_cur]);
  }
- 
+
 +ggml_tensor * llama_kv_cache_context::cpy_k_idx(ggml_context * ctx, ggml_tensor * k_idx_cur, ggml_tensor * k_idxs, int32_t il) const {
 +    return kv->cpy_k_idx(ctx, k_idx_cur, k_idxs, il, sinfos[i_cur]);
 +}
@@ -2888,10 +2888,10 @@ index 5382cd726..138a7c63b 100644
  ggml_tensor * llama_kv_cache_context::build_input_k_idxs(ggml_context * ctx, const llama_ubatch & ubatch) const {
      return kv->build_input_k_idxs(ctx, ubatch);
  }
-@@ -2642,6 +3504,10 @@ void llama_kv_cache_context::set_input_pos_bucket(ggml_tensor * dst, const llama
+@@ -2642,6 +3504,10 @@ void llama_kv_cache_context::set_input_p
      kv->set_input_pos_bucket(dst, ubatch);
  }
- 
+
 +void llama_kv_cache_context::set_input_pos_rel_flat(ggml_tensor * dst, const llama_ubatch * ubatch, uint32_t extent) const {
 +    kv->set_input_pos_rel_flat(dst, ubatch, extent);
 +}
@@ -2899,29 +2899,29 @@ index 5382cd726..138a7c63b 100644
  void llama_kv_cache_context::set_input_k_rot(ggml_tensor * dst) const {
      kv->set_input_k_rot(dst);
  }
-diff --git a/src/llama-kv-cache.h b/src/llama-kv-cache.h
-index 6cb6dbd2f..274ef4492 100644
+Index: b/src/llama-kv-cache.h
+===================================================================
 --- a/src/llama-kv-cache.h
 +++ b/src/llama-kv-cache.h
 @@ -6,12 +6,14 @@
  #include "llama-memory.h"
- 
+
  #include <unordered_map>
 +#include <string>
  #include <vector>
- 
+
  struct llama_cparams;
  struct llama_hparams;
  struct llama_model;
  struct llama_context;
 +struct skippy_kv_page_desc;
- 
+
  //
  // llama_kv_cache
 @@ -93,6 +95,12 @@ public:
- 
+
      using slot_info_vec_t = std::vector<slot_info>;
- 
+
 +    struct compaction_move {
 +        uint32_t strm;
 +        uint32_t src;
@@ -2932,12 +2932,12 @@ index 6cb6dbd2f..274ef4492 100644
      //       instead pass all necessary info (e.g. hparams, dev layers, arch, etc.) directly
      //       likely through `struct llama_memory_params`
 @@ -163,22 +171,45 @@ public:
- 
+
      std::vector<uint32_t> get_layer_ids() const;
      ggml_tensor * get_k_storage(int32_t il) const;
 -
      const llama_kv_cells & get_cells(llama_seq_id seq_id) const;
- 
+
 +    bool stage_export_kv_page(
 +            llama_seq_id seq_id,
 +            int32_t layer_start,
@@ -2960,9 +2960,9 @@ index 6cb6dbd2f..274ef4492 100644
      //
      // graph_build API
      //
- 
+
      uint32_t get_n_kv(const slot_info & sinfo) const;
- 
+
 +    // active cell count when position p lives in physical cell p; 0 for any non-contiguous layout
 +    uint32_t get_n_kv_pos_contiguous(const slot_info & sinfo, const llama_ubatch & ubatch) const;
 +
@@ -2970,18 +2970,18 @@ index 6cb6dbd2f..274ef4492 100644
      ggml_tensor * get_k(ggml_context * ctx, int32_t il, uint32_t n_kv, const slot_info & sinfo) const;
      ggml_tensor * get_v(ggml_context * ctx, int32_t il, uint32_t n_kv, const slot_info & sinfo) const;
 +    ggml_tensor * get_k_idx(ggml_context * ctx, int32_t il, uint32_t n_kv, const slot_info & sinfo) const;
- 
+
      // store k_cur and v_cur in the cache based on the provided head location
      ggml_tensor * cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il, const slot_info & sinfo) const;
      ggml_tensor * cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggml_tensor * v_idxs, int32_t il, const slot_info & sinfo) const;
 +    ggml_tensor * cpy_k_idx(ggml_context * ctx, ggml_tensor * k_idx_cur, ggml_tensor * k_idxs, int32_t il, const slot_info & sinfo) const;
- 
+
      //
      // preparation API
 @@ -198,6 +229,10 @@ public:
      // emplace the ubatch context into slot: [sinfo.idxs[0...ubatch.n_tokens - 1]]
      void apply_ubatch(const slot_info & sinfo, const llama_ubatch & ubatch);
- 
+
 +    // move used cells toward the beginning of each stream and copy the backing KV rows
 +    std::vector<compaction_move> compact_cells();
 +    void copy_compacted_cells(const std::vector<compaction_move> & moves) const;
@@ -2992,42 +2992,42 @@ index 6cb6dbd2f..274ef4492 100644
 @@ -216,6 +251,10 @@ public:
      void set_input_kq_mask   (ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn) const;
      void set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch * ubatch) const;
- 
+
 +    // inkling: fill dst I32 [n_kv, n_tokens] with flat rel-bias gather indices,
 +    // idx(i, j) = i*(extent + 1) + rel; empty/out-of-band cells map to the zero-bias column `extent`
 +    void set_input_pos_rel_flat(ggml_tensor * dst, const llama_ubatch * ubatch, uint32_t extent) const;
 +
      void set_input_k_rot(ggml_tensor * dst) const;
      void set_input_v_rot(ggml_tensor * dst) const;
- 
+
 @@ -230,9 +269,11 @@ private:
- 
+
          ggml_tensor * k;
          ggml_tensor * v;
 +        ggml_tensor * k_idx;   // MSA single-head indexer keys, F32
- 
+
          std::vector<ggml_tensor *> k_stream;
          std::vector<ggml_tensor *> v_stream;
 +        std::vector<ggml_tensor *> k_idx_stream;
      };
- 
+
      bool v_trans = true;  // the value tensor is transposed
 @@ -261,6 +302,9 @@ private:
      // env: LLAMA_KV_CACHE_DEBUG
      int debug = 0;
- 
+
 +    // set when a k_idx (indexer) cache exists and the stream layout supports MSA (single seq, or one stream per seq)
 +    bool msa_strict_slots = false;
 +
      // this is the SWA type of the cache - not to be confused with the model SWA type
      const llama_swa_type swa_type = LLAMA_SWA_TYPE_NONE;
- 
+
 @@ -293,6 +337,7 @@ private:
- 
+
      size_t size_k_bytes() const;
      size_t size_v_bytes() const;
 +    size_t size_k_idx_bytes() const;
- 
+
      ggml_tensor * build_rope_shift(
              const llama_cparams & cparams,
 @@ -340,7 +385,8 @@ public:
@@ -3037,15 +3037,15 @@ index 6cb6dbd2f..274ef4492 100644
 -            stream_copy_info sc_info);
 +            stream_copy_info sc_info,
 +            bool did_compact);
- 
+
      // used to create a batch processing context from a batch
      llama_kv_cache_context(
 @@ -365,6 +411,7 @@ public:
      //
- 
+
      uint32_t get_n_kv() const;
 +    uint32_t get_n_kv_pos_contiguous() const;
- 
+
      ggml_type type_k() const;
      ggml_type type_v() const;
 @@ -372,6 +419,7 @@ public:
@@ -3053,7 +3053,7 @@ index 6cb6dbd2f..274ef4492 100644
      ggml_tensor * get_k(ggml_context * ctx, int32_t il) const;
      ggml_tensor * get_v(ggml_context * ctx, int32_t il) const;
 +    ggml_tensor * get_k_idx(ggml_context * ctx, int32_t il) const;
- 
+
      // store k_cur and v_cur in the cache based on the provided head location
      // note: the heads in k_cur and v_cur should be laid out contiguously in memory
 @@ -381,6 +429,7 @@ public:
@@ -3061,7 +3061,7 @@ index 6cb6dbd2f..274ef4492 100644
      ggml_tensor * cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il) const;
      ggml_tensor * cpy_v(ggml_context * ctx, ggml_tensor * v_cur, ggml_tensor * v_idxs, int32_t il) const;
 +    ggml_tensor * cpy_k_idx(ggml_context * ctx, ggml_tensor * k_idx_cur, ggml_tensor * k_idxs, int32_t il) const;
- 
+
      // create destination indices for each head of the current batch for where it would be written in the KV cache
      // the indices address the global KV cache (not per stream) - this is not relevant for the user of this API, but
 @@ -397,6 +446,7 @@ public:
@@ -3069,66 +3069,70 @@ index 6cb6dbd2f..274ef4492 100644
      void set_input_kq_mask   (ggml_tensor * dst, const llama_ubatch * ubatch, bool causal_attn) const;
      void set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch * ubatch) const;
 +    void set_input_pos_rel_flat(ggml_tensor * dst, const llama_ubatch * ubatch, uint32_t extent) const; // inkling
- 
+
      void set_input_k_rot(ggml_tensor * dst) const;
      void set_input_v_rot(ggml_tensor * dst) const;
 @@ -404,8 +454,8 @@ public:
  private:
      llama_memory_status status;
- 
+
 -    llama_kv_cache * kv;
 -    llama_context * lctx;
 +    llama_kv_cache * kv = nullptr;
 +    llama_context * lctx = nullptr;
- 
+
      //
      // update context
-diff --git a/src/llama-kv-cells.h b/src/llama-kv-cells.h
-index fddd31a0b..aab32c9e3 100644
+Index: b/src/llama-kv-cells.h
+===================================================================
 --- a/src/llama-kv-cells.h
 +++ b/src/llama-kv-cells.h
 @@ -45,6 +45,7 @@ public:
- 
+
          for (uint32_t s = 0; s < LLAMA_MAX_SEQ; ++s) {
              seq_pos[s].clear();
 +            seq_pos_index_mismatch[s] = 0;
          }
      }
- 
+
 @@ -97,24 +98,32 @@ public:
      }
- 
+
      // move cell isrc to idst (used during defrag)
 -    //void mv(uint32_t isrc, uint32_t idst) {
 -    //    assert(isrc < pos.size());
 -    //    assert(idst < pos.size());
+-
+-    //    assert(pos[idst] == -1);
+-    //    assert(pos[isrc] != -1);
+-
+-    //    pos  [idst] = pos  [isrc];
+-    //    shift[idst] = shift[isrc];
+-    //    seq  [idst] = seq  [isrc];
+-
+-    //    pos  [isrc] = -1;
+-    //    shift[isrc] =  0;
+-    //    seq  [isrc].reset();
+-
+-    //    used.erase (isrc);
+-    //    used.insert(idst);
+-    //}
 +    void mv(uint32_t isrc, uint32_t idst) {
 +        assert(isrc < pos.size());
 +        assert(idst < pos.size());
 +        assert(isrc != idst);
- 
--    //    assert(pos[idst] == -1);
--    //    assert(pos[isrc] != -1);
++
 +        assert(pos[idst] == -1);
 +        assert(seq[idst].none());
 +        assert(pos[isrc] != -1);
- 
--    //    pos  [idst] = pos  [isrc];
--    //    shift[idst] = shift[isrc];
--    //    seq  [idst] = seq  [isrc];
++
 +        seq_pos_rm(isrc);
- 
--    //    pos  [isrc] = -1;
--    //    shift[isrc] =  0;
--    //    seq  [isrc].reset();
++
 +        pos  [idst] = pos  [isrc];
 +        ext  [idst] = ext  [isrc];
 +        shift[idst] = shift[isrc];
 +        seq  [idst] = seq  [isrc];
- 
--    //    used.erase (isrc);
--    //    used.insert(idst);
--    //}
++
 +        pos  [isrc] = -1;
 +        ext  [isrc].reset();
 +        shift[isrc] =  0;
@@ -3139,40 +3143,40 @@ index fddd31a0b..aab32c9e3 100644
 +
 +        seq_pos_add(idst);
 +    }
- 
+
      // copy the state of cells [i, i + n) (used for save/restore the state of the cells)
      llama_kv_cells cp(uint32_t i, uint32_t n) const {
 @@ -242,7 +251,7 @@ public:
          assert(seq_id >= 0);
- 
+
          seq[i].reset(seq_id);
 -        seq_pos_dec(seq_id, pos[i]);
 +        seq_pos_dec(seq_id, pos[i], i);
- 
+
          if (seq[i].none()) {
              pos[i] = -1;
 @@ -266,7 +275,7 @@ public:
              seq[i].reset();
- 
+
              seq[i].set(seq_id);
 -            seq_pos_inc(seq_id, pos[i]);
 +            seq_pos_inc(seq_id, pos[i], i);
- 
+
              return false;
          }
 @@ -312,7 +321,7 @@ public:
          assert(!seq[i].test(seq_id));
- 
+
          seq[i].set(seq_id);
 -        seq_pos_inc(seq_id, pos[i]);
 +        seq_pos_inc(seq_id, pos[i], i);
      }
- 
+
      // return the sequence id of this cell
 @@ -359,6 +368,23 @@ public:
          return seq_pos[seq_id].rbegin()->first;
      }
- 
+
 +    // Whether every position for seq_id is stored in the cell with the same
 +    // index and the represented positions form the dense range [0, max].
 +    // The mismatch count is maintained with the existing seq_pos index so this
@@ -3196,18 +3200,18 @@ index fddd31a0b..aab32c9e3 100644
 @@ -498,26 +524,38 @@ private:
      //
      std::map<llama_pos, int> seq_pos[LLAMA_MAX_SEQ];
- 
+
 +    // Number of cells for each sequence whose physical cell index differs
 +    // from its logical position.
 +    uint32_t seq_pos_index_mismatch[LLAMA_MAX_SEQ] = {};
 +
      // helper functions for updating `seq_pos`, once cell at a time:
- 
+
 -    void seq_pos_dec(llama_seq_id s, llama_pos p) {
 +    void seq_pos_dec(llama_seq_id s, llama_pos p, uint32_t i) {
          auto it = seq_pos[s].find(p);
          assert(it != seq_pos[s].end());
- 
+
 +        if (p != static_cast<llama_pos>(i)) {
 +            assert(seq_pos_index_mismatch[s] > 0);
 +            --seq_pos_index_mismatch[s];
@@ -3217,7 +3221,7 @@ index fddd31a0b..aab32c9e3 100644
              seq_pos[s].erase(it);
          }
      }
- 
+
 -    void seq_pos_inc(llama_seq_id s, llama_pos p) {
 +    void seq_pos_inc(llama_seq_id s, llama_pos p, uint32_t i) {
          seq_pos[s][p]++;
@@ -3225,7 +3229,7 @@ index fddd31a0b..aab32c9e3 100644
 +            ++seq_pos_index_mismatch[s];
 +        }
      }
- 
+
      // remove cell i
      void seq_pos_rm(uint32_t i) {
          for (int s = 0; s < LLAMA_MAX_SEQ; ++s) {
@@ -3244,33 +3248,33 @@ index fddd31a0b..aab32c9e3 100644
              }
          }
      }
-diff --git a/src/llama-memory-recurrent.cpp b/src/llama-memory-recurrent.cpp
-index ef82eb976..4f1f1df8d 100644
+Index: b/src/llama-memory-recurrent.cpp
+===================================================================
 --- a/src/llama-memory-recurrent.cpp
 +++ b/src/llama-memory-recurrent.cpp
-@@ -26,7 +26,8 @@ llama_memory_recurrent::llama_memory_recurrent(
+@@ -26,7 +26,8 @@ llama_memory_recurrent::llama_memory_rec
                   uint32_t   n_seq_max,
                   uint32_t   n_rs_seq,
      const layer_filter_cb & filter) : hparams(model.hparams), n_seq_max(n_seq_max) {
 -    const int32_t n_layer = hparams.n_layer();
 +    // MTP layers append recurrent state beyond the trunk layer count.
 +    const int32_t n_layer = hparams.n_layer_all;
- 
+
      head = 0;
      size = mem_size;
-@@ -865,7 +866,7 @@ void llama_memory_recurrent::state_write_meta(llama_io_write_i & io, const std::
- 
+@@ -865,7 +866,7 @@ void llama_memory_recurrent::state_write
+
  void llama_memory_recurrent::state_write_data(llama_io_write_i & io, const std::vector<std::pair<uint32_t, uint32_t>> & cell_ranges) const {
      const uint32_t s_trans = 0;
 -    const uint32_t n_layer = hparams.n_layer();
 +    const uint32_t n_layer = hparams.n_layer_all;
- 
+
      io.write(&s_trans, sizeof(s_trans));
      io.write(&n_layer, sizeof(n_layer));
-@@ -1049,8 +1050,8 @@ bool llama_memory_recurrent::state_read_data(llama_io_read_i & io, uint32_t cell
+@@ -1049,8 +1050,8 @@ bool llama_memory_recurrent::state_read_
      io.read(&s_trans, sizeof(s_trans));
      io.read(&n_layer, sizeof(n_layer));
- 
+
 -    if (n_layer != hparams.n_layer()) {
 -        LLAMA_LOG_ERROR("%s: mismatched layer count (%u instead of %u)\n", __func__, n_layer, hparams.n_layer());
 +    if (n_layer != hparams.n_layer_all) {
@@ -3278,14 +3282,14 @@ index ef82eb976..4f1f1df8d 100644
          return false;
      }
      if (cell_count > size) {
-diff --git a/src/llama-model-loader.cpp b/src/llama-model-loader.cpp
-index 3d50f8a1c..1086cad36 100644
+Index: b/src/llama-model-loader.cpp
+===================================================================
 --- a/src/llama-model-loader.cpp
 +++ b/src/llama-model-loader.cpp
 @@ -18,6 +18,25 @@ static const size_t kiB = 1024;
  static const size_t MiB = 1024*kiB;
  static const size_t GiB = 1024*MiB;
- 
+
 +static thread_local llama_model_loader_stage_filter g_skippy_filter;
 +static thread_local bool g_skippy_last_tensor_filtered = false;
 +
@@ -3361,17 +3365,17 @@ index 3d50f8a1c..1086cad36 100644
 +        }
          uint16_t n_split = 0;
          get_key(llm_kv(LLM_KV_SPLIT_COUNT), n_split, false);
- 
+
          // Load additional GGML contexts
 -        if (n_split > 1) {
 +        if (!ordered_parts && n_split > 1) {
              // make sure the main file is loaded first
              uint16_t idx = 0;
              const std::string kv_split_no = llm_kv(LLM_KV_SPLIT_NO);
-@@ -1090,14 +1149,101 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1090,14 +1149,93 @@ struct ggml_tensor * llama_model_loader:
          return it->second.get();
      };
- 
+
 -    auto buft_for_tensor = [&](ggml_tensor * t_meta) -> ggml_backend_buffer_type_t {
 -        if (!t_meta) {
 -            if (flags & TENSOR_NOT_REQUIRED) {
@@ -3398,8 +3402,8 @@ index 3d50f8a1c..1086cad36 100644
 +        llm_tensor tn_tensor = tn.tensor;
 +        if (tn.tensor == LLM_TENSOR_TOKEN_EMBD && (flags & TENSOR_DUPLICATED)) {
 +            tn_tensor = LLM_TENSOR_OUTPUT;
-         }
- 
++        }
++
 +        llm_tensor_info info;
 +        try {
 +            info = llm_tensor_info_for(tn_tensor);
@@ -3443,22 +3447,14 @@ index 3d50f8a1c..1086cad36 100644
 +            if (t_meta) {
 +                const bool requested_tensor_exists =
 +                        !(flags & TENSOR_NOT_REQUIRED) || requested_shape_matches(t_meta);
-+                const std::string tensor_name = tn.str();
-+                bool first_filtered_request = true;
-+                if (requested_tensor_exists && !(flags & TENSOR_DUPLICATED)) {
-+                    first_filtered_request = skippy_counted_filtered_tensors.insert(tensor_name).second;
-+                }
 +                const size_t nbytes = ggml_nbytes(t_meta);
 +                LLAMA_LOG_DEBUG(
 +                        "llama_model_loader: stage filter skipping tensor %s (size = %zu bytes)\n",
-+                        tensor_name.c_str(),
++                        tn.str().c_str(),
 +                        nbytes);
 +
-+                if (requested_tensor_exists && first_filtered_request) {
-+                    size_data -= nbytes;
-+                    if (!(flags & TENSOR_DUPLICATED)) {
-+                        n_created++;
-+                    }
++                if (requested_tensor_exists && !(flags & TENSOR_DUPLICATED)) {
++                    n_created++;
 +                }
 +                g_skippy_last_tensor_filtered = true;
 +            } else {
@@ -3466,8 +3462,8 @@ index 3d50f8a1c..1086cad36 100644
 +            }
 +
 +            return true;
-+        }
-+
+         }
+
 +        return false;
 +    };
 +
@@ -3475,10 +3471,10 @@ index 3d50f8a1c..1086cad36 100644
          // some models use the token embedding tensor as the output, but since these are used in different layers and with different ops
          // the tensor is duplicated
          // to handle this, we check if the tensor is duplicated, and if so, we assume that it is being loaded as the output tensor
-@@ -1113,6 +1259,20 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1113,6 +1251,20 @@ struct ggml_tensor * llama_model_loader:
              throw std::runtime_error(format("missing tensor info mapping for %s", tn.str().c_str()));
          }
- 
+
 +        if (stage_filter_excludes(t_meta)) {
 +            return nullptr;
 +        }
@@ -3496,9 +3492,9 @@ index 3d50f8a1c..1086cad36 100644
          // skip unused tensors
          if (info.op == GGML_OP_NONE || (flags & TENSOR_SKIP)) {
              const size_t nbytes = ggml_nbytes(t_meta);
-@@ -1269,6 +1429,16 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1269,6 +1421,16 @@ struct ggml_tensor * llama_model_loader:
      }
- 
+
      LLAMA_LOG_DEBUG("%s: loading tensor %s\n", __func__, tn.str().c_str());
 +
 +    // The stage filter must be consulted BEFORE the tensor is looked up: a filtered
@@ -3513,8 +3509,50 @@ index 3d50f8a1c..1086cad36 100644
      const struct ggml_tensor * cur = check_tensor_dims(tn.str(), ne, !(flags & TENSOR_NOT_REQUIRED), flags & TENSOR_ALLOW_RESHAPE);
      if (cur == NULL) {
          return NULL;
-diff --git a/src/llama-model-loader.h b/src/llama-model-loader.h
-index d6b31c231..74fc6c093 100644
+@@ -1305,14 +1467,10 @@ struct ggml_tensor * llama_model_loader:
+         }
+     }
+
+-    const bool duplicated = flags & TENSOR_DUPLICATED;
+-
+     struct ggml_tensor * tensor = ggml_dup_tensor(ctx, &t_meta);
+     ggml_set_name(tensor, ggml_get_name(&t_meta));
+
+-    if (duplicated) {
+-        size_data += ggml_nbytes(&t_meta);
+-    } else {
++    if (!(flags & TENSOR_DUPLICATED)) {
+         n_created++;
+     }
+
+@@ -1364,9 +1522,22 @@ void llama_model_loader::init_mappings(b
+         }
+     }
+
+-    // compute the total size of all tensors for progress reporting
+-    for (const auto & it : weights_map) {
+-        size_data += ggml_nbytes(it.second.tensor);
++    // Match load_all_data exactly once model contexts exist. Quantization calls
++    // init_mappings before model construction and uses load_data_for instead.
++    if (!ctx_map.empty()) {
++        size_data = 0;
++        for (const auto & [_, ctx] : ctx_map) {
++            for (ggml_tensor * tensor = ggml_get_first_tensor(ctx.get()); tensor; tensor = ggml_get_next_tensor(ctx.get(), tensor)) {
++                if (get_weight(ggml_get_name(tensor)) != nullptr) {
++                    size_data += ggml_nbytes(tensor);
++                }
++            }
++        }
++    } else {
++        size_data = 0;
++        for (const auto & [_, weight] : weights_map) {
++            size_data += ggml_nbytes(weight.tensor);
++        }
+     }
+ }
+
+Index: b/src/llama-model-loader.h
+===================================================================
 --- a/src/llama-model-loader.h
 +++ b/src/llama-model-loader.h
 @@ -14,12 +14,26 @@
@@ -3522,12 +3560,12 @@ index d6b31c231..74fc6c093 100644
  #include <stdexcept>
  #include <unordered_map>
 +#include <unordered_set>
- 
+
  using llama_buf_map = std::unordered_map<uint32_t, ggml_backend_buffer_t>;
- 
+
  // lists of buffer types used for each layer
  using buft_list_t = std::vector<std::pair<ggml_backend_dev_t, ggml_backend_buffer_type_t>>;
- 
+
 +struct llama_model_loader_stage_filter {
 +    bool enabled = false;
 +    int32_t layer_start = 0;
@@ -3544,15 +3582,7 @@ index d6b31c231..74fc6c093 100644
  enum llama_fver {
      GGUF_FILE_VERSION_V1 = 1,
      GGUF_FILE_VERSION_V2 = 2,
-@@ -90,6 +104,7 @@ struct llama_model_loader {
- 
-     std::map<std::string, llama_tensor_weight, weight_name_comparer> weights_map;
-     std::unordered_map<std::string, llama_model_kv_override> kv_overrides;
-+    std::unordered_set<std::string> skippy_counted_filtered_tensors;
-     const llama_model_tensor_buft_override * tensor_buft_overrides;
- 
-     gguf_context_ptr metadata_ptr;
-@@ -127,6 +142,7 @@ struct llama_model_loader {
+@@ -127,6 +141,7 @@ struct llama_model_loader {
          void * set_tensor_data_ud,
          const std::string & fname,
          std::vector<std::string> & splits, // optional, only need if the split does not follow naming scheme
@@ -3560,11 +3590,11 @@ index d6b31c231..74fc6c093 100644
          FILE * file,
          llama_load_mode load_mode,
          bool check_tensors,
-diff --git a/src/llama-model-saver.cpp b/src/llama-model-saver.cpp
-index abca773a9..837ac505f 100644
+Index: b/src/llama-model-saver.cpp
+===================================================================
 --- a/src/llama-model-saver.cpp
 +++ b/src/llama-model-saver.cpp
-@@ -30,6 +30,7 @@ bool llama_model_saver_supports_arch(llm_arch arch) {
+@@ -30,6 +30,7 @@ bool llama_model_saver_supports_arch(llm
          case LLM_ARCH_MUSE_GLIMMER:
          case LLM_ARCH_MELLUM:
          case LLM_ARCH_LAGUNA:
@@ -3572,8 +3602,8 @@ index abca773a9..837ac505f 100644
              return false;
          default:
              return true;
-diff --git a/src/llama-model.cpp b/src/llama-model.cpp
-index 3bf3a22f2..25bde1b26 100644
+Index: b/src/llama-model.cpp
+===================================================================
 --- a/src/llama-model.cpp
 +++ b/src/llama-model.cpp
 @@ -11,7 +11,6 @@
@@ -3585,7 +3615,7 @@ index 3bf3a22f2..25bde1b26 100644
  #include "llama-memory-hybrid.h"
  #include "llama-memory-hybrid-iswa.h"
 @@ -40,8 +39,6 @@
- 
+
  static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params & params) {
      switch (arch) {
 -        case LLM_ARCH_CLIP:
@@ -3593,7 +3623,7 @@ index 3bf3a22f2..25bde1b26 100644
          case LLM_ARCH_LLAMA:
              return new llama_model_llama(params);
          case LLM_ARCH_LLAMA4:
-@@ -114,8 +111,6 @@ static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params
+@@ -114,8 +111,6 @@ static llama_model * llama_model_mapping
              return new llama_model_qwen3vl(params);
          case LLM_ARCH_QWEN3VLMOE:
              return new llama_model_qwen3vlmoe(params);
@@ -3602,7 +3632,7 @@ index 3bf3a22f2..25bde1b26 100644
          case LLM_ARCH_PHI2:
              return new llama_model_phi2(params);
          case LLM_ARCH_PHI3:
-@@ -176,8 +171,6 @@ static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params
+@@ -176,8 +171,6 @@ static llama_model * llama_model_mapping
              return new llama_model_olmo2(params);
          case LLM_ARCH_OLMOE:
              return new llama_model_olmoe(params);
@@ -3611,7 +3641,7 @@ index 3bf3a22f2..25bde1b26 100644
          case LLM_ARCH_OPENELM:
              return new llama_model_openelm(params);
          case LLM_ARCH_GPTNEOX:
-@@ -238,8 +231,6 @@ static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params
+@@ -238,8 +231,6 @@ static llama_model * llama_model_mapping
              return new llama_model_granite(params);
          case LLM_ARCH_GRANITE_MOE:
              return new llama_model_granite_moe(params);
@@ -3620,7 +3650,7 @@ index 3bf3a22f2..25bde1b26 100644
          case LLM_ARCH_MINICPM:
              return new llama_model_minicpm(params);
          case LLM_ARCH_GRANITE_HYBRID:
-@@ -320,6 +311,8 @@ static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params
+@@ -320,6 +311,8 @@ static llama_model * llama_model_mapping
              return new llama_model_kimi_linear(params);
          case LLM_ARCH_STEP35:
              return new llama_model_step35(params);
@@ -3629,7 +3659,7 @@ index 3bf3a22f2..25bde1b26 100644
          default:
              throw std::runtime_error(std::string("unsupported model architecture: '") + llm_arch_name(arch) + "'");
      }
-@@ -827,7 +820,6 @@ const char * llm_type_name(llm_type type) {
+@@ -827,7 +820,6 @@ const char * llm_type_name(llm_type type
          case LLM_TYPE_100B_A6B:      return "100B.A6B";
          case LLM_TYPE_102B_A12B:     return "102B.A12B";
          case LLM_TYPE_106B_A12B:     return "106B.A12B";
@@ -3637,16 +3667,16 @@ index 3bf3a22f2..25bde1b26 100644
          case LLM_TYPE_120B_A12B:     return "120B.A12B";
          case LLM_TYPE_122B_A10B:     return "122B.A10B";
          case LLM_TYPE_196B_A11B:     return "196B.A11B";
-@@ -1145,6 +1137,7 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
+@@ -1145,6 +1137,7 @@ void llama_model_base::load_hparams(llam
      std::fill(hparams.is_swa_impl.begin(),   hparams.is_swa_impl.end(), 0);
      std::fill(hparams.is_recr_impl.begin(),  hparams.is_recr_impl.end(),  llm_arch_is_recurrent(ml.get_arch()) ? 1 : 0);
      std::fill(hparams.is_indexer_full_impl.begin(), hparams.is_indexer_full_impl.end(), 0);
 +    std::fill(hparams.indexer_types.begin(), hparams.indexer_types.end(), -1);
- 
+
      std::fill(hparams.xielu_alpha_n.begin(), hparams.xielu_alpha_n.end(), 0.0f);
      std::fill(hparams.xielu_alpha_p.begin(), hparams.xielu_alpha_p.end(), 0.0f);
-@@ -1323,13 +1316,29 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
- 
+@@ -1323,13 +1316,29 @@ bool llama_model_base::load_tensors(llam
+
      const int i_gpu_start = std::max(n_layer_all + 1 - n_gpu_layers, 0);
      const int act_gpu_layers = devices.empty() ? 0 : std::min(n_gpu_layers, n_layer_all + 1);
 +    const auto stage_filter = llama_model_loader_get_stage_filter();
@@ -3676,9 +3706,9 @@ index 3bf3a22f2..25bde1b26 100644
          auto * dev = devices.at(layer_gpu).dev;
          LLAMA_LOG_DEBUG("load_tensors: layer %3d assigned to device %s, is_swa = %d\n", il, ggml_backend_dev_name(dev), is_swa);
          return {dev, &pimpl->gpu_buft_list.at(dev)};
-@@ -1413,13 +1422,13 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
+@@ -1413,13 +1422,13 @@ bool llama_model_base::load_tensors(llam
              }
- 
+
              // MoE expert weight scales (per-expert, shape {n_expert})
 -            if (!layer.ffn_gate_exps_s && layer.ffn_gate_exps) {
 +            if (!layer.ffn_gate_exps_s && (layer.ffn_gate_exps || ml.get_tensor_meta(tn(LLM_TENSOR_FFN_GATE_EXPS, "scale", i).str().c_str()) != nullptr)) {
@@ -3692,14 +3722,14 @@ index 3bf3a22f2..25bde1b26 100644
 +            if (!layer.ffn_up_exps_s && (layer.ffn_up_exps || ml.get_tensor_meta(tn(LLM_TENSOR_FFN_UP_EXPS, "scale", i).str().c_str()) != nullptr)) {
                  layer.ffn_up_exps_s = create_tensor(tn(LLM_TENSOR_FFN_UP_EXPS, "scale", i), {n_expert}, TENSOR_NOT_REQUIRED);
              }
- 
-@@ -1520,7 +1529,7 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
+
+@@ -1520,7 +1529,7 @@ bool llama_model_base::load_tensors(llam
              }
          }
      }
 -    ml.done_getting_tensors();
 +    ml.done_getting_tensors(llama_model_loader_get_stage_filter().enabled);
- 
+
      // Tied NVFP4 output is valid when no separate LM-head scale tensors are present.
      // If sidecar scales exist, the output weight must be an actual output tensor.
 @@ -1918,7 +1927,6 @@ void llama_model::print_info() const {
@@ -3710,10 +3740,10 @@ index 3bf3a22f2..25bde1b26 100644
                  arch == LLM_ARCH_NEMOTRON_H_MOE) {
              LLAMA_LOG_INFO("%s: f_embedding_scale     = %f\n", __func__, hparams.f_embedding_scale);
              LLAMA_LOG_INFO("%s: f_residual_scale      = %f\n", __func__, hparams.f_residual_scale);
-@@ -2058,6 +2066,22 @@ ggml_tensor * llama_model::get_rope_factors(const llama_cparams & cparams, int i
+@@ -2058,6 +2066,22 @@ ggml_tensor * llama_model::get_rope_fact
      return layers[il].rope_short;
  }
- 
+
 +static llama_memory_i::layer_filter_cb skippy_stage_memory_filter(
 +        llama_memory_i::layer_filter_cb filter,
 +        enum llama_context_type ctx_type) {
@@ -3732,8 +3762,8 @@ index 3bf3a22f2..25bde1b26 100644
 +
  llama_memory_i * llama_model::create_memory(const llama_memory_params & params, const llama_cparams & cparams) const {
      llama_memory_i * res;
- 
-@@ -2081,13 +2105,10 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+
+@@ -2081,13 +2105,10 @@ llama_memory_i * llama_model::create_mem
              {
                  res = nullptr;
              } break;
@@ -3750,7 +3780,7 @@ index 3bf3a22f2..25bde1b26 100644
                          *this,
                          params.type_k,
                          params.type_v,
-@@ -2100,143 +2121,17 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2100,143 +2121,17 @@ llama_memory_i * llama_model::create_mem
                          hparams.n_swa,
                          hparams.swa_type,
                          nullptr,
@@ -3894,10 +3924,10 @@ index 3bf3a22f2..25bde1b26 100644
 -                const bool mtp_on_hybrid_nemotron =
 -                    params.ctx_type == LLAMA_CONTEXT_TYPE_MTP && arch == LLM_ARCH_NEMOTRON_H_MOE;
 +                    (arch == LLM_ARCH_QWEN35 || arch == LLM_ARCH_QWEN35MOE);
- 
+
                  if (llm_arch_is_recurrent(arch)) {
                      res = new llama_memory_recurrent(
-@@ -2247,15 +2142,26 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2247,15 +2142,26 @@ llama_memory_i * llama_model::create_mem
                              std::max((uint32_t) 1, cparams.n_seq_max),
                              cparams.n_seq_max,
                              cparams.n_rs_seq,
@@ -3926,7 +3956,7 @@ index 3bf3a22f2..25bde1b26 100644
                      } else if (arch == LLM_ARCH_NEMOTRON_H || arch == LLM_ARCH_NEMOTRON_H_MOE) {
                          filter_attn = [&](uint32_t il) {
                              return !hparams.is_recr(il) && hparams.n_ff(il) == 0;
-@@ -2263,7 +2169,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2263,7 +2169,7 @@ llama_memory_i * llama_model::create_mem
                          filter_recr = [&](uint32_t il) {
                              return hparams.is_recr(il) && hparams.n_ff(il) == 0;
                          };
@@ -3935,25 +3965,25 @@ index 3bf3a22f2..25bde1b26 100644
                          filter_attn = [&](uint32_t il) {
                              return il < hparams.n_layer() && !hparams.is_recr(il);
                          };
-@@ -2272,6 +2178,9 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2272,6 +2178,9 @@ llama_memory_i * llama_model::create_mem
                          };
                      }
- 
+
 +                    filter_attn = skippy_stage_memory_filter(std::move(filter_attn), params.ctx_type);
 +                    filter_recr = skippy_stage_memory_filter(std::move(filter_recr), params.ctx_type);
 +
                      if (hparams.swa_type != LLAMA_SWA_TYPE_NONE) {
                          // Use hybrid-iswa for hybrid models with SWA
                          res = new llama_memory_hybrid_iswa(
-@@ -2329,13 +2238,11 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2329,13 +2238,11 @@ llama_memory_i * llama_model::create_mem
                          };
                      }
- 
+
 -                    if (mtp_on_hybrid_qwen || mtp_on_hybrid_nemotron) {
 +                    if (mtp_on_hybrid_qwen35) {
                          filter = [&](uint32_t il) { return il >= hparams.n_layer(); };
                      }
- 
+
 -                    if ((arch == LLM_ARCH_STEP35 || arch == LLM_ARCH_HY_V3 || arch == LLM_ARCH_GLM_DSA ||
 -                            arch == LLM_ARCH_MIMO2 || arch == LLM_ARCH_DEEPSEEK32) &&
 -                            hparams.n_layer_nextn > 0) {
@@ -3961,10 +3991,10 @@ index 3bf3a22f2..25bde1b26 100644
                          if (params.ctx_type == LLAMA_CONTEXT_TYPE_MTP) {
                              filter = [&](uint32_t il) { return il >= hparams.n_layer(); };
                          } else {
-@@ -2343,7 +2250,34 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2343,7 +2250,34 @@ llama_memory_i * llama_model::create_mem
                          }
                      }
- 
+
 -                    if (hparams.swa_type != LLAMA_SWA_TYPE_NONE) {
 +                    if ((arch == LLM_ARCH_DEEPSEEK2 || arch == LLM_ARCH_GLM_DSA) && hparams.n_layer_nextn > 0) {
 +                        if (params.ctx_type == LLAMA_CONTEXT_TYPE_MTP) {
@@ -3995,25 +4025,25 @@ index 3bf3a22f2..25bde1b26 100644
 +                                reuse);
 +                    } else if (hparams.swa_type != LLAMA_SWA_TYPE_NONE) {
                          GGML_ASSERT(hparams.is_swa_any());
- 
+
                          if (arch == LLM_ARCH_GEMMA4_ASSISTANT) {
-@@ -2463,7 +2397,6 @@ llama_model_params llama_model_default_params() {
+@@ -2463,7 +2397,6 @@ llama_model_params llama_model_default_p
          /*.use_extra_bufts             =*/ true,
          /*.no_host                     =*/ false,
          /*.no_alloc                    =*/ false,
 -        /*.load_mtp                    =*/ false,
      };
- 
+
      return result;
-@@ -2579,6 +2512,7 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
+@@ -2579,6 +2512,7 @@ llama_rope_type llama_model_rope_type(co
          case LLM_ARCH_NEMOTRON_H:
          case LLM_ARCH_NEMOTRON_H_MOE:
          case LLM_ARCH_KIMI_LINEAR:
 +        case LLM_ARCH_INKLING:
              return LLAMA_ROPE_TYPE_NONE;
- 
+
          // use what we call a normal RoPE, operating on pairs of consecutive head values
-@@ -2601,13 +2535,11 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
+@@ -2601,13 +2535,11 @@ llama_rope_type llama_model_rope_type(co
          case LLM_ARCH_DEEPSEEK2OCR:
          case LLM_ARCH_DEEPSEEK32:
          case LLM_ARCH_DEEPSEEK4:
@@ -4027,7 +4057,7 @@ index 3bf3a22f2..25bde1b26 100644
          case LLM_ARCH_CHAMELEON:
          case LLM_ARCH_BAILINGMOE:
          case LLM_ARCH_NEO_BERT:
-@@ -2694,11 +2626,8 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
+@@ -2694,11 +2626,8 @@ llama_rope_type llama_model_rope_type(co
          case LLM_ARCH_STEP35:
          case LLM_ARCH_TALKIE:
          case LLM_ARCH_MELLUM:
@@ -4037,28 +4067,28 @@ index 3bf3a22f2..25bde1b26 100644
 -            // DSV4 DSpark drafters use DeepSeek-V4's normal RoPE; legacy DFlash backbones are NeoX
 -            return model->hparams.dsv4_hc_mult > 0 ? LLAMA_ROPE_TYPE_NORM : LLAMA_ROPE_TYPE_NEOX;
 +            return LLAMA_ROPE_TYPE_NEOX;
- 
+
          case LLM_ARCH_QWEN2VL:
          case LLM_ARCH_PADDLEOCR:
-@@ -2707,7 +2636,6 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
+@@ -2707,7 +2636,6 @@ llama_rope_type llama_model_rope_type(co
          case LLM_ARCH_QWEN3VLMOE:
          case LLM_ARCH_QWEN35:
          case LLM_ARCH_QWEN35MOE:
 -        case LLM_ARCH_QWEN3TTS:
              return LLAMA_ROPE_TYPE_IMROPE;
- 
+
          case LLM_ARCH_GLM4:
-@@ -2882,8 +2810,7 @@ llama_model_base::llama_model_base(const struct llama_model_params & params) : l
+@@ -2882,8 +2810,7 @@ llama_model_base::llama_model_base(const
      TENSOR_DUPLICATED     (llama_model_loader::TENSOR_DUPLICATED),
      TENSOR_NOT_REQUIRED   (llama_model_loader::TENSOR_NOT_REQUIRED),
      TENSOR_SKIP           (llama_model_loader::TENSOR_SKIP),
 -    TENSOR_SKIP_IF_VIRTUAL(llama_model_loader::TENSOR_SKIP_IF_VIRTUAL),
 -    TENSOR_ALLOW_RESHAPE  (llama_model_loader::TENSOR_ALLOW_RESHAPE) {}
 +    TENSOR_SKIP_IF_VIRTUAL(llama_model_loader::TENSOR_SKIP_IF_VIRTUAL) {}
- 
+
  ggml_tensor * llama_model_base::create_tensor(const LLM_TN_IMPL & tn, const std::initializer_list<int64_t> & ne, int flags) {
      GGML_ASSERT(ml != nullptr);
-@@ -2902,23 +2829,9 @@ void llama_model_base::create_tensor_qkv(llama_layer & layer, int bid,
+@@ -2902,23 +2829,9 @@ void llama_model_base::create_tensor_qkv
          int64_t n_embd_, int64_t n_embd_q_, int64_t n_embd_k_, int64_t n_embd_v_,
          int flags) {
      const int64_t n_embd_qkv = n_embd_q_ + n_embd_k_ + n_embd_v_;
@@ -4084,7 +4114,7 @@ index 3bf3a22f2..25bde1b26 100644
          layer.wqkv_b = create_tensor(tn(LLM_TENSOR_ATTN_QKV, "bias", bid), {n_embd_qkv}, TENSOR_NOT_REQUIRED | TENSOR_SKIP_IF_VIRTUAL);
      } else {
          layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q, "weight", bid), {n_embd_, n_embd_q_}, flags);
-@@ -2938,38 +2851,3 @@ const int32_t * llama_model_target_layer_ids(const struct llama_model * model) {
+@@ -2938,38 +2851,3 @@ const int32_t * llama_model_target_layer
  uint32_t llama_model_target_layer_ids_n(const struct llama_model * model) {
      return (uint32_t) model->target_layer_ids.size();
  }
@@ -4123,8 +4153,8 @@ index 3bf3a22f2..25bde1b26 100644
 -
 -    return (uint32_t) nelements;
 -}
-diff --git a/src/llama-model.h b/src/llama-model.h
-index 1dd090438..7fed4f910 100644
+Index: b/src/llama-model.h
+===================================================================
 --- a/src/llama-model.h
 +++ b/src/llama-model.h
 @@ -130,7 +130,6 @@ enum llm_type {
@@ -4138,7 +4168,7 @@ index 1dd090438..7fed4f910 100644
 @@ -223,24 +222,6 @@ struct llama_layer_nextn {
      struct ggml_tensor * shared_head_norm      = nullptr;
  };
- 
+
 -struct llama_layer_switch_lora {
 -    struct ggml_tensor * a_q    = nullptr;
 -    struct ggml_tensor * b_q    = nullptr;
@@ -4161,9 +4191,9 @@ index 1dd090438..7fed4f910 100644
      // normalization
      struct ggml_tensor * attn_norm       = nullptr;
 @@ -552,6 +533,15 @@ struct llama_layer {
- 
+
      struct llama_layer_nextn nextn;
- 
+
 +    // inkling (private arch)
 +    struct ggml_tensor * wr             = nullptr; // attn_r  [n_embd, n_head*d_rel]
 +    struct ggml_tensor * attn_rel_proj  = nullptr; // [rel_extent, d_rel] (checkpoint [d_rel, E] orientation)
@@ -4175,23 +4205,23 @@ index 1dd090438..7fed4f910 100644
 +
      struct llama_layer_switch_lora switch_lora;
  };
- 
-@@ -739,7 +729,6 @@ struct llama_model_base : public llama_model {
+
+@@ -739,7 +729,6 @@ struct llama_model_base : public llama_m
      const int TENSOR_NOT_REQUIRED;
      const int TENSOR_SKIP;
      const int TENSOR_SKIP_IF_VIRTUAL;
 -    const int TENSOR_ALLOW_RESHAPE;
- 
+
      explicit llama_model_base(const llama_model_params & params);
      virtual ~llama_model_base() = default;
-diff --git a/src/llama-quant.cpp b/src/llama-quant.cpp
-index fd6e787bd..9d8e3dae2 100644
+Index: b/src/llama-quant.cpp
+===================================================================
 --- a/src/llama-quant.cpp
 +++ b/src/llama-quant.cpp
-@@ -326,6 +326,16 @@ static bool tensor_allows_quantization(const llama_model_quantize_params * param
+@@ -326,6 +326,16 @@ static bool tensor_allows_quantization(c
      quantize &= name.find("ssm_conv1d") == std::string::npos;
      quantize &= name.find("shortconv.conv.weight") == std::string::npos;
- 
+
 +    // keep Inkling's shortconv kernels and rel-proj table unquantized; arch-gated so the
 +    // name substrings cannot hit another architecture
 +    if (arch == LLM_ARCH_INKLING) {
@@ -4205,20 +4235,20 @@ index fd6e787bd..9d8e3dae2 100644
      // do not quantize MiniMax's indexer projection weights, they are tiny
      quantize &= name.find("indexer.k_proj.weight") == std::string::npos;
      quantize &= name.find("indexer.q_proj.weight") == std::string::npos;
-@@ -893,7 +903,7 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
+@@ -893,7 +903,7 @@ static void llama_model_quantize_impl(co
      const llama_model_kv_override * kv_overrides = params->kv_overrides;
      std::vector<std::string> splits = {};
      llama_model_loader ml(/*metadata*/ nullptr, /*set_tensor_data*/ nullptr, /*set_tensor_data_ud*/ nullptr,
 -        fname_inp, splits, /*file*/ nullptr, /*load_mode*/ load_mode, /*check_tensors*/ true, /*no_alloc*/ false, /*load_mtp*/ true, kv_overrides, nullptr);
 +        fname_inp, splits, /*ordered_parts*/ false, /*file*/ nullptr, /*load_mode*/ load_mode, /*check_tensors*/ true, /*no_alloc*/ false, /*load_mtp*/ true, kv_overrides, nullptr);
      ml.init_mappings(false); // no prefetching
- 
+
      auto mparams = llama_model_default_params();
-diff --git a/src/llama-vocab.cpp b/src/llama-vocab.cpp
-index 4a01dfd4c..837fef8a3 100644
+Index: b/src/llama-vocab.cpp
+===================================================================
 --- a/src/llama-vocab.cpp
 +++ b/src/llama-vocab.cpp
-@@ -433,6 +433,12 @@ struct llm_tokenizer_bpe : llm_tokenizer {
+@@ -433,6 +433,12 @@ struct llm_tokenizer_bpe : llm_tokenizer
                      "[^\\r\\n\\p{L}\\p{N}]?((?=[\\p{L}])([^a-z]))*((?=[\\p{L}])([^A-Z]))+(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])?|[^\\r\\n\\p{L}\\p{N}]?((?=[\\p{L}])([^a-z]))+((?=[\\p{L}])([^A-Z]))*(?:'[sS]|'[tT]|'[rR][eE]|'[vV][eE]|'[mM]|'[lL][lL]|'[dD])?|\\p{N}{1,3}| ?[^\\s\\p{L}\\p{N}]+[\\r\\n/]*|\\s*[\\r\\n]+|\\s+(?!\\S)|\\s+",
                  };
                  break;
@@ -4231,19 +4261,19 @@ index 4a01dfd4c..837fef8a3 100644
              case LLAMA_VOCAB_PRE_TYPE_GRANITE_EMB_MULTI:
                  // Same lookaheads as GPT4O but with \p{M} added so combining marks
                  // (diacritics) attach to their base letters. Avoids excessive
-@@ -2297,6 +2303,10 @@ void llama_vocab::impl::load(llama_model_loader & ml, const LLM_KV & kv) {
-                 tokenizer_pre == "talkie") {
+@@ -2298,6 +2304,10 @@ void llama_vocab::impl::load(llama_model
                  pre_type = LLAMA_VOCAB_PRE_TYPE_GPT4O;
                  clean_spaces = false;
-+            } else if (
+             } else if (
 +                tokenizer_pre == "inkling") {
 +                pre_type = LLAMA_VOCAB_PRE_TYPE_INKLING;
 +                clean_spaces = false;
-             } else if (
++            } else if (
                  tokenizer_pre == "granite-embed-multi-97m") {
                  pre_type = LLAMA_VOCAB_PRE_TYPE_GRANITE_EMB_MULTI;
-diff --git a/src/llama-vocab.h b/src/llama-vocab.h
-index b7c289263..65e43f671 100644
+                 clean_spaces = false;
+Index: b/src/llama-vocab.h
+===================================================================
 --- a/src/llama-vocab.h
 +++ b/src/llama-vocab.h
 @@ -65,6 +65,7 @@ enum llama_vocab_pre_type {
@@ -4252,14 +4282,14 @@ index b7c289263..65e43f671 100644
      LLAMA_VOCAB_PRE_TYPE_LAGUNA            = 56,
 +    LLAMA_VOCAB_PRE_TYPE_INKLING           = 57,
  };
- 
+
  struct LLM_KV;
-diff --git a/src/llama.cpp b/src/llama.cpp
-index d6e0bbfef..59e5040fb 100644
+Index: b/src/llama.cpp
+===================================================================
 --- a/src/llama.cpp
 +++ b/src/llama.cpp
-@@ -302,9 +302,9 @@ static bool llama_prepare_model_devices(const llama_model_params & params, llama
- 
+@@ -302,9 +302,9 @@ static bool llama_prepare_model_devices(
+
  // Returns 0 on success, -1 on error, and -2 on cancellation via llama_progress_callback
  static std::pair<int, llama_model *> llama_model_load(struct gguf_context * metadata, llama_model_set_tensor_data_t set_tensor_data, void * set_tensor_data_ud,
 -        const std::string & fname, std::vector<std::string> & splits, FILE * file, llama_model_params & params) {
@@ -4268,9 +4298,9 @@ index d6e0bbfef..59e5040fb 100644
 -        llama_model_loader ml(metadata, set_tensor_data, set_tensor_data_ud, fname, splits, file, params.load_mode,
 +        llama_model_loader ml(metadata, set_tensor_data, set_tensor_data_ud, fname, splits, ordered_parts, file, params.load_mode,
              params.check_tensors, params.no_alloc, params.load_mtp, params.kv_overrides, params.tensor_buft_overrides);
- 
+
          ml.print_info();
-@@ -369,6 +369,7 @@ static struct llama_model * llama_model_load_from_file_impl(
+@@ -369,6 +369,7 @@ static struct llama_model * llama_model_
          void * set_tensor_data_ud,
          const std::string & path_model,
          std::vector<std::string> & splits,
@@ -4278,16 +4308,16 @@ index d6e0bbfef..59e5040fb 100644
          FILE * file,
          struct llama_model_params params) {
      {
-@@ -411,7 +412,7 @@ static struct llama_model * llama_model_load_from_file_impl(
+@@ -411,7 +412,7 @@ static struct llama_model * llama_model_
          };
      }
- 
+
 -    const auto [status, model] = llama_model_load(metadata, set_tensor_data, set_tensor_data_ud, path_model, splits, file, params);
 +    const auto [status, model] = llama_model_load(metadata, set_tensor_data, set_tensor_data_ud, path_model, splits, ordered_parts, file, params);
      GGML_ASSERT(status <= 0);
      if (status < 0) {
          if (status == -1) {
-@@ -439,7 +440,7 @@ struct llama_model * llama_model_init_from_user(
+@@ -439,7 +440,7 @@ struct llama_model * llama_model_init_fr
      std::vector<std::string> splits = {};
      params.load_mode = LLAMA_LOAD_MODE_NONE;
      params.use_extra_bufts = false;
@@ -4296,16 +4326,16 @@ index d6e0bbfef..59e5040fb 100644
  }
  // deprecated
  struct llama_model * llama_load_model_from_file(
-@@ -452,7 +453,7 @@ struct llama_model * llama_model_load_from_file(
+@@ -452,7 +453,7 @@ struct llama_model * llama_model_load_fr
          const char * path_model,
          struct llama_model_params params) {
      std::vector<std::string> splits = {};
 -    return llama_model_load_from_file_impl(nullptr, nullptr, nullptr, path_model, splits, /*file*/ nullptr, params);
 +    return llama_model_load_from_file_impl(nullptr, nullptr, nullptr, path_model, splits, /*ordered_parts*/ false, /*file*/ nullptr, params);
  }
- 
+
  struct llama_model * llama_model_load_from_splits(
-@@ -468,7 +469,27 @@ struct llama_model * llama_model_load_from_splits(
+@@ -468,7 +469,27 @@ struct llama_model * llama_model_load_fr
      for (size_t i = 0; i < n_paths; ++i) {
          splits.push_back(paths[i]);
      }
@@ -4332,30 +4362,30 @@ index d6e0bbfef..59e5040fb 100644
 +    }
 +    return llama_model_load_from_file_impl(nullptr, nullptr, nullptr, parts.front(), parts, /*ordered_parts*/ true, /*file*/ nullptr, params);
  }
- 
+
  struct llama_model * llama_model_load_from_file_ptr(FILE * file, struct llama_model_params params) {
-@@ -478,7 +499,7 @@ struct llama_model * llama_model_load_from_file_ptr(FILE * file, struct llama_mo
+@@ -478,7 +499,7 @@ struct llama_model * llama_model_load_fr
      }
      std::string path_model;
      std::vector<std::string> splits = {};
 -    return llama_model_load_from_file_impl(nullptr, nullptr, nullptr, path_model, splits, file, params);
 +    return llama_model_load_from_file_impl(nullptr, nullptr, nullptr, path_model, splits, /*ordered_parts*/ false, file, params);
  }
- 
+
  void llama_model_save_to_file(const struct llama_model * model, const char * path_model) {
-@@ -603,4 +624,3 @@ const char * llama_print_system_info(void) {
- 
+@@ -603,4 +624,3 @@ const char * llama_print_system_info(voi
+
      return s.c_str();
  }
 -
-diff --git a/src/models/afmoe.cpp b/src/models/afmoe.cpp
-index 063b21425..b388e586a 100644
+Index: b/src/models/afmoe.cpp
+===================================================================
 --- a/src/models/afmoe.cpp
 +++ b/src/models/afmoe.cpp
-@@ -113,7 +113,12 @@ llama_model_afmoe::graph::graph(const llama_model & model, const llm_graph_param
+@@ -113,7 +113,12 @@ llama_model_afmoe::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4363,27 +4393,27 @@ index 063b21425..b388e586a 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // MuP scaling: embeddings * sqrt(hidden_size)
      // mup_enabled = true, hidden_size = 1024, scale = 32.0
-@@ -123,11 +128,11 @@ llama_model_afmoe::graph::graph(const llama_model & model, const llm_graph_param
+@@ -123,11 +128,11 @@ llama_model_afmoe::graph::graph(const ll
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
      auto * inp_attn = build_attn_inp_kv_iswa();
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
      const float kq_scale = 1.0f/sqrtf(float(n_embd_head));
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const float freq_base_l  = model.get_rope_freq_base (cparams, il);
          const float freq_scale_l = model.get_rope_freq_scale(cparams, il);
- 
-@@ -269,6 +274,13 @@ llama_model_afmoe::graph::graph(const llama_model & model, const llm_graph_param
- 
+
+@@ -269,6 +274,13 @@ llama_model_afmoe::graph::graph(const ll
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -4394,14 +4424,14 @@ index 063b21425..b388e586a 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/apertus.cpp b/src/models/apertus.cpp
-index 6dfb8905f..88f6799e6 100644
+Index: b/src/models/apertus.cpp
+===================================================================
 --- a/src/models/apertus.cpp
 +++ b/src/models/apertus.cpp
-@@ -66,7 +66,12 @@ llama_model_apertus::graph::graph(const llama_model & model, const llm_graph_par
+@@ -66,7 +66,12 @@ llama_model_apertus::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4409,25 +4439,25 @@ index 6dfb8905f..88f6799e6 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      ggml_tensor * inp_pos  = build_inp_pos();
      auto *        inp_attn = build_attn_inp_kv();
-@@ -74,9 +79,9 @@ llama_model_apertus::graph::graph(const llama_model & model, const llm_graph_par
+@@ -74,9 +79,9 @@ llama_model_apertus::graph::graph(const
      const float kq_scale =
          hparams.f_attention_scale == 0.0f ? 1.0f / sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          cur = build_norm(inpL, model.layers[il].attn_norm, nullptr, LLM_NORM_RMS, il);
-@@ -155,6 +160,13 @@ llama_model_apertus::graph::graph(const llama_model & model, const llm_graph_par
- 
+@@ -155,6 +160,13 @@ llama_model_apertus::graph::graph(const
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -4436,16 +4466,16 @@ index 6dfb8905f..88f6799e6 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, nullptr, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/arcee.cpp b/src/models/arcee.cpp
-index 9536e7c5d..7711f805e 100644
+Index: b/src/models/arcee.cpp
+===================================================================
 --- a/src/models/arcee.cpp
 +++ b/src/models/arcee.cpp
-@@ -54,7 +54,12 @@ llama_model_arcee::graph::graph(const llama_model & model, const llm_graph_param
+@@ -54,7 +54,12 @@ llama_model_arcee::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4453,25 +4483,25 @@ index 9536e7c5d..7711f805e 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -63,9 +68,9 @@ llama_model_arcee::graph::graph(const llama_model & model, const llm_graph_param
- 
+@@ -63,9 +68,9 @@ llama_model_arcee::graph::graph(const ll
+
      const float kq_scale = hparams.f_attention_scale == 0.0f ? 1.0f/sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -140,6 +145,13 @@ llama_model_arcee::graph::graph(const llama_model & model, const llm_graph_param
- 
+@@ -140,6 +145,13 @@ llama_model_arcee::graph::graph(const ll
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -4482,14 +4512,14 @@ index 9536e7c5d..7711f805e 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/arctic.cpp b/src/models/arctic.cpp
-index 09ee0f752..a2b3e6cf8 100644
+Index: b/src/models/arctic.cpp
+===================================================================
 --- a/src/models/arctic.cpp
 +++ b/src/models/arctic.cpp
-@@ -62,16 +62,21 @@ llama_model_arctic::graph::graph(const llama_model & model, const llm_graph_para
+@@ -62,16 +62,21 @@ llama_model_arctic::graph::graph(const l
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4497,24 +4527,24 @@ index 09ee0f752..a2b3e6cf8 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -163,6 +168,13 @@ llama_model_arctic::graph::graph(const llama_model & model, const llm_graph_para
- 
+@@ -163,6 +168,13 @@ llama_model_arctic::graph::graph(const l
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -4525,14 +4555,14 @@ index 09ee0f752..a2b3e6cf8 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/arwkv7.cpp b/src/models/arwkv7.cpp
-index b38b20647..85c073c93 100644
+Index: b/src/models/arwkv7.cpp
+===================================================================
 --- a/src/models/arwkv7.cpp
 +++ b/src/models/arwkv7.cpp
-@@ -124,7 +124,12 @@ llama_model_arwkv7::graph::graph(const llama_model & model, const llm_graph_para
+@@ -124,7 +124,12 @@ llama_model_arwkv7::graph::graph(const l
      ggml_tensor * inpL;
      ggml_tensor * v_first = nullptr;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4540,13 +4570,13 @@ index b38b20647..85c073c93 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      auto * rs_inp = build_rs_inp();
- 
-@@ -132,9 +137,18 @@ llama_model_arwkv7::graph::graph(const llama_model & model, const llm_graph_para
+
+@@ -132,9 +137,18 @@ llama_model_arwkv7::graph::graph(const l
      const auto n_seq_tokens = ubatch.n_seq_tokens;
      const auto n_seqs = ubatch.n_seqs;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    if (stage_filtered && il_start > 0) {
 +        auto inp = std::make_unique<llm_graph_input_rwkv7_v_first>(n_embd);
@@ -4558,32 +4588,32 @@ index b38b20647..85c073c93 100644
 +    }
 +
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const llama_layer * layer = &model.layers[il];
          inpL = ggml_reshape_3d(ctx0, inpL, n_embd, n_seq_tokens, n_seqs);
- 
-@@ -151,6 +165,9 @@ llama_model_arwkv7::graph::graph(const llama_model & model, const llm_graph_para
+
+@@ -151,6 +165,9 @@ llama_model_arwkv7::graph::graph(const l
                  );
- 
+
          cur = build_rwkv7_time_mix(rs_inp, att_norm, x_prev, v_first, ubatch, il);
 +        if (stage_filtered && !stage_filter.include_output && il_start == 0 && il == 0) {
 +            res->t_skippy_rwkv7_v_first = v_first;
 +        }
- 
+
          token_shift = ggml_view_3d(ctx0, att_norm, n_embd, 1, n_seqs, att_norm->nb[1], att_norm->nb[2], (n_seq_tokens-1)*n_embd*ggml_element_size(att_norm));
          ggml_build_forward_expand(gf, build_rwkv_token_shift_store(token_shift, ubatch, il));
-@@ -161,7 +178,7 @@ llama_model_arwkv7::graph::graph(const llama_model & model, const llm_graph_para
+@@ -161,7 +178,7 @@ llama_model_arwkv7::graph::graph(const l
          cur     = ggml_reshape_2d(ctx0, cur,     n_embd, n_tokens);
          ffn_inp = ggml_reshape_2d(ctx0, ffn_inp, n_embd, n_tokens);
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur     = ggml_get_rows(ctx0, cur,     inp_out_ids);
              ffn_inp = ggml_get_rows(ctx0, ffn_inp, inp_out_ids);
          }
-@@ -187,6 +204,12 @@ llama_model_arwkv7::graph::graph(const llama_model & model, const llm_graph_para
+@@ -187,6 +204,12 @@ llama_model_arwkv7::graph::graph(const l
          // input for next layer
          inpL = cur;
      }
@@ -4595,15 +4625,15 @@ index b38b20647..85c073c93 100644
 +    }
      cur = inpL;
      cur = build_norm(cur, model.output_norm, model.output_norm_b, LLM_NORM_RMS, -1);
- 
-diff --git a/src/models/baichuan.cpp b/src/models/baichuan.cpp
-index 585f36141..8e9dc3028 100644
+
+Index: b/src/models/baichuan.cpp
+===================================================================
 --- a/src/models/baichuan.cpp
 +++ b/src/models/baichuan.cpp
-@@ -52,16 +52,21 @@ llama_model_baichuan::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -52,16 +52,21 @@ llama_model_baichuan::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4611,33 +4641,33 @@ index 585f36141..8e9dc3028 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = model.type == LLM_TYPE_7B ? build_inp_pos() : nullptr;
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          cur = build_norm(inpL,
-@@ -103,7 +108,7 @@ llama_model_baichuan::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -103,7 +108,7 @@ llama_model_baichuan::graph::graph(const
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -138,6 +143,13 @@ llama_model_baichuan::graph::graph(const llama_model & model, const llm_graph_pa
- 
+@@ -138,6 +143,13 @@ llama_model_baichuan::graph::graph(const
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -4648,14 +4678,14 @@ index 585f36141..8e9dc3028 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/bailingmoe.cpp b/src/models/bailingmoe.cpp
-index 7faf73c83..3fa8e41d0 100644
+Index: b/src/models/bailingmoe.cpp
+===================================================================
 --- a/src/models/bailingmoe.cpp
 +++ b/src/models/bailingmoe.cpp
-@@ -63,16 +63,21 @@ llama_model_bailingmoe::graph::graph(const llama_model & model, const llm_graph_
+@@ -63,16 +63,21 @@ llama_model_bailingmoe::graph::graph(con
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4663,24 +4693,24 @@ index 7faf73c83..3fa8e41d0 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -163,6 +168,13 @@ llama_model_bailingmoe::graph::graph(const llama_model & model, const llm_graph_
- 
+@@ -163,6 +168,13 @@ llama_model_bailingmoe::graph::graph(con
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -4691,14 +4721,14 @@ index 7faf73c83..3fa8e41d0 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/bailingmoe2.cpp b/src/models/bailingmoe2.cpp
-index 5000e9c6d..2d95fc677 100644
+Index: b/src/models/bailingmoe2.cpp
+===================================================================
 --- a/src/models/bailingmoe2.cpp
 +++ b/src/models/bailingmoe2.cpp
-@@ -99,16 +99,21 @@ llama_model_bailingmoe2::graph::graph(const llama_model & model, const llm_graph
+@@ -99,16 +99,21 @@ llama_model_bailingmoe2::graph::graph(co
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4706,33 +4736,33 @@ index 5000e9c6d..2d95fc677 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -141,7 +146,7 @@ llama_model_bailingmoe2::graph::graph(const llama_model & model, const llm_graph
+@@ -141,7 +146,7 @@ llama_model_bailingmoe2::graph::graph(co
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f / sqrtf(float(n_embd_head)), il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -199,6 +204,13 @@ llama_model_bailingmoe2::graph::graph(const llama_model & model, const llm_graph
- 
+@@ -199,6 +204,13 @@ llama_model_bailingmoe2::graph::graph(co
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -4741,24 +4771,24 @@ index 5000e9c6d..2d95fc677 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/bitnet.cpp b/src/models/bitnet.cpp
-index c83302745..20faa0697 100644
+Index: b/src/models/bitnet.cpp
+===================================================================
 --- a/src/models/bitnet.cpp
 +++ b/src/models/bitnet.cpp
-@@ -16,6 +16,7 @@ void llama_model_bitnet::load_arch_tensors(llama_model_loader &) {
- 
+@@ -16,6 +16,7 @@ void llama_model_bitnet::load_arch_tenso
+
      // output
      output_norm = create_tensor(tn(LLM_TENSOR_OUTPUT_NORM, "weight"), {n_embd}, 0);
 +    output      = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD,  "weight"), {n_embd, n_vocab}, TENSOR_DUPLICATED);
- 
+
      for (int i = 0; i < n_layer; ++i) {
          auto & layer = layers[i];
-@@ -56,16 +57,21 @@ llama_model_bitnet::graph::graph(const llama_model & model, const llm_graph_para
+@@ -56,16 +57,21 @@ llama_model_bitnet::graph::graph(const l
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4766,24 +4796,24 @@ index c83302745..20faa0697 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          cur = build_norm(inpL,
-@@ -152,6 +158,13 @@ llama_model_bitnet::graph::graph(const llama_model & model, const llm_graph_para
- 
+@@ -152,6 +158,13 @@ llama_model_bitnet::graph::graph(const l
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -4794,24 +4824,24 @@ index c83302745..20faa0697 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-@@ -160,8 +173,7 @@ llama_model_bitnet::graph::graph(const llama_model & model, const llm_graph_para
+@@ -160,8 +173,7 @@ llama_model_bitnet::graph::graph(const l
      res->t_embd = cur;
- 
+
      // lm_head
 -    // FIXME: do not use model.tok_embd directly, duplicate as model.output
 -    cur = build_lora_mm(model.tok_embd, cur);
 +    cur = build_lora_mm(model.output, cur);
- 
+
      cb(cur, "result_output", -1);
      res->t_logits = cur;
-diff --git a/src/models/bloom.cpp b/src/models/bloom.cpp
-index 609d2ddf9..021ea67a6 100644
+Index: b/src/models/bloom.cpp
+===================================================================
 --- a/src/models/bloom.cpp
 +++ b/src/models/bloom.cpp
-@@ -70,19 +70,26 @@ llama_model_bloom::graph::graph(const llama_model & model, const llm_graph_param
+@@ -70,19 +70,26 @@ llama_model_bloom::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4819,9 +4849,9 @@ index 609d2ddf9..021ea67a6 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    inpL = build_norm(inpL,
 -            model.tok_norm,
 -            model.tok_norm_b,
@@ -4834,28 +4864,28 @@ index 609d2ddf9..021ea67a6 100644
 +                LLM_NORM, 0);
 +        cb(inpL, "inp_norm", 0);
 +    }
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          cur = build_norm(inpL,
                  model.layers[il].attn_norm,
                  model.layers[il].attn_norm_b,
-@@ -99,7 +106,7 @@ llama_model_bloom::graph::graph(const llama_model & model, const llm_graph_param
+@@ -99,7 +106,7 @@ llama_model_bloom::graph::graph(const ll
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur  = ggml_get_rows(ctx0,  cur, inp_out_ids);
              inpL = ggml_get_rows(ctx0, inpL, inp_out_ids);
          }
-@@ -134,6 +141,13 @@ llama_model_bloom::graph::graph(const llama_model & model, const llm_graph_param
+@@ -134,6 +141,13 @@ llama_model_bloom::graph::graph(const ll
          inpL = cur;
      }
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(inpL, "stage_boundary", il_end - 1);
 +        res->t_embd = inpL;
@@ -4866,14 +4896,14 @@ index 609d2ddf9..021ea67a6 100644
      cur = build_norm(inpL,
              model.output_norm,
              model.output_norm_b,
-diff --git a/src/models/chatglm.cpp b/src/models/chatglm.cpp
-index 7ae5b938f..ad6ea6e76 100644
+Index: b/src/models/chatglm.cpp
+===================================================================
 --- a/src/models/chatglm.cpp
 +++ b/src/models/chatglm.cpp
-@@ -63,16 +63,21 @@ llama_model_chatglm::graph::graph(const llama_model & model, const llm_graph_par
+@@ -63,16 +63,21 @@ llama_model_chatglm::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4881,24 +4911,24 @@ index 7ae5b938f..ad6ea6e76 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          cur = build_norm(inpL,
-@@ -144,6 +149,13 @@ llama_model_chatglm::graph::graph(const llama_model & model, const llm_graph_par
+@@ -144,6 +149,13 @@ llama_model_chatglm::graph::graph(const
          inpL = cur;
      }
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(inpL, "stage_boundary", il_end - 1);
 +        res->t_embd = inpL;
@@ -4909,14 +4939,14 @@ index 7ae5b938f..ad6ea6e76 100644
      cur = build_norm(inpL,
              model.output_norm,
              NULL,
-diff --git a/src/models/codeshell.cpp b/src/models/codeshell.cpp
-index de53bb981..bc7cc8865 100644
+Index: b/src/models/codeshell.cpp
+===================================================================
 --- a/src/models/codeshell.cpp
 +++ b/src/models/codeshell.cpp
-@@ -59,16 +59,21 @@ llama_model_codeshell::graph::graph(const llama_model & model, const llm_graph_p
+@@ -59,16 +59,21 @@ llama_model_codeshell::graph::graph(cons
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4924,24 +4954,24 @@ index de53bb981..bc7cc8865 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          cur = build_norm(inpL,
                  model.layers[il].attn_norm,
                  model.layers[il].attn_norm_b,
-@@ -136,6 +141,13 @@ llama_model_codeshell::graph::graph(const llama_model & model, const llm_graph_p
+@@ -136,6 +141,13 @@ llama_model_codeshell::graph::graph(cons
          inpL = cur;
      }
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(inpL, "stage_boundary", il_end - 1);
 +        res->t_embd = inpL;
@@ -4952,14 +4982,14 @@ index de53bb981..bc7cc8865 100644
      cur = build_norm(inpL,
              model.output_norm,
              model.output_norm_b,
-diff --git a/src/models/cohere2.cpp b/src/models/cohere2.cpp
-index e2b366256..1223aae3f 100644
+Index: b/src/models/cohere2.cpp
+===================================================================
 --- a/src/models/cohere2.cpp
 +++ b/src/models/cohere2.cpp
-@@ -59,16 +59,21 @@ llama_model_cohere2::graph::graph(const llama_model & model, const llm_graph_par
+@@ -59,16 +59,21 @@ llama_model_cohere2::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -4967,33 +4997,33 @@ index e2b366256..1223aae3f 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv_iswa();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const bool is_swa = hparams.is_swa(il);
          // UNUSED:
          // const float freq_base_l  = model.get_rope_freq_base (cparams, il);
-@@ -111,7 +116,7 @@ llama_model_cohere2::graph::graph(const llama_model & model, const llm_graph_par
+@@ -111,7 +116,7 @@ llama_model_cohere2::graph::graph(const
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur     = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpL    = ggml_get_rows(ctx0, inpL, inp_out_ids);
              ffn_inp = ggml_get_rows(ctx0, ffn_inp, inp_out_ids);
-@@ -142,6 +147,13 @@ llama_model_cohere2::graph::graph(const llama_model & model, const llm_graph_par
- 
+@@ -142,6 +147,13 @@ llama_model_cohere2::graph::graph(const
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -5002,16 +5032,16 @@ index e2b366256..1223aae3f 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/command-r.cpp b/src/models/command-r.cpp
-index 94a46188b..260012552 100644
+Index: b/src/models/command-r.cpp
+===================================================================
 --- a/src/models/command-r.cpp
 +++ b/src/models/command-r.cpp
-@@ -54,16 +54,21 @@ llama_model_command_r::graph::graph(const llama_model & model, const llm_graph_p
+@@ -54,16 +54,21 @@ llama_model_command_r::graph::graph(cons
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -5019,21 +5049,21 @@ index 94a46188b..260012552 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          // norm
          cur = build_norm(inpL, model.layers[il].attn_norm, NULL, LLM_NORM, il);
          cb(cur, "attn_norm", il);
-@@ -98,7 +103,7 @@ llama_model_command_r::graph::graph(const llama_model & model, const llm_graph_p
+@@ -98,7 +103,7 @@ llama_model_command_r::graph::graph(cons
                      model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f / sqrtf(float(n_embd_head)), il);
          }
@@ -5042,10 +5072,10 @@ index 94a46188b..260012552 100644
              cur     = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpL    = ggml_get_rows(ctx0, inpL, inp_out_ids);
              ffn_inp = ggml_get_rows(ctx0, ffn_inp, inp_out_ids);
-@@ -126,6 +131,13 @@ llama_model_command_r::graph::graph(const llama_model & model, const llm_graph_p
+@@ -126,6 +131,13 @@ llama_model_command_r::graph::graph(cons
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -5054,16 +5084,16 @@ index 94a46188b..260012552 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/dbrx.cpp b/src/models/dbrx.cpp
-index 4f5ac4d06..f2d5238f4 100644
+Index: b/src/models/dbrx.cpp
+===================================================================
 --- a/src/models/dbrx.cpp
 +++ b/src/models/dbrx.cpp
-@@ -53,16 +53,21 @@ llama_model_dbrx::graph::graph(const llama_model & model, const llm_graph_params
+@@ -53,16 +53,21 @@ llama_model_dbrx::graph::graph(const lla
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -5071,24 +5101,24 @@ index 4f5ac4d06..f2d5238f4 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -137,6 +142,13 @@ llama_model_dbrx::graph::graph(const llama_model & model, const llm_graph_params
- 
+@@ -137,6 +142,13 @@ llama_model_dbrx::graph::graph(const lla
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -5099,14 +5129,14 @@ index 4f5ac4d06..f2d5238f4 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM, -1);
-diff --git a/src/models/deci.cpp b/src/models/deci.cpp
-index cdfcf29e0..d732efe45 100644
+Index: b/src/models/deci.cpp
+===================================================================
 --- a/src/models/deci.cpp
 +++ b/src/models/deci.cpp
-@@ -86,7 +86,12 @@ llama_model_deci::graph::graph(const llama_model & model, const llm_graph_params
+@@ -86,7 +86,12 @@ llama_model_deci::graph::graph(const lla
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -5114,25 +5144,25 @@ index cdfcf29e0..d732efe45 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -96,9 +101,9 @@ llama_model_deci::graph::graph(const llama_model & model, const llm_graph_params
+@@ -96,9 +101,9 @@ llama_model_deci::graph::graph(const lla
      const float kq_scale =
          hparams.f_attention_scale == 0.0f ? 1.0f / sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA     = inpL;
          const int64_t n_head_kv = hparams.n_head_kv(il);
          const int64_t n_head    = hparams.n_head(il);
-@@ -176,6 +181,13 @@ llama_model_deci::graph::graph(const llama_model & model, const llm_graph_params
+@@ -176,6 +181,13 @@ llama_model_deci::graph::graph(const lla
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -5141,13 +5171,13 @@ index cdfcf29e0..d732efe45 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/deepseek2.cpp b/src/models/deepseek2.cpp
-index ba90c0d07..feb055702 100644
+Index: b/src/models/deepseek2.cpp
+===================================================================
 --- a/src/models/deepseek2.cpp
 +++ b/src/models/deepseek2.cpp
-@@ -20,6 +20,9 @@ void llama_model_deepseek2::load_arch_hparams(llama_model_loader & ml) {
+@@ -20,6 +20,9 @@ void llama_model_deepseek2::load_arch_hp
      ml.get_key(LLM_KV_EXPERT_WEIGHTS_SCALE,       hparams.expert_weights_scale, false);
      ml.get_key(LLM_KV_EXPERT_WEIGHTS_NORM,        hparams.expert_weights_norm, false);
      ml.get_key(LLM_KV_EXPERT_GATING_FUNC,         hparams.expert_gating_func, false);
@@ -5157,10 +5187,10 @@ index ba90c0d07..feb055702 100644
      if (hparams.expert_gating_func == LLAMA_EXPERT_GATING_FUNC_TYPE_NONE) {
          // for compatibility with existing DeepSeek V2 and V2.5 GGUFs
          // that have no expert_gating_func model parameter set
-@@ -37,11 +40,6 @@ void llama_model_deepseek2::load_arch_hparams(llama_model_loader & ml) {
+@@ -37,11 +40,6 @@ void llama_model_deepseek2::load_arch_hp
          hparams.rope_yarn_log_mul /= 0.1f;
      }
- 
+
 -    // NextN/MTP
 -    ml.get_key(LLM_KV_NEXTN_PREDICT_LAYERS, hparams.n_layer_nextn, false);
 -    GGML_ASSERT(hparams.n_layer_nextn == 0 ||
@@ -5169,15 +5199,15 @@ index ba90c0d07..feb055702 100644
      // (optional) temperature tuning - used by mistral-large
      ml.get_key(LLM_KV_ATTENTION_TEMPERATURE_SCALE,  hparams.f_attn_temp_scale,       false);
      ml.get_key(LLM_KV_ATTENTION_TEMPERATURE_LENGTH, hparams.n_attn_temp_floor_scale, false); // FIXME why not use temperature_length?
-@@ -57,20 +55,10 @@ void llama_model_deepseek2::load_arch_hparams(llama_model_loader & ml) {
+@@ -57,20 +55,10 @@ void llama_model_deepseek2::load_arch_hp
      }
  }
- 
+
 -void llama_model_deepseek2::load_arch_tensors(llama_model_loader & ml) {
 +void llama_model_deepseek2::load_arch_tensors(llama_model_loader &) {
      LLAMA_LOAD_LOCALS;
      const int64_t n_expert_shared = hparams.n_expert_shared;
- 
+
 -    const bool mtp_only = (hparams.n_layer_nextn > 0) && (ml.get_weight("blk.0.attn_norm.weight") == nullptr);
 -    const std::string mtp_probe = "blk." + std::to_string(n_layer) + ".nextn.eh_proj.weight";
 -    const bool trunk_only = (hparams.n_layer_nextn > 0) && (ml.get_weight(mtp_probe.c_str()) == nullptr);
@@ -5189,24 +5219,24 @@ index ba90c0d07..feb055702 100644
 -    }
 -
      const bool is_mla = hparams.is_mla();
- 
+
      // note: these are the actual head sizes you get when treating as MHA or after "decompression" using wv_b for MLA
-@@ -98,43 +86,42 @@ void llama_model_deepseek2::load_arch_tensors(llama_model_loader & ml) {
- 
+@@ -98,43 +86,42 @@ void llama_model_deepseek2::load_arch_te
+
      for (int i = 0; i < n_layer_all; ++i) {
          auto & layer = layers[i];
 -        const int flags = i < n_layer ? trunk_flags : mtp_flags;
- 
+
 -        layer.attn_norm = create_tensor(tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd}, flags);
 +        layer.attn_norm = create_tensor(tn(LLM_TENSOR_ATTN_NORM, "weight", i), {n_embd}, 0);
          if (q_lora_rank > 0) {
 -            layer.attn_q_a_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_A_NORM, "weight", i), {q_lora_rank}, flags);
 +            layer.attn_q_a_norm = create_tensor(tn(LLM_TENSOR_ATTN_Q_A_NORM, "weight", i), {q_lora_rank}, 0);
          }
- 
+
 -        layer.attn_kv_a_norm = create_tensor(tn(LLM_TENSOR_ATTN_KV_A_NORM, "weight", i), {kv_lora_rank}, flags);
 +        layer.attn_kv_a_norm = create_tensor(tn(LLM_TENSOR_ATTN_KV_A_NORM, "weight", i), {kv_lora_rank}, 0);
- 
+
          if (q_lora_rank > 0) {
 -            layer.wq_a = create_tensor(tn(LLM_TENSOR_ATTN_Q_A, "weight", i), {n_embd, q_lora_rank}, flags);
 -            layer.wq_b = create_tensor(tn(LLM_TENSOR_ATTN_Q_B, "weight", i), {q_lora_rank, n_head * n_embd_head_k_mla}, flags);
@@ -5216,10 +5246,10 @@ index ba90c0d07..feb055702 100644
 -            layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q, "weight", i), {n_embd, n_head * n_embd_head_k_mla}, flags);
 +            layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q, "weight", i), {n_embd, n_head * n_embd_head_k_mla}, 0);
          }
- 
+
 -        layer.wkv_a_mqa = create_tensor(tn(LLM_TENSOR_ATTN_KV_A_MQA, "weight", i), {n_embd, kv_lora_rank + n_embd_head_qk_rope}, flags);
 +        layer.wkv_a_mqa = create_tensor(tn(LLM_TENSOR_ATTN_KV_A_MQA, "weight", i), {n_embd, kv_lora_rank + n_embd_head_qk_rope}, 0);
- 
+
          // note: only old legacy GGUF files will have the unsplit wkv_b tensor in
          if (is_mla) {
 -            layer.wk_b = create_tensor(tn(LLM_TENSOR_ATTN_K_B, "weight", i), {n_embd_head_qk_nope, kv_lora_rank, n_head}, flags);
@@ -5230,13 +5260,13 @@ index ba90c0d07..feb055702 100644
 -            layer.wkv_b = create_tensor(tn(LLM_TENSOR_ATTN_KV_B, "weight", i), {kv_lora_rank, n_head * (n_embd_head_qk_nope + n_embd_head_v_mla)}, flags);
 +            layer.wkv_b = create_tensor(tn(LLM_TENSOR_ATTN_KV_B, "weight", i), {kv_lora_rank, n_head * (n_embd_head_qk_nope + n_embd_head_v_mla)}, 0);
          }
- 
+
 -        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_head * n_embd_head_v_mla, n_embd}, flags);
 +        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), {n_head * n_embd_head_v_mla, n_embd}, 0);
- 
+
 -        layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, flags);
 +        layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, 0);
- 
+
          if (i < (int) hparams.n_layer_dense_lead) {
 -            layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff}, flags);
 -            layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", i), {  n_ff, n_embd}, flags);
@@ -5249,18 +5279,18 @@ index ba90c0d07..feb055702 100644
 -            layer.ffn_exp_probs_b = create_tensor(tn(LLM_TENSOR_FFN_EXP_PROBS_B, "bias", i), {n_expert}, TENSOR_NOT_REQUIRED | flags);
 +            layer.ffn_gate_inp = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP, "weight", i), {n_embd, n_expert}, 0);
 +            layer.ffn_exp_probs_b = create_tensor(tn(LLM_TENSOR_FFN_EXP_PROBS_B, "bias", i), {n_expert}, TENSOR_NOT_REQUIRED);
- 
+
              if (n_expert == 0) {
                  throw std::runtime_error("n_expert must be > 0");
-@@ -144,23 +131,22 @@ void llama_model_deepseek2::load_arch_tensors(llama_model_loader & ml) {
+@@ -144,23 +131,22 @@ void llama_model_deepseek2::load_arch_te
              }
- 
+
              // MoE branch
 -            layer.ffn_down_exps = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i), {n_ff_exp,   n_embd, n_expert}, flags);
 -            create_tensor_gate_up_exps(layer, i, n_embd, n_ff_exp, n_expert, flags);
 +            layer.ffn_down_exps = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i), {n_ff_exp,   n_embd, n_expert}, 0);
 +            create_tensor_gate_up_exps(layer, i, n_embd, n_ff_exp, n_expert, 0);
- 
+
              // Shared expert branch
 -            layer.ffn_gate_shexp = create_tensor(tn(LLM_TENSOR_FFN_GATE_SHEXP, "weight", i), {n_embd, n_ff_exp * n_expert_shared}, flags);
 -            layer.ffn_down_shexp = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP, "weight", i), {        n_ff_exp * n_expert_shared, n_embd}, flags);
@@ -5269,7 +5299,7 @@ index ba90c0d07..feb055702 100644
 +            layer.ffn_down_shexp = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP, "weight", i), {        n_ff_exp * n_expert_shared, n_embd}, 0);
 +            layer.ffn_up_shexp   = create_tensor(tn(LLM_TENSOR_FFN_UP_SHEXP,   "weight", i), {n_embd, n_ff_exp * n_expert_shared}, 0);
          }
- 
+
 -        // NextN/MTP tensors
          if (i >= n_layer) {
 -            layer.nextn.eh_proj          = create_tensor(tn(LLM_TENSOR_NEXTN_EH_PROJ, "weight", i), { 2 * n_embd, n_embd }, mtp_flags);
@@ -5287,7 +5317,7 @@ index ba90c0d07..feb055702 100644
          }
      }
  }
-@@ -169,254 +155,8 @@ std::unique_ptr<llm_graph_context> llama_model_deepseek2::build_arch_graph(const
+@@ -169,254 +155,8 @@ std::unique_ptr<llm_graph_context> llama
      if (params.gtype == LLM_GRAPH_TYPE_DECODER_MTP) {
          return std::make_unique<graph_mtp>(*this, params);
      }
@@ -5425,7 +5455,7 @@ index ba90c0d07..feb055702 100644
 -                ggml_row_size(kv_cmpr_pe->type, kv_lora_rank + n_embd_head_qk_rope),
 -                ggml_row_size(kv_cmpr_pe->type, kv_lora_rank));
 -    cb(k_pe, "mtp_k_pe", il);
- 
+-
 -    kv_cmpr = build_norm(kv_cmpr, layer.attn_kv_a_norm, nullptr, LLM_NORM_RMS, il);
 -    cb(kv_cmpr, "mtp_kv_cmpr_norm", il);
 -
@@ -5533,7 +5563,7 @@ index ba90c0d07..feb055702 100644
 -            : model.output_s;
 -
 -    GGML_ASSERT(head_w && "GLM4 MTP: missing LM head (nextn.shared_head_head or model.output)");
--
+
 -    cur = build_lora_mm(head_w, cur, head_s);
 -    cb(cur, "result_output", -1);
 -
@@ -5541,12 +5571,12 @@ index ba90c0d07..feb055702 100644
 -    ggml_build_forward_expand(gf, cur);
 +    return std::make_unique<graph>(*this, params);
  }
- 
+
  llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_params & params) :
-@@ -450,8 +190,16 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -450,8 +190,16 @@ llama_model_deepseek2::graph::graph(cons
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 +    const int effective_n_layers = n_layer;
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -5558,13 +5588,13 @@ index ba90c0d07..feb055702 100644
      // {n_embd, n_tokens}
 -    inpL = build_inp_embd(model.tok_embd);
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // (optional) temperature tuning - used by mistral-large
      ggml_tensor * inp_attn_scale = nullptr;
-@@ -462,12 +210,22 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -462,12 +210,22 @@ llama_model_deepseek2::graph::graph(cons
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
 -    auto * inp_attn_kv = !is_mla ? build_attn_inp_kv() : nullptr;
 -    auto * inp_attn_k  =  is_mla ? build_attn_inp_k()  : nullptr;
 +    bool use_absorbed_mla = is_mla;
@@ -5576,28 +5606,28 @@ index ba90c0d07..feb055702 100644
 +            }
 +        }
 +    }
- 
--    ggml_tensor * inp_out_ids = build_inp_out_ids();
++
 +    auto * inp_attn_kv = !use_absorbed_mla ? build_attn_inp_kv() : nullptr;
 +    auto * inp_attn_k  =  use_absorbed_mla ? build_attn_inp_k()  : nullptr;
- 
--    for (int il = 0; il < n_layer; ++il) {
+
+-    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
-+
+
+-    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -563,7 +321,7 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -563,7 +321,7 @@ llama_model_deepseek2::graph::graph(cons
              kv_cmpr = build_norm(kv_cmpr, model.layers[il].attn_kv_a_norm, nullptr, LLM_NORM_RMS, il);
              cb(kv_cmpr, "kv_cmpr", il);
- 
+
 -            if (is_mla) {
 +            if (use_absorbed_mla) {
                  // {n_embd_head_qk_nope, n_tokens, n_head}
                  q_nope = ggml_permute(ctx0, q_nope, 0, 2, 1, 3);
                  cb(q_nope, "q_nope_perm", il);
-@@ -641,7 +399,7 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -641,7 +399,7 @@ llama_model_deepseek2::graph::graph(cons
                              Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, kq_scale, il);
              }
          }
@@ -5606,10 +5636,10 @@ index ba90c0d07..feb055702 100644
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -699,12 +457,23 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -699,12 +457,23 @@ llama_model_deepseek2::graph::graph(cons
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        if (!cparams.embeddings_nextn_masked && inp_out_ids) {
 +            cur = ggml_get_rows(ctx0, cur, inp_out_ids);
@@ -5622,17 +5652,17 @@ index ba90c0d07..feb055702 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "h_nextn", -1);
      res->t_h_nextn = cur;
- 
+
 -    if (cparams.embeddings_nextn && !cparams.embeddings_nextn_masked && inp_out_ids) {
 +    if (!cparams.embeddings_nextn_masked && inp_out_ids) {
          cur = ggml_get_rows(ctx0, cur, inp_out_ids);
      }
- 
-@@ -719,3 +488,257 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
- 
+
+@@ -719,3 +488,257 @@ llama_model_deepseek2::graph::graph(cons
+
      ggml_build_forward_expand(gf, cur);
  }
 +
@@ -5889,23 +5919,23 @@ index ba90c0d07..feb055702 100644
 +    res->t_logits = cur;
 +    ggml_build_forward_expand(gf, cur);
 +}
-diff --git a/src/models/deepseek32.cpp b/src/models/deepseek32.cpp
-index 8a07a0b71..e1be8ef15 100644
+Index: b/src/models/deepseek32.cpp
+===================================================================
 --- a/src/models/deepseek32.cpp
 +++ b/src/models/deepseek32.cpp
-@@ -211,6 +211,8 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
- 
+@@ -211,6 +211,8 @@ llama_model_deepseek32::graph::graph(con
+
      ggml_tensor * inp_out_ids = build_inp_out_ids();
- 
+
 +    ggml_tensor * shared_top_k = nullptr;
 +
      for (int il = 0; il < n_layer; ++il) {
          ggml_tensor * inpSA = inpL;
- 
-@@ -228,8 +230,15 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
- 
+
+@@ -228,8 +230,15 @@ llama_model_deepseek32::graph::graph(con
+
              ggml_tensor * top_k = nullptr;
- 
+
 +            const bool has_indexer =
 +                model.layers[il].indexer_attn_q_b &&
 +                model.layers[il].indexer_attn_k &&
@@ -5918,8 +5948,8 @@ index 8a07a0b71..e1be8ef15 100644
 +            if (has_indexer) {
                  ggml_tensor * indexer_q = ggml_mul_mat(ctx0, model.layers[il].indexer_attn_q_b, qr);
                  cb(indexer_q, "indexer_q", il);
- 
-@@ -359,6 +368,11 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
+
+@@ -359,6 +368,11 @@ llama_model_deepseek32::graph::graph(con
                  uint32_t n_top_k = indexer_score->ne[0] < n_indexer_top_k ? indexer_score->ne[0] : n_indexer_top_k;
                  top_k = ggml_cont(ctx0, ggml_top_k(ctx0, indexer_score, n_top_k));
                  cb(top_k, "top_k", il);
@@ -5929,16 +5959,16 @@ index 8a07a0b71..e1be8ef15 100644
 +                top_k = shared_top_k;
 +                cb(top_k, "top_k_shared", il);
              }
- 
+
              ggml_tensor * q = ggml_mul_mat(ctx0, model.layers[il].wq_b, qr);
-diff --git a/src/models/dots1.cpp b/src/models/dots1.cpp
-index 07d6ab1b7..ea7e03b0c 100644
+Index: b/src/models/dots1.cpp
+===================================================================
 --- a/src/models/dots1.cpp
 +++ b/src/models/dots1.cpp
-@@ -81,16 +81,21 @@ llama_model_dots1::graph::graph(const llama_model & model, const llm_graph_param
+@@ -81,16 +81,21 @@ llama_model_dots1::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -5946,24 +5976,24 @@ index 07d6ab1b7..ea7e03b0c 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -178,6 +183,13 @@ llama_model_dots1::graph::graph(const llama_model & model, const llm_graph_param
+@@ -178,6 +183,13 @@ llama_model_dots1::graph::graph(const ll
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -5972,16 +6002,16 @@ index 07d6ab1b7..ea7e03b0c 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/dream.cpp b/src/models/dream.cpp
-index abe737c33..b8902bb7b 100644
+Index: b/src/models/dream.cpp
+===================================================================
 --- a/src/models/dream.cpp
 +++ b/src/models/dream.cpp
-@@ -60,16 +60,21 @@ llama_model_dream::graph::graph(const llama_model & model, const llm_graph_param
+@@ -60,16 +60,21 @@ llama_model_dream::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -5989,24 +6019,24 @@ index abe737c33..b8902bb7b 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_no_cache();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -123,6 +128,13 @@ llama_model_dream::graph::graph(const llama_model & model, const llm_graph_param
+@@ -123,6 +128,13 @@ llama_model_dream::graph::graph(const ll
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -6015,16 +6045,16 @@ index abe737c33..b8902bb7b 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/ernie4-5-moe.cpp b/src/models/ernie4-5-moe.cpp
-index 8d9ff1386..66ec33e4c 100644
+Index: b/src/models/ernie4-5-moe.cpp
+===================================================================
 --- a/src/models/ernie4-5-moe.cpp
 +++ b/src/models/ernie4-5-moe.cpp
-@@ -14,17 +14,22 @@ llama_model_ernie4_5_moe::graph::graph(const llama_model & model, const llm_grap
+@@ -14,17 +14,22 @@ llama_model_ernie4_5_moe::graph::graph(c
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -6032,25 +6062,25 @@ index 8d9ff1386..66ec33e4c 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
      GGML_ASSERT(hparams.n_moe_layer_step > 0 && "Ernie 4.5 MoE requires n_moe_layer_step > 0");
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
          // norm
          {
-@@ -118,6 +123,13 @@ llama_model_ernie4_5_moe::graph::graph(const llama_model & model, const llm_grap
+@@ -118,6 +123,13 @@ llama_model_ernie4_5_moe::graph::graph(c
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -6059,16 +6089,16 @@ index 8d9ff1386..66ec33e4c 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/ernie4-5.cpp b/src/models/ernie4-5.cpp
-index 895cf690b..fff2c2476 100644
+Index: b/src/models/ernie4-5.cpp
+===================================================================
 --- a/src/models/ernie4-5.cpp
 +++ b/src/models/ernie4-5.cpp
-@@ -83,16 +83,21 @@ llama_model_ernie4_5::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -83,16 +83,21 @@ llama_model_ernie4_5::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -6076,24 +6106,24 @@ index 895cf690b..fff2c2476 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -149,6 +154,13 @@ llama_model_ernie4_5::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -149,6 +154,13 @@ llama_model_ernie4_5::graph::graph(const
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -6102,16 +6132,16 @@ index 895cf690b..fff2c2476 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/exaone-moe.cpp b/src/models/exaone-moe.cpp
-index 5aed93794..f5946ddfc 100644
+Index: b/src/models/exaone-moe.cpp
+===================================================================
 --- a/src/models/exaone-moe.cpp
 +++ b/src/models/exaone-moe.cpp
-@@ -120,16 +120,21 @@ llama_model_exaone_moe::graph::graph(const llama_model & model, const llm_graph_
+@@ -120,16 +120,21 @@ llama_model_exaone_moe::graph::graph(con
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -6119,21 +6149,21 @@ index 5aed93794..f5946ddfc 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn_iswa = build_attn_inp_kv_iswa();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // use RoPE for SWA layers
-@@ -168,7 +173,7 @@ llama_model_exaone_moe::graph::graph(const llama_model & model, const llm_graph_
+@@ -168,7 +173,7 @@ llama_model_exaone_moe::graph::graph(con
                  Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f / sqrtf(float(n_embd_head)), il);
              cb(cur, "attn_out", il);
          }
@@ -6142,10 +6172,10 @@ index 5aed93794..f5946ddfc 100644
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -228,6 +233,13 @@ llama_model_exaone_moe::graph::graph(const llama_model & model, const llm_graph_
+@@ -228,6 +233,13 @@ llama_model_exaone_moe::graph::graph(con
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -6155,15 +6185,15 @@ index 5aed93794..f5946ddfc 100644
 +
      // final norm
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
-diff --git a/src/models/exaone.cpp b/src/models/exaone.cpp
-index 676fb37b5..22daba948 100644
+
+Index: b/src/models/exaone.cpp
+===================================================================
 --- a/src/models/exaone.cpp
 +++ b/src/models/exaone.cpp
-@@ -53,16 +53,21 @@ llama_model_exaone::graph::graph(const llama_model & model, const llm_graph_para
+@@ -53,16 +53,21 @@ llama_model_exaone::graph::graph(const l
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -6171,21 +6201,21 @@ index 676fb37b5..22daba948 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -92,7 +97,7 @@ llama_model_exaone::graph::graph(const llama_model & model, const llm_graph_para
+@@ -92,7 +97,7 @@ llama_model_exaone::graph::graph(const l
                      model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f / sqrtf(float(n_embd_head)), il);
          }
@@ -6194,10 +6224,10 @@ index 676fb37b5..22daba948 100644
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -121,6 +126,13 @@ llama_model_exaone::graph::graph(const llama_model & model, const llm_graph_para
+@@ -121,6 +126,13 @@ llama_model_exaone::graph::graph(const l
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -6206,16 +6236,16 @@ index 676fb37b5..22daba948 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/exaone4.cpp b/src/models/exaone4.cpp
-index 863268abc..306d73a95 100644
+Index: b/src/models/exaone4.cpp
+===================================================================
 --- a/src/models/exaone4.cpp
 +++ b/src/models/exaone4.cpp
-@@ -94,7 +94,12 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
+@@ -94,7 +94,12 @@ llama_model_exaone4::graph<iswa>::graph(
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -6223,22 +6253,22 @@ index 863268abc..306d73a95 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -107,9 +112,9 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
+@@ -107,9 +112,9 @@ llama_model_exaone4::graph<iswa>::graph(
      } else {
          inp_attn = build_attn_inp_kv();
      }
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // use RoPE for SWA layers or non-SWA models
-@@ -145,7 +150,7 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
+@@ -145,7 +150,7 @@ llama_model_exaone4::graph<iswa>::graph(
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f / sqrtf(float(n_embd_head)), il);
              cb(cur, "attn_out", il);
          }
@@ -6247,10 +6277,10 @@ index 863268abc..306d73a95 100644
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -176,6 +181,13 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
+@@ -176,6 +181,13 @@ llama_model_exaone4::graph<iswa>::graph(
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -6259,16 +6289,16 @@ index 863268abc..306d73a95 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/falcon-h1.cpp b/src/models/falcon-h1.cpp
-index d6ef2d519..1222a5d49 100644
+Index: b/src/models/falcon-h1.cpp
+===================================================================
 --- a/src/models/falcon-h1.cpp
 +++ b/src/models/falcon-h1.cpp
-@@ -116,7 +116,12 @@ llama_model_falcon_h1::graph::graph(const llama_model & model, const llm_graph_p
+@@ -116,7 +116,12 @@ llama_model_falcon_h1::graph::graph(cons
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -6276,34 +6306,34 @@ index d6ef2d519..1222a5d49 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -127,9 +132,9 @@ llama_model_falcon_h1::graph::graph(const llama_model & model, const llm_graph_p
+@@ -127,9 +132,9 @@ llama_model_falcon_h1::graph::graph(cons
      const float kq_scale =
          hparams.f_attention_scale == 0.0f ? 1.0f / sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          cur = build_norm(inpL, model.layers[il].attn_norm, NULL, LLM_NORM_RMS, il);
-@@ -166,7 +171,7 @@ llama_model_falcon_h1::graph::graph(const llama_model & model, const llm_graph_p
+@@ -166,7 +171,7 @@ llama_model_falcon_h1::graph::graph(cons
          inpSA = ggml_add(ctx0, cur, inpSA);
          cb(cur, "layer_out", il);
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -194,6 +199,13 @@ llama_model_falcon_h1::graph::graph(const llama_model & model, const llm_graph_p
+@@ -194,6 +199,13 @@ llama_model_falcon_h1::graph::graph(cons
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -6312,16 +6342,16 @@ index d6ef2d519..1222a5d49 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/falcon.cpp b/src/models/falcon.cpp
-index b2ad90b32..00f3bd4f9 100644
+Index: b/src/models/falcon.cpp
+===================================================================
 --- a/src/models/falcon.cpp
 +++ b/src/models/falcon.cpp
-@@ -56,16 +56,21 @@ llama_model_falcon::graph::graph(const llama_model & model, const llm_graph_para
+@@ -56,16 +56,21 @@ llama_model_falcon::graph::graph(const l
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -6329,33 +6359,33 @@ index b2ad90b32..00f3bd4f9 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * attn_norm;
- 
+
          attn_norm = build_norm(inpL,
-@@ -112,7 +117,7 @@ llama_model_falcon::graph::graph(const llama_model & model, const llm_graph_para
+@@ -112,7 +117,7 @@ llama_model_falcon::graph::graph(const l
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur       = ggml_get_rows(ctx0,       cur, inp_out_ids);
              inpL      = ggml_get_rows(ctx0,      inpL, inp_out_ids);
              attn_norm = ggml_get_rows(ctx0, attn_norm, inp_out_ids);
-@@ -143,6 +148,13 @@ llama_model_falcon::graph::graph(const llama_model & model, const llm_graph_para
- 
+@@ -143,6 +148,13 @@ llama_model_falcon::graph::graph(const l
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -6366,43 +6396,44 @@ index b2ad90b32..00f3bd4f9 100644
      // norm
      cur = build_norm(cur,
              model.output_norm,
-diff --git a/src/models/gemma.cpp b/src/models/gemma.cpp
-index 651cd7e64..d6d7cae7d 100644
+Index: b/src/models/gemma.cpp
+===================================================================
 --- a/src/models/gemma.cpp
 +++ b/src/models/gemma.cpp
-@@ -44,19 +44,26 @@ llama_model_gemma::graph::graph(const llama_model & model, const llm_graph_param
+@@ -44,19 +44,26 @@ llama_model_gemma::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
+-
+-    inpL = ggml_scale(ctx0, inpL, sqrtf(n_embd));
+-    cb(inpL, "inp_scaled", -1);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
 +    const int il_start = stage_filtered ? stage_filter.layer_start : 0;
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
- 
--    inpL = ggml_scale(ctx0, inpL, sqrtf(n_embd));
--    cb(inpL, "inp_scaled", -1);
++
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
 +
 +    if (!stage_filtered || il_start == 0) {
 +        inpL = ggml_scale(ctx0, inpL, sqrtf(n_embd));
 +        cb(inpL, "inp_scaled", -1);
 +    }
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          // norm
          cur = build_norm(inpL,
                  model.layers[il].attn_norm, NULL,
-@@ -90,7 +97,7 @@ llama_model_gemma::graph::graph(const llama_model & model, const llm_graph_param
+@@ -90,7 +97,7 @@ llama_model_gemma::graph::graph(const ll
                      model.layers[il].wo, NULL, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f, il);
          }
@@ -6411,10 +6442,10 @@ index 651cd7e64..d6d7cae7d 100644
              cur  = ggml_get_rows(ctx0,  cur, inp_out_ids);
              inpL = ggml_get_rows(ctx0, inpL, inp_out_ids);
          }
-@@ -122,6 +129,13 @@ llama_model_gemma::graph::graph(const llama_model & model, const llm_graph_param
+@@ -122,6 +129,13 @@ llama_model_gemma::graph::graph(const ll
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -6425,43 +6456,44 @@ index 651cd7e64..d6d7cae7d 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/gemma2.cpp b/src/models/gemma2.cpp
-index 2fbfb15a9..7e1154a92 100644
+Index: b/src/models/gemma2.cpp
+===================================================================
 --- a/src/models/gemma2.cpp
 +++ b/src/models/gemma2.cpp
-@@ -65,19 +65,26 @@ llama_model_gemma2::graph::graph(const llama_model & model, const llm_graph_para
+@@ -65,19 +65,26 @@ llama_model_gemma2::graph::graph(const l
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
+-
+-    inpL = ggml_scale(ctx0, inpL, sqrtf(n_embd));
+-    cb(inpL, "inp_scaled", -1);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
 +    const int il_start = stage_filtered ? stage_filter.layer_start : 0;
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
- 
--    inpL = ggml_scale(ctx0, inpL, sqrtf(n_embd));
--    cb(inpL, "inp_scaled", -1);
++
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
 +
 +    if (!stage_filtered || il_start == 0) {
 +        inpL = ggml_scale(ctx0, inpL, sqrtf(n_embd));
 +        cb(inpL, "inp_scaled", -1);
 +    }
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv_iswa();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const float freq_base_l  = model.get_rope_freq_base (cparams, il);
          const float freq_scale_l = model.get_rope_freq_scale(cparams, il);
- 
-@@ -113,7 +120,7 @@ llama_model_gemma2::graph::graph(const llama_model & model, const llm_graph_para
+
+@@ -113,7 +120,7 @@ llama_model_gemma2::graph::graph(const l
                      model.layers[il].wo, NULL, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f, il);
          }
@@ -6470,10 +6502,10 @@ index 2fbfb15a9..7e1154a92 100644
              cur  = ggml_get_rows(ctx0,  cur, inp_out_ids);
              inpL = ggml_get_rows(ctx0, inpL, inp_out_ids);
          }
-@@ -155,6 +162,13 @@ llama_model_gemma2::graph::graph(const llama_model & model, const llm_graph_para
+@@ -155,6 +162,13 @@ llama_model_gemma2::graph::graph(const l
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -6484,14 +6516,14 @@ index 2fbfb15a9..7e1154a92 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/gemma3.cpp b/src/models/gemma3.cpp
-index 690194529..de94cdb53 100644
+Index: b/src/models/gemma3.cpp
+===================================================================
 --- a/src/models/gemma3.cpp
 +++ b/src/models/gemma3.cpp
-@@ -87,11 +87,18 @@ llama_model_gemma3::graph<iswa>::graph(const llama_model & model, const llm_grap
+@@ -87,11 +87,18 @@ llama_model_gemma3::graph<iswa>::graph(c
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -6499,7 +6531,7 @@ index 690194529..de94cdb53 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // important: do not normalize weights for raw embeddings input (i.e. encoded image embeddings)
 -    inpL = ggml_scale(ctx0, inpL, ubatch.token ? sqrtf(n_embd) : 1.0f);
 -    cb(inpL, "inp_scaled", -1);
@@ -6507,22 +6539,22 @@ index 690194529..de94cdb53 100644
 +        inpL = ggml_scale(ctx0, inpL, ubatch.token ? sqrtf(n_embd) : 1.0f);
 +        cb(inpL, "inp_scaled", -1);
 +    }
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -106,9 +113,9 @@ llama_model_gemma3::graph<iswa>::graph(const llama_model & model, const llm_grap
+@@ -106,9 +113,9 @@ llama_model_gemma3::graph<iswa>::graph(c
          inp_attn = build_attn_inp_kv();
      }
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          float freq_base_l  = 0.0f;
          float freq_scale_l = 0.0f;
- 
-@@ -157,7 +164,7 @@ llama_model_gemma3::graph<iswa>::graph(const llama_model & model, const llm_grap
+
+@@ -157,7 +164,7 @@ llama_model_gemma3::graph<iswa>::graph(c
                      model.layers[il].wo, NULL, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f, il);
          }
@@ -6531,10 +6563,10 @@ index 690194529..de94cdb53 100644
              cur  = ggml_get_rows(ctx0,  cur, inp_out_ids);
              inpL = ggml_get_rows(ctx0, inpL, inp_out_ids);
          }
-@@ -199,6 +206,13 @@ llama_model_gemma3::graph<iswa>::graph(const llama_model & model, const llm_grap
+@@ -199,6 +206,13 @@ llama_model_gemma3::graph<iswa>::graph(c
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -6545,14 +6577,14 @@ index 690194529..de94cdb53 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/gemma3n.cpp b/src/models/gemma3n.cpp
-index 83eb8250a..8e712f757 100644
+Index: b/src/models/gemma3n.cpp
+===================================================================
 --- a/src/models/gemma3n.cpp
 +++ b/src/models/gemma3n.cpp
-@@ -98,11 +98,47 @@ llama_model_gemma3n::graph::graph(const llama_model & model, const llm_graph_par
+@@ -98,11 +98,47 @@ llama_model_gemma3n::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -6579,17 +6611,17 @@ index 83eb8250a..8e712f757 100644
 +            stage_inp->tokens = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, ubatch.n_tokens);
 +            cb(stage_inp->tokens, "inp_stage_tokens", -1);
 +            ggml_set_input(stage_inp->tokens);
- 
--    // important: do not normalize weights for raw embeddings input (i.e. encoded image embeddings)
--    inpL = ggml_scale(ctx0, inpL, ubatch.token ? sqrtf(n_embd) : 1.0f);
--    cb(inpL, "inp_scaled", -1);
++
 +            inp_per_layer_proj = ggml_get_rows(ctx0, model.tok_embd, stage_inp->tokens);
 +            inp_per_layer_proj = ggml_scale(ctx0, inp_per_layer_proj, sqrtf(n_embd));
 +            cb(inp_per_layer_proj, "inp_per_layer_proj_embd", -1);
 +
 +            res->add_input(std::move(stage_inp));
 +        }
-+
+
+-    // important: do not normalize weights for raw embeddings input (i.e. encoded image embeddings)
+-    inpL = ggml_scale(ctx0, inpL, ubatch.token ? sqrtf(n_embd) : 1.0f);
+-    cb(inpL, "inp_scaled", -1);
 +    } else {
 +        inpL = build_inp_embd(model.tok_embd);
 +
@@ -6598,16 +6630,16 @@ index 83eb8250a..8e712f757 100644
 +        cb(inpL, "inp_scaled", -1);
 +        inp_per_layer_proj = inpL;
 +    }
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -114,11 +150,11 @@ llama_model_gemma3n::graph::graph(const llama_model & model, const llm_graph_par
+@@ -114,11 +150,11 @@ llama_model_gemma3n::graph::graph(const
      ggml_build_forward_expand(gf, inp_per_layer);
- 
+
      // inp_per_layer now has shape: [n_embd_altup, n_tokens, n_layer]
 -    inp_per_layer = project_per_layer_inputs(inpL, inp_per_layer);
 +    inp_per_layer = project_per_layer_inputs(inp_per_layer_proj ? inp_per_layer_proj : ggml_view_2d_slice(ctx0, inpL, i_altup_act), inp_per_layer);
- 
+
      // inpL now has only 1 altup, project it to the rest of the altups
      // these "added" altups will be concat to the last dim of inpL
 -    {
@@ -6615,19 +6647,19 @@ index 83eb8250a..8e712f757 100644
          ggml_tensor * target_magnitude = calc_magnitude(inpL);
          ggml_tensor * inp_repeated     = ggml_repeat_4d(ctx0, inpL, n_embd, n_tokens, n_altup - 1, 1);
          ggml_tensor * altup_added =
-@@ -130,7 +166,7 @@ llama_model_gemma3n::graph::graph(const llama_model & model, const llm_graph_par
+@@ -130,7 +166,7 @@ llama_model_gemma3n::graph::graph(const
      }
      // inpL now has shape: [n_embd, n_tokens, n_altup]
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          // this block is made to be closely resemble Gemma3p5DecoderLayer on python code
          const float freq_base_l  = model.get_rope_freq_base(cparams, il);
          const float freq_scale_l = model.get_rope_freq_scale(cparams, il);
-@@ -262,6 +298,16 @@ llama_model_gemma3n::graph::graph(const llama_model & model, const llm_graph_par
+@@ -262,6 +298,16 @@ llama_model_gemma3n::graph::graph(const
      }
      cur = inpL;  // [n_embd, n_tokens, n_altup]
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        cur = ggml_cont(ctx0, cur);
@@ -6641,7 +6673,7 @@ index 83eb8250a..8e712f757 100644
      // cur now has multiple altup(s), we want to merge them back to 1 altup
      {
          ggml_tensor * target_magnitude = calc_magnitude(ggml_view_2d_slice(ctx0, cur, i_altup_act));  // [n_embd, n_tokens]
-@@ -320,7 +366,12 @@ ggml_tensor * llama_model_gemma3n::graph::build_inp_per_layer() {
+@@ -320,7 +366,12 @@ ggml_tensor * llama_model_gemma3n::graph
      auto inp = std::make_unique<llm_graph_input_embd>(n_embd);
      ggml_tensor * inp_per_layer;
      float tok_embd_scale = sqrtf((float) n_embd_altup);
@@ -6655,7 +6687,7 @@ index 83eb8250a..8e712f757 100644
          inp->tokens = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, ubatch.n_tokens);
          ggml_set_input(inp->tokens);
          res->t_inp_tokens = inp->tokens;
-@@ -328,7 +379,14 @@ ggml_tensor * llama_model_gemma3n::graph::build_inp_per_layer() {
+@@ -328,7 +379,14 @@ ggml_tensor * llama_model_gemma3n::graph
          inp_per_layer = ggml_reshape_3d(ctx0, inp_per_layer, n_embd_altup, n_layer, n_tokens);
          inp_per_layer = ggml_scale     (ctx0, inp_per_layer, tok_embd_scale);
          cb(inp_per_layer, "inp_per_layer_selected", -1);
@@ -6671,25 +6703,25 @@ index 83eb8250a..8e712f757 100644
      } else {
          // Multimodal embedding path: use padding token (ID=0) embedding
          // TODO: verify if this is the correct behavior in transformers implementation
-diff --git a/src/models/gemma4.cpp b/src/models/gemma4.cpp
-index e44f423bd..df485fb1d 100644
+Index: b/src/models/gemma4.cpp
+===================================================================
 --- a/src/models/gemma4.cpp
 +++ b/src/models/gemma4.cpp
-@@ -98,8 +98,9 @@ void llama_model_gemma4::load_arch_tensors(llama_model_loader &) {
+@@ -98,8 +98,9 @@ void llama_model_gemma4::load_arch_tenso
          layer.ffn_post_norm = create_tensor(tn(LLM_TENSOR_FFN_POST_NORM, "weight", i), {n_embd}, 0);
- 
+
          // MoE router
 +        const std::string ffn_gate_inp_name = tn(LLM_TENSOR_FFN_GATE_INP, "weight", i).str();
          layer.ffn_gate_inp = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP, "weight", i), {n_embd, n_expert}, TENSOR_NOT_REQUIRED);
 -        bool has_expert = layer.ffn_gate_inp != nullptr;
 +        bool has_expert = layer.ffn_gate_inp != nullptr || ml->get_tensor_meta(ffn_gate_inp_name.c_str()) != nullptr;
- 
+
          // norm
          if (has_expert) {
-@@ -149,7 +150,12 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
+@@ -149,7 +150,12 @@ llama_model_gemma4::graph::graph(const l
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -6697,16 +6729,16 @@ index e44f423bd..df485fb1d 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // important: do not normalize weights for raw embeddings input (i.e. encoded image emdeddings)
      inpL = ggml_scale(ctx0, inpL, ubatch.token ? sqrtf(n_embd) : 1.0f);
-@@ -161,18 +167,39 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
+@@ -161,18 +167,39 @@ llama_model_gemma4::graph::graph(const l
      // TODO: is causal == true correct? might need some changes
      auto * inp_attn = build_attn_inp_kv_iswa();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
      ggml_tensor * inp_per_layer = nullptr;
      if (model.per_layer_tok_embd) {
 +        ggml_tensor * inp_per_layer_proj = inpL;
@@ -6732,19 +6764,19 @@ index e44f423bd..df485fb1d 100644
 +
          inp_per_layer = build_inp_per_layer();
          ggml_build_forward_expand(gf, inp_per_layer);
- 
+
          // inp_per_layer shape: [n_embd_per_layer, n_tokens, n_layer]
 -        inp_per_layer = project_per_layer_inputs(inpL, inp_per_layer);
 +        inp_per_layer = project_per_layer_inputs(inp_per_layer_proj, inp_per_layer);
      }
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const int64_t n_embd_head = hparams.n_embd_head_k(il);
          GGML_ASSERT(n_embd_head == hparams.n_embd_head_v(il));
- 
-@@ -248,7 +275,7 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
- 
+
+@@ -248,7 +275,7 @@ llama_model_gemma4::graph::graph(const l
+
          // TODO @ngxson : strip unused token right after the last KV layer to speed up prompt processing
          // keep all rows when extracting unmasked nextn embeddings (MTP target needs the hidden state for every token)
 -        if (il == n_layer - 1 && inp_out_ids && cparams.embeddings_nextn_masked) {
@@ -6752,10 +6784,10 @@ index e44f423bd..df485fb1d 100644
              cur  = ggml_get_rows(ctx0,  cur, inp_out_ids);
              inpL = ggml_get_rows(ctx0, inpL, inp_out_ids);
          }
-@@ -375,6 +402,13 @@ llama_model_gemma4::graph::graph(const llama_model & model, const llm_graph_para
+@@ -375,6 +402,13 @@ llama_model_gemma4::graph::graph(const l
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -6766,8 +6798,8 @@ index e44f423bd..df485fb1d 100644
      cur = build_norm(cur,
              model.output_norm, nullptr,
              LLM_NORM_RMS, -1);
-@@ -415,7 +449,12 @@ ggml_tensor * llama_model_gemma4::graph::build_inp_per_layer() {
- 
+@@ -415,7 +449,12 @@ ggml_tensor * llama_model_gemma4::graph:
+
      ggml_tensor * inp_per_layer;
      float tok_embd_scale = sqrtf((float) n_embd_per_layer);
 -    if (ubatch.token) {
@@ -6780,10 +6812,10 @@ index e44f423bd..df485fb1d 100644
          inp->tokens = ggml_new_tensor_1d(ctx0, GGML_TYPE_I32, ubatch.n_tokens);
          ggml_set_input(inp->tokens);
          res->t_inp_tokens = inp->tokens;
-@@ -425,7 +464,13 @@ ggml_tensor * llama_model_gemma4::graph::build_inp_per_layer() {
+@@ -425,7 +464,13 @@ ggml_tensor * llama_model_gemma4::graph:
          inp_per_layer = ggml_scale     (ctx0, inp_per_layer, tok_embd_scale);
          cb(inp_per_layer, "inp_per_layer_selected", -1);
- 
+
 -        res->add_input(std::move(inp));
 +        if (ubatch.token) {
 +            res->add_input(std::move(inp));
@@ -6795,14 +6827,14 @@ index e44f423bd..df485fb1d 100644
      } else {
          // Multimodal embedding path: use padding token (ID=0) embedding
          // TODO: verify if this is the correct behavior in transformers implementation
-diff --git a/src/models/glm4.cpp b/src/models/glm4.cpp
-index b4326c5f2..c4e951a1e 100644
+Index: b/src/models/glm4.cpp
+===================================================================
 --- a/src/models/glm4.cpp
 +++ b/src/models/glm4.cpp
-@@ -80,10 +80,18 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
+@@ -80,10 +80,18 @@ llama_model_glm4::graph::graph(const lla
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    // Only process up to last layer (skip final NextN layer)
 +    // Final layer tensors are loaded but not processed in forward pass
@@ -6813,28 +6845,28 @@ index b4326c5f2..c4e951a1e 100644
 +    const int il_end   = stage_filtered ? std::min(stage_filter.layer_end, n_transformer_layers) : n_transformer_layers;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      bool use_mrope = hparams.use_mrope();
 -    if (ubatch.embd && !use_mrope) {
 +    if (ubatch.embd && !use_mrope && !stage_filtered) {
          // unfortunately, we need to forcefully stop here, to avoid users complaining about wrong results
          GGML_ABORT("This GGUF does not support multimodal. Please reconvert it.");
      }
-@@ -93,11 +101,11 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
- 
+@@ -93,11 +101,11 @@ llama_model_glm4::graph::graph(const lla
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
      // Only process up to last layer (skip final NextN layer)
      // Final layer tensors are loaded but not processed in forward pass
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // Pre-attention norm
-@@ -136,7 +144,7 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
+@@ -136,7 +144,7 @@ llama_model_glm4::graph::graph(const lla
                      model.layers[il].wo, NULL, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f / sqrtf(float(n_embd_head)), il);
          }
@@ -6843,7 +6875,7 @@ index b4326c5f2..c4e951a1e 100644
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -174,8 +182,17 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
+@@ -174,8 +182,17 @@ llama_model_glm4::graph::graph(const lla
          // input for next layer
          inpL = cur;
      }
@@ -6859,29 +6891,29 @@ index b4326c5f2..c4e951a1e 100644
      // Final norm
 -    cur = build_norm(inpL, model.output_norm, NULL, LLM_NORM_RMS, -1);
 +    cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
      res->t_embd = cur;
-diff --git a/src/models/gpt2.cpp b/src/models/gpt2.cpp
-index 45afbccc1..cf3c658a9 100644
+Index: b/src/models/gpt2.cpp
+===================================================================
 --- a/src/models/gpt2.cpp
 +++ b/src/models/gpt2.cpp
-@@ -64,22 +64,28 @@ llama_model_gpt2::graph::graph(const llama_model & model, const llm_graph_params
+@@ -64,22 +64,28 @@ llama_model_gpt2::graph::graph(const lla
      ggml_tensor * pos;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
 +    const int il_start = stage_filtered ? stage_filter.layer_start : 0;
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
- 
+
 -    // inp_pos - contains the positions
 -    ggml_tensor * inp_pos = build_inp_pos();
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    pos = ggml_get_rows(ctx0, model.pos_embd, inp_pos);
 -    cb(pos, "pos_embd", -1);
 +    if (!stage_filtered || il_start == 0) {
@@ -6889,34 +6921,34 @@ index 45afbccc1..cf3c658a9 100644
 +        ggml_tensor * inp_pos = build_inp_pos();
 +        pos = ggml_get_rows(ctx0, model.pos_embd, inp_pos);
 +        cb(pos, "pos_embd", -1);
- 
+
 -    inpL = ggml_add(ctx0, inpL, pos);
 -    cb(inpL, "inpL", -1);
 +        inpL = ggml_add(ctx0, inpL, pos);
 +        cb(inpL, "inpL", -1);
 +    }
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          cur = build_norm(inpL,
                  model.layers[il].attn_norm,
                  model.layers[il].attn_norm_b,
-@@ -96,7 +102,7 @@ llama_model_gpt2::graph::graph(const llama_model & model, const llm_graph_params
+@@ -96,7 +102,7 @@ llama_model_gpt2::graph::graph(const lla
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur  = ggml_get_rows(ctx0,  cur, inp_out_ids);
              inpL = ggml_get_rows(ctx0, inpL, inp_out_ids);
          }
-@@ -131,6 +137,13 @@ llama_model_gpt2::graph::graph(const llama_model & model, const llm_graph_params
+@@ -131,6 +137,13 @@ llama_model_gpt2::graph::graph(const lla
          inpL = cur;
      }
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(inpL, "stage_boundary", il_end - 1);
 +        res->t_embd = inpL;
@@ -6927,14 +6959,14 @@ index 45afbccc1..cf3c658a9 100644
      cur = build_norm(inpL,
              model.output_norm,
              model.output_norm_b,
-diff --git a/src/models/gptneox.cpp b/src/models/gptneox.cpp
-index ed5e8c50d..d5e4a7205 100644
+Index: b/src/models/gptneox.cpp
+===================================================================
 --- a/src/models/gptneox.cpp
 +++ b/src/models/gptneox.cpp
-@@ -92,16 +92,21 @@ llama_model_gptneox::graph::graph(const llama_model & model, const llm_graph_par
+@@ -92,16 +92,21 @@ llama_model_gptneox::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -6942,33 +6974,33 @@ index ed5e8c50d..d5e4a7205 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          cur = build_norm(inpL,
                  model.layers[il].attn_norm,
                  model.layers[il].attn_norm_b,
-@@ -134,7 +139,7 @@ llama_model_gptneox::graph::graph(const llama_model & model, const llm_graph_par
+@@ -134,7 +139,7 @@ llama_model_gptneox::graph::graph(const
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur  = ggml_get_rows(ctx0,  cur, inp_out_ids);
              inpL = ggml_get_rows(ctx0, inpL, inp_out_ids);
          }
-@@ -202,6 +207,13 @@ llama_model_gptneox::graph::graph(const llama_model & model, const llm_graph_par
+@@ -202,6 +207,13 @@ llama_model_gptneox::graph::graph(const
          }
      }
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(inpL, "stage_boundary", il_end - 1);
 +        res->t_embd = inpL;
@@ -6979,14 +7011,14 @@ index ed5e8c50d..d5e4a7205 100644
      cur = build_norm(inpL,
              model.output_norm,
              model.output_norm_b,
-diff --git a/src/models/granite-hybrid.cpp b/src/models/granite-hybrid.cpp
-index eb23095ae..e12b977c3 100644
+Index: b/src/models/granite-hybrid.cpp
+===================================================================
 --- a/src/models/granite-hybrid.cpp
 +++ b/src/models/granite-hybrid.cpp
-@@ -139,11 +139,16 @@ llama_model_granite_hybrid::graph::graph(const llama_model & model, const llm_gr
+@@ -139,11 +139,16 @@ llama_model_granite_hybrid::graph::graph
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -6994,24 +7026,24 @@ index eb23095ae..e12b977c3 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      auto * inp = build_inp_mem_hybrid();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
      // Positional embeddings populated if rope enabled
      ggml_tensor * inp_pos = nullptr;
-@@ -151,7 +156,7 @@ llama_model_granite_hybrid::graph::graph(const llama_model & model, const llm_gr
+@@ -151,7 +156,7 @@ llama_model_granite_hybrid::graph::graph
          inp_pos = build_inp_pos();
      }
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          struct ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -177,6 +182,12 @@ llama_model_granite_hybrid::graph::graph(const llama_model & model, const llm_gr
+@@ -177,6 +182,12 @@ llama_model_granite_hybrid::graph::graph
          // input for next layer
          inpL = cur;
      }
@@ -7021,17 +7053,17 @@ index eb23095ae..e12b977c3 100644
 +        ggml_build_forward_expand(gf, inpL);
 +        return;
 +    }
- 
+
      cur = inpL;
- 
-diff --git a/src/models/granite.cpp b/src/models/granite.cpp
-index 4a75c5ff3..fb75406f4 100644
+
+Index: b/src/models/granite.cpp
+===================================================================
 --- a/src/models/granite.cpp
 +++ b/src/models/granite.cpp
 @@ -123,7 +123,12 @@ llama_model_granite::graph::graph(
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7039,25 +7071,25 @@ index 4a75c5ff3..fb75406f4 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - built only if rope enabled
      ggml_tensor * inp_pos = nullptr;
 @@ -132,9 +137,9 @@ llama_model_granite::graph::graph(
      }
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
- 
+
          // Granite Vision 4.1 deepstack: inject the projector stream that
          // targets decoder layer `il` before the decoder runs.
 @@ -162,7 +167,7 @@ llama_model_granite::graph::graph(
              cur, inp_pos, inp_attn,
              model, n_embd_head, il);
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
@@ -7066,7 +7098,7 @@ index 4a75c5ff3..fb75406f4 100644
 @@ -174,6 +179,13 @@ llama_model_granite::graph::graph(
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7077,14 +7109,14 @@ index 4a75c5ff3..fb75406f4 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/grok.cpp b/src/models/grok.cpp
-index 42f38af67..53f683914 100644
+Index: b/src/models/grok.cpp
+===================================================================
 --- a/src/models/grok.cpp
 +++ b/src/models/grok.cpp
-@@ -92,16 +92,21 @@ llama_model_grok::graph::graph(const llama_model & model, const llm_graph_params
+@@ -92,16 +92,21 @@ llama_model_grok::graph::graph(const lla
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7092,24 +7124,24 @@ index 42f38af67..53f683914 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -198,6 +203,13 @@ llama_model_grok::graph::graph(const llama_model & model, const llm_graph_params
+@@ -198,6 +203,13 @@ llama_model_grok::graph::graph(const lla
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7120,14 +7152,14 @@ index 42f38af67..53f683914 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/grovemoe.cpp b/src/models/grovemoe.cpp
-index 643a448e5..12fce2051 100644
+Index: b/src/models/grovemoe.cpp
+===================================================================
 --- a/src/models/grovemoe.cpp
 +++ b/src/models/grovemoe.cpp
-@@ -75,16 +75,21 @@ llama_model_grovemoe::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -75,16 +75,21 @@ llama_model_grovemoe::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7135,24 +7167,24 @@ index 643a448e5..12fce2051 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -178,6 +183,13 @@ llama_model_grovemoe::graph::graph(const llama_model & model, const llm_graph_pa
- 
+@@ -178,6 +183,13 @@ llama_model_grovemoe::graph::graph(const
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7161,16 +7193,16 @@ index 643a448e5..12fce2051 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/hunyuan-moe.cpp b/src/models/hunyuan-moe.cpp
-index 4d55f5e7f..3abe5aef4 100644
+Index: b/src/models/hunyuan-moe.cpp
+===================================================================
 --- a/src/models/hunyuan-moe.cpp
 +++ b/src/models/hunyuan-moe.cpp
-@@ -62,7 +62,12 @@ llama_model_hunyuan_moe::graph::graph(const llama_model & model, const llm_graph
+@@ -62,7 +62,12 @@ llama_model_hunyuan_moe::graph::graph(co
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7178,22 +7210,22 @@ index 4d55f5e7f..3abe5aef4 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -71,9 +76,9 @@ llama_model_hunyuan_moe::graph::graph(const llama_model & model, const llm_graph
- 
+@@ -71,9 +76,9 @@ llama_model_hunyuan_moe::graph::graph(co
+
      const float kq_scale = 1.0f / sqrtf(float(n_embd_head));
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -122,7 +127,7 @@ llama_model_hunyuan_moe::graph::graph(const llama_model & model, const llm_graph
+@@ -122,7 +127,7 @@ llama_model_hunyuan_moe::graph::graph(co
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, kq_scale, il);
              cb(cur, "attn_out", il);
          }
@@ -7202,10 +7234,10 @@ index 4d55f5e7f..3abe5aef4 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -171,6 +176,13 @@ llama_model_hunyuan_moe::graph::graph(const llama_model & model, const llm_graph
+@@ -171,6 +176,13 @@ llama_model_hunyuan_moe::graph::graph(co
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7216,14 +7248,14 @@ index 4d55f5e7f..3abe5aef4 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/hunyuan-vl.cpp b/src/models/hunyuan-vl.cpp
-index da9bb74de..cbf767f7a 100644
+Index: b/src/models/hunyuan-vl.cpp
+===================================================================
 --- a/src/models/hunyuan-vl.cpp
 +++ b/src/models/hunyuan-vl.cpp
-@@ -71,7 +71,12 @@ llama_model_hunyuan_vl::graph::graph(const llama_model & model, const llm_graph_
+@@ -71,7 +71,12 @@ llama_model_hunyuan_vl::graph::graph(con
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7231,22 +7263,22 @@ index da9bb74de..cbf767f7a 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -80,9 +85,9 @@ llama_model_hunyuan_vl::graph::graph(const llama_model & model, const llm_graph_
- 
+@@ -80,9 +85,9 @@ llama_model_hunyuan_vl::graph::graph(con
+
      const float kq_scale = 1.0f / sqrtf(float(n_embd_head));
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -144,7 +149,7 @@ llama_model_hunyuan_vl::graph::graph(const llama_model & model, const llm_graph_
+@@ -144,7 +149,7 @@ llama_model_hunyuan_vl::graph::graph(con
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, kq_scale, il);
              cb(cur, "attn_out", il);
          }
@@ -7255,10 +7287,10 @@ index da9bb74de..cbf767f7a 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -174,6 +179,13 @@ llama_model_hunyuan_vl::graph::graph(const llama_model & model, const llm_graph_
+@@ -174,6 +179,13 @@ llama_model_hunyuan_vl::graph::graph(con
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7269,14 +7301,14 @@ index da9bb74de..cbf767f7a 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/internlm2.cpp b/src/models/internlm2.cpp
-index f6cfdfb94..c44bc35fa 100644
+Index: b/src/models/internlm2.cpp
+===================================================================
 --- a/src/models/internlm2.cpp
 +++ b/src/models/internlm2.cpp
-@@ -47,16 +47,21 @@ llama_model_internlm2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -47,16 +47,21 @@ llama_model_internlm2::graph::graph(cons
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7284,21 +7316,21 @@ index f6cfdfb94..c44bc35fa 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -91,7 +96,7 @@ llama_model_internlm2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -91,7 +96,7 @@ llama_model_internlm2::graph::graph(cons
                      model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
@@ -7307,10 +7339,10 @@ index f6cfdfb94..c44bc35fa 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -122,6 +127,13 @@ llama_model_internlm2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -122,6 +127,13 @@ llama_model_internlm2::graph::graph(cons
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7321,14 +7353,14 @@ index f6cfdfb94..c44bc35fa 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/jais.cpp b/src/models/jais.cpp
-index 415103ce2..1c77c02b1 100644
+Index: b/src/models/jais.cpp
+===================================================================
 --- a/src/models/jais.cpp
 +++ b/src/models/jais.cpp
-@@ -60,13 +60,18 @@ llama_model_jais::graph::graph(const llama_model & model, const llm_graph_params
+@@ -60,13 +60,18 @@ llama_model_jais::graph::graph(const lla
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7336,18 +7368,18 @@ index 415103ce2..1c77c02b1 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          cur = build_norm(inpL,
                  model.layers[il].attn_norm,
                  model.layers[il].attn_norm_b,
-@@ -115,6 +120,13 @@ llama_model_jais::graph::graph(const llama_model & model, const llm_graph_params
+@@ -115,6 +120,13 @@ llama_model_jais::graph::graph(const lla
          // input for next layer
          inpL = cur;
      }
@@ -7361,14 +7393,14 @@ index 415103ce2..1c77c02b1 100644
      cur = build_norm(inpL,
              model.output_norm,
              model.output_norm_b,
-diff --git a/src/models/jais2.cpp b/src/models/jais2.cpp
-index 8610fcc9f..cd71d5dbc 100644
+Index: b/src/models/jais2.cpp
+===================================================================
 --- a/src/models/jais2.cpp
 +++ b/src/models/jais2.cpp
-@@ -66,7 +66,12 @@ llama_model_jais2::graph::graph(const llama_model & model, const llm_graph_param
+@@ -66,7 +66,12 @@ llama_model_jais2::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7376,24 +7408,24 @@ index 8610fcc9f..cd71d5dbc 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -74,9 +79,9 @@ llama_model_jais2::graph::graph(const llama_model & model, const llm_graph_param
+@@ -74,9 +79,9 @@ llama_model_jais2::graph::graph(const ll
      // KV input for attention
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          // Pre-attention LayerNorm
          cur = build_norm(inpL,
                  model.layers[il].attn_norm,
-@@ -143,6 +148,13 @@ llama_model_jais2::graph::graph(const llama_model & model, const llm_graph_param
+@@ -143,6 +148,13 @@ llama_model_jais2::graph::graph(const ll
      }
- 
+
      // Final LayerNorm
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(inpL, "stage_boundary", il_end - 1);
@@ -7405,14 +7437,14 @@ index 8610fcc9f..cd71d5dbc 100644
      cur = build_norm(inpL,
              model.output_norm,
              model.output_norm_b,
-diff --git a/src/models/jamba.cpp b/src/models/jamba.cpp
-index dba160b01..2b69aabab 100644
+Index: b/src/models/jamba.cpp
+===================================================================
 --- a/src/models/jamba.cpp
 +++ b/src/models/jamba.cpp
-@@ -111,14 +111,19 @@ llama_model_jamba::graph::graph(const llama_model & model, const llm_graph_param
+@@ -111,14 +111,19 @@ llama_model_jamba::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
 +    const int il_start = stage_filtered ? stage_filter.layer_start : 0;
@@ -7421,18 +7453,18 @@ index dba160b01..2b69aabab 100644
      // {n_embd, n_tokens}
 -    inpL = build_inp_embd(model.tok_embd);
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      auto * inp_hybrid = build_inp_mem_hybrid();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const int64_t n_head_kv = hparams.n_head_kv(il);
- 
+
          cur = build_norm(inpL, model.layers[il].attn_norm, NULL, LLM_NORM_RMS, il);
-@@ -137,7 +142,7 @@ llama_model_jamba::graph::graph(const llama_model & model, const llm_graph_param
+@@ -137,7 +142,7 @@ llama_model_jamba::graph::graph(const ll
                      model.layers[il].wo, NULL, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, NULL, NULL, NULL, 1.0f/sqrtf(float(n_embd_head)), il);
          }
@@ -7441,7 +7473,7 @@ index dba160b01..2b69aabab 100644
              cur  = ggml_get_rows(ctx0,  cur, inp_out_ids);
              inpL = ggml_get_rows(ctx0, inpL, inp_out_ids);
          }
-@@ -182,6 +187,13 @@ llama_model_jamba::graph::graph(const llama_model & model, const llm_graph_param
+@@ -182,6 +187,13 @@ llama_model_jamba::graph::graph(const ll
          // input for next layer
          inpL = cur;
      }
@@ -7454,15 +7486,15 @@ index dba160b01..2b69aabab 100644
 +
      // final rmsnorm
      cur = build_norm(inpL, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
-diff --git a/src/models/kimi-linear.cpp b/src/models/kimi-linear.cpp
-index 367f6990d..2426dfa0f 100644
+
+Index: b/src/models/kimi-linear.cpp
+===================================================================
 --- a/src/models/kimi-linear.cpp
 +++ b/src/models/kimi-linear.cpp
-@@ -236,7 +236,12 @@ llama_model_kimi_linear::graph::graph(const llama_model & model, const llm_graph
+@@ -236,7 +236,12 @@ llama_model_kimi_linear::graph::graph(co
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7471,30 +7503,30 @@ index 367f6990d..2426dfa0f 100644
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
      cb(inpL, "model.embed_tokens", -1);
- 
+
      // Note: Kimi MLA does NOT use RoPE (rotary_emb=None in vLLM)
-@@ -249,7 +254,7 @@ llama_model_kimi_linear::graph::graph(const llama_model & model, const llm_graph
+@@ -249,7 +254,7 @@ llama_model_kimi_linear::graph::graph(co
      auto * inp_attn_k = hparams.is_mla() ? inp_k->get_attn() : nullptr;
- 
+
      // Output ids for selecting which tokens to output
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
      // Kimi dimension constants
      const int64_t n_head = hparams.n_head();
-@@ -275,7 +280,7 @@ llama_model_kimi_linear::graph::graph(const llama_model & model, const llm_graph
+@@ -275,7 +280,7 @@ llama_model_kimi_linear::graph::graph(co
      // Attention scale for MLA
      const float kq_scale_mla = 1.0f / sqrtf((float)n_embd_head_k_mla);
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const auto & layer = model.layers[il];
          ggml_tensor * inpSA = inpL;
- 
-@@ -535,6 +540,13 @@ llama_model_kimi_linear::graph::graph(const llama_model & model, const llm_graph
+
+@@ -535,6 +540,13 @@ llama_model_kimi_linear::graph::graph(co
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7504,15 +7536,15 @@ index 367f6990d..2426dfa0f 100644
 +
      // Final Norm
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
-diff --git a/src/models/laguna.cpp b/src/models/laguna.cpp
-index 82c9a9538..e23087c68 100644
+
+Index: b/src/models/laguna.cpp
+===================================================================
 --- a/src/models/laguna.cpp
 +++ b/src/models/laguna.cpp
-@@ -158,7 +158,12 @@ llama_model_laguna::graph::graph(const llama_model & model, const llm_graph_para
+@@ -158,7 +158,12 @@ llama_model_laguna::graph::graph(const l
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7521,25 +7553,25 @@ index 82c9a9538..e23087c68 100644
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
      // No MuP embedding scale (laguna omits this; afmoe scales by sqrt(hidden)).
- 
+
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -167,11 +172,11 @@ llama_model_laguna::graph::graph(const llama_model & model, const llm_graph_para
+@@ -167,11 +172,11 @@ llama_model_laguna::graph::graph(const l
      const bool has_swa = hparams.swa_type != LLAMA_SWA_TYPE_NONE;
      llm_graph_input_attn_kv      * inp_attn_kv   = has_swa ? nullptr : build_attn_inp_kv();
      llm_graph_input_attn_kv_iswa * inp_attn_iswa = has_swa ? build_attn_inp_kv_iswa() : nullptr;
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
      const float kq_scale = 1.0f / sqrtf(float(n_embd_head));
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const bool    is_swa_il   = hparams.is_swa(il);
          const int64_t n_head_il   = hparams.n_head(il);
          const int64_t n_head_kv_il = hparams.n_head_kv(il);
-@@ -321,6 +326,14 @@ llama_model_laguna::graph::graph(const llama_model & model, const llm_graph_para
+@@ -321,6 +326,14 @@ llama_model_laguna::graph::graph(const l
      }
- 
+
      cur = inpL;
 +
 +    if (stage_filtered && !stage_filter.include_output) {
@@ -7552,13 +7584,13 @@ index 82c9a9538..e23087c68 100644
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
      cb(cur, "result_norm", -1);
      res->t_embd = cur;
-diff --git a/src/models/lfm2.cpp b/src/models/lfm2.cpp
-index 70e837d6e..3534c9565 100644
+Index: b/src/models/lfm2.cpp
+===================================================================
 --- a/src/models/lfm2.cpp
 +++ b/src/models/lfm2.cpp
-@@ -226,7 +226,20 @@ llama_model_lfm2::graph<iswa>::graph(const llama_model & model, const llm_graph_
+@@ -226,7 +226,20 @@ llama_model_lfm2::graph<iswa>::graph(con
      };
- 
+
      // actual graph construction starts here
 -    ggml_tensor * cur = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
@@ -7576,35 +7608,35 @@ index 70e837d6e..3534c9565 100644
 +
 +    ggml_tensor * cur = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
      cb(cur, "model.embed_tokens", -1);
- 
+
      ggml_build_forward_expand(gf, cur);
-@@ -238,10 +251,10 @@ llama_model_lfm2::graph<iswa>::graph(const llama_model & model, const llm_graph_
+@@ -238,10 +251,10 @@ llama_model_lfm2::graph<iswa>::graph(con
          inp_hybrid = build_inp_mem_hybrid();
      }
- 
+
 -    ggml_tensor * inp_pos     = build_inp_pos();
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_pos     = has_attention_layer ? build_inp_pos() : nullptr;
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const bool is_moe_layer = il >= static_cast<int>(hparams.n_layer_dense_lead);
- 
+
          auto * prev_cur = cur;
-@@ -251,7 +264,7 @@ llama_model_lfm2::graph<iswa>::graph(const llama_model & model, const llm_graph_
+@@ -251,7 +264,7 @@ llama_model_lfm2::graph<iswa>::graph(con
          cur = hparams.is_recr(il) ? build_shortconv_block(cur, inp_hybrid->get_recr(), il) :
                                      build_attn_block(cur, inp_pos, inp_hybrid->get_attn(), il);
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur      = ggml_get_rows(ctx0, cur, inp_out_ids);
              prev_cur = ggml_get_rows(ctx0, prev_cur, inp_out_ids);
          }
-@@ -271,6 +284,13 @@ llama_model_lfm2::graph<iswa>::graph(const llama_model & model, const llm_graph_
+@@ -271,6 +284,13 @@ llama_model_lfm2::graph<iswa>::graph(con
          cb(cur, "l_out", il);
      }
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7615,14 +7647,14 @@ index 70e837d6e..3534c9565 100644
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
      cb(cur, "result_norm", -1);
      res->t_embd = cur;
-diff --git a/src/models/llada-moe.cpp b/src/models/llada-moe.cpp
-index 2ae893864..6debd1303 100644
+Index: b/src/models/llada-moe.cpp
+===================================================================
 --- a/src/models/llada-moe.cpp
 +++ b/src/models/llada-moe.cpp
-@@ -60,16 +60,21 @@ llama_model_llada_moe::graph::graph(const llama_model & model, const llm_graph_p
+@@ -60,16 +60,21 @@ llama_model_llada_moe::graph::graph(cons
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7630,24 +7662,24 @@ index 2ae893864..6debd1303 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_no_cache();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -146,6 +151,13 @@ llama_model_llada_moe::graph::graph(const llama_model & model, const llm_graph_p
+@@ -146,6 +151,13 @@ llama_model_llada_moe::graph::graph(cons
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7658,14 +7690,14 @@ index 2ae893864..6debd1303 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/llada.cpp b/src/models/llada.cpp
-index 87d4259f9..47e2f9dfc 100644
+Index: b/src/models/llada.cpp
+===================================================================
 --- a/src/models/llada.cpp
 +++ b/src/models/llada.cpp
-@@ -78,7 +78,12 @@ llama_model_llada::graph::graph(const llama_model & model, const llm_graph_param
+@@ -78,7 +78,12 @@ llama_model_llada::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7673,25 +7705,25 @@ index 87d4259f9..47e2f9dfc 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -86,9 +91,9 @@ llama_model_llada::graph::graph(const llama_model & model, const llm_graph_param
+@@ -86,9 +91,9 @@ llama_model_llada::graph::graph(const ll
      // Non-causal attention for diffusion
      auto * inp_attn = build_attn_inp_no_cache();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -143,6 +148,13 @@ llama_model_llada::graph::graph(const llama_model & model, const llm_graph_param
+@@ -143,6 +148,13 @@ llama_model_llada::graph::graph(const ll
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7700,16 +7732,16 @@ index 87d4259f9..47e2f9dfc 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/llama.cpp b/src/models/llama.cpp
-index 4bfebc884..23864f0dd 100644
+Index: b/src/models/llama.cpp
+===================================================================
 --- a/src/models/llama.cpp
 +++ b/src/models/llama.cpp
-@@ -105,7 +105,12 @@ llama_model_llama::graph<embed>::graph(const llama_model & model, const llm_grap
+@@ -105,7 +105,12 @@ llama_model_llama::graph<embed>::graph(c
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7717,25 +7749,25 @@ index 4bfebc884..23864f0dd 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -121,9 +126,9 @@ llama_model_llama::graph<embed>::graph(const llama_model & model, const llm_grap
- 
+@@ -121,9 +126,9 @@ llama_model_llama::graph<embed>::graph(c
+
      const float kq_scale = hparams.f_attention_scale == 0.0f ? 1.0f/sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          res->t_layer_inp[il] = inpL;
- 
+
          ggml_tensor * inpSA = inpL;
-@@ -228,6 +233,13 @@ llama_model_llama::graph<embed>::graph(const llama_model & model, const llm_grap
+@@ -228,6 +233,13 @@ llama_model_llama::graph<embed>::graph(c
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7746,14 +7778,14 @@ index 4bfebc884..23864f0dd 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/llama4.cpp b/src/models/llama4.cpp
-index 7194c72a5..1f3f1c358 100644
+Index: b/src/models/llama4.cpp
+===================================================================
 --- a/src/models/llama4.cpp
 +++ b/src/models/llama4.cpp
-@@ -113,14 +113,30 @@ llama_model_llama4::graph<iswa>::graph(const llama_model & model, const llm_grap
+@@ -113,14 +113,30 @@ llama_model_llama4::graph<iswa>::graph(c
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7761,10 +7793,10 @@ index 7194c72a5..1f3f1c358 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      // temperature tuning
      ggml_tensor * inp_attn_scale = nullptr;
 -    inp_attn_scale = build_inp_attn_scale();
@@ -7780,22 +7812,22 @@ index 7194c72a5..1f3f1c358 100644
 +    if (uses_attn_temp) {
 +        inp_attn_scale = build_inp_attn_scale();
 +    }
- 
+
      using inp_attn_type = std::conditional_t<iswa, llm_graph_input_attn_kv_iswa, llm_graph_input_attn_kv>;
      inp_attn_type * inp_attn = nullptr;
-@@ -133,9 +149,9 @@ llama_model_llama4::graph<iswa>::graph(const llama_model & model, const llm_grap
- 
+@@ -133,9 +149,9 @@ llama_model_llama4::graph<iswa>::graph(c
+
      const float kq_scale = hparams.f_attention_scale == 0.0f ? 1.0f/sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const float freq_base_l  = model.get_rope_freq_base (cparams, il);
          const float freq_scale_l = model.get_rope_freq_scale(cparams, il);
- 
-@@ -191,7 +207,7 @@ llama_model_llama4::graph<iswa>::graph(const llama_model & model, const llm_grap
+
+@@ -191,7 +207,7 @@ llama_model_llama4::graph<iswa>::graph(c
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, kq_scale, il);
              cb(cur, "attn_out", il);
          }
@@ -7804,10 +7836,10 @@ index 7194c72a5..1f3f1c358 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -253,6 +269,13 @@ llama_model_llama4::graph<iswa>::graph(const llama_model & model, const llm_grap
+@@ -253,6 +269,13 @@ llama_model_llama4::graph<iswa>::graph(c
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7818,14 +7850,14 @@ index 7194c72a5..1f3f1c358 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/maincoder.cpp b/src/models/maincoder.cpp
-index ae56a26a1..631e4057f 100644
+Index: b/src/models/maincoder.cpp
+===================================================================
 --- a/src/models/maincoder.cpp
 +++ b/src/models/maincoder.cpp
-@@ -53,16 +53,21 @@ llama_model_maincoder::graph::graph(const llama_model & model, const llm_graph_p
+@@ -53,16 +53,21 @@ llama_model_maincoder::graph::graph(cons
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -7833,24 +7865,24 @@ index ae56a26a1..631e4057f 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -134,6 +139,13 @@ llama_model_maincoder::graph::graph(const llama_model & model, const llm_graph_p
+@@ -134,6 +139,13 @@ llama_model_maincoder::graph::graph(cons
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -7861,14 +7893,14 @@ index ae56a26a1..631e4057f 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/mamba.cpp b/src/models/mamba.cpp
-index 0d94e9828..99e2c825e 100644
+Index: b/src/models/mamba.cpp
+===================================================================
 --- a/src/models/mamba.cpp
 +++ b/src/models/mamba.cpp
-@@ -88,14 +88,19 @@ llama_model_mamba::graph::graph(const llama_model & model, const llm_graph_param
+@@ -88,14 +88,19 @@ llama_model_mamba::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
 +    const int il_start = stage_filtered ? stage_filter.layer_start : 0;
@@ -7877,30 +7909,30 @@ index 0d94e9828..99e2c825e 100644
      // {n_embd, n_tokens}
 -    inpL = build_inp_embd(model.tok_embd);
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      auto * rs_inp = build_rs_inp();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          // norm
          cur = build_norm(inpL, model.layers[il].attn_norm, NULL, LLM_NORM_RMS, il);
          cb(cur, "attn_norm", il);
-@@ -106,7 +111,7 @@ llama_model_mamba::graph::graph(const llama_model & model, const llm_graph_param
+@@ -106,7 +111,7 @@ llama_model_mamba::graph::graph(const ll
              cur = build_mamba_layer(rs_inp, cur, model, ubatch, il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur  = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpL = ggml_get_rows(ctx0, inpL, inp_out_ids);
          }
-@@ -121,6 +126,13 @@ llama_model_mamba::graph::graph(const llama_model & model, const llm_graph_param
+@@ -121,6 +126,13 @@ llama_model_mamba::graph::graph(const ll
          inpL = cur;
      }
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(inpL, "stage_boundary", il_end - 1);
 +        res->t_embd = inpL;
@@ -7910,19 +7942,19 @@ index 0d94e9828..99e2c825e 100644
 +
      // final rmsnorm
      cur = build_norm(inpL, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
-diff --git a/src/models/mimo2.cpp b/src/models/mimo2.cpp
-index d50e186cc..04eaa2173 100644
+
+Index: b/src/models/mimo2.cpp
+===================================================================
 --- a/src/models/mimo2.cpp
 +++ b/src/models/mimo2.cpp
-@@ -25,17 +25,9 @@ void llama_model_mimo2::load_arch_hparams(llama_model_loader & ml) {
+@@ -25,17 +25,9 @@ void llama_model_mimo2::load_arch_hparam
      }
  }
- 
+
 -void llama_model_mimo2::load_arch_tensors(llama_model_loader & ml) {
 +void llama_model_mimo2::load_arch_tensors(llama_model_loader &) {
      LLAMA_LOAD_LOCALS;
- 
+
 -    const std::string mtp_probe = "blk." + std::to_string(n_layer) + ".nextn.eh_proj.weight";
 -    const bool trunk_only = (hparams.n_layer_nextn > 0) && (ml.get_weight(mtp_probe.c_str()) == nullptr);
 -    int mtp_flags         = trunk_only ? TENSOR_NOT_REQUIRED : 0;
@@ -7932,30 +7964,30 @@ index d50e186cc..04eaa2173 100644
 -    }
 -
      tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, 0);
- 
+
      // output
-@@ -48,46 +40,41 @@ void llama_model_mimo2::load_arch_tensors(llama_model_loader & ml) {
+@@ -48,46 +40,41 @@ void llama_model_mimo2::load_arch_tensor
          uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(i);
          uint32_t n_head = hparams.n_head(i);
- 
+
 +        // NextN/MTP layers (the last n_nextn blocks) are preserved but disabled pending support
          const bool is_nextn = i >= n_layer;
 -        const int  flags    = is_nextn ? mtp_flags : 0;
 +        const int  skip     = is_nextn ? TENSOR_SKIP : 0;
- 
+
 -        create_tensor_qkv(layer, i, n_embd, n_embd_head_k * n_head, n_embd_k_gqa, n_embd_v_gqa, flags);
 -        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), { n_embd_head_v * n_head, n_embd }, flags);
 +        create_tensor_qkv(layer, i, n_embd, n_embd_head_k * n_head, n_embd_k_gqa, n_embd_v_gqa, skip);
 +        layer.wo = create_tensor(tn(LLM_TENSOR_ATTN_OUT, "weight", i), { n_embd_head_v * n_head, n_embd }, skip);
- 
+
 -        layer.attn_norm  = create_tensor(tn(LLM_TENSOR_ATTN_NORM,  "weight", i), {n_embd}, flags);
 -        layer.attn_sinks = create_tensor(tn(LLM_TENSOR_ATTN_SINKS, "weight", i), {n_head}, TENSOR_NOT_REQUIRED | flags);
 +        layer.attn_norm  = create_tensor(tn(LLM_TENSOR_ATTN_NORM,  "weight", i), {n_embd}, skip);
 +        layer.attn_sinks = create_tensor(tn(LLM_TENSOR_ATTN_SINKS, "weight", i), {n_head}, TENSOR_NOT_REQUIRED | skip);
- 
+
 -        layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, flags);
 +        layer.ffn_norm = create_tensor(tn(LLM_TENSOR_FFN_NORM, "weight", i), {n_embd}, skip);
- 
+
          // non-MoE branch
 -        layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff}, TENSOR_NOT_REQUIRED | flags);
 -        layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", i), {  n_ff, n_embd}, TENSOR_NOT_REQUIRED | flags);
@@ -7963,7 +7995,7 @@ index d50e186cc..04eaa2173 100644
 +        layer.ffn_gate = create_tensor(tn(LLM_TENSOR_FFN_GATE, "weight", i), {n_embd,   n_ff}, TENSOR_NOT_REQUIRED | skip);
 +        layer.ffn_down = create_tensor(tn(LLM_TENSOR_FFN_DOWN, "weight", i), {  n_ff, n_embd}, TENSOR_NOT_REQUIRED | skip);
 +        layer.ffn_up   = create_tensor(tn(LLM_TENSOR_FFN_UP,   "weight", i), {n_embd,   n_ff}, TENSOR_NOT_REQUIRED | skip);
- 
+
          // MoE branch
          int64_t n_ff_exp = hparams.n_ff_exp;
 -        layer.ffn_gate_inp  = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,  "weight", i), {n_embd, n_expert}, TENSOR_NOT_REQUIRED | flags);
@@ -7976,7 +8008,7 @@ index d50e186cc..04eaa2173 100644
 +        layer.ffn_down_exps = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i), {n_ff_exp,   n_embd, n_expert}, TENSOR_NOT_REQUIRED | skip);
 +        layer.ffn_up_exps   = create_tensor(tn(LLM_TENSOR_FFN_UP_EXPS,   "weight", i), {n_embd, n_ff_exp,   n_expert}, TENSOR_NOT_REQUIRED | skip);
 +        layer.ffn_exp_probs_b = create_tensor(tn(LLM_TENSOR_FFN_EXP_PROBS_B, "bias", i), {n_expert}, TENSOR_NOT_REQUIRED | skip);
- 
+
          if (is_nextn) {
 -            layer.nextn.eh_proj          = create_tensor(tn(LLM_TENSOR_NEXTN_EH_PROJ,          "weight", i), {2 * n_embd, n_embd}, flags);
 -            layer.nextn.enorm            = create_tensor(tn(LLM_TENSOR_NEXTN_ENORM,            "weight", i), {n_embd}, flags);
@@ -7992,18 +8024,18 @@ index d50e186cc..04eaa2173 100644
          }
      }
  }
- 
+
  std::unique_ptr<llm_graph_context> llama_model_mimo2::build_arch_graph(const llm_graph_params & params) const {
 -    if (params.gtype == LLM_GRAPH_TYPE_DECODER_MTP) {
 -        return std::make_unique<graph_mtp>(*this, params);
 -    }
      return std::make_unique<graph>(*this, params);
  }
- 
-@@ -95,17 +82,20 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
+
+@@ -95,17 +82,20 @@ llama_model_mimo2::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const float v_scale = hparams.f_attn_value_scale;
 +
@@ -8013,34 +8045,34 @@ index d50e186cc..04eaa2173 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      ggml_tensor * inp_pos = build_inp_pos();
      auto * inp_attn = build_attn_inp_kv_iswa();
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
-+    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+-
 -    const float v_scale = hparams.f_attn_value_scale;
 -    const bool emit_h_nextn = cparams.embeddings_nextn;
 -    const bool crop_last_layer = inp_out_ids && (!emit_h_nextn || cparams.embeddings_nextn_masked);
--
++    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          uint32_t n_head_l    = hparams.n_head(il);
-@@ -183,7 +173,7 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
+@@ -183,7 +173,7 @@ llama_model_mimo2::graph::graph(const ll
              }
          }
- 
+
 -        if (il == n_layer - 1 && crop_last_layer) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -233,13 +223,11 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
- 
+@@ -233,13 +223,11 @@ llama_model_mimo2::graph::graph(const ll
+
      cur = inpL;
- 
+
 -    if (emit_h_nextn) {
 -        cb(cur, "h_nextn", -1);
 -        res->t_h_nextn = cur;
@@ -8054,10 +8086,10 @@ index d50e186cc..04eaa2173 100644
 +        ggml_build_forward_expand(gf, cur);
 +        return;
      }
- 
+
      cur = build_norm(cur,
-@@ -257,143 +245,3 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
- 
+@@ -257,143 +245,3 @@ llama_model_mimo2::graph::graph(const ll
+
      ggml_build_forward_expand(gf, cur);
  }
 -
@@ -8200,14 +8232,14 @@ index d50e186cc..04eaa2173 100644
 -    res->t_logits = cur;
 -    ggml_build_forward_expand(gf, cur);
 -}
-diff --git a/src/models/minicpm3.cpp b/src/models/minicpm3.cpp
-index e011b1ff0..ec121e8b7 100644
+Index: b/src/models/minicpm3.cpp
+===================================================================
 --- a/src/models/minicpm3.cpp
 +++ b/src/models/minicpm3.cpp
-@@ -75,7 +75,12 @@ llama_model_minicpm3::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -75,7 +75,12 @@ llama_model_minicpm3::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8215,25 +8247,25 @@ index e011b1ff0..ec121e8b7 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // scale the input embeddings
      inpL = ggml_scale(ctx0, inpL, scale_embd);
-@@ -86,9 +91,9 @@ llama_model_minicpm3::graph::graph(const llama_model & model, const llm_graph_pa
- 
+@@ -86,9 +91,9 @@ llama_model_minicpm3::graph::graph(const
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          ggml_tensor * rope_factors = model.get_rope_factors(cparams, il);
-@@ -238,6 +243,13 @@ llama_model_minicpm3::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -238,6 +243,13 @@ llama_model_minicpm3::graph::graph(const
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8244,14 +8276,14 @@ index e011b1ff0..ec121e8b7 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/minimax-m2.cpp b/src/models/minimax-m2.cpp
-index 86a8ae2b1..fe667d549 100644
+Index: b/src/models/minimax-m2.cpp
+===================================================================
 --- a/src/models/minimax-m2.cpp
 +++ b/src/models/minimax-m2.cpp
-@@ -53,13 +53,18 @@ llama_model_minimax_m2::graph::graph(const llama_model & model, const llm_graph_
+@@ -53,13 +53,18 @@ llama_model_minimax_m2::graph::graph(con
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8259,30 +8291,30 @@ index 86a8ae2b1..fe667d549 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      ggml_tensor * inp_pos = build_inp_pos();
      auto inp_attn = build_attn_inp_kv();
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          res->t_layer_inp[il] = inpL;
- 
+
          ggml_tensor * inpSA = inpL;
-@@ -114,7 +119,7 @@ llama_model_minimax_m2::graph::graph(const llama_model & model, const llm_graph_
+@@ -114,7 +119,7 @@ llama_model_minimax_m2::graph::graph(con
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -152,6 +157,13 @@ llama_model_minimax_m2::graph::graph(const llama_model & model, const llm_graph_
- 
+@@ -152,6 +157,13 @@ llama_model_minimax_m2::graph::graph(con
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8293,14 +8325,14 @@ index 86a8ae2b1..fe667d549 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/mistral3.cpp b/src/models/mistral3.cpp
-index 9a8e3f9a5..4203192b7 100644
+Index: b/src/models/mistral3.cpp
+===================================================================
 --- a/src/models/mistral3.cpp
 +++ b/src/models/mistral3.cpp
-@@ -99,7 +99,12 @@ llama_model_mistral3::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -99,7 +99,12 @@ llama_model_mistral3::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8308,22 +8340,22 @@ index 9a8e3f9a5..4203192b7 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -114,9 +119,9 @@ llama_model_mistral3::graph::graph(const llama_model & model, const llm_graph_pa
- 
+@@ -114,9 +119,9 @@ llama_model_mistral3::graph::graph(const
+
      const float kq_scale = hparams.f_attention_scale == 0.0f ? 1.0f/sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -161,7 +166,7 @@ llama_model_mistral3::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -161,7 +166,7 @@ llama_model_mistral3::graph::graph(const
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, kq_scale, il);
              cb(cur, "attn_out", il);
          }
@@ -8332,10 +8364,10 @@ index 9a8e3f9a5..4203192b7 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -218,6 +223,13 @@ llama_model_mistral3::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -218,6 +223,13 @@ llama_model_mistral3::graph::graph(const
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8346,14 +8378,14 @@ index 9a8e3f9a5..4203192b7 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/mpt.cpp b/src/models/mpt.cpp
-index d094fd9f8..3b008a5db 100644
+Index: b/src/models/mpt.cpp
+===================================================================
 --- a/src/models/mpt.cpp
 +++ b/src/models/mpt.cpp
-@@ -73,11 +73,16 @@ llama_model_mpt::graph::graph(const llama_model & model, const llm_graph_params
+@@ -73,11 +73,16 @@ llama_model_mpt::graph::graph(const llam
      ggml_tensor * pos;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8361,39 +8393,39 @@ index d094fd9f8..3b008a5db 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    if (model.pos_embd) {
 +    if ((!stage_filtered || il_start == 0) && model.pos_embd) {
          // inp_pos - contains the positions
          ggml_tensor * inp_pos = build_inp_pos();
          pos                   = ggml_get_rows(ctx0, model.pos_embd, inp_pos);
-@@ -87,9 +92,9 @@ llama_model_mpt::graph::graph(const llama_model & model, const llm_graph_params
+@@ -87,9 +92,9 @@ llama_model_mpt::graph::graph(const llam
          cb(inpL, "inpL", -1);
      }
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * attn_norm;
- 
+
          attn_norm = build_norm(inpL, model.layers[il].attn_norm, model.layers[il].attn_norm_b, LLM_NORM, il);
-@@ -124,7 +129,7 @@ llama_model_mpt::graph::graph(const llama_model & model, const llm_graph_params
+@@ -124,7 +129,7 @@ llama_model_mpt::graph::graph(const llam
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f / sqrtf(float(n_embd_head)), il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur  = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpL = ggml_get_rows(ctx0, inpL, inp_out_ids);
          }
-@@ -156,6 +161,13 @@ llama_model_mpt::graph::graph(const llama_model & model, const llm_graph_params
- 
+@@ -156,6 +161,13 @@ llama_model_mpt::graph::graph(const llam
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8402,16 +8434,16 @@ index d094fd9f8..3b008a5db 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, model.output_norm_b, LLM_NORM, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/nemotron-h.cpp b/src/models/nemotron-h.cpp
-index cd2af3179..22a980f17 100644
+Index: b/src/models/nemotron-h.cpp
+===================================================================
 --- a/src/models/nemotron-h.cpp
 +++ b/src/models/nemotron-h.cpp
-@@ -171,14 +171,19 @@ llama_model_nemotron_h::graph::graph(const llama_model & model, const llm_graph_
+@@ -171,14 +171,19 @@ llama_model_nemotron_h::graph::graph(con
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8420,21 +8452,21 @@ index cd2af3179..22a980f17 100644
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
      ggml_build_forward_expand(gf, inpL);
- 
+
      auto * inp = build_inp_mem_hybrid();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          struct ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -210,6 +215,13 @@ llama_model_nemotron_h::graph::graph(const llama_model & model, const llm_graph_
- 
+@@ -210,6 +215,13 @@ llama_model_nemotron_h::graph::graph(con
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8443,16 +8475,16 @@ index cd2af3179..22a980f17 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      // seed for the MTP/NextN draft head
-diff --git a/src/models/nemotron.cpp b/src/models/nemotron.cpp
-index 6e2bd9a33..5b91df3d8 100644
+Index: b/src/models/nemotron.cpp
+===================================================================
 --- a/src/models/nemotron.cpp
 +++ b/src/models/nemotron.cpp
-@@ -56,16 +56,21 @@ llama_model_nemotron::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -56,16 +56,21 @@ llama_model_nemotron::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8460,24 +8492,24 @@ index 6e2bd9a33..5b91df3d8 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -133,6 +138,13 @@ llama_model_nemotron::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -133,6 +138,13 @@ llama_model_nemotron::graph::graph(const
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8488,14 +8520,14 @@ index 6e2bd9a33..5b91df3d8 100644
      cur = build_norm(cur,
              model.output_norm, model.output_norm_b,
              LLM_NORM, -1);
-diff --git a/src/models/olmo.cpp b/src/models/olmo.cpp
-index 9f7a2ba60..162cb4bc9 100644
+Index: b/src/models/olmo.cpp
+===================================================================
 --- a/src/models/olmo.cpp
 +++ b/src/models/olmo.cpp
-@@ -49,16 +49,21 @@ llama_model_olmo::graph::graph(const llama_model & model, const llm_graph_params
+@@ -49,16 +49,21 @@ llama_model_olmo::graph::graph(const lla
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8503,21 +8535,21 @@ index 9f7a2ba60..162cb4bc9 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -93,7 +98,7 @@ llama_model_olmo::graph::graph(const llama_model & model, const llm_graph_params
+@@ -93,7 +98,7 @@ llama_model_olmo::graph::graph(const lla
                      model.layers[il].wo, nullptr, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
@@ -8526,10 +8558,10 @@ index 9f7a2ba60..162cb4bc9 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -125,6 +130,13 @@ llama_model_olmo::graph::graph(const llama_model & model, const llm_graph_params
+@@ -125,6 +130,13 @@ llama_model_olmo::graph::graph(const lla
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8540,14 +8572,14 @@ index 9f7a2ba60..162cb4bc9 100644
      cur = build_norm(cur,
              NULL, NULL,
              LLM_NORM, -1);
-diff --git a/src/models/olmo2.cpp b/src/models/olmo2.cpp
-index cb52cdef7..38b3de364 100644
+Index: b/src/models/olmo2.cpp
+===================================================================
 --- a/src/models/olmo2.cpp
 +++ b/src/models/olmo2.cpp
-@@ -71,7 +71,12 @@ llama_model_olmo2::graph<iswa>::graph(const llama_model & model, const llm_graph
+@@ -71,7 +71,12 @@ llama_model_olmo2::graph<iswa>::graph(co
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8555,22 +8587,22 @@ index cb52cdef7..38b3de364 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -84,9 +89,9 @@ llama_model_olmo2::graph<iswa>::graph(const llama_model & model, const llm_graph
+@@ -84,9 +89,9 @@ llama_model_olmo2::graph<iswa>::graph(co
      } else {
          inp_attn = build_attn_inp_kv();
      }
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          cur = inpL;
-@@ -153,7 +158,7 @@ llama_model_olmo2::graph<iswa>::graph(const llama_model & model, const llm_graph
+@@ -153,7 +158,7 @@ llama_model_olmo2::graph<iswa>::graph(co
                      model.layers[il].wo, NULL, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
@@ -8579,10 +8611,10 @@ index cb52cdef7..38b3de364 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -190,6 +195,13 @@ llama_model_olmo2::graph<iswa>::graph(const llama_model & model, const llm_graph
+@@ -190,6 +195,13 @@ llama_model_olmo2::graph<iswa>::graph(co
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8593,14 +8625,14 @@ index cb52cdef7..38b3de364 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/olmoe.cpp b/src/models/olmoe.cpp
-index 1e2baeb20..4c6c4ef81 100644
+Index: b/src/models/olmoe.cpp
+===================================================================
 --- a/src/models/olmoe.cpp
 +++ b/src/models/olmoe.cpp
-@@ -59,16 +59,21 @@ llama_model_olmoe::graph::graph(const llama_model & model, const llm_graph_param
+@@ -59,16 +59,21 @@ llama_model_olmoe::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8608,21 +8640,21 @@ index 1e2baeb20..4c6c4ef81 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -121,7 +126,7 @@ llama_model_olmoe::graph::graph(const llama_model & model, const llm_graph_param
+@@ -121,7 +126,7 @@ llama_model_olmoe::graph::graph(const ll
                      model.layers[il].wo, NULL, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
@@ -8631,10 +8663,10 @@ index 1e2baeb20..4c6c4ef81 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -157,6 +162,13 @@ llama_model_olmoe::graph::graph(const llama_model & model, const llm_graph_param
+@@ -157,6 +162,13 @@ llama_model_olmoe::graph::graph(const ll
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8645,14 +8677,14 @@ index 1e2baeb20..4c6c4ef81 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/openai-moe.cpp b/src/models/openai-moe.cpp
-index c91bae1c3..8c4d7bed5 100644
+Index: b/src/models/openai-moe.cpp
+===================================================================
 --- a/src/models/openai-moe.cpp
 +++ b/src/models/openai-moe.cpp
-@@ -65,16 +65,21 @@ llama_model_openai_moe::graph::graph(const llama_model & model, const llm_graph_
+@@ -65,16 +65,21 @@ llama_model_openai_moe::graph::graph(con
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8660,22 +8692,22 @@ index c91bae1c3..8c4d7bed5 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv_iswa();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          res->t_layer_inp[il] = inpL;
- 
+
          const float freq_base_l  = model.get_rope_freq_base (cparams, il);
-@@ -116,7 +121,7 @@ llama_model_openai_moe::graph::graph(const llama_model & model, const llm_graph_
- 
+@@ -116,7 +121,7 @@ llama_model_openai_moe::graph::graph(con
+
              cb(cur, "attn_out", il);
          }
 -        if (il == n_layer - 1 && inp_out_ids && cparams.embeddings_nextn_masked) {
@@ -8683,10 +8715,10 @@ index c91bae1c3..8c4d7bed5 100644
              // skip computing output for unused tokens
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
-@@ -154,6 +159,13 @@ llama_model_openai_moe::graph::graph(const llama_model & model, const llm_graph_
+@@ -154,6 +159,13 @@ llama_model_openai_moe::graph::graph(con
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8695,14 +8727,14 @@ index c91bae1c3..8c4d7bed5 100644
 +    }
 +
      res->t_h_nextn = cur;
- 
+
      if (!cparams.embeddings_nextn_masked && inp_out_ids) {
-diff --git a/src/models/openelm.cpp b/src/models/openelm.cpp
-index 13120bd32..33ca072f0 100644
+Index: b/src/models/openelm.cpp
+===================================================================
 --- a/src/models/openelm.cpp
 +++ b/src/models/openelm.cpp
-@@ -54,16 +54,21 @@ llama_model_openelm::graph::graph(const llama_model & model, const llm_graph_par
- 
+@@ -54,16 +54,21 @@ llama_model_openelm::graph::graph(const
+
      ggml_tensor * cur;
      ggml_tensor * inpL;
 -    inpL = build_inp_embd(model.tok_embd);
@@ -8712,24 +8744,24 @@ index 13120bd32..33ca072f0 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const int64_t n_head    = hparams.n_head(il);
          const int64_t n_head_kv = hparams.n_head_kv(il);
          const int64_t n_head_qkv = 2*n_head_kv + n_head;
-@@ -154,6 +159,13 @@ llama_model_openelm::graph::graph(const llama_model & model, const llm_graph_par
+@@ -154,6 +159,13 @@ llama_model_openelm::graph::graph(const
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8740,14 +8772,14 @@ index 13120bd32..33ca072f0 100644
      // norm
      cur = build_norm(cur,
              model.output_norm, NULL,
-diff --git a/src/models/orion.cpp b/src/models/orion.cpp
-index 863a28222..99609dbe9 100644
+Index: b/src/models/orion.cpp
+===================================================================
 --- a/src/models/orion.cpp
 +++ b/src/models/orion.cpp
-@@ -49,16 +49,21 @@ llama_model_orion::graph::graph(const llama_model & model, const llm_graph_param
+@@ -49,16 +49,21 @@ llama_model_orion::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8755,24 +8787,24 @@ index 863a28222..99609dbe9 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -124,6 +129,13 @@ llama_model_orion::graph::graph(const llama_model & model, const llm_graph_param
+@@ -124,6 +129,13 @@ llama_model_orion::graph::graph(const ll
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8783,14 +8815,14 @@ index 863a28222..99609dbe9 100644
      cur = build_norm(cur,
              model.output_norm, model.output_norm_b,
              LLM_NORM, -1);
-diff --git a/src/models/phi2.cpp b/src/models/phi2.cpp
-index 81b1ad12c..f82e0c74a 100644
+Index: b/src/models/phi2.cpp
+===================================================================
 --- a/src/models/phi2.cpp
 +++ b/src/models/phi2.cpp
-@@ -54,16 +54,21 @@ llama_model_phi2::graph::graph(const llama_model & model, const llm_graph_params
+@@ -54,16 +54,21 @@ llama_model_phi2::graph::graph(const lla
      ggml_tensor * ffn_output;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8798,21 +8830,21 @@ index 81b1ad12c..f82e0c74a 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          attn_norm_output = build_norm(inpL,
                  model.layers[il].attn_norm,
                  model.layers[il].attn_norm_b,
-@@ -98,7 +103,7 @@ llama_model_phi2::graph::graph(const llama_model & model, const llm_graph_params
+@@ -98,7 +103,7 @@ llama_model_phi2::graph::graph(const lla
                      model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f, il);
          }
@@ -8821,7 +8853,7 @@ index 81b1ad12c..f82e0c74a 100644
              cur              = ggml_get_rows(ctx0,              cur, inp_out_ids);
              inpL             = ggml_get_rows(ctx0,             inpL, inp_out_ids);
              attn_norm_output = ggml_get_rows(ctx0, attn_norm_output, inp_out_ids);
-@@ -122,6 +127,14 @@ llama_model_phi2::graph::graph(const llama_model & model, const llm_graph_params
+@@ -122,6 +127,14 @@ llama_model_phi2::graph::graph(const lla
          // input for next layer
          inpL = cur;
      }
@@ -8836,14 +8868,14 @@ index 81b1ad12c..f82e0c74a 100644
      cur = build_norm(inpL,
              model.output_norm,
              model.output_norm_b,
-diff --git a/src/models/phi3.cpp b/src/models/phi3.cpp
-index 716ff814c..6d3026905 100644
+Index: b/src/models/phi3.cpp
+===================================================================
 --- a/src/models/phi3.cpp
 +++ b/src/models/phi3.cpp
-@@ -73,7 +73,12 @@ llama_model_phi3::graph<iswa>::graph(const llama_model & model, const llm_graph_
+@@ -73,7 +73,12 @@ llama_model_phi3::graph<iswa>::graph(con
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8851,22 +8883,22 @@ index 716ff814c..6d3026905 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -86,9 +91,9 @@ llama_model_phi3::graph<iswa>::graph(const llama_model & model, const llm_graph_
+@@ -86,9 +91,9 @@ llama_model_phi3::graph<iswa>::graph(con
      } else {
          inp_attn = build_attn_inp_kv();
      }
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          auto * residual = inpL;
- 
+
          // self-attention
-@@ -127,7 +132,7 @@ llama_model_phi3::graph<iswa>::graph(const llama_model & model, const llm_graph_
+@@ -127,7 +132,7 @@ llama_model_phi3::graph<iswa>::graph(con
                      model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f, il);
          }
@@ -8875,7 +8907,7 @@ index 716ff814c..6d3026905 100644
              cur      = ggml_get_rows(ctx0, cur,      inp_out_ids);
              residual = ggml_get_rows(ctx0, residual, inp_out_ids);
          }
-@@ -171,6 +176,14 @@ llama_model_phi3::graph<iswa>::graph(const llama_model & model, const llm_graph_
+@@ -171,6 +176,14 @@ llama_model_phi3::graph<iswa>::graph(con
          // input for next layer
          inpL = cur;
      }
@@ -8890,14 +8922,14 @@ index 716ff814c..6d3026905 100644
      cur = build_norm(inpL,
              model.output_norm,
              model.output_norm_b,
-diff --git a/src/models/plamo.cpp b/src/models/plamo.cpp
-index 246144519..fbc65bfac 100644
+Index: b/src/models/plamo.cpp
+===================================================================
 --- a/src/models/plamo.cpp
 +++ b/src/models/plamo.cpp
-@@ -45,16 +45,21 @@ llama_model_plamo::graph::graph(const llama_model & model, const llm_graph_param
+@@ -45,16 +45,21 @@ llama_model_plamo::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -8905,24 +8937,24 @@ index 246144519..fbc65bfac 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          // norm
          cur = build_norm(inpL,
                  model.layers[il].attn_norm, NULL,
-@@ -119,6 +124,13 @@ llama_model_plamo::graph::graph(const llama_model & model, const llm_graph_param
+@@ -119,6 +124,13 @@ llama_model_plamo::graph::graph(const ll
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8933,13 +8965,13 @@ index 246144519..fbc65bfac 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/plamo2.cpp b/src/models/plamo2.cpp
-index 0b81513c3..07d0bee7b 100644
+Index: b/src/models/plamo2.cpp
+===================================================================
 --- a/src/models/plamo2.cpp
 +++ b/src/models/plamo2.cpp
-@@ -113,16 +113,21 @@ llama_model_plamo2::graph::graph(const llama_model & model, const llm_graph_para
+@@ -113,16 +113,21 @@ llama_model_plamo2::graph::graph(const l
      ggml_tensor * inpL;
- 
+
      // {n_embd, n_tokens}
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
@@ -8949,23 +8981,23 @@ index 0b81513c3..07d0bee7b 100644
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
      cb(inpL, "embedding_output", -1);
- 
+
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_hybrid = build_inp_mem_hybrid();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * residual = inpL;
- 
+
          // ggml_graph_add_node(gf, model.layers[il].attn_norm);
-@@ -182,6 +187,13 @@ llama_model_plamo2::graph::graph(const llama_model & model, const llm_graph_para
- 
+@@ -182,6 +187,13 @@ llama_model_plamo2::graph::graph(const l
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -8976,13 +9008,13 @@ index 0b81513c3..07d0bee7b 100644
      // final norm
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
      cb(cur, "result_norm", -1);
-diff --git a/src/models/plamo3.cpp b/src/models/plamo3.cpp
-index 16d0b1dce..1c9d04ad9 100644
+Index: b/src/models/plamo3.cpp
+===================================================================
 --- a/src/models/plamo3.cpp
 +++ b/src/models/plamo3.cpp
-@@ -74,7 +74,12 @@ llama_model_plamo3::graph<iswa>::graph(const llama_model & model, const llm_grap
+@@ -74,7 +74,12 @@ llama_model_plamo3::graph<iswa>::graph(c
      const int64_t head_dim_v = hparams.n_embd_head_v();
- 
+
      ggml_tensor * cur;
 -    ggml_tensor * inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
@@ -8992,24 +9024,24 @@ index 16d0b1dce..1c9d04ad9 100644
 +
 +    ggml_tensor * inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      using inp_attn_type = std::conditional_t<iswa, llm_graph_input_attn_kv_iswa, llm_graph_input_attn_kv>;
-@@ -86,9 +91,9 @@ llama_model_plamo3::graph<iswa>::graph(const llama_model & model, const llm_grap
+@@ -86,9 +91,9 @@ llama_model_plamo3::graph<iswa>::graph(c
          inp_attn = build_attn_inp_kv();
      }
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * residual = inpL;
- 
+
          float freq_base_l  = 0.0f;
-@@ -183,6 +188,13 @@ llama_model_plamo3::graph<iswa>::graph(const llama_model & model, const llm_grap
- 
+@@ -183,6 +188,13 @@ llama_model_plamo3::graph<iswa>::graph(c
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -9019,14 +9051,14 @@ index 16d0b1dce..1c9d04ad9 100644
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
      res->t_embd = cur;
- 
-diff --git a/src/models/plm.cpp b/src/models/plm.cpp
-index 8ca325f5e..0dd5142fa 100644
+
+Index: b/src/models/plm.cpp
+===================================================================
 --- a/src/models/plm.cpp
 +++ b/src/models/plm.cpp
-@@ -57,16 +57,21 @@ llama_model_plm::graph::graph(const llama_model & model, const llm_graph_params
+@@ -57,16 +57,21 @@ llama_model_plm::graph::graph(const llam
      ggml_tensor * inpL;
- 
+
      // {n_embd, n_tokens}
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
@@ -9035,24 +9067,24 @@ index 8ca325f5e..0dd5142fa 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -198,6 +203,13 @@ llama_model_plm::graph::graph(const llama_model & model, const llm_graph_params
+@@ -198,6 +203,13 @@ llama_model_plm::graph::graph(const llam
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -9063,14 +9095,14 @@ index 8ca325f5e..0dd5142fa 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/qwen.cpp b/src/models/qwen.cpp
-index 1f5dff384..becc84eee 100644
+Index: b/src/models/qwen.cpp
+===================================================================
 --- a/src/models/qwen.cpp
 +++ b/src/models/qwen.cpp
-@@ -48,16 +48,21 @@ llama_model_qwen::graph::graph(const llama_model & model, const llm_graph_params
+@@ -48,16 +48,21 @@ llama_model_qwen::graph::graph(const lla
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -9078,24 +9110,24 @@ index 1f5dff384..becc84eee 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          cur = build_norm(inpL,
-@@ -123,6 +128,13 @@ llama_model_qwen::graph::graph(const llama_model & model, const llm_graph_params
+@@ -123,6 +128,13 @@ llama_model_qwen::graph::graph(const lla
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -9106,14 +9138,14 @@ index 1f5dff384..becc84eee 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/qwen2.cpp b/src/models/qwen2.cpp
-index e9c2ea80a..6362851e7 100644
+Index: b/src/models/qwen2.cpp
+===================================================================
 --- a/src/models/qwen2.cpp
 +++ b/src/models/qwen2.cpp
-@@ -59,16 +59,21 @@ llama_model_qwen2::graph::graph(const llama_model & model, const llm_graph_param
+@@ -59,16 +59,21 @@ llama_model_qwen2::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -9121,21 +9153,21 @@ index e9c2ea80a..6362851e7 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -103,7 +108,7 @@ llama_model_qwen2::graph::graph(const llama_model & model, const llm_graph_param
+@@ -103,7 +108,7 @@ llama_model_qwen2::graph::graph(const ll
                      model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
@@ -9144,10 +9176,10 @@ index e9c2ea80a..6362851e7 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -134,6 +139,13 @@ llama_model_qwen2::graph::graph(const llama_model & model, const llm_graph_param
+@@ -134,6 +139,13 @@ llama_model_qwen2::graph::graph(const ll
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -9158,12 +9190,12 @@ index e9c2ea80a..6362851e7 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/qwen2moe.cpp b/src/models/qwen2moe.cpp
-index e831ed11a..9f02cec3a 100644
+Index: b/src/models/qwen2moe.cpp
+===================================================================
 --- a/src/models/qwen2moe.cpp
 +++ b/src/models/qwen2moe.cpp
-@@ -20,7 +20,10 @@ void llama_model_qwen2moe::load_arch_tensors(llama_model_loader &) {
- 
+@@ -20,7 +20,10 @@ void llama_model_qwen2moe::load_arch_ten
+
      // output
      output_norm = create_tensor(tn(LLM_TENSOR_OUTPUT_NORM, "weight"), {n_embd}, 0);
 -    output      = create_tensor(tn(LLM_TENSOR_OUTPUT,      "weight"), {n_embd, n_vocab}, 0);
@@ -9171,13 +9203,13 @@ index e831ed11a..9f02cec3a 100644
 +    if (output == NULL) {
 +        output = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, TENSOR_DUPLICATED);
 +    }
- 
+
      for (int i = 0; i < n_layer; ++i) {
          auto & layer = layers[i];
-@@ -71,16 +74,21 @@ llama_model_qwen2moe::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -71,16 +74,21 @@ llama_model_qwen2moe::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -9185,21 +9217,21 @@ index e831ed11a..9f02cec3a 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -115,7 +123,7 @@ llama_model_qwen2moe::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -115,7 +123,7 @@ llama_model_qwen2moe::graph::graph(const
                      model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
@@ -9208,10 +9240,10 @@ index e831ed11a..9f02cec3a 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -177,6 +185,13 @@ llama_model_qwen2moe::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -177,6 +185,13 @@ llama_model_qwen2moe::graph::graph(const
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -9222,14 +9254,14 @@ index e831ed11a..9f02cec3a 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/qwen2vl.cpp b/src/models/qwen2vl.cpp
-index d79db682c..d5f8ba3ac 100644
+Index: b/src/models/qwen2vl.cpp
+===================================================================
 --- a/src/models/qwen2vl.cpp
 +++ b/src/models/qwen2vl.cpp
-@@ -48,7 +48,12 @@ llama_model_qwen2vl::graph::graph(const llama_model & model, const llm_graph_par
+@@ -48,7 +48,12 @@ llama_model_qwen2vl::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -9237,22 +9269,22 @@ index d79db682c..d5f8ba3ac 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -58,9 +63,9 @@ llama_model_qwen2vl::graph::graph(const llama_model & model, const llm_graph_par
+@@ -58,9 +63,9 @@ llama_model_qwen2vl::graph::graph(const
      int sections[4];
      std::copy(std::begin(hparams.rope_sections), std::begin(hparams.rope_sections) + 4, sections);
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -95,7 +100,7 @@ llama_model_qwen2vl::graph::graph(const llama_model & model, const llm_graph_par
+@@ -95,7 +100,7 @@ llama_model_qwen2vl::graph::graph(const
                      model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
@@ -9261,10 +9293,10 @@ index d79db682c..d5f8ba3ac 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -126,6 +131,13 @@ llama_model_qwen2vl::graph::graph(const llama_model & model, const llm_graph_par
+@@ -126,6 +131,13 @@ llama_model_qwen2vl::graph::graph(const
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -9275,14 +9307,14 @@ index d79db682c..d5f8ba3ac 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/qwen3.cpp b/src/models/qwen3.cpp
-index f4b2a2aeb..9991ce56b 100644
+Index: b/src/models/qwen3.cpp
+===================================================================
 --- a/src/models/qwen3.cpp
 +++ b/src/models/qwen3.cpp
-@@ -59,16 +59,21 @@ llama_model_qwen3::graph::graph(const llama_model & model, const llm_graph_param
+@@ -59,16 +59,21 @@ llama_model_qwen3::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -9290,21 +9322,21 @@ index f4b2a2aeb..9991ce56b 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          res->t_layer_inp[il] = inpL;
- 
+
          ggml_tensor * inpSA = inpL;
-@@ -111,7 +116,7 @@ llama_model_qwen3::graph::graph(const llama_model & model, const llm_graph_param
+@@ -111,7 +116,7 @@ llama_model_qwen3::graph::graph(const ll
                      model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
@@ -9313,10 +9345,10 @@ index f4b2a2aeb..9991ce56b 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -142,6 +147,13 @@ llama_model_qwen3::graph::graph(const llama_model & model, const llm_graph_param
+@@ -142,6 +147,13 @@ llama_model_qwen3::graph::graph(const ll
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -9327,14 +9359,14 @@ index f4b2a2aeb..9991ce56b 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/qwen35.cpp b/src/models/qwen35.cpp
-index 309dd4324..e50b80219 100644
+Index: b/src/models/qwen35.cpp
+===================================================================
 --- a/src/models/qwen35.cpp
 +++ b/src/models/qwen35.cpp
-@@ -146,17 +146,29 @@ llama_model_qwen35::graph::graph(const llama_model & model, const llm_graph_para
+@@ -146,17 +146,29 @@ llama_model_qwen35::graph::graph(const l
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -9349,35 +9381,35 @@ index 309dd4324..e50b80219 100644
 +    }
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      cb(inpL, "model.input_embed", -1);
- 
+
      auto * inp = build_inp_mem_hybrid();
- 
+
 -    ggml_tensor * inp_pos     = build_inp_pos();
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_pos     = has_attention_layer ? build_inp_pos() : nullptr;
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
      // MTP/NextN layers are loaded as extra decoder blocks but not executed in the main pass.
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          res->t_layer_inp[il] = inpL;
- 
+
          ggml_tensor * inpSA = inpL;
-@@ -175,7 +187,7 @@ llama_model_qwen35::graph::graph(const llama_model & model, const llm_graph_para
+@@ -175,7 +187,7 @@ llama_model_qwen35::graph::graph(const l
              cur = build_layer_attn(inp->get_attn(), cur, inp_pos, sections, il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids && cparams.embeddings_nextn_masked) {
 +        if (il == il_end - 1 && inp_out_ids && cparams.embeddings_nextn_masked) {
              cur   = ggml_get_rows(ctx0, cur,   inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -207,6 +219,13 @@ llama_model_qwen35::graph::graph(const llama_model & model, const llm_graph_para
+@@ -207,6 +219,13 @@ llama_model_qwen35::graph::graph(const l
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -9386,16 +9418,16 @@ index 309dd4324..e50b80219 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, nullptr, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "h_nextn", -1);
-diff --git a/src/models/qwen35moe.cpp b/src/models/qwen35moe.cpp
-index 38f2a5798..99d667f56 100644
+Index: b/src/models/qwen35moe.cpp
+===================================================================
 --- a/src/models/qwen35moe.cpp
 +++ b/src/models/qwen35moe.cpp
-@@ -169,17 +169,29 @@ llama_model_qwen35moe::graph::graph(const llama_model & model, const llm_graph_p
+@@ -169,17 +169,29 @@ llama_model_qwen35moe::graph::graph(cons
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -9410,26 +9442,26 @@ index 38f2a5798..99d667f56 100644
 +    }
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      cb(inpL, "model.input_embed", -1);
- 
+
      auto * inp = build_inp_mem_hybrid();
- 
+
 -    ggml_tensor * inp_pos     = build_inp_pos();
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_pos     = has_attention_layer ? build_inp_pos() : nullptr;
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
      // MTP/NextN layers are loaded as extra decoder blocks but not executed in the main pass.
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          res->t_layer_inp[il] = inpL;
- 
+
          ggml_tensor * inpSA = inpL;
-@@ -230,6 +242,13 @@ llama_model_qwen35moe::graph::graph(const llama_model & model, const llm_graph_p
+@@ -230,6 +242,13 @@ llama_model_qwen35moe::graph::graph(cons
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -9439,15 +9471,15 @@ index 38f2a5798..99d667f56 100644
 +
      // post-norm hidden state feeds both the LM head and the MTP seed below
      cur = build_norm(cur, model.output_norm, nullptr, LLM_NORM_RMS, -1);
- 
-diff --git a/src/models/qwen3moe.cpp b/src/models/qwen3moe.cpp
-index 6f6df5390..ba08a4e1d 100644
+
+Index: b/src/models/qwen3moe.cpp
+===================================================================
 --- a/src/models/qwen3moe.cpp
 +++ b/src/models/qwen3moe.cpp
-@@ -68,16 +68,21 @@ llama_model_qwen3moe::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -68,16 +68,21 @@ llama_model_qwen3moe::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -9455,24 +9487,24 @@ index 6f6df5390..ba08a4e1d 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          res->t_layer_inp[il] = inpL;
- 
+
          ggml_tensor * inpSA = inpL;
-@@ -162,6 +167,13 @@ llama_model_qwen3moe::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -162,6 +167,13 @@ llama_model_qwen3moe::graph::graph(const
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -9483,14 +9515,14 @@ index 6f6df5390..ba08a4e1d 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/qwen3next.cpp b/src/models/qwen3next.cpp
-index 0808fd87a..8c925a863 100644
+Index: b/src/models/qwen3next.cpp
+===================================================================
 --- a/src/models/qwen3next.cpp
 +++ b/src/models/qwen3next.cpp
-@@ -13,11 +13,7 @@ void llama_model_qwen3next::load_arch_hparams(llama_model_loader & ml) {
+@@ -13,11 +13,7 @@ void llama_model_qwen3next::load_arch_hp
      ml.get_key(LLM_KV_SSM_TIME_STEP_RANK, hparams.ssm_dt_rank);
      ml.get_key(LLM_KV_SSM_GROUP_COUNT,    hparams.ssm_n_group);
- 
+
 -    // NextN/MTP: extra decoder block appended beyond the main stack
 -    ml.get_key(LLM_KV_NEXTN_PREDICT_LAYERS, hparams.n_layer_nextn, false);
 -    GGML_ASSERT(hparams.n_layer_nextn < hparams.n_layer_all && "n_layer_nextn must be < n_layer_all");
@@ -9500,41 +9532,41 @@ index 0808fd87a..8c925a863 100644
      if (!ml.get_key_or_arr(LLM_KV_ATTENTION_RECURRENT_LAYERS, hparams.is_recr_impl, hparams.n_layer_all, false)) {
          uint32_t full_attn_interval = 4;
          ml.get_key(LLM_KV_FULL_ATTENTION_INTERVAL, full_attn_interval, false);
-@@ -32,17 +28,13 @@ void llama_model_qwen3next::load_arch_hparams(llama_model_loader & ml) {
+@@ -32,17 +28,13 @@ void llama_model_qwen3next::load_arch_hp
      }
  }
- 
+
 -void llama_model_qwen3next::load_arch_tensors(llama_model_loader & ml) {
 +void llama_model_qwen3next::load_arch_tensors(llama_model_loader &) {
      LLAMA_LOAD_LOCALS;
- 
+
      if (n_expert == 0) {
          throw std::runtime_error(arch_name() + " model cannot have zero experts");
      }
- 
+
 -    const bool mtp_only = (hparams.n_layer_nextn > 0) && (ml.get_weight("blk.0.attn_norm.weight") == nullptr);
 -    const int trunk_flags = mtp_only ? TENSOR_NOT_REQUIRED : 0;
 -    int mtp_flags = !ml.load_mtp ? TENSOR_SKIP : 0;
 -
      tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), { n_embd, n_vocab }, 0);
- 
+
      // output
-@@ -69,73 +61,49 @@ void llama_model_qwen3next::load_arch_tensors(llama_model_loader & ml) {
+@@ -69,73 +61,49 @@ void llama_model_qwen3next::load_arch_te
      const int64_t qkvz_dim = key_dim * 2 + value_dim * 2;
      const int64_t ba_dim   = n_v_heads * 2;
- 
+
 -    auto load_block_trunk = [&](int il, int flags) {
 -        auto & layer = layers[il];
 -        const uint32_t n_ff_shexp = hparams.n_ff_shexp > 0 ? hparams.n_ff_shexp : hparams.n_ff(il);
 +    for (int i = 0; i < n_layer; ++i) {
 +        auto & layer = layers[i];
 +        const uint32_t n_ff_shexp = hparams.n_ff_shexp > 0 ? hparams.n_ff_shexp : hparams.n_ff(i);
- 
+
 -        layer.attn_norm      = create_tensor(tn(LLM_TENSOR_ATTN_NORM,      "weight", il), { n_embd }, flags);
 -        layer.attn_post_norm = create_tensor(tn(LLM_TENSOR_ATTN_POST_NORM, "weight", il), { n_embd }, flags);
 +        layer.attn_norm      = create_tensor(tn(LLM_TENSOR_ATTN_NORM,      "weight", i), { n_embd }, 0);
 +        layer.attn_post_norm = create_tensor(tn(LLM_TENSOR_ATTN_POST_NORM, "weight", i), { n_embd }, 0);
- 
+
 -        if (!hparams.is_recr(il)) {
 +        if (!hparams.is_recr(i)) {
              // Attention layers
@@ -9571,14 +9603,14 @@ index 0808fd87a..8c925a863 100644
 +            layer.ssm_norm       = create_tensor(tn(LLM_TENSOR_SSM_NORM,       "weight", i), { head_v_dim }, 0);
 +            layer.ssm_out        = create_tensor(tn(LLM_TENSOR_SSM_OUT,        "weight", i), { value_dim, n_embd }, 0);
          }
- 
+
 -        layer.ffn_gate_inp  = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,  "weight", il), { n_embd, n_expert }, flags);
 -        layer.ffn_down_exps = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", il), { n_ff_exp, n_embd, n_expert }, flags);
 -        create_tensor_gate_up_exps(layer, il, n_embd, n_ff_exp, n_expert, flags);
 +        layer.ffn_gate_inp  = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,  "weight", i), { n_embd, n_expert }, 0);
 +        layer.ffn_down_exps = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i), { n_ff_exp, n_embd, n_expert }, 0);
 +        create_tensor_gate_up_exps(layer, i, n_embd, n_ff_exp, n_expert, 0);
- 
+
          // Shared experts
 -        layer.ffn_gate_inp_shexp = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP_SHEXP, "weight", il), { n_embd }, flags);
 -        layer.ffn_gate_shexp     = create_tensor(tn(LLM_TENSOR_FFN_GATE_SHEXP,     "weight", il), { n_embd, n_ff_shexp }, flags);
@@ -9612,18 +9644,18 @@ index 0808fd87a..8c925a863 100644
 +        layer.ffn_down_shexp     = create_tensor(tn(LLM_TENSOR_FFN_DOWN_SHEXP,     "weight", i), { n_ff_shexp, n_embd }, 0);
      }
  }
- 
+
  std::unique_ptr<llm_graph_context> llama_model_qwen3next::build_arch_graph(const llm_graph_params & params) const {
 -    if (params.gtype == LLM_GRAPH_TYPE_DECODER_MTP) {
 -        return std::make_unique<graph_mtp>(*this, params);
 -    }
      return std::make_unique<graph>(*this, params);
  }
- 
-@@ -144,16 +112,27 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
+
+@@ -144,16 +112,27 @@ llama_model_qwen3next::graph::graph(cons
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -9639,33 +9671,33 @@ index 0808fd87a..8c925a863 100644
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
      cb(inpL, "model.embed_tokens", -1);
- 
+
      auto * inp = build_inp_mem_hybrid();
- 
+
 -    ggml_tensor * inp_pos     = build_inp_pos();
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_pos     = has_attention_layer ? build_inp_pos() : nullptr;
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    // MTP/NextN layers are loaded as extra decoder blocks but not executed in the main pass.
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          res->t_layer_inp[il] = inpL;
- 
+
          ggml_tensor * inpSA = inpL;
-@@ -172,7 +151,7 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
+@@ -172,7 +151,7 @@ llama_model_qwen3next::graph::graph(cons
              cur = build_layer_attn(inp->get_attn(), cur, inp_pos, il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids && cparams.embeddings_nextn_masked) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -204,16 +183,16 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
+@@ -204,16 +183,16 @@ llama_model_qwen3next::graph::graph(cons
      }
      cur = inpL;
- 
+
 -    // post-norm hidden state is input to both the LM head and the MTP head
 -    cur = build_norm(cur, model.output_norm, nullptr, LLM_NORM_RMS, -1);
 -
@@ -9680,17 +9712,17 @@ index 0808fd87a..8c925a863 100644
 +        ggml_build_forward_expand(gf, cur);
 +        return;
      }
- 
+
 +    // Final norm
 +    cur = build_norm(cur, model.output_norm, nullptr, LLM_NORM_RMS, -1);
 +
      cb(cur, "result_norm", -1);
      res->t_embd = cur;
- 
-@@ -226,6 +205,14 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
+
+@@ -226,6 +205,14 @@ llama_model_qwen3next::graph::graph(cons
      ggml_build_forward_expand(gf, cur);
  }
- 
+
 +// utility to get one slice from the third dimension
 +// input dim:  [x, y, c, b]
 +// output dim: [x, y, 1, b]
@@ -9702,38 +9734,38 @@ index 0808fd87a..8c925a863 100644
  ggml_tensor * llama_model_qwen3next::graph::build_norm_gated(
          ggml_tensor * input,
          ggml_tensor * weights,
-@@ -248,7 +235,7 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_attn(
+@@ -248,7 +235,7 @@ ggml_tensor * llama_model_qwen3next::gra
      // Order: joint QG projection, QG split, Q norm, KV projection, K norm, RoPE, attention
- 
+
      // Qwen3Next uses a single Q projection that outputs query + gate
 -    ggml_tensor * Qcur_full = build_lora_mm(model.layers[il].wq, cur, model.layers[il].wq_s);
 +    ggml_tensor * Qcur_full = build_lora_mm(model.layers[il].wq, cur);
      cb(Qcur_full, "Qcur_full", il);
- 
+
      Qcur_full = ggml_reshape_4d(ctx0, Qcur_full, n_embd_head * 2, n_head, n_tokens, 1);
-@@ -264,10 +251,10 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_attn(
+@@ -264,10 +251,10 @@ ggml_tensor * llama_model_qwen3next::gra
                       Qcur_full->nb[1], Qcur_full->nb[2], Qcur_full->nb[3], n_embd_head * ggml_element_size(Qcur_full));
      cb(gate, "gate", il);
- 
+
 -    ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur, model.layers[il].wk_s);
 +    ggml_tensor * Kcur = build_lora_mm(model.layers[il].wk, cur);
      cb(Kcur, "Kcur", il);
- 
+
 -    ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur, model.layers[il].wv_s);
 +    ggml_tensor * Vcur = build_lora_mm(model.layers[il].wv, cur);
      cb(Vcur, "Vcur", il);
- 
+
      Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
-@@ -306,6 +293,8 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_attn(
+@@ -306,6 +293,8 @@ ggml_tensor * llama_model_qwen3next::gra
      gate = ggml_sigmoid(ctx0, gate);
      cb(gate, "gate_sigmoid", il);
- 
+
 +    gate = ggml_reshape_2d(ctx0, gate, n_embd_head * n_head, n_tokens);
 +
      cur = ggml_mul(ctx0, cur, gate);
      cb(cur, "attn_gated", il);
- 
-@@ -580,19 +569,16 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_ffn(ggml_tensor * cur, c
+
+@@ -580,19 +569,16 @@ ggml_tensor * llama_model_qwen3next::gra
                  LLM_FFN_SILU, true,
                  hparams.expert_weights_scale,
                  LLAMA_EXPERT_GATING_FUNC_TYPE_SOFTMAX, il,
@@ -9743,7 +9775,7 @@ index 0808fd87a..8c925a863 100644
 -                model.layers[il].ffn_down_exps_s);
 +                nullptr, model.layers[il].ffn_gate_up_exps);
          cb(moe_out, "ffn_moe_out", il);
- 
+
          // Add shared experts if present - following Qwen3Next reference implementation
          if (model.layers[il].ffn_up_shexp != nullptr) {
              ggml_tensor * ffn_shexp =
@@ -9757,7 +9789,7 @@ index 0808fd87a..8c925a863 100644
                      NULL,
                      LLM_FFN_SILU, LLM_FFN_PAR, il);
              cb(ffn_shexp, "ffn_shexp", il);
-@@ -626,198 +612,3 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_ffn(ggml_tensor * cur, c
+@@ -626,198 +612,3 @@ ggml_tensor * llama_model_qwen3next::gra
      }
      return cur;
  }
@@ -9956,14 +9988,14 @@ index 0808fd87a..8c925a863 100644
 -    res->t_logits = cur;
 -    ggml_build_forward_expand(gf, cur);
 -}
-diff --git a/src/models/qwen3vl.cpp b/src/models/qwen3vl.cpp
-index 5596620f0..290583ef6 100644
+Index: b/src/models/qwen3vl.cpp
+===================================================================
 --- a/src/models/qwen3vl.cpp
 +++ b/src/models/qwen3vl.cpp
-@@ -68,7 +68,12 @@ llama_model_qwen3vl::graph::graph(const llama_model & model, const llm_graph_par
+@@ -68,7 +68,12 @@ llama_model_qwen3vl::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -9971,43 +10003,43 @@ index 5596620f0..290583ef6 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      int sections[4];
      std::copy(std::begin(hparams.rope_sections), std::begin(hparams.rope_sections) + 4, sections);
-@@ -78,9 +83,9 @@ llama_model_qwen3vl::graph::graph(const llama_model & model, const llm_graph_par
- 
+@@ -78,9 +83,9 @@ llama_model_qwen3vl::graph::graph(const
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -122,7 +127,7 @@ llama_model_qwen3vl::graph::graph(const llama_model & model, const llm_graph_par
+@@ -122,7 +127,7 @@ llama_model_qwen3vl::graph::graph(const
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -149,7 +154,7 @@ llama_model_qwen3vl::graph::graph(const llama_model & model, const llm_graph_par
+@@ -149,7 +154,7 @@ llama_model_qwen3vl::graph::graph(const
          cur = build_cvec(cur, il);
          cb(cur, "l_out", il);
- 
+
 -        if (il < (int) n_deepstack_layers) {
 +        if ((!stage_filtered || il_start == 0) && il < (int) n_deepstack_layers) {
              ggml_tensor * ds = ggml_view_2d(ctx0, res->t_inp_embd, n_embd, n_tokens, res->t_inp_embd->nb[1], (il + 1) * n_embd * sizeof(float));
              cur = ggml_add(ctx0, cur, ds);
              cb(cur, "deepstack_out", il);
-@@ -161,6 +166,13 @@ llama_model_qwen3vl::graph::graph(const llama_model & model, const llm_graph_par
- 
+@@ -161,6 +166,13 @@ llama_model_qwen3vl::graph::graph(const
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -10018,14 +10050,14 @@ index 5596620f0..290583ef6 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/qwen3vlmoe.cpp b/src/models/qwen3vlmoe.cpp
-index 7c41592f7..33c961a41 100644
+Index: b/src/models/qwen3vlmoe.cpp
+===================================================================
 --- a/src/models/qwen3vlmoe.cpp
 +++ b/src/models/qwen3vlmoe.cpp
-@@ -73,7 +73,12 @@ llama_model_qwen3vlmoe::graph::graph(const llama_model & model, const llm_graph_
+@@ -73,7 +73,12 @@ llama_model_qwen3vlmoe::graph::graph(con
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -10033,43 +10065,43 @@ index 7c41592f7..33c961a41 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      int sections[4];
      std::copy(std::begin(hparams.rope_sections), std::begin(hparams.rope_sections) + 4, sections);
-@@ -83,9 +88,9 @@ llama_model_qwen3vlmoe::graph::graph(const llama_model & model, const llm_graph_
- 
+@@ -83,9 +88,9 @@ llama_model_qwen3vlmoe::graph::graph(con
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -127,7 +132,7 @@ llama_model_qwen3vlmoe::graph::graph(const llama_model & model, const llm_graph_
+@@ -127,7 +132,7 @@ llama_model_qwen3vlmoe::graph::graph(con
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -161,7 +166,7 @@ llama_model_qwen3vlmoe::graph::graph(const llama_model & model, const llm_graph_
+@@ -161,7 +166,7 @@ llama_model_qwen3vlmoe::graph::graph(con
          cur = build_cvec(cur, il);
          cb(cur, "l_out", il);
- 
+
 -        if (il < (int) n_deepstack_layers) {
 +        if ((!stage_filtered || il_start == 0) && il < (int) n_deepstack_layers) {
              ggml_tensor * ds = ggml_view_2d(ctx0, res->t_inp_embd, n_embd, n_tokens, res->t_inp_embd->nb[1], (il + 1) * n_embd * sizeof(float));
              cur = ggml_add(ctx0, cur, ds);
              cb(cur, "deepstack_out", il);
-@@ -173,6 +178,13 @@ llama_model_qwen3vlmoe::graph::graph(const llama_model & model, const llm_graph_
- 
+@@ -173,6 +178,13 @@ llama_model_qwen3vlmoe::graph::graph(con
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -10080,14 +10112,14 @@ index 7c41592f7..33c961a41 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/refact.cpp b/src/models/refact.cpp
-index a46c358fa..0226a7fdf 100644
+Index: b/src/models/refact.cpp
+===================================================================
 --- a/src/models/refact.cpp
 +++ b/src/models/refact.cpp
-@@ -84,13 +84,18 @@ llama_model_refact::graph::graph(const llama_model & model, const llm_graph_para
+@@ -84,13 +84,18 @@ llama_model_refact::graph::graph(const l
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -10095,21 +10127,21 @@ index a46c358fa..0226a7fdf 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          cur = build_norm(inpL,
-@@ -143,6 +148,13 @@ llama_model_refact::graph::graph(const llama_model & model, const llm_graph_para
+@@ -143,6 +148,13 @@ llama_model_refact::graph::graph(const l
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -10120,14 +10152,14 @@ index a46c358fa..0226a7fdf 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/rnd1.cpp b/src/models/rnd1.cpp
-index fc276ce59..8d39e03bb 100644
+Index: b/src/models/rnd1.cpp
+===================================================================
 --- a/src/models/rnd1.cpp
 +++ b/src/models/rnd1.cpp
-@@ -71,7 +71,12 @@ llama_model_rnd1::graph::graph(const llama_model & model, const llm_graph_params
+@@ -71,7 +71,12 @@ llama_model_rnd1::graph::graph(const lla
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -10135,25 +10167,25 @@ index fc276ce59..8d39e03bb 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -79,9 +84,9 @@ llama_model_rnd1::graph::graph(const llama_model & model, const llm_graph_params
+@@ -79,9 +84,9 @@ llama_model_rnd1::graph::graph(const lla
      // Non-causal attention for diffusion
      auto * inp_attn = build_attn_inp_no_cache();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -160,6 +165,13 @@ llama_model_rnd1::graph::graph(const llama_model & model, const llm_graph_params
+@@ -160,6 +165,13 @@ llama_model_rnd1::graph::graph(const lla
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -10164,23 +10196,23 @@ index fc276ce59..8d39e03bb 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/rwkv6.cpp b/src/models/rwkv6.cpp
-index 0b5013dc7..bb9471ea5 100644
+Index: b/src/models/rwkv6.cpp
+===================================================================
 --- a/src/models/rwkv6.cpp
 +++ b/src/models/rwkv6.cpp
-@@ -62,7 +62,7 @@ void llama_model_rwkv6::load_arch_tensors(llama_model_loader &) {
+@@ -62,7 +62,7 @@ void llama_model_rwkv6::load_arch_tensor
          layer.time_mix_lerp_r = create_tensor(tn(LLM_TENSOR_TIME_MIX_LERP_R, "weight", i), {n_embd, 1, 1}, TENSOR_NOT_REQUIRED);
          layer.time_mix_lerp_g = create_tensor(tn(LLM_TENSOR_TIME_MIX_LERP_G, "weight", i), {n_embd, 1, 1}, TENSOR_NOT_REQUIRED);
          layer.time_mix_lerp_fused = create_tensor(tn(LLM_TENSOR_TIME_MIX_LERP_FUSED, "weight", i), {n_embd, 1, 1, 5}, TENSOR_NOT_REQUIRED);
 -        GGML_ASSERT(!(layer.time_mix_lerp_fused == NULL && layer.time_mix_lerp_w == NULL));
 +        GGML_ASSERT(layer.time_mix_lerp_x == NULL || !(layer.time_mix_lerp_fused == NULL && layer.time_mix_lerp_w == NULL));
- 
+
          layer.time_mix_first = create_tensor(tn(LLM_TENSOR_TIME_MIX_FIRST, "weight", i), {head_size, n_embd / head_size}, 0);
          layer.time_mix_decay = create_tensor(tn(LLM_TENSOR_TIME_MIX_DECAY, "weight", i), {n_embd}, 0);
-@@ -98,8 +98,15 @@ llama_model_rwkv6::graph::graph(const llama_model & model, const llm_graph_param
+@@ -98,8 +98,15 @@ llama_model_rwkv6::graph::graph(const ll
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 -    inpL = build_norm(inpL, model.tok_norm, model.tok_norm_b, LLM_NORM, 0);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
@@ -10192,31 +10224,31 @@ index 0b5013dc7..bb9471ea5 100644
 +    if (il_start == 0) {
 +        inpL = build_norm(inpL, model.tok_norm, model.tok_norm_b, LLM_NORM, 0);
 +    }
- 
+
      auto * rs_inp = build_rs_inp();
- 
-@@ -107,9 +114,9 @@ llama_model_rwkv6::graph::graph(const llama_model & model, const llm_graph_param
+
+@@ -107,9 +114,9 @@ llama_model_rwkv6::graph::graph(const ll
      const auto n_seq_tokens = ubatch.n_seq_tokens;
      const auto n_seqs       = ubatch.n_seqs;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const llama_layer * layer = &model.layers[il];
          inpL                      = ggml_reshape_3d(ctx0, inpL, n_embd, n_seq_tokens, n_seqs);
- 
-@@ -152,7 +159,7 @@ llama_model_rwkv6::graph::graph(const llama_model & model, const llm_graph_param
+
+@@ -152,7 +159,7 @@ llama_model_rwkv6::graph::graph(const ll
          x_prev   = ggml_reshape_2d(ctx0, x_prev, n_embd, n_tokens);
          cur      = ggml_reshape_2d(ctx0, cur, n_embd, n_tokens);
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              ffn_inp  = ggml_get_rows(ctx0, ffn_inp, inp_out_ids);
              ffn_norm = ggml_get_rows(ctx0, ffn_norm, inp_out_ids);
              x_prev   = ggml_get_rows(ctx0, x_prev, inp_out_ids);
-@@ -170,6 +177,12 @@ llama_model_rwkv6::graph::graph(const llama_model & model, const llm_graph_param
+@@ -170,6 +177,12 @@ llama_model_rwkv6::graph::graph(const ll
          // input for next layer
          inpL = cur;
      }
@@ -10228,15 +10260,15 @@ index 0b5013dc7..bb9471ea5 100644
 +    }
      cur = inpL;
      cur = build_norm(cur, model.output_norm, model.output_norm_b, LLM_NORM, -1);
- 
-diff --git a/src/models/rwkv6qwen2.cpp b/src/models/rwkv6qwen2.cpp
-index 6c7db5144..ba530ccfb 100644
+
+Index: b/src/models/rwkv6qwen2.cpp
+===================================================================
 --- a/src/models/rwkv6qwen2.cpp
 +++ b/src/models/rwkv6qwen2.cpp
-@@ -87,7 +87,12 @@ llama_model_rwkv6qwen2::graph::graph(const llama_model & model, const llm_graph_
+@@ -87,7 +87,12 @@ llama_model_rwkv6qwen2::graph::graph(con
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -10244,24 +10276,24 @@ index 6c7db5144..ba530ccfb 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      auto * rs_inp = build_rs_inp();
- 
-@@ -95,9 +100,9 @@ llama_model_rwkv6qwen2::graph::graph(const llama_model & model, const llm_graph_
+
+@@ -95,9 +100,9 @@ llama_model_rwkv6qwen2::graph::graph(con
      const auto n_seq_tokens = ubatch.n_seq_tokens;
      const auto n_seqs = ubatch.n_seqs;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const llama_layer * layer = &model.layers[il];
          inpL = ggml_reshape_3d(ctx0, inpL, n_embd, n_seq_tokens, n_seqs);
- 
-@@ -153,6 +158,13 @@ llama_model_rwkv6qwen2::graph::graph(const llama_model & model, const llm_graph_
+
+@@ -153,6 +158,13 @@ llama_model_rwkv6qwen2::graph::graph(con
      }
- 
+
      cur = inpL;
 +
 +    if (stage_filtered && !stage_filter.include_output) {
@@ -10271,16 +10303,16 @@ index 6c7db5144..ba530ccfb 100644
 +        return;
 +    }
      cur = build_norm(cur, model.output_norm, model.output_norm_b, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);
-diff --git a/src/models/rwkv7.cpp b/src/models/rwkv7.cpp
-index 67c51f5b5..5c4991177 100644
+Index: b/src/models/rwkv7.cpp
+===================================================================
 --- a/src/models/rwkv7.cpp
 +++ b/src/models/rwkv7.cpp
-@@ -129,8 +129,15 @@ llama_model_rwkv7::graph::graph(const llama_model & model, const llm_graph_param
+@@ -129,8 +129,15 @@ llama_model_rwkv7::graph::graph(const ll
      ggml_tensor * inpL;
      ggml_tensor * v_first = nullptr;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 -    inpL = build_norm(inpL, model.tok_norm, model.tok_norm_b, LLM_NORM, 0);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
@@ -10292,13 +10324,13 @@ index 67c51f5b5..5c4991177 100644
 +    if (il_start == 0) {
 +        inpL = build_norm(inpL, model.tok_norm, model.tok_norm_b, LLM_NORM, 0);
 +    }
- 
+
      auto * rs_inp = build_rs_inp();
- 
-@@ -138,9 +145,18 @@ llama_model_rwkv7::graph::graph(const llama_model & model, const llm_graph_param
+
+@@ -138,9 +145,18 @@ llama_model_rwkv7::graph::graph(const ll
      const auto n_seq_tokens = ubatch.n_seq_tokens;
      const auto n_seqs       = ubatch.n_seqs;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    if (stage_filtered && il_start > 0) {
 +        auto inp = std::make_unique<llm_graph_input_rwkv7_v_first>(n_embd);
@@ -10310,32 +10342,32 @@ index 67c51f5b5..5c4991177 100644
 +    }
 +
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const llama_layer * layer = &model.layers[il];
          inpL                      = ggml_reshape_3d(ctx0, inpL, n_embd, n_seq_tokens, n_seqs);
- 
-@@ -159,6 +175,9 @@ llama_model_rwkv7::graph::graph(const llama_model & model, const llm_graph_param
+
+@@ -159,6 +175,9 @@ llama_model_rwkv7::graph::graph(const ll
              ggml_view_3d(ctx0, att_norm, n_embd, n_seq_tokens - 1, n_seqs, att_norm->nb[1], att_norm->nb[2], 0), 1);
- 
+
          cur = build_rwkv7_time_mix(rs_inp, att_norm, x_prev, v_first, ubatch, il);
 +        if (stage_filtered && !stage_filter.include_output && il_start == 0 && il == 0) {
 +            res->t_skippy_rwkv7_v_first = v_first;
 +        }
- 
+
          ggml_tensor * ffn_inp = ggml_add(ctx0, cur, inpL);
          cb(ffn_inp, "ffn_inp", il);
-@@ -182,7 +201,7 @@ llama_model_rwkv7::graph::graph(const llama_model & model, const llm_graph_param
+@@ -182,7 +201,7 @@ llama_model_rwkv7::graph::graph(const ll
          ffn_norm = ggml_reshape_2d(ctx0, ffn_norm, n_embd, n_tokens);
          x_prev   = ggml_reshape_2d(ctx0, x_prev, n_embd, n_tokens);
- 
+
 -        if (il == n_layer - 1 && inp_out_ids) {
 +        if (il == il_end - 1 && inp_out_ids) {
              ffn_inp  = ggml_get_rows(ctx0, ffn_inp, inp_out_ids);
              ffn_norm = ggml_get_rows(ctx0, ffn_norm, inp_out_ids);
              x_prev   = ggml_get_rows(ctx0, x_prev, inp_out_ids);
-@@ -196,6 +215,12 @@ llama_model_rwkv7::graph::graph(const llama_model & model, const llm_graph_param
+@@ -196,6 +215,12 @@ llama_model_rwkv7::graph::graph(const ll
          // input for next layer
          inpL = cur;
      }
@@ -10347,15 +10379,15 @@ index 67c51f5b5..5c4991177 100644
 +    }
      cur = inpL;
      cur = build_norm(cur, model.output_norm, model.output_norm_b, LLM_NORM, -1);
- 
-diff --git a/src/models/seed-oss.cpp b/src/models/seed-oss.cpp
-index 57de881a0..c49415551 100644
+
+Index: b/src/models/seed-oss.cpp
+===================================================================
 --- a/src/models/seed-oss.cpp
 +++ b/src/models/seed-oss.cpp
-@@ -55,7 +55,12 @@ llama_model_seed_oss::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -55,7 +55,12 @@ llama_model_seed_oss::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -10363,25 +10395,25 @@ index 57de881a0..c49415551 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -64,9 +69,9 @@ llama_model_seed_oss::graph::graph(const llama_model & model, const llm_graph_pa
- 
+@@ -64,9 +69,9 @@ llama_model_seed_oss::graph::graph(const
+
      const float kq_scale = hparams.f_attention_scale == 0.0f ? 1.0f/sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -134,6 +139,13 @@ llama_model_seed_oss::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -134,6 +139,13 @@ llama_model_seed_oss::graph::graph(const
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -10392,14 +10424,14 @@ index 57de881a0..c49415551 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/smallthinker.cpp b/src/models/smallthinker.cpp
-index a8e3d957f..6a7c16032 100644
+Index: b/src/models/smallthinker.cpp
+===================================================================
 --- a/src/models/smallthinker.cpp
 +++ b/src/models/smallthinker.cpp
-@@ -83,7 +83,12 @@ llama_model_smallthinker::graph<iswa>::graph(const llama_model & model, const ll
+@@ -83,7 +83,12 @@ llama_model_smallthinker::graph<iswa>::g
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -10407,25 +10439,25 @@ index a8e3d957f..6a7c16032 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -96,9 +101,9 @@ llama_model_smallthinker::graph<iswa>::graph(const llama_model & model, const ll
+@@ -96,9 +101,9 @@ llama_model_smallthinker::graph<iswa>::g
      } else {
          inp_attn = build_attn_inp_kv();
      }
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          const float freq_base_l  = model.get_rope_freq_base (cparams, il);
          const float freq_scale_l = model.get_rope_freq_scale(cparams, il);
- 
-@@ -173,6 +178,13 @@ llama_model_smallthinker::graph<iswa>::graph(const llama_model & model, const ll
+
+@@ -173,6 +178,13 @@ llama_model_smallthinker::graph<iswa>::g
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -10436,14 +10468,14 @@ index a8e3d957f..6a7c16032 100644
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
      cb(cur, "result_norm", -1);
      res->t_embd = cur;
-diff --git a/src/models/smollm3.cpp b/src/models/smollm3.cpp
-index c67d967b2..9fa28f8fc 100644
+Index: b/src/models/smollm3.cpp
+===================================================================
 --- a/src/models/smollm3.cpp
 +++ b/src/models/smollm3.cpp
-@@ -52,7 +52,12 @@ llama_model_smollm3::graph::graph(const llama_model & model, const llm_graph_par
+@@ -52,7 +52,12 @@ llama_model_smollm3::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -10451,25 +10483,25 @@ index c67d967b2..9fa28f8fc 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -61,9 +66,9 @@ llama_model_smollm3::graph::graph(const llama_model & model, const llm_graph_par
- 
+@@ -61,9 +66,9 @@ llama_model_smollm3::graph::graph(const
+
      const float kq_scale = hparams.f_attention_scale == 0.0f ? 1.0f/sqrtf(float(n_embd_head)) : hparams.f_attention_scale;
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          const bool use_rope = (il + 1) % hparams.n_no_rope_layer_step != 0;
-@@ -135,6 +140,13 @@ llama_model_smollm3::graph::graph(const llama_model & model, const llm_graph_par
+@@ -135,6 +140,13 @@ llama_model_smollm3::graph::graph(const
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -10480,14 +10512,14 @@ index c67d967b2..9fa28f8fc 100644
      cur = build_norm(cur,
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
-diff --git a/src/models/stablelm.cpp b/src/models/stablelm.cpp
-index bf6087b87..767cb1dac 100644
+Index: b/src/models/stablelm.cpp
+===================================================================
 --- a/src/models/stablelm.cpp
 +++ b/src/models/stablelm.cpp
-@@ -56,16 +56,21 @@ llama_model_stablelm::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -56,16 +56,21 @@ llama_model_stablelm::graph::graph(const
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -10495,21 +10527,21 @@ index bf6087b87..767cb1dac 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          // norm
          cur = build_norm(inpL,
                  model.layers[il].attn_norm,
-@@ -116,7 +121,7 @@ llama_model_stablelm::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -116,7 +121,7 @@ llama_model_stablelm::graph::graph(const
                      model.layers[il].wo, NULL, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
@@ -10518,10 +10550,10 @@ index bf6087b87..767cb1dac 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpL  = ggml_get_rows(ctx0,  inpL, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
-@@ -154,6 +159,13 @@ llama_model_stablelm::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -154,6 +159,13 @@ llama_model_stablelm::graph::graph(const
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -10532,50 +10564,50 @@ index bf6087b87..767cb1dac 100644
      cur = build_norm(cur,
              model.output_norm,
              model.output_norm_b,
-diff --git a/src/models/starcoder.cpp b/src/models/starcoder.cpp
-index f73a88fd4..25445567b 100644
+Index: b/src/models/starcoder.cpp
+===================================================================
 --- a/src/models/starcoder.cpp
 +++ b/src/models/starcoder.cpp
-@@ -65,22 +65,29 @@ llama_model_starcoder::graph::graph(const llama_model & model, const llm_graph_p
+@@ -65,22 +65,29 @@ llama_model_starcoder::graph::graph(cons
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
 +    const int il_start = stage_filtered ? stage_filter.layer_start : 0;
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
- 
+
 -    // inp_pos - contains the positions
 -    ggml_tensor * inp_pos = build_inp_pos();
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * pos = ggml_get_rows(ctx0, model.pos_embd, inp_pos);
 -    cb(pos, "pos_embd", -1);
 +    if (!stage_filtered || il_start == 0) {
 +        // inp_pos - contains the positions
 +        ggml_tensor * inp_pos = build_inp_pos();
- 
+
 -    inpL = ggml_add(ctx0, inpL, pos);
 -    cb(inpL, "inpL", -1);
 +        ggml_tensor * pos = ggml_get_rows(ctx0, model.pos_embd, inp_pos);
 +        cb(pos, "pos_embd", -1);
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +        inpL = ggml_add(ctx0, inpL, pos);
 +        cb(inpL, "inpL", -1);
 +    }
 +
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          cur = build_norm(inpL,
                  model.layers[il].attn_norm,
                  model.layers[il].attn_norm_b,
-@@ -128,6 +135,13 @@ llama_model_starcoder::graph::graph(const llama_model & model, const llm_graph_p
+@@ -128,6 +135,13 @@ llama_model_starcoder::graph::graph(cons
          // input for next layer
          inpL = cur;
      }
@@ -10589,14 +10621,14 @@ index f73a88fd4..25445567b 100644
      cur = build_norm(inpL,
              model.output_norm,
              model.output_norm_b,
-diff --git a/src/models/starcoder2.cpp b/src/models/starcoder2.cpp
-index b81b46937..af2bc1128 100644
+Index: b/src/models/starcoder2.cpp
+===================================================================
 --- a/src/models/starcoder2.cpp
 +++ b/src/models/starcoder2.cpp
-@@ -65,16 +65,21 @@ llama_model_starcoder2::graph::graph(const llama_model & model, const llm_graph_
+@@ -65,16 +65,21 @@ llama_model_starcoder2::graph::graph(con
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -10604,21 +10636,21 @@ index b81b46937..af2bc1128 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          // norm
-@@ -109,7 +114,7 @@ llama_model_starcoder2::graph::graph(const llama_model & model, const llm_graph_
+@@ -109,7 +114,7 @@ llama_model_starcoder2::graph::graph(con
                      model.layers[il].wo, model.layers[il].wo_b, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f/sqrtf(float(n_embd_head)), il);
          }
@@ -10627,10 +10659,10 @@ index b81b46937..af2bc1128 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -141,6 +146,13 @@ llama_model_starcoder2::graph::graph(const llama_model & model, const llm_graph_
+@@ -141,6 +146,13 @@ llama_model_starcoder2::graph::graph(con
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -10641,14 +10673,14 @@ index b81b46937..af2bc1128 100644
      cur = build_norm(cur,
              model.output_norm, model.output_norm_b,
              LLM_NORM, -1);
-diff --git a/src/models/step35.cpp b/src/models/step35.cpp
-index 5b1d90258..3b264d9e1 100644
+Index: b/src/models/step35.cpp
+===================================================================
 --- a/src/models/step35.cpp
 +++ b/src/models/step35.cpp
-@@ -196,13 +196,18 @@ llama_model_step35::graph::graph(const llama_model & model, const llm_graph_para
+@@ -196,13 +196,18 @@ llama_model_step35::graph::graph(const l
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -10660,26 +10692,26 @@ index 5b1d90258..3b264d9e1 100644
      auto        * inp_attn    = build_attn_inp_kv_iswa();
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
      // MTP/NextN layers are loaded as extra decoder blocks but not executed in the main pass.
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          const uint32_t n_head_l    = hparams.n_head(il);
-@@ -289,7 +294,7 @@ llama_model_step35::graph::graph(const llama_model & model, const llm_graph_para
+@@ -289,7 +294,7 @@ llama_model_step35::graph::graph(const l
              cb(cur, "attn_proj", il);
          }
- 
+
 -        if (il == n_layer - 1 && inp_out_ids && cparams.embeddings_nextn_masked) {
 +        if (il == il_end - 1 && inp_out_ids && cparams.embeddings_nextn_masked) {
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -348,6 +353,13 @@ llama_model_step35::graph::graph(const llama_model & model, const llm_graph_para
- 
+@@ -348,6 +353,13 @@ llama_model_step35::graph::graph(const l
+
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -10689,11 +10721,11 @@ index 5b1d90258..3b264d9e1 100644
 +
      cb(cur, "h_nextn", -1);
      res->t_h_nextn = cur;
- 
-@@ -536,12 +548,16 @@ llama_model_step35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
+
+@@ -536,12 +548,16 @@ llama_model_step35::graph_mtp::graph_mtp
      cur = ggml_add(ctx0, cur, ffn_inp);
      cb(cur, "mtp_post_ffn", il);
- 
+
 +    // Pre-norm hidden state: used by the AR draft loop to seed the next MTP step.
      ggml_tensor * inp_out_ids = build_inp_out_ids();
 -    cur = ggml_get_rows(ctx0, cur, inp_out_ids);
@@ -10703,22 +10735,22 @@ index 5b1d90258..3b264d9e1 100644
 +    }
 +    cb(h_nextn, "h_nextn", -1);
 +    res->t_h_nextn = h_nextn;
- 
+
 -    // Pre-norm hidden state: used by the AR draft loop to seed the next MTP step.
 -    cb(cur, "h_nextn", -1);
 -    res->t_h_nextn = cur;
 +    cur = ggml_get_rows(ctx0, cur, inp_out_ids);
- 
+
      ggml_tensor * head_norm_w = layer.nextn.shared_head_norm
              ? layer.nextn.shared_head_norm
-diff --git a/src/models/xverse.cpp b/src/models/xverse.cpp
-index 313500129..0aada2095 100644
+Index: b/src/models/xverse.cpp
+===================================================================
 --- a/src/models/xverse.cpp
 +++ b/src/models/xverse.cpp
-@@ -47,16 +47,21 @@ llama_model_xverse::graph::graph(const llama_model & model, const llm_graph_para
+@@ -47,16 +47,21 @@ llama_model_xverse::graph::graph(const l
      ggml_tensor * cur;
      ggml_tensor * inpL;
- 
+
 -    inpL = build_inp_embd(model.tok_embd);
 +    const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
 +    const bool stage_filtered = stage_filter.enabled;
@@ -10726,24 +10758,24 @@ index 313500129..0aada2095 100644
 +    const int il_end   = stage_filtered ? stage_filter.layer_end   : n_layer;
 +
 +    inpL = build_inp_embd(stage_filtered && il_start > 0 ? nullptr : model.tok_embd);
- 
+
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
- 
+
      auto * inp_attn = build_attn_inp_kv();
- 
+
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 +    ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
- 
+
 -    for (int il = 0; il < n_layer; ++il) {
 +    for (int il = il_start; il < il_end; ++il) {
          ggml_tensor * inpSA = inpL;
- 
+
          cur = build_norm(inpL,
-@@ -121,6 +126,13 @@ llama_model_xverse::graph::graph(const llama_model & model, const llm_graph_para
+@@ -121,6 +126,13 @@ llama_model_xverse::graph::graph(const l
      }
      cur = inpL;
- 
+
 +    if (stage_filtered && !stage_filter.include_output) {
 +        cb(cur, "stage_boundary", il_end - 1);
 +        res->t_embd = cur;
@@ -10752,5 +10784,5 @@ index 313500129..0aada2095 100644
 +    }
 +
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
- 
+
      cb(cur, "result_norm", -1);


### PR DESCRIPTION
🤖 Filtered staged loads now derive progress/completion bytes from the tensors the loader will actually upload. This prevents tied embedding/output requests from subtracting retained physical bytes, prematurely unmapping later tensor data and crashing CUDA uploads.

## What changed

- Removed per-logical-request `size_data` decrement/increment bookkeeping from stage filtering.
- After logical tensors are created, recompute `size_data` by traversing every created buffer context exactly as `load_all_data` does.
- Include only tensors resolving through `weights_map`: this mirrors `load_all_data`'s traversal, including its `get_weight` guard, so `size_data` equals what the loader will count. The guard is defensive — no known serving path creates a context tensor without a `weights_map` entry.
- Count a tied physical weight twice when materialized in two contexts because it is uploaded twice; count same-context reuse once.
- No public Skippy ABI change.

## Evidence

Issue #1298 instrumentation showed a tied `token_embd.weight` retained as input and filtered as logical output. Global `size_data` was understated by exactly 165,306,368 bytes. Completion fired after the embedding context, preserving only the embedding mmap interval and unmapping the layer-weight tail; the next CUDA upload read `blk.0.attn_norm.weight` from that unmapped tail.

## Validation

At `a8d44708`:

- full 18-patch replay from pinned llama.cpp `030ebb558...` succeeds;
- `just build` succeeds on Apple Silicon, including patched native runtime build and Metal product packaging;
- `git diff --check` passes.

Quantization pre-model `init_mappings` preserves the historical weights-map total; model-load contexts use traversal accounting. The two branches are **deliberately not interchangeable** and `size_data` now means different things by call site: the `ctx_map` traversal answers "what will this loader upload", the `weights_map` fallback answers "what physical weights exist". Quantization needs the latter because it calls `init_mappings` before model construction, so contexts are absent while `weights_map` is populated; it calls `load_data_for` rather than `load_all_data`, so it never reaches the traversal. Staged filtering is unreachable from quantization: the loader is constructed non-staged (`llama-quant.cpp:905`, `ordered_parts=false`) and the filter is `thread_local` state established only by RAII `skippy_filter_scope` at the three model-open sites in patch 0005. Conflating the branches is the class of assumption that caused #1298.

**Scope of the runtime evidence.** The V100 replay exercised the model-load `ctx_map` branch, including the arm where one physical weight is uploaded twice in a single loader (counted twice, 648,313,856 balances) — a dedup-by-name implementation would undercount by 165,306,368 bytes and reintroduce the bug. The `weights_map` fallback branch added at `a8d44708` has **not** executed in any run; its safety rests on the reachability argument above, not on measurement. No runtime claim is made about the split-expert `nullptr` arm.

Runtime replay of the preserved one-GPU CUDA reproducer and published-package validation are follow-up gates before merge.

## Patch queue

The fix is folded into patch 0001, which owns staged model loading/filtering. The patch file was refreshed from the pinned upstream tree; later patches apply cleanly.


