### PR TITLE
CI: pin Depot audit to merged policy

### DIFF
--- a/.github/actions/audit-depot-pr-isolation/action.yml
+++ b/.github/actions/audit-depot-pr-isolation/action.yml
@@ -152,27 +152,94 @@ runs:
           fi
         done
 
+        # Docker configuration is parsed with the runner's Python 3 standard
+        # library.  The audit runs before checkout/setup steps, so do not rely
+        # on a repository virtualenv or a package installed by the job.  The
+        # hosted GitHub images and the pinned Depot runner image both provide
+        # python3/python; an unexpected image without either fails closed.
+        python_bin=""
+        for candidate in python3 python; do
+          if command -v "$candidate" >/dev/null 2>&1; then
+            python_bin="$(command -v "$candidate")"
+            break
+          fi
+        done
+        if [[ -z "$python_bin" ]]; then
+          echo "Docker auth JSON audit requires Python 3 on the runner (runtime)" >&2
+          exit 1
+        fi
+        if ! "$python_bin" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 6) else 1)' >/dev/null 2>&1; then
+          echo "Docker auth JSON audit requires Python 3.6 or newer (runtime)" >&2
+          exit 1
+        fi
         docker_config="${DOCKER_CONFIG:-${HOME:-}/.docker}/config.json"
         docker_auth_config="${DOCKER_AUTH_CONFIG:-}"
-        if [[ "$depot_selected" == "true" ]]; then
-          if [[ -n "$docker_auth_config" ]]; then
-            echo "PR runner has Docker registry authentication configured (DOCKER_AUTH_CONFIG)" >&2
-            exit 1
-          fi
-          if [[ -f "$docker_config" ]] &&
-             grep -Eiq '"(auths|credHelpers|credsStore)"[[:space:]]*:' "$docker_config"; then
-            echo "PR runner has Docker registry authentication configured (config.json)" >&2
-            exit 1
-          fi
-        else
-          if [[ -n "$docker_auth_config" ]] &&
-             printf '%s' "$docker_auth_config" | grep -Eiq 'depot[.]dev'; then
-            echo "Hosted PR runner has Depot Docker registry authentication configured (DOCKER_AUTH_CONFIG)" >&2
-            exit 1
-          fi
-          if [[ -f "$docker_config" ]] &&
-             grep -Eiq 'depot[.]dev' "$docker_config"; then
-            echo "Hosted PR runner has Depot Docker registry authentication configured (config.json)" >&2
-            exit 1
-          fi
-        fi
+        AUDIT_DOCKER_AUTH_CONFIG="$docker_auth_config" \
+          AUDIT_DOCKER_CONFIG_PATH="$docker_config" \
+          AUDIT_DEPOT_SELECTED="$depot_selected" \
+          "$python_bin" - <<'PY'
+        import json
+        import os
+        import sys
+
+        depot_selected = os.environ.get("AUDIT_DEPOT_SELECTED", "")
+        auth_config = os.environ.get("AUDIT_DOCKER_AUTH_CONFIG", "")
+        config_path = os.environ.get("AUDIT_DOCKER_CONFIG_PATH", "")
+
+        def fail(message):
+            print(message, file=sys.stderr)
+            raise SystemExit(1)
+
+        def reject_constant(value):
+            raise ValueError(f"non-standard JSON constant: {value}")
+
+        def parse_source(label, raw):
+            try:
+                document = json.loads(raw, parse_constant=reject_constant)
+            except (TypeError, ValueError, RecursionError):
+                fail(f"PR runner Docker auth JSON is malformed ({label})")
+            if not isinstance(document, dict):
+                fail(f"PR runner Docker auth JSON is malformed ({label})")
+
+            if depot_selected == "true":
+                # Preserve the strict Depot policy: a Docker auth/config
+                # section is forbidden even when it is empty.  A valid config
+                # without any auth section remains an inert Docker config.
+                if any(name in document for name in ("auths", "credHelpers", "credsStore")):
+                    fail(f"PR runner has Docker registry authentication configured ({label})")
+                return
+
+            for name in ("auths", "credHelpers"):
+                if name not in document:
+                    continue
+                section = document[name]
+                if not isinstance(section, dict):
+                    fail(f"PR runner Docker auth JSON is malformed ({label})")
+                if any("depot.dev" in key.casefold() for key in section):
+                    fail(
+                        "Hosted PR runner has Depot Docker registry authentication "
+                        f"configured ({label})"
+                    )
+            if "credsStore" in document:
+                store = document["credsStore"]
+                if not isinstance(store, str):
+                    fail(f"PR runner Docker auth JSON is malformed ({label})")
+                if "depot.dev" in store.casefold():
+                    fail(
+                        "Hosted PR runner has Depot Docker registry authentication "
+                        f"configured ({label})"
+                    )
+
+        if depot_selected == "true" and auth_config:
+            fail("PR runner has Docker registry authentication configured (DOCKER_AUTH_CONFIG)")
+        if auth_config:
+            parse_source("DOCKER_AUTH_CONFIG", auth_config)
+        if os.path.isfile(config_path):
+            try:
+                with open(config_path, "r", encoding="utf-8") as config_file:
+                    parse_source("config.json", config_file.read())
+            except UnicodeError:
+                fail("PR runner Docker auth JSON is malformed (config.json)")
+            except OSError:
+                fail("PR runner Docker auth JSON could not be read (config.json)")
+        PY

--- a/.github/actions/audit-depot-pr-isolation/action.yml
+++ b/.github/actions/audit-depot-pr-isolation/action.yml
@@ -152,15 +152,27 @@ runs:
           fi
         done
 
-        docker_auth_config="${DOCKER_AUTH_CONFIG:-}"
-        if [[ -n "$docker_auth_config" ]]; then
-          echo "PR runner has Docker registry authentication configured (DOCKER_AUTH_CONFIG)" >&2
-          exit 1
-        fi
-
         docker_config="${DOCKER_CONFIG:-${HOME:-}/.docker}/config.json"
-        if [[ -f "$docker_config" ]] &&
-           grep -Eiq '"(auths|credHelpers|credsStore)"[[:space:]]*:' "$docker_config"; then
-          echo "PR runner has Docker registry authentication configured (config.json)" >&2
-          exit 1
+        docker_auth_config="${DOCKER_AUTH_CONFIG:-}"
+        if [[ "$depot_selected" == "true" ]]; then
+          if [[ -n "$docker_auth_config" ]]; then
+            echo "PR runner has Docker registry authentication configured (DOCKER_AUTH_CONFIG)" >&2
+            exit 1
+          fi
+          if [[ -f "$docker_config" ]] &&
+             grep -Eiq '"(auths|credHelpers|credsStore)"[[:space:]]*:' "$docker_config"; then
+            echo "PR runner has Docker registry authentication configured (config.json)" >&2
+            exit 1
+          fi
+        else
+          if [[ -n "$docker_auth_config" ]] &&
+             printf '%s' "$docker_auth_config" | grep -Eiq 'depot[.]dev'; then
+            echo "Hosted PR runner has Depot Docker registry authentication configured (DOCKER_AUTH_CONFIG)" >&2
+            exit 1
+          fi
+          if [[ -f "$docker_config" ]] &&
+             grep -Eiq 'depot[.]dev' "$docker_config"; then
+            echo "Hosted PR runner has Depot Docker registry authentication configured (config.json)" >&2
+            exit 1
+          fi
         fi

--- a/.github/workflows/ci-linux-host-slice.yml
+++ b/.github/workflows/ci-linux-host-slice.yml
@@ -106,7 +106,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_8, 'depot-') }}

--- a/.github/workflows/ci-linux-host-slice.yml
+++ b/.github/workflows/ci-linux-host-slice.yml
@@ -106,7 +106,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_8, 'depot-') }}

--- a/.github/workflows/ci-linux-host-slice.yml
+++ b/.github/workflows/ci-linux-host-slice.yml
@@ -106,7 +106,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_8, 'depot-') }}

--- a/.github/workflows/ci-linux-product-slice.yml
+++ b/.github/workflows/ci-linux-product-slice.yml
@@ -84,7 +84,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/ci-linux-product-slice.yml
+++ b/.github/workflows/ci-linux-product-slice.yml
@@ -84,7 +84,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/ci-linux-product-slice.yml
+++ b/.github/workflows/ci-linux-product-slice.yml
@@ -84,7 +84,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/ci-linux-runtime-slice.yml
+++ b/.github/workflows/ci-linux-runtime-slice.yml
@@ -104,7 +104,7 @@ jobs:
       LLAMA_STAGE_SKIP_NCCL: "1"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_16, 'depot-') }}

--- a/.github/workflows/ci-linux-runtime-slice.yml
+++ b/.github/workflows/ci-linux-runtime-slice.yml
@@ -104,7 +104,7 @@ jobs:
       LLAMA_STAGE_SKIP_NCCL: "1"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_16, 'depot-') }}

--- a/.github/workflows/ci-linux-runtime-slice.yml
+++ b/.github/workflows/ci-linux-runtime-slice.yml
@@ -104,7 +104,7 @@ jobs:
       LLAMA_STAGE_SKIP_NCCL: "1"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_16, 'depot-') }}

--- a/.github/workflows/ci-macos-host-slice.yml
+++ b/.github/workflows/ci-macos-host-slice.yml
@@ -91,7 +91,7 @@ jobs:
       matrix:
         host: ${{ fromJson(inputs.hosts_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-host-slice.yml
+++ b/.github/workflows/ci-macos-host-slice.yml
@@ -91,7 +91,7 @@ jobs:
       matrix:
         host: ${{ fromJson(inputs.hosts_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-host-slice.yml
+++ b/.github/workflows/ci-macos-host-slice.yml
@@ -91,7 +91,7 @@ jobs:
       matrix:
         host: ${{ fromJson(inputs.hosts_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-product-slice.yml
+++ b/.github/workflows/ci-macos-product-slice.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         runtime: ${{ fromJson(inputs.runtime_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-product-slice.yml
+++ b/.github/workflows/ci-macos-product-slice.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         runtime: ${{ fromJson(inputs.runtime_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-product-slice.yml
+++ b/.github/workflows/ci-macos-product-slice.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         runtime: ${{ fromJson(inputs.runtime_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-runtime-slice.yml
+++ b/.github/workflows/ci-macos-runtime-slice.yml
@@ -85,7 +85,7 @@ jobs:
       LLAMA_STAGE_BACKEND: ${{ matrix.runtime.backend }}
       LLAMA_STAGE_BUILD_DIR: ${{ matrix.runtime.build_dir }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-runtime-slice.yml
+++ b/.github/workflows/ci-macos-runtime-slice.yml
@@ -85,7 +85,7 @@ jobs:
       LLAMA_STAGE_BACKEND: ${{ matrix.runtime.backend }}
       LLAMA_STAGE_BUILD_DIR: ${{ matrix.runtime.build_dir }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-runtime-slice.yml
+++ b/.github/workflows/ci-macos-runtime-slice.yml
@@ -85,7 +85,7 @@ jobs:
       LLAMA_STAGE_BACKEND: ${{ matrix.runtime.backend }}
       LLAMA_STAGE_BUILD_DIR: ${{ matrix.runtime.build_dir }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-platform-checks-slice.yml
+++ b/.github/workflows/ci-platform-checks-slice.yml
@@ -98,7 +98,7 @@ jobs:
       matrix:
         check: ${{ fromJson(inputs.platform_checks_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(fromJSON(needs.runner_policy.outputs.runner_by_platform)[matrix.check.platform], 'depot-') }}

--- a/.github/workflows/ci-platform-checks-slice.yml
+++ b/.github/workflows/ci-platform-checks-slice.yml
@@ -98,7 +98,7 @@ jobs:
       matrix:
         check: ${{ fromJson(inputs.platform_checks_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(fromJSON(needs.runner_policy.outputs.runner_by_platform)[matrix.check.platform], 'depot-') }}

--- a/.github/workflows/ci-platform-checks-slice.yml
+++ b/.github/workflows/ci-platform-checks-slice.yml
@@ -98,7 +98,7 @@ jobs:
       matrix:
         check: ${{ fromJson(inputs.platform_checks_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(fromJSON(needs.runner_policy.outputs.runner_by_platform)[matrix.check.platform], 'depot-') }}

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 20
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -129,7 +129,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 15
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -165,7 +165,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_8, 'depot-') }}
@@ -219,7 +219,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 5
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 20
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -129,7 +129,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 15
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -165,7 +165,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_8, 'depot-') }}
@@ -219,7 +219,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 5
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -92,7 +92,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 20
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -129,7 +129,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 15
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -165,7 +165,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_8, 'depot-') }}
@@ -219,7 +219,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 5
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -105,7 +105,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -105,7 +105,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -105,7 +105,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -74,7 +74,7 @@ jobs:
       run:
         working-directory: crates/mesh-llm-ui
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -74,7 +74,7 @@ jobs:
       run:
         working-directory: crates/mesh-llm-ui
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -74,7 +74,7 @@ jobs:
       run:
         working-directory: crates/mesh-llm-ui
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-web-slice.yml
+++ b/.github/workflows/ci-web-slice.yml
@@ -73,7 +73,7 @@ jobs:
       run:
         working-directory: crates/mesh-llm-ui
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -122,7 +122,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 20
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-web-slice.yml
+++ b/.github/workflows/ci-web-slice.yml
@@ -73,7 +73,7 @@ jobs:
       run:
         working-directory: crates/mesh-llm-ui
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -122,7 +122,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 20
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-web-slice.yml
+++ b/.github/workflows/ci-web-slice.yml
@@ -73,7 +73,7 @@ jobs:
       run:
         working-directory: crates/mesh-llm-ui
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -122,7 +122,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 20
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-windows-host-slice.yml
+++ b/.github/workflows/ci-windows-host-slice.yml
@@ -94,7 +94,7 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/ci-windows-host-slice.yml
+++ b/.github/workflows/ci-windows-host-slice.yml
@@ -94,7 +94,7 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/ci-windows-host-slice.yml
+++ b/.github/workflows/ci-windows-host-slice.yml
@@ -94,7 +94,7 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/ci-windows-product-slice.yml
+++ b/.github/workflows/ci-windows-product-slice.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         runtime: ${{ fromJson(inputs.runtime_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/ci-windows-product-slice.yml
+++ b/.github/workflows/ci-windows-product-slice.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         runtime: ${{ fromJson(inputs.runtime_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/ci-windows-product-slice.yml
+++ b/.github/workflows/ci-windows-product-slice.yml
@@ -77,7 +77,7 @@ jobs:
       matrix:
         runtime: ${{ fromJson(inputs.runtime_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/ci-windows-runtime-slice.yml
+++ b/.github/workflows/ci-windows-runtime-slice.yml
@@ -88,7 +88,7 @@ jobs:
       WINDOWS_VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION || '1.4.328.1' }}
       ROCM_HIP_SDK_FILENAME: AMD-Software-PRO-Edition-25.Q3-WinSvr2022-For-HIP.exe
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/ci-windows-runtime-slice.yml
+++ b/.github/workflows/ci-windows-runtime-slice.yml
@@ -88,7 +88,7 @@ jobs:
       WINDOWS_VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION || '1.4.328.1' }}
       ROCM_HIP_SDK_FILENAME: AMD-Software-PRO-Edition-25.Q3-WinSvr2022-For-HIP.exe
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/ci-windows-runtime-slice.yml
+++ b/.github/workflows/ci-windows-runtime-slice.yml
@@ -88,7 +88,7 @@ jobs:
       WINDOWS_VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION || '1.4.328.1' }}
       ROCM_HIP_SDK_FILENAME: AMD-Software-PRO-Edition-25.Q3-WinSvr2022-For-HIP.exe
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -218,7 +218,7 @@ jobs:
     env:
       LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-static
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}
@@ -326,7 +326,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -218,7 +218,7 @@ jobs:
     env:
       LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-static
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}
@@ -326,7 +326,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -218,7 +218,7 @@ jobs:
     env:
       LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-static
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}
@@ -326,7 +326,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/static-abi-artifact.yml
+++ b/.github/workflows/static-abi-artifact.yml
@@ -146,7 +146,7 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       SCCACHE_GHA_ENABLED: "true"
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/static-abi-artifact.yml
+++ b/.github/workflows/static-abi-artifact.yml
@@ -146,7 +146,7 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       SCCACHE_GHA_ENABLED: "true"
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/static-abi-artifact.yml
+++ b/.github/workflows/static-abi-artifact.yml
@@ -146,7 +146,7 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       SCCACHE_GHA_ENABLED: "true"
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -103,7 +103,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_RW_MODE: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event.inputs.original_event_name == 'pull_request' || github.event.inputs.original_event_name == 'pull_request_target') && 'READ_ONLY' || 'READ_WRITE' }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -103,7 +103,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_RW_MODE: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event.inputs.original_event_name == 'pull_request' || github.event.inputs.original_event_name == 'pull_request_target') && 'READ_ONLY' || 'READ_WRITE' }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -103,7 +103,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_RW_MODE: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event.inputs.original_event_name == 'pull_request' || github.event.inputs.original_event_name == 'pull_request_target') && 'READ_ONLY' || 'READ_WRITE' }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -38,7 +38,7 @@ class CiArtifactActionTests(unittest.TestCase):
         }
         protected_pre_checkout_action = (
             "Mesh-LLM/mesh-llm/.github/actions/"
-            "audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93"
+            "audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3"
         )
 
         for path in (*action_files, *workflow_files):

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -38,7 +38,7 @@ class CiArtifactActionTests(unittest.TestCase):
         }
         protected_pre_checkout_action = (
             "Mesh-LLM/mesh-llm/.github/actions/"
-            "audit-depot-pr-isolation@b5dc126b0abe9b990cccbbf65796c26af7a09dc8"
+            "audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a"
         )
 
         for path in (*action_files, *workflow_files):

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -38,7 +38,7 @@ class CiArtifactActionTests(unittest.TestCase):
         }
         protected_pre_checkout_action = (
             "Mesh-LLM/mesh-llm/.github/actions/"
-            "audit-depot-pr-isolation@7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a"
+            "audit-depot-pr-isolation@88be2089e9c900f9149db44c4c72a11f657a2a93"
         )
 
         for path in (*action_files, *workflow_files):

--- a/scripts/tests/test_depot_canary_workflow.py
+++ b/scripts/tests/test_depot_canary_workflow.py
@@ -105,6 +105,8 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
         self.assertIn("URL userinfo", action)
         self.assertIn('docker_config="${DOCKER_CONFIG:-${HOME:-}/.docker}/config.json"', action)
         self.assertIn('grep -Eiq \'"(auths|credHelpers|credsStore)"', action)
+        self.assertIn('if [[ "$depot_selected" == "true" ]]; then', action)
+        self.assertIn("grep -Eiq 'depot[.]dev'", action)
 
     def test_pr_audit_receives_central_runner_provider_selection(self) -> None:
         workflow_root = ROOT / ".github" / "workflows"
@@ -374,6 +376,39 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                     docker_config_content=safe_config,
                 )
                 self.assertNotEqual(result.returncode, 0)
+            if script_name == "audit action":
+                with self.subTest(script=script_name, provider="hosted", auth="DOCKER_AUTH_CONFIG"):
+                    result = run_probe(
+                        script,
+                        *valid_endpoints[0],
+                        docker_auth_config=safe_config,
+                        depot_selected="false",
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                with self.subTest(script=script_name, provider="hosted", auth="config.json"):
+                    result = run_probe(
+                        script,
+                        *valid_endpoints[0],
+                        docker_config_content=safe_config,
+                        depot_selected="false",
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                with self.subTest(script=script_name, provider="hosted", auth="DOCKER_AUTH_CONFIG depot.dev"):
+                    result = run_probe(
+                        script,
+                        *valid_endpoints[0],
+                        docker_auth_config=depot_auth,
+                        depot_selected="false",
+                    )
+                    self.assertNotEqual(result.returncode, 0)
+                with self.subTest(script=script_name, provider="hosted", auth="config.json depot.dev"):
+                    result = run_probe(
+                        script,
+                        *valid_endpoints[0],
+                        docker_config_content=depot_config,
+                        depot_selected="false",
+                    )
+                    self.assertNotEqual(result.returncode, 0)
             with self.subTest(script=script_name, auth="unset"):
                 result = run_probe(script, *valid_endpoints[0])
                 self.assertEqual(result.returncode, 0, result.stderr)

--- a/scripts/tests/test_depot_canary_workflow.py
+++ b/scripts/tests/test_depot_canary_workflow.py
@@ -104,9 +104,12 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
         self.assertIn("allow_depot_remote_cache", action)
         self.assertIn("URL userinfo", action)
         self.assertIn('docker_config="${DOCKER_CONFIG:-${HOME:-}/.docker}/config.json"', action)
-        self.assertIn('grep -Eiq \'"(auths|credHelpers|credsStore)"', action)
-        self.assertIn('if [[ "$depot_selected" == "true" ]]; then', action)
-        self.assertIn("grep -Eiq 'depot[.]dev'", action)
+        self.assertIn('python_bin=""', action)
+        self.assertIn('json.loads(raw, parse_constant=reject_constant)', action)
+        self.assertIn('casefold()', action)
+        self.assertIn('"auths", "credHelpers"', action)
+        self.assertIn("Docker auth JSON is malformed", action)
+        self.assertIn('depot_selected == "true"', action)
 
     def test_pr_audit_receives_central_runner_provider_selection(self) -> None:
         workflow_root = ROOT / ".github" / "workflows"
@@ -350,7 +353,10 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
 
         depot_auth = '{"auths":{"REGISTRY.DEPOT.DEV":{"auth":"secret"}}}'
         depot_config = '{"auths":{"registry.depot.dev":{"auth":"secret"}}}'
+        escaped_depot_auth = r'{"auths":{"registry\u002eDEPOT\u002eDEV":{"auth":"secret"}}}'
+        escaped_depot_helpers = r'{"credHelpers":{"REGISTRY\u002eDEPOT\u002eDEV":"secret"}}'
         safe_config = '{"auths":{"ghcr.io":{"auth":"secret"}}}'
+        malformed_config = '{"auths":'
         for script_name, script in (
             ("audit action", action_script),
             ("Depot canary", canary_script),
@@ -369,11 +375,42 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                     docker_config_content=depot_config,
                 )
                 self.assertNotEqual(result.returncode, 0)
+            for escaped_auth in (escaped_depot_auth, escaped_depot_helpers):
+                with self.subTest(script=script_name, auth="escaped DOCKER_AUTH_CONFIG"):
+                    result = run_probe(
+                        script,
+                        *valid_endpoints[0],
+                        docker_auth_config=escaped_auth,
+                    )
+                    self.assertNotEqual(result.returncode, 0)
+                with self.subTest(script=script_name, auth="escaped config.json"):
+                    result = run_probe(
+                        script,
+                        *valid_endpoints[0],
+                        docker_config_content=escaped_auth,
+                    )
+                    self.assertNotEqual(result.returncode, 0)
             with self.subTest(script=script_name, auth="any config.json"):
                 result = run_probe(
                     script,
                     *valid_endpoints[0],
                     docker_config_content=safe_config,
+                )
+                self.assertNotEqual(result.returncode, 0)
+            with self.subTest(script=script_name, auth="malformed DOCKER_AUTH_CONFIG"):
+                result = run_probe(
+                    script,
+                    *valid_endpoints[0],
+                    docker_auth_config=malformed_config,
+                    depot_selected="false" if script_name == "audit action" else "true",
+                )
+                self.assertNotEqual(result.returncode, 0)
+            with self.subTest(script=script_name, auth="malformed config.json"):
+                result = run_probe(
+                    script,
+                    *valid_endpoints[0],
+                    docker_config_content=malformed_config,
+                    depot_selected="false" if script_name == "audit action" else "true",
                 )
                 self.assertNotEqual(result.returncode, 0)
             if script_name == "audit action":
@@ -406,6 +443,39 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                         script,
                         *valid_endpoints[0],
                         docker_config_content=depot_config,
+                        depot_selected="false",
+                    )
+                    self.assertNotEqual(result.returncode, 0)
+                for escaped_auth in (escaped_depot_auth, escaped_depot_helpers):
+                    with self.subTest(script=script_name, provider="hosted", auth="escaped DOCKER_AUTH_CONFIG"):
+                        result = run_probe(
+                            script,
+                            *valid_endpoints[0],
+                            docker_auth_config=escaped_auth,
+                            depot_selected="false",
+                        )
+                        self.assertNotEqual(result.returncode, 0)
+                    with self.subTest(script=script_name, provider="hosted", auth="escaped config.json"):
+                        result = run_probe(
+                            script,
+                            *valid_endpoints[0],
+                            docker_config_content=escaped_auth,
+                            depot_selected="false",
+                        )
+                        self.assertNotEqual(result.returncode, 0)
+                with self.subTest(script=script_name, provider="hosted", auth="malformed DOCKER_AUTH_CONFIG"):
+                    result = run_probe(
+                        script,
+                        *valid_endpoints[0],
+                        docker_auth_config=malformed_config,
+                        depot_selected="false",
+                    )
+                    self.assertNotEqual(result.returncode, 0)
+                with self.subTest(script=script_name, provider="hosted", auth="malformed config.json"):
+                    result = run_probe(
+                        script,
+                        *valid_endpoints[0],
+                        docker_config_content=malformed_config,
                         depot_selected="false",
                     )
                     self.assertNotEqual(result.returncode, 0)


### PR DESCRIPTION
Repins all 22 protected Depot audit calls from the pre-squash commit to merged main commit 7df7e6fafa6c87ad0fac7d46dcb7c9ce5d64b01a. This fixes Windows runner setup failures fetching the old action archive. The change is mechanical only: no job, matrix, command, artifact, cache, or runner-policy shape changes. Validation: actionlint, 80 focused tests, audit-before-checkout census, and git diff check.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Updated pinned security and isolation checks across CI workflows and artifact builds on Linux, macOS, and Windows.
  - Applied the update consistently across SDK, platform, quality, and runtime validation jobs.

- **Bug Fixes**
  - Improved Docker authentication validation with structured JSON parsing.
  - Provider-specific checks now allow unrelated registry credentials while blocking Depot credentials and malformed configurations.

- **Tests**
  - Expanded coverage for provider selection, escaped registry keys, malformed authentication data, and Docker configuration scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->