### PR TITLE
fix(skippy): restore recurrent shared prefixes

### DIFF
--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -331,9 +331,41 @@ impl StageOpenAiBackend {
         let mut decoded_prefill_suffix = false;
         if restored_prefill_tokens < prefill_tokens.len() {
             decoded_prefill_suffix = true;
-            runtime
-                .prefill(session_id, &prefill_tokens[restored_prefill_tokens..])
-                .map_err(openai_backend_error)?;
+            if let Some(kv) = self.kv.as_ref().filter(|kv| kv.payload_is_exact_state()) {
+                // Recurrent and full-state payloads cannot reconstruct a shorter
+                // shared prefix from the state at the end of the request. Stop
+                // at the near-tail grid boundary while prefilling and snapshot
+                // native state there; the final exact state is recorded by
+                // `record_and_evict_kv` below. One checkpoint bounds both the
+                // extra prefill split and the very large recurrent-state export.
+                let base = self.local_kv_message_base(session_id, request.ids);
+                let checkpoint =
+                    kv.exact_shared_checkpoint_identity(&self.config, &base, 0, prefill_tokens);
+                if let Some(identity) = checkpoint.filter(|identity| {
+                    identity.identity.token_count as usize > restored_prefill_tokens
+                }) {
+                    let boundary = identity.identity.token_count as usize;
+                    runtime
+                        .prefill(
+                            session_id,
+                            &prefill_tokens[restored_prefill_tokens..boundary],
+                        )
+                        .map_err(openai_backend_error)?;
+                    kv.record_exact_state(&mut runtime, session_id, &identity)
+                        .map_err(openai_backend_error)?;
+                    runtime
+                        .prefill(session_id, &prefill_tokens[boundary..])
+                        .map_err(openai_backend_error)?;
+                } else {
+                    runtime
+                        .prefill(session_id, &prefill_tokens[restored_prefill_tokens..])
+                        .map_err(openai_backend_error)?;
+                }
+            } else {
+                runtime
+                    .prefill(session_id, &prefill_tokens[restored_prefill_tokens..])
+                    .map_err(openai_backend_error)?;
+            }
         }
         cache_stats.matched_prefix_tokens = saturating_u32(restored_prefill_tokens);
         cache_stats.suffix_prefill_tokens =

--- a/crates/skippy-server/src/kv_integration/identity.rs
+++ b/crates/skippy-server/src/kv_integration/identity.rs
@@ -103,6 +103,33 @@ impl KvStageIntegration {
             })
             .collect()
     }
+
+    /// Pick a recurrent/full-state checkpoint below the near-tail page.
+    ///
+    /// The near-tail grid page can still include a short request-specific tail.
+    /// One additional stride below it leaves room for that tail while keeping
+    /// suffix prefill bounded for a changed-tail request.
+    pub(crate) fn exact_shared_checkpoint_identity(
+        &self,
+        config: &StageConfig,
+        base: &MessageBase,
+        token_start: u64,
+        token_ids: &[i32],
+    ) -> Option<PrefillKvIdentity> {
+        self.candidate_policy
+            .candidate_token_counts(token_ids.len() as u64)
+            .into_iter()
+            .filter(|token_count| *token_count < token_ids.len() as u64)
+            .nth(1)
+            .map(|token_count| {
+                self.prefill_identity(
+                    config,
+                    base,
+                    token_start,
+                    &token_ids[..token_count as usize],
+                )
+            })
+    }
 }
 
 #[cfg(test)]
@@ -247,6 +274,15 @@ mod tests {
             .find(|identity| identity.identity.token_count == 2231)
             .expect("lookup identities should include exact second prompt");
 
+        let checkpoint = kv
+            .exact_shared_checkpoint_identity(&config, &base, 0, &recorded_tokens)
+            .expect("exact-state shared checkpoint");
+        assert_eq!(checkpoint.identity.token_count, 2048);
+        let lookup_checkpoint = lookup_identities
+            .iter()
+            .find(|identity| identity.identity.token_count == 2048)
+            .expect("lookup identities should probe checkpoint");
+        assert_eq!(checkpoint.page_id, lookup_checkpoint.page_id);
         assert_eq!(recorded_shared.page_id, lookup_shared.page_id);
         assert_ne!(recorded_exact.page_id, lookup_exact.page_id);
     }

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -168,6 +168,10 @@ impl KvStageIntegration {
         self.mode
     }
 
+    pub(crate) fn payload_is_exact_state(&self) -> bool {
+        self.payload.is_exact_state()
+    }
+
     pub fn should_lookup(&self) -> bool {
         matches!(
             self.mode,

--- a/third_party/llama.cpp/patches/0020-skippy-preserve-recurrent-state-metadata-on-restore.patch
+++ b/third_party/llama.cpp/patches/0020-skippy-preserve-recurrent-state-metadata-on-restore.patch
@@ -1,0 +1,227 @@
+From 11f7f23fd34d9076572e19128dd70cba1f2d7af6 Mon Sep 17 00:00:00 2001
+From: Jimmy
+ <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a02b36a8@meshllm.communities.buzz.xyz>
+Date: Sat, 15 Aug 2026 15:06:25 +1000
+Subject: [PATCH] skippy: preserve recurrent state metadata on restore
+
+Co-authored-by: Jimmy <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a02b36a8@meshllm.communities.buzz.xyz>
+Signed-off-by: Jimmy <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a02b36a8@meshllm.communities.buzz.xyz>
+---
+ src/skippy/state.cpp                          |  16 +-
+ tests/CMakeLists.txt                          |   1 +
+ .../test-skippy-recurrent-state-roundtrip.cpp | 159 ++++++++++++++++++
+ 3 files changed, 163 insertions(+), 13 deletions(-)
+ create mode 100644 tests/test-skippy-recurrent-state-roundtrip.cpp
+
+diff --git a/src/skippy/state.cpp b/src/skippy/state.cpp
+index a70701844..a5ab006aa 100644
+--- a/src/skippy/state.cpp
++++ b/src/skippy/state.cpp
+@@ -356,24 +356,14 @@ enum skippy_status skippy_import_recurrent_state(
+         return SKIPPY_STATUS_UNSUPPORTED;
+     }
+ 
+-    std::vector<uint8_t> remapped(
+-            static_cast<const uint8_t *>(input),
+-            static_cast<const uint8_t *>(input) + input_bytes);
+-    constexpr size_t seq_id_offset = sizeof(uint32_t);
+-    if (remapped.size() < seq_id_offset + sizeof(llama_seq_id)) {
+-        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "recurrent state input is too small");
+-        return SKIPPY_STATUS_INVALID_ARGUMENT;
+-    }
+-    std::memcpy(remapped.data() + seq_id_offset, &session->seq_id, sizeof(session->seq_id));
+-
+     session->ctx->synchronize();
+     const size_t read = llama_state_seq_set_data_ext(
+             session->ctx,
+-            remapped.data(),
+-            remapped.size(),
++            static_cast<const uint8_t *>(input),
++            input_bytes,
+             session->seq_id,
+             LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
+-    if (read != remapped.size()) {
++    if (read != input_bytes) {
+         skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "failed to import recurrent state");
+         return SKIPPY_STATUS_RUNTIME_ERROR;
+     }
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 6aa8e347a..2bd82bf8b 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -154,6 +154,7 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
+     llama_build_and_test(test-skippy-kv-page-export.cpp)
+     llama_build_and_test(test-skippy-verify-checkpoint-retirement.cpp)
+     llama_build_and_test(test-skippy-kv-cells-contiguous.cpp)
++    llama_build_and_test(test-skippy-recurrent-state-roundtrip.cpp)
+     # these tests are disabled on Windows because they use internal functions not exported with LLAMA_API (when building with shared libraries)
+     llama_build_and_test(test-sampling.cpp)
+     llama_build_and_test(test-reasoning-budget.cpp)
+diff --git a/tests/test-skippy-recurrent-state-roundtrip.cpp b/tests/test-skippy-recurrent-state-roundtrip.cpp
+new file mode 100644
+index 000000000..9ef80a6ce
+--- /dev/null
++++ b/tests/test-skippy-recurrent-state-roundtrip.cpp
+@@ -0,0 +1,159 @@
++#include "../src/llama-batch.h"
++#include "../src/llama-io.h"
++#include "../src/llama-memory-recurrent.h"
++#include "../src/llama-model.h"
++
++#include "ggml-backend.h"
++
++#include <cstdio>
++#include <cstring>
++#include <memory>
++#include <stdexcept>
++#include <vector>
++
++class buffer_writer final : public llama_io_write_i {
++public:
++    void write(const void * src, size_t size) override {
++        const auto * bytes = static_cast<const uint8_t *>(src);
++        data.insert(data.end(), bytes, bytes + size);
++    }
++
++    void write_tensor(ggml_tensor * tensor, size_t offset, size_t size) override {
++        const size_t old_size = data.size();
++        data.resize(old_size + size);
++        ggml_backend_tensor_get(tensor, data.data() + old_size, offset, size);
++    }
++
++    size_t n_bytes() override {
++        return data.size();
++    }
++
++    std::vector<uint8_t> data;
++};
++
++class buffer_reader final : public llama_io_read_i {
++public:
++    explicit buffer_reader(const std::vector<uint8_t> & data) : data(data) {}
++
++    void read(void * dst, size_t size) override {
++        require(size);
++        std::memcpy(dst, data.data() + offset, size);
++        offset += size;
++    }
++
++    void read_tensor(ggml_tensor * tensor, size_t tensor_offset, size_t size) override {
++        require(size);
++        ggml_backend_tensor_set(tensor, data.data() + offset, tensor_offset, size);
++        offset += size;
++    }
++
++    size_t n_bytes() override {
++        return offset;
++    }
++
++private:
++    void require(size_t size) const {
++        if (size > data.size() - offset) {
++            throw std::runtime_error("unexpectedly reached end of recurrent-state buffer");
++        }
++    }
++
++    const std::vector<uint8_t> & data;
++    size_t offset = 0;
++};
++
++static llama_memory_recurrent make_memory(const llama_model & model) {
++    return llama_memory_recurrent(
++            model,
++            GGML_TYPE_F32,
++            GGML_TYPE_F32,
++            false,
++            4,
++            2,
++            0,
++            {});
++}
++
++int main() {
++    std::unique_ptr<llama_model> model(llama_model_create(LLM_ARCH_MAMBA, llama_model_default_params()));
++    if (!model) {
++        std::fprintf(stderr, "failed to create test model\n");
++        return 1;
++    }
++
++    model->hparams.n_layer_all = 1;
++    model->hparams.n_embd_r_impl = 4;
++    model->hparams.ssm_d_state = 2;
++    model->hparams.ssm_d_inner = 2;
++
++    auto source = make_memory(*model);
++    llama_pos source_pos = 7;
++    llama_seq_id source_seq_id = 0;
++    llama_seq_id * source_seq_ids = &source_seq_id;
++    int32_t source_n_seq_id = 1;
++    llama_ubatch source_batch = {};
++    source_batch.b_equal_seqs = 1;
++    source_batch.n_tokens = 1;
++    source_batch.n_seq_tokens = 1;
++    source_batch.n_seqs = 1;
++    source_batch.n_pos = 1;
++    source_batch.pos = &source_pos;
++    source_batch.n_seq_id = &source_n_seq_id;
++    source_batch.seq_id = &source_seq_ids;
++    if (!source.find_slot(source_batch)) {
++        std::fprintf(stderr, "failed to allocate source recurrent cell\n");
++        return 2;
++    }
++
++    const std::vector<float> source_r = { 1.0f, 2.0f, 3.0f, 4.0f };
++    const std::vector<float> source_s = { 5.0f, 6.0f, 7.0f, 8.0f };
++    ggml_backend_tensor_set(source.r_l[0], source_r.data(), 0, source_r.size() * sizeof(float));
++    ggml_backend_tensor_set(source.s_l[0], source_s.data(), 0, source_s.size() * sizeof(float));
++
++    buffer_writer writer;
++    source.state_write(writer, source_seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
++
++    uint32_t cell_count = 0;
++    llama_pos serialized_pos = -1;
++    uint32_t serialized_n_seq_id = 1;
++    std::memcpy(&cell_count, writer.data.data(), sizeof(cell_count));
++    std::memcpy(&serialized_pos, writer.data.data() + sizeof(cell_count), sizeof(serialized_pos));
++    std::memcpy(
++            &serialized_n_seq_id,
++            writer.data.data() + sizeof(cell_count) + sizeof(serialized_pos),
++            sizeof(serialized_n_seq_id));
++    if (cell_count != 1 || serialized_pos != source_pos || serialized_n_seq_id != 0) {
++        std::fprintf(stderr, "unexpected single-sequence recurrent-state metadata\n");
++        return 3;
++    }
++
++    auto destination = make_memory(*model);
++    constexpr llama_seq_id destination_seq_id = 1;
++    buffer_reader reader(writer.data);
++    destination.state_read(reader, destination_seq_id, LLAMA_STATE_SEQ_FLAGS_PARTIAL_ONLY);
++
++    if (reader.n_bytes() != writer.n_bytes()) {
++        std::fprintf(stderr, "recurrent-state round-trip byte count mismatch\n");
++        return 4;
++    }
++    if (destination.seq_pos_min(destination_seq_id) != source_pos ||
++            destination.seq_pos_max(destination_seq_id) != source_pos) {
++        std::fprintf(stderr, "recurrent-state position was not preserved across sequence ids\n");
++        return 5;
++    }
++    if (destination.seq_pos_min(source_seq_id) != -1) {
++        std::fprintf(stderr, "recurrent state retained the source sequence id\n");
++        return 6;
++    }
++
++    std::vector<float> restored_r(source_r.size());
++    std::vector<float> restored_s(source_s.size());
++    ggml_backend_tensor_get(destination.r_l[0], restored_r.data(), 0, restored_r.size() * sizeof(float));
++    ggml_backend_tensor_get(destination.s_l[0], restored_s.data(), 0, restored_s.size() * sizeof(float));
++    if (restored_r != source_r || restored_s != source_s) {
++        std::fprintf(stderr, "recurrent tensor data changed during cross-sequence restore\n");
++        return 7;
++    }
++
++    return 0;
++}
+-- 
+2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0020-skippy-preserve-recurrent-state-metadata-on-restore.patch
+++ b/third_party/llama.cpp/patches/0020-skippy-preserve-recurrent-state-metadata-on-restore.patch
@@ -1,4 +1,4 @@
-From 11f7f23fd34d9076572e19128dd70cba1f2d7af6 Mon Sep 17 00:00:00 2001
+From 80d9f9bfdebc46d6e58213871b9d30d7096768e6 Mon Sep 17 00:00:00 2001
 From: Jimmy
  <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a02b36a8@meshllm.communities.buzz.xyz>
 Date: Sat, 15 Aug 2026 15:06:25 +1000
@@ -7,12 +7,27 @@ Subject: [PATCH] skippy: preserve recurrent state metadata on restore
 Co-authored-by: Jimmy <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a02b36a8@meshllm.communities.buzz.xyz>
 Signed-off-by: Jimmy <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a02b36a8@meshllm.communities.buzz.xyz>
 ---
+ src/llama-kv-cache.cpp                        |   2 +-
  src/skippy/state.cpp                          |  16 +-
  tests/CMakeLists.txt                          |   1 +
+ tests/test-skippy-kv-page-export.cpp          |   8 +-
  .../test-skippy-recurrent-state-roundtrip.cpp | 159 ++++++++++++++++++
- 3 files changed, 163 insertions(+), 13 deletions(-)
+ 5 files changed, 169 insertions(+), 17 deletions(-)
  create mode 100644 tests/test-skippy-recurrent-state-roundtrip.cpp
 
+diff --git a/src/llama-kv-cache.cpp b/src/llama-kv-cache.cpp
+index 190c6aff9..9af3c442e 100644
+--- a/src/llama-kv-cache.cpp
++++ b/src/llama-kv-cache.cpp
+@@ -1663,7 +1663,7 @@ bool llama_kv_cache::stage_import_kv_page(
+     }
+     if (desc.layer_start < 0 ||
+             desc.layer_end <= desc.layer_start ||
+-            static_cast<uint32_t>(desc.layer_end) > hparams.n_layer() ||
++            static_cast<uint32_t>(desc.layer_end) > hparams.n_layer_all ||
+             desc.token_count == 0) {
+         error = "invalid native KV page descriptor";
+         return false;
 diff --git a/src/skippy/state.cpp b/src/skippy/state.cpp
 index a70701844..a5ab006aa 100644
 --- a/src/skippy/state.cpp
@@ -57,6 +72,43 @@ index 6aa8e347a..2bd82bf8b 100644
      # these tests are disabled on Windows because they use internal functions not exported with LLAMA_API (when building with shared libraries)
      llama_build_and_test(test-sampling.cpp)
      llama_build_and_test(test-reasoning-budget.cpp)
+diff --git a/tests/test-skippy-kv-page-export.cpp b/tests/test-skippy-kv-page-export.cpp
+index 82075076c..96937c8dc 100644
+--- a/tests/test-skippy-kv-page-export.cpp
++++ b/tests/test-skippy-kv-page-export.cpp
+@@ -16,7 +16,8 @@ int main() {
+         return 1;
+     }
+     llama_hparams hparams = {};
+-    hparams.n_layer_all = 1;
++    hparams.n_layer_all = 2;
++    hparams.n_layer_nextn = 1;
+     hparams.n_embd_head_k_full = 4;
+     hparams.n_embd_head_v_full = 4;
+     hparams.n_embd_head_k_swa = 4;
+@@ -40,7 +41,7 @@ int main() {
+             0,
+             LLAMA_SWA_TYPE_NONE,
+             nullptr,
+-            {},
++            [](int32_t il) { return il == 0; },
+             {},
+             {});
+ 
+@@ -122,11 +123,12 @@ int main() {
+             0,
+             LLAMA_SWA_TYPE_NONE,
+             nullptr,
+-            {},
++            [](int32_t il) { return il == 0; },
+             {},
+             {});
+     restore_kv.apply_ubatch(slot, ubatch);
+ 
++    desc.layer_end = 2;
+     if (!restore_kv.stage_import_kv_page(
+                 0,
+                 desc,
 diff --git a/tests/test-skippy-recurrent-state-roundtrip.cpp b/tests/test-skippy-recurrent-state-roundtrip.cpp
 new file mode 100644
 index 000000000..9ef80a6ce


### PR DESCRIPTION
## Summary
- preserve recurrent-state metadata when restoring native Skippy state
- snapshot one exact recurrent/full-state checkpoint during prefill for changed-tail shared-prefix reuse
- avoid re-snapshotting a checkpoint behind an already restored prefix

## Validation
- `RUSTFLAGS='-D warnings' cargo test -p skippy-server` — 445 passed
- clean `scripts/prepare-llama.sh pinned` patch replay — passed
- `just release-host-build` — passed (deployment-target linker warnings only)
- Qwen3.8 27B Q4_K_M full KV/tool-loop gate — 7/7 passed
  - tool loops: 2/2
  - overlap loops: 2/2, 4114 cached tokens
  - changed-tail shared prefix: 3968/4116 cached tokens
  - exact replay: 4115/4116 cached tokens
  - native fatal-pattern scan: clean

## Notes
The patch file retains two pre-existing whitespace warnings in added blank lines; clean `git am` replay succeeds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved reuse of shared generation state during exact-state requests, reducing redundant prefilling when applicable.
  * Maintained efficient direct prefilling when shared state cannot be reused.

* **Bug Fixes**
  * Improved restoration of recurrent generation state, preserving metadata, sequence positions, tensor data, and source isolation.
  * Enhanced validation for restored state across supported model layers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->