### PR TITLE
ci: isolate native caches on Depot PR runners

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -105,7 +105,10 @@ from that same catalog.
 - `prepare-static-abi-input`: portable static ABI archive.
 - `compose-product-input`: exact host/runtime verification and composition.
 - `restore-smoke-inputs`: product/model extraction for consumers.
-- `select-ci-runners`: provider labels and Depot cache permission.
+- `select-ci-runners`: provider labels, Depot cache permission, and the
+  provider-derived `allow_native_github_cache` output. Depot-selected direct
+  PRs set it to false; hosted PR and trusted main/release/manual selections
+  retain native GitHub cache behavior.
 - `configure-sccache-gha`: event/provider-derived compiler-cache setup.
 - `capture-sccache-stats`: machine-readable cache evidence.
 
@@ -167,8 +170,12 @@ Relevant repository variable names include `DEPOT_RUNNERS_ENABLED`,
 `DEPOT_PR_CANARY_REF` (absent by default; one exact
 `refs/pull/<number>/merge` ref only). The latter is a bounded selector
 canary, not a cache-isolation proof or a replacement for the global PR gate.
-Native Actions-cache consumers remain a documented unresolved boundary for
-any future Depot PR run. Other variables include `CUDA_VERSION`,
+The eligible five-lane Depot-PR graph now disables every native GitHub cache
+consumer (explicit cache actions, setup-* package caches, rust-cache, static /
+Metal / Windows / Swift ABI caches and Windows SDK cache toggles) when that
+output is false; cache misses rebuild normally. This checked-in mode does not
+prove the absence of ambient Depot/WebDAV authority, so the runtime sentinel
+and no-secret/no-token canaries remain required. Other variables include `CUDA_VERSION`,
 `VULKAN_SDK_VERSION`, smoke configuration variables, and release/deployment
 variables. Secret values never belong in this inventory;
 known names include `HF_TOKEN`, release-attestation keys, `CARGO_REGISTRY_TOKEN`

--- a/.github/actions/restore-windows-abi-cache/action.yml
+++ b/.github/actions/restore-windows-abi-cache/action.yml
@@ -30,7 +30,7 @@ inputs:
   allow-native-github-cache:
     description: Whether the protected provider policy permits native GitHub cache APIs.
     required: false
-    default: "true"
+    default: "false"
 
 outputs:
   cache-hit:

--- a/.github/actions/restore-windows-abi-cache/action.yml
+++ b/.github/actions/restore-windows-abi-cache/action.yml
@@ -27,6 +27,10 @@ inputs:
     description: Windows ROCm HIP SDK filename/version; required for the ROCm backend.
     required: false
     default: ""
+  allow-native-github-cache:
+    description: Whether the protected provider policy permits native GitHub cache APIs.
+    required: false
+    default: "true"
 
 outputs:
   cache-hit:
@@ -203,6 +207,7 @@ runs:
 
     - name: Restore exact Windows ABI cache
       id: restore
+      if: ${{ inputs.allow-native-github-cache == 'true' }}
       uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ${{ steps.identity.outputs.build-dir }}

--- a/.github/actions/select-ci-runners/action.yml
+++ b/.github/actions/select-ci-runners/action.yml
@@ -46,6 +46,9 @@ outputs:
   allow_depot_remote_cache:
     description: Whether this trusted runner selection may use Depot's remote cache.
     value: ${{ steps.select.outputs.allow_depot_remote_cache }}
+  allow_native_github_cache:
+    description: Whether this provider/trust selection may use native GitHub Actions cache APIs.
+    value: ${{ steps.select.outputs.allow_native_github_cache }}
   runner:
     description: Default two-vCPU Linux runner label.
     value: ${{ steps.select.outputs.runner }}
@@ -126,6 +129,7 @@ runs:
         trusted_repository="Mesh-LLM/mesh-llm"
         depot_enabled=false
         allow_depot_remote_cache=false
+        allow_native_github_cache=true
         is_direct_pull_request=false
         is_dispatched_pull_request=false
         dispatch_original_event="${INPUT_ORIGINAL_EVENT_NAME:-}"
@@ -201,6 +205,17 @@ runs:
           allow_depot_remote_cache=true
         fi
 
+        # Depot runners do not provide GitHub's branch-isolated cache
+        # authority.  Native GitHub cache APIs are therefore disabled for a
+        # directly selected PR, while hosted PRs and trusted main/release or
+        # manual paths retain their existing cache behavior.  This value is
+        # derived only from the protected provider policy; callers cannot opt
+        # a Depot PR back in by supplying a cache-related input.
+        if [[ "$depot_enabled" == "true" && \
+          "$is_direct_pull_request" == "true" ]]; then
+          allow_native_github_cache=false
+        fi
+
         if [[ "$depot_enabled" == "true" ]]; then
           runner=depot-ubuntu-24.04
           runner_4=depot-ubuntu-24.04-4
@@ -228,6 +243,7 @@ runs:
         {
           echo "depot_enabled=$depot_enabled"
           echo "allow_depot_remote_cache=$allow_depot_remote_cache"
+          echo "allow_native_github_cache=$allow_native_github_cache"
           echo "runner=$runner"
           echo "runner_4=$runner_4"
           echo "runner_8=$runner_8"

--- a/.github/actions/setup-windows-rocm-sdk/action.yml
+++ b/.github/actions/setup-windows-rocm-sdk/action.yml
@@ -10,12 +10,17 @@ inputs:
     description: Directory used to cache downloaded HIP SDK installers.
     required: false
     default: sdk-installer-cache
+  allow-native-github-cache:
+    description: Whether the protected provider policy permits native GitHub cache APIs.
+    required: false
+    default: "true"
 
 runs:
   using: composite
   steps:
     - name: Cache HIP SDK installers
       id: installer-cache
+      if: ${{ inputs.allow-native-github-cache == 'true' }}
       uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
       with:
         path: ${{ inputs.installer-cache-dir }}/rocm

--- a/.github/actions/setup-windows-rocm-sdk/action.yml
+++ b/.github/actions/setup-windows-rocm-sdk/action.yml
@@ -13,7 +13,7 @@ inputs:
   allow-native-github-cache:
     description: Whether the protected provider policy permits native GitHub cache APIs.
     required: false
-    default: "true"
+    default: "false"
 
 runs:
   using: composite

--- a/.github/workflows/ci-linux-host-slice.yml
+++ b/.github/workflows/ci-linux-host-slice.yml
@@ -63,6 +63,7 @@ jobs:
     outputs:
       runner_8: ${{ steps.policy.outputs.runner_8 }}
       allow_depot_remote_cache: ${{ steps.policy.outputs.allow_depot_remote_cache }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -118,7 +119,8 @@ jobs:
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_depot_remote_cache: ${{ needs.runner_policy.outputs.allow_depot_remote_cache }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+      - if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
         continue-on-error: true
         with:
           workspaces: . -> target

--- a/.github/workflows/ci-linux-product-slice.yml
+++ b/.github/workflows/ci-linux-product-slice.yml
@@ -45,6 +45,7 @@ jobs:
       contents: read
     outputs:
       runner: ${{ steps.policy.outputs.runner }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:

--- a/.github/workflows/ci-linux-runtime-slice.yml
+++ b/.github/workflows/ci-linux-runtime-slice.yml
@@ -56,6 +56,7 @@ jobs:
     outputs:
       runner_16: ${{ steps.policy.outputs.runner_16 }}
       allow_depot_remote_cache: ${{ steps.policy.outputs.allow_depot_remote_cache }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -125,7 +126,8 @@ jobs:
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_depot_remote_cache: ${{ needs.runner_policy.outputs.allow_depot_remote_cache }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+      - if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
         continue-on-error: true
         with:
           workspaces: . -> target

--- a/.github/workflows/ci-macos-host-slice.yml
+++ b/.github/workflows/ci-macos-host-slice.yml
@@ -58,6 +58,7 @@ jobs:
       contents: read
     outputs:
       runner_macos: ${{ steps.policy.outputs.runner_macos }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -98,7 +99,8 @@ jobs:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+      - if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
         continue-on-error: true
         with:
           workspaces: . -> target

--- a/.github/workflows/ci-macos-product-slice.yml
+++ b/.github/workflows/ci-macos-product-slice.yml
@@ -44,6 +44,7 @@ jobs:
       contents: read
     outputs:
       runner_macos: ${{ steps.policy.outputs.runner_macos }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:

--- a/.github/workflows/ci-macos-runtime-slice.yml
+++ b/.github/workflows/ci-macos-runtime-slice.yml
@@ -49,6 +49,7 @@ jobs:
       contents: read
     outputs:
       runner_macos: ${{ steps.policy.outputs.runner_macos }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:

--- a/.github/workflows/ci-platform-checks-slice.yml
+++ b/.github/workflows/ci-platform-checks-slice.yml
@@ -56,6 +56,7 @@ jobs:
       runner_macos: ${{ steps.policy.outputs.runner_macos }}
       runner_windows: ${{ steps.policy.outputs.runner_windows }}
       runner_by_platform: ${{ steps.platform_runners.outputs.runner_by_platform }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -160,7 +161,7 @@ jobs:
         if: ${{ matrix.check.kind == 'unit' }}
         run: mkdir -p "$LLAMA_STAGE_BUILD_DIR"
       - name: Restore static Metal ABI build
-        if: ${{ matrix.check.kind == 'unit' }}
+        if: ${{ matrix.check.kind == 'unit' && needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
         id: llama_cache
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
@@ -176,7 +177,7 @@ jobs:
         if: ${{ matrix.check.kind == 'unit' && steps.llama_cache.outputs.cache-hit != 'true' }}
         run: scripts/build-llama.sh
       - name: Save static Metal ABI build
-        if: ${{ matrix.check.kind == 'unit' && steps.llama_cache.outputs.cache-hit != 'true' && (inputs.original_event_name == 'pull_request' || (github.ref == 'refs/heads/main' && inputs.original_event_name != 'pull_request_target')) }}
+        if: ${{ matrix.check.kind == 'unit' && needs.runner_policy.outputs.allow_native_github_cache == 'true' && steps.llama_cache.outputs.cache-hit != 'true' && (inputs.original_event_name == 'pull_request' || (github.ref == 'refs/heads/main' && inputs.original_event_name != 'pull_request_target')) }}
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ${{ env.LLAMA_STAGE_BUILD_DIR }}

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -65,6 +65,7 @@ jobs:
       runner_4: ${{ steps.policy.outputs.runner_4 }}
       runner_8: ${{ steps.policy.outputs.runner_8 }}
       allow_depot_remote_cache: ${{ steps.policy.outputs.allow_depot_remote_cache }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -173,7 +174,8 @@ jobs:
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_depot_remote_cache: ${{ needs.runner_policy.outputs.allow_depot_remote_cache }}
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+      - if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
         continue-on-error: true
         with:
           workspaces: . -> target

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -59,6 +59,7 @@ jobs:
       contents: read
     outputs:
       runner: ${{ steps.policy.outputs.runner }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -120,7 +121,8 @@ jobs:
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_depot_remote_cache: "false"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+      - if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
         continue-on-error: true
         with:
           workspaces: . -> target

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -42,6 +42,7 @@ jobs:
       contents: read
     outputs:
       runner_4: ${{ steps.policy.outputs.runner_4 }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -91,6 +92,7 @@ jobs:
         run: pnpm config set store-dir ~/.pnpm-store
       - name: Restore pnpm store
         id: pnpm_cache
+        if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.pnpm-store

--- a/.github/workflows/ci-web-slice.yml
+++ b/.github/workflows/ci-web-slice.yml
@@ -41,6 +41,7 @@ jobs:
       contents: read
     outputs:
       runner_4: ${{ steps.policy.outputs.runner_4 }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -90,6 +91,7 @@ jobs:
         run: pnpm config set store-dir ~/.pnpm-store
       - name: Restore pnpm store
         id: pnpm_cache
+        if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
         uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.pnpm-store
@@ -98,7 +100,7 @@ jobs:
       - name: Install UI dependencies
         run: pnpm i --frozen-lockfile
       - name: Save pnpm store
-        if: ${{ steps.pnpm_cache.outputs.cache-hit != 'true' }}
+        if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' && steps.pnpm_cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ~/.pnpm-store
@@ -128,7 +130,8 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
-          cache: npm
+          package-manager-cache: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
+          cache: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' && 'npm' || '' }}
           cache-dependency-path: |
             .github/cache-version.txt
             website/package-lock.json

--- a/.github/workflows/ci-windows-host-slice.yml
+++ b/.github/workflows/ci-windows-host-slice.yml
@@ -58,6 +58,7 @@ jobs:
       contents: read
     outputs:
       runner_windows: ${{ steps.policy.outputs.runner_windows }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -108,7 +109,8 @@ jobs:
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_depot_remote_cache: "false"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+      - if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
         continue-on-error: true
         with:
           workspaces: . -> target

--- a/.github/workflows/ci-windows-product-slice.yml
+++ b/.github/workflows/ci-windows-product-slice.yml
@@ -44,6 +44,7 @@ jobs:
       contents: read
     outputs:
       runner_windows: ${{ steps.policy.outputs.runner_windows }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:

--- a/.github/workflows/ci-windows-runtime-slice.yml
+++ b/.github/workflows/ci-windows-runtime-slice.yml
@@ -48,6 +48,7 @@ jobs:
       contents: read
     outputs:
       runner_windows: ${{ steps.policy.outputs.runner_windows }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -123,6 +124,7 @@ jobs:
           cuda_toolchain_version: ${{ env.WINDOWS_CUDA_VERSION }}
           vulkan_toolchain_version: ${{ env.WINDOWS_VULKAN_SDK_VERSION }}
           rocm_toolchain_version: ${{ env.ROCM_HIP_SDK_FILENAME }}
+          allow-native-github-cache: ${{ needs.runner_policy.outputs.allow_native_github_cache }}
       - name: Install CUDA toolkit
         if: ${{ matrix.runtime.backend == 'cuda' }}
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
@@ -130,7 +132,7 @@ jobs:
           cuda: ${{ env.WINDOWS_CUDA_VERSION }}
           method: network
           sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "visual_studio_integration"]'
-          use-github-cache: true
+          use-github-cache: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
           use-local-cache: true
           log-file-suffix: windows-cuda
       - name: Install Vulkan SDK
@@ -138,7 +140,7 @@ jobs:
         uses: jakoch/install-vulkan-sdk-action@3c53c378c9bfbb2ea122a1cc164a837d4004c871 # v1.5.2
         with:
           vulkan_version: ${{ env.WINDOWS_VULKAN_SDK_VERSION }}
-          cache: true
+          cache: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
           cache_save_if: ${{ inputs.original_event_name != 'pull_request' && inputs.original_event_name != 'pull_request_target' }}
           stripdown: true
       - name: Install ROCm HIP SDK
@@ -146,6 +148,7 @@ jobs:
         uses: ./.github/actions/setup-windows-rocm-sdk
         with:
           rocm-hip-sdk-filename: ${{ env.ROCM_HIP_SDK_FILENAME }}
+          allow-native-github-cache: ${{ needs.runner_policy.outputs.allow_native_github_cache }}
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
           arch: x64
@@ -159,7 +162,7 @@ jobs:
           target: ${{ matrix.runtime.target }}
           output_dir: runtime-input
       - name: Save exact PR-scoped Windows ABI build
-        if: ${{ inputs.original_event_name == 'pull_request' && steps.llama_cache.outputs.cache-hit != 'true' }}
+        if: ${{ inputs.original_event_name == 'pull_request' && needs.runner_policy.outputs.allow_native_github_cache == 'true' && steps.llama_cache.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: ${{ steps.llama_cache.outputs.cache-path }}

--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -102,6 +102,7 @@ jobs:
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}
       allow_depot_remote_cache: ${{ steps.resolve.outputs.allow_depot_remote_cache }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1400,6 +1400,7 @@ jobs:
           backend: cpu
           build_dir: ${{ env.LLAMA_STAGE_BUILD_DIR }}
           toolchain_epoch: ${{ steps.native_toolchain.outputs.epoch }}
+          allow-native-github-cache: "true"
       - name: Initialize MSVC for native runtime
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
@@ -1479,6 +1480,7 @@ jobs:
           cuda_toolchain_version: ${{ env.WINDOWS_CUDA_VERSION }}
           vulkan_toolchain_version: ${{ env.WINDOWS_VULKAN_SDK_VERSION }}
           rocm_toolchain_version: ${{ env.ROCM_HIP_SDK_FILENAME }}
+          allow-native-github-cache: "true"
       - name: Prepare dispatched release version
         if: github.event_name == 'workflow_dispatch'
         shell: bash
@@ -1536,6 +1538,7 @@ jobs:
         uses: ./.github/actions/setup-windows-rocm-sdk
         with:
           rocm-hip-sdk-filename: ${{ env.ROCM_HIP_SDK_FILENAME }}
+          allow-native-github-cache: "true"
       - name: Initialize MSVC for native runtime
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:

--- a/.github/workflows/static-abi-artifact.yml
+++ b/.github/workflows/static-abi-artifact.yml
@@ -68,6 +68,7 @@ jobs:
     outputs:
       runner: ${{ steps.resolve.outputs.runner }}
       allow_depot_remote_cache: ${{ steps.policy.outputs.allow_depot_remote_cache }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -175,6 +176,7 @@ jobs:
 
       - name: Cache portable static ABI input
         id: static_abi_cache
+        if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: static-abi-artifact-output

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -65,6 +65,7 @@ jobs:
       contents: read
     outputs:
       runner_macos: ${{ steps.policy.outputs.runner_macos }}
+      allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -146,7 +147,8 @@ jobs:
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: 24
-          cache: pnpm
+          package-manager-cache: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
+          cache: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' && 'pnpm' || '' }}
           cache-dependency-path: |
             .github/cache-version.txt
             crates/mesh-llm-ui/pnpm-lock.yaml
@@ -166,7 +168,8 @@ jobs:
         with:
           include_tool_versions: "true"
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+      - if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
         continue-on-error: true
         with:
           workspaces: . -> target
@@ -178,6 +181,7 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
 
       - name: Restore exact Swift native ABI cache
+        if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
         uses: actions/cache@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
         with:
           path: .deps/llama-build

--- a/.github/workflows/windows-warm-caches.yml
+++ b/.github/workflows/windows-warm-caches.yml
@@ -70,6 +70,7 @@ jobs:
           backend: cpu
           build_dir: ${{ env.LLAMA_STAGE_BUILD_DIR }}
           toolchain_epoch: ${{ steps.native_toolchain.outputs.epoch }}
+          allow-native-github-cache: "true"
       - name: Initialize MSVC for CPU runtime
         if: steps.llama_cache.outputs.cache-hit != 'true'
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
@@ -163,6 +164,7 @@ jobs:
           cuda_toolchain_version: ${{ env.WINDOWS_CUDA_VERSION }}
           vulkan_toolchain_version: ${{ env.WINDOWS_VULKAN_SDK_VERSION }}
           rocm_toolchain_version: ${{ env.ROCM_HIP_SDK_FILENAME }}
+          allow-native-github-cache: "true"
       - name: Install CUDA toolkit
         if: ${{ matrix.backend == 'cuda' && steps.llama_cache.outputs.cache-hit != 'true' }}
         uses: Jimver/cuda-toolkit@3d45d157f327c09c04b50ee6ccdea2d9d017ec76 # v0.2.35
@@ -215,6 +217,7 @@ jobs:
         uses: ./.github/actions/setup-windows-rocm-sdk
         with:
           rocm-hip-sdk-filename: ${{ env.ROCM_HIP_SDK_FILENAME }}
+          allow-native-github-cache: "true"
       - name: Initialize MSVC for native runtime
         if: steps.llama_cache.outputs.cache-hit != 'true'
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -235,10 +235,12 @@ global `DEPOT_PR_RUNNERS_ENABLED` gate remains absent/false. Fork heads,
 GitHub-hosted runners. Depot's documented GitHub cache path is
 repository-scoped and not branch-isolated; automatic cache redirection can
 expose repository-wide cache authority to PR code. Cache-key prefixes are not
-isolation. Native `actions/cache` consumers remain an unresolved boundary for
-the canary hook, so the hook is not itself an isolation proof and must not be
-enabled until the actual Depot/WebDAV authority is tested or those consumers
-are explicitly disabled.
+isolation. The central selector now emits `allow_native_github_cache=false`
+for a Depot-selected direct PR, and all eligible native GitHub cache consumers
+are conditionally disabled while the underlying install/build commands remain
+unchanged. This removes the checked-in cache API path but is not an ambient
+Depot/WebDAV authority proof; the actual runner sentinel and no-token checks
+remain required before enabling the canary or global PR gate.
 
 Before a PR Depot path is enabled, an administrator must prove:
 

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -199,8 +199,8 @@ without Depot cache, WebDAV, registry, or transparent GitHub-cache authority.
 
 The remaining runtime questions are:
 
-1. Does `actions/cache` on a fresh Depot runner use GitHub's native
-   branch-isolated cache, or must all cache actions remain disabled for PR jobs?
+1. Does a fresh Depot runner expose any ambient Depot/WebDAV/cache authority
+   to a PR job even when the checked-in native cache consumers are disabled?
 2. Does a trusted main build retain its intended cache behavior with automatic
    Depot connectivity disabled, or should it use GitHub native cache only?
 3. Can a same-repository PR and a fork PR both run the protected canary with no
@@ -210,12 +210,14 @@ The remaining runtime questions are:
 5. Does the restricted runner group continue to allow only the exact protected
    workflow refs after the PR canary is enabled?
 
-The checked-in selector and negative audit do not prove this boundary. Native
-`actions/cache` consumers on a Depot runner can still read repository/base
-caches, so a canary ref must either target the actual Depot/WebDAV authority
-with an approved non-secret marker protocol or explicitly disable every
-relevant cache consumer before any PR code is placed on Depot. This repository
-does neither yet; the canary remains an external runtime/admin prerequisite.
+The selector now emits a provider-derived `allow_native_github_cache` output.
+Every eligible Depot-selected direct PR cache consumer is skipped or passed a
+disabled cache input, while installation and build commands remain active;
+cache misses therefore rebuild normally. This closes the checked-in native
+GitHub-cache path but does not prove that a fresh Depot runner cannot reach an
+ambient Depot/WebDAV/cache service. The canary must still target the actual
+authority with an approved non-secret marker protocol and verify no read/write
+or registry token access; it remains an external runtime/admin prerequisite.
 
 Do not introduce a long-lived Depot organization token without a separate
 security review and explicit authorization.

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -324,6 +324,15 @@ The implemented policy uses that isolation selectively:
 | Website npm store | Website-only lockfile-keyed cache | Later same-PR website runs avoid downloading the unchanged dependency store |
 | GitHub artifacts | Never used as cross-run caches | Immutable producers/consumers remain correct within one run; reruns recreate run-scoped artifacts |
 
+For a Depot-selected direct PR, the central runner policy emits
+`allow_native_github_cache=false`. Every native GitHub cache consumer in the
+eligible five-lane build graph (explicit `actions/cache`, setup-node package
+caches, rust-cache, static/Metal/Windows/Swift ABI caches, and Windows SDK
+cache toggles) is then skipped or disabled; the installation and build steps
+still run and regenerate on a miss. Hosted PRs and trusted main/release/manual
+paths retain the existing cache behavior. This is a checked-in consumer
+policy, not proof that a Depot runner has no ambient Depot/WebDAV authority.
+
 This is intentionally not a universal PR write-through policy. Cargo target
 caches are commonly hundreds of megabytes to several gigabytes per row; making
 every PR matrix row publish one would multiply storage, increase upload time,
@@ -334,13 +343,12 @@ must still regenerate successfully after a miss.
 
 Depot PR execution is not enabled. The bounded `DEPOT_PR_CANARY_REF` selector
 hook exists only to exercise a single protected same-repository ref after the
-external gates are ready. Native `actions/cache` consumers on a Depot runner
-may still read repository/base caches; a selector result, cache-key prefix or
-negative credential audit is not proof of cache isolation. Cache isolation,
-protected default-branch runner-owning workflow refs, no-secret/no-token
-execution and a sentinel canary are prerequisites in
-`ci/DEPOT_MIGRATION.md`. Do not change Depot settings or runner groups in a
-workflow refactor.
+external gates are ready. The implemented no-native-cache mode prevents the
+checked-in GitHub cache consumers from reading or writing on that Depot PR,
+but it does not prove that a runner has no ambient Depot/WebDAV/cache
+authority. A protected runner-group check, no-secret/no-token execution and
+the non-secret sentinel canary in `ci/DEPOT_MIGRATION.md` remain prerequisites.
+Do not change Depot settings or runner groups in a workflow refactor.
 
 The external administrative posture now has automatic Depot Cache and Registry
 Actions connectivity disabled and the Depot runner group restricted to this

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -618,6 +618,87 @@ class CiArtifactActionTests(unittest.TestCase):
             action,
         )
 
+    def test_windows_native_cache_inputs_fail_closed_and_callers_opt_in(
+        self,
+    ) -> None:
+        for action_name in (
+            "restore-windows-abi-cache",
+            "setup-windows-rocm-sdk",
+        ):
+            with self.subTest(action=action_name):
+                action = self.read_action(action_name)
+                input_start = action.index("  allow-native-github-cache:")
+                input_end = action.find("\n\n", input_start)
+                input_block = action[input_start:input_end]
+                self.assertIn('required: false', input_block)
+                self.assertIn('default: "false"', input_block)
+                self.assertNotIn('default: "true"', input_block)
+
+        expected_callers = {
+            "restore-windows-abi-cache": {
+                "ci-windows-runtime-slice.yml": 1,
+                "release.yml": 2,
+                "windows-warm-caches.yml": 2,
+            },
+            "setup-windows-rocm-sdk": {
+                "ci-windows-runtime-slice.yml": 1,
+                "release.yml": 1,
+                "windows-warm-caches.yml": 1,
+            },
+        }
+        policy_value = (
+            "allow-native-github-cache: "
+            "${{ needs.runner_policy.outputs.allow_native_github_cache }}"
+        )
+        for action_name, expected_counts in expected_callers.items():
+            calls: list[tuple[str, str]] = []
+            for workflow_path in sorted(
+                (ROOT / ".github" / "workflows").glob("*.yml")
+            ):
+                lines = workflow_path.read_text(encoding="utf-8").splitlines()
+                for index, line in enumerate(lines):
+                    marker = f"uses: ./.github/actions/{action_name}"
+                    if marker not in line:
+                        continue
+                    line_indent = len(line) - len(line.lstrip())
+                    step_indent = line_indent
+                    for candidate in reversed(lines[:index]):
+                        candidate_indent = len(candidate) - len(candidate.lstrip())
+                        if candidate_indent <= line_indent and candidate.lstrip().startswith("-"):
+                            step_indent = candidate_indent
+                            break
+                    start = index
+                    while start > 0:
+                        candidate = lines[start - 1]
+                        candidate_indent = len(candidate) - len(candidate.lstrip())
+                        if candidate_indent == step_indent and candidate.lstrip().startswith("-"):
+                            start -= 1
+                            break
+                        if candidate_indent < step_indent:
+                            break
+                        start -= 1
+                    end = index + 1
+                    while end < len(lines):
+                        candidate = lines[end]
+                        candidate_indent = len(candidate) - len(candidate.lstrip())
+                        if candidate_indent == step_indent and candidate.lstrip().startswith("-"):
+                            break
+                        end += 1
+                    calls.append((workflow_path.name, "\n".join(lines[start:end])))
+
+            actual_counts: dict[str, int] = {}
+            for workflow_name, block in calls:
+                actual_counts[workflow_name] = actual_counts.get(workflow_name, 0) + 1
+                with self.subTest(action=action_name, workflow=workflow_name):
+                    if workflow_name == "ci-windows-runtime-slice.yml":
+                        self.assertIn(policy_value, block)
+                    else:
+                        self.assertIn(
+                            'allow-native-github-cache: "true"',
+                            block,
+                        )
+            self.assertEqual(expected_counts, actual_counts)
+
     def test_native_toolchain_epoch_is_exact_and_shared_with_build_stamp(
         self,
     ) -> None:

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -1938,6 +1938,15 @@ class CiArtifactActionTests(unittest.TestCase):
                     outputs["allow_depot_remote_cache"],
                     cache_enabled,
                 )
+                expected_native_cache = (
+                    "false"
+                    if enabled == "true" and event_name == "pull_request"
+                    else "true"
+                )
+                self.assertEqual(
+                    outputs["allow_native_github_cache"],
+                    expected_native_cache,
+                )
                 self.assertEqual(outputs["runner"], runner)
                 expected_arm = (
                     "depot-ubuntu-24.04-arm"
@@ -1982,6 +1991,10 @@ class CiArtifactActionTests(unittest.TestCase):
             untrusted_repository["allow_depot_remote_cache"],
             "false",
         )
+        self.assertEqual(
+            untrusted_repository["allow_native_github_cache"],
+            "true",
+        )
 
         fork_head_repository = self.run_runner_selector(
             event_name="pull_request",
@@ -1993,6 +2006,10 @@ class CiArtifactActionTests(unittest.TestCase):
         )
         self.assertEqual(fork_head_repository["depot_enabled"], "false")
         self.assertEqual(fork_head_repository["runner"], "ubuntu-24.04")
+        self.assertEqual(
+            fork_head_repository["allow_native_github_cache"],
+            "true",
+        )
 
         runner_contract_change = self.run_runner_selector(
             event_name="pull_request",
@@ -2004,6 +2021,10 @@ class CiArtifactActionTests(unittest.TestCase):
         )
         self.assertEqual(runner_contract_change["depot_enabled"], "false")
         self.assertEqual(runner_contract_change["runner"], "ubuntu-24.04")
+        self.assertEqual(
+            runner_contract_change["allow_native_github_cache"],
+            "true",
+        )
 
         non_merge_ref = self.run_runner_selector(
             event_name="pull_request",
@@ -2029,6 +2050,10 @@ class CiArtifactActionTests(unittest.TestCase):
             untrusted_dispatch["allow_depot_remote_cache"],
             "false",
         )
+        self.assertEqual(
+            untrusted_dispatch["allow_native_github_cache"],
+            "true",
+        )
 
         canary_pr = self.run_runner_selector(
             event_name="pull_request",
@@ -2041,6 +2066,7 @@ class CiArtifactActionTests(unittest.TestCase):
         self.assertEqual(canary_pr["depot_enabled"], "true")
         self.assertEqual(canary_pr["runner"], "depot-ubuntu-24.04")
         self.assertEqual(canary_pr["allow_depot_remote_cache"], "false")
+        self.assertEqual(canary_pr["allow_native_github_cache"], "false")
 
         for name, kwargs in (
             (
@@ -2167,6 +2193,149 @@ class CiArtifactActionTests(unittest.TestCase):
             pr = pr_path.read_text(encoding="utf-8")
             self.assertNotIn("depot-ubuntu", pr)
             self.assertNotIn("SCCACHE_GHA_ENABLED: \"false\"", pr)
+
+    def test_depot_pr_native_cache_consumers_are_centrally_disabled(self) -> None:
+        eligible_consumers = {
+            "ci-quality-slice.yml": ("Swatinem/rust-cache@",),
+            "ci-web-slice.yml": (
+                "uses: actions/cache/restore@",
+                "uses: actions/cache/save@",
+            ),
+            "ci-ui-artifact-slice.yml": ("uses: actions/cache/restore@",),
+            "ci-linux-host-slice.yml": ("Swatinem/rust-cache@",),
+            "ci-linux-runtime-slice.yml": ("Swatinem/rust-cache@",),
+            "ci-rust-tests-slice.yml": ("Swatinem/rust-cache@",),
+            "ci-macos-host-slice.yml": ("Swatinem/rust-cache@",),
+            "ci-platform-checks-slice.yml": (
+                "uses: actions/cache/restore@",
+                "uses: actions/cache/save@",
+            ),
+            "ci-windows-host-slice.yml": ("Swatinem/rust-cache@",),
+            "ci-windows-runtime-slice.yml": (
+                "uses: ./.github/actions/restore-windows-abi-cache",
+                "use-github-cache:",
+                "uses: jakoch/install-vulkan-sdk-action@",
+                "uses: ./.github/actions/setup-windows-rocm-sdk",
+                "uses: actions/cache/save@",
+            ),
+            "static-abi-artifact.yml": ("uses: actions/cache@",),
+            "swift-sdk-artifact.yml": (
+                "cache: ${{ needs.runner_policy.outputs.allow_native_github_cache",
+                "Swatinem/rust-cache@",
+                "uses: actions/cache@",
+            ),
+        }
+        expected_jobs = {
+            "ci-quality-slice.yml": {
+                "runner_policy", "quality_contracts", "rust_fmt", "rust_clippy", "cli_docs_sync",
+            },
+            "ci-web-slice.yml": {"runner_policy", "ui_quality", "website"},
+            "ci-ui-artifact-slice.yml": {"runner_policy", "ui_artifact"},
+            "ci-linux-host-slice.yml": {"runner_policy", "linux_host"},
+            "ci-linux-runtime-slice.yml": {"runner_policy", "linux_runtime"},
+            "ci-rust-tests-slice.yml": {"runner_policy", "rust_tests"},
+            "ci-macos-host-slice.yml": {"runner_policy", "macos_host"},
+            "ci-platform-checks-slice.yml": {"runner_policy", "platform_checks"},
+            "ci-windows-host-slice.yml": {"runner_policy", "windows_host"},
+            "ci-windows-runtime-slice.yml": {"runner_policy", "windows_runtime"},
+            "static-abi-artifact.yml": {"runner_policy", "static_abi_artifact"},
+            "swift-sdk-artifact.yml": {"runner_policy", "swift_sdk_artifact"},
+        }
+
+        def step_block(workflow: str, marker: str) -> str:
+            lines = workflow.splitlines()
+            for index, line in enumerate(lines):
+                if marker not in line:
+                    continue
+                indent = len(line) - len(line.lstrip())
+                step_indent = indent if line.lstrip().startswith("-") else indent - 2
+                start = index
+                while start > 0:
+                    candidate = lines[start - 1]
+                    candidate_indent = len(candidate) - len(candidate.lstrip())
+                    if candidate_indent == step_indent and candidate.lstrip().startswith("-"):
+                        start -= 1
+                        break
+                    if candidate_indent < step_indent:
+                        break
+                    start -= 1
+                end = index + 1
+                while end < len(lines):
+                    candidate = lines[end]
+                    candidate_indent = len(candidate) - len(candidate.lstrip())
+                    if candidate_indent == step_indent and candidate.lstrip().startswith("-"):
+                        break
+                    end += 1
+                return "\n".join(lines[start:end])
+            self.fail(f"missing cache consumer marker: {marker}")
+
+        for filename, markers in eligible_consumers.items():
+            workflow = (
+                ROOT / ".github" / "workflows" / filename
+            ).read_text(encoding="utf-8")
+            with self.subTest(workflow=filename):
+                self.assertIn(
+                    "allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}",
+                    workflow,
+                )
+                for marker in markers:
+                    block = step_block(workflow, marker)
+                    with self.subTest(consumer=marker):
+                        self.assertIn("allow_native_github_cache", block)
+
+        for filename, jobs in expected_jobs.items():
+            workflow = (
+                ROOT / ".github" / "workflows" / filename
+            ).read_text(encoding="utf-8")
+            job_section = workflow.split("\njobs:\n", maxsplit=1)[1]
+            actual_jobs = set(re.findall(r"^  ([A-Za-z0-9_]+):", job_section, re.MULTILINE))
+            with self.subTest(workflow=filename):
+                self.assertEqual(jobs, actual_jobs)
+                self.assertNotRegex(
+                    job_section,
+                    r"^  [A-Za-z0-9_]+:\n(?:    [^\n]*\n){0,4}    if:.*allow_native_github_cache",
+                )
+
+        website = (
+            ROOT / ".github" / "workflows" / "ci-web-slice.yml"
+        ).read_text(encoding="utf-8")
+        swift = (
+            ROOT / ".github" / "workflows" / "swift-sdk-artifact.yml"
+        ).read_text(encoding="utf-8")
+        windows = (
+            ROOT / ".github" / "workflows" / "ci-windows-runtime-slice.yml"
+        ).read_text(encoding="utf-8")
+        native_cache_expression = (
+            "needs.runner_policy.outputs.allow_native_github_cache == 'true'"
+        )
+        self.assertIn(
+            f"cache: ${{{{ {native_cache_expression} && 'npm' || '' }}}}",
+            website,
+        )
+        self.assertIn(
+            f"package-manager-cache: ${{{{ {native_cache_expression} }}}}",
+            website,
+        )
+        self.assertIn(
+            f"cache: ${{{{ {native_cache_expression} && 'pnpm' || '' }}}}",
+            swift,
+        )
+        self.assertIn(
+            f"package-manager-cache: ${{{{ {native_cache_expression} }}}}",
+            swift,
+        )
+        self.assertIn(
+            f"use-github-cache: ${{{{ {native_cache_expression} }}}}",
+            windows,
+        )
+        self.assertIn(
+            f"cache: ${{{{ {native_cache_expression} }}}}",
+            windows,
+        )
+
+        for action_name in ("restore-windows-abi-cache", "setup-windows-rocm-sdk"):
+            action = self.read_action(action_name)
+            self.assertIn("inputs.allow-native-github-cache == 'true'", action)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_ci_workflow_artifacts.py
+++ b/scripts/tests/test_ci_workflow_artifacts.py
@@ -178,7 +178,10 @@ class CiWorkflowArtifactTests(unittest.TestCase):
         self.assertIn("uses: actions/cache/restore@", ui)
         self.assertNotIn("uses: actions/cache/save@", ui)
         self.assertIn("uses: actions/cache/save@", web)
-        self.assertIn("cache: npm", web)
+        self.assertIn(
+            "cache: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' && 'npm' || '' }}",
+            web,
+        )
         self.assertIn("website/package-lock.json", web)
         self.assertIn("working-directory: website", web)
         self.assertIn("run: npm ci", web)

--- a/scripts/tests/test_pr_workflow_artifacts.py
+++ b/scripts/tests/test_pr_workflow_artifacts.py
@@ -252,7 +252,10 @@ class PrWorkflowArtifactTests(unittest.TestCase):
         website = self.workflow("ci-web-slice.yml")
         self.assertNotIn("name: Save pnpm store", ui_artifact)
         self.assertEqual(1, website.count("name: Save pnpm store"))
-        self.assertIn("cache: npm", website)
+        self.assertIn(
+            "cache: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' && 'npm' || '' }}",
+            website,
+        )
         self.assertIn("website/package-lock.json", website)
 
         windows = self.workflow("ci-windows-runtime-slice.yml")


### PR DESCRIPTION
## Summary

- derive native GitHub cache permission from the protected runner policy
- disable every checked-in native cache consumer for Depot-selected direct PR jobs
- keep install/build commands, artifacts, matrices, dependencies, summaries, and five-lane CI shape unchanged
- document that runtime Depot/WebDAV/no-token sentinel proof remains required before PR activation

## Cache coverage

This gates pnpm/npm setup caches, `Swatinem/rust-cache`, static/Metal/Swift/Windows ABI caches, CUDA/Vulkan GitHub cache integration, and the ROCm installer cache. Job-local PR sccache remains enabled.

Hosted PRs and trusted main/release/manual paths retain their existing cache behavior.

## Validation

- `just ci-validate` — 444 passed, 7 skipped; actionlint and all repository consistency checks passed
- focused selector/cache/audit/lane/trust suites — 110 passed
- independent structural audit — all five PR and five main entrypoints byte-identical; all 17 changed reusable workflows preserve jobs, matrices, `needs`, commands, containers, artifacts, stable summaries, fail-fast, and parallelism
- independent cache-consumer closure audit — no unguarded eligible consumer found
- `git diff --check`

## Remaining rollout gates

This PR intentionally does not enable `DEPOT_PR_RUNNERS_ENABLED` or `DEPOT_PR_CANARY_REF`, alter runner groups, or change Depot settings. A bounded runtime canary must still prove no ambient Depot/WebDAV/registry authority, provider parity, and rollback behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added centralized CI cache controls based on runner policy.
  * Depot-selected pull requests now skip native GitHub caching while continuing installation, builds, and artifact regeneration on cache misses.
  * Extended policy-based cache controls across Linux, macOS, Windows, UI, web, SDK, ABI, and quality workflows.
  * Preserved native caching for release and warm-cache workflows.

* **Documentation**
  * Clarified cache behavior, prerequisites, and runtime isolation validation requirements.

* **Tests**
  * Added coverage for cache-policy outputs and conditional cache behavior across supported CI scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->