### PR TITLE
[canary] docs: clarify runtime and SDK ownership

### DIFF
--- a/crates/mesh-llm-host-runtime/src/lib.rs
+++ b/crates/mesh-llm-host-runtime/src/lib.rs
@@ -18,6 +18,9 @@ mod runtime;
 mod runtime_data;
 mod system;
 
+// This crate root owns the host runtime boundary: runtime orchestration,
+// inference, networking, and product composition stay reachable through the
+// same host contract while their implementations remain in domain modules.
 pub mod sdk;
 
 pub mod proto {

--- a/crates/mesh-llm-nodejs/src/lib.rs
+++ b/crates/mesh-llm-nodejs/src/lib.rs
@@ -1,5 +1,9 @@
 #![forbid(unsafe_code)]
 
+// This addon owns the JavaScript-facing SDK boundary. Keep conversion,
+// lifecycle, and error translation here; runtime and wire behavior belongs to
+// mesh-llm-sdk so every binding observes the same SDK contract.
+
 #[cfg(feature = "embedded-runtime")]
 use mesh_llm_sdk::embedded_runtime::{EmbeddedChatMessage, EmbeddedServingController};
 use mesh_llm_sdk::events::{Event, EventListener};

--- a/crates/mesh-llm-sdk/src/lib.rs
+++ b/crates/mesh-llm-sdk/src/lib.rs
@@ -1,5 +1,9 @@
 #![forbid(unsafe_code)]
 
+// This crate is the stable Rust SDK ownership boundary. Keep client,
+// embedded-serving, and platform-facing adapters aligned here while their
+// implementations remain in the owning modules and crates.
+
 use std::collections::BTreeMap;
 use std::net::IpAddr;
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary

- document the host-runtime crate ownership boundary
- document the Rust SDK ownership boundary
- document the Node.js adapter ownership boundary

This is an intentionally non-functional, source-owned change used as the bounded same-repository CI rollout fixture. It does not modify CI, manifests, commands, artifacts, matrices, or build shape.

## CI rollout evidence

- planner mode: `pr-ready` / `pull_request`
- base SHA: `ceab59b01ddbb1ef055888511b7a7303582aafbe`
- source SHA: `6d049d5bf0815afb07389dfb1ac8381f0d71afa0`
- exact live compact-plan digest: `b4f42228c5a53b1d785572c17ede206f28fe0d053aa5858c8a6231310bd6b004`
- `runner_contract_required=false`
- selected domains: Rust, runtime/product, Rust SDK, macOS, Windows
- stable Website lane remains present but intentionally skips for this source-only change

Rollout sequence: first collect the hosted baseline with the PR canary gate absent; then set only the exact merge ref in `DEPOT_PR_CANARY_REF`, rerun the identical head/plan, compare providers/queue/artifacts, and remove the variable immediately after the bounded trial.

## Local validation

- `just with-lld cargo fmt --all -- --check`
- `git diff --check`
- planner PR-ready projection and changed-path allowlist
