### PR TITLE
CI: exercise Depot authority sentinel

### DIFF
--- a/crates/mesh-llm-host-runtime/src/lib.rs
+++ b/crates/mesh-llm-host-runtime/src/lib.rs
@@ -1,5 +1,8 @@
 #![recursion_limit = "256"]
 
+// CI authority-sentinel fixture: this comment-only change gives the protected
+// pull-request probe real merge-ref context without changing runtime behavior.
+
 mod api;
 mod capture;
 pub mod command_support;


### PR DESCRIPTION
## Purpose

This is a disposable, comment-only probe PR for the protected Depot cache-authority sentinel. It must not be merged.

The source change creates a real same-repository pull-request merge ref without changing runtime behavior or CI-control files. Normal build jobs must remain hosted; only the separately gated, protected, no-checkout authority sentinel may select Depot after the exact sentinel variables are configured.

## Validation

- `just with-lld cargo fmt --all -- --check`
- `git diff --check`

The PR will be closed and its sentinel variables removed after seed, PR-probe, and trusted-main verification evidence is collected.