### PR TITLE
Advertise externally observed UDP ports so port-remapped containers are directly reachable

### DIFF
--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -57,7 +57,7 @@ skippy-runtime = { path = "../skippy-runtime", version = "0.72.1"  }
 skippy-ffi = { path = "../skippy-ffi", version = "0.72.1", default-features = false }
 skippy-server = { path = "../skippy-server", version = "0.72.1"  }
 skippy-topology = { path = "../skippy-topology", version = "0.72.1"  }
-iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
+iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs", "unstable-net-report"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -57,6 +57,11 @@ skippy-runtime = { path = "../skippy-runtime", version = "0.72.1"  }
 skippy-ffi = { path = "../skippy-ffi", version = "0.72.1", default-features = false }
 skippy-server = { path = "../skippy-server", version = "0.72.1"  }
 skippy-topology = { path = "../skippy-topology", version = "0.72.1"  }
+# `unstable-net-report` is exempt from iroh's semver guarantees (iroh/src/lib.rs
+# "may change in any release without a major version bump"). `mesh::stun` reads
+# `net_report().global_v4` and `mapping_varies_by_dest_ipv4` directly, so any
+# iroh bump must re-verify both fields. Only this crate enables the feature;
+# the other iroh pins in the workspace deliberately do not.
 iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs", "unstable-net-report"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }

--- a/crates/mesh-llm-host-runtime/src/mesh/node.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node.rs
@@ -33,7 +33,7 @@ pub struct RouteEntry {
 pub struct Node {
     pub(crate) endpoint: Endpoint,
     pub(crate) endpoint_secret_key: SecretKey,
-    pub(crate) public_addr: Option<std::net::SocketAddr>,
+    pub(crate) public_addr: Option<self::stun::PublicAddr>,
     pub(crate) quic_bind: QuicBindSelection,
     pub(crate) relay_policy: RelayPolicy,
     pub(crate) owner_keypair: Option<crate::crypto::OwnerKeypair>,
@@ -687,11 +687,12 @@ impl Node {
             .await;
         }
 
-        // Use iroh's net report because it probes through the endpoint's actual QUIC sockets.
-        // Its direct address includes the observed NAT-mapped port; substituting the configured
-        // bind port would advertise an address that was never verified externally.
+        // Take the address a remote probe server *observed* us from, so the advertised
+        // port is the NAT-mapped one rather than whatever port we bound locally. Local
+        // interface enumeration cannot tell those apart, and on hosts that hold a public
+        // IP on the container interface it silently advertises the unmapped port.
         let public_addr = if relay.policy.uses_raw_stun() {
-            stun_public_addr(&endpoint).await
+            stun_public_addr(&endpoint, relay.policy).await
         } else {
             tracing::info!("Raw STUN: disabled by LAN-only discovery mode");
             None

--- a/crates/mesh-llm-host-runtime/src/mesh/node_identity.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node_identity.rs
@@ -105,10 +105,24 @@ impl Node {
     pub async fn invite_token(&self) -> String {
         let mut addr = self.endpoint_addr_for_advertisement();
         // Inject STUN-discovered public address if relay STUN didn't provide one.
-        if let Some(pub_addr) = self.public_addr
-            && !endpoint_addr_has_public_ipv4(&addr)
-        {
-            addr.addrs.insert(TransportAddr::Ip(pub_addr));
+        // An observed address supersedes any locally-enumerated public candidate:
+        // enumeration carries the port we bound, which is wrong wherever the host
+        // remaps ports, and `endpoint.addr()` mixes both kinds indistinguishably.
+        if let Some(pub_addr) = self.public_addr {
+            match pub_addr.source {
+                stun::PublicAddrSource::Observed => {
+                    addr.addrs.retain(|candidate| match candidate {
+                        TransportAddr::Ip(socket) => !is_public_ipv4_candidate(socket),
+                        _ => true,
+                    });
+                    addr.addrs.insert(TransportAddr::Ip(pub_addr.addr));
+                }
+                stun::PublicAddrSource::LocallyEnumerated => {
+                    if !endpoint_addr_has_public_ipv4(&addr) {
+                        addr.addrs.insert(TransportAddr::Ip(pub_addr.addr));
+                    }
+                }
+            }
         }
         addr = filter_endpoint_addr_for_bind_ip(
             addr,

--- a/crates/mesh-llm-host-runtime/src/mesh/stun.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/stun.rs
@@ -1,31 +1,136 @@
 use super::*;
 use iroh::Watcher;
 
-fn public_ipv4_addr(endpoint_addr: &iroh::EndpointAddr) -> Option<std::net::SocketAddr> {
+/// How a public IPv4 candidate for our direct path was obtained.
+///
+/// The two carry different trust: an observed address was reported back to us by
+/// a remote probe server, so it carries the NAT-mapped port. An enumerated one
+/// came from our own interfaces and carries whatever port we bound locally, which
+/// is wrong on any host that remaps ports.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum PublicAddrSource {
+    /// Reported by a remote probe server via the endpoint's net report.
+    Observed,
+    /// Read from our own interfaces; the port is unverified.
+    LocallyEnumerated,
+}
+
+/// A public IPv4 candidate together with how much we trust its port.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) struct PublicAddr {
+    pub(crate) addr: std::net::SocketAddr,
+    pub(crate) source: PublicAddrSource,
+}
+
+/// Reason an externally-observed address could not be used for the direct path.
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub(crate) enum ObservedAddrReject {
+    /// The net report completed but observed no global IPv4 address.
+    NoGlobalIpv4,
+    /// The observed address differs per probe destination, so it is not punchable.
+    MappingVariesByDestination,
+}
+
+/// Decide whether a net report yields an address safe to advertise as our direct path.
+///
+/// `global_v4` is the address a remote probe server observed us from, so it carries
+/// the NAT-mapped port rather than the port we happen to have bound inside a
+/// container. A mapping that varies by probe destination is address-dependent NAT
+/// and cannot be hole-punched, so it is rejected rather than advertised.
+pub(crate) fn observed_public_ipv4(
+    report: &iroh::unstable_net_report::NetReport,
+) -> Result<std::net::SocketAddr, ObservedAddrReject> {
+    if report.mapping_varies_by_dest_ipv4 == Some(true) {
+        return Err(ObservedAddrReject::MappingVariesByDestination);
+    }
+
+    report
+        .global_v4
+        .map(std::net::SocketAddr::V4)
+        .ok_or(ObservedAddrReject::NoGlobalIpv4)
+}
+
+/// Pick a locally-enumerated public IPv4 candidate from the endpoint's addresses.
+///
+/// This is the pre-existing behaviour and is only used when no remote probe can
+/// run at all, which is the case when relays are disabled: net reports have no
+/// server to ask, so `global_v4` is never populated. Its port is unverified.
+fn enumerated_public_ipv4(endpoint_addr: &iroh::EndpointAddr) -> Option<std::net::SocketAddr> {
     endpoint_addr
         .ip_addrs()
         .copied()
         .find(is_public_ipv4_candidate)
 }
 
-pub(crate) async fn stun_public_addr(endpoint: &iroh::Endpoint) -> Option<std::net::SocketAddr> {
-    let mut addresses = endpoint.watch_addr();
+/// Outcome of inspecting one net report: either we are done, or we keep waiting.
+enum ReportVerdict {
+    Settled(Option<PublicAddr>),
+    KeepWaiting,
+}
+
+fn verdict_for(report: Option<&iroh::unstable_net_report::NetReport>) -> ReportVerdict {
+    let Some(report) = report else {
+        return ReportVerdict::KeepWaiting;
+    };
+    match observed_public_ipv4(report) {
+        Ok(addr) => {
+            tracing::info!(%addr, "QUIC endpoint observed public address");
+            ReportVerdict::Settled(Some(PublicAddr {
+                addr,
+                source: PublicAddrSource::Observed,
+            }))
+        }
+        Err(ObservedAddrReject::MappingVariesByDestination) => {
+            tracing::warn!(
+                "QUIC endpoint public address varies by probe destination — \
+                 address-dependent NAT, direct UDP unavailable"
+            );
+            ReportVerdict::Settled(None)
+        }
+        Err(ObservedAddrReject::NoGlobalIpv4) => ReportVerdict::KeepWaiting,
+    }
+}
+
+/// Discover a public IPv4 address to advertise as this node's direct path.
+///
+/// With relays configured, this waits for a net report and uses the address a
+/// remote server observed. With relays disabled there is nobody to probe, so it
+/// falls back to interface enumeration and marks the result unverified.
+pub(crate) async fn stun_public_addr(
+    endpoint: &iroh::Endpoint,
+    relay_policy: RelayPolicy,
+) -> Option<PublicAddr> {
+    if !relay_policy.uses_relay() {
+        // No relay map means no QAD probe target, so `global_v4` will never be
+        // populated. Preserve the previous enumerated behaviour rather than
+        // regressing relay-disabled hosts to no direct address at all.
+        let addr = enumerated_public_ipv4(&endpoint.addr())?;
+        tracing::info!(
+            %addr,
+            "Public address from local interfaces; port unverified (no relay to probe from)"
+        );
+        return Some(PublicAddr {
+            addr,
+            source: PublicAddrSource::LocallyEnumerated,
+        });
+    }
+
+    let mut reports = endpoint.net_report();
     let deadline =
         tokio::time::Instant::now() + std::time::Duration::from_secs(iroh::NET_REPORT_TIMEOUT);
 
     loop {
-        if let Some(addr) = public_ipv4_addr(&addresses.get()) {
-            tracing::info!(%addr, "QUIC endpoint discovered public address");
-            return Some(addr);
+        if let ReportVerdict::Settled(addr) = verdict_for(reports.get().as_ref()) {
+            return addr;
         }
 
         let remaining = deadline
             .checked_duration_since(tokio::time::Instant::now())
             .unwrap_or_default();
-        match tokio::time::timeout(remaining, addresses.updated()).await {
+        match tokio::time::timeout(remaining, reports.updated()).await {
             Ok(Ok(_)) => {}
             Ok(Err(_)) | Err(_) => {
-                tracing::warn!("QUIC endpoint could not discover a public address");
+                tracing::warn!("QUIC endpoint could not observe a public address");
                 return None;
             }
         }
@@ -35,22 +140,74 @@ pub(crate) async fn stun_public_addr(endpoint: &iroh::Endpoint) -> Option<std::n
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::net::SocketAddrV4;
 
-    #[test]
-    fn preserves_port_discovered_by_quic_endpoint() {
-        let endpoint_id = iroh::SecretKey::generate().public();
-        let mapped = std::net::SocketAddr::from(([9, 9, 9, 9], 45_678));
-        let endpoint_addr = iroh::EndpointAddr::new(endpoint_id).with_ip_addr(mapped);
-
-        assert_eq!(public_ipv4_addr(&endpoint_addr), Some(mapped));
+    fn report_with(
+        global_v4: Option<SocketAddrV4>,
+        varies: Option<bool>,
+    ) -> iroh::unstable_net_report::NetReport {
+        let mut report = iroh::unstable_net_report::NetReport::default();
+        report.udp_v4 = global_v4.is_some();
+        report.global_v4 = global_v4;
+        report.mapping_varies_by_dest_ipv4 = varies;
+        report
     }
 
     #[test]
-    fn ignores_local_quic_endpoint_addresses() {
-        let endpoint_id = iroh::SecretKey::generate().public();
-        let endpoint_addr = iroh::EndpointAddr::new(endpoint_id)
-            .with_ip_addr(std::net::SocketAddr::from(([192, 168, 1, 8], 45_678)));
+    fn uses_externally_observed_mapped_port() {
+        // The container bound 41842; the observed port is Vast's remap, 23555.
+        let observed = SocketAddrV4::new([213, 5, 72, 196].into(), 23_555);
+        assert_eq!(
+            observed_public_ipv4(&report_with(Some(observed), Some(false))),
+            Ok(std::net::SocketAddr::V4(observed))
+        );
+    }
 
-        assert_eq!(public_ipv4_addr(&endpoint_addr), None);
+    #[test]
+    fn rejects_report_without_global_ipv4() {
+        assert_eq!(
+            observed_public_ipv4(&report_with(None, Some(false))),
+            Err(ObservedAddrReject::NoGlobalIpv4)
+        );
+    }
+
+    #[test]
+    fn rejects_address_dependent_mapping() {
+        let observed = SocketAddrV4::new([213, 5, 72, 196].into(), 23_555);
+        assert_eq!(
+            observed_public_ipv4(&report_with(Some(observed), Some(true))),
+            Err(ObservedAddrReject::MappingVariesByDestination)
+        );
+    }
+
+    #[test]
+    fn accepts_when_variance_is_unknown() {
+        // A single-probe report leaves variance unmeasured; that is not evidence of
+        // address-dependent NAT, so the observed address is still usable.
+        let observed = SocketAddrV4::new([173, 239, 92, 155].into(), 41_842);
+        assert_eq!(
+            observed_public_ipv4(&report_with(Some(observed), None)),
+            Ok(std::net::SocketAddr::V4(observed))
+        );
+    }
+
+    #[test]
+    fn enumerates_public_candidate_when_no_relay_can_be_probed() {
+        let endpoint_id = iroh::SecretKey::generate().public();
+        let public = std::net::SocketAddr::from(([9, 9, 9, 9], 45_678));
+        let addr = iroh::EndpointAddr::new(endpoint_id)
+            .with_ip_addr(std::net::SocketAddr::from(([192, 168, 1, 8], 45_678)))
+            .with_ip_addr(public);
+
+        assert_eq!(enumerated_public_ipv4(&addr), Some(public));
+    }
+
+    #[test]
+    fn enumeration_ignores_private_candidates() {
+        let endpoint_id = iroh::SecretKey::generate().public();
+        let addr = iroh::EndpointAddr::new(endpoint_id)
+            .with_ip_addr(std::net::SocketAddr::from(([172, 17, 0, 2], 41_842)));
+
+        assert_eq!(enumerated_public_ipv4(&addr), None);
     }
 }


### PR DESCRIPTION
## What changes for users

A node running inside a container whose UDP port is remapped by the host (Vast.ai and similar cloud GPU providers) is now reachable directly by its peers. Previously such a node advertised the port it bound *inside* the container, so no peer could reach it and every mesh split silently fell back to the relay — adding ~52 ms per boundary crossing and making split throughput numbers meaningless.

When a node's address cannot support a direct path, it now says so instead of advertising something unverified:

```
WARN QUIC endpoint public address varies by probe destination — address-dependent NAT, direct UDP unavailable
```

Fixes #1300.

## Architecture

`mesh::stun::stun_public_addr` previously took the first globally-routable IPv4 from `endpoint.watch_addr()`. That set is **local interface enumeration**, so a locally-enumerated candidate and an externally-observed one are the same type and indistinguishable. On a container holding a public IP on its own interface, the local candidate wins — carrying the container's port, not the host's mapped port.

Three changes:

1. **Observed address, where one exists.** With relays configured, discovery reads `endpoint.net_report()`. `Report::global_v4` is set from a QAD probe reply (`iroh-1.0.3/src/net_report/report.rs:81-99`), i.e. the address a relay observed us from, so it carries the NAT-mapped port by construction rather than by inference.

2. **Explicit rejection instead of silent wrong answers.** `mapping_varies_by_dest_ipv4 == Some(true)` means iroh saw *different* addresses from different relays (`report.rs:88-95`) — address-dependent NAT, not hole-punchable — so it is rejected with a warning rather than advertised. Variance being *unmeasured* (`None`) is not evidence of that and is still accepted.

3. **The source is now in the type.** `PublicAddr { addr, source: Observed | LocallyEnumerated }` replaces a bare `SocketAddr`, because the bug was precisely that the two were indistinguishable. `invite_token` uses it: an `Observed` address *replaces* any enumerated public candidate in the advertised set; a `LocallyEnumerated` one only fills a gap, preserving today's behaviour.

### Relay-disabled hosts keep working

Net reports probe *through relays*. With `RelayMode::Disabled` the relay map is empty, no QAD probe runs, and `global_v4` is never populated — so a net-report-only implementation would have left LAN-only and relay-disabled nodes with **no** public address at all, a regression. Those hosts fall back to interface enumeration and log that the port is unverified. Reviewers should check this reasoning specifically; it is the part most likely to be wrong.

### Cost: an unstable iroh feature

`Endpoint::net_report()` is gated behind iroh's `unstable-net-report`, explicitly outside semver ("may change in any release without a major version bump"). Enabled on `mesh-llm-host-runtime` only. The alternative is keeping a discovery path that cannot distinguish observed from enumerated addresses, which is the defect. **This is a maintainer call, not mine.**

## Protocol

No wire change. The advertised direct address is an existing gossip field; only its derivation changes, and the set now excludes a stale enumerated candidate when a verified one exists. Older peers see a reachable address where they previously saw an unreachable one.

## Dependency commitment — requires an unstable iroh feature

This enables `unstable-net-report` on `mesh-llm-host-runtime` only:

```toml
-iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
+iroh = { version = "1.0.3", default-features = false, features = [..., "unstable-net-report"] }
```

iroh documents that surface as exempt from semantic versioning (`iroh-1.0.3/src/lib.rs:294-299`):

> *"This API is unstable and gated behind the `unstable-net-report` feature. It is not covered by semantic versioning guarantees and may change in any release without a major version bump."*

`observed_public_ipv4` reads `report.global_v4` and `report.mapping_varies_by_dest_ipv4` directly, so **a patch-level iroh bump can break the build or silently change field semantics.** Any pinned-iroh bump must re-verify both fields.

This is a deliberate maintenance commitment, not an oversight: there is no stable iroh API exposing the externally-observed tuple, so the alternative is not addressing #1300 at all. Flagging it so a reviewer accepts it knowingly rather than discovering it at the next dependency bump. Raised by @Dario in review.

## Validation

- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings` — clean
- `cargo test -p mesh-llm-host-runtime --lib` — **2475 passed, 0 failed**
- `cargo fmt --all --check` — clean

Six unit tests cover the decision, including the exact Estonia shape (bound 41842, observed 23555). The previous test could not have caught this bug: it *constructed* the address it then asserted on, so it never exercised the observed-vs-enumerated distinction.

**Not validated on hardware.** Proving the direct path end-to-end needs a cross-host run on a port-remapping provider. Do not read this as field-proven.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved public address detection and NAT-mapped port reporting.
  * Added more reliable handling for relay-enabled and relay-disabled network configurations.
  * Prevented destination-dependent address mappings from being used.
  * Improved invite address selection to avoid conflicting or redundant public IPv4 addresses.
  * Added fallback behavior when remote network observations are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->