### PR TITLE
docs: record Depot PR rollout evidence

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -197,12 +197,15 @@ restored and exactly validated that poison, then failed its intended expected-
 miss gate. This proves unsafe repository-scoped cross-trust authority, so it is
 not a successful isolation result. The bounded exception knowingly accepts
 that risk for exact ref/SHA-approved same-repository revisions to gain CI
-iteration speed; it is not permanent-isolation evidence. Fork PR validation,
-provider-parity/capacity comparison,
-namespace purge/expiry confirmation and rollback remain pending. Fork PR
-validation remains hosted and is the no-Depot-authority half of the sentinel
-acceptance evidence; only the exact same-repository sentinel ref may exercise
-the diagnostic Depot job. All three sentinel cache phases attest the
+iteration speed; it is not permanent-isolation evidence. The exact-SHA
+five-lane candidate, provider comparison, and identical-SHA hosted rollback
+are recorded in `.omo/specs/depot-pr-rollout-evidence.md`; Quality and Linux
+were eligible, Website had insufficient samples, and macOS/Windows hit the
+capacity rollback threshold. Fork PR validation and namespace purge/expiry
+confirmation remain pending. Fork PR validation remains hosted and is the
+no-Depot-authority half of the sentinel acceptance evidence; only the exact
+same-repository sentinel ref may exercise the diagnostic Depot job. All three
+sentinel cache phases attest the
 provider-injected `ACTIONS_CACHE_URL`/`ACTIONS_RESULTS_URL` structure before
 invoking pinned `actions/cache` restore/save actions. The shell attestation
 does not require ambient `ACTIONS_RUNTIME_TOKEN`: GitHub's

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -200,8 +200,9 @@ that risk for exact ref/SHA-approved same-repository revisions to gain CI
 iteration speed; it is not permanent-isolation evidence. The exact-SHA
 five-lane candidate, provider comparison, and identical-SHA hosted rollback
 are recorded in `.omo/specs/depot-pr-rollout-evidence.md`; Quality and Linux
-were eligible, Website had insufficient samples, and macOS/Windows hit the
-capacity rollback threshold. Fork PR validation and namespace purge/expiry
+had favorable queue observations but remain unclassified because execution
+was cache-confounded, Website had insufficient samples, and macOS/Windows hit
+the capacity rollback threshold. Fork PR validation and namespace purge/expiry
 confirmation remain pending. Fork PR validation remains hosted and is the
 no-Depot-authority half of the sentinel acceptance evidence; only the exact
 same-repository sentinel ref may exercise the diagnostic Depot job. All three

--- a/.omo/specs/depot-pr-rollout-evidence.md
+++ b/.omo/specs/depot-pr-rollout-evidence.md
@@ -1,0 +1,106 @@
+# Depot PR bounded-exception rollout evidence
+
+Status: candidate and hosted rollback complete
+
+This record captures the 2026-08-15 validation of the time-bounded,
+same-repository PR exception defined in `ci/DEPOT_PR_RISK_EXCEPTION.md`. It is
+evidence that the protected routing and unchanged build graph work; it is not
+evidence of cache isolation. The previously recorded sentinel still proves
+that Depot's Actions-cache authority crosses the PR/main trust boundary.
+
+## Fixed test identity
+
+- Pull request: `#1335`
+- Head SHA: `631df713d86cd12e89e7e4e7d75b5360ca1de81e`
+- Merge ref: `refs/pull/1335/merge`
+- Workflows: Quality `31856900751`, Website `31856900758`, Linux
+  `31856900875`, macOS `31856900858`, Windows `31856900759`
+- Attempt 1: GitHub-hosted baseline
+- Attempt 2: exact ref/SHA-approved Depot candidate
+- Attempt 3: gate-absent GitHub-hosted rollback
+
+All three attempts use the same source SHA and protected workflow graph. The
+candidate was armed only with `DEPOT_PR_RUNNERS_ENABLED=true` plus the exact
+approved ref and SHA. All three bounded-exception variables were deleted
+immediately after attempt 2 completed and before attempt 3 was requested.
+
+## Depot candidate result
+
+All five attempt-2 workflows and their stable `PR / <lane>` summaries completed
+successfully. Forty-one executed eligible ordinary rows succeeded on Depot;
+two additional Depot-selected matrix rows were expected skips. Hosted control,
+summary, credential-bearing smoke, and hardware-exception jobs retained their
+documented providers. The approved `gpu-nvidia` CUDA smoke also succeeded.
+
+Every inspected Depot executor ran the protected isolation audit before
+checkout, selected `allow_native_github_cache=true`, and kept
+`allow_depot_remote_cache=false`. Cache hits were observed on Linux, Website,
+and Windows rows. Those hits are the intentional cross-branch acceleration
+accepted by the exception, not a provenance or correctness claim.
+
+Depot macOS jobs do not expose GitHub-hosted `ImageOS`/`ImageVersion` values.
+The Metal, portable, unit, host, product, and Swift-input rows nevertheless
+passed using the reviewed tool-version fingerprint fallback. The resolved
+Metal/unit epoch was
+`runner-macOS-ARM64-native-1d61d7c9cf228ea257cd32496f60045c23a10cc70feaef902473d8b786873a57`.
+
+## Provider comparison
+
+Schema-v3 reports were generated from the attempt-1 and attempt-2 raw job data
+under `/tmp`; raw reports are intentionally not checked in. Queue values below
+are job runner-queue p95 for common ordinary executor families, and execution
+values are execution p95.
+
+| Lane | Hosted / Depot jobs | Queue p95 hosted → Depot | Execution p95 hosted → Depot | Deterministic result |
+| --- | ---: | ---: | ---: | --- |
+| Quality | 5 / 5 | 58.0s → 1.0s | 502.4s → 171.8s | `eligible` |
+| Website | 2 / 2 | 170.6s → 1.0s | 188.5s → 165.95s | `hold` (fewer than 3 samples) |
+| Linux | 16 / 16 | 163.25s → 1.0s | 1306.75s → 749.75s | `eligible` |
+| macOS | 7 / 7 | 407.5s → 590.0s | 1026.4s → 808.4s | `rollback` (queue contamination) |
+| Windows | 11 / 11 | 2369.5s → 3419.5s | 1636.5s → 1907.0s | `rollback` (queue contamination) |
+
+Provider sets were disjoint and job families, OS, architecture, source, plan,
+toolchain policy, and cache mode were comparable. Attempt 2 was a rerun, so
+workflow wall/queue timing is intentionally excluded; job queue and execution
+timing remain valid.
+
+The Windows workflow preserves `max-parallel: 1` for both native-runtime and
+product matrices. GitHub therefore leaves sibling matrix rows queued even when
+Depot Windows runners are visibly idle. The collector lacks dependency-ready
+timestamps and counts that intentional serial wait as runner queue. The formal
+capacity classification remains `rollback`; the idle-runner view must not be
+misreported as provider starvation. macOS also remains formally contaminated
+and requires more capacity evidence before any performance claim.
+
+## Hosted rollback evidence
+
+Attempt 3 ran after all three approval variables were deleted. Quality,
+Website, Linux, macOS, and Windows all completed successfully, including their
+stable `PR / <lane>` summaries. The complete job-name sets were exactly equal
+between attempts 2 and 3 for each workflow. Provider choice was the only
+routing difference: attempt 3 used `ubuntu-24.04`, `macos-15`, and
+`windows-2022`, plus the unchanged approved `gpu-nvidia` smoke exception, and
+contained no `depot-*` labels.
+
+The rollback conclusions matched the candidate: Quality 9 success/3 expected
+skips, Website 6 success, Linux 32 success/5 expected skips, macOS 19
+success/1 expected skip, and Windows 19 success. No source, plan, matrix,
+dependency, artifact, command, test, or stable-summary change was required.
+Deleting the variables therefore proved the documented one-policy-change
+rollback on the identical SHA and graph.
+
+## Decision
+
+The candidate proves that the exact ref/SHA approval path can run the eligible
+five-lane executor denominator on Depot without changing plan membership,
+commands, artifacts, tests, or stable summaries. It does not remove the shared
+cache risk and does not justify permanent or fork activation. Each
+same-repository revision still requires an explicit maintainer decision under
+the expiry and controls in `ci/DEPOT_PR_RISK_EXCEPTION.md`; the variables stay
+absent between approvals.
+
+Quality and Linux provide positive iteration-speed evidence. Website needs a
+larger sample, and macOS/Windows remain formal rollback classifications. These
+results do not weaken the automatic 2026-09-14 expiry, the
+no-secret/credential exceptions, or the requirement for provider-enforced
+per-PR cache authority before making the policy permanent.

--- a/.omo/specs/depot-pr-rollout-evidence.md
+++ b/.omo/specs/depot-pr-rollout-evidence.md
@@ -13,16 +13,38 @@ that Depot's Actions-cache authority crosses the PR/main trust boundary.
 - Pull request: `#1335`
 - Head SHA: `631df713d86cd12e89e7e4e7d75b5360ca1de81e`
 - Merge ref: `refs/pull/1335/merge`
-- Workflows: Quality `31856900751`, Website `31856900758`, Linux
-  `31856900875`, macOS `31856900858`, Windows `31856900759`
 - Attempt 1: GitHub-hosted baseline
 - Attempt 2: exact ref/SHA-approved Depot candidate
 - Attempt 3: gate-absent GitHub-hosted rollback
 
-All three attempts use the same source SHA and protected workflow graph. The
-candidate was armed only with `DEPOT_PR_RUNNERS_ENABLED=true` plus the exact
-approved ref and SHA. All three bounded-exception variables were deleted
-immediately after attempt 2 completed and before attempt 3 was requested.
+The source SHA is identical in every row below. `E` is one representative
+ordinary executor job and `S` is the stable lane-summary job.
+
+| Attempt | Lane / workflow run | Relevant job IDs (`E` / `S`) | Protected base SHA |
+| ---: | --- | --- | --- |
+| 1 | Quality `31856900751` | `94943336698` / `94944531916` | `19dfd731a00454161a486117eca28e9c1bce3dfb` |
+| 1 | Website `31856900758` | `94943463706` / `94944272901` | `19dfd731a00454161a486117eca28e9c1bce3dfb` |
+| 1 | Linux `31856900875` | `94943343184` / `94948475940` | `19dfd731a00454161a486117eca28e9c1bce3dfb` |
+| 1 | macOS `31856900858` | `94943361090` / `94946328625` | `19dfd731a00454161a486117eca28e9c1bce3dfb` |
+| 1 | Windows `31856900759` | `94943335837` / `94949094847` | `19dfd731a00454161a486117eca28e9c1bce3dfb` |
+| 2 | Quality `31856900751` | `94949254565` / `94949627063` | `19dfd731a00454161a486117eca28e9c1bce3dfb` |
+| 2 | Website `31856900758` | `94949254364` / `94949620720` | `19dfd731a00454161a486117eca28e9c1bce3dfb` |
+| 2 | Linux `31856900875` | `94949255563` / `94951376609` | `19dfd731a00454161a486117eca28e9c1bce3dfb` |
+| 2 | macOS `31856900858` | `94949261037` / `94952506197` | `19dfd731a00454161a486117eca28e9c1bce3dfb` |
+| 2 | Windows `31856900759` | `94949257612` / `94960217656` | `19dfd731a00454161a486117eca28e9c1bce3dfb` |
+| 3 | Quality `31856900751` | `94965049631` / `94966569930` | `1854b527c417770ed4c651c7afdd398a7bea5fa0` |
+| 3 | Website `31856900758` | `94965041540` / `94966339212` | `1854b527c417770ed4c651c7afdd398a7bea5fa0` |
+| 3 | Linux `31856900875` | `94965140517` / `94969537370` | `1854b527c417770ed4c651c7afdd398a7bea5fa0` |
+| 3 | macOS `31856900858` | `94965516732` / `94968237314` | `1854b527c417770ed4c651c7afdd398a7bea5fa0` |
+| 3 | Windows `31856900759` | `94965087121` / `94968895592` | `1854b527c417770ed4c651c7afdd398a7bea5fa0` |
+
+The protected default branch advanced before attempt 3. A path-limited diff
+between the two protected revisions changed only `.github/workflows/release.yml`;
+none of the PR-referenced lane/slice/action/planner files changed. The complete
+job-name sets were also exactly equal across attempts. The candidate was armed
+only with `DEPOT_PR_RUNNERS_ENABLED=true` plus the exact approved ref and SHA.
+All three bounded-exception variables were deleted immediately after attempt 2
+completed and before attempt 3 was requested.
 
 ## Depot candidate result
 
@@ -48,21 +70,24 @@ Metal/unit epoch was
 
 Schema-v3 reports were generated from the attempt-1 and attempt-2 raw job data
 under `/tmp`; raw reports are intentionally not checked in. Queue values below
-are job runner-queue p95 for common ordinary executor families, and execution
-values are execution p95.
+are job runner-queue p95 for common ordinary executor families.
 
-| Lane | Hosted / Depot jobs | Queue p95 hosted → Depot | Execution p95 hosted → Depot | Deterministic result |
-| --- | ---: | ---: | ---: | --- |
-| Quality | 5 / 5 | 58.0s → 1.0s | 502.4s → 171.8s | `eligible` |
-| Website | 2 / 2 | 170.6s → 1.0s | 188.5s → 165.95s | `hold` (fewer than 3 samples) |
-| Linux | 16 / 16 | 163.25s → 1.0s | 1306.75s → 749.75s | `eligible` |
-| macOS | 7 / 7 | 407.5s → 590.0s | 1026.4s → 808.4s | `rollback` (queue contamination) |
-| Windows | 11 / 11 | 2369.5s → 3419.5s | 1636.5s → 1907.0s | `rollback` (queue contamination) |
+| Lane | Hosted / Depot jobs | Queue p95 hosted → Depot | Queue signal |
+| --- | ---: | ---: | --- |
+| Quality | 5 / 5 | 58.0s → 1.0s | favorable, but full comparison unclassified |
+| Website | 2 / 2 | 170.6s → 1.0s | insufficient sample |
+| Linux | 16 / 16 | 163.25s → 1.0s | favorable, but full comparison unclassified |
+| macOS | 7 / 7 | 407.5s → 590.0s | `rollback` (queue contamination) |
+| Windows | 11 / 11 | 2369.5s → 3419.5s | `rollback` (queue contamination) |
 
 Provider sets were disjoint and job families, OS, architecture, source, plan,
-toolchain policy, and cache mode were comparable. Attempt 2 was a rerun, so
-workflow wall/queue timing is intentionally excluded; job queue and execution
-timing remain valid.
+and toolchain policy matched. Cache authority and actual hit/miss state did
+not: the Depot candidate intentionally used repository-wide cross-branch cache
+entries, while hosted PR cache access remained ref-scoped. Execution timings
+are therefore cache-confounded and are not used for a provider-speed or
+eligibility claim. Runner queue occurs before cache restore and is retained as
+a capacity observation. Attempt 2 was a rerun, so workflow wall/queue timing is
+also intentionally excluded.
 
 The Windows workflow preserves `max-parallel: 1` for both native-runtime and
 product matrices. GitHub therefore leaves sibling matrix rows queued even when
@@ -99,8 +124,9 @@ same-repository revision still requires an explicit maintainer decision under
 the expiry and controls in `ci/DEPOT_PR_RISK_EXCEPTION.md`; the variables stay
 absent between approvals.
 
-Quality and Linux provide positive iteration-speed evidence. Website needs a
-larger sample, and macOS/Windows remain formal rollback classifications. These
-results do not weaken the automatic 2026-09-14 expiry, the
+Quality and Linux provide favorable queue observations, not normalized
+execution-speed evidence. Website needs a larger sample, and macOS/Windows
+remain formal rollback classifications. These results do not weaken the
+automatic 2026-09-14 expiry, the
 no-secret/credential exceptions, or the requirement for provider-enforced
 per-PR cache authority before making the policy permanent.

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -318,8 +318,12 @@ successful isolation result. The temporary exception knowingly accepts it only
 when `DEPOT_PR_RUNNERS_ENABLED=true`, `DEPOT_PR_APPROVED_REF` and
 `DEPOT_PR_APPROVED_SHA` match exactly, and the 2026-09-14 UTC deadline is still
 active. A provider-isolation redesign and a new successful sentinel are
-required before that exception can become permanent; fork,
-provider-parity, capacity and rollback evidence remain pending.
+required before that exception can become permanent. The exact-SHA five-lane
+candidate, provider-separated comparison, and identical-SHA hosted rollback
+are recorded in `.omo/specs/depot-pr-rollout-evidence.md`; Quality and Linux
+were eligible, Website had insufficient samples, and macOS/Windows hit the
+capacity rollback threshold. Fork validation and namespace purge/expiry
+confirmation remain pending.
 
 Before a permanent PR Depot path is enabled, an administrator must prove:
 

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -321,8 +321,9 @@ active. A provider-isolation redesign and a new successful sentinel are
 required before that exception can become permanent. The exact-SHA five-lane
 candidate, provider-separated comparison, and identical-SHA hosted rollback
 are recorded in `.omo/specs/depot-pr-rollout-evidence.md`; Quality and Linux
-were eligible, Website had insufficient samples, and macOS/Windows hit the
-capacity rollback threshold. Fork validation and namespace purge/expiry
+had favorable queue observations but remain unclassified because execution
+was cache-confounded, Website had insufficient samples, and macOS/Windows hit
+the capacity rollback threshold. Fork validation and namespace purge/expiry
 confirmation remain pending.
 
 Before a permanent PR Depot path is enabled, an administrator must prove:

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -212,11 +212,12 @@ docs-only change must not delete them.
 
 The exact-SHA five-lane candidate, provider-separated comparison, and
 identical-SHA hosted rollback are recorded in
-`.omo/specs/depot-pr-rollout-evidence.md`. Quality and Linux were eligible,
-Website had insufficient samples, and macOS/Windows hit the deterministic
-capacity rollback threshold. The fork PR canary and namespace purge/expiry
-confirmation remain pending. Fork validation must stay hosted and remains the
-no-Depot-authority half of the acceptance evidence.
+`.omo/specs/depot-pr-rollout-evidence.md`. Quality and Linux had favorable
+queue observations but remain unclassified because execution was
+cache-confounded; Website had insufficient samples, and macOS/Windows hit the
+deterministic capacity rollback threshold. The fork PR canary and namespace
+purge/expiry confirmation remain pending. Fork validation must stay hosted and
+remains the no-Depot-authority half of the acceptance evidence.
 
 Disabling automatic Depot Cache and Registry Actions connectivity removes the
 direct Depot build-tool/registry credential path that blocked the first canary

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -210,10 +210,13 @@ present: seed `mesh-llm-depot-authority-seed-v1-4089d6c8551820aa86b7780157729786
 (308 B). Purge or provider-expiry confirmation remains pending; this
 docs-only change must not delete them.
 
-The fork PR canary, provider-parity/capacity comparison, namespace
-purge/expiry confirmation and rollback evidence remain pending. Fork
-validation must stay hosted and remains the no-Depot-authority half of the
-acceptance evidence.
+The exact-SHA five-lane candidate, provider-separated comparison, and
+identical-SHA hosted rollback are recorded in
+`.omo/specs/depot-pr-rollout-evidence.md`. Quality and Linux were eligible,
+Website had insufficient samples, and macOS/Windows hit the deterministic
+capacity rollback threshold. The fork PR canary and namespace purge/expiry
+confirmation remain pending. Fork validation must stay hosted and remains the
+no-Depot-authority half of the acceptance evidence.
 
 Disabling automatic Depot Cache and Registry Actions connectivity removes the
 direct Depot build-tool/registry credential path that blocked the first canary

--- a/ci/DEPOT_PR_RISK_EXCEPTION.md
+++ b/ci/DEPOT_PR_RISK_EXCEPTION.md
@@ -135,6 +135,15 @@ The selector fails hosted at the start of 2026-09-14 UTC. Extending the window
 requires a reviewed source change to the expiry and this decision record; a
 repository variable cannot extend it.
 
+## Validation record
+
+The exact-SHA five-lane Depot canary, provider-separated schema-v3 metrics,
+macOS toolchain fallback proof, and identical-SHA hosted rollback are recorded
+in `.omo/specs/depot-pr-rollout-evidence.md`. That record preserves the strict
+capacity classifications and the Windows serial-matrix timing caveat. A green
+functional canary or rollback does not supersede the unsafe cache-authority
+sentinel above and does not relax this exception's scope or expiry.
+
 ## Exit criteria
 
 Remove this exception when Depot or GitHub offers and verifies either:

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -324,11 +324,24 @@ too, but an exact maintainer-approved merge ref and head SHA may use Depot under
 the time-bounded cache-risk exception in `ci/DEPOT_PR_RISK_EXCEPTION.md`. The
 other exception is uncredentialed CUDA smoke on the approved ephemeral
 `gpu-nvidia` scale set described above. PRs use the same protected reusable
-lanes and receive no repository secrets. Trusted `main` Linux roles may use Depot only when
-`DEPOT_RUNNERS_ENABLED` is exactly `true`; macOS, Windows, credential-bearing
-smokes and other hardware-qualified work retain explicit approved placement.
-Provider choice never changes plan membership, commands, artifacts, tests or
-summaries.
+lanes and receive no repository secrets. On routine trusted-`main` pushes,
+Linux roles may use Depot only when `DEPOT_RUNNERS_ENABLED` is exactly `true`;
+macOS, Windows, credential-bearing smokes and other hardware-qualified work
+retain explicit approved placement. The separate exact same-repository PR
+exception may also select eligible build/test rows on Depot macOS 15 and
+Windows 2022, subject to the same policy and documented exceptions. Provider
+choice never changes plan membership, commands, artifacts, tests or summaries.
+
+Depot coverage is reported against the selected ordinary-executor denominator,
+not against every job in the Actions run. For a plan, the denominator is every
+ordinary build/test executor row that the same event, trust profile, platform,
+architecture and policy make eligible for Depot; the numerator is the subset
+that actually receives a `depot-*` label. Control-plane planning,
+runner/selector diagnostics and lane summaries are outside the denominator;
+credential-bearing smokes, `gpu-nvidia` hardware, and unsupported or Intel
+macOS rows without a Depot-equivalent remain documented provider exceptions
+and are reported separately. Therefore “100% Depot” means 100% of eligible
+ordinary executor rows, not that every check or job is hosted by Depot.
 
 The central selector normally makes the Depot cache namespace inert by emitting
 `allow_native_github_cache=false` and `allow_depot_remote_cache=false`. During
@@ -456,7 +469,8 @@ those guarded cache consumers on both the selected PR and eligible trusted-main
 Depot jobs. Depot's lack of branch isolation means the cache can cross the PR,
 main, and other-PR trust boundaries. That accepted risk, including the exact
 sentinel evidence and rollback procedure, is documented in
-`ci/DEPOT_PR_RISK_EXCEPTION.md`.
+`ci/DEPOT_PR_RISK_EXCEPTION.md`; the exact-SHA canary, metrics, and hosted
+rollback evidence are recorded in `.omo/specs/depot-pr-rollout-evidence.md`.
 
 This is intentionally not a universal PR write-through policy. Cargo target
 caches are commonly hundreds of megabytes to several gigabytes per row; making
@@ -492,10 +506,13 @@ repository-scoped cross-trust authority. It is the basis of the explicitly
 accepted temporary risk, not evidence of isolation. Permanent enablement still
 requires a provider-isolation redesign and a new successful sentinel.
 
-Branch/main provider-parity, fork PR canary, capacity/namespace purge or expiry,
-and rollback evidence remain pending; those checks are distinct from the
-settings verification and must pass after the redesign before PR placement is
-enabled.
+The exact-SHA five-lane candidate, provider-separated comparison, and
+identical-SHA hosted rollback are recorded in
+`.omo/specs/depot-pr-rollout-evidence.md`. Quality and Linux were eligible,
+Website had insufficient samples, and macOS/Windows hit the deterministic
+capacity rollback threshold. The fork PR canary and namespace purge/expiry
+confirmation remain pending; permanent placement still requires a successful
+post-redesign isolation sentinel and acceptable capacity evidence.
 
 ## Required extension pattern
 

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -508,11 +508,13 @@ requires a provider-isolation redesign and a new successful sentinel.
 
 The exact-SHA five-lane candidate, provider-separated comparison, and
 identical-SHA hosted rollback are recorded in
-`.omo/specs/depot-pr-rollout-evidence.md`. Quality and Linux were eligible,
-Website had insufficient samples, and macOS/Windows hit the deterministic
-capacity rollback threshold. The fork PR canary and namespace purge/expiry
-confirmation remain pending; permanent placement still requires a successful
-post-redesign isolation sentinel and acceptable capacity evidence.
+`.omo/specs/depot-pr-rollout-evidence.md`. Quality and Linux had favorable
+queue observations but remain unclassified because execution was
+cache-confounded; Website had insufficient samples, and macOS/Windows hit the
+deterministic capacity rollback threshold. The fork PR canary and namespace
+purge/expiry confirmation remain pending; permanent placement still requires
+a successful post-redesign isolation sentinel and acceptable capacity
+evidence.
 
 ## Required extension pattern
 


### PR DESCRIPTION
## Summary
- record the exact-SHA five-lane Depot candidate and identical-SHA hosted rollback
- preserve the accepted cache-authority risk and time-bounded exception
- define the truthful eligible-executor meaning of 100% Depot
- report provider-separated schema-v3 results, including macOS/Windows rollback classifications and the Windows serial-matrix caveat

## Validation
- all five Depot candidate lanes and stable summaries passed
- all five hosted rollback lanes and stable summaries passed with exact job-name graph parity
- `just ci-validate` (473 tests, 7 expected skips)
- focused CI policy suite (75 tests)
- `actionlint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated CI guidance with exact-SHA Depot validation results, provider comparisons, and hosted rollback evidence.
  * Documented eligibility, capacity outcomes, and fallback behavior across Linux, macOS, Windows, Quality, and Website workflows.
  * Clarified cache-isolation safeguards, approval requirements, expiry controls, credential restrictions, and hosted fork validation.
  * Recorded remaining follow-up items, including fork-canary validation, namespace cleanup confirmation, and isolation-sentinel requirements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->