### PR TITLE
[CANARY] verify approved Depot PR runners

### DIFF
--- a/crates/mesh-llm-host-runtime/README.md
+++ b/crates/mesh-llm-host-runtime/README.md
@@ -1,5 +1,7 @@
 # mesh-llm-host-runtime
 
+<!-- Depot PR runner activation canary; intentionally no runtime effect. -->
+
 `mesh-llm-host-runtime` composes the host-side mesh node runtime. It wires
 model resolution, local serving, discovery, networking, runtime state, plugins,
 the management API, and the shipped CLI entrypoint used by the `mesh-llm`

--- a/crates/mesh-llm-ui/README.md
+++ b/crates/mesh-llm-ui/README.md
@@ -1,5 +1,7 @@
 # mesh-llm-ui
 
+<!-- Depot PR runner activation canary; intentionally no runtime effect. -->
+
 `mesh-llm-ui` owns the Mesh LLM React console and the Rust asset surface used
 by the host API server and SDK console packages.
 

--- a/scripts/build-mac.sh
+++ b/scripts/build-mac.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env zsh
+# Depot PR runner activation canary; intentionally no behavioral effect.
 # Compatibility entry point for the unified macOS development product.
 # The host is dynamic; native ABI compilation happens only in runtime packaging.
 

--- a/scripts/build-windows.ps1
+++ b/scripts/build-windows.ps1
@@ -7,6 +7,8 @@ param(
     [switch]$HostOnly
 )
 
+# Depot PR runner activation canary; intentionally no behavioral effect.
+
 $ErrorActionPreference = "Stop"
 
 $scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path

--- a/sdk/kotlin/README.md
+++ b/sdk/kotlin/README.md
@@ -1,5 +1,7 @@
 # MeshLLM Kotlin SDK
 
+<!-- Depot PR runner activation canary; intentionally no runtime effect. -->
+
 Kotlin/Android bindings for mesh-llm model management, local serving, and mesh
 inference.
 

--- a/sdk/swift/README.md
+++ b/sdk/swift/README.md
@@ -1,5 +1,7 @@
 # MeshLLM Swift SDK
 
+<!-- Depot PR runner activation canary; intentionally no runtime effect. -->
+
 Swift Package for connecting to mesh-llm meshes from iOS, Mac Catalyst, and macOS apps.
 
 The SDK usage guide, native runtime packaging notes, examples, and platform

--- a/website/src/index.njk
+++ b/website/src/index.njk
@@ -4,6 +4,7 @@ title: Mesh LLM
 description: Mesh serves large local models across multiple machines through one OpenAI-compatible endpoint.
 bodyClass: home-intro
 ---
+{# Depot PR runner activation canary; intentionally no rendered effect. #}
 <main>
   {% include "sections/hero.njk" %}
   {% include "sections/trust-strip.njk" %}


### PR DESCRIPTION
## Purpose

Controlled, non-merge activation canary for the time-bounded Depot PR risk exception. The source changes are comments only, but their owned paths deliberately select Quality, Website/UI, Linux, macOS, Windows, all runtime backend rows, Rust tests, and Rust/Kotlin/Swift SDK rows.

## Sequence

1. Let this exact head finish once with the PR Depot variables absent (hosted baseline).
2. Set `DEPOT_PR_RUNNERS_ENABLED=true`, `DEPOT_PR_APPROVED_REF=refs/pull/<this>/merge`, and `DEPOT_PR_APPROVED_SHA=<this exact head>`.
3. Rerun the same five workflow runs without changing the head or plan and verify all eligible ordinary executor rows use Depot.
4. Remove the approval variables, rerun the same head again, and verify hosted rollback with identical plan/job shape.
5. Close without merge after metrics are captured.

Known exceptions remain hosted/self-hosted: planning and stable summaries, credential-bearing smoke consumers, and the approved CUDA GPU hardware smoke. This canary knowingly accepts the repository-wide Depot cache risk documented in `ci/DEPOT_PR_RISK_EXCEPTION.md`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added non-functional build and documentation markers to support automated project checks.
  * No changes to runtime behavior, rendered website content, scripts, or public interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->