### PR TITLE
CI: Depot authority sentinel probe

### DIFF
--- a/crates/mesh-llm-host-runtime/src/lib.rs
+++ b/crates/mesh-llm-host-runtime/src/lib.rs
@@ -1,5 +1,8 @@
 #![recursion_limit = "256"]
 
+// CI authority-sentinel fixture: this comment-only change provides a real
+// pull-request merge ref without changing runtime behavior.
+
 mod api;
 mod capture;
 pub mod command_support;


### PR DESCRIPTION
Disposable protected CI probe for the Depot authority sentinel protocol.

This PR contains only a comment fixture and must not be merged. Repository sentinel variables will be bound to its exact merge ref only for the bounded seed/PR-write/main-verify sequence, then removed immediately.