### PR TITLE
Allow bounded Depot caching for approved PRs

### DIFF
--- a/.agents/skills/manage-ci/SKILL.md
+++ b/.agents/skills/manage-ci/SKILL.md
@@ -204,7 +204,8 @@ owning source, and update the inventory and topology in the same change.
 - A caller may not choose a privileged runner label or independently grant
   remote-cache access. The workflow that owns `runs-on` must derive both from
   repository, event, ref, trust profile, architecture, and a bounded size.
-- Ordinary PR jobs remain GitHub-hosted; an explicitly approved ephemeral,
+- Ordinary PR jobs remain GitHub-hosted unless the bounded same-repository
+  Depot risk exception below is active; an explicitly approved ephemeral,
   uncredentialed hardware runner may own a documented GPU smoke exception.
   Eligible trusted main jobs may use
   Depot only through the exact-string `DEPOT_RUNNERS_ENABLED` gate and retain a
@@ -222,14 +223,14 @@ owning source, and update the inventory and topology in the same change.
 - Provider changes must not alter source checkout, commands, profile,
   artifacts, tests, required checks, or plan membership.
 
-### Depot PR prohibition and future gate
+### Bounded Depot PR cache-risk exception
 
 Depot Cache currently scopes entries by repository but not by branch and
 automatically connects GitHub-cache API consumers on Depot runners. Cache-key
 prefixes, job-local sccache, and a trusted caller do not prevent checked-out PR
 code from using injected cache authority directly.
 
-Do not enable Depot for PR code until all of the following are proven:
+The provider-isolation requirements below remain the desired end state:
 
 1. Automatic Depot Cache connectivity is disabled for the PR runner context,
    or Depot supplies a comparably strong per-PR namespace and read/write policy.
@@ -245,16 +246,42 @@ Do not enable Depot for PR code until all of the following are proven:
 6. GitHub-hosted rollback remains one checked provider-policy change and does
    not change the plan or artifact graph.
 
-This is future work. Do not mutate Depot organization settings, runner groups,
-or PR runner routing as part of ordinary workflow refactoring.
+Until the provider supplies that end state, maintainers may deliberately accept
+the documented repository-wide cache risk for one exact same-repository PR
+head under all of these controls:
+
+- the exception has a checked-in UTC expiry and fails hosted after it;
+- `DEPOT_PR_RUNNERS_ENABLED` is exactly `true`;
+- `DEPOT_PR_APPROVED_REF` exactly matches `refs/pull/<number>/merge` and
+  `DEPOT_PR_APPROVED_SHA` exactly matches the current PR head SHA;
+- the head repository is exactly `Mesh-LLM/mesh-llm`; forks remain hosted;
+- CI-control, workflow, runner-policy and cache-policy changes force hosted;
+- the protected default-branch runner-owning workflows remain the executor;
+- PR jobs receive no repository secrets or registry credentials; and
+- rollback is deletion/false of the PR gate or either exact approval value.
+
+This is an explicit speed-versus-isolation decision, not evidence that Depot
+cache is isolated. While active, GitHub Actions cache API consumers on selected
+Depot PR and trusted-main jobs may share Depot's repository-wide namespace.
+Treat that namespace as attacker-controlled and keep release, publishing,
+deployment and credential-bearing jobs off it. Record the rationale, known
+failure modes, owner, start, expiry and rollback in
+`ci/DEPOT_PR_RISK_EXCEPTION.md`.
+
+GitHub's `all_external_contributors` workflow-approval policy does not cover a
+same-repository branch pushed by a collaborator. Do not describe that setting
+as the approval boundary for this exception. The exact maintainer-controlled
+ref and head-SHA variables are the checked-in per-PR approval boundary and must
+be refreshed after every PR synchronization.
 
 ## Cache contract
 
 - Declare cache mode per slice: no remote cache, PR restore-only/isolated, or
   trusted read-write. Derive it from the same policy as runner placement.
-- GitHub-hosted PR writes remain isolated from trusted main: protected
+- GitHub-hosted PR writes remain isolated from trusted main: normal protected
   same-repository and fork lanes explicitly force restore-only cache mode even
-  though their workflow ref is the default branch. Trusted
+  though their workflow ref is the default branch. The bounded Depot exception
+  is the documented cross-branch deviation. Trusted
   main/release/warmers own shared publication. Do not save large shared
   Rust/native caches from PRs.
 - GitHub scopes caches created by `pull_request` runs to that PR's merge ref.

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -122,11 +122,11 @@ inputs and dated reports belong under `/tmp` or a tracking issue/artifact, not
 under `ci/` or this inventory.
 
 Artifacts are correctness boundaries; caches only accelerate regeneration.
-PR artifacts generally retain for one day. Protected same-repository and fork
-lanes cannot publish shared trusted-main caches, and Depot cache access is
-denied. The Depot namespace is intentionally unused by trusted workflows;
-purge/expiry is required before PR activation, and an inert proxy is not
-authority-isolation proof. Large Cargo target caches restore trusted-main entries but remain
+PR artifacts generally retain for one day. Fork lanes cannot publish shared
+trusted-main caches. Same-repository PRs normally use GitHub's ref-scoped cache;
+an exact approved revision may temporarily use Depot's shared cross-branch
+namespace under `ci/DEPOT_PR_RISK_EXCEPTION.md`. That namespace is treated as
+untrusted input, not an authority or correctness boundary. Large Cargo target caches restore trusted-main entries but remain
 restore-only on PRs. Exact Linux static ABI, Swift ABI, macOS Metal unit ABI,
 and Windows native ABI caches may publish into GitHub's isolated PR merge-ref
 scope for same-PR reruns. The Website slice is the sole publisher for the
@@ -141,10 +141,12 @@ non-fail-fast, failed producers suppress only declared consumers through
 ## Providers and variables
 
 GitHub-hosted labels are `ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-15`, and
-`windows-2022`. Depot labels are selected only by `select-ci-runners` for
-trusted main Linux when `DEPOT_RUNNERS_ENABLED` is exactly `true`; no workflow
-accepts a raw provider label. Current ordinary PR execution remains hosted
-until the protected PR gate is separately activated. The intended final gate
+`windows-2022`. Depot labels are selected only by `select-ci-runners`; no
+workflow accepts a raw provider label. Trusted main Linux requires
+`DEPOT_RUNNERS_ENABLED=true`. An exact same-repository PR revision may use the
+time-bounded exception only when `DEPOT_PR_RUNNERS_ENABLED=true` and both
+`DEPOT_PR_APPROVED_REF` and `DEPOT_PR_APPROVED_SHA` match; it expires on
+2026-09-14 UTC. Forks remain hosted. The intended permanent gate
 may cover eligible build/test rows across Linux, Depot macOS 15 and Windows
 2022 when equivalent images/architectures exist; planning/required summaries,
 credential-bearing smokes, `gpu-nvidia` hardware and uncertified Intel macOS
@@ -152,10 +154,11 @@ rows remain exceptions. The documented `gpu-nvidia` ephemeral scale set is
 the sole current uncredentialed, hardware-qualified same-repository PR
 exception.
 
-The future Depot PR gate is documented in `ci/DEPOT_MIGRATION.md`. It requires
-cache isolation, no PR cache/registry tokens, exact protected workflow refs,
-ephemeral runners, a sentinel canary, and a tested GitHub rollback. No Depot
-settings or runner groups are changed by this workflow refactor.
+The permanent Depot PR gate is documented in `ci/DEPOT_MIGRATION.md`; the
+accepted temporary findings and risks are in
+`ci/DEPOT_PR_RISK_EXCEPTION.md`. Permanent activation requires cache
+isolation, no PR cache/registry tokens, exact protected workflow refs,
+ephemeral runners, a successful sentinel, and a tested GitHub rollback.
 
 External administrative posture is now verified as follows: automatic Depot
 Cache connectivity is disabled, automatic Registry Actions authentication is
@@ -176,9 +179,10 @@ the enclosing PR run was later cancelled during cleanup. Trusted-main verify
 [run 31817111471 / job 94821343605](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31817111471/job/94821343605)
 restored and exactly validated that poison, then failed its intended expected-
 miss gate. This proves unsafe repository-scoped cross-trust authority, so it is
-not a successful isolation result. `DEPOT_PR_RUNNERS_ENABLED`,
-`DEPOT_PR_CANARY_REF`, `DEPOT_PR_SENTINEL_REF` and `DEPOT_PR_SENTINEL_ID`
-remain absent. Fork PR validation, provider-parity/capacity comparison,
+not a successful isolation result. The bounded exception knowingly accepts
+that risk for exact ref/SHA-approved same-repository revisions to gain CI
+iteration speed; it is not permanent-isolation evidence. Fork PR validation,
+provider-parity/capacity comparison,
 namespace purge/expiry confirmation and rollback remain pending. Fork PR
 validation remains hosted and is the no-Depot-authority half of the sentinel
 acceptance evidence; only the exact same-repository sentinel ref may exercise
@@ -195,24 +199,27 @@ a cache hit and exact marker bytes before the trusted-seed gate, and thereby
 proves the same-job Node token/write path; main verify's poison miss remains
 the cross-scope proof.
 
-The provider contract required before PR placement is enabled is a documented,
+The provider contract required before permanent PR placement is enabled is a documented,
 server-enforced per-connection/job/ref control for the GitHub Actions cache
 path. It must either leave PR jobs on GitHub-native branch-scoped
 `ACTIONS_CACHE_URL`/`ACTIONS_RESULTS_URL` and runtime-token semantics with no
 Depot proxy or direct cache token, or issue a PR-isolated namespace/token whose
-ACL permits reads/writes only within that PR, denying reads/writes from trusted
-main/release and every other PR namespace, without exposing `DEPOT_CACHE_TOKEN`.
+ACL permits reads and writes only within that PR, denying reads and writes from
+trusted main/release and every other PR namespace, without exposing
+`DEPOT_CACHE_TOKEN`.
 Key prefixes, loopback proxies,
 ephemeral runners and the org switches are not equivalent controls. A fresh
 same-repository PR, fork PR and trusted-main seed/verify sentinel must prove
-the selected behavior before any PR gate or canary variable is armed.
+the selected behavior before the temporary exception is removed.
 Bracketed IPv6 authorities use the fixed runner's Python 3.8+ stdlib
 `ipaddress` classifier; parser absence/version/invalidity fails closed.
 Attestation reports only value-free variable/reason classes and fails closed
 on malformed or missing backend data.
 
 Relevant repository variable names include `DEPOT_RUNNERS_ENABLED`,
-`DEPOT_PR_RUNNERS_ENABLED` (absent/false until protected PR activation),
+`DEPOT_PR_RUNNERS_ENABLED` (global temporary exception gate),
+`DEPOT_PR_APPROVED_REF` (one exact merge ref), `DEPOT_PR_APPROVED_SHA` (the
+exact lowercase PR head SHA; refresh after every push),
 `DEPOT_PR_CANARY_REF` (absent by default; one exact
 `refs/pull/<number>/merge` ref only), `DEPOT_PR_SENTINEL_REF` (absent by
 default; one exact same-repository merge ref used only by the protected
@@ -222,10 +229,11 @@ deliberately armed). The canary and sentinel variables are bounded selectors,
 not cache-isolation proofs or replacements for the global PR gate. The normal
 Quality runner policy continues to use `DEPOT_PR_CANARY_REF`; the sentinel
 uses a separate selector output and cannot move the normal build jobs.
-The eligible five-lane Depot graph now disables every native GitHub cache
-consumer (explicit cache actions, setup-* package caches, rust-cache, static /
-Metal / Windows / Swift ABI caches and Windows SDK cache toggles) and Depot
-remote cache when those outputs are false; cache misses rebuild normally. This checked-in mode does not
+The eligible five-lane Depot graph disables every native GitHub cache consumer
+when `allow_native_github_cache=false`. During the bounded exception the exact
+approved PR and eligible trusted-main Depot jobs set that output true for
+cross-branch Depot Actions-cache reuse; direct Depot remote cache remains
+false. This checked-in mode does not
 prove the absence of ambient Depot/WebDAV authority, so the runtime sentinel
 has recorded unsafe repository-scoped cross-trust authority and must be
 redesigned and repeated successfully; no-secret/no-token, fork and provider-

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -107,8 +107,11 @@ from that same catalog.
 - `restore-smoke-inputs`: product/model extraction for consumers.
 - `select-ci-runners`: provider labels, cache permissions, and the
   provider-derived `allow_native_github_cache` / `allow_depot_remote_cache`
-  outputs. Every Depot selection sets both outputs to false; hosted PR,
-  release, and cache-warmer selections retain native GitHub cache behavior.
+  outputs. Depot selections disable both cache paths by default. During the
+  bounded approved exception, the exact PR revision and eligible trusted-main
+  Depot jobs enable the GitHub Actions cache API while direct Depot remote
+  cache remains disabled. Hosted PR, release, and cache-warmer selections
+  retain native GitHub cache behavior.
 - `configure-sccache-gha`: event/provider-derived compiler-cache setup.
 - `capture-sccache-stats`: machine-readable cache evidence.
 

--- a/.github/actions/audit-depot-pr-isolation/action.yml
+++ b/.github/actions/audit-depot-pr-isolation/action.yml
@@ -1,5 +1,5 @@
-name: Audit Depot PR isolation
-description: Fail closed when a PR build receives Depot cache, registry, or compiler-cache authority.
+name: Audit Depot PR authority
+description: Enforce the selected PR cache-risk policy and reject unapproved Depot or registry authority.
 
 inputs:
   original_event_name:
@@ -47,11 +47,10 @@ runs:
           exit 1
         fi
 
-        if [[ "$depot_selected" == "true" &&
-              "$allow_native_github_cache" != "false" ]]; then
-          echo "Depot selection requires native GitHub cache disabled (allow_native_github_cache)" >&2
-          exit 1
-        fi
+        # allow_native_github_cache is derived by the protected runner policy.
+        # During the bounded risk exception it intentionally enables GitHub
+        # Actions cache API consumers on Depot's cross-branch proxy. Keep the
+        # separate direct Depot remote-cache path disabled.
         if [[ "$depot_selected" == "true" &&
               "$allow_depot_remote_cache" != "false" ]]; then
           echo "Depot selection requires remote cache disabled (allow_depot_remote_cache)" >&2
@@ -133,7 +132,12 @@ runs:
             continue
           fi
           endpoint_lower="$(printf '%s' "$endpoint" | tr '[:upper:]' '[:lower:]')"
-          if [[ "$endpoint_lower" == *depot.dev* ]]; then
+          # A selected Depot PR with native cache enabled is the explicit,
+          # time-bounded exception: its Actions endpoints may be Depot's
+          # repository-wide proxy. All other PR contexts remain fail-closed.
+          if [[ "$endpoint_lower" == *depot.dev* &&
+                !( "$depot_selected" == "true" &&
+                   "$allow_native_github_cache" == "true" ) ]]; then
             echo "PR runner received a Depot Actions endpoint ($endpoint_name)" >&2
             exit 1
           fi
@@ -143,6 +147,13 @@ runs:
             exit 1
           fi
           if [[ "$depot_selected" != "true" ]]; then
+            continue
+          fi
+          if [[ "$allow_native_github_cache" == "true" ]]; then
+            if [[ ! "$endpoint_lower" =~ ^https?:// || -z "$authority" ]]; then
+              echo "PR runner received a malformed Actions endpoint ($endpoint_name)" >&2
+              exit 1
+            fi
             continue
           fi
           if ! is_github_endpoint "$endpoint" &&

--- a/.github/actions/select-ci-runners/action.yml
+++ b/.github/actions/select-ci-runners/action.yml
@@ -15,6 +15,9 @@ inputs:
   head_repository:
     description: Exact owner/name of the pull-request head repository, or repository outside PR events.
     required: true
+  head_sha:
+    description: Exact pull-request head SHA, or current SHA outside pull-request events.
+    required: true
   ref:
     description: Fully qualified Git ref used to enforce the trusted-main boundary.
     required: true
@@ -28,6 +31,14 @@ inputs:
     default: "false"
   pr_canary_ref:
     description: Optional exact pull-request merge ref selected for a protected canary.
+    required: false
+    default: ""
+  pr_approved_ref:
+    description: Maintainer-approved exact pull-request merge ref for the bounded risk exception.
+    required: false
+    default: ""
+  pr_approved_sha:
+    description: Maintainer-approved exact pull-request head SHA for the bounded risk exception.
     required: false
     default: ""
   force_hosted:
@@ -47,7 +58,7 @@ outputs:
     description: Whether this trusted runner selection may use Depot's remote cache.
     value: ${{ steps.select.outputs.allow_depot_remote_cache }}
   allow_native_github_cache:
-    description: Whether this provider/trust selection may use native GitHub Actions cache APIs.
+    description: Whether this provider/trust selection may use GitHub Actions cache APIs, including Depot's transparent proxy on Depot runners.
     value: ${{ steps.select.outputs.allow_native_github_cache }}
   runner:
     description: Default two-vCPU Linux runner label.
@@ -92,10 +103,13 @@ runs:
         DISPATCH_ORIGINAL_EVENT_NAME: ${{ github.event.inputs.original_event_name || '' }}
         INPUT_REPOSITORY: ${{ inputs.repository }}
         INPUT_HEAD_REPOSITORY: ${{ inputs.head_repository }}
+        INPUT_HEAD_SHA: ${{ inputs.head_sha }}
         INPUT_REF: ${{ inputs.ref }}
         INPUT_DEPOT_MAIN_ENABLED: ${{ inputs.depot_main_enabled }}
         INPUT_DEPOT_PR_ENABLED: ${{ inputs.depot_pr_enabled }}
         INPUT_PR_CANARY_REF: ${{ inputs.pr_canary_ref }}
+        INPUT_PR_APPROVED_REF: ${{ inputs.pr_approved_ref }}
+        INPUT_PR_APPROVED_SHA: ${{ inputs.pr_approved_sha }}
         INPUT_FORCE_HOSTED: ${{ inputs.force_hosted }}
         INPUT_MANUAL_USE_DEPOT: ${{ inputs.manual_use_depot }}
       run: |
@@ -121,6 +135,29 @@ runs:
           exit 1
         fi
 
+        pr_approved_ref="${INPUT_PR_APPROVED_REF:-}"
+        if [[ -n "$pr_approved_ref" &&
+          ! "$pr_approved_ref" =~ ^refs/pull/[0-9]+/merge$ ]]; then
+          echo "INPUT_PR_APPROVED_REF must be an exact pull-request merge ref" >&2
+          exit 1
+        fi
+        pr_approved_sha="${INPUT_PR_APPROVED_SHA:-}"
+        if [[ -n "$pr_approved_sha" &&
+          ! "$pr_approved_sha" =~ ^[0-9a-f]{40}$ ]]; then
+          echo "INPUT_PR_APPROVED_SHA must be an exact lowercase commit SHA" >&2
+          exit 1
+        fi
+
+        # This checked-in deadline makes the accepted repository-wide cache
+        # risk self-expiring. Extending it requires a reviewed source change.
+        depot_pr_exception_expires="2026-09-14"
+        current_utc_date="$(date -u +%F)"
+        depot_pr_exception_active=false
+        if [[ "$INPUT_DEPOT_PR_ENABLED" == "true" &&
+          "$current_utc_date" < "$depot_pr_exception_expires" ]]; then
+          depot_pr_exception_active=true
+        fi
+
         # A direct PR may opt into Depot only when this protected repository
         # explicitly enables the feature, or when one exact merge ref is
         # selected for the protected canary. Both the base and PR-head
@@ -131,6 +168,7 @@ runs:
         allow_depot_remote_cache=false
         allow_native_github_cache=true
         is_direct_pull_request=false
+        risk_exception_selected=false
         is_dispatched_pull_request=false
         dispatch_original_event="${INPUT_ORIGINAL_EVENT_NAME:-}"
         if [[ -z "$dispatch_original_event" ]]; then
@@ -145,10 +183,19 @@ runs:
               "$INPUT_HEAD_REPOSITORY" == "$trusted_repository" && \
               "$INPUT_REF" =~ ^refs/pull/[0-9]+/merge$ && \
               "$INPUT_FORCE_HOSTED" == "false" && \
-              ( "$INPUT_DEPOT_PR_ENABLED" == "true" ||
+              ( ( "$depot_pr_exception_active" == "true" &&
+                  -n "$pr_approved_ref" &&
+                  "$INPUT_REF" == "$pr_approved_ref" &&
+                  -n "$pr_approved_sha" &&
+                  "$INPUT_HEAD_SHA" == "$pr_approved_sha" ) ||
                 ( -n "$pr_canary_ref" && "$INPUT_REF" == "$pr_canary_ref" ) ) ]]; then
               is_direct_pull_request=true
               depot_enabled=true
+              if [[ "$depot_pr_exception_active" == "true" &&
+                "$INPUT_REF" == "$pr_approved_ref" &&
+                "$INPUT_HEAD_SHA" == "$pr_approved_sha" ]]; then
+                risk_exception_selected=true
+              fi
             fi
             ;;
           pull_request_target)
@@ -194,14 +241,23 @@ runs:
             ;;
         esac
 
-        # Depot's Actions cache namespace is intentionally inert for every
-        # Depot selection. Native GitHub cache APIs and Depot's remote cache
-        # are both disabled; hosted selections retain native GitHub cache
-        # behavior. These values are derived only from provider policy, so a
-        # caller cannot opt a Depot build back into either cache authority.
+        # Depot remote build-tool cache remains disabled. During the bounded
+        # risk exception, selected PR jobs and eligible trusted-main jobs may
+        # use the GitHub Actions cache API, which Depot transparently maps to
+        # its repository-wide, cross-branch namespace. This is an intentional
+        # speed-versus-isolation decision recorded in CI documentation.
         if [[ "$depot_enabled" == "true" ]]; then
           allow_depot_remote_cache=false
           allow_native_github_cache=false
+          if [[ "$depot_pr_exception_active" == "true" &&
+            ( "$risk_exception_selected" == "true" ||
+              ( "$INPUT_EVENT_NAME" == "push" &&
+                "$INPUT_REF" == "refs/heads/main" ) ||
+              ( "$INPUT_EVENT_NAME" == "workflow_dispatch" &&
+                "$INPUT_REF" == "refs/heads/main" &&
+                "$is_dispatched_pull_request" == "false" ) ) ]]; then
+            allow_native_github_cache=true
+          fi
         fi
 
         if [[ "$depot_enabled" == "true" ]]; then

--- a/.github/workflows/ci-linux-host-slice.yml
+++ b/.github/workflows/ci-linux-host-slice.yml
@@ -77,10 +77,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: ${{ vars.DEPOT_RUNNERS_ENABLED == 'true' }}
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
           manual_use_depot: ${{ inputs.use_depot }}
 

--- a/.github/workflows/ci-linux-product-slice.yml
+++ b/.github/workflows/ci-linux-product-slice.yml
@@ -60,11 +60,14 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           # Product composition is not in the trusted-main Depot allowlist.
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
 
   linux_product:

--- a/.github/workflows/ci-linux-runtime-slice.yml
+++ b/.github/workflows/ci-linux-runtime-slice.yml
@@ -70,10 +70,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: ${{ vars.DEPOT_RUNNERS_ENABLED == 'true' }}
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
           manual_use_depot: ${{ inputs.use_depot }}
 

--- a/.github/workflows/ci-macos-host-slice.yml
+++ b/.github/workflows/ci-macos-host-slice.yml
@@ -73,10 +73,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
 
   macos_host:

--- a/.github/workflows/ci-macos-product-slice.yml
+++ b/.github/workflows/ci-macos-product-slice.yml
@@ -59,10 +59,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
 
   macos_product:

--- a/.github/workflows/ci-macos-runtime-slice.yml
+++ b/.github/workflows/ci-macos-runtime-slice.yml
@@ -64,10 +64,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
 
   macos_runtime:

--- a/.github/workflows/ci-platform-checks-slice.yml
+++ b/.github/workflows/ci-platform-checks-slice.yml
@@ -71,10 +71,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
       - name: Map platform runners explicitly
         id: platform_runners

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -81,10 +81,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: ${{ vars.DEPOT_RUNNERS_ENABLED == 'true' }}
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
           manual_use_depot: ${{ inputs.use_depot }}
       - name: Select provider for the protected authority sentinel
@@ -95,12 +98,15 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           # The diagnostic is selected only by its exact sentinel ref. The
           # ordinary and global PR gates must not activate this exception.
           depot_main_enabled: 'false'
           depot_pr_enabled: 'false'
           pr_canary_ref: ${{ vars.DEPOT_PR_SENTINEL_REF }}
+          pr_approved_ref: ''
+          pr_approved_sha: ''
           force_hosted: ${{ inputs.force_hosted }}
           manual_use_depot: 'false'
 

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -74,11 +74,14 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           # Rust tests are not in the existing trusted-main Depot allowlist.
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
 
   rust_tests:

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -57,12 +57,15 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           # The pre-existing trusted-main allowlist does not include this
           # producer. PR placement is independently gated and cache-isolated.
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
 
   ui_artifact:

--- a/.github/workflows/ci-web-slice.yml
+++ b/.github/workflows/ci-web-slice.yml
@@ -56,11 +56,14 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           # Website is not in the existing trusted-main Depot allowlist.
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
 
   ui_quality:

--- a/.github/workflows/ci-windows-host-slice.yml
+++ b/.github/workflows/ci-windows-host-slice.yml
@@ -73,10 +73,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
 
   windows_host:

--- a/.github/workflows/ci-windows-product-slice.yml
+++ b/.github/workflows/ci-windows-product-slice.yml
@@ -59,10 +59,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
 
   windows_product:

--- a/.github/workflows/ci-windows-runtime-slice.yml
+++ b/.github/workflows/ci-windows-runtime-slice.yml
@@ -63,10 +63,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
 
   windows_runtime:

--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -169,16 +169,12 @@ jobs:
                 runner="$RUNNER_MACOS"
               else
                 runner=macos-15
+                ALLOW_NATIVE_GITHUB_CACHE=true
               fi
               ALLOW_DEPOT_REMOTE_CACHE=false
               ;;
             *) echo "unsupported native SDK producer target: $TARGET" >&2; exit 1 ;;
           esac
-          if [[ "$runner" == depot-* ]]; then
-            ALLOW_NATIVE_GITHUB_CACHE=false
-          else
-            ALLOW_NATIVE_GITHUB_CACHE=true
-          fi
           {
             echo "runner=$runner"
             echo "allow_depot_remote_cache=$ALLOW_DEPOT_REMOTE_CACHE"

--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -116,10 +116,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: ${{ vars.DEPOT_RUNNERS_ENABLED == 'true' }}
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
           manual_use_depot: ${{ inputs.use_depot }}
       - name: Resolve runner size and target

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,7 @@ jobs:
           original_event_name: ''
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: ${{ vars.DEPOT_RUNNERS_ENABLED == 'true' }}
           depot_pr_enabled: 'false'

--- a/.github/workflows/static-abi-artifact.yml
+++ b/.github/workflows/static-abi-artifact.yml
@@ -82,10 +82,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: ${{ vars.DEPOT_RUNNERS_ENABLED == 'true' }}
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
           manual_use_depot: ${{ inputs.use_depot }}
       - name: Resolve runner size and target

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -80,10 +80,13 @@ jobs:
           original_event_name: ${{ inputs.original_event_name }}
           repository: ${{ github.repository }}
           head_repository: ${{ github.event.pull_request.head.repo.full_name }}
+          head_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           ref: ${{ github.ref }}
           depot_main_enabled: 'false'
           depot_pr_enabled: ${{ vars.DEPOT_PR_RUNNERS_ENABLED == 'true' }}
           pr_canary_ref: ${{ vars.DEPOT_PR_CANARY_REF }}
+          pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}
+          pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}
           force_hosted: ${{ inputs.force_hosted }}
 
   swift_sdk_artifact:

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -2,8 +2,9 @@
 
 Status: implemented on this branch. The shared planner, focused PR and main
 entrypoints, manual controller, topic/platform lane workflows, platform-pure reusable
-graphs, contracts and documentation are checked in. Ruleset migration and
-Depot PR execution remain separate future work.
+graphs, contracts and documentation are checked in. Ruleset migration remains
+separate work. Exact same-repository PR revisions may use Depot under the
+time-bounded exception in `ci/DEPOT_PR_RISK_EXCEPTION.md`.
 
 Owners: MeshLLM maintainers
 
@@ -42,7 +43,8 @@ or cache identity.
 - Existing static ABI, native SDK, Swift, smoke and HF workflows remain
   lower-level reusable producers/consumers.
 - Current PR routing is GitHub-hosted except for the documented uncredentialed
-  CUDA smoke on the approved ephemeral GPU scale set; trusted-main Depot
+  CUDA smoke and an exact maintainer-approved same-repository merge ref/head SHA
+  selected under the checked-in Depot cache-risk deadline; trusted-main Depot
   selection remains behind the existing exact-string policy gate.
 - `ci-quality-slice.yml` contains an additive protected authority-sentinel
   diagnostic selected by separate `DEPOT_PR_SENTINEL_REF` and
@@ -233,9 +235,11 @@ stay on their approved placement. Trusted main Linux work may use Depot only
 when DEPOT_RUNNERS_ENABLED is exactly true, with a GitHub-hosted fallback.
 Callers never provide raw labels or independent remote-cache permission.
 
-Depot PR execution is not enabled. The selector has a bounded
-`DEPOT_PR_CANARY_REF` hook for one exact same-repository merge ref, while the
-global `DEPOT_PR_RUNNERS_ENABLED` gate remains absent/false. The Quality slice
+Permanent Depot PR execution is not enabled. The selector has a bounded
+`DEPOT_PR_CANARY_REF` hook for one exact same-repository merge ref. The separate
+temporary exception requires `DEPOT_PR_RUNNERS_ENABLED`, exact
+`DEPOT_PR_APPROVED_REF`, exact `DEPOT_PR_APPROVED_SHA`, and the checked-in
+2026-09-14 UTC deadline. The Quality slice
 also has a separate `DEPOT_PR_SENTINEL_REF` selector and
 `DEPOT_PR_SENTINEL_ID` validation for one no-checkout authority diagnostic;
 the ordinary Quality jobs still use `DEPOT_PR_CANARY_REF`, and a global PR gate
@@ -247,18 +251,16 @@ non-matching refs remain hosted/no-Depot; malformed selector configuration is
 rejected by the central selector. Depot's documented GitHub cache path is
 repository-scoped and not branch-isolated; automatic cache redirection can
 expose repository-wide cache authority to PR code. Cache-key prefixes are not
-isolation. The central selector now emits both
-`allow_native_github_cache=false` and `allow_depot_remote_cache=false` for
-every Depot selection, including trusted main; all eligible native GitHub and
-Depot remote-cache consumers are conditionally disabled while the underlying
-install/build commands remain unchanged. Hosted release and cache-warmer
-paths retain their existing GitHub cache behavior. The Depot namespace is
-intentionally unused by trusted workflows, so existing entries must be purged
-or expire before the PR gate. A GitHub-owned or strict loopback proxy is inert
-transport only, not an ambient authority proof; the completed sentinel has
-shown unsafe repository-scoped cross-trust access, so a provider-isolation
-redesign and a new successful sentinel remain required before enabling the
-canary or global PR gate.
+isolation. The central selector emits
+`allow_depot_remote_cache=false` for every Depot selection. Outside the bounded
+exception, native Actions-cache consumers are disabled. During the exception,
+an exact approved PR revision and eligible trusted-main Depot jobs emit
+`allow_native_github_cache=true`, deliberately sharing Depot's repository-wide,
+cross-branch Actions-cache namespace for iteration speed. Hosted release and
+cache-warmer paths retain their existing GitHub cache behavior. This is
+accepted risk, not an ambient authority proof; the completed sentinel has shown
+unsafe repository-scoped cross-trust access, so a provider-isolation redesign
+and a new successful sentinel remain required for permanent activation.
 
 The admin-verified organization switches have a narrower effect than the
 checked-in consumer policy: they remove direct `DEPOT_CACHE_TOKEN`/WebDAV
@@ -312,12 +314,14 @@ the enclosing PR run was later cancelled during cleanup. Trusted-main verify
 [run 31817111471 / job 94821343605](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31817111471/job/94821343605)
 restored and exactly validated that poison, then failed its intended expected-
 miss gate. This is unsafe repository-scoped cross-trust authority, not a
-successful isolation result. Keep `DEPOT_PR_RUNNERS_ENABLED` and all sentinel /
-canary variables absent. A provider-isolation redesign and a new successful
-sentinel are required before PR Depot can be reconsidered; fork,
+successful isolation result. The temporary exception knowingly accepts it only
+when `DEPOT_PR_RUNNERS_ENABLED=true`, `DEPOT_PR_APPROVED_REF` and
+`DEPOT_PR_APPROVED_SHA` match exactly, and the 2026-09-14 UTC deadline is still
+active. A provider-isolation redesign and a new successful sentinel are
+required before that exception can become permanent; fork,
 provider-parity, capacity and rollback evidence remain pending.
 
-Before a PR Depot path is enabled, an administrator must prove:
+Before a permanent PR Depot path is enabled, an administrator must prove:
 
 1. the provider's documented per-connection/job/ref control selects either
    GitHub-native branch-scoped Actions cache endpoints/token with no Depot

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -1,19 +1,23 @@
 # Depot runner transition
 
-Status: trusted-main support exists; pull-request execution is future work and
-is disabled. Automatic Depot Cache and Registry Actions connectivity are
+Status: trusted-main support exists. A time-bounded, explicitly accepted
+cache-risk exception permits individually approved same-repository PR revisions
+through 2026-09-14 UTC; forks remain hosted. Automatic Depot Cache and Registry Actions connectivity are
 admin-verified off. Those switches remove Depot's direct `DEPOT_CACHE_TOKEN`,
 build-tool cache preconfiguration and Registry Actions authentication from
 fresh runners; they do not provide a documented per-connection/job/ref ACL or
 disable for the GitHub Actions cache proxy/runtime-token path. The Depot runner
 group is admin-verified restricted to this repository and the protected
-workflow allowlist. The controlled trusted-main/PR authority probe is complete
-and demonstrates unsafe repository-scoped cross-trust authority; fork,
-provider-parity, capacity and rollback evidence still block PR activation.
+workflow allowlist. The controlled trusted-main/PR authority probe demonstrates
+unsafe repository-scoped cross-trust authority. Maintainers have knowingly
+accepted that risk temporarily to improve CI iteration speed; it remains a
+blocker to permanent activation.
 
-Checked-in policy now treats Depot's cache namespace as unused: every Depot
-selection disables both native GitHub Actions cache and Depot remote cache.
-Purge or expiry of existing entries remains an activation prerequisite.
+During the bounded exception, the exact approved PR and eligible trusted-main
+Depot jobs may use the GitHub Actions cache API and therefore Depot's shared,
+cross-branch namespace. Direct Depot build-tool remote cache remains disabled.
+The complete findings, risks, approval controls, expiry, and rollback procedure
+are recorded in `ci/DEPOT_PR_RISK_EXCEPTION.md`.
 
 The complete PR/main composition design is in
 `.omo/specs/pr-ci-optimization.md`. This document contains the durable Depot
@@ -29,38 +33,35 @@ Depot is a placement provider, not a different CI graph.
 - `.github/actions/select-ci-runners` owns current Linux provider selection.
 - `DEPOT_RUNNERS_ENABLED == 'true'` permits eligible trusted `main` Linux jobs
   to select Depot. Every eligible role retains a GitHub-hosted fallback.
-- `DEPOT_PR_RUNNERS_ENABLED == 'true'` is the independent same-repository PR
-  placement gate. It must remain absent or `false`: the controlled
-  same-repository authority probe below demonstrated unsafe repository-scoped
-  cross-trust access, and a new successful sentinel after provider-isolation
-  redesign is required before reconsideration. Branch/main provider parity and
-  the fork sentinel remain separate pending gates; a missing value fails closed.
+- `DEPOT_PR_RUNNERS_ENABLED == 'true'` opens only the bounded exception window.
+  It selects no PR by itself. `DEPOT_PR_APPROVED_REF` must exactly match the
+  current `refs/pull/<number>/merge` ref and `DEPOT_PR_APPROVED_SHA` must exactly
+  match its lowercase 40-character head SHA. A new push invalidates approval.
+  The checked-in selector expires this path on 2026-09-14 UTC; a missing,
+  malformed, stale, or expired value fails hosted.
 - `DEPOT_PR_CANARY_REF` is an optional, exact
   `refs/pull/<number>/merge` selector for one protected same-repository canary
   ref. It does not enable the global PR gate, does not grant remote cache
   permission, and fails closed for forks, target/dispatch events, malformed or
   non-matching refs, and planner-forced hosted paths. It remains unset until
   the external isolation gates pass.
-- Pull requests, feature refs, tags, credential-bearing smokes and
-  hardware-qualified GPU work retain their approved non-Depot placement until
-  the protected PR executor is separately activated. The intended executor may
+- Fork pull requests, feature refs, tags, credential-bearing smokes and
+  hardware-qualified GPU work retain their approved non-Depot placement. The bounded executor may
   cover eligible build/test jobs in Linux, Depot macOS 15 and Windows 2022
   lanes when an equivalent image/architecture exists; control-plane planning
   and required summaries remain hosted, and Intel macOS without an equivalent
   remains hosted.
 - Callers never provide a raw Depot label or a separate remote-cache
   permission. Runner and cache policy come from one event-derived decision.
-- The PR isolation audit receives that selected-provider and cache-policy
-  decision. Depot-selected PR jobs accept only GitHub-owned Actions endpoints
-  or a strict loopback proxy (`http[s]://localhost|127.0.0.1|[::1]:<port>/<path>`);
-  hosted PR jobs retain their approved local transport while still rejecting
-  Depot credentials, `depot.dev` redirects, and URL userinfo.
-- The Depot cache namespace is intentionally unused by trusted workflows:
-  Depot selections disable both native GitHub cache APIs and Depot remote
-  cache. Purge or expire any existing namespace entries before enabling the PR
-  gate. A proxy's presence is inert transport, not proof of authority
-  isolation; activation remains blocked until no trusted consumer uses Depot
-  cache.
+- The PR authority audit receives that selected-provider and cache-policy
+  decision. During the exception it permits the selected Depot Actions-cache
+  proxy but still rejects direct Depot cache tokens, WebDAV/sccache authority,
+  registry credentials, Docker auth, and URL userinfo before checkout.
+- The selector emits `allow_native_github_cache=true` only for an exactly
+  approved PR revision and eligible trusted-main Depot work while the global
+  exception and checked-in deadline are active. Depot transparently maps that
+  API to its shared repository namespace. `allow_depot_remote_cache` remains
+  false. This is accepted risk, not proof of authority isolation.
 
 Disabling Depot must change placement only. It must not change plan membership,
 commands, artifacts, smoke coverage or required checks.
@@ -128,9 +129,9 @@ the GitHub Actions cache proxy and its runtime-token path. The sentinel proved
 that this path remains repository-scoped and crosses the trusted-main/PR
 boundary; it therefore remains unsafe even with both switches unchecked.
 
-Do not migrate required checks, enable Depot for PR content, or change cache
-isolation during this provider rollout. Those are independent changes with
-their own acceptance gates below.
+Do not migrate required checks or broaden the PR exception during this provider
+rollout. The bounded cache-risk exception is an independent, reviewed decision;
+permanent activation still has the acceptance gates below.
 
 ## Current intended runner-group boundary
 
@@ -194,10 +195,12 @@ the experiment and removed immediately afterward. Its exact evidence is:
 This is an unsafe repository-scoped cross-trust authority result: the
 same-repository PR path could read the trusted marker and publish a marker that
 trusted main later restored. The intended failures are evidence that the gates
-fired after the probes, not successful isolation. Do not enable PR Depot from
-this result. A provider-isolation redesign and a new successful sentinel are
-required before any reconsideration. `DEPOT_PR_RUNNERS_ENABLED`,
-`DEPOT_PR_CANARY_REF`, `DEPOT_PR_SENTINEL_REF` and `DEPOT_PR_SENTINEL_ID`
+fired after the probes, not successful isolation. It does not justify a claim
+of isolation. The temporary decision in `ci/DEPOT_PR_RISK_EXCEPTION.md`
+explicitly accepts this risk for exact maintainer-approved same-repository PR
+revisions; a provider-isolation redesign and a new successful sentinel remain
+required before the exception can become permanent. `DEPOT_PR_CANARY_REF`,
+`DEPOT_PR_SENTINEL_REF` and `DEPOT_PR_SENTINEL_ID`
 remain absent. No Depot settings or runner groups were changed; the bounded
 repository variables were temporarily armed and then removed. Read-only Cache
 Explorer evidence verifies that both randomized non-secret entries are still
@@ -297,16 +300,14 @@ runtime questions are:
 5. Does the restricted runner group continue to allow only the exact protected
    workflow refs after the PR canary is enabled?
 
-The selector now emits provider-derived `allow_native_github_cache` and
-`allow_depot_remote_cache` outputs. Every Depot selection emits
-`allow_native_github_cache=false` and `allow_depot_remote_cache=false`; hosted
-selections retain native GitHub cache (`allow_native_github_cache=true`) while
-Depot remote cache remains disabled (`allow_depot_remote_cache=false`). Every
-eligible Depot-selected direct PR cache consumer is skipped or passed a
-disabled cache input, while installation and build commands remain active;
-cache misses therefore rebuild normally. This closes the checked-in native
-GitHub-cache path but does not prove that a fresh Depot runner cannot reach an
-ambient Depot/WebDAV/cache service. The canary must still target the actual
+The selector emits provider-derived `allow_native_github_cache` and
+`allow_depot_remote_cache` outputs. Depot remote build-tool cache remains
+disabled. Outside the bounded exception, Depot selections keep native Actions
+cache consumers disabled. During the exception, an exact approved PR revision
+and eligible trusted-main Depot jobs emit `allow_native_github_cache=true`,
+deliberately exercising Depot's repository-wide Actions-cache proxy for
+cross-branch reuse. This improves iteration speed but does not establish an
+authority boundary. The canary must still target the actual
 authority with an approved non-secret marker protocol and verify no read/write
 or registry token access; it remains an external runtime/admin prerequisite.
 
@@ -332,11 +333,14 @@ protected workflows must:
 - run on ephemeral Depot instances;
 - be exact selected workflows allowed by the runner group.
 
-After every acceptance canary passes, activate PR placement with the repository
-variable `DEPOT_PR_RUNNERS_ENABLED=true`. Roll back immediately by setting it to
-`false` (or deleting it) and rerun the identical PR plan; this changes provider
-placement only and must leave commands, matrices, artifacts, and required checks
-unchanged. `DEPOT_RUNNERS_ENABLED` remains the separate trusted-main gate.
+Permanent activation still requires every acceptance canary. The temporary
+exception additionally requires `DEPOT_PR_RUNNERS_ENABLED=true`, exact
+`DEPOT_PR_APPROVED_REF` and exact `DEPOT_PR_APPROVED_SHA`, and expires in checked-in
+policy on 2026-09-14 UTC. Roll back immediately by removing any approval value
+or setting the global PR gate to `false`, then rerun the identical PR plan; this
+changes provider placement only and must leave commands, matrices, artifacts,
+and required checks unchanged. `DEPOT_RUNNERS_ENABLED` remains the separate
+trusted-main placement gate.
 
 CI workflow, action, planner, ownership, runner and cache-policy changes must
 remain on the local GitHub-hosted path. A PR may not modify the workflow that

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -242,9 +242,10 @@ This creates a cache-poisoning path into trusted main/release consumers.
 
 ### Required provider isolation contract
 
-Before any PR runner gate or canary is enabled, Depot must expose a supported,
-server-enforced per-connection/job/ref control for the GitHub Actions cache
-path. The control must choose one of these safe outcomes for an untrusted PR:
+Before permanent PR activation or any context outside the reviewed temporary
+exception, Depot must expose a supported, server-enforced
+per-connection/job/ref control for the GitHub Actions cache path. The control
+must choose one of these safe outcomes for an untrusted PR:
 
 - leave the job on GitHub-native branch-scoped `ACTIONS_CACHE_URL`,
   `ACTIONS_RESULTS_URL` and runtime-token semantics, with no Depot cache proxy
@@ -261,8 +262,8 @@ ephemeral runners, the organization switch above, and runner-group workflow
 restrictions are not substitutes for this server-enforced control. The
 provider must document the control and its trust/ref semantics, and a fresh
 same-repository PR, fork PR and trusted-main seed/verify sentinel must prove
-the selected outcome before `DEPOT_PR_RUNNERS_ENABLED` or any canary selector
-is armed.
+the selected outcome before the exception is made permanent or a canary is
+treated as isolation evidence.
 
 Official references:
 

--- a/ci/DEPOT_PR_RISK_EXCEPTION.md
+++ b/ci/DEPOT_PR_RISK_EXCEPTION.md
@@ -1,0 +1,150 @@
+# Depot PR cache-risk exception
+
+Status: **accepted, bounded exception**
+
+- Decision date: 2026-08-14
+- Automatic expiry: 2026-09-14 00:00 UTC
+- Scope: same-repository `pull_request` merge refs only
+- Objective: reduce CI iteration time while Depot and GitHub finish stronger
+  cache-authority controls
+
+## Decision
+
+MeshLLM knowingly accepts repository-wide, cross-branch Depot Actions-cache
+authority for individually approved same-repository pull requests during this
+exception window. This is a deliberate speed-versus-isolation decision, not a
+claim that Depot currently provides branch or pull-request cache isolation.
+
+The exception does not apply to forks, `pull_request_target`, releases,
+publishing, deployment, credential-bearing smoke jobs, CI-policy changes, or
+jobs outside the existing eligible runner-selection set.
+
+## Findings
+
+Depot documents that GitHub Actions cache API consumers on Depot runners are
+transparently routed to Depot Cache and that entries are repository-scoped,
+without branch isolation. That includes `actions/cache` and setup actions that
+use the GitHub cache API. Depot's ephemeral compute boundary does not provide a
+separate cache authority boundary. See [Depot's GitHub Actions cache
+integration](https://depot.dev/docs/cache/integrations/github-actions) and
+[Depot runner overview](https://depot.dev/docs/github-actions/overview).
+
+GitHub's native dependency cache has ref-based access rules, including the
+synthetic merge ref used for pull requests. Those rules describe GitHub's cache
+service, not Depot's repository-wide proxy. See [GitHub dependency-cache
+reference](https://docs.github.com/en/actions/reference/workflows-and-actions/dependency-caching).
+
+GitHub is developing finer cache access modes, but the public proposal and
+implementation work do not constitute a supported Depot server-side ACL. See
+[GitHub Community discussion 194493](https://github.com/orgs/community/discussions/194493),
+[actions/runner PR 4538](https://github.com/actions/runner/pull/4538), and
+[actions/cache PR 1781](https://github.com/actions/cache/pull/1781).
+
+Depot has a useful untrusted-fork isolation design for remote Docker/BuildKit
+builds: an OIDC flow sends fork builds to ephemeral builders without the main
+cache. That product path does not cover arbitrary jobs on managed
+`runs-on: depot-*` runners or their transparent Actions-cache proxy. See
+[Depot's OSS fork-build design](https://depot.dev/blog/github-actions-oss-fork-builds).
+
+The controlled MeshLLM sentinel proved the current cross-trust behavior:
+
+- trusted seed run `31816775585` saved a marker;
+- same-repository PR run `31816869128`, job `94821057215`, restored that trusted
+  marker and saved then restored its own poison marker;
+- trusted-main verify run `31817111471`, job `94821343605`, restored the PR
+  poison marker.
+
+The result is evidence of shared authority, not a successful isolation test.
+
+## Risks we are accepting
+
+An approved same-repository PR can:
+
+- read non-secret cache data written by trusted main or another PR;
+- publish a cache entry that a later trusted-main job may restore;
+- publish entries visible to other PR namespaces;
+- corrupt or crowd the repository cache namespace, causing failures, cache
+  misses, resource consumption, or slower builds;
+- exploit a future cache consumer that incorrectly treats restored files as a
+  correctness or trust boundary.
+
+Cache entries can outlive the PR and the approval that created them. Cache keys,
+restore prefixes, ephemeral runners, and maintainer review reduce likelihood or
+impact but do not create a security boundary.
+
+No secret, signing key, release credential, registry credential, or privileged
+deployment input may be stored in or derived from this cache. Artifacts with
+explicit validation remain the correctness boundary.
+
+## Approval and compensating controls
+
+The repository's GitHub setting currently reports
+`approval_policy=all_external_contributors`. GitHub's approval button therefore
+protects workflows submitted by external contributors and forks; it does not
+gate a branch pushed inside `Mesh-LLM/mesh-llm` by a collaborator. We do not
+claim that setting as the same-repository approval control.
+
+The protected runner policy implements an explicit equivalent for this
+exception. Depot is selected only when all of the following are true:
+
+1. `DEPOT_PR_RUNNERS_ENABLED` is exactly `true`.
+2. `DEPOT_PR_APPROVED_REF` exactly equals the current
+   `refs/pull/<number>/merge` ref.
+3. `DEPOT_PR_APPROVED_SHA` exactly equals the lowercase 40-character PR head
+   SHA.
+4. The head and base repositories are both exactly `Mesh-LLM/mesh-llm`.
+5. The protected default-branch reusable workflow owns runner selection.
+6. The planner has not forced hosted execution for CI/workflow/policy changes.
+7. The checked-in expiry has not been reached.
+
+A new push changes the head SHA and automatically returns the PR to
+GitHub-hosted runners until a maintainer reviews and updates the approval SHA.
+Forks always remain GitHub-hosted. The audit still rejects direct Depot cache
+tokens, WebDAV/sccache authority, registry credentials, Docker registry auth,
+and URL userinfo before checkout.
+
+## Cross-branch cache behavior
+
+While the exception is active, the central policy enables the GitHub Actions
+cache API for the exact approved Depot PR and for eligible trusted-main Depot
+jobs. Depot maps those requests to its repository-wide namespace, allowing the
+intended cross-branch reuse. The separate direct Depot build-tool remote-cache
+flag remains disabled.
+
+The shared namespace must be treated as attacker-controlled input. Cache
+restore may improve speed, but a cache hit never proves provenance or
+correctness.
+
+## Operation and rollback
+
+To approve one reviewed PR revision, a maintainer with repository-variable
+authority sets the global gate to `true`, the approved merge ref, and the exact
+head SHA. The approved SHA must be refreshed after every push. Remove the two
+approval values after the run or when the PR closes.
+
+Immediate rollback is any one of:
+
+- delete or set `DEPOT_PR_RUNNERS_ENABLED=false`;
+- delete `DEPOT_PR_APPROVED_REF`;
+- delete `DEPOT_PR_APPROVED_SHA`.
+
+The same workflow graph then selects GitHub-hosted runners. No source, matrix,
+artifact, command, or required-summary change is needed.
+
+The selector fails hosted at the start of 2026-09-14 UTC. Extending the window
+requires a reviewed source change to the expiry and this decision record; a
+repository variable cannot extend it.
+
+## Exit criteria
+
+Remove this exception when Depot or GitHub offers and verifies either:
+
+- GitHub-native branch/ref-scoped Actions-cache authority on the PR runner with
+  no Depot proxy or alternate Depot cache credential; or
+- a server-enforced namespace/token ACL scoped exclusively to the current PR,
+  denying reads and writes from trusted main, release, and every other PR.
+
+Before treating either control as an isolation boundary, rerun the trusted
+seed, same-repository PR, fork, PR-write/self-restore, and trusted-main verify
+sentinel. The expected result is no trusted read by the PR and no PR write
+visible to trusted main or another PR.

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -271,26 +271,26 @@ from being duplicated into every composed product artifact.
 ## Provider and cache policy
 
 `.github/actions/select-ci-runners` maps semantic roles to approved labels.
-Pull requests use GitHub-hosted runners for ordinary work. The sole current
-exception is uncredentialed CUDA smoke on the approved ephemeral `gpu-nvidia`
-scale set described above. Same-repository and fork PRs use the same protected
-reusable lanes and receive no repository secrets. Their caches are restore-only
-even though the protected workflow ref is `main`; neither may publish
-trusted-main cache entries. Trusted `main` Linux roles may use Depot only when
+Fork pull requests use GitHub-hosted runners. Same-repository PRs normally do
+too, but an exact maintainer-approved merge ref and head SHA may use Depot under
+the time-bounded cache-risk exception in `ci/DEPOT_PR_RISK_EXCEPTION.md`. The
+other exception is uncredentialed CUDA smoke on the approved ephemeral
+`gpu-nvidia` scale set described above. PRs use the same protected reusable
+lanes and receive no repository secrets. Trusted `main` Linux roles may use Depot only when
 `DEPOT_RUNNERS_ENABLED` is exactly `true`; macOS, Windows, credential-bearing
 smokes and other hardware-qualified work retain explicit approved placement.
 Provider choice never changes plan membership, commands, artifacts, tests or
 summaries.
 
-The central selector makes the Depot cache namespace intentionally inert for
-every Depot selection, including trusted `main`: it emits both
-`allow_native_github_cache=false` and `allow_depot_remote_cache=false`. Hosted
-release and cache-warmer workflows retain their existing GitHub cache behavior.
-Any pre-existing Depot namespace entries must be purged or allowed to expire
-before the PR gate is enabled. A GitHub-owned or strict loopback Actions-cache
-proxy is inert transport only; its presence is not proof of authority
-isolation, and the gate remains closed until no trusted workflow consumes the
-Depot namespace.
+The central selector normally makes the Depot cache namespace inert by emitting
+`allow_native_github_cache=false` and `allow_depot_remote_cache=false`. During
+the bounded exception, the exact approved PR revision and eligible trusted-main
+Depot jobs emit `allow_native_github_cache=true`, enabling intentional
+cross-branch reuse through Depot's repository-wide Actions-cache proxy. Direct
+Depot build-tool remote cache remains disabled. This is a conscious iteration-
+speed tradeoff and the shared cache is treated as attacker-controlled input,
+not a correctness or authority boundary. Hosted release and cache-warmer
+workflows retain their existing GitHub cache behavior.
 
 The admin-verified organization switches have a narrower meaning than that
 consumer policy: disabling automatic Depot Cache and Registry Actions
@@ -311,6 +311,14 @@ hosted. The canary gate never grants remote Depot cache permission and does not
 replace the global PR gate. Maintainers must not set it until the external
 isolation protocol proves the actual Depot/WebDAV and Actions-cache authority
 boundary.
+
+The ordinary PR selector also requires the independent global gate plus exact
+`DEPOT_PR_APPROVED_REF` and `DEPOT_PR_APPROVED_SHA` values. The SHA binding
+invalidates approval after every push, forks and CI-policy changes remain
+hosted, and the source-enforced exception expires on 2026-09-14 UTC. GitHub's
+`all_external_contributors` approval policy covers external contributors, not
+same-repository collaborator branches; the exact ref/SHA values are therefore
+the protected same-repository maintainer approval control.
 
 The Quality slice also contains a separate, additive authority-sentinel
 selector. It reads `DEPOT_PR_SENTINEL_REF` (not `DEPOT_PR_CANARY_REF`) and
@@ -384,7 +392,7 @@ The implemented policy uses that isolation selectively:
 | Website npm store | Website-only lockfile-keyed cache | Later same-PR website runs avoid downloading the unchanged dependency store |
 | GitHub artifacts | Never used as cross-run caches | Immutable producers/consumers remain correct within one run; reruns recreate run-scoped artifacts |
 
-For any Depot-selected run, the central runner policy emits
+Outside the bounded exception, a Depot-selected run emits
 `allow_native_github_cache=false` and `allow_depot_remote_cache=false`. Every
 native GitHub cache consumer in the
 eligible five-lane build graph (explicit `actions/cache`, setup-node package
@@ -395,6 +403,13 @@ main/release/manual paths retain the existing cache behavior. This is a
 checked-in consumer policy, not proof that a Depot runner has no ambient
 Depot/WebDAV authority.
 
+For an exactly approved exception run, `allow_native_github_cache=true` enables
+those guarded cache consumers on both the selected PR and eligible trusted-main
+Depot jobs. Depot's lack of branch isolation means the cache can cross the PR,
+main, and other-PR trust boundaries. That accepted risk, including the exact
+sentinel evidence and rollback procedure, is documented in
+`ci/DEPOT_PR_RISK_EXCEPTION.md`.
+
 This is intentionally not a universal PR write-through policy. Cargo target
 caches are commonly hundreds of megabytes to several gigabytes per row; making
 every PR matrix row publish one would multiply storage, increase upload time,
@@ -403,15 +418,12 @@ caches have substantially better reuse-to-storage value. Cache hits are always
 an optimization: native stamps/manifests/checksums are verified, and every job
 must still regenerate successfully after a miss.
 
-Depot PR execution is not enabled. The bounded `DEPOT_PR_CANARY_REF` selector
-hook exists only to exercise a single protected same-repository ref after the
-external gates are ready. The implemented cache-inert mode prevents the
-checked-in GitHub and Depot cache consumers from reading or writing on any
-Depot run, but it does not prove that a runner has no ambient Depot/WebDAV/cache
-authority. A protected runner-group check, no-secret/no-token execution,
-namespace purge/expiry, provider-isolation redesign and a new successful
-non-secret sentinel in `ci/DEPOT_MIGRATION.md` remain prerequisites.
-Do not change Depot settings or runner groups in a workflow refactor.
+Permanent Depot PR execution is not yet approved. The bounded exception permits
+only an exact same-repository ref/SHA through 2026-09-14 UTC. A protected
+runner-group check, no-secret/no-direct-token execution, provider-isolation
+redesign, and a new successful non-secret sentinel remain prerequisites for
+removing that deadline. Do not change Depot settings or runner groups in a
+workflow refactor.
 
 The external administrative posture now has automatic Depot Cache and Registry
 Actions connectivity disabled and the Depot runner group restricted to this
@@ -428,10 +440,9 @@ enclosing PR run was later cancelled during cleanup. Trusted-main verify
 [run 31817111471 / job 94821343605](https://github.com/Mesh-LLM/mesh-llm/actions/runs/31817111471/job/94821343605)
 restored and exactly validated that poison and failed its intended expected-
 miss gate. This proves unsafe
-repository-scoped cross-trust authority. Do not enable PR Depot without a
-provider-isolation redesign and a new successful sentinel; all
-`DEPOT_PR_RUNNERS_ENABLED`, `DEPOT_PR_CANARY_REF`, `DEPOT_PR_SENTINEL_REF` and
-`DEPOT_PR_SENTINEL_ID` variables remain absent.
+repository-scoped cross-trust authority. It is the basis of the explicitly
+accepted temporary risk, not evidence of isolation. Permanent enablement still
+requires a provider-isolation redesign and a new successful sentinel.
 
 Branch/main provider-parity, fork PR canary, capacity/namespace purge or expiry,
 and rollback evidence remain pending; those checks are distinct from the

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -314,9 +314,13 @@ class CiArtifactActionTests(unittest.TestCase):
         original_event_name: str = "",
         repository: str = "Mesh-LLM/mesh-llm",
         head_repository: str | None = None,
+        head_sha: str = "0123456789abcdef0123456789abcdef01234567",
         pr_enabled: str = "false",
         pr_canary_ref: str = "",
+        pr_approved_ref: str = "",
+        pr_approved_sha: str = "",
         force_hosted: str = "false",
+        current_date: str = "2026-08-14",
     ) -> dict[str, str]:
         action = self.read_action("select-ci-runners")
         run_block = action.split("      run: |\n", maxsplit=1)[1]
@@ -326,23 +330,36 @@ class CiArtifactActionTests(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as temp_dir:
             output = Path(temp_dir) / "github-output"
+            bin_dir = Path(temp_dir) / "bin"
+            bin_dir.mkdir()
+            date = bin_dir / "date"
+            date.write_text(
+                "#!/bin/sh\nprintf '%s\\n' \"$SELECTOR_TEST_DATE\"\n",
+                encoding="utf-8",
+            )
+            date.chmod(0o755)
             result = subprocess.run(
                 ["bash", "-c", script],
                 cwd=ROOT,
                 env={
                     **os.environ,
+                    "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+                    "SELECTOR_TEST_DATE": current_date,
                     "GITHUB_OUTPUT": str(output),
                     "INPUT_EVENT_NAME": event_name,
                     "INPUT_ORIGINAL_EVENT_NAME": original_event_name,
                     "GITHUB_EVENT_NAME": event_name,
                     "INPUT_REPOSITORY": repository,
                     "INPUT_HEAD_REPOSITORY": head_repository or repository,
+                    "INPUT_HEAD_SHA": head_sha,
                     "GITHUB_REPOSITORY": repository,
                     "INPUT_REF": ref,
                     "GITHUB_REF": ref,
                     "INPUT_DEPOT_MAIN_ENABLED": main_enabled,
                     "INPUT_DEPOT_PR_ENABLED": pr_enabled,
                     "INPUT_PR_CANARY_REF": pr_canary_ref,
+                    "INPUT_PR_APPROVED_REF": pr_approved_ref,
+                    "INPUT_PR_APPROVED_SHA": pr_approved_sha,
                     "INPUT_FORCE_HOSTED": force_hosted,
                     "INPUT_MANUAL_USE_DEPOT": manual_enabled,
                     "DISPATCH_ORIGINAL_EVENT_NAME": original_event_name,
@@ -1171,8 +1188,20 @@ class CiArtifactActionTests(unittest.TestCase):
                     "head_repository: ${{ github.event.pull_request.head.repo.full_name }}",
                     workflow,
                 )
+                self.assertIn(
+                    "head_sha: ${{ github.event.pull_request.head.sha || github.sha }}",
+                    workflow,
+                )
                 self.assertIn("ref: ${{ github.ref }}", workflow)
                 self.assertIn("depot_pr_enabled:", workflow)
+                self.assertIn(
+                    "pr_approved_ref: ${{ vars.DEPOT_PR_APPROVED_REF }}",
+                    workflow,
+                )
+                self.assertIn(
+                    "pr_approved_sha: ${{ vars.DEPOT_PR_APPROVED_SHA }}",
+                    workflow,
+                )
                 self.assertIn("default) runner=", workflow)
                 self.assertIn("RUNNER_ARM", workflow)
 
@@ -1894,6 +1923,28 @@ class CiArtifactActionTests(unittest.TestCase):
         self.assertIn("depot-ubuntu-24.04-arm-16", action)
         self.assertIn("depot-macos-15", action)
         self.assertIn("depot-windows-2022", action)
+        self.assertIn('depot_pr_exception_expires="2026-09-14"', action)
+        self.assertIn("INPUT_PR_APPROVED_REF", action)
+        self.assertIn("INPUT_PR_APPROVED_SHA", action)
+
+        selector_calls = 0
+        approved_policy_calls = 0
+        for workflow_path in sorted(
+            (ROOT / ".github" / "workflows").glob("*.yml")
+        ):
+            lines = workflow_path.read_text(encoding="utf-8").splitlines()
+            for index, line in enumerate(lines):
+                if "uses: ./.github/actions/select-ci-runners" not in line:
+                    continue
+                selector_calls += 1
+                block = "\n".join(lines[index : index + 20])
+                with self.subTest(selector_caller=workflow_path.name):
+                    self.assertIn("head_sha:", block)
+                if "pr_approved_ref:" in block:
+                    approved_policy_calls += 1
+                    self.assertIn("pr_approved_sha:", block)
+        self.assertEqual(selector_calls, 19)
+        self.assertEqual(approved_policy_calls, 18)
 
         cases = (
             (
@@ -2045,6 +2096,20 @@ class CiArtifactActionTests(unittest.TestCase):
                     manual_enabled=manual,
                     original_event_name=original_event_name,
                     pr_enabled=pr_enabled,
+                    pr_approved_ref=(
+                        ref
+                        if event_name == "pull_request"
+                        and pr_enabled == "true"
+                        and runner.startswith("depot-")
+                        else ""
+                    ),
+                    pr_approved_sha=(
+                        "0123456789abcdef0123456789abcdef01234567"
+                        if event_name == "pull_request"
+                        and pr_enabled == "true"
+                        and runner.startswith("depot-")
+                        else ""
+                    ),
                 )
                 enabled = "true" if runner.startswith("depot-") else "false"
                 self.assertEqual(outputs["depot_enabled"], enabled)
@@ -2053,9 +2118,9 @@ class CiArtifactActionTests(unittest.TestCase):
                     cache_enabled,
                 )
                 expected_native_cache = (
-                    "false"
-                    if enabled == "true"
-                    else "true"
+                    "true"
+                    if event_name == "pull_request" and enabled == "true"
+                    else "false" if enabled == "true" else "true"
                 )
                 self.assertEqual(
                     outputs["allow_native_github_cache"],
@@ -2097,6 +2162,8 @@ class CiArtifactActionTests(unittest.TestCase):
             main_enabled="true",
             manual_enabled="true",
             pr_enabled="true",
+            pr_approved_ref="refs/pull/12/merge",
+            pr_approved_sha="0123456789abcdef0123456789abcdef01234567",
             repository="attacker/mesh-llm",
         )
         self.assertEqual(untrusted_repository["depot_enabled"], "false")
@@ -2116,6 +2183,8 @@ class CiArtifactActionTests(unittest.TestCase):
             main_enabled="true",
             manual_enabled="true",
             pr_enabled="true",
+            pr_approved_ref="refs/pull/12/merge",
+            pr_approved_sha="0123456789abcdef0123456789abcdef01234567",
             head_repository="attacker/mesh-llm",
         )
         self.assertEqual(fork_head_repository["depot_enabled"], "false")
@@ -2131,6 +2200,8 @@ class CiArtifactActionTests(unittest.TestCase):
             main_enabled="true",
             manual_enabled="true",
             pr_enabled="true",
+            pr_approved_ref="refs/pull/12/merge",
+            pr_approved_sha="0123456789abcdef0123456789abcdef01234567",
             force_hosted="true",
         )
         self.assertEqual(runner_contract_change["depot_enabled"], "false")
@@ -2146,6 +2217,8 @@ class CiArtifactActionTests(unittest.TestCase):
             main_enabled="true",
             manual_enabled="true",
             pr_enabled="true",
+            pr_approved_ref="refs/pull/12/merge",
+            pr_approved_sha="0123456789abcdef0123456789abcdef01234567",
         )
         self.assertEqual(non_merge_ref["depot_enabled"], "false")
         self.assertEqual(non_merge_ref["runner"], "ubuntu-24.04")
@@ -2181,6 +2254,53 @@ class CiArtifactActionTests(unittest.TestCase):
         self.assertEqual(canary_pr["runner"], "depot-ubuntu-24.04")
         self.assertEqual(canary_pr["allow_depot_remote_cache"], "false")
         self.assertEqual(canary_pr["allow_native_github_cache"], "false")
+
+        unapproved_pr = self.run_runner_selector(
+            event_name="pull_request",
+            ref="refs/pull/12/merge",
+            main_enabled="false",
+            manual_enabled="false",
+            pr_enabled="true",
+        )
+        self.assertEqual(unapproved_pr["depot_enabled"], "false")
+        self.assertEqual(unapproved_pr["runner"], "ubuntu-24.04")
+
+        stale_approval = self.run_runner_selector(
+            event_name="pull_request",
+            ref="refs/pull/12/merge",
+            main_enabled="false",
+            manual_enabled="false",
+            pr_enabled="true",
+            pr_approved_ref="refs/pull/12/merge",
+            pr_approved_sha="fedcba9876543210fedcba9876543210fedcba98",
+        )
+        self.assertEqual(stale_approval["depot_enabled"], "false")
+
+        expired_approval = self.run_runner_selector(
+            event_name="pull_request",
+            ref="refs/pull/12/merge",
+            main_enabled="false",
+            manual_enabled="false",
+            pr_enabled="true",
+            pr_approved_ref="refs/pull/12/merge",
+            pr_approved_sha="0123456789abcdef0123456789abcdef01234567",
+            current_date="2026-09-14",
+        )
+        self.assertEqual(expired_approval["depot_enabled"], "false")
+        self.assertEqual(expired_approval["allow_native_github_cache"], "true")
+
+        trusted_main_cross_branch_cache = self.run_runner_selector(
+            event_name="push",
+            ref="refs/heads/main",
+            main_enabled="true",
+            manual_enabled="false",
+            pr_enabled="true",
+        )
+        self.assertEqual(trusted_main_cross_branch_cache["depot_enabled"], "true")
+        self.assertEqual(
+            trusted_main_cross_branch_cache["allow_native_github_cache"],
+            "true",
+        )
 
         for name, kwargs in (
             (
@@ -2255,10 +2375,13 @@ class CiArtifactActionTests(unittest.TestCase):
                     "INPUT_EVENT_NAME": "pull_request",
                     "INPUT_REPOSITORY": "Mesh-LLM/mesh-llm",
                     "INPUT_HEAD_REPOSITORY": "Mesh-LLM/mesh-llm",
+                    "INPUT_HEAD_SHA": "0123456789abcdef0123456789abcdef01234567",
                     "INPUT_REF": "refs/pull/12/merge",
                     "INPUT_DEPOT_MAIN_ENABLED": "false",
                     "INPUT_DEPOT_PR_ENABLED": "false",
                     "INPUT_PR_CANARY_REF": "refs/heads/main",
+                    "INPUT_PR_APPROVED_REF": "",
+                    "INPUT_PR_APPROVED_SHA": "",
                     "INPUT_FORCE_HOSTED": "false",
                     "INPUT_MANUAL_USE_DEPOT": "false",
                 },
@@ -2308,7 +2431,7 @@ class CiArtifactActionTests(unittest.TestCase):
             self.assertNotIn("depot-ubuntu", pr)
             self.assertNotIn("SCCACHE_GHA_ENABLED: \"false\"", pr)
 
-    def test_depot_pr_native_cache_consumers_are_centrally_disabled(self) -> None:
+    def test_depot_pr_native_cache_consumers_obey_central_policy(self) -> None:
         eligible_consumers = {
             "ci-quality-slice.yml": ("Swatinem/rust-cache@",),
             "ci-web-slice.yml": (

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -385,6 +385,9 @@ class CiArtifactActionTests(unittest.TestCase):
         target: str,
         runner_size: str,
         manual_use_depot: str = "false",
+        pr_enabled: str = "false",
+        pr_approved_ref: str = "",
+        pr_approved_sha: str = "",
     ) -> tuple[subprocess.CompletedProcess[str], dict[str, str]]:
         workflow = (
             ROOT / ".github" / "workflows" / workflow_name
@@ -395,6 +398,9 @@ class CiArtifactActionTests(unittest.TestCase):
             main_enabled=depot_enabled,
             manual_enabled=manual_use_depot,
             repository=repository,
+            pr_enabled=pr_enabled,
+            pr_approved_ref=pr_approved_ref,
+            pr_approved_sha=pr_approved_sha,
         )
         policy = workflow.split(
             "      - name: Resolve runner size and target\n",
@@ -424,6 +430,9 @@ class CiArtifactActionTests(unittest.TestCase):
                     "POLICY_EVENT_NAME": event_name,
                     "ALLOW_DEPOT_REMOTE_CACHE": selected[
                         "allow_depot_remote_cache"
+                    ],
+                    "ALLOW_NATIVE_GITHUB_CACHE": selected[
+                        "allow_native_github_cache"
                     ],
                     "RUNNER_DEFAULT": selected["runner"],
                     "RUNNER_4": selected["runner_4"],
@@ -1324,6 +1333,28 @@ class CiArtifactActionTests(unittest.TestCase):
             )
 
             if workflow_name == "native-sdk-artifact.yml":
+                approved_pr_sha = (
+                    "0123456789abcdef0123456789abcdef01234567"
+                )
+                result, outputs = self.run_reusable_runner_policy(
+                    workflow_name,
+                    repository="Mesh-LLM/mesh-llm",
+                    event_name="pull_request",
+                    ref="refs/pull/12/merge",
+                    depot_enabled="false",
+                    target="x86_64-unknown-linux-gnu",
+                    runner_size="8",
+                    pr_enabled="true",
+                    pr_approved_ref="refs/pull/12/merge",
+                    pr_approved_sha=approved_pr_sha,
+                )
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(outputs["runner"], "depot-ubuntu-24.04-8")
+                self.assertEqual(
+                    outputs["allow_native_github_cache"],
+                    "true",
+                )
+
                 result, outputs = self.run_reusable_runner_policy(
                     workflow_name,
                     repository="Mesh-LLM/mesh-llm",

--- a/scripts/tests/test_depot_authority_sentinel.py
+++ b/scripts/tests/test_depot_authority_sentinel.py
@@ -87,11 +87,20 @@ class DepotAuthoritySentinelTests(unittest.TestCase):
         )
         with tempfile.TemporaryDirectory() as temp_dir:
             output = Path(temp_dir) / "github-output"
+            bin_dir = Path(temp_dir) / "bin"
+            bin_dir.mkdir()
+            date = bin_dir / "date"
+            date.write_text(
+                "#!/bin/sh\nprintf '2026-08-14\\n'\n",
+                encoding="utf-8",
+            )
+            date.chmod(0o755)
             result = subprocess.run(
                 ["bash", "-c", script],
                 cwd=ROOT,
                 env={
                     **os.environ,
+                    "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
                     "GITHUB_OUTPUT": str(output),
                     "GITHUB_EVENT_NAME": event_name,
                     "GITHUB_REPOSITORY": repository,
@@ -100,10 +109,13 @@ class DepotAuthoritySentinelTests(unittest.TestCase):
                     "INPUT_ORIGINAL_EVENT_NAME": event_name,
                     "INPUT_REPOSITORY": repository,
                     "INPUT_HEAD_REPOSITORY": head_repository,
+                    "INPUT_HEAD_SHA": "0123456789abcdef0123456789abcdef01234567",
                     "INPUT_REF": ref,
                     "INPUT_DEPOT_MAIN_ENABLED": "false",
                     "INPUT_DEPOT_PR_ENABLED": pr_enabled,
                     "INPUT_PR_CANARY_REF": sentinel_ref,
+                    "INPUT_PR_APPROVED_REF": "",
+                    "INPUT_PR_APPROVED_SHA": "",
                     "INPUT_FORCE_HOSTED": force_hosted,
                     "INPUT_MANUAL_USE_DEPOT": "false",
                     "DISPATCH_ORIGINAL_EVENT_NAME": "",
@@ -240,7 +252,7 @@ class DepotAuthoritySentinelTests(unittest.TestCase):
             sentinel_ref="", pr_enabled="true"
         )
         self.assertEqual(global_gate.returncode, 0, global_gate.stderr)
-        self.assertEqual(global_outputs["depot_enabled"], "true")
+        self.assertEqual(global_outputs["depot_enabled"], "false")
         self.assertIn("github.ref == vars.DEPOT_PR_SENTINEL_REF", self.sentinel)
 
     def test_normal_quality_jobs_keep_the_existing_provider_output(self) -> None:

--- a/scripts/tests/test_depot_canary_workflow.py
+++ b/scripts/tests/test_depot_canary_workflow.py
@@ -418,7 +418,8 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
         )
         self.assertIn("depot_selected", action)
         self.assertIn("INPUT_DEPOT_SELECTED", action)
-        self.assertIn('if [[ "$endpoint_lower" == *depot.dev* ]]', action)
+        self.assertIn('if [[ "$endpoint_lower" == *depot.dev* &&', action)
+        self.assertIn('"$allow_native_github_cache" == "true"', action)
         self.assertIn("allow_native_github_cache", action)
         self.assertIn("allow_depot_remote_cache", action)
         self.assertIn("URL userinfo", action)
@@ -476,6 +477,7 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
             docker_auth_config: str | None = None,
             docker_config_content: str | None = None,
             depot_selected: str = "true",
+            allow_native_github_cache: str | None = None,
             unset_endpoints: bool = False,
             **extra_environment: str,
         ) -> subprocess.CompletedProcess[str]:
@@ -496,7 +498,9 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                     "INPUT_ORIGINAL_EVENT_NAME": "pull_request",
                     "INPUT_DEPOT_SELECTED": depot_selected,
                     "INPUT_ALLOW_NATIVE_GITHUB_CACHE": (
-                        "false" if depot_selected == "true" else "true"
+                        allow_native_github_cache
+                        if allow_native_github_cache is not None
+                        else "false" if depot_selected == "true" else "true"
                     ),
                     "INPUT_ALLOW_DEPOT_REMOTE_CACHE": "false",
                     "ACTIONS_CACHE_URL": cache_url,
@@ -597,6 +601,14 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                     result = run_probe(script, *endpoints)
                     self.assertEqual(result.returncode, 0, result.stderr)
             if script_name == "audit action":
+                with self.subTest(script=script_name, bounded_exception=True):
+                    result = run_probe(
+                        script,
+                        "https://cache.depot.dev/cache",
+                        "https://results.example.invalid/results",
+                        allow_native_github_cache="true",
+                    )
+                    self.assertEqual(result.returncode, 0, result.stderr)
                 with self.subTest(script=script_name, provider="malformed"):
                     result = run_probe(
                         script,
@@ -766,13 +778,27 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                             ):
                                 self.assertNotIn(forbidden_fragment, result.stderr)
             if script_name == "audit action":
-                with self.subTest(script=script_name, policy="native cache enabled"):
+                with self.subTest(
+                    script=script_name,
+                    policy="bounded native cache exception",
+                ):
                     result = run_probe(
                         script,
                         *valid_endpoints[0],
                         INPUT_ALLOW_NATIVE_GITHUB_CACHE="true",
                     )
-                    self.assertNotEqual(result.returncode, 0)
+                    self.assertEqual(result.returncode, 0, result.stderr)
+                    malformed = run_probe(
+                        script,
+                        "ftp://cache.depot.dev/cache",
+                        valid_endpoints[0][1],
+                        allow_native_github_cache="true",
+                    )
+                    self.assertNotEqual(malformed.returncode, 0)
+                    self.assertNotIn(
+                        "ftp://cache.depot.dev/cache",
+                        malformed.stderr,
+                    )
                 with self.subTest(script=script_name, policy="Depot remote cache enabled"):
                     result = run_probe(
                         script,


### PR DESCRIPTION
## Summary

- document the observed Depot cross-branch cache authority and the explicitly accepted, time-bounded risk
- require an exact maintainer-approved PR merge ref and head SHA before same-repository PR jobs can select Depot
- enable the GitHub Actions cache API for the approved Depot PR and eligible trusted-main jobs while keeping direct Depot cache, registry, fork, and CI-policy authority blocked
- expire the exception automatically on 2026-09-14 UTC

## Safety

GitHub workflow approval for `all_external_contributors` does not cover same-repository collaborator branches. The protected selector therefore requires `DEPOT_PR_RUNNERS_ENABLED=true`, exact `DEPOT_PR_APPROVED_REF`, and exact `DEPOT_PR_APPROVED_SHA`; every push invalidates the approval SHA and CI-policy changes force hosted execution.

## Validation

- `just ci-validate` (460 passed, 7 expected skips)
- focused selector/audit/sentinel/reusable-workflow tests (73 passed)
- `actionlint -config-file .github/actionlint.yaml`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a temporary, approval-based option for eligible same-repository pull requests to use Depot runners.
  * Enabled guarded GitHub Actions cache access for approved runs while keeping Depot remote caching disabled.
  * Added exact revision validation, expiration controls, hosted fallback, and rollback safeguards.

* **Bug Fixes**
  * Improved enforcement for unapproved, stale, expired, forked, or malformed requests.

* **Documentation**
  * Documented the exception, associated risks, monitoring requirements, rollback procedures, and expiration date.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->