### PR TITLE
CI: identify failing Depot canary endpoint

### DIFF
--- a/.github/workflows/depot-canary.yml
+++ b/.github/workflows/depot-canary.yml
@@ -138,16 +138,16 @@ jobs:
             # lookalike host suffixes.
             authority="$(endpoint_host "$endpoint_lower")"
             if [[ "$endpoint_lower" == *depot.dev* ]]; then
-              echo "GitHub Actions cache was transparently redirected to Depot (endpoint)" >&2
+              echo "GitHub Actions cache was transparently redirected to Depot ($endpoint_name)" >&2
               exit 1
             fi
             if [[ "$authority" == *"@"* ]]; then
-              echo "GitHub Actions endpoint contains URL userinfo (endpoint)" >&2
+              echo "GitHub Actions endpoint contains URL userinfo ($endpoint_name)" >&2
               exit 1
             fi
             if ! is_github_endpoint "$endpoint" &&
                ! is_loopback_endpoint "$endpoint"; then
-              echo "GitHub Actions endpoint is not GitHub-owned or loopback (endpoint)" >&2
+              echo "GitHub Actions endpoint is not GitHub-owned or loopback ($endpoint_name)" >&2
               exit 1
             fi
           done

--- a/scripts/tests/test_depot_canary_workflow.py
+++ b/scripts/tests/test_depot_canary_workflow.py
@@ -59,6 +59,18 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
         self.assertIn(r"\[::1\]", self.workflow)
         self.assertIn("numeric", self.workflow.lower())
         self.assertIn("transparently redirected to Depot", self.workflow)
+        self.assertIn(
+            'GitHub Actions cache was transparently redirected to Depot ($endpoint_name)',
+            self.workflow,
+        )
+        self.assertIn(
+            'GitHub Actions endpoint contains URL userinfo ($endpoint_name)',
+            self.workflow,
+        )
+        self.assertIn(
+            'GitHub Actions endpoint is not GitHub-owned or loopback ($endpoint_name)',
+            self.workflow,
+        )
         self.assertIn("ACTIONS_RESULTS_URL", self.workflow)
         self.assertIn("actions\\.githubusercontent\\.com", self.workflow)
         self.assertNotIn(",,}", self.workflow)
@@ -308,6 +320,17 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                 with self.subTest(script=script_name, endpoints=endpoints):
                     result = run_probe(script, *endpoints)
                     self.assertNotEqual(result.returncode, 0)
+            if script_name == "Depot canary":
+                with self.subTest(script=script_name, diagnostic="endpoint name only"):
+                    endpoint = "https://cache.example.invalid/cache"
+                    result = run_probe(
+                        script,
+                        endpoint,
+                        valid_endpoints[0][1],
+                    )
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("ACTIONS_CACHE_URL", result.stderr)
+                    self.assertNotIn(endpoint, result.stderr)
             if script_name == "audit action":
                 with self.subTest(script=script_name, policy="native cache enabled"):
                     result = run_probe(

--- a/scripts/tests/test_depot_canary_workflow.py
+++ b/scripts/tests/test_depot_canary_workflow.py
@@ -321,16 +321,36 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                     result = run_probe(script, *endpoints)
                     self.assertNotEqual(result.returncode, 0)
             if script_name == "Depot canary":
-                with self.subTest(script=script_name, diagnostic="endpoint name only"):
-                    endpoint = "https://cache.example.invalid/cache"
-                    result = run_probe(
-                        script,
-                        endpoint,
-                        valid_endpoints[0][1],
-                    )
-                    self.assertNotEqual(result.returncode, 0)
-                    self.assertIn("ACTIONS_CACHE_URL", result.stderr)
-                    self.assertNotIn(endpoint, result.stderr)
+                diagnostic_cases = (
+                    (
+                        "unsupported host",
+                        "https://cache.example.invalid/cache",
+                        "GitHub Actions endpoint is not GitHub-owned or loopback",
+                    ),
+                    (
+                        "Depot redirect",
+                        "https://cache.depot.dev/cache",
+                        "GitHub Actions cache was transparently redirected to Depot",
+                    ),
+                    (
+                        "URL userinfo",
+                        "https://actions.githubusercontent.com:443@attacker.example/",
+                        "GitHub Actions endpoint contains URL userinfo",
+                    ),
+                )
+                for diagnostic, endpoint, message in diagnostic_cases:
+                    with self.subTest(script=script_name, diagnostic=diagnostic):
+                        result = run_probe(
+                            script,
+                            endpoint,
+                            valid_endpoints[0][1],
+                        )
+                        self.assertNotEqual(result.returncode, 0)
+                        self.assertIn(
+                            f"{message} (ACTIONS_CACHE_URL)",
+                            result.stderr,
+                        )
+                        self.assertNotIn(endpoint, result.stderr)
             if script_name == "audit action":
                 with self.subTest(script=script_name, policy="native cache enabled"):
                     result = run_probe(


### PR DESCRIPTION
Summary:
- report only the failing Actions endpoint variable name in the negative Depot canary
- keep endpoint values and tokens out of logs
- preserve the existing fail-closed endpoint allowlist
- add executable regression coverage for name-only diagnostics

Validation:
- just ci-validate: 448 tests, 7 skipped
- focused Depot canary tests: 6/6
- extracted audit/canary bash syntax checks
- actionlint
- git diff --check

Follow-up to negative canary run 31787445524. This intentionally does not relax PR runner isolation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved endpoint validation errors by identifying the specific configuration variable requiring attention, including `ACTIONS_CACHE_URL`, `ACTIONS_RESULTS_URL`, or `ACTIONS_RUNTIME_URL`.
  - Prevented sensitive endpoint values from appearing in validation diagnostics.
- **Tests**
  - Added coverage for unsupported hosts, redirected endpoints, credential-bearing URLs, and invalid configurations.
  - Verified diagnostics identify the relevant configuration variable while omitting endpoint values from error output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->