### PR TITLE
CI: add protected Depot authority sentinel

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -171,9 +171,12 @@ remains hosted and is the no-Depot-authority half of the sentinel acceptance
 evidence; only the exact same-repository sentinel ref may exercise the
 diagnostic Depot job. All three sentinel cache phases attest the
 provider-injected `ACTIONS_CACHE_URL`/`ACTIONS_RESULTS_URL` structure and
-require a runtime token before invoking `actions/cache`; attestation reports
-only value-free variable/reason classes and fails closed on malformed or
-missing backend data.
+require a runtime token before invoking `actions/cache`; the non-loopback
+check includes all IPv4 `127/8` and IPv4-mapped IPv6 loopback spellings.
+Bracketed IPv6 authorities use the fixed runner's Python 3.8+ stdlib
+`ipaddress` classifier; parser absence/version/invalidity fails closed.
+Attestation reports only value-free variable/reason classes and fails closed
+on malformed or missing backend data.
 
 Relevant repository variable names include `DEPOT_RUNNERS_ENABLED`,
 `DEPOT_PR_RUNNERS_ENABLED` (absent/false until protected PR activation),

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -46,7 +46,7 @@ removable after this branch's runner contract is active on protected main.
 | `ci-linux-lane.yml` | Linux host/runtime/product/Rust/SDK/smoke graph with one platform-local UI producer |
 | `ci-macos-lane.yml` | macOS host/runtime/product/platform/Swift/Metal graph with one platform-local UI producer |
 | `ci-windows-lane.yml` | Windows host/runtime/product/platform graph with one platform-local UI producer |
-| `ci-quality-slice.yml` | Contracts, format, Clippy and CLI/docs guard |
+| `ci-quality-slice.yml` | Contracts, format, Clippy and CLI/docs guard; additive protected authority sentinel |
 | `ci-web-slice.yml` | Console quality and public website build |
 | `ci-ui-artifact-slice.yml` | Immutable console distribution producer |
 | `static-abi-artifact.yml` | Typed static llama ABI producer with internal runner policy and an exact toolchain-epoch output |
@@ -164,14 +164,28 @@ the exact protected workflow refs. The repository token cannot independently
 inspect organization runner-group settings through the API (403), so these
 remain external facts rather than checked-in evidence. The protected
 branch/main canary, same-repository PR canary, fork PR canary, provider-parity
-comparison, and rollback run are still pending; `DEPOT_RUNNERS_ENABLED` or a
-successful manual canary does not prove PR isolation.
+comparison, and rollback run are still pending; `DEPOT_PR_SENTINEL_REF` and
+`DEPOT_PR_SENTINEL_ID` are unset by default, and `DEPOT_RUNNERS_ENABLED` or a
+successful manual canary does not prove PR isolation. Fork PR validation
+remains hosted and is the no-Depot-authority half of the sentinel acceptance
+evidence; only the exact same-repository sentinel ref may exercise the
+diagnostic Depot job. All three sentinel cache phases attest the
+provider-injected `ACTIONS_CACHE_URL`/`ACTIONS_RESULTS_URL` structure and
+require a runtime token before invoking `actions/cache`; attestation reports
+only value-free variable/reason classes and fails closed on malformed or
+missing backend data.
 
 Relevant repository variable names include `DEPOT_RUNNERS_ENABLED`,
-`DEPOT_PR_RUNNERS_ENABLED` (absent/false until protected PR activation), and
+`DEPOT_PR_RUNNERS_ENABLED` (absent/false until protected PR activation),
 `DEPOT_PR_CANARY_REF` (absent by default; one exact
-`refs/pull/<number>/merge` ref only). The latter is a bounded selector
-canary, not a cache-isolation proof or a replacement for the global PR gate.
+`refs/pull/<number>/merge` ref only), `DEPOT_PR_SENTINEL_REF` (absent by
+default; one exact same-repository merge ref used only by the protected
+no-checkout authority diagnostic), and `DEPOT_PR_SENTINEL_ID` (absent by
+default; exactly 32 lowercase hexadecimal characters when the diagnostic is
+deliberately armed). The canary and sentinel variables are bounded selectors,
+not cache-isolation proofs or replacements for the global PR gate. The normal
+Quality runner policy continues to use `DEPOT_PR_CANARY_REF`; the sentinel
+uses a separate selector output and cannot move the normal build jobs.
 The eligible five-lane Depot graph now disables every native GitHub cache
 consumer (explicit cache actions, setup-* package caches, rust-cache, static /
 Metal / Windows / Swift ABI caches and Windows SDK cache toggles) and Depot

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -257,6 +257,9 @@ jobs:
             exit 1
           fi
 
+  # Explicit diagnostic exception: this no-checkout job attests the
+  # provider-injected cache authority itself, outside the normal build-cache
+  # gate and build graph.
   authority_sentinel:
     name: Depot PR authority sentinel
     needs: runner_policy
@@ -304,6 +307,46 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Keep this parser identical in every no-checkout authority phase.
+          # A local composite action would require checkout here, weakening
+          # the pinned-cache/no-checkout boundary.
+          is_loopback_authority() {
+            local authority="$1"
+            [[ "$authority" =~ ^localhost(:[0-9]{1,5})?$ ]] && return 0
+            [[ "$authority" =~ ^127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]{1,5})?$ ]] && return 0
+            if [[ "$authority" != \[*\]* ]]; then
+              return 1
+            fi
+            if ! command -v python3 >/dev/null 2>&1; then
+              return 2
+            fi
+            local host="${authority#\[}"
+            host="${host%%\]*}"
+            local python_status
+            if printf '%s\n' "$host" | python3 -c '
+          import ipaddress
+          import sys
+
+          value = sys.stdin.read().strip()
+          if sys.version_info < (3, 8):
+              raise SystemExit(2)
+          try:
+              address = ipaddress.ip_address(value)
+          except ValueError:
+              raise SystemExit(2)
+          mapped = getattr(address, "ipv4_mapped", None)
+          raise SystemExit(0 if address.is_loopback or (mapped is not None and mapped.is_loopback) else 3)
+          ' >/dev/null 2>&1; then
+              return 0
+            else
+              python_status=$?
+            fi
+            if (( python_status == 3 )); then
+              return 1
+            fi
+            return 2
+          }
+
           attest_cache_endpoint() {
             local endpoint_name="$1"
             local endpoint="${!endpoint_name:-}"
@@ -327,9 +370,10 @@ jobs:
                 reason=userinfo
               elif [[ "$authority" =~ ^([a-z0-9-]+\.)*actions\.githubusercontent\.com(:[0-9]{1,5})?$ ]]; then
                 reason=github
-              elif [[ "$authority" =~ ^(localhost|127\.0\.0\.1)(:[0-9]{1,5})?$ ||
-                      "$authority" =~ ^\[::1\](:[0-9]{1,5})?$ ]]; then
+              elif is_loopback_authority "$authority"; then
                 reason=loopback
+              elif [[ "$?" -eq 2 ]]; then
+                reason=parser
               elif [[ "$suffix" != /* ]]; then
                 reason=path
               elif [[ "$authority" =~ ^\[[^]]+\]:([0-9]+)$ ]]; then

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -66,6 +66,8 @@ jobs:
       runner_8: ${{ steps.policy.outputs.runner_8 }}
       allow_depot_remote_cache: ${{ steps.policy.outputs.allow_depot_remote_cache }}
       allow_native_github_cache: ${{ steps.policy.outputs.allow_native_github_cache }}
+      authority_sentinel_runner: ${{ steps.sentinel_policy.outputs.runner }}
+      authority_sentinel_depot_enabled: ${{ steps.sentinel_policy.outputs.depot_enabled }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -85,6 +87,22 @@ jobs:
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
           force_hosted: ${{ inputs.force_hosted }}
           manual_use_depot: ${{ inputs.use_depot }}
+      - name: Select provider for the protected authority sentinel
+        id: sentinel_policy
+        uses: ./.github/actions/select-ci-runners
+        with:
+          event_name: ${{ github.event_name }}
+          original_event_name: ${{ inputs.original_event_name }}
+          repository: ${{ github.repository }}
+          head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.ref }}
+          # The diagnostic is selected only by its exact sentinel ref. The
+          # ordinary and global PR gates must not activate this exception.
+          depot_main_enabled: 'false'
+          depot_pr_enabled: 'false'
+          pr_canary_ref: ${{ vars.DEPOT_PR_SENTINEL_REF }}
+          force_hosted: ${{ inputs.force_hosted }}
+          manual_use_depot: 'false'
 
   quality_contracts:
     name: CI contracts and consistency
@@ -238,3 +256,165 @@ jobs:
             echo "Rust CLI surface changed without a public website docs/example update." >&2
             exit 1
           fi
+
+  authority_sentinel:
+    name: Depot PR authority sentinel
+    needs: runner_policy
+    if: >-
+      needs.runner_policy.outputs.authority_sentinel_depot_enabled == 'true' &&
+      inputs.original_event_name == 'pull_request' &&
+      github.event_name == 'pull_request' &&
+      github.ref == vars.DEPOT_PR_SENTINEL_REF
+    runs-on: ${{ needs.runner_policy.outputs.authority_sentinel_runner }}
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - name: Validate protected sentinel identity
+        id: validate
+        shell: bash
+        env:
+          SENTINEL_ID: ${{ vars.DEPOT_PR_SENTINEL_ID }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          CONFIGURED_SENTINEL_REF: ${{ vars.DEPOT_PR_SENTINEL_REF }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$SENTINEL_ID" =~ ^[0-9a-f]{32}$ ]]; then
+            echo "DEPOT_PR_SENTINEL_ID must be exactly 32 lowercase hexadecimal characters" >&2
+            exit 1
+          fi
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]{0,8}$ ]]; then
+            echo "github.event.pull_request.number must be a canonical positive integer" >&2
+            exit 1
+          fi
+          expected_ref="refs/pull/${PR_NUMBER}/merge"
+          if [[ "$CONFIGURED_SENTINEL_REF" != "$expected_ref" ]]; then
+            echo "DEPOT_PR_SENTINEL_REF does not match the pull-request merge ref" >&2
+            exit 1
+          fi
+          seed_key="mesh-llm-depot-authority-seed-v1-${SENTINEL_ID}"
+          poison_key="mesh-llm-depot-authority-pr-v1-${SENTINEL_ID}-pr-${PR_NUMBER}"
+          {
+            printf 'sentinel_id=%s\n' "$SENTINEL_ID"
+            printf 'pr_number=%s\n' "$PR_NUMBER"
+            printf 'seed_key=%s\n' "$seed_key"
+            printf 'poison_key=%s\n' "$poison_key"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Attest provider-injected cache backend
+        shell: bash
+        run: |
+          set -euo pipefail
+          attest_cache_endpoint() {
+            local endpoint_name="$1"
+            local endpoint="${!endpoint_name:-}"
+            local endpoint_lower
+            endpoint_lower="$(printf '%s' "$endpoint" | tr '[:upper:]' '[:lower:]')"
+            local reason=""
+            if [[ -z "$endpoint" ]]; then
+              reason=missing
+            elif [[ "$endpoint" =~ [[:space:]] ]]; then
+              reason=whitespace
+            elif [[ "$endpoint_lower" != http://* ]]; then
+              reason=scheme
+            else
+              local remainder="${endpoint_lower#http://}"
+              local authority="${remainder%%[/?#]*}"
+              local suffix="${remainder#"$authority"}"
+              local port=""
+              if [[ -z "$authority" ]]; then
+                reason=authority
+              elif [[ "$authority" == *"@"* ]]; then
+                reason=userinfo
+              elif [[ "$authority" =~ ^([a-z0-9-]+\.)*actions\.githubusercontent\.com(:[0-9]{1,5})?$ ]]; then
+                reason=github
+              elif [[ "$authority" =~ ^(localhost|127\.0\.0\.1)(:[0-9]{1,5})?$ ||
+                      "$authority" =~ ^\[::1\](:[0-9]{1,5})?$ ]]; then
+                reason=loopback
+              elif [[ "$suffix" != /* ]]; then
+                reason=path
+              elif [[ "$authority" =~ ^\[[^]]+\]:([0-9]+)$ ]]; then
+                port="${BASH_REMATCH[1]}"
+              elif [[ "$authority" =~ ^[^:]+:([0-9]+)$ ]]; then
+                port="${BASH_REMATCH[1]}"
+              else
+                reason=port
+              fi
+              if [[ -z "$reason" ]] &&
+                 ! [[ "$port" =~ ^[0-9]{1,5}$ ]] ; then
+                reason=port
+              fi
+              if [[ -z "$reason" ]] &&
+                 ! (( 10#$port >= 1 && 10#$port <= 65535 )); then
+                reason=port
+              fi
+            fi
+            if [[ -n "$reason" ]]; then
+              printf 'cache backend attestation failed (variable=%s reason=%s)\n' \
+                "$endpoint_name" "$reason" >&2
+              return 1
+            fi
+          }
+          attest_cache_endpoint ACTIONS_CACHE_URL
+          attest_cache_endpoint ACTIONS_RESULTS_URL
+          if [[ -z "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
+            echo "cache backend attestation failed (variable=ACTIONS_RUNTIME_TOKEN reason=missing)" >&2
+            exit 1
+          fi
+
+      - name: Restore trusted authority marker
+        id: restore_seed
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .depot-authority-sentinel
+          key: ${{ steps.validate.outputs.seed_key }}
+          fail-on-cache-miss: false
+
+      - name: Validate trusted seed marker content on hit
+        shell: bash
+        env:
+          SENTINEL_ID: ${{ steps.validate.outputs.sentinel_id }}
+          CACHE_HIT: ${{ steps.restore_seed.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          if [[ "$CACHE_HIT" != "true" ]]; then
+            exit 0
+          fi
+          expected_file="$(mktemp)"
+          trap 'rm -f "$expected_file"' EXIT
+          printf 'mesh-llm-depot-authority-marker-v1\nsentinel_id=%s\n' \
+            "$SENTINEL_ID" > "$expected_file"
+          if [[ ! -f .depot-authority-sentinel/marker ]] ||
+             ! cmp -s "$expected_file" .depot-authority-sentinel/marker; then
+            echo "trusted authority marker content mismatch" >&2
+            exit 1
+          fi
+
+      - name: Replace with deterministic PR poison marker
+        shell: bash
+        env:
+          SENTINEL_ID: ${{ steps.validate.outputs.sentinel_id }}
+          PR_NUMBER: ${{ steps.validate.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          rm -rf -- .depot-authority-sentinel
+          mkdir -p .depot-authority-sentinel
+          printf 'mesh-llm-depot-authority-pr-marker-v1\nsentinel_id=%s\npr_number=%s\n' \
+            "$SENTINEL_ID" "$PR_NUMBER" > .depot-authority-sentinel/marker
+
+      - name: Save PR poison marker
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .depot-authority-sentinel
+          key: ${{ steps.validate.outputs.poison_key }}
+
+      - name: Require trusted seed isolation after poison publication
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.restore_seed.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          if [[ "$CACHE_HIT" == "true" ]]; then
+            echo "Trusted authority marker was readable by the PR probe" >&2
+            exit 1
+          fi
+          echo "Trusted seed was not readable; pending trusted-main verify-pr-write."

--- a/.github/workflows/depot-canary.yml
+++ b/.github/workflows/depot-canary.yml
@@ -2,6 +2,26 @@ name: Depot Runner Canary
 
 on:
   workflow_dispatch:
+    inputs:
+      mode:
+        description: Run the resource audit or one bounded cache-authority sentinel phase.
+        required: true
+        default: audit
+        type: choice
+        options:
+          - audit
+          - seed
+          - verify-pr-write
+      sentinel_id:
+        description: Lowercase 32-hex identifier used only in the fixed sentinel key grammar.
+        required: false
+        default: ''
+        type: string
+      pr_number:
+        description: Canonical positive pull-request number for the bounded poison key.
+        required: false
+        default: ''
+        type: string
 
 permissions: {}
 
@@ -15,7 +35,8 @@ jobs:
     if: >-
       github.repository == 'Mesh-LLM/mesh-llm' &&
       github.event_name == 'workflow_dispatch' &&
-      github.ref == 'refs/heads/main'
+      github.ref == 'refs/heads/main' &&
+      github.event.inputs.mode == 'audit'
     strategy:
       fail-fast: false
       matrix:
@@ -259,3 +280,321 @@ jobs:
             echo "| Depot registry credentials/config injected | no |"
             echo "| GitHub cache transparently redirected to Depot | no |"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  seed_authority_marker:
+    name: Seed trusted authority marker
+    if: >-
+      github.repository == 'Mesh-LLM/mesh-llm' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.inputs.mode == 'seed'
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - name: Validate bounded sentinel identity
+        id: validate
+        shell: bash
+        env:
+          SENTINEL_ID: ${{ github.event.inputs.sentinel_id }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          CONFIGURED_SENTINEL_ID: ${{ vars.DEPOT_PR_SENTINEL_ID }}
+          CONFIGURED_SENTINEL_REF: ${{ vars.DEPOT_PR_SENTINEL_REF }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$SENTINEL_ID" =~ ^[0-9a-f]{32}$ ]]; then
+            echo "sentinel_id must be exactly 32 lowercase hexadecimal characters" >&2
+            exit 1
+          fi
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]{0,8}$ ]]; then
+            echo "pr_number must be a canonical positive integer" >&2
+            exit 1
+          fi
+          if [[ ! "$CONFIGURED_SENTINEL_ID" =~ ^[0-9a-f]{32}$ ]]; then
+            echo "DEPOT_PR_SENTINEL_ID must be exactly 32 lowercase hexadecimal characters" >&2
+            exit 1
+          fi
+          if [[ "$SENTINEL_ID" != "$CONFIGURED_SENTINEL_ID" ]]; then
+            echo "sentinel_id does not match DEPOT_PR_SENTINEL_ID" >&2
+            exit 1
+          fi
+          expected_ref="refs/pull/${PR_NUMBER}/merge"
+          if [[ "$CONFIGURED_SENTINEL_REF" != "$expected_ref" ]]; then
+            echo "DEPOT_PR_SENTINEL_REF does not match the requested pull request" >&2
+            exit 1
+          fi
+          seed_key="mesh-llm-depot-authority-seed-v1-${SENTINEL_ID}"
+          poison_key="mesh-llm-depot-authority-pr-v1-${SENTINEL_ID}-pr-${PR_NUMBER}"
+          {
+            printf 'sentinel_id=%s\n' "$SENTINEL_ID"
+            printf 'seed_key=%s\n' "$seed_key"
+            printf 'poison_key=%s\n' "$poison_key"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Attest provider-injected cache backend
+        shell: bash
+        run: |
+          set -euo pipefail
+          attest_cache_endpoint() {
+            local endpoint_name="$1"
+            local endpoint="${!endpoint_name:-}"
+            local endpoint_lower
+            endpoint_lower="$(printf '%s' "$endpoint" | tr '[:upper:]' '[:lower:]')"
+            local reason=""
+            if [[ -z "$endpoint" ]]; then
+              reason=missing
+            elif [[ "$endpoint" =~ [[:space:]] ]]; then
+              reason=whitespace
+            elif [[ "$endpoint_lower" != http://* ]]; then
+              reason=scheme
+            else
+              local remainder="${endpoint_lower#http://}"
+              local authority="${remainder%%[/?#]*}"
+              local suffix="${remainder#"$authority"}"
+              local port=""
+              if [[ -z "$authority" ]]; then
+                reason=authority
+              elif [[ "$authority" == *"@"* ]]; then
+                reason=userinfo
+              elif [[ "$authority" =~ ^([a-z0-9-]+\.)*actions\.githubusercontent\.com(:[0-9]{1,5})?$ ]]; then
+                reason=github
+              elif [[ "$authority" =~ ^(localhost|127\.0\.0\.1)(:[0-9]{1,5})?$ ||
+                      "$authority" =~ ^\[::1\](:[0-9]{1,5})?$ ]]; then
+                reason=loopback
+              elif [[ "$suffix" != /* ]]; then
+                reason=path
+              elif [[ "$authority" =~ ^\[[^]]+\]:([0-9]+)$ ]]; then
+                port="${BASH_REMATCH[1]}"
+              elif [[ "$authority" =~ ^[^:]+:([0-9]+)$ ]]; then
+                port="${BASH_REMATCH[1]}"
+              else
+                reason=port
+              fi
+              if [[ -z "$reason" ]] &&
+                 ! [[ "$port" =~ ^[0-9]{1,5}$ ]] ; then
+                reason=port
+              fi
+              if [[ -z "$reason" ]] &&
+                 ! (( 10#$port >= 1 && 10#$port <= 65535 )); then
+                reason=port
+              fi
+            fi
+            if [[ -n "$reason" ]]; then
+              printf 'cache backend attestation failed (variable=%s reason=%s)\n' \
+                "$endpoint_name" "$reason" >&2
+              return 1
+            fi
+          }
+          attest_cache_endpoint ACTIONS_CACHE_URL
+          attest_cache_endpoint ACTIONS_RESULTS_URL
+          if [[ -z "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
+            echo "cache backend attestation failed (variable=ACTIONS_RUNTIME_TOKEN reason=missing)" >&2
+            exit 1
+          fi
+
+      - name: Prepare deterministic non-secret marker
+        shell: bash
+        env:
+          SENTINEL_ID: ${{ steps.validate.outputs.sentinel_id }}
+        run: |
+          set -euo pipefail
+          marker_dir=".depot-authority-sentinel"
+          mkdir -p "$marker_dir"
+          printf 'mesh-llm-depot-authority-marker-v1\nsentinel_id=%s\n' \
+            "$SENTINEL_ID" > "$marker_dir/marker"
+
+      - name: Save trusted authority marker
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .depot-authority-sentinel
+          key: ${{ steps.validate.outputs.seed_key }}
+
+      - name: Clear local marker before trusted restore
+        shell: bash
+        run: rm -rf -- .depot-authority-sentinel
+
+      - name: Restore trusted authority marker
+        id: verify_marker
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .depot-authority-sentinel
+          key: ${{ steps.validate.outputs.seed_key }}
+          fail-on-cache-miss: true
+
+      - name: Require trusted marker hit
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.verify_marker.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          [[ "$CACHE_HIT" == "true" ]]
+
+      - name: Validate trusted marker content
+        shell: bash
+        env:
+          SENTINEL_ID: ${{ steps.validate.outputs.sentinel_id }}
+        run: |
+          set -euo pipefail
+          expected_file="$(mktemp)"
+          trap 'rm -f "$expected_file"' EXIT
+          printf 'mesh-llm-depot-authority-marker-v1\nsentinel_id=%s\n' \
+            "$SENTINEL_ID" > "$expected_file"
+          if [[ ! -f .depot-authority-sentinel/marker ]] ||
+             ! cmp -s "$expected_file" .depot-authority-sentinel/marker; then
+            echo "trusted authority marker content mismatch" >&2
+            exit 1
+          fi
+
+  verify_pr_write:
+    name: Verify PR poison marker is isolated
+    if: >-
+      github.repository == 'Mesh-LLM/mesh-llm' &&
+      github.event_name == 'workflow_dispatch' &&
+      github.ref == 'refs/heads/main' &&
+      github.event.inputs.mode == 'verify-pr-write'
+    runs-on: depot-ubuntu-24.04
+    timeout-minutes: 10
+    permissions: {}
+    steps:
+      - name: Validate bounded sentinel identity
+        id: validate
+        shell: bash
+        env:
+          SENTINEL_ID: ${{ github.event.inputs.sentinel_id }}
+          PR_NUMBER: ${{ github.event.inputs.pr_number }}
+          CONFIGURED_SENTINEL_ID: ${{ vars.DEPOT_PR_SENTINEL_ID }}
+          CONFIGURED_SENTINEL_REF: ${{ vars.DEPOT_PR_SENTINEL_REF }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$SENTINEL_ID" =~ ^[0-9a-f]{32}$ ]]; then
+            echo "sentinel_id must be exactly 32 lowercase hexadecimal characters" >&2
+            exit 1
+          fi
+          if [[ ! "$PR_NUMBER" =~ ^[1-9][0-9]{0,8}$ ]]; then
+            echo "pr_number must be a canonical positive integer" >&2
+            exit 1
+          fi
+          if [[ ! "$CONFIGURED_SENTINEL_ID" =~ ^[0-9a-f]{32}$ ]]; then
+            echo "DEPOT_PR_SENTINEL_ID must be exactly 32 lowercase hexadecimal characters" >&2
+            exit 1
+          fi
+          if [[ "$SENTINEL_ID" != "$CONFIGURED_SENTINEL_ID" ]]; then
+            echo "sentinel_id does not match DEPOT_PR_SENTINEL_ID" >&2
+            exit 1
+          fi
+          expected_ref="refs/pull/${PR_NUMBER}/merge"
+          if [[ "$CONFIGURED_SENTINEL_REF" != "$expected_ref" ]]; then
+            echo "DEPOT_PR_SENTINEL_REF does not match the requested pull request" >&2
+            exit 1
+          fi
+          poison_key="mesh-llm-depot-authority-pr-v1-${SENTINEL_ID}-pr-${PR_NUMBER}"
+          {
+            printf 'sentinel_id=%s\n' "$SENTINEL_ID"
+            printf 'pr_number=%s\n' "$PR_NUMBER"
+            printf 'poison_key=%s\n' "$poison_key"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Attest provider-injected cache backend
+        shell: bash
+        run: |
+          set -euo pipefail
+          attest_cache_endpoint() {
+            local endpoint_name="$1"
+            local endpoint="${!endpoint_name:-}"
+            local endpoint_lower
+            endpoint_lower="$(printf '%s' "$endpoint" | tr '[:upper:]' '[:lower:]')"
+            local reason=""
+            if [[ -z "$endpoint" ]]; then
+              reason=missing
+            elif [[ "$endpoint" =~ [[:space:]] ]]; then
+              reason=whitespace
+            elif [[ "$endpoint_lower" != http://* ]]; then
+              reason=scheme
+            else
+              local remainder="${endpoint_lower#http://}"
+              local authority="${remainder%%[/?#]*}"
+              local suffix="${remainder#"$authority"}"
+              local port=""
+              if [[ -z "$authority" ]]; then
+                reason=authority
+              elif [[ "$authority" == *"@"* ]]; then
+                reason=userinfo
+              elif [[ "$authority" =~ ^([a-z0-9-]+\.)*actions\.githubusercontent\.com(:[0-9]{1,5})?$ ]]; then
+                reason=github
+              elif [[ "$authority" =~ ^(localhost|127\.0\.0\.1)(:[0-9]{1,5})?$ ||
+                      "$authority" =~ ^\[::1\](:[0-9]{1,5})?$ ]]; then
+                reason=loopback
+              elif [[ "$suffix" != /* ]]; then
+                reason=path
+              elif [[ "$authority" =~ ^\[[^]]+\]:([0-9]+)$ ]]; then
+                port="${BASH_REMATCH[1]}"
+              elif [[ "$authority" =~ ^[^:]+:([0-9]+)$ ]]; then
+                port="${BASH_REMATCH[1]}"
+              else
+                reason=port
+              fi
+              if [[ -z "$reason" ]] &&
+                 ! [[ "$port" =~ ^[0-9]{1,5}$ ]] ; then
+                reason=port
+              fi
+              if [[ -z "$reason" ]] &&
+                 ! (( 10#$port >= 1 && 10#$port <= 65535 )); then
+                reason=port
+              fi
+            fi
+            if [[ -n "$reason" ]]; then
+              printf 'cache backend attestation failed (variable=%s reason=%s)\n' \
+                "$endpoint_name" "$reason" >&2
+              return 1
+            fi
+          }
+          attest_cache_endpoint ACTIONS_CACHE_URL
+          attest_cache_endpoint ACTIONS_RESULTS_URL
+          if [[ -z "${ACTIONS_RUNTIME_TOKEN:-}" ]]; then
+            echo "cache backend attestation failed (variable=ACTIONS_RUNTIME_TOKEN reason=missing)" >&2
+            exit 1
+          fi
+
+      - name: Clear local poison marker before trusted restore
+        shell: bash
+        run: rm -rf -- .depot-authority-sentinel
+
+      - name: Probe PR poison marker
+        id: probe
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: .depot-authority-sentinel
+          key: ${{ steps.validate.outputs.poison_key }}
+          fail-on-cache-miss: false
+
+      - name: Validate PR poison marker content on hit
+        shell: bash
+        env:
+          SENTINEL_ID: ${{ steps.validate.outputs.sentinel_id }}
+          PR_NUMBER: ${{ steps.validate.outputs.pr_number }}
+          CACHE_HIT: ${{ steps.probe.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          if [[ "$CACHE_HIT" != "true" ]]; then
+            exit 0
+          fi
+          expected_file="$(mktemp)"
+          trap 'rm -f "$expected_file"' EXIT
+          printf 'mesh-llm-depot-authority-pr-marker-v1\nsentinel_id=%s\npr_number=%s\n' \
+            "$SENTINEL_ID" "$PR_NUMBER" > "$expected_file"
+          if [[ ! -f .depot-authority-sentinel/marker ]] ||
+             ! cmp -s "$expected_file" .depot-authority-sentinel/marker; then
+            echo "trusted main observed an unexpected poison marker content" >&2
+            exit 1
+          fi
+
+      - name: Require PR poison marker miss
+        shell: bash
+        env:
+          CACHE_HIT: ${{ steps.probe.outputs.cache-hit }}
+        run: |
+          set -euo pipefail
+          if [[ "$CACHE_HIT" == "true" ]]; then
+            echo "PR poison marker was visible to trusted main (cache isolation failure)" >&2
+            exit 1
+          fi

--- a/.github/workflows/depot-canary.yml
+++ b/.github/workflows/depot-canary.yml
@@ -335,6 +335,46 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Keep this parser identical in every no-checkout authority phase.
+          # A local composite action would require checkout here, weakening
+          # the pinned-cache/no-checkout boundary.
+          is_loopback_authority() {
+            local authority="$1"
+            [[ "$authority" =~ ^localhost(:[0-9]{1,5})?$ ]] && return 0
+            [[ "$authority" =~ ^127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]{1,5})?$ ]] && return 0
+            if [[ "$authority" != \[*\]* ]]; then
+              return 1
+            fi
+            if ! command -v python3 >/dev/null 2>&1; then
+              return 2
+            fi
+            local host="${authority#\[}"
+            host="${host%%\]*}"
+            local python_status
+            if printf '%s\n' "$host" | python3 -c '
+          import ipaddress
+          import sys
+
+          value = sys.stdin.read().strip()
+          if sys.version_info < (3, 8):
+              raise SystemExit(2)
+          try:
+              address = ipaddress.ip_address(value)
+          except ValueError:
+              raise SystemExit(2)
+          mapped = getattr(address, "ipv4_mapped", None)
+          raise SystemExit(0 if address.is_loopback or (mapped is not None and mapped.is_loopback) else 3)
+          ' >/dev/null 2>&1; then
+              return 0
+            else
+              python_status=$?
+            fi
+            if (( python_status == 3 )); then
+              return 1
+            fi
+            return 2
+          }
+
           attest_cache_endpoint() {
             local endpoint_name="$1"
             local endpoint="${!endpoint_name:-}"
@@ -358,9 +398,10 @@ jobs:
                 reason=userinfo
               elif [[ "$authority" =~ ^([a-z0-9-]+\.)*actions\.githubusercontent\.com(:[0-9]{1,5})?$ ]]; then
                 reason=github
-              elif [[ "$authority" =~ ^(localhost|127\.0\.0\.1)(:[0-9]{1,5})?$ ||
-                      "$authority" =~ ^\[::1\](:[0-9]{1,5})?$ ]]; then
+              elif is_loopback_authority "$authority"; then
                 reason=loopback
+              elif [[ "$?" -eq 2 ]]; then
+                reason=parser
               elif [[ "$suffix" != /* ]]; then
                 reason=path
               elif [[ "$authority" =~ ^\[[^]]+\]:([0-9]+)$ ]]; then
@@ -498,6 +539,46 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
+          # Keep this parser identical in every no-checkout authority phase.
+          # A local composite action would require checkout here, weakening
+          # the pinned-cache/no-checkout boundary.
+          is_loopback_authority() {
+            local authority="$1"
+            [[ "$authority" =~ ^localhost(:[0-9]{1,5})?$ ]] && return 0
+            [[ "$authority" =~ ^127\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}(:[0-9]{1,5})?$ ]] && return 0
+            if [[ "$authority" != \[*\]* ]]; then
+              return 1
+            fi
+            if ! command -v python3 >/dev/null 2>&1; then
+              return 2
+            fi
+            local host="${authority#\[}"
+            host="${host%%\]*}"
+            local python_status
+            if printf '%s\n' "$host" | python3 -c '
+          import ipaddress
+          import sys
+
+          value = sys.stdin.read().strip()
+          if sys.version_info < (3, 8):
+              raise SystemExit(2)
+          try:
+              address = ipaddress.ip_address(value)
+          except ValueError:
+              raise SystemExit(2)
+          mapped = getattr(address, "ipv4_mapped", None)
+          raise SystemExit(0 if address.is_loopback or (mapped is not None and mapped.is_loopback) else 3)
+          ' >/dev/null 2>&1; then
+              return 0
+            else
+              python_status=$?
+            fi
+            if (( python_status == 3 )); then
+              return 1
+            fi
+            return 2
+          }
+
           attest_cache_endpoint() {
             local endpoint_name="$1"
             local endpoint="${!endpoint_name:-}"
@@ -521,9 +602,10 @@ jobs:
                 reason=userinfo
               elif [[ "$authority" =~ ^([a-z0-9-]+\.)*actions\.githubusercontent\.com(:[0-9]{1,5})?$ ]]; then
                 reason=github
-              elif [[ "$authority" =~ ^(localhost|127\.0\.0\.1)(:[0-9]{1,5})?$ ||
-                      "$authority" =~ ^\[::1\](:[0-9]{1,5})?$ ]]; then
+              elif is_loopback_authority "$authority"; then
                 reason=loopback
+              elif [[ "$?" -eq 2 ]]; then
+                reason=parser
               elif [[ "$suffix" != /* ]]; then
                 reason=path
               elif [[ "$authority" =~ ^\[[^]]+\]:([0-9]+)$ ]]; then

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -267,9 +267,12 @@ permissions, no checkout, no secrets and only the fixed
 `.depot-authority-sentinel` path. Before each cache action it requires the
 provider-injected `ACTIONS_CACHE_URL` and `ACTIONS_RESULTS_URL` to be present
 and structurally attested as HTTP endpoints with a nonempty, non-GitHub,
-non-loopback authority, numeric port and explicit path, plus a nonempty
+non-loopback authority (including all IPv4 `127/8` and IPv4-mapped IPv6
+loopback spellings), numeric port and explicit path, plus a nonempty
 `ACTIONS_RUNTIME_TOKEN`; it reports only variable/reason classes and never
 endpoint values. Manual seed/verify inputs bind to the configured sentinel ID
+and use the fixed runner's Python 3.8+ stdlib `ipaddress` classifier for every
+bracketed IPv6 spelling; parser absence/version/invalidity fails closed.
 and exact merge ref. The PR probe restores the trusted seed (not lookup-only),
 validates exact seed marker content on a hit, replaces it with a deterministic
 non-secret poison marker, saves the exact Stage 1 poison key, then fails only

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -44,6 +44,11 @@ or cache identity.
 - Current PR routing is GitHub-hosted except for the documented uncredentialed
   CUDA smoke on the approved ephemeral GPU scale set; trusted-main Depot
   selection remains behind the existing exact-string policy gate.
+- `ci-quality-slice.yml` contains an additive protected authority-sentinel
+  diagnostic selected by separate `DEPOT_PR_SENTINEL_REF` and
+  `DEPOT_PR_SENTINEL_ID` variables. It does not add a PR entrypoint, planner
+  row, build command, matrix, artifact, producer/consumer edge or required
+  summary; normal Quality jobs continue using the existing provider selector.
 - Current CI docs, inventory, skill and agent instructions describe this graph.
 - `pr_builds.yml` remains reusable-only and inert during the migration so the
   pre-merge protected runner contract can find its legacy filename; it has no
@@ -230,9 +235,16 @@ Callers never provide raw labels or independent remote-cache permission.
 
 Depot PR execution is not enabled. The selector has a bounded
 `DEPOT_PR_CANARY_REF` hook for one exact same-repository merge ref, while the
-global `DEPOT_PR_RUNNERS_ENABLED` gate remains absent/false. Fork heads,
-`pull_request_target`, dispatches and planner-forced hosted paths remain on
-GitHub-hosted runners. Depot's documented GitHub cache path is
+global `DEPOT_PR_RUNNERS_ENABLED` gate remains absent/false. The Quality slice
+also has a separate `DEPOT_PR_SENTINEL_REF` selector and
+`DEPOT_PR_SENTINEL_ID` validation for one no-checkout authority diagnostic;
+the ordinary Quality jobs still use `DEPOT_PR_CANARY_REF`, and a global PR gate
+alone cannot run the sentinel. The diagnostic runs only when the actual and
+original event are `pull_request`, the exact configured merge ref selects
+Depot, and the head repository is this repository. Fork heads,
+`pull_request_target`, dispatches, planner-forced hosted paths, missing or
+non-matching refs remain hosted/no-Depot; malformed selector configuration is
+rejected by the central selector. Depot's documented GitHub cache path is
 repository-scoped and not branch-isolated; automatic cache redirection can
 expose repository-wide cache authority to PR code. Cache-key prefixes are not
 isolation. The central selector now emits both
@@ -246,6 +258,26 @@ or expire before the PR gate. A GitHub-owned or strict loopback proxy is inert
 transport only, not an ambient authority proof; the actual runner sentinel
 and no-token checks remain required before enabling the canary or global PR
 gate.
+
+The sentinel is deliberately outside the planner/build graph and does not
+invoke `audit-depot-pr-isolation`: that audit rejects the ambient endpoint
+before cache access, whereas this diagnostic must exercise the actual restore
+and save authority without executing PR-controlled code. Its job has empty
+permissions, no checkout, no secrets and only the fixed
+`.depot-authority-sentinel` path. Before each cache action it requires the
+provider-injected `ACTIONS_CACHE_URL` and `ACTIONS_RESULTS_URL` to be present
+and structurally attested as HTTP endpoints with a nonempty, non-GitHub,
+non-loopback authority, numeric port and explicit path, plus a nonempty
+`ACTIONS_RUNTIME_TOKEN`; it reports only variable/reason classes and never
+endpoint values. Manual seed/verify inputs bind to the configured sentinel ID
+and exact merge ref. The PR probe restores the trusted seed (not lookup-only),
+validates exact seed marker content on a hit, replaces it with a deterministic
+non-secret poison marker, saves the exact Stage 1 poison key, then fails only
+after saving if the seed was readable. A seed miss passes with the trusted-main
+`verify-pr-write` phase pending; main verify fully restores and validates exact
+poison content before its expected-miss failure. Fork PRs remain hosted and
+provide the no-Depot-authority evidence; only the exact same-repository
+sentinel ref exercises the Depot diagnostic.
 
 Before a PR Depot path is enabled, an administrator must prove:
 

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -288,6 +288,78 @@ the untrusted PR probe:
 
 Cache-key separation alone does not satisfy this test.
 
+The first checked-in half of this protocol is the manual `depot-canary.yml`
+sentinel. On protected `main`, an operator may dispatch `mode=seed` with a
+fresh lowercase 32-hex `sentinel_id` and canonical positive `pr_number`. The
+workflow derives the only accepted keys internally:
+`mesh-llm-depot-authority-seed-v1-<id>` and
+`mesh-llm-depot-authority-pr-v1-<id>-pr-<number>`. It writes a deterministic,
+non-secret marker at the fixed relative `.depot-authority-sentinel` path. Before
+any cache action, all three cache phases attest that the provider-injected
+`ACTIONS_CACHE_URL` and `ACTIONS_RESULTS_URL` are present, value-free
+structurally validated HTTP endpoints with a non-GitHub/non-loopback authority,
+numeric port and explicit path, and that `ACTIONS_RUNTIME_TOKEN` is present.
+The pinned Actions-cache save/restore actions then exercise that attested
+remote backend. Seed and verify inputs are bound to the configured sentinel ID
+and exact merge ref before cache access. Seed clears its local marker, performs
+a full restore and validates the exact marker content; verify performs a full
+restore and validates exact poison content before its expected-miss check. The
+protected PR probe uses that same path and exact marker grammar so cache-version
+metadata cannot vary across jobs. After the protected PR probe publishes the
+bounded poison key, dispatch `mode=verify-pr-write` with the same validated
+inputs; a hit fails because trusted main saw a PR publication. The existing
+default `mode=audit` remains the negative resource/credential audit across the
+full Depot matrix and is unchanged.
+
+These diagnostic keys are deliberately outside normal build/cache policy and
+must be purged or allowed to expire after each experiment.
+
+The bounded protected PR half is now checked in as an additive diagnostic job
+inside `ci-quality-slice.yml`. It has its own central-selector input variables:
+`DEPOT_PR_SENTINEL_REF` selects one exact same-repository
+`refs/pull/<number>/merge` ref, and `DEPOT_PR_SENTINEL_ID` supplies the same
+validated 32-lowercase-hex identity used by the manual seed. The ordinary
+quality runner policy continues to read `DEPOT_PR_CANARY_REF`, so enabling the
+sentinel selector cannot move the normal Quality jobs or any other build row to
+Depot. The diagnostic job is outside the planner's required slice graph: it
+does not add a plan row, producer, consumer, artifact, matrix, or `needs` edge
+to the existing build jobs, and the protected Quality lane still completes
+through its existing `quality` and `runner_contract` summary dependencies.
+
+The sentinel job runs only when the actual event is `pull_request`, the
+protected lane receives `original_event_name=pull_request`, the central
+selector selects Depot for the exact configured merge ref, and the event's
+head repository is this repository. Fork heads, `pull_request_target`,
+dispatches, planner `force_hosted`, a missing selector variable, or a
+non-matching ref remain hosted/no-Depot; a malformed selector ref is rejected
+by the central selector before any runner is selected. A global
+`DEPOT_PR_RUNNERS_ENABLED=true` value alone does not run the diagnostic job.
+
+This exception deliberately does not invoke `audit-depot-pr-isolation`: that
+audit is designed to reject non-GitHub/loopback endpoints before a build, while
+this no-checkout job must exercise the actual cache restore/save authority and
+record the result without executing PR-controlled code. The job has
+`permissions: {}`, performs no checkout, receives no secrets, and uses only the
+fixed `.depot-authority-sentinel` path. Before the pinned cache restore it
+attests the provider-injected remote backend using the same structural
+non-GitHub/non-loopback HTTP contract and requires a nonempty runtime token; no
+endpoint, host, path, port or token value is printed. It validates the
+repository variable and the actual `github.event.pull_request.number`,
+restores the trusted seed (not lookup-only), validates exact seed marker
+content on a hit, replaces the path with a deterministic non-secret poison
+marker, saves the exact Stage 1 poison key, then fails only if the trusted seed
+was readable. A seed miss passes with a pending trusted-main
+`verify-pr-write` check; a seed hit is reported only after the poison save has
+completed.
+
+Fork PRs remain on the hosted path and provide the no-Depot-authority half of
+the acceptance evidence; only the same-repository exact sentinel ref can
+exercise this protected Depot authority probe. This hook remains inert until
+`DEPOT_PR_SENTINEL_REF` and `DEPOT_PR_SENTINEL_ID` are deliberately set for an
+operator-run experiment. It is not the global PR activation gate, does not
+grant cache or registry authority, and does not authorize setting
+`DEPOT_PR_RUNNERS_ENABLED`.
+
 ## Activation gate
 
 Do not enable Depot for PR content until:

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -297,8 +297,12 @@ workflow derives the only accepted keys internally:
 non-secret marker at the fixed relative `.depot-authority-sentinel` path. Before
 any cache action, all three cache phases attest that the provider-injected
 `ACTIONS_CACHE_URL` and `ACTIONS_RESULTS_URL` are present, value-free
-structurally validated HTTP endpoints with a non-GitHub/non-loopback authority,
-numeric port and explicit path, and that `ACTIONS_RUNTIME_TOKEN` is present.
+structurally validated HTTP endpoints with a non-GitHub/non-loopback authority
+(including all IPv4 `127/8` and IPv4-mapped IPv6 loopback spellings), numeric
+port and explicit path, and that `ACTIONS_RUNTIME_TOKEN` is present.
+Bracketed authorities use the fixed runner's Python 3.8+ stdlib `ipaddress`
+classifier for every IPv6 spelling; missing, too-old or invalid parser state
+fails closed with only a `parser` reason class.
 The pinned Actions-cache save/restore actions then exercise that attested
 remote backend. Seed and verify inputs are bound to the configured sentinel ID
 and exact merge ref before cache access. Seed clears its local marker, performs
@@ -342,7 +346,8 @@ record the result without executing PR-controlled code. The job has
 `permissions: {}`, performs no checkout, receives no secrets, and uses only the
 fixed `.depot-authority-sentinel` path. Before the pinned cache restore it
 attests the provider-injected remote backend using the same structural
-non-GitHub/non-loopback HTTP contract and requires a nonempty runtime token; no
+non-GitHub/non-loopback HTTP contract (including all IPv4 `127/8` and
+IPv4-mapped IPv6 loopback spellings) and requires a nonempty runtime token; no
 endpoint, host, path, port or token value is printed. It validates the
 repository variable and the actual `github.event.pull_request.number`,
 restores the trusted seed (not lookup-only), validates exact seed marker

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -303,6 +303,35 @@ replace the global PR gate. Maintainers must not set it until the external
 isolation protocol proves the actual Depot/WebDAV and Actions-cache authority
 boundary.
 
+The Quality slice also contains a separate, additive authority-sentinel
+selector. It reads `DEPOT_PR_SENTINEL_REF` (not `DEPOT_PR_CANARY_REF`) and
+emits a separate runner/depot decision used only by the no-checkout
+`authority_sentinel` diagnostic job. The ordinary Quality jobs continue to use
+the existing `runner_policy` outputs, so this hook cannot change their provider
+or the normal plan/build graph. The job is eligible only for the exact
+same-repository `pull_request` merge ref with
+`original_event_name=pull_request`; a global `DEPOT_PR_RUNNERS_ENABLED=true`
+value alone is insufficient. Forks, target/dispatch events, force-hosted
+signals, missing/non-matching refs and malformed refs remain hosted/no-Depot
+(malformed selector configuration is rejected by the central selector).
+
+This diagnostic exception intentionally skips `audit-depot-pr-isolation`: the
+audit rejects the ambient non-GitHub endpoint before cache access, while the
+sentinel must exercise the actual restore/save authority without checking out
+PR code. It has empty permissions, no checkout or secrets, validates the
+separate `DEPOT_PR_SENTINEL_ID` and actual PR number, restores the trusted seed
+at `.depot-authority-sentinel`, and gates only after publication. Before any
+cache action, it attests the provider-injected `ACTIONS_CACHE_URL` and
+`ACTIONS_RESULTS_URL` as value-free structural HTTP endpoints with a nonempty
+non-GitHub/non-loopback authority, numeric port and explicit path, and requires
+`ACTIONS_RUNTIME_TOKEN`; malformed/missing inputs fail closed without printing
+endpoint, host, path, port or token values. Seed and poison markers are
+validated byte-for-byte on cache hits. It is outside planner slices and does
+not add build commands, matrices, artifacts, or producer/consumer edges; the
+existing Quality lane summary still gates on its normal `quality` and
+`runner_contract` jobs. Fork PRs remain hosted and provide the
+no-Depot-authority evidence.
+
 The intended PR-Depot end state preserves the same five entry workflows and
 matching protected lane calls. After the external cache and runner-group gates
 in `ci/DEPOT_MIGRATION.md` are proven, provider policy may select ephemeral

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -323,10 +323,14 @@ separate `DEPOT_PR_SENTINEL_ID` and actual PR number, restores the trusted seed
 at `.depot-authority-sentinel`, and gates only after publication. Before any
 cache action, it attests the provider-injected `ACTIONS_CACHE_URL` and
 `ACTIONS_RESULTS_URL` as value-free structural HTTP endpoints with a nonempty
-non-GitHub/non-loopback authority, numeric port and explicit path, and requires
+non-GitHub/non-loopback authority (including all IPv4 `127/8` and IPv4-mapped
+IPv6 loopback spellings), numeric port and explicit path, and requires
 `ACTIONS_RUNTIME_TOKEN`; malformed/missing inputs fail closed without printing
-endpoint, host, path, port or token values. Seed and poison markers are
-validated byte-for-byte on cache hits. It is outside planner slices and does
+endpoint, host, path, port or token values. Endpoint authorities are classified
+with the fixed runner's Python 3.8+ stdlib `ipaddress` parser for all bracketed
+IPv6 spellings; parser absence/version/invalidity fails closed. Seed and poison
+markers are validated byte-for-byte on cache hits. It is outside planner
+slices and does
 not add build commands, matrices, artifacts, or producer/consumer edges; the
 existing Quality lane summary still gates on its normal `quality` and
 `runner_contract` jobs. Fork PRs remain hosted and provide the

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -2341,7 +2341,7 @@ class CiArtifactActionTests(unittest.TestCase):
         }
         expected_jobs = {
             "ci-quality-slice.yml": {
-                "runner_policy", "quality_contracts", "rust_fmt", "rust_clippy", "cli_docs_sync",
+                "runner_policy", "quality_contracts", "rust_fmt", "rust_clippy", "cli_docs_sync", "authority_sentinel",
             },
             "ci-web-slice.yml": {"runner_policy", "ui_quality", "website"},
             "ci-ui-artifact-slice.yml": {"runner_policy", "ui_artifact"},

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -2479,6 +2479,30 @@ class CiArtifactActionTests(unittest.TestCase):
             2,
         )
 
+    def test_authority_sentinel_is_explicit_cache_gate_exemption(self) -> None:
+        workflow = (
+            ROOT / ".github" / "workflows" / "ci-quality-slice.yml"
+        ).read_text(encoding="utf-8")
+        jobs = workflow.split("\njobs:\n", maxsplit=1)[1]
+        match = re.search(
+            r"^  authority_sentinel:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+            jobs,
+            re.MULTILINE | re.DOTALL,
+        )
+        self.assertIsNotNone(match)
+        sentinel = match.group("body")
+        self.assertIn(
+            "# Explicit diagnostic exception: this no-checkout job attests the",
+            workflow,
+        )
+        self.assertIn("authority_sentinel", jobs)
+        self.assertIn("Attest provider-injected cache backend", sentinel)
+        self.assertIn("actions/cache/restore@", sentinel)
+        self.assertIn("actions/cache/save@", sentinel)
+        self.assertNotIn("allow_native_github_cache", sentinel)
+        self.assertNotIn("allow_depot_remote_cache", sentinel)
+        self.assertNotIn("audit-depot-pr-isolation@", sentinel)
+
     def test_depot_sccache_consumers_receive_both_central_cache_outputs(self) -> None:
         provider_workflows = (
             "ci-quality-slice.yml",

--- a/scripts/tests/test_depot_authority_sentinel.py
+++ b/scripts/tests/test_depot_authority_sentinel.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import tempfile
 import unittest
@@ -19,8 +20,11 @@ class DepotAuthoritySentinelTests(unittest.TestCase):
         self.workflow = (WORKFLOWS / "ci-quality-slice.yml").read_text(
             encoding="utf-8"
         )
+        self.canary = (WORKFLOWS / "depot-canary.yml").read_text(
+            encoding="utf-8"
+        )
         self.selector = SELECTOR.read_text(encoding="utf-8")
-        self.sentinel = self.workflow.split("  authority_sentinel:\n", 1)[1]
+        self.sentinel = self._job_block(self.workflow, "authority_sentinel")
 
     @staticmethod
     def _job_block(workflow: str, job_name: str) -> str:
@@ -33,6 +37,37 @@ class DepotAuthoritySentinelTests(unittest.TestCase):
         if match is None:
             raise AssertionError(f"missing job {job_name}")
         return match.group("body")
+
+    @staticmethod
+    def _job_names(workflow: str) -> set[str]:
+        jobs = workflow.split("\njobs:\n", 1)[1]
+        return set(re.findall(r"^  ([A-Za-z0-9_-]+):", jobs, re.MULTILINE))
+
+    @staticmethod
+    def _step_names(job: str) -> list[str]:
+        return re.findall(r"^      - name: (.+)$", job, re.MULTILINE)
+
+    @staticmethod
+    def _step_block(job: str, step_name: str) -> str:
+        match = re.search(
+            rf"^      - name: {re.escape(step_name)}\n(?P<body>.*?)(?=^      - name:|\Z)",
+            job,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        if match is None:
+            raise AssertionError(f"missing step {step_name}")
+        return match.group("body")
+
+    @classmethod
+    def _step_script(cls, job: str, step_name: str) -> str:
+        run = re.search(
+            r"^        run: \|\n(?P<script>.*)",
+            cls._step_block(job, step_name),
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        if run is None:
+            raise AssertionError(f"step {step_name} has no run script")
+        return dedent(run.group("script"))
 
     def _run_selector(
         self,
@@ -86,18 +121,14 @@ class DepotAuthoritySentinelTests(unittest.TestCase):
             return result, outputs
 
     def _validation_script(self) -> str:
-        block = self.sentinel.split(
-            "        run: |\n", 1
-        )[1].split("\n      - name:", 1)[0]
-        return "set -euo pipefail\n" + dedent(block)
+        return "set -euo pipefail\n" + self._step_script(
+            self.sentinel, "Validate protected sentinel identity"
+        )
 
     def _attestation_script(self) -> str:
-        start = self.sentinel.index(
-            "      - name: Attest provider-injected cache backend"
+        return "set -euo pipefail\n" + self._step_script(
+            self.sentinel, "Attest provider-injected cache backend"
         )
-        block = self.sentinel[start:].split("        run: |\n", 1)[1]
-        block = block.split("\n      - name:", 1)[0]
-        return "set -euo pipefail\n" + dedent(block)
 
     def _run_validation(
         self,
@@ -129,9 +160,10 @@ class DepotAuthoritySentinelTests(unittest.TestCase):
         results_url: str,
         *,
         runtime_token: str = "non-secret-runtime-token",
+        path: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
         environment = {
-            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "PATH": path or os.environ.get("PATH", "/usr/bin:/bin"),
             "ACTIONS_CACHE_URL": cache_url,
             "ACTIONS_RESULTS_URL": results_url,
             "ACTIONS_RUNTIME_TOKEN": runtime_token,
@@ -139,7 +171,7 @@ class DepotAuthoritySentinelTests(unittest.TestCase):
         if runtime_token == "":
             environment.pop("ACTIONS_RUNTIME_TOKEN")
         return subprocess.run(
-            ["bash", "-c", self._attestation_script()],
+            ["/bin/bash", "-c", self._attestation_script()],
             cwd=ROOT,
             env=environment,
             check=False,
@@ -335,17 +367,27 @@ class DepotAuthoritySentinelTests(unittest.TestCase):
         self.assertNotEqual(number_mismatch.returncode, 0)
 
     def test_cache_probe_restores_then_publishes_before_gate(self) -> None:
-        restore_index = self.sentinel.index("id: restore_seed")
-        replace_index = self.sentinel.index("Replace with deterministic PR poison marker")
-        save_index = self.sentinel.index("Save PR poison marker")
-        gate_index = self.sentinel.index("Require trusted seed isolation after poison publication")
-        self.assertLess(restore_index, replace_index)
-        self.assertLess(replace_index, save_index)
-        self.assertLess(save_index, gate_index)
-        restore = self.sentinel[restore_index:replace_index]
+        step_names = self._step_names(self.sentinel)
+        positions = {name: index for index, name in enumerate(step_names)}
+        self.assertLess(
+            positions["Restore trusted authority marker"],
+            positions["Replace with deterministic PR poison marker"],
+        )
+        self.assertLess(
+            positions["Replace with deterministic PR poison marker"],
+            positions["Save PR poison marker"],
+        )
+        self.assertLess(
+            positions["Save PR poison marker"],
+            positions["Require trusted seed isolation after poison publication"],
+        )
+        restore = self._step_block(self.sentinel, "Restore trusted authority marker")
         self.assertNotIn("lookup-only", restore)
         self.assertIn("uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25", restore)
-        self.assertIn("uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25", self.sentinel[save_index:gate_index])
+        self.assertIn(
+            "uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25",
+            self._step_block(self.sentinel, "Save PR poison marker"),
+        )
         self.assertIn("rm -rf -- .depot-authority-sentinel", self.sentinel)
         self.assertIn(
             "Trusted seed was not readable; pending trusted-main verify-pr-write.",
@@ -362,12 +404,37 @@ class DepotAuthoritySentinelTests(unittest.TestCase):
         self.assertEqual(result.stdout, "")
         self.assertEqual(result.stderr, "")
 
+        for endpoint in (
+            "http://126.255.255.255:1234/cache",
+            "http://128.0.0.0:1234/cache",
+            "http://[::ffff:126.255.255.255]:1234/cache",
+            "http://[::ffff:7e00:1]:1234/cache",
+            "http://[2001:db8::1]:1234/cache",
+        ):
+            with self.subTest(non_loopback=endpoint):
+                result = self._run_attestation(endpoint, valid_results)
+                self.assertEqual(result.returncode, 0, result.stderr)
+
         invalid_cases = (
             ("https://cache.example.invalid:1234/cache", "scheme"),
             ("http://actions.githubusercontent.com:1234/cache", "github"),
             ("http://localhost:1234/cache", "loopback"),
             ("http://127.0.0.1:1234/cache", "loopback"),
+            ("http://127.0.0.0:1234/cache", "loopback"),
+            ("http://127.1.2.3:1234/cache", "loopback"),
+            ("http://127.255.255.255:1234/cache", "loopback"),
             ("http://[::1]:1234/cache", "loopback"),
+            ("http://[::ffff:127.0.0.1]:1234/cache", "loopback"),
+            ("http://[::ffff:127.255.255.255]:1234/cache", "loopback"),
+            ("http://[::ffff:7f00:1]:1234/cache", "loopback"),
+            ("http://[0:0:0:0:0:ffff:127.0.0.1]:1234/cache", "loopback"),
+            ("http://[0:0:0:0:0:ffff:7f00:1]:1234/cache", "loopback"),
+            ("http://[0:0:0:0:0:0:0:1]:1234/cache", "loopback"),
+            ("http://[0::1]:1234/cache", "loopback"),
+            ("http://[0:0:0:0::1]:1234/cache", "loopback"),
+            ("http://[0::ffff:127.0.0.1]:1234/cache", "loopback"),
+            ("http://[0:0:0:0::ffff:127.0.0.1]:1234/cache", "loopback"),
+            ("http://[not-an-ip]:1234/cache", "parser"),
             ("http://user@cache.example.invalid:1234/cache", "userinfo"),
             ("http://cache.example.invalid/cache", "port"),
             ("http://cache.example.invalid:0/cache", "port"),
@@ -401,59 +468,145 @@ class DepotAuthoritySentinelTests(unittest.TestCase):
         )
         self.assertNotIn("non-secret-runtime-token", missing_token.stderr)
 
+        with tempfile.TemporaryDirectory() as bin_dir:
+            tr_path = shutil.which("tr")
+            self.assertIsNotNone(tr_path)
+            os.symlink(tr_path, Path(bin_dir) / "tr")
+            parser_missing = self._run_attestation(
+                "http://[2001:db8::1]:1234/cache",
+                valid_results,
+                path=bin_dir,
+            )
+        self.assertNotEqual(parser_missing.returncode, 0)
+        self.assertIn(
+            "cache backend attestation failed (variable=ACTIONS_CACHE_URL reason=parser)",
+            parser_missing.stderr,
+        )
+        self.assertNotIn("2001:db8::1", parser_missing.stderr)
+        self.assertIn("sys.version_info < (3, 8)", self._attestation_script())
+
+        with tempfile.TemporaryDirectory() as bin_dir:
+            tr_path = shutil.which("tr")
+            self.assertIsNotNone(tr_path)
+            os.symlink(tr_path, Path(bin_dir) / "tr")
+            fake_python = Path(bin_dir) / "python3"
+            fake_python.write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+            fake_python.chmod(0o755)
+            classifier_failed = self._run_attestation(
+                "http://[2001:db8::1]:1234/cache",
+                valid_results,
+                path=bin_dir,
+            )
+        self.assertNotEqual(classifier_failed.returncode, 0)
+        self.assertIn(
+            "cache backend attestation failed (variable=ACTIONS_CACHE_URL reason=parser)",
+            classifier_failed.stderr,
+        )
+        self.assertNotIn("2001:db8::1", classifier_failed.stderr)
+
+    def test_authority_attestation_copies_are_identical(self) -> None:
+        quality_script = self._attestation_script()
+        seed_script = "set -euo pipefail\n" + self._step_script(
+            self._job_block(self.canary, "seed_authority_marker"),
+            "Attest provider-injected cache backend",
+        )
+        verify_script = "set -euo pipefail\n" + self._step_script(
+            self._job_block(self.canary, "verify_pr_write"),
+            "Attest provider-injected cache backend",
+        )
+        self.assertEqual(quality_script, seed_script)
+        self.assertEqual(quality_script, verify_script)
+        for required in (
+            "is_loopback_authority()",
+            "127\\.[0-9]{1,3}",
+            "command -v python3",
+            "import ipaddress",
+            "sys.version_info < (3, 8)",
+            "ipv4_mapped",
+            "else 3",
+            "python_status == 3",
+            "ACTIONS_CACHE_URL",
+            "ACTIONS_RESULTS_URL",
+            "ACTIONS_RUNTIME_TOKEN",
+        ):
+            self.assertIn(required, quality_script)
+
     def test_five_pr_entrypoints_and_existing_build_shape_are_unchanged(self) -> None:
         expected = {
-            "pr_quality.yml",
-            "pr_website.yml",
-            "pr_linux.yml",
-            "pr_macos.yml",
-            "pr_windows.yml",
+            "pr_quality.yml": ("quality", "Quality", "quality"),
+            "pr_website.yml": ("website", "Website", "website"),
+            "pr_linux.yml": ("Linux", "Linux", "linux"),
+            "pr_macos.yml": ("macOS", "macOS", "macos"),
+            "pr_windows.yml": ("Windows", "Windows", "windows"),
         }
         validation_entrypoints = {
             path.name
             for path in WORKFLOWS.glob("pr_*.yml")
             if "  pull_request:" in path.read_text(encoding="utf-8")
         }
-        self.assertEqual(validation_entrypoints, expected)
+        self.assertEqual(validation_entrypoints, set(expected))
 
-        for name in ("ci-quality-lane.yml", *sorted(expected)):
-            current = (WORKFLOWS / name).read_text(encoding="utf-8")
-            baseline_entry = subprocess.check_output(
-                ["git", "show", f"HEAD:.github/workflows/{name}"],
-                cwd=ROOT,
-                text=True,
-            )
-            self.assertEqual(current, baseline_entry, name)
-
-        baseline = subprocess.check_output(
-            ["git", "show", "HEAD:.github/workflows/ci-quality-slice.yml"],
-            cwd=ROOT,
-            text=True,
+        quality_lane = (WORKFLOWS / "ci-quality-lane.yml").read_text(
+            encoding="utf-8"
         )
-        current_jobs = self.workflow.split("\njobs:\n", 1)[1]
-        baseline_jobs = baseline.split("\njobs:\n", 1)[1]
         self.assertEqual(
-            {
-                line.split(":", 1)[0].strip()
-                for line in current_jobs.splitlines()
-                if line.startswith("  ") and not line.startswith("    ")
-            },
-            {
-                line.split(":", 1)[0].strip()
-                for line in baseline_jobs.splitlines()
-                if line.startswith("  ") and not line.startswith("    ")
-            }
-            | {"authority_sentinel"},
+            self._job_names(quality_lane),
+            {"quality", "runner_contract", "summary"},
         )
+        self.assertIn(
+            "uses: ./.github/workflows/ci-quality-slice.yml",
+            self._job_block(quality_lane, "quality"),
+        )
+        self.assertIn(
+            "uses: ./.github/workflows/ci-runner-contract-slice.yml",
+            self._job_block(quality_lane, "runner_contract"),
+        )
+        summary = self._job_block(quality_lane, "summary")
+        self.assertIn("needs: [quality, runner_contract]", summary)
+        self.assertIn("runs-on: ubuntu-24.04", summary)
+
+        for filename, (plan_name, lane_name, lane_id) in expected.items():
+            workflow = (WORKFLOWS / filename).read_text(encoding="utf-8")
+            with self.subTest(workflow=filename):
+                self.assertEqual(
+                    self._job_names(workflow),
+                    {"plan", "lane", "required"},
+                )
+                plan = self._job_block(workflow, "plan")
+                lane = self._job_block(workflow, "lane")
+                required = self._job_block(workflow, "required")
+                self.assertIn(f"name: Plan {plan_name}", plan)
+                self.assertIn("runs-on: ubuntu-24.04", plan)
+                self.assertIn(
+                    f"uses: Mesh-LLM/mesh-llm/.github/workflows/ci-{lane_id}-lane.yml@main",
+                    lane,
+                )
+                self.assertIn(f"name: {lane_name}", lane)
+                self.assertIn(f"name: PR / {lane_name}", required)
+                self.assertIn("needs: [plan, lane]", required)
+                self.assertIn("runs-on: ubuntu-24.04", required)
+                self.assertIn("permissions: {}", required)
+
+        expected_slice_jobs = {
+            "runner_policy": "runs-on: ubuntu-24.04",
+            "quality_contracts": "runs-on: ${{ needs.runner_policy.outputs.runner_4 }}",
+            "rust_fmt": "runs-on: ${{ needs.runner_policy.outputs.runner_4 }}",
+            "rust_clippy": "runs-on: ${{ needs.runner_policy.outputs.runner_8 }}",
+            "cli_docs_sync": "runs-on: ${{ needs.runner_policy.outputs.runner_4 }}",
+            "authority_sentinel": "runs-on: ${{ needs.runner_policy.outputs.authority_sentinel_runner }}",
+        }
+        self.assertEqual(self._job_names(self.workflow), set(expected_slice_jobs))
+        for job_name, runner_expression in expected_slice_jobs.items():
+            with self.subTest(job=job_name):
+                self.assertIn(runner_expression, self._job_block(self.workflow, job_name))
+
         for job_name in (
             "quality_contracts",
             "rust_fmt",
             "rust_clippy",
             "cli_docs_sync",
         ):
-            current_job = self._job_block(self.workflow, job_name)
-            baseline_job = self._job_block(baseline, job_name)
-            self.assertEqual(current_job.rstrip(), baseline_job.rstrip(), job_name)
+            self.assertNotIn("authority_sentinel", self._job_block(self.workflow, job_name))
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_depot_authority_sentinel.py
+++ b/scripts/tests/test_depot_authority_sentinel.py
@@ -1,0 +1,460 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import re
+import subprocess
+import tempfile
+import unittest
+from textwrap import dedent
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOWS = ROOT / ".github" / "workflows"
+SELECTOR = ROOT / ".github" / "actions" / "select-ci-runners" / "action.yml"
+
+
+class DepotAuthoritySentinelTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.workflow = (WORKFLOWS / "ci-quality-slice.yml").read_text(
+            encoding="utf-8"
+        )
+        self.selector = SELECTOR.read_text(encoding="utf-8")
+        self.sentinel = self.workflow.split("  authority_sentinel:\n", 1)[1]
+
+    @staticmethod
+    def _job_block(workflow: str, job_name: str) -> str:
+        jobs = workflow.split("\njobs:\n", 1)[1]
+        match = re.search(
+            rf"^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+            jobs,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        if match is None:
+            raise AssertionError(f"missing job {job_name}")
+        return match.group("body")
+
+    def _run_selector(
+        self,
+        *,
+        event_name: str = "pull_request",
+        ref: str = "refs/pull/42/merge",
+        repository: str = "Mesh-LLM/mesh-llm",
+        head_repository: str = "Mesh-LLM/mesh-llm",
+        sentinel_ref: str = "refs/pull/42/merge",
+        force_hosted: str = "false",
+        pr_enabled: str = "false",
+    ) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
+        run_block = self.selector.split("      run: |\n", 1)[1]
+        script = "\n".join(
+            line[8:] if line.startswith("        ") else line
+            for line in run_block.splitlines()
+        )
+        with tempfile.TemporaryDirectory() as temp_dir:
+            output = Path(temp_dir) / "github-output"
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=ROOT,
+                env={
+                    **os.environ,
+                    "GITHUB_OUTPUT": str(output),
+                    "GITHUB_EVENT_NAME": event_name,
+                    "GITHUB_REPOSITORY": repository,
+                    "GITHUB_REF": ref,
+                    "INPUT_EVENT_NAME": event_name,
+                    "INPUT_ORIGINAL_EVENT_NAME": event_name,
+                    "INPUT_REPOSITORY": repository,
+                    "INPUT_HEAD_REPOSITORY": head_repository,
+                    "INPUT_REF": ref,
+                    "INPUT_DEPOT_MAIN_ENABLED": "false",
+                    "INPUT_DEPOT_PR_ENABLED": pr_enabled,
+                    "INPUT_PR_CANARY_REF": sentinel_ref,
+                    "INPUT_FORCE_HOSTED": force_hosted,
+                    "INPUT_MANUAL_USE_DEPOT": "false",
+                    "DISPATCH_ORIGINAL_EVENT_NAME": "",
+                },
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            outputs = {}
+            if output.exists():
+                outputs = dict(
+                    line.split("=", maxsplit=1)
+                    for line in output.read_text(encoding="utf-8").splitlines()
+                )
+            return result, outputs
+
+    def _validation_script(self) -> str:
+        block = self.sentinel.split(
+            "        run: |\n", 1
+        )[1].split("\n      - name:", 1)[0]
+        return "set -euo pipefail\n" + dedent(block)
+
+    def _attestation_script(self) -> str:
+        start = self.sentinel.index(
+            "      - name: Attest provider-injected cache backend"
+        )
+        block = self.sentinel[start:].split("        run: |\n", 1)[1]
+        block = block.split("\n      - name:", 1)[0]
+        return "set -euo pipefail\n" + dedent(block)
+
+    def _run_validation(
+        self,
+        sentinel_id: str,
+        pr_number: str,
+        configured_ref: str = "refs/pull/42/merge",
+    ) -> tuple[subprocess.CompletedProcess[str], str]:
+        with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as output:
+            result = subprocess.run(
+                ["bash", "-c", self._validation_script()],
+                cwd=ROOT,
+                env={
+                    "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                    "SENTINEL_ID": sentinel_id,
+                    "PR_NUMBER": pr_number,
+                    "CONFIGURED_SENTINEL_REF": configured_ref,
+                    "GITHUB_OUTPUT": output.name,
+                },
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            output.seek(0)
+            return result, output.read()
+
+    def _run_attestation(
+        self,
+        cache_url: str,
+        results_url: str,
+        *,
+        runtime_token: str = "non-secret-runtime-token",
+    ) -> subprocess.CompletedProcess[str]:
+        environment = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "ACTIONS_CACHE_URL": cache_url,
+            "ACTIONS_RESULTS_URL": results_url,
+            "ACTIONS_RUNTIME_TOKEN": runtime_token,
+        }
+        if runtime_token == "":
+            environment.pop("ACTIONS_RUNTIME_TOKEN")
+        return subprocess.run(
+            ["bash", "-c", self._attestation_script()],
+            cwd=ROOT,
+            env=environment,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_selector_truth_table_is_separate_from_normal_policy(self) -> None:
+        cases = (
+            ("exact same-repository PR ref", {}, True),
+            (
+                "missing sentinel ref",
+                {"sentinel_ref": ""},
+                False,
+            ),
+            (
+                "different PR ref",
+                {"sentinel_ref": "refs/pull/43/merge"},
+                False,
+            ),
+            (
+                "fork head",
+                {"head_repository": "attacker/mesh-llm"},
+                False,
+            ),
+            (
+                "forced hosted",
+                {"force_hosted": "true"},
+                False,
+            ),
+            (
+                "pull request target",
+                {"event_name": "pull_request_target"},
+                False,
+            ),
+            (
+                "dispatch with PR source",
+                {
+                    "event_name": "workflow_dispatch",
+                    "ref": "refs/heads/main",
+                },
+                False,
+            ),
+            (
+                "non-merge ref",
+                {"ref": "refs/pull/42/head"},
+                False,
+            ),
+        )
+        for name, kwargs, expected_depot in cases:
+            with self.subTest(case=name):
+                result, outputs = self._run_selector(**kwargs)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(outputs["depot_enabled"], str(expected_depot).lower())
+                self.assertEqual(
+                    outputs["runner"],
+                    "depot-ubuntu-24.04" if expected_depot else "ubuntu-24.04",
+                )
+
+        malformed, outputs = self._run_selector(sentinel_ref="refs/heads/main")
+        self.assertNotEqual(malformed.returncode, 0)
+        self.assertIn("exact pull-request merge ref", malformed.stderr)
+        self.assertEqual(outputs, {})
+
+        global_gate, global_outputs = self._run_selector(
+            sentinel_ref="", pr_enabled="true"
+        )
+        self.assertEqual(global_gate.returncode, 0, global_gate.stderr)
+        self.assertEqual(global_outputs["depot_enabled"], "true")
+        self.assertIn("github.ref == vars.DEPOT_PR_SENTINEL_REF", self.sentinel)
+
+    def test_normal_quality_jobs_keep_the_existing_provider_output(self) -> None:
+        policy = self.workflow.split("  runner_policy:\n", 1)[1].split(
+            "\n  quality_contracts:", 1
+        )[0]
+        self.assertIn(
+            "pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}",
+            policy,
+        )
+        self.assertIn(
+            "pr_canary_ref: ${{ vars.DEPOT_PR_SENTINEL_REF }}",
+            policy,
+        )
+        self.assertIn("depot_main_enabled: 'false'", policy)
+        self.assertIn("depot_pr_enabled: 'false'", policy)
+        self.assertIn("manual_use_depot: 'false'", policy)
+        self.assertIn(
+            "authority_sentinel_runner: ${{ steps.sentinel_policy.outputs.runner }}",
+            self.workflow,
+        )
+        self.assertIn(
+            "authority_sentinel_depot_enabled: ${{ steps.sentinel_policy.outputs.depot_enabled }}",
+            self.workflow,
+        )
+
+        for job_name in (
+            "quality_contracts",
+            "rust_fmt",
+            "rust_clippy",
+            "cli_docs_sync",
+        ):
+            job = self._job_block(self.workflow, job_name)
+            self.assertRegex(
+                job,
+                r"runs-on: \$\{\{ needs\.runner_policy\.outputs\.runner_(4|8) \}\}",
+            )
+            self.assertNotIn("sentinel_policy", job)
+
+    def test_authority_job_is_protected_and_has_no_pr_code_or_audit(self) -> None:
+        self.assertIn(
+            "needs.runner_policy.outputs.authority_sentinel_depot_enabled == 'true'",
+            self.sentinel,
+        )
+        self.assertIn("inputs.original_event_name == 'pull_request'", self.sentinel)
+        self.assertIn("github.event_name == 'pull_request'", self.sentinel)
+        self.assertIn("github.ref == vars.DEPOT_PR_SENTINEL_REF", self.sentinel)
+        self.assertIn(
+            "runs-on: ${{ needs.runner_policy.outputs.authority_sentinel_runner }}",
+            self.sentinel,
+        )
+        self.assertIn("permissions: {}", self.sentinel)
+        for forbidden in (
+            "actions/checkout@",
+            "source_sha",
+            "secrets.",
+            "audit-depot-pr-isolation@",
+        ):
+            self.assertNotIn(forbidden, self.sentinel)
+        self.assertIn("SENTINEL_ID: ${{ vars.DEPOT_PR_SENTINEL_ID }}", self.sentinel)
+        self.assertIn(
+            "PR_NUMBER: ${{ github.event.pull_request.number }}",
+            self.sentinel,
+        )
+
+    def test_sentinel_identity_and_key_grammar_are_bounded(self) -> None:
+        self.assertIn(
+            "if [[ ! \"$SENTINEL_ID\" =~ ^[0-9a-f]{32}$ ]]",
+            self.sentinel,
+        )
+        self.assertIn(
+            "if [[ ! \"$PR_NUMBER\" =~ ^[1-9][0-9]{0,8}$ ]]",
+            self.sentinel,
+        )
+        self.assertIn(
+            "seed_key=\"mesh-llm-depot-authority-seed-v1-${SENTINEL_ID}\"",
+            self.sentinel,
+        )
+        self.assertIn(
+            "poison_key=\"mesh-llm-depot-authority-pr-v1-${SENTINEL_ID}-pr-${PR_NUMBER}\"",
+            self.sentinel,
+        )
+        self.assertNotIn("key: ${{ vars.", self.sentinel)
+        self.assertNotIn("key: ${{ github.", self.sentinel)
+
+        valid_id = "0123456789abcdef0123456789abcdef"
+        valid_pr = "42"
+        result, output = self._run_validation(valid_id, valid_pr)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(
+            output,
+            "sentinel_id="
+            f"{valid_id}\n"
+            "pr_number=42\n"
+            "seed_key=mesh-llm-depot-authority-seed-v1-"
+            f"{valid_id}\n"
+            "poison_key=mesh-llm-depot-authority-pr-v1-"
+            f"{valid_id}-pr-42\n",
+        )
+        for invalid_id in (
+            "",
+            "ABCDEF0123456789abcdef0123456789",
+            "0" * 31,
+            "0" * 33,
+        ):
+            with self.subTest(invalid_id=invalid_id):
+                result, _ = self._run_validation(invalid_id, valid_pr)
+                self.assertNotEqual(result.returncode, 0)
+        for invalid_pr in ("", "0", "01", "+1", " 1", "1 ", "1" * 10):
+            with self.subTest(invalid_pr=invalid_pr):
+                result, _ = self._run_validation(valid_id, invalid_pr)
+                self.assertNotEqual(result.returncode, 0)
+        mismatch, _ = self._run_validation(
+            valid_id,
+            valid_pr,
+            configured_ref="refs/pull/43/merge",
+        )
+        self.assertNotEqual(mismatch.returncode, 0)
+        number_mismatch, _ = self._run_validation(
+            valid_id,
+            "43",
+            configured_ref="refs/pull/42/merge",
+        )
+        self.assertNotEqual(number_mismatch.returncode, 0)
+
+    def test_cache_probe_restores_then_publishes_before_gate(self) -> None:
+        restore_index = self.sentinel.index("id: restore_seed")
+        replace_index = self.sentinel.index("Replace with deterministic PR poison marker")
+        save_index = self.sentinel.index("Save PR poison marker")
+        gate_index = self.sentinel.index("Require trusted seed isolation after poison publication")
+        self.assertLess(restore_index, replace_index)
+        self.assertLess(replace_index, save_index)
+        self.assertLess(save_index, gate_index)
+        restore = self.sentinel[restore_index:replace_index]
+        self.assertNotIn("lookup-only", restore)
+        self.assertIn("uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25", restore)
+        self.assertIn("uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25", self.sentinel[save_index:gate_index])
+        self.assertIn("rm -rf -- .depot-authority-sentinel", self.sentinel)
+        self.assertIn(
+            "Trusted seed was not readable; pending trusted-main verify-pr-write.",
+            self.sentinel,
+        )
+        self.assertIn('if [[ "$CACHE_HIT" == "true" ]]', self.sentinel)
+        self.assertNotIn("${endpoint,,}", self.sentinel)
+
+    def test_authority_backend_attestation_is_value_free_and_fail_closed(self) -> None:
+        valid_cache = "http://cache.example.invalid:1234/cache"
+        valid_results = "http://results.example.invalid:5678/results"
+        result = self._run_attestation(valid_cache, valid_results)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout, "")
+        self.assertEqual(result.stderr, "")
+
+        invalid_cases = (
+            ("https://cache.example.invalid:1234/cache", "scheme"),
+            ("http://actions.githubusercontent.com:1234/cache", "github"),
+            ("http://localhost:1234/cache", "loopback"),
+            ("http://127.0.0.1:1234/cache", "loopback"),
+            ("http://[::1]:1234/cache", "loopback"),
+            ("http://user@cache.example.invalid:1234/cache", "userinfo"),
+            ("http://cache.example.invalid/cache", "port"),
+            ("http://cache.example.invalid:0/cache", "port"),
+            ("http://cache.example.invalid:65536/cache", "port"),
+            ("http://cache.example.invalid:1234", "path"),
+            ("http://cache.example.invalid:1234/cache with-space", "whitespace"),
+        )
+        for endpoint, reason in invalid_cases:
+            with self.subTest(endpoint=endpoint, reason=reason):
+                result = self._run_attestation(endpoint, valid_results)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "cache backend attestation failed (variable=ACTIONS_CACHE_URL "
+                    f"reason={reason})",
+                    result.stderr,
+                )
+                self.assertNotIn(endpoint, result.stderr)
+                self.assertNotIn("cache.example.invalid", result.stderr)
+                self.assertNotIn("actions.githubusercontent.com", result.stderr)
+                self.assertNotIn("non-secret-runtime-token", result.stderr)
+
+        missing_token = self._run_attestation(
+            valid_cache,
+            valid_results,
+            runtime_token="",
+        )
+        self.assertNotEqual(missing_token.returncode, 0)
+        self.assertIn(
+            "cache backend attestation failed (variable=ACTIONS_RUNTIME_TOKEN reason=missing)",
+            missing_token.stderr,
+        )
+        self.assertNotIn("non-secret-runtime-token", missing_token.stderr)
+
+    def test_five_pr_entrypoints_and_existing_build_shape_are_unchanged(self) -> None:
+        expected = {
+            "pr_quality.yml",
+            "pr_website.yml",
+            "pr_linux.yml",
+            "pr_macos.yml",
+            "pr_windows.yml",
+        }
+        validation_entrypoints = {
+            path.name
+            for path in WORKFLOWS.glob("pr_*.yml")
+            if "  pull_request:" in path.read_text(encoding="utf-8")
+        }
+        self.assertEqual(validation_entrypoints, expected)
+
+        for name in ("ci-quality-lane.yml", *sorted(expected)):
+            current = (WORKFLOWS / name).read_text(encoding="utf-8")
+            baseline_entry = subprocess.check_output(
+                ["git", "show", f"HEAD:.github/workflows/{name}"],
+                cwd=ROOT,
+                text=True,
+            )
+            self.assertEqual(current, baseline_entry, name)
+
+        baseline = subprocess.check_output(
+            ["git", "show", "HEAD:.github/workflows/ci-quality-slice.yml"],
+            cwd=ROOT,
+            text=True,
+        )
+        current_jobs = self.workflow.split("\njobs:\n", 1)[1]
+        baseline_jobs = baseline.split("\njobs:\n", 1)[1]
+        self.assertEqual(
+            {
+                line.split(":", 1)[0].strip()
+                for line in current_jobs.splitlines()
+                if line.startswith("  ") and not line.startswith("    ")
+            },
+            {
+                line.split(":", 1)[0].strip()
+                for line in baseline_jobs.splitlines()
+                if line.startswith("  ") and not line.startswith("    ")
+            }
+            | {"authority_sentinel"},
+        )
+        for job_name in (
+            "quality_contracts",
+            "rust_fmt",
+            "rust_clippy",
+            "cli_docs_sync",
+        ):
+            current_job = self._job_block(self.workflow, job_name)
+            baseline_job = self._job_block(baseline, job_name)
+            self.assertEqual(current_job.rstrip(), baseline_job.rstrip(), job_name)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_depot_canary_workflow.py
+++ b/scripts/tests/test_depot_canary_workflow.py
@@ -2,6 +2,7 @@ import unittest
 import os
 from pathlib import Path
 import re
+import shutil
 import subprocess
 import tempfile
 from textwrap import dedent
@@ -28,10 +29,21 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
 
     @staticmethod
     def _step_script(job: str, step_name: str) -> str:
-        start = job.index(f"      - name: {step_name}")
-        body = job[start:].split("        run: |\n", 1)[1]
-        body = body.split("\n      - name:", 1)[0]
-        return dedent(body)
+        match = re.search(
+            rf"^      - name: {re.escape(step_name)}\n(?P<body>.*?)(?=^      - name:|\Z)",
+            job,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        if match is None:
+            raise AssertionError(f"missing step {step_name}")
+        run = re.search(
+            r"^        run: \|\n(?P<script>.*)",
+            match.group("body"),
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        if run is None:
+            raise AssertionError(f"step {step_name} has no run script")
+        return dedent(run.group("script"))
 
     def _run_attestation(
         self,
@@ -40,9 +52,10 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
         results_url: str,
         *,
         runtime_token: str = "non-secret-runtime-token",
+        path: str | None = None,
     ) -> subprocess.CompletedProcess[str]:
         environment = {
-            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "PATH": path or os.environ.get("PATH", "/usr/bin:/bin"),
             "ACTIONS_CACHE_URL": cache_url,
             "ACTIONS_RESULTS_URL": results_url,
             "ACTIONS_RUNTIME_TOKEN": runtime_token,
@@ -50,7 +63,7 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
         if runtime_token == "":
             environment.pop("ACTIONS_RUNTIME_TOKEN")
         return subprocess.run(
-            ["bash", "-c", "set -euo pipefail\n" + script],
+            ["/bin/bash", "-c", "set -euo pipefail\n" + script],
             check=False,
             capture_output=True,
             text=True,
@@ -84,12 +97,9 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
         for mode in ("audit", "seed", "verify-pr-write"):
             self.assertIn(f"          - {mode}", self.workflow)
 
-        audit_start = self.workflow.index("  runner:")
-        seed_start = self.workflow.index("  seed_authority_marker:")
-        verify_start = self.workflow.index("  verify_pr_write:")
-        audit = self.workflow[audit_start:seed_start]
-        seed = self.workflow[seed_start:verify_start]
-        verify = self.workflow[verify_start:]
+        audit = self._job_block("runner")
+        seed = self._job_block("seed_authority_marker")
+        verify = self._job_block("verify_pr_write")
 
         self.assertIn("github.event.inputs.mode == 'audit'", audit)
         self.assertIn("github.event.inputs.mode == 'seed'", seed)
@@ -281,7 +291,21 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                 ("ACTIONS_CACHE_URL", "http://actions.githubusercontent.com:1234/cache", "github"),
                 ("ACTIONS_CACHE_URL", "http://localhost:1234/cache", "loopback"),
                 ("ACTIONS_CACHE_URL", "http://127.0.0.1:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://127.0.0.0:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://127.1.2.3:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://127.255.255.255:1234/cache", "loopback"),
                 ("ACTIONS_CACHE_URL", "http://[::1]:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://[::ffff:127.0.0.1]:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://[::ffff:127.255.255.255]:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://[::ffff:7f00:1]:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://[0:0:0:0:0:ffff:127.0.0.1]:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://[0:0:0:0:0:ffff:7f00:1]:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://[0:0:0:0:0:0:0:1]:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://[0::1]:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://[0:0:0:0::1]:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://[0::ffff:127.0.0.1]:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://[0:0:0:0::ffff:127.0.0.1]:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://[not-an-ip]:1234/cache", "parser"),
                 ("ACTIONS_CACHE_URL", "http://user@cache.example.invalid:1234/cache", "userinfo"),
                 ("ACTIONS_CACHE_URL", "http://cache.example.invalid/cache", "port"),
                 ("ACTIONS_CACHE_URL", "http://cache.example.invalid:0/cache", "port"),
@@ -435,14 +459,18 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         action_run = action.split("      run: |\n", maxsplit=1)[1]
         action_script = dedent(action_run)
-        canary_start = self.workflow.index("          depot_selected=true")
-        canary_end = self.workflow.index(
-            "          {\n",
-            canary_start,
+        runner_script = self._step_script(
+            self._job_block("runner"),
+            "Verify ephemeral runner resources",
         )
-        canary_script = "set -euo pipefail\n" + dedent(
-            self.workflow[canary_start:canary_end],
+        cache_probe = re.search(
+            r"^depot_selected=true\n(?P<body>.*?)(?=^\{\n|\Z)",
+            runner_script,
+            flags=re.MULTILINE | re.DOTALL,
         )
+        if cache_probe is None:
+            raise AssertionError("missing canary cache probe")
+        canary_script = "set -euo pipefail\n" + cache_probe.group(0)
 
         def run_probe(
             script: str,

--- a/scripts/tests/test_depot_canary_workflow.py
+++ b/scripts/tests/test_depot_canary_workflow.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 from pathlib import Path
+import re
 import subprocess
 import tempfile
 from textwrap import dedent
@@ -13,6 +14,48 @@ WORKFLOW = ROOT / ".github" / "workflows" / "depot-canary.yml"
 class DepotCanaryWorkflowTests(unittest.TestCase):
     def setUp(self) -> None:
         self.workflow = WORKFLOW.read_text(encoding="utf-8")
+
+    def _job_block(self, job_name: str) -> str:
+        jobs = self.workflow.split("\njobs:\n", 1)[1]
+        match = re.search(
+            rf"^  {re.escape(job_name)}:\n(?P<body>.*?)(?=^  [A-Za-z0-9_-]+:\n|\Z)",
+            jobs,
+            flags=re.MULTILINE | re.DOTALL,
+        )
+        if match is None:
+            raise AssertionError(f"missing job {job_name}")
+        return match.group("body")
+
+    @staticmethod
+    def _step_script(job: str, step_name: str) -> str:
+        start = job.index(f"      - name: {step_name}")
+        body = job[start:].split("        run: |\n", 1)[1]
+        body = body.split("\n      - name:", 1)[0]
+        return dedent(body)
+
+    def _run_attestation(
+        self,
+        script: str,
+        cache_url: str,
+        results_url: str,
+        *,
+        runtime_token: str = "non-secret-runtime-token",
+    ) -> subprocess.CompletedProcess[str]:
+        environment = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+            "ACTIONS_CACHE_URL": cache_url,
+            "ACTIONS_RESULTS_URL": results_url,
+            "ACTIONS_RUNTIME_TOKEN": runtime_token,
+        }
+        if runtime_token == "":
+            environment.pop("ACTIONS_RUNTIME_TOKEN")
+        return subprocess.run(
+            ["bash", "-c", "set -euo pipefail\n" + script],
+            check=False,
+            capture_output=True,
+            text=True,
+            env=environment,
+        )
 
     def test_canary_has_no_code_or_credential_access(self) -> None:
         self.assertIn("permissions: {}", self.workflow)
@@ -34,6 +77,250 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                 self.assertIn(f"- {runner}", self.workflow)
         self.assertIn("expected_arch=aarch64", self.workflow)
         self.assertIn('actual_arch="$(uname -m)"', self.workflow)
+
+    def test_canary_sentinel_modes_are_single_runner_and_cache_bounded(self) -> None:
+        self.assertIn("type: choice", self.workflow)
+        self.assertIn("default: audit", self.workflow)
+        for mode in ("audit", "seed", "verify-pr-write"):
+            self.assertIn(f"          - {mode}", self.workflow)
+
+        audit_start = self.workflow.index("  runner:")
+        seed_start = self.workflow.index("  seed_authority_marker:")
+        verify_start = self.workflow.index("  verify_pr_write:")
+        audit = self.workflow[audit_start:seed_start]
+        seed = self.workflow[seed_start:verify_start]
+        verify = self.workflow[verify_start:]
+
+        self.assertIn("github.event.inputs.mode == 'audit'", audit)
+        self.assertIn("github.event.inputs.mode == 'seed'", seed)
+        self.assertIn("github.event.inputs.mode == 'verify-pr-write'", verify)
+        for block in (seed, verify):
+            with self.subTest(block=block.splitlines()[0]):
+                self.assertIn("permissions: {}", block)
+                self.assertIn("runs-on: depot-ubuntu-24.04", block)
+                self.assertNotIn("actions/checkout", block)
+                self.assertNotIn("secrets.", block)
+
+        self.assertIn(
+            "printf 'mesh-llm-depot-authority-marker-v1\\nsentinel_id=%s\\n'",
+            seed,
+        )
+        self.assertIn(
+            "uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25",
+            seed,
+        )
+        self.assertIn(
+            "uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25",
+            seed,
+        )
+        self.assertNotIn("lookup-only: true", seed)
+        self.assertIn("fail-on-cache-miss: true", seed)
+        self.assertIn("Clear local marker before trusted restore", seed)
+        self.assertIn("Validate trusted marker content", seed)
+        self.assertIn("cmp -s", seed)
+        self.assertIn(
+            "key: ${{ steps.validate.outputs.seed_key }}",
+            seed,
+        )
+        self.assertEqual(seed.count("path: .depot-authority-sentinel"), 2)
+        self.assertIn(
+            "key: ${{ steps.validate.outputs.poison_key }}",
+            verify,
+        )
+        self.assertIn("path: .depot-authority-sentinel", verify)
+        self.assertNotIn("lookup-only: true", verify)
+        self.assertIn("fail-on-cache-miss: false", verify)
+        self.assertIn("Clear local poison marker before trusted restore", verify)
+        self.assertIn("Validate PR poison marker content on hit", verify)
+        self.assertIn("cmp -s", verify)
+        self.assertIn("PR poison marker was visible to trusted main", verify)
+
+        for block in (seed, verify):
+            self.assertIn("Attest provider-injected cache backend", block)
+            self.assertIn("ACTIONS_CACHE_URL", block)
+            self.assertIn("ACTIONS_RESULTS_URL", block)
+            self.assertIn("ACTIONS_RUNTIME_TOKEN", block)
+            self.assertIn("cache backend attestation failed", block)
+            self.assertNotIn("${endpoint,,}", block)
+
+    def test_sentinel_inputs_are_strict_and_derive_fixed_keys(self) -> None:
+        seed = self.workflow.split("  seed_authority_marker:", 1)[1].split(
+            "  verify_pr_write:", 1
+        )[0]
+        verify = self.workflow.split("  verify_pr_write:", 1)[1]
+
+        def validation_script(block: str) -> str:
+            run_marker = "        run: |\n"
+            script = block.split(run_marker, 1)[1].split(
+                "\n      - name:", 1
+            )[0]
+            return "set -euo pipefail\n" + dedent(script)
+
+        def run_validation(
+            script: str,
+            sentinel_id: str,
+            pr_number: str,
+            configured_id: str = "0123456789abcdef0123456789abcdef",
+            configured_ref: str = "refs/pull/42/merge",
+        ) -> tuple[subprocess.CompletedProcess[str], str]:
+            with tempfile.NamedTemporaryFile(mode="w+", encoding="utf-8") as output:
+                environment = {
+                    "PATH": os.environ.get("PATH", "/usr/bin:/bin"),
+                    "SENTINEL_ID": sentinel_id,
+                    "PR_NUMBER": pr_number,
+                    "CONFIGURED_SENTINEL_ID": configured_id,
+                    "CONFIGURED_SENTINEL_REF": configured_ref,
+                    "GITHUB_OUTPUT": output.name,
+                }
+                result = subprocess.run(
+                    ["bash", "-c", script],
+                    check=False,
+                    capture_output=True,
+                    text=True,
+                    env=environment,
+                )
+                output.seek(0)
+                return result, output.read()
+
+        valid_id = "0123456789abcdef0123456789abcdef"
+        valid_pr = "42"
+        seed_result, seed_output = run_validation(
+            validation_script(seed), valid_id, valid_pr
+        )
+        self.assertEqual(seed_result.returncode, 0, seed_result.stderr)
+        self.assertEqual(
+            seed_output,
+            "sentinel_id="
+            f"{valid_id}\n"
+            "seed_key=mesh-llm-depot-authority-seed-v1-"
+            f"{valid_id}\n"
+            "poison_key=mesh-llm-depot-authority-pr-v1-"
+            f"{valid_id}-pr-{valid_pr}\n",
+        )
+
+        verify_result, verify_output = run_validation(
+            validation_script(verify), valid_id, valid_pr
+        )
+        self.assertEqual(verify_result.returncode, 0, verify_result.stderr)
+        self.assertEqual(
+            verify_output,
+            "sentinel_id="
+            f"{valid_id}\n"
+            "pr_number=42\n"
+            "poison_key=mesh-llm-depot-authority-pr-v1-"
+            f"{valid_id}-pr-{valid_pr}\n",
+        )
+
+        for sentinel_id in (
+            "",
+            "ABCDEF0123456789abcdef0123456789",
+            "0" * 31,
+            "0" * 33,
+        ):
+            with self.subTest(sentinel_id=sentinel_id):
+                result, _ = run_validation(
+                    validation_script(seed), sentinel_id, valid_pr
+                )
+                self.assertNotEqual(result.returncode, 0)
+
+        for pr_number in ("", "0", "01", "+1", " 1", "1 ", "1" * 10):
+            with self.subTest(pr_number=pr_number):
+                result, _ = run_validation(
+                    validation_script(seed), valid_id, pr_number
+                )
+                self.assertNotEqual(result.returncode, 0)
+
+        for script_name, script in (("seed", seed), ("verify", verify)):
+            with self.subTest(script=script_name, mismatch="id"):
+                result, _ = run_validation(
+                    validation_script(script),
+                    valid_id,
+                    valid_pr,
+                    configured_id="fedcba9876543210fedcba9876543210",
+                )
+                self.assertNotEqual(result.returncode, 0)
+            with self.subTest(script=script_name, mismatch="ref"):
+                result, _ = run_validation(
+                    validation_script(script),
+                    valid_id,
+                    valid_pr,
+                    configured_ref="refs/pull/43/merge",
+                )
+                self.assertNotEqual(result.returncode, 0)
+            with self.subTest(script=script_name, mismatch="number"):
+                result, _ = run_validation(
+                    validation_script(script),
+                    valid_id,
+                    "43",
+                    configured_ref="refs/pull/42/merge",
+                )
+                self.assertNotEqual(result.returncode, 0)
+
+    def test_all_cache_phases_attest_non_github_remote_backend(self) -> None:
+        valid_cache = "http://cache.example.invalid:1234/cache"
+        valid_results = "http://results.example.invalid:5678/results"
+        scripts = {
+            "seed": self._step_script(
+                self._job_block("seed_authority_marker"),
+                "Attest provider-injected cache backend",
+            ),
+            "verify-pr-write": self._step_script(
+                self._job_block("verify_pr_write"),
+                "Attest provider-injected cache backend",
+            ),
+        }
+        for phase, script in scripts.items():
+            with self.subTest(phase=phase, backend="valid"):
+                result = self._run_attestation(script, valid_cache, valid_results)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, "")
+                self.assertEqual(result.stderr, "")
+
+            invalid_cases = (
+                ("ACTIONS_CACHE_URL", "https://cache.example.invalid:1234/cache", "scheme"),
+                ("ACTIONS_CACHE_URL", "http://actions.githubusercontent.com:1234/cache", "github"),
+                ("ACTIONS_CACHE_URL", "http://localhost:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://127.0.0.1:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://[::1]:1234/cache", "loopback"),
+                ("ACTIONS_CACHE_URL", "http://user@cache.example.invalid:1234/cache", "userinfo"),
+                ("ACTIONS_CACHE_URL", "http://cache.example.invalid/cache", "port"),
+                ("ACTIONS_CACHE_URL", "http://cache.example.invalid:0/cache", "port"),
+                ("ACTIONS_CACHE_URL", "http://cache.example.invalid:65536/cache", "port"),
+                ("ACTIONS_CACHE_URL", "http://cache.example.invalid:1234", "path"),
+                ("ACTIONS_CACHE_URL", "http://cache.example.invalid:1234/cache with-space", "whitespace"),
+                ("ACTIONS_RESULTS_URL", "https://results.example.invalid:5678/results", "scheme"),
+                ("ACTIONS_RESULTS_URL", "http://results.example.invalid/results", "port"),
+                ("ACTIONS_RESULTS_URL", "http://results.example.invalid:5678", "path"),
+            )
+            for endpoint_name, endpoint, reason in invalid_cases:
+                with self.subTest(phase=phase, endpoint=endpoint_name, reason=reason):
+                    cache_url = endpoint if endpoint_name == "ACTIONS_CACHE_URL" else valid_cache
+                    results_url = endpoint if endpoint_name == "ACTIONS_RESULTS_URL" else valid_results
+                    result = self._run_attestation(script, cache_url, results_url)
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(
+                        f"cache backend attestation failed (variable={endpoint_name} reason={reason})",
+                        result.stderr,
+                    )
+                    self.assertNotIn(endpoint, result.stderr)
+                    self.assertNotIn("cache.example.invalid", result.stderr)
+                    self.assertNotIn("results.example.invalid", result.stderr)
+                    self.assertNotIn("actions.githubusercontent.com", result.stderr)
+                    self.assertNotIn("non-secret-runtime-token", result.stderr)
+
+            with self.subTest(phase=phase, token="missing"):
+                result = self._run_attestation(
+                    script,
+                    valid_cache,
+                    valid_results,
+                    runtime_token="",
+                )
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(
+                    "cache backend attestation failed (variable=ACTIONS_RUNTIME_TOKEN reason=missing)",
+                    result.stderr,
+                )
+                self.assertNotIn("non-secret-runtime-token", result.stderr)
 
     def test_canary_fails_closed_on_cache_and_registry_injection(self) -> None:
         self.assertIn("forbidden_names=", self.workflow)


### PR DESCRIPTION
## Summary

- add a protected, no-checkout PR authority sentinel without changing the five PR entrypoints or ordinary build routing
- extend the manual Depot canary with bounded seed and trusted-main verify phases
- bind every phase to an exact sentinel ID, PR number, and merge ref, and attest the provider-injected remote cache backend before pinned cache actions
- document the inert rollout protocol and add exhaustive fail-closed workflow contracts

## Security properties

- no PR source checkout or PR code execution in the sentinel job
- no secrets and empty job permissions
- exact same-repository pull-request merge-ref selection only
- ordinary/global Depot PR gates cannot activate the sentinel
- deterministic non-secret marker content and fixed cache-key grammar
- backend failures expose only variable/reason classes, never endpoint or token values

## Validation

- `just ci-validate` (458 tests, 7 expected skips)
- focused sentinel/canary tests (16)
- independent CI artifact/lane/PR workflow tests (77)
- `actionlint`
- Bash syntax checks for 26 workflow run blocks
- `git diff --check`

Independent review: approved with no blockers after verifying exact identity binding, backend attestation, full restore/content checks, and unchanged existing PR build graph.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a protected CI authority-sentinel diagnostic to validate cache isolation on approved pull-request references.
  - Added manual canary modes for auditing, seeding, and pull-request write verification.
  - Added strict validation for sentinel identity, references, cache endpoints, and runtime credentials.
  - Invalid, forked, or unsupported configurations remain on hosted runners without affecting normal CI routing.

- **Documentation**
  - Documented sentinel behavior, cache verification, restrictions, and fail-closed handling.

- **Tests**
  - Added comprehensive coverage for routing, validation, cache markers, and existing CI behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->