### PR TITLE
ci: fingerprint Depot macOS toolchains

### DIFF
--- a/.github/actions/resolve-native-toolchain-epoch/action.yml
+++ b/.github/actions/resolve-native-toolchain-epoch/action.yml
@@ -47,16 +47,22 @@ runs:
         else
           image_os="${ImageOS:-}"
           image_version="${ImageVersion:-}"
-          if [[ -z "$image_os" || -z "$image_version" ]]; then
-            echo "ImageOS and ImageVersion are required for a hosted native toolchain epoch" >&2
+          if [[ -n "$image_os" && -n "$image_version" ]]; then
+            epoch="github-${image_os}-${image_version}-${RUNNER_ARCH_VALUE}"
+          elif [[ "$INPUT_INCLUDE_TOOL_VERSIONS" == "true" ]]; then
+            # Depot macOS runners intentionally do not expose the GitHub-hosted
+            # ImageOS/ImageVersion variables. The exact OS/compiler/tool digest
+            # below is the cache-safe identity for those provider images.
+            epoch="runner-${RUNNER_OS_VALUE}-${RUNNER_ARCH_VALUE}"
+          else
+            echo "ImageOS and ImageVersion are required unless exact native tool versions are included" >&2
             exit 1
           fi
-          epoch="github-${image_os}-${image_version}-${RUNNER_ARCH_VALUE}"
 
           if [[ "$INPUT_INCLUDE_TOOL_VERSIONS" == "true" ]]; then
             case "$RUNNER_OS_VALUE" in
               macOS)
-                version_commands=(xcodebuild clang cmake ninja)
+                version_commands=(sw_vers xcodebuild clang cmake ninja)
                 ;;
               Linux)
                 version_commands=(cc c++ cmake ninja)
@@ -75,6 +81,7 @@ runs:
             if [[ "$RUNNER_OS_VALUE" == "macOS" ]]; then
               tool_digest="$(
                 {
+                  sw_vers -productVersion
                   xcodebuild -version
                   clang --version
                   cmake --version

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -746,9 +746,11 @@ class CiArtifactActionTests(unittest.TestCase):
         for contract in (
             'image_os="${ImageOS:-}"',
             'image_version="${ImageVersion:-}"',
+            'epoch="runner-${RUNNER_OS_VALUE}-${RUNNER_ARCH_VALUE}"',
             'INPUT_PINNED_EPOCH: ${{ inputs.pinned_epoch }}',
             'echo "epoch=$epoch" >> "$GITHUB_OUTPUT"',
             'echo "MESH_LLM_LLAMA_TOOLCHAIN_EPOCH=$epoch" >> "$GITHUB_ENV"',
+            "sw_vers -productVersion",
             "xcodebuild -version",
             "cmake --version",
             "ninja --version",
@@ -795,6 +797,71 @@ class CiArtifactActionTests(unittest.TestCase):
                         "native_toolchain.outputs.epoch",
                         cache_block,
                     )
+
+    def test_native_toolchain_epoch_fingerprints_depot_macos_without_image_vars(
+        self,
+    ) -> None:
+        action = self.read_action("resolve-native-toolchain-epoch")
+        run_block = action.split("      run: |\n", maxsplit=1)[1]
+        script = "\n".join(
+            line[8:] if line.startswith("        ") else line
+            for line in run_block.splitlines()
+        )
+
+        with tempfile.TemporaryDirectory() as temp_dir:
+            workspace = Path(temp_dir)
+            bin_dir = workspace / "bin"
+            bin_dir.mkdir()
+            for command in ("sw_vers", "xcodebuild", "clang", "cmake", "ninja"):
+                executable = bin_dir / command
+                executable.write_text(
+                    "#!/bin/sh\nprintf 'fixture-%s-1\\n' \"${0##*/}\"\n",
+                    encoding="utf-8",
+                )
+                executable.chmod(0o755)
+
+            environment = {
+                **os.environ,
+                "PATH": f"{bin_dir}:{os.environ.get('PATH', '')}",
+                "GITHUB_OUTPUT": str(workspace / "github-output"),
+                "GITHUB_ENV": str(workspace / "github-env"),
+                "INPUT_PINNED_EPOCH": "",
+                "INPUT_INCLUDE_TOOL_VERSIONS": "true",
+                "RUNNER_OS_VALUE": "macOS",
+                "RUNNER_ARCH_VALUE": "ARM64",
+            }
+            environment.pop("ImageOS", None)
+            environment.pop("ImageVersion", None)
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            output = (workspace / "github-output").read_text(encoding="utf-8")
+            self.assertRegex(
+                output,
+                r"^epoch=runner-macOS-ARM64-native-[0-9a-f]{64}\n$",
+            )
+
+            environment["INPUT_INCLUDE_TOOL_VERSIONS"] = "false"
+            result = subprocess.run(
+                ["bash", "-c", script],
+                cwd=ROOT,
+                env=environment,
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "ImageOS and ImageVersion are required unless exact native tool versions are included",
+                result.stderr,
+            )
 
     def test_push_routing_diffs_the_complete_event_range(self) -> None:
         action = self.read_action("compute-changes")


### PR DESCRIPTION
## Summary
- preserve GitHub-hosted ImageOS/ImageVersion cache identity
- derive a cache-safe Depot macOS identity from runner OS/arch plus exact OS and tool versions when hosted image metadata is absent
- keep missing metadata fail-closed unless exact tool versions are included
- add an executable regression test for the Depot macOS environment

## Evidence
- `just ci-validate` (462 tests, 7 expected skips)
- focused native toolchain epoch tests
- `actionlint -config-file .github/actionlint.yaml`
- extracted action Bash `bash -n`
- `git diff --check`

## Live failure addressed
Depot macOS runners connected successfully during PR #1335, but the macOS jobs failed because Depot does not define GitHub-hosted `ImageOS`/`ImageVersion`. Audit-before-checkout passed; this patch addresses only that deterministic metadata compatibility gap.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native toolchain detection on macOS environments that do not provide runner image metadata.
  * Toolchain fingerprints now include the macOS product version for more accurate environment identification.
  * Environments with explicit tool versions can now resolve successfully without image details, while configurations missing required version information continue to be rejected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->