### PR TITLE
ci: repin Depot PR isolation audit

### DIFF
--- a/.github/workflows/ci-linux-host-slice.yml
+++ b/.github/workflows/ci-linux-host-slice.yml
@@ -109,7 +109,7 @@ jobs:
       RUSTC_WRAPPER: sccache
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_8, 'depot-') }}

--- a/.github/workflows/ci-linux-product-slice.yml
+++ b/.github/workflows/ci-linux-product-slice.yml
@@ -87,7 +87,7 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/ci-linux-runtime-slice.yml
+++ b/.github/workflows/ci-linux-runtime-slice.yml
@@ -107,7 +107,7 @@ jobs:
       LLAMA_STAGE_SKIP_NCCL: "1"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_16, 'depot-') }}

--- a/.github/workflows/ci-macos-host-slice.yml
+++ b/.github/workflows/ci-macos-host-slice.yml
@@ -94,7 +94,7 @@ jobs:
       matrix:
         host: ${{ fromJson(inputs.hosts_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-product-slice.yml
+++ b/.github/workflows/ci-macos-product-slice.yml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         runtime: ${{ fromJson(inputs.runtime_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-macos-runtime-slice.yml
+++ b/.github/workflows/ci-macos-runtime-slice.yml
@@ -88,7 +88,7 @@ jobs:
       LLAMA_STAGE_BACKEND: ${{ matrix.runtime.backend }}
       LLAMA_STAGE_BUILD_DIR: ${{ matrix.runtime.build_dir }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/.github/workflows/ci-platform-checks-slice.yml
+++ b/.github/workflows/ci-platform-checks-slice.yml
@@ -101,7 +101,7 @@ jobs:
       matrix:
         check: ${{ fromJson(inputs.platform_checks_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(fromJSON(needs.runner_policy.outputs.runner_by_platform)[matrix.check.platform], 'depot-') }}

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -116,7 +116,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 20
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -153,7 +153,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 15
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -189,7 +189,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_8, 'depot-') }}
@@ -243,7 +243,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 5
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -108,7 +108,7 @@ jobs:
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -77,7 +77,7 @@ jobs:
       run:
         working-directory: crates/mesh-llm-ui
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-web-slice.yml
+++ b/.github/workflows/ci-web-slice.yml
@@ -76,7 +76,7 @@ jobs:
       run:
         working-directory: crates/mesh-llm-ui
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}
@@ -125,7 +125,7 @@ jobs:
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
     timeout-minutes: 20
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_4, 'depot-') }}

--- a/.github/workflows/ci-windows-host-slice.yml
+++ b/.github/workflows/ci-windows-host-slice.yml
@@ -97,7 +97,7 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       RUSTC_WRAPPER: sccache
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/ci-windows-product-slice.yml
+++ b/.github/workflows/ci-windows-product-slice.yml
@@ -80,7 +80,7 @@ jobs:
       matrix:
         runtime: ${{ fromJson(inputs.runtime_matrix) }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/ci-windows-runtime-slice.yml
+++ b/.github/workflows/ci-windows-runtime-slice.yml
@@ -91,7 +91,7 @@ jobs:
       WINDOWS_VULKAN_SDK_VERSION: ${{ vars.VULKAN_SDK_VERSION || '1.4.328.1' }}
       ROCM_HIP_SDK_FILENAME: AMD-Software-PRO-Edition-25.Q3-WinSvr2022-For-HIP.exe
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_windows, 'depot-') }}

--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -217,7 +217,7 @@ jobs:
     env:
       LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-static
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}
@@ -325,7 +325,7 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/static-abi-artifact.yml
+++ b/.github/workflows/static-abi-artifact.yml
@@ -149,7 +149,7 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       SCCACHE_GHA_ENABLED: "true"
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -106,7 +106,7 @@ jobs:
       SCCACHE_GHA_ENABLED: "true"
       SCCACHE_GHA_RW_MODE: ${{ (github.event_name == 'pull_request' || github.event_name == 'pull_request_target' || github.event.inputs.original_event_name == 'pull_request' || github.event.inputs.original_event_name == 'pull_request_target') && 'READ_ONLY' || 'READ_WRITE' }}
     steps:
-      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:
           original_event_name: ${{ inputs.original_event_name }}
           depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner_macos, 'depot-') }}

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -38,7 +38,7 @@ class CiArtifactActionTests(unittest.TestCase):
         }
         protected_pre_checkout_action = (
             "Mesh-LLM/mesh-llm/.github/actions/"
-            "audit-depot-pr-isolation@6daacb8a15a3e71f4bdfab1e88e417cb5c0017a3"
+            "audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16"
         )
 
         for path in (*action_files, *workflow_files):


### PR DESCRIPTION
## Summary
- repin all protected PR audit callers to the reviewed bounded-exception-aware action revision
- update the exact audit pin contract expectation
- preserve workflow graph, matrices, commands, cache-policy inputs, and artifacts

## Root cause
The live Depot PR canary selected the intended Depot runners and emitted `allow_native_github_cache=true`, but callers still executed the older audit revision, which rejected that approved bounded-exception combination before checkout.

## Validation
- `just ci-validate` (461 tests, 7 expected skips)
- `actionlint -config-file .github/actionlint.yaml`
- 66 focused CI policy/audit tests
- `git diff --check`
- census: 22 workflow refs at the new immutable SHA, zero old or `@main` refs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the pinned CI isolation action across Linux, macOS, Windows, SDK, artifact, quality, and testing workflows.
  - Standardized workflow checks on the newer action revision without changing job behavior or inputs.

- **Tests**
  - Updated CI artifact validation to expect the refreshed protected checkout action revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->