### PR TITLE
fix(ffi): match mtmd_helper_bitmap_init_from_buf's current signature

### DIFF
--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -316,6 +316,20 @@ pub struct MtmdInputChunks {
 }
 
 #[repr(C)]
+pub struct MtmdHelperVideo {
+    _private: [u8; 0],
+}
+
+/// Mirrors llama.cpp's `mtmd_helper_bitmap_wrapper`: the decoded bitmap plus
+/// an optional video context (non-null only for video inputs, which own the
+/// frame storage the bitmap points into).
+#[repr(C)]
+pub struct MtmdHelperBitmapWrapper {
+    pub bitmap: *mut MtmdBitmap,
+    pub video_ctx: *mut MtmdHelperVideo,
+}
+
+#[repr(C)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum MtmdInputChunkType {
     Text = 0,
@@ -888,7 +902,8 @@ mod dynamic {
         mtmd_context_params_default() -> MtmdContextParams;
         mtmd_init_from_file(mmproj_fname: *const c_char, text_model: *const Opaque, ctx_params: MtmdContextParams) -> *mut MtmdContext;
         mtmd_free(ctx: *mut MtmdContext);
-        mtmd_helper_bitmap_init_from_buf(ctx: *mut MtmdContext, buf: *const u8, len: usize) -> *mut MtmdBitmap;
+        mtmd_helper_bitmap_init_from_buf(ctx: *mut MtmdContext, buf: *const u8, len: usize, placeholder: bool) -> MtmdHelperBitmapWrapper;
+        mtmd_helper_video_free(video: *mut MtmdHelperVideo);
         mtmd_bitmap_free(bitmap: *mut MtmdBitmap);
         mtmd_input_chunks_init() -> *mut MtmdInputChunks;
         mtmd_input_chunks_free(chunks: *mut MtmdInputChunks);
@@ -1753,7 +1768,10 @@ unsafe extern "C" {
         ctx: *mut MtmdContext,
         buf: *const u8,
         len: usize,
-    ) -> *mut MtmdBitmap;
+        placeholder: bool,
+    ) -> MtmdHelperBitmapWrapper;
+
+    pub fn mtmd_helper_video_free(video: *mut MtmdHelperVideo);
 
     pub fn mtmd_bitmap_free(bitmap: *mut MtmdBitmap);
 

--- a/crates/skippy-runtime/src/media.rs
+++ b/crates/skippy-runtime/src/media.rs
@@ -95,12 +95,18 @@ impl StageModel {
 
         struct Bitmap {
             raw: *mut skippy_ffi::MtmdBitmap,
+            video: *mut skippy_ffi::MtmdHelperVideo,
         }
         impl Drop for Bitmap {
             fn drop(&mut self) {
                 if !self.raw.is_null() {
                     unsafe {
                         skippy_ffi::mtmd_bitmap_free(self.raw);
+                    }
+                }
+                if !self.video.is_null() {
+                    unsafe {
+                        skippy_ffi::mtmd_helper_video_free(self.video);
                     }
                 }
             }
@@ -123,17 +129,22 @@ impl StageModel {
             if item.bytes.is_empty() {
                 return Err(anyhow!("media item must not be empty"));
             }
-            let raw = unsafe {
+            let wrapper = unsafe {
                 skippy_ffi::mtmd_helper_bitmap_init_from_buf(
                     projector.raw,
                     item.bytes.as_ptr(),
                     item.bytes.len(),
+                    false,
                 )
             };
-            if raw.is_null() {
+            let bitmap = Bitmap {
+                raw: wrapper.bitmap,
+                video: wrapper.video_ctx,
+            };
+            if bitmap.raw.is_null() {
                 return Err(anyhow!("failed to decode media item for projector"));
             }
-            bitmaps.push(Bitmap { raw });
+            bitmaps.push(bitmap);
         }
 
         let chunks = Chunks {
@@ -254,12 +265,18 @@ impl StageModel {
 
         struct Bitmap {
             raw: *mut skippy_ffi::MtmdBitmap,
+            video: *mut skippy_ffi::MtmdHelperVideo,
         }
         impl Drop for Bitmap {
             fn drop(&mut self) {
                 if !self.raw.is_null() {
                     unsafe {
                         skippy_ffi::mtmd_bitmap_free(self.raw);
+                    }
+                }
+                if !self.video.is_null() {
+                    unsafe {
+                        skippy_ffi::mtmd_helper_video_free(self.video);
                     }
                 }
             }
@@ -292,17 +309,22 @@ impl StageModel {
             if item.bytes.is_empty() {
                 return Err(anyhow!("media item must not be empty"));
             }
-            let raw = unsafe {
+            let wrapper = unsafe {
                 skippy_ffi::mtmd_helper_bitmap_init_from_buf(
                     projector.raw,
                     item.bytes.as_ptr(),
                     item.bytes.len(),
+                    false,
                 )
             };
-            if raw.is_null() {
+            let bitmap = Bitmap {
+                raw: wrapper.bitmap,
+                video: wrapper.video_ctx,
+            };
+            if bitmap.raw.is_null() {
                 return Err(anyhow!("failed to decode media item for projector"));
             }
-            bitmaps.push(Bitmap { raw });
+            bitmaps.push(bitmap);
         }
 
         let chunks = Chunks {


### PR DESCRIPTION
## Problem

Every vision request through the OpenAI surface fails with HTTP 502 `multimodal tokenization failed with status 2` / `multimodal prompt evaluation failed with status 1`. The native log shows the mechanism:

```
mtmd_tokenize: error: number of media markers in text (0) does not match number of bitmaps (1)
mtmd_encode_chunk_impl: image tokens batch is placeholder
failed to encode image slice
```

The model itself is fine — the same GGUF + mmproj through `llama-mtmd-cli --jinja` (built from the vendored llama.cpp checkout) describes images perfectly.

## Root cause

The vendored llama.cpp changed `mtmd_helper_bitmap_init_from_buf` when video support landed:

```c
// now: 4 args, returns a wrapper struct
mtmd_helper_bitmap_wrapper mtmd_helper_bitmap_init_from_buf(ctx, buf, len, bool placeholder);
struct mtmd_helper_bitmap_wrapper { mtmd_bitmap * bitmap; mtmd_helper_video * video_ctx; };
```

but `skippy-ffi` still declared the old 3-arg bare-pointer form. On aarch64 the wrapper's first field happens to come back in x0, so the bitmap pointer accidentally survived — but the new `placeholder` argument read **garbage from an unset register**. Whenever it read nonzero, llama.cpp constructed an empty placeholder bitmap, and every downstream encode failed at the placeholder gate. Text-only paths never call this helper, which is why nothing else broke.

## Fix

- Update the FFI declaration to the 4-arg wrapper-returning form (`MtmdHelperBitmapWrapper { bitmap, video_ctx }`), pass `placeholder = false`.
- Add `mtmd_helper_video_free` and free the video context alongside the bitmap in both `eval_media` and `eval_media_frame`.

## Verification

Muse-Glimmer-30B Q4_K_M + mmproj on M4/Metal, `POST /v1/chat/completions` with an `image_url` data-URI part:

- **Before**: 502 at the placeholder gate, native log `image tokens batch is placeholder`
- **After**: image preprocessing and encoding succeed — native log `encoding image slice... image slice encoded in 566 ms`, generation proceeds
- Text-only requests unchanged ("391" sanity check passes)
- Control: `llama-mtmd-cli --jinja` with identical model files works, confirming the break was in the FFI layer, not the model or vendored llama.cpp

Note: with this fix the image encodes and generation runs, but Glimmer's vision output then hits a separate response-parsing issue (`peg-native` chat parser rejects the vision-turn output) — that's an unrelated bug in the chat-format parser, will file separately. This PR fixes the FFI break that blocked all multimodal input at the bitmap layer.

Clippy clean on both crates.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved multimedia bitmap handling with support for placeholder images and associated video context data.
  * Added safer cleanup for video-related resources during media processing.

* **Bug Fixes**
  * Preserved bitmap validation and error handling while improving resource management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->