### PR TITLE
Docs: define Depot PR cache isolation contract

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -199,9 +199,10 @@ The provider contract required before PR placement is enabled is a documented,
 server-enforced per-connection/job/ref control for the GitHub Actions cache
 path. It must either leave PR jobs on GitHub-native branch-scoped
 `ACTIONS_CACHE_URL`/`ACTIONS_RESULTS_URL` and runtime-token semantics with no
-Depot proxy or direct cache token, or issue a PR-isolated namespace whose ACL
-denies reads/writes outside that PR and prevents trusted main/release restores,
-without exposing `DEPOT_CACHE_TOKEN`. Key prefixes, loopback proxies,
+Depot proxy or direct cache token, or issue a PR-isolated namespace/token whose
+ACL permits reads/writes only within that PR, denying reads/writes from trusted
+main/release and every other PR namespace, without exposing `DEPOT_CACHE_TOKEN`.
+Key prefixes, loopback proxies,
 ephemeral runners and the org switches are not equivalent controls. A fresh
 same-repository PR, fork PR and trusted-main seed/verify sentinel must prove
 the selected behavior before any PR gate or canary variable is armed.

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -162,7 +162,11 @@ Cache connectivity is disabled, automatic Registry Actions authentication is
 disabled, and the Depot runner group is restricted to `Mesh-LLM/mesh-llm` and
 the exact protected workflow refs. The repository token cannot independently
 inspect organization runner-group settings through the API (403), so these
-remain external facts rather than checked-in evidence. The controlled
+remain external facts rather than checked-in evidence. The two switches remove
+Depot's direct `DEPOT_CACHE_TOKEN`/WebDAV build-tool preconfiguration and
+Registry Actions authentication on fresh runners; they do not document or
+enforce a per-connection/job/ref disable or ACL for the GitHub Actions cache
+proxy/runtime-token path. The controlled
 trusted-main seed [run 31816775585](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816775585)
 succeeded at `main` commit `9e977e246`; the same-repository PR authority
 sentinel [run 31816869128 / job 94821057215](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816869128/job/94821057215)
@@ -190,6 +194,17 @@ The protected PR probe clears and fully restores its saved poison key, requires
 a cache hit and exact marker bytes before the trusted-seed gate, and thereby
 proves the same-job Node token/write path; main verify's poison miss remains
 the cross-scope proof.
+
+The provider contract required before PR placement is enabled is a documented,
+server-enforced per-connection/job/ref control for the GitHub Actions cache
+path. It must either leave PR jobs on GitHub-native branch-scoped
+`ACTIONS_CACHE_URL`/`ACTIONS_RESULTS_URL` and runtime-token semantics with no
+Depot proxy or direct cache token, or issue a PR-isolated namespace whose ACL
+denies reads/writes outside that PR and prevents trusted main/release restores,
+without exposing `DEPOT_CACHE_TOKEN`. Key prefixes, loopback proxies,
+ephemeral runners and the org switches are not equivalent controls. A fresh
+same-repository PR, fork PR and trusted-main seed/verify sentinel must prove
+the selected behavior before any PR gate or canary variable is armed.
 Bracketed IPv6 authorities use the fixed runner's Python 3.8+ stdlib
 `ipaddress` classifier; parser absence/version/invalidity fails closed.
 Attestation reports only value-free variable/reason classes and fails closed

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -269,8 +269,9 @@ proved that path remains repository-scoped across the trusted-main/PR boundary.
 The required provider contract is therefore a supported, server-enforced
 per-connection/job/ref control that either leaves PR jobs on GitHub-native
 branch-scoped Actions endpoints/token with no Depot proxy or direct cache
-token, or issues a PR-isolated namespace whose ACL prevents trusted
-main/release reads and restores, without exposing `DEPOT_CACHE_TOKEN`.
+token, or issues a PR-isolated namespace/token whose ACL permits reads and
+writes only within that PR, denying reads and writes from trusted main/release
+and every other PR namespace, without exposing `DEPOT_CACHE_TOKEN`.
 
 The sentinel is deliberately outside the planner/build graph and does not
 invoke `audit-depot-pr-isolation`: that audit rejects the ambient endpoint
@@ -320,7 +321,9 @@ Before a PR Depot path is enabled, an administrator must prove:
 
 1. the provider's documented per-connection/job/ref control selects either
    GitHub-native branch-scoped Actions cache endpoints/token with no Depot
-   cache token, or a PR-isolated namespace inaccessible to trusted main/release;
+   cache token, or a PR-isolated namespace/token whose ACL permits reads and
+   writes only within that PR, denying reads and writes from trusted
+   main/release and every other PR namespace;
 2. same-repository and fork PRs receive no cache, registry or repository secret
    authority;
 3. hostile PRs cannot read a trusted sentinel or publish an entry restored by

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -260,6 +260,18 @@ shown unsafe repository-scoped cross-trust access, so a provider-isolation
 redesign and a new successful sentinel remain required before enabling the
 canary or global PR gate.
 
+The admin-verified organization switches have a narrower effect than the
+checked-in consumer policy: they remove direct `DEPOT_CACHE_TOKEN`/WebDAV
+build-tool preconfiguration and Registry Actions authentication from fresh
+runners, but they do not document or enforce a per-connection/job/ref disable
+or ACL for the GitHub Actions cache proxy/runtime-token path. The sentinel
+proved that path remains repository-scoped across the trusted-main/PR boundary.
+The required provider contract is therefore a supported, server-enforced
+per-connection/job/ref control that either leaves PR jobs on GitHub-native
+branch-scoped Actions endpoints/token with no Depot proxy or direct cache
+token, or issues a PR-isolated namespace whose ACL prevents trusted
+main/release reads and restores, without exposing `DEPOT_CACHE_TOKEN`.
+
 The sentinel is deliberately outside the planner/build graph and does not
 invoke `audit-depot-pr-isolation`: that audit rejects the ambient endpoint
 before cache access, whereas this diagnostic must exercise the actual restore
@@ -306,7 +318,9 @@ provider-parity, capacity and rollback evidence remain pending.
 
 Before a PR Depot path is enabled, an administrator must prove:
 
-1. automatic Depot cache connectivity is disabled or provides per-PR isolation;
+1. the provider's documented per-connection/job/ref control selects either
+   GitHub-native branch-scoped Actions cache endpoints/token with no Depot
+   cache token, or a PR-isolated namespace inaccessible to trusted main/release;
 2. same-repository and fork PRs receive no cache, registry or repository secret
    authority;
 3. hostile PRs cannot read a trusted sentinel or publish an entry restored by

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -2,11 +2,14 @@
 
 Status: trusted-main support exists; pull-request execution is future work and
 is disabled. Automatic Depot Cache and Registry Actions connectivity are
-admin-verified off, and the Depot runner group is admin-verified restricted to
-this repository and the protected workflow allowlist. The controlled
-trusted-main/PR authority probe is complete and demonstrates unsafe
-repository-scoped cross-trust authority; fork, provider-parity, capacity and
-rollback evidence still block PR activation.
+admin-verified off. Those switches remove Depot's direct `DEPOT_CACHE_TOKEN`,
+build-tool cache preconfiguration and Registry Actions authentication from
+fresh runners; they do not provide a documented per-connection/job/ref ACL or
+disable for the GitHub Actions cache proxy/runtime-token path. The Depot runner
+group is admin-verified restricted to this repository and the protected
+workflow allowlist. The controlled trusted-main/PR authority probe is complete
+and demonstrates unsafe repository-scoped cross-trust authority; fork,
+provider-parity, capacity and rollback evidence still block PR activation.
 
 Checked-in policy now treats Depot's cache namespace as unused: every Depot
 selection disables both native GitHub Actions cache and Depot remote cache.
@@ -118,9 +121,12 @@ Actions authentication is disabled, and the Depot runner group is restricted
 to `Mesh-LLM/mesh-llm` with exact protected workflow refs. The repository token
 cannot independently inspect organization runner-group settings through the
 API (403), so this remains external activation state rather than checked-in
-proof. The settings remove automatic credential authority; they do not prove
-that a protected main build, same-repository PR, or fork PR receives the
-intended provider, cache mode, or rollback behavior.
+proof. The switches remove the provider's direct Depot build-tool and registry
+credential path (including automatic `DEPOT_CACHE_TOKEN`/WebDAV setup), but
+they do not document or enforce a per-connection/job/ref disable or ACL for
+the GitHub Actions cache proxy and its runtime-token path. The sentinel proved
+that this path remains repository-scoped and crosses the trusted-main/PR
+boundary; it therefore remains unsafe even with both switches unchecked.
 
 Do not migrate required checks, enable Depot for PR content, or change cache
 isolation during this provider rollout. Those are independent changes with
@@ -193,9 +199,13 @@ this result. A provider-isolation redesign and a new successful sentinel are
 required before any reconsideration. `DEPOT_PR_RUNNERS_ENABLED`,
 `DEPOT_PR_CANARY_REF`, `DEPOT_PR_SENTINEL_REF` and `DEPOT_PR_SENTINEL_ID`
 remain absent. No Depot settings or runner groups were changed; the bounded
-repository variables were temporarily armed and then removed. The randomized
-non-secret seed and poison entries may remain until provider expiry or an
-administrator confirms namespace purge.
+repository variables were temporarily armed and then removed. Read-only Cache
+Explorer evidence verifies that both randomized non-secret entries are still
+present: seed `mesh-llm-depot-authority-seed-v1-4089d6c8551820aa86b7780157729786`
+(303 B) and poison
+`mesh-llm-depot-authority-pr-v1-4089d6c8551820aa86b7780157729786-pr-1327`
+(308 B). Purge or provider-expiry confirmation remains pending; this
+docs-only change must not delete them.
 
 The fork PR canary, provider-parity/capacity comparison, namespace
 purge/expiry confirmation and rollback evidence remain pending. Fork
@@ -203,10 +213,13 @@ validation must stay hosted and remains the no-Depot-authority half of the
 acceptance evidence.
 
 Disabling automatic Depot Cache and Registry Actions connectivity removes the
-repository-wide credential path that blocked the first canary, but it does not
-override this observed authority result or prove provider parity, branch/main
-cache behavior, or fork isolation. Those remaining checks and the isolation
-redesign are prerequisites for PR execution on Depot.
+direct Depot build-tool/registry credential path that blocked the first canary
+(including automatic `DEPOT_CACHE_TOKEN`/WebDAV preconfiguration), but it does
+not disable or isolate the GitHub Actions cache proxy/runtime-token path. The
+sentinel used that path and proved repository-scoped cross-trust authority, so
+the switch state does not override the observed result or prove provider
+parity, branch/main cache behavior, or fork isolation. Those remaining checks
+and the isolation redesign are prerequisites for PR execution on Depot.
 
 Depot documents these GitHub Actions cache properties:
 
@@ -224,6 +237,29 @@ cache keys and access the service directly. Prefixes, restore-only intent,
 job-local sccache and a default-branch caller do not remove that authority.
 This creates a cache-poisoning path into trusted main/release consumers.
 
+### Required provider isolation contract
+
+Before any PR runner gate or canary is enabled, Depot must expose a supported,
+server-enforced per-connection/job/ref control for the GitHub Actions cache
+path. The control must choose one of these safe outcomes for an untrusted PR:
+
+- leave the job on GitHub-native branch-scoped `ACTIONS_CACHE_URL`,
+  `ACTIONS_RESULTS_URL` and runtime-token semantics, with no Depot cache proxy
+  or direct Depot cache token; or
+- issue a PR-isolated cache namespace and token whose ACL denies reads and
+  writes outside that PR and prevents trusted `main`/release jobs from reading
+  or restoring PR entries, again without exposing a direct `DEPOT_CACHE_TOKEN`.
+
+The contract must cover `actions/cache`, setup-* cache consumers and any other
+GitHub Actions cache API caller, including the provider's
+`ACTIONS_RUNTIME_TOKEN` injection. Cache-key prefixes, a loopback proxy,
+ephemeral runners, the organization switch above, and runner-group workflow
+restrictions are not substitutes for this server-enforced control. The
+provider must document the control and its trust/ref semantics, and a fresh
+same-repository PR, fork PR and trusted-main seed/verify sentinel must prove
+the selected outcome before `DEPOT_PR_RUNNERS_ENABLED` or any canary selector
+is armed.
+
 Official references:
 
 - [Depot GitHub Actions cache](https://depot.dev/docs/cache/integrations/github-actions)
@@ -238,7 +274,10 @@ Depot documents an organization setting named **Allow Actions jobs to
 automatically connect to Depot Cache**. That setting and automatic Registry
 Actions authentication are now admin-verified off. The negative
 `depot-canary.yml` contract checks that this posture reaches fresh runners
-without Depot cache, WebDAV, registry, or transparent GitHub-cache authority.
+without direct Depot build-tool/WebDAV or registry preconfiguration. It does
+not establish a provider-side disable or per-PR ACL for the GitHub Actions
+cache proxy/runtime-token path; the authority sentinel is the required proof
+for that path and currently records unsafe repository-scoped access.
 
 The controlled probe above answers the first question for the current runner:
 the same-repository PR path exposed repository-scoped authority. The remaining

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -246,9 +246,10 @@ path. The control must choose one of these safe outcomes for an untrusted PR:
 - leave the job on GitHub-native branch-scoped `ACTIONS_CACHE_URL`,
   `ACTIONS_RESULTS_URL` and runtime-token semantics, with no Depot cache proxy
   or direct Depot cache token; or
-- issue a PR-isolated cache namespace and token whose ACL denies reads and
-  writes outside that PR and prevents trusted `main`/release jobs from reading
-  or restoring PR entries, again without exposing a direct `DEPOT_CACHE_TOKEN`.
+- issue a PR-isolated cache namespace and token whose ACL permits reads and
+  writes only within that PR, denying reads and writes from trusted
+  `main`/release jobs and every other PR namespace, again without exposing a
+  direct `DEPOT_CACHE_TOKEN`.
 
 The contract must cover `actions/cache`, setup-* cache consumers and any other
 GitHub Actions cache API caller, including the provider's

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -292,6 +292,15 @@ proxy is inert transport only; its presence is not proof of authority
 isolation, and the gate remains closed until no trusted workflow consumes the
 Depot namespace.
 
+The admin-verified organization switches have a narrower meaning than that
+consumer policy: disabling automatic Depot Cache and Registry Actions
+connectivity removes the direct `DEPOT_CACHE_TOKEN`/WebDAV build-tool
+preconfiguration and Registry Actions authentication from fresh runners. It
+does not document or enforce a per-connection/job/ref disable or ACL for the
+GitHub Actions cache proxy/runtime-token path. The controlled sentinel proved
+that this path remains repository-scoped and crosses the trusted-main/PR
+boundary, so switch state is not an isolation proof.
+
 The selector also accepts the optional repository variable
 `DEPOT_PR_CANARY_REF`. When it is absent (the default), no canary PR is
 selected and the normal global `DEPOT_PR_RUNNERS_ENABLED` gate is unchanged.
@@ -406,7 +415,10 @@ Do not change Depot settings or runner groups in a workflow refactor.
 
 The external administrative posture now has automatic Depot Cache and Registry
 Actions connectivity disabled and the Depot runner group restricted to this
-repository and its exact protected workflow refs. The controlled trusted-main
+repository and its exact protected workflow refs. The switches remove the
+direct Depot build-tool/registry credential path (including automatic
+`DEPOT_CACHE_TOKEN`/WebDAV preconfiguration), but do not disable or isolate the
+GitHub Actions cache proxy/runtime-token path. The controlled trusted-main
 seed [run 31816775585](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816775585)
 at `main` commit `9e977e246` succeeded. The same-repository PR authority sentinel
 [run 31816869128 / job 94821057215](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31816869128/job/94821057215),


### PR DESCRIPTION
## Summary
- distinguish Depot's disabled Registry/build-tool cache switches from the still-active GitHub Actions cache proxy authority
- document the server-enforced provider isolation contract required before enabling Depot for untrusted PR jobs
- record the unsafe seed/poison sentinel evidence and the remaining Cache Explorer entries
- keep all `DEPOT_PR_*` gates absent and make no workflow, runner, or settings changes

## Why
The controlled sentinel demonstrated that a same-repository PR could restore a trusted seed and publish a poison entry later restored by trusted main. Depot's documented repository-scoped cache has no branch isolation, so workflow-level cache flags and key prefixes are not a security boundary.

## Validation
- `just ci-validate` (460 tests, 7 skipped)
- `actionlint -config-file .github/actionlint.yaml`
- `git diff --check`
- all five current main lanes at `f2fa14e32b0a3860daaaffdf703856645efb4364` completed successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that disabling direct Depot Cache and Registry authentication does not disable GitHub Actions cache proxy access.
  - Documented cross-trust cache risks and required provider-enforced isolation before activation.
  - Added validation requirements covering same-repository pull requests, fork pull requests, and trusted-main workflows.
  - Expanded migration guidance, cache-canary checks, failure conditions, and administrator checklists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->