### PR TITLE
Docs: record unsafe Depot PR authority

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -1,8 +1,8 @@
 # MeshLLM CI inventory
 
-This file records checked-in CI facts. It is not a record of historical runs
-or live GitHub/Depot administration. Read it with `../SKILL.md` and `ci/ci.md`
-before editing CI.
+This file records checked-in CI facts and selected controlled probe evidence.
+It is not a complete historical run log or live GitHub/Depot administration.
+Read it with `../SKILL.md` and `ci/ci.md` before editing CI.
 
 ## Entry workflows
 
@@ -162,14 +162,22 @@ Cache connectivity is disabled, automatic Registry Actions authentication is
 disabled, and the Depot runner group is restricted to `Mesh-LLM/mesh-llm` and
 the exact protected workflow refs. The repository token cannot independently
 inspect organization runner-group settings through the API (403), so these
-remain external facts rather than checked-in evidence. The protected
-branch/main canary, same-repository PR canary, fork PR canary, provider-parity
-comparison, and rollback run are still pending; `DEPOT_PR_SENTINEL_REF` and
-`DEPOT_PR_SENTINEL_ID` are unset by default, and `DEPOT_RUNNERS_ENABLED` or a
-successful manual canary does not prove PR isolation. Fork PR validation
-remains hosted and is the no-Depot-authority half of the sentinel acceptance
-evidence; only the exact same-repository sentinel ref may exercise the
-diagnostic Depot job. All three sentinel cache phases attest the
+remain external facts rather than checked-in evidence. The controlled
+trusted-main seed [run 31816775585](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816775585)
+succeeded at `main` commit `9e977e246`; the same-repository PR authority
+sentinel [run 31816869128 / job 94821057215](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816869128/job/94821057215)
+read and exactly validated the trusted seed, saved/cleared/restored and
+exactly validated the poison, then failed its intended seed-isolation gate;
+trusted-main verify [run 31817111471 / job 94821343605](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31817111471/job/94821343605)
+restored and exactly validated that poison, then failed its intended expected-
+miss gate. This proves unsafe repository-scoped cross-trust authority, so it is
+not a successful isolation result. `DEPOT_PR_RUNNERS_ENABLED`,
+`DEPOT_PR_CANARY_REF`, `DEPOT_PR_SENTINEL_REF` and `DEPOT_PR_SENTINEL_ID`
+remain absent. Fork PR validation, provider-parity/capacity comparison,
+namespace purge/expiry confirmation and rollback remain pending. Fork PR
+validation remains hosted and is the no-Depot-authority half of the sentinel
+acceptance evidence; only the exact same-repository sentinel ref may exercise
+the diagnostic Depot job. All three sentinel cache phases attest the
 provider-injected `ACTIONS_CACHE_URL`/`ACTIONS_RESULTS_URL` structure before
 invoking pinned `actions/cache` restore/save actions. The shell attestation
 does not require ambient `ACTIONS_RUNTIME_TOKEN`: GitHub's
@@ -202,7 +210,9 @@ consumer (explicit cache actions, setup-* package caches, rust-cache, static /
 Metal / Windows / Swift ABI caches and Windows SDK cache toggles) and Depot
 remote cache when those outputs are false; cache misses rebuild normally. This checked-in mode does not
 prove the absence of ambient Depot/WebDAV authority, so the runtime sentinel
-and no-secret/no-token canaries remain required. Other variables include `CUDA_VERSION`,
+has recorded unsafe repository-scoped cross-trust authority and must be
+redesigned and repeated successfully; no-secret/no-token, fork and provider-
+parity canaries remain required. Other variables include `CUDA_VERSION`,
 `VULKAN_SDK_VERSION`, smoke configuration variables, and release/deployment
 variables. Secret values never belong in this inventory;
 known names include `HF_TOKEN`, release-attestation keys, `CARGO_REGISTRY_TOKEN`

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -168,7 +168,8 @@ succeeded at `main` commit `9e977e246`; the same-repository PR authority
 sentinel [run 31816869128 / job 94821057215](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816869128/job/94821057215)
 read and exactly validated the trusted seed, saved/cleared/restored and
 exactly validated the poison, then failed its intended seed-isolation gate;
-trusted-main verify [run 31817111471 / job 94821343605](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31817111471/job/94821343605)
+the enclosing PR run was later cancelled during cleanup. Trusted-main verify
+[run 31817111471 / job 94821343605](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31817111471/job/94821343605)
 restored and exactly validated that poison, then failed its intended expected-
 miss gate. This proves unsafe repository-scoped cross-trust authority, so it is
 not a successful isolation result. `DEPOT_PR_RUNNERS_ENABLED`,

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -255,9 +255,10 @@ install/build commands remain unchanged. Hosted release and cache-warmer
 paths retain their existing GitHub cache behavior. The Depot namespace is
 intentionally unused by trusted workflows, so existing entries must be purged
 or expire before the PR gate. A GitHub-owned or strict loopback proxy is inert
-transport only, not an ambient authority proof; the actual runner sentinel
-and no-token checks remain required before enabling the canary or global PR
-gate.
+transport only, not an ambient authority proof; the completed sentinel has
+shown unsafe repository-scoped cross-trust access, so a provider-isolation
+redesign and a new successful sentinel remain required before enabling the
+canary or global PR gate.
 
 The sentinel is deliberately outside the planner/build graph and does not
 invoke `audit-depot-pr-isolation`: that audit rejects the ambient endpoint
@@ -287,6 +288,21 @@ trusted-main `verify-pr-write` phase pending; main verify's poison miss remains
 the cross-scope proof. Fork PRs remain hosted and
 provide the no-Depot-authority evidence; only the exact same-repository
 sentinel ref exercises the Depot diagnostic.
+
+Controlled evidence now records the authority result: trusted-main seed
+[run 31816775585](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816775585)
+succeeded at `main` commit `9e977e246`; the same-repository PR sentinel
+[run 31816869128 / job 94821057215](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816869128/job/94821057215)
+restored and exactly validated the trusted seed, saved/cleared/restored and
+exactly validated the poison, then failed its intended seed-isolation gate;
+trusted-main verify
+[run 31817111471 / job 94821343605](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31817111471/job/94821343605)
+restored and exactly validated that poison, then failed its intended expected-
+miss gate. This is unsafe repository-scoped cross-trust authority, not a
+successful isolation result. Keep `DEPOT_PR_RUNNERS_ENABLED` and all sentinel /
+canary variables absent. A provider-isolation redesign and a new successful
+sentinel are required before PR Depot can be reconsidered; fork,
+provider-parity, capacity and rollback evidence remain pending.
 
 Before a PR Depot path is enabled, an administrator must prove:
 

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -295,7 +295,7 @@ succeeded at `main` commit `9e977e246`; the same-repository PR sentinel
 [run 31816869128 / job 94821057215](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816869128/job/94821057215)
 restored and exactly validated the trusted seed, saved/cleared/restored and
 exactly validated the poison, then failed its intended seed-isolation gate;
-trusted-main verify
+the enclosing PR run was later cancelled during cleanup. Trusted-main verify
 [run 31817111471 / job 94821343605](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31817111471/job/94821343605)
 restored and exactly validated that poison, then failed its intended expected-
 miss gate. This is unsafe repository-scoped cross-trust authority, not a

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -3,18 +3,19 @@
 Status: trusted-main support exists; pull-request execution is future work and
 is disabled. Automatic Depot Cache and Registry Actions connectivity are
 admin-verified off, and the Depot runner group is admin-verified restricted to
-this repository and the protected workflow allowlist. The checked-in graph and
-collector define the remaining branch/main and same-repository/fork canaries;
-those runtime checks still block PR activation.
+this repository and the protected workflow allowlist. The controlled
+trusted-main/PR authority probe is complete and demonstrates unsafe
+repository-scoped cross-trust authority; fork, provider-parity, capacity and
+rollback evidence still block PR activation.
 
 Checked-in policy now treats Depot's cache namespace as unused: every Depot
 selection disables both native GitHub Actions cache and Depot remote cache.
 Purge or expiry of existing entries remains an activation prerequisite.
 
 The complete PR/main composition design is in
-`.omo/specs/pr-ci-optimization.md`. This document contains only the durable
-Depot policy and activation gates. It intentionally contains no historical run
-results or timing conclusions.
+`.omo/specs/pr-ci-optimization.md`. This document contains the durable Depot
+policy, activation gates and the controlled authority-probe evidence below;
+it intentionally contains no timing conclusions.
 
 ## Provider contract
 
@@ -26,9 +27,11 @@ Depot is a placement provider, not a different CI graph.
 - `DEPOT_RUNNERS_ENABLED == 'true'` permits eligible trusted `main` Linux jobs
   to select Depot. Every eligible role retains a GitHub-hosted fallback.
 - `DEPOT_PR_RUNNERS_ENABLED == 'true'` is the independent same-repository PR
-  placement gate. It must remain absent or `false` until the branch/main
-  provider-parity, same-repository, and fork sentinel canaries below pass; a
-  missing value fails closed.
+  placement gate. It must remain absent or `false`: the controlled
+  same-repository authority probe below demonstrated unsafe repository-scoped
+  cross-trust access, and a new successful sentinel after provider-isolation
+  redesign is required before reconsideration. Branch/main provider parity and
+  the fork sentinel remain separate pending gates; a missing value fails closed.
 - `DEPOT_PR_CANARY_REF` is an optional, exact
   `refs/pull/<number>/merge` selector for one protected same-repository canary
   ref. It does not enable the global PR gate, does not grant remote cache
@@ -169,13 +172,41 @@ Re-verify it with organization-admin authority if the group, repository, or
 workflow allowlist changes. A repository token returning `403` is not an
 independent proof of the configuration.
 
-## Why PR canaries remain pending
+## Controlled authority probe: unsafe cross-trust result
+
+The protected seed/verify workflows and reusable PR slice came from `main`
+commit `9e977e246`; the authoritative PR rerun used source head `e0c9be507`.
+The bounded sentinel ID/ref repository variables were temporarily armed for
+the experiment and removed immediately afterward. Its exact evidence is:
+
+| Phase | Evidence | Outcome |
+| --- | --- | --- |
+| Trusted-main seed | [run 31816775585](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816775585), `main` at `9e977e246` | Successful seed publication |
+| Same-repository PR authority sentinel | [run 31816869128](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816869128), [job 94821057215](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816869128/job/94821057215), PR source `e0c9be507`, protected slice `9e977e246` | The sentinel job failed after restoring and exactly validating the trusted seed, then saving, clearing, restoring and exactly validating the poison marker; the overall superseded probe run was later cancelled during cleanup |
+| Trusted-main verify | [run 31817111471](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31817111471), [job 94821343605](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31817111471/job/94821343605) | Restored and exactly validated the PR poison marker; then failed the intended expected-miss gate |
+
+This is an unsafe repository-scoped cross-trust authority result: the
+same-repository PR path could read the trusted marker and publish a marker that
+trusted main later restored. The intended failures are evidence that the gates
+fired after the probes, not successful isolation. Do not enable PR Depot from
+this result. A provider-isolation redesign and a new successful sentinel are
+required before any reconsideration. `DEPOT_PR_RUNNERS_ENABLED`,
+`DEPOT_PR_CANARY_REF`, `DEPOT_PR_SENTINEL_REF` and `DEPOT_PR_SENTINEL_ID`
+remain absent. No Depot settings or runner groups were changed; the bounded
+repository variables were temporarily armed and then removed. The randomized
+non-secret seed and poison entries may remain until provider expiry or an
+administrator confirms namespace purge.
+
+The fork PR canary, provider-parity/capacity comparison, namespace
+purge/expiry confirmation and rollback evidence remain pending. Fork
+validation must stay hosted and remains the no-Depot-authority half of the
+acceptance evidence.
 
 Disabling automatic Depot Cache and Registry Actions connectivity removes the
-repository-wide credential path that blocked the first canary. It does not by
-itself prove provider parity, branch/main cache behavior, or that a same-
-repository or fork PR cannot publish an entry later restored by trusted main.
-Those runtime isolation checks remain prerequisites for PR execution on Depot.
+repository-wide credential path that blocked the first canary, but it does not
+override this observed authority result or prove provider parity, branch/main
+cache behavior, or fork isolation. Those remaining checks and the isolation
+redesign are prerequisites for PR execution on Depot.
 
 Depot documents these GitHub Actions cache properties:
 
@@ -209,15 +240,18 @@ Actions authentication are now admin-verified off. The negative
 `depot-canary.yml` contract checks that this posture reaches fresh runners
 without Depot cache, WebDAV, registry, or transparent GitHub-cache authority.
 
-The remaining runtime questions are:
+The controlled probe above answers the first question for the current runner:
+the same-repository PR path exposed repository-scoped authority. The remaining
+runtime questions are:
 
-1. Does a fresh Depot runner expose any ambient Depot/WebDAV/cache authority
-   to a PR job even when the checked-in native cache consumers are disabled?
+1. What provider-isolation redesign prevents that observed authority from
+   crossing trust boundaries while preserving the same cache probe contract?
 2. Do hosted release and cache-warmer jobs retain their intended GitHub cache
    behavior while trusted Depot selections remain cache-inert, and have all
    existing Depot namespace entries been purged or expired?
-3. Can a same-repository PR and a fork PR both run the protected canary with no
-   Depot cache/registry authority and no entry that trusted main later restores?
+3. Can a redesigned same-repository PR path and a fork PR both run the
+   protected canary with no Depot cache/registry authority and no entry that
+   trusted main later restores?
 4. Does provider parity hold for the same checked plan, commands, artifacts,
    and required results on GitHub and Depot?
 5. Does the restricted runner group continue to allow only the exact protected

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -408,14 +408,14 @@ The external administrative posture now has automatic Depot Cache and Registry
 Actions connectivity disabled and the Depot runner group restricted to this
 repository and its exact protected workflow refs. The controlled trusted-main
 seed [run 31816775585](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816775585)
-at `main` commit `9e977e246`, same-repository PR authority sentinel
+at `main` commit `9e977e246` succeeded. The same-repository PR authority sentinel
 [run 31816869128 / job 94821057215](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816869128/job/94821057215),
-and trusted-main verify
+read and exactly validated the trusted seed, published and exactly validated
+the poison marker, and then failed its intended seed-isolation gate; the
+enclosing PR run was later cancelled during cleanup. Trusted-main verify
 [run 31817111471 / job 94821343605](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31817111471/job/94821343605)
-are complete. The PR sentinel read and exactly validated the trusted seed,
-published and exactly validated the poison marker, and then failed its
-intended seed-isolation gate; trusted main later restored and exactly validated
-that poison and failed its intended expected-miss gate. This proves unsafe
+restored and exactly validated that poison and failed its intended expected-
+miss gate. This proves unsafe
 repository-scoped cross-trust authority. Do not enable PR Depot without a
 provider-isolation redesign and a new successful sentinel; all
 `DEPOT_PR_RUNNERS_ENABLED`, `DEPOT_PR_CANARY_REF`, `DEPOT_PR_SENTINEL_REF` and

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -400,16 +400,31 @@ external gates are ready. The implemented cache-inert mode prevents the
 checked-in GitHub and Depot cache consumers from reading or writing on any
 Depot run, but it does not prove that a runner has no ambient Depot/WebDAV/cache
 authority. A protected runner-group check, no-secret/no-token execution,
-namespace purge/expiry, and the non-secret sentinel canary in
-`ci/DEPOT_MIGRATION.md` remain prerequisites.
+namespace purge/expiry, provider-isolation redesign and a new successful
+non-secret sentinel in `ci/DEPOT_MIGRATION.md` remain prerequisites.
 Do not change Depot settings or runner groups in a workflow refactor.
 
 The external administrative posture now has automatic Depot Cache and Registry
 Actions connectivity disabled and the Depot runner group restricted to this
-repository and its exact protected workflow refs. The negative main canary,
-branch/main provider-parity check, same-repository PR canary, fork PR canary,
-and rollback evidence remain pending; those runtime checks are distinct from
-the settings verification and must pass before PR placement is enabled.
+repository and its exact protected workflow refs. The controlled trusted-main
+seed [run 31816775585](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816775585)
+at `main` commit `9e977e246`, same-repository PR authority sentinel
+[run 31816869128 / job 94821057215](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816869128/job/94821057215),
+and trusted-main verify
+[run 31817111471 / job 94821343605](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31817111471/job/94821343605)
+are complete. The PR sentinel read and exactly validated the trusted seed,
+published and exactly validated the poison marker, and then failed its
+intended seed-isolation gate; trusted main later restored and exactly validated
+that poison and failed its intended expected-miss gate. This proves unsafe
+repository-scoped cross-trust authority. Do not enable PR Depot without a
+provider-isolation redesign and a new successful sentinel; all
+`DEPOT_PR_RUNNERS_ENABLED`, `DEPOT_PR_CANARY_REF`, `DEPOT_PR_SENTINEL_REF` and
+`DEPOT_PR_SENTINEL_ID` variables remain absent.
+
+Branch/main provider-parity, fork PR canary, capacity/namespace purge or expiry,
+and rollback evidence remain pending; those checks are distinct from the
+settings verification and must pass after the redesign before PR placement is
+enabled.
 
 ## Required extension pattern
 


### PR DESCRIPTION
## Summary
- record the exact trusted-main seed, PR sentinel, and trusted-main verify evidence
- document that Depot cache authority crossed the PR/main trust boundary in both directions
- keep PR Depot gates absent and require provider-isolation redesign plus a new successful sentinel
- preserve remaining fork/provider-parity/capacity/purge/rollback gates as pending

## Validation
- `just ci-validate` (460 tests, 7 skipped)
- focused CI workflow contract tests (80)
- `git diff --check`
- independent evidence verification against live GitHub runs

Docs only; no workflow, product, settings, runner-group, or gate changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CI and Depot migration guidance with results from controlled cache-isolation checks.
  * Documented unsafe cross-trust cache access and the requirement for provider-isolation improvements.
  * Clarified that Depot-based pull request caching remains disabled pending successful isolation, fork, parity, capacity, expiry, and rollback validation.
  * Added detailed evidence, outcomes, and remaining verification requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->