### PR TITLE
Return IDs for OpenAI tool calls on local-model-only serving

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/streaming.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/streaming.rs
@@ -1152,6 +1152,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn chat_sse_preserves_worker_assigned_tool_call_ids() {
+        // skippy-server assigns `call_<uuid>` before the body reaches MoA.
+        // The SSE adapter must forward that id rather than substituting its
+        // `call_0` fallback, so the client can pair its tool result.
+        let response = serde_json::json!({
+            "id": "chatcmpl-moa-tool",
+            "object": "chat.completion",
+            "model": "mesh",
+            "choices": [{
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": null,
+                    "tool_calls": [{
+                        "id": "call_d3af7876d2c44ea19baff5339fb53b1b",
+                        "type": "function",
+                        "function": {"name": "read", "arguments": "{\"path\":\"/x\"}"}
+                    }]
+                },
+                "finish_reason": "tool_calls"
+            }]
+        });
+        let raw = capture_chat_sse_body(response).await;
+        assert!(
+            raw.contains("call_d3af7876d2c44ea19baff5339fb53b1b"),
+            "worker tool_call id must survive the SSE adapter\nraw: {raw}"
+        );
+        assert!(
+            !raw.contains("\"id\":\"call_0\""),
+            "SSE adapter must not fall back to call_0 when an id is present\nraw: {raw}"
+        );
+    }
+
+    #[tokio::test]
     async fn responses_sse_emits_multiple_deltas_for_long_content() {
         let long_content = "Hello world. ".repeat(40);
         let response = serde_json::json!({

--- a/crates/mesh-llm-host-runtime/src/network/openai/tool_call_ids.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/tool_call_ids.rs
@@ -184,6 +184,39 @@ mod tests {
     }
 
     #[test]
+    fn chat_completion_json_normalizer_preserves_skippy_assigned_tool_call_ids() {
+        // skippy-server now assigns `call_<uuid>` before the body reaches the
+        // proxy. The front door must pass those through untouched rather than
+        // rewriting them to `call_mesh_*`, so a client that already saw the id
+        // in a streamed chunk can still pair its tool result.
+        let body = br#"{"id":"chatcmpl-a","object":"chat.completion","choices":[{"message":{"tool_calls":[{"id":"call_d3af7876d2c44ea19baff5339fb53b1b","type":"function","function":{"name":"read_file","arguments":"{}"}}]}}]}"#;
+        let normalized = normalize_chat_completion_json_body(body).unwrap();
+        let parsed: serde_json::Value = serde_json::from_slice(&normalized).unwrap();
+
+        assert_eq!(
+            parsed["choices"][0]["message"]["tool_calls"][0]["id"],
+            "call_d3af7876d2c44ea19baff5339fb53b1b"
+        );
+    }
+
+    #[test]
+    fn chat_stream_normalizer_preserves_skippy_assigned_tool_call_ids() {
+        let mut state = ChatStreamNormalizationState {
+            synthetic_seed: Some(42),
+            ..Default::default()
+        };
+        let normalized = state.normalize_data(
+            r#"{"id":"chatcmpl-a","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"tool_calls":[{"index":0,"id":"call_d3af7876d2c44ea19baff5339fb53b1b","type":"function","function":{"name":"read_file","arguments":"{}"}}]},"finish_reason":null}]}"#,
+        );
+        let parsed: serde_json::Value = serde_json::from_str(&normalized).unwrap();
+
+        assert_eq!(
+            parsed["choices"][0]["delta"]["tool_calls"][0]["id"],
+            "call_d3af7876d2c44ea19baff5339fb53b1b"
+        );
+    }
+
+    #[test]
     fn chat_completion_json_normalizer_keeps_ids_unique_across_choices() {
         let body = br#"{"id":"chatcmpl-a","object":"chat.completion","choices":[{"message":{"tool_calls":[{"type":"function","function":{"name":"first","arguments":"{}"}},{"type":"function","function":{"name":"second","arguments":"{}"}}]}},{"message":{"tool_calls":[{"type":"function","function":{"name":"third","arguments":"{}"}}]}}]}"#;
         let normalized = normalize_chat_completion_json_body(body).unwrap();

--- a/crates/skippy-server/src/frontend/generation/parsing.rs
+++ b/crates/skippy-server/src/frontend/generation/parsing.rs
@@ -17,6 +17,7 @@ use skippy_runtime::ChatTemplateOptions;
 use skippy_runtime::GenerationSignalWindow;
 use skippy_runtime::MediaInput;
 use std::collections::BTreeMap;
+use std::collections::HashSet;
 
 pub(in crate::frontend) fn ensure_requested_model(
     advertised_model_id: &str,
@@ -301,19 +302,24 @@ pub(in crate::frontend) fn parsed_tool_calls_from_message_value(
 }
 
 pub(in crate::frontend) fn ensure_tool_call_ids(tool_calls: &mut [Value]) {
+    let mut emitted_ids = HashSet::new();
     for tool_call in tool_calls {
         let Some(object) = tool_call.as_object_mut() else {
             continue;
         };
-        let has_valid_id = object
+        let valid_unseen_id = object
             .get("id")
             .and_then(Value::as_str)
-            .is_some_and(|id| !id.trim().is_empty());
-        if !has_valid_id {
-            object.insert(
-                "id".to_string(),
-                Value::String(format!("call_{}", uuid::Uuid::new_v4().simple())),
-            );
+            .filter(|id| !id.trim().is_empty())
+            .filter(|id| emitted_ids.insert((*id).to_string()));
+        if valid_unseen_id.is_none() {
+            let id = loop {
+                let candidate = format!("call_{}", uuid::Uuid::new_v4().simple());
+                if emitted_ids.insert(candidate.clone()) {
+                    break candidate;
+                }
+            };
+            object.insert("id".to_string(), Value::String(id));
         }
     }
 }

--- a/crates/skippy-server/src/frontend/generation/parsing.rs
+++ b/crates/skippy-server/src/frontend/generation/parsing.rs
@@ -293,10 +293,29 @@ pub(in crate::frontend) fn parsed_tool_calls_from_message_value(
     if tool_calls.is_empty() {
         return None;
     }
+    ensure_tool_call_ids(&mut tool_calls);
     Some(ParsedToolCalls {
         content: string_field(value, "content"),
         tool_calls: Value::Array(tool_calls),
     })
+}
+
+pub(in crate::frontend) fn ensure_tool_call_ids(tool_calls: &mut [Value]) {
+    for tool_call in tool_calls {
+        let Some(object) = tool_call.as_object_mut() else {
+            continue;
+        };
+        let has_valid_id = object
+            .get("id")
+            .and_then(Value::as_str)
+            .is_some_and(|id| !id.trim().is_empty());
+        if !has_valid_id {
+            object.insert(
+                "id".to_string(),
+                Value::String(format!("call_{}", uuid::Uuid::new_v4().simple())),
+            );
+        }
+    }
 }
 
 pub(in crate::frontend) fn string_field(value: &Value, field: &str) -> Option<String> {

--- a/crates/skippy-server/src/frontend/prompting.rs
+++ b/crates/skippy-server/src/frontend/prompting.rs
@@ -322,6 +322,7 @@ pub(super) fn parse_emulated_chat_output(
         if request.parallel_tool_calls == Some(false) {
             calls.truncate(1);
         }
+        crate::frontend::generation::ensure_tool_call_ids(&mut calls);
         Some(Value::Array(calls))
     };
     Some(ParsedChatMessage {

--- a/crates/skippy-server/src/frontend/tests/prompting.rs
+++ b/crates/skippy-server/src/frontend/tests/prompting.rs
@@ -108,6 +108,23 @@ fn assigns_id_when_llama_message_tool_call_omits_it() {
 }
 
 #[test]
+fn assigns_unique_ids_when_llama_message_tool_calls_repeat_an_id() {
+    let mut request = tool_request();
+    request.parallel_tool_calls = Some(true);
+    let parsed = parsed_tool_calls_from_message_json(
+        r#"{"role":"assistant","content":null,"tool_calls":[{"id":"call_duplicate","type":"function","function":{"name":"lookup","arguments":"{\"city\":\"Sydney\"}"}},{"id":"call_duplicate","type":"function","function":{"name":"lookup","arguments":"{\"city\":\"Melbourne\"}"}}]}"#,
+        &request,
+    )
+    .expect("tool calls");
+
+    let first_id = parsed.tool_calls[0]["id"].as_str().expect("first id");
+    let second_id = parsed.tool_calls[1]["id"].as_str().expect("second id");
+    assert_eq!(first_id, "call_duplicate");
+    assert!(second_id.starts_with("call_"));
+    assert_ne!(first_id, second_id);
+}
+
+#[test]
 fn parses_llama_message_reasoning_content() {
     let parsed = parsed_chat_message_from_json(
         r#"{"role":"assistant","reasoning_content":"Checked facts first.","content":"Final answer."}"#,

--- a/crates/skippy-server/src/frontend/tests/prompting.rs
+++ b/crates/skippy-server/src/frontend/tests/prompting.rs
@@ -96,6 +96,18 @@ fn parses_llama_message_tool_calls() {
 }
 
 #[test]
+fn assigns_id_when_llama_message_tool_call_omits_it() {
+    let parsed = parsed_tool_calls_from_message_json(
+        r#"{"role":"assistant","content":null,"tool_calls":[{"type":"function","function":{"name":"lookup","arguments":"{\"city\":\"Sydney\"}"}}]}"#,
+        &tool_request(),
+    )
+    .expect("tool call");
+
+    let id = parsed.tool_calls[0]["id"].as_str().expect("tool call id");
+    assert!(id.starts_with("call_"));
+}
+
+#[test]
 fn parses_llama_message_reasoning_content() {
     let parsed = parsed_chat_message_from_json(
         r#"{"role":"assistant","reasoning_content":"Checked facts first.","content":"Final answer."}"#,
@@ -426,6 +438,7 @@ fn emulated_output_final_parses_tool_call() {
     assert_eq!(parsed.content.as_deref(), Some("Let me check."));
     let calls = parsed.tool_calls.expect("tool calls");
     assert_eq!(calls[0]["function"]["name"], "lookup");
+    assert!(calls[0]["id"].as_str().unwrap().starts_with("call_"));
     let args: serde_json::Value =
         serde_json::from_str(calls[0]["function"]["arguments"].as_str().unwrap()).unwrap();
     assert_eq!(args["city"], "Sydney");


### PR DESCRIPTION
OpenAI-compatible clients now get an `id` on every returned tool call, so they can pair the follow-up `role: "tool"` message with the call that produced it — including on `serve --local-model-only`, where they previously got none.

`skippy-server` preserves a valid, unique model-provided id and mints `call_<uuid>` for an absent, blank, or duplicate one, on both the native-template and emulated tool-call paths. Streaming and non-streaming responses share the same normalized calls.

## Why this is needed after #658

#658 added a tool-call ID normalizer in the host-runtime OpenAI layer (`network/openai/tool_call_ids.rs`). Its only consumers are `response/json_adaptation.rs:101` and `response/stream_translation.rs:84`, both inside `network/openai/ingress.rs::api_proxy` — and `api_proxy` is spawned from exactly one site, `runtime/serving_surface.rs:1215`, the mesh serving surface.

`serve --local-model-only` never reaches it. That topology binds skippy's HTTP listener straight onto the user-facing `--port` (`runtime/local_model_only.rs:222-229` → `runtime/local.rs:749`/`:871`); the ephemeral inner port allocated at `runtime/local.rs:550` is a mesh-path-only construct. So on this documented mode (`README.md:88`, `:118-138`) there is no proxy in the path and no normalizer, and skippy itself never minted an id — `frontend/tool_emulation.rs:498` says so in its own comment: *"Returns the tool-call object without an id; downstream assembly assigns `call_mesh_*` ids."* Downstream does not exist here.

Assigning in `skippy-server` is the only single place that covers both topologies.

## Front door and MoA are unaffected

Both already supply an id and continue to. This PR adds tests that pin the passthrough, because skippy now sends an id where those layers previously saw none:

- front door, buffered and streaming: a skippy-assigned `call_<uuid>` is preserved rather than rewritten to `call_mesh_*` (the existing `has_id` / `tool_call_id` guards already did this; now asserted)
- MoA chat SSE: the worker's id is forwarded rather than replaced by the adapter's `call_0` fallback (`moa_gateway/streaming.rs:228-240`)

No behavior change on either path.

## Validation

At `a2f58e50`, rebased onto `main` @ `1854b527`:

- `cargo test -p skippy-server` — 447 passed
- `cargo test -p mesh-llm-host-runtime --lib` — 2480 passed, 8 ignored
- `cargo clippy -p skippy-server --all-targets -- -D warnings` — clean
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings` — clean
- `cargo fmt --all -- --check` — clean

CodeRabbit's earlier duplicate-ID feedback is addressed in `a96d4e8b` (HashSet dedupe plus a regression test for a model that repeats an id).

### Scope of evidence

Unit and integration tests only. This revision was not exercised against a live model — the lab hardware is in use for unrelated work. The prior revision (`04cbd61e`, identical `skippy-server` change) was validated end to end on Apple Silicon with a strict agent fixture that performs no client-side ID synthesis: first response returned `finish_reason: tool_calls` with a generated `call_<uuid>`, the tool executed, the second response returned the expected value, and the session completed with `stopReason: end_turn`. The commit added since then is tests only.

A live `--local-model-only` reproduction of the original missing-`id` response has not been captured; the claim that the normalizer is absent on that path is a source trace, cited above.

Closes #1303.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool calls now consistently receive unique, non-empty identifiers.
  * Existing valid tool-call IDs are preserved, including IDs assigned during streaming.
  * Missing, duplicate, or invalid IDs are automatically replaced with generated `call_...` identifiers.
  * Invalid non-object tool-call values are safely ignored.

* **Tests**
  * Added coverage for emulated, parallel, JSON, and streaming tool-call scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->