### PR TITLE
feat(catalog): recommend Qwen3.8 27B Q4_K_M

### DIFF
--- a/crates/mesh-client/src/models/catalog.json
+++ b/crates/mesh-client/src/models/catalog.json
@@ -295,6 +295,19 @@
     }
   },
   {
+    "name": "Qwen3.8-27B-Q4_K_M",
+    "file": "Qwen3.8-27B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/resolve/main/Qwen3.8-27B-Q4_K_M.gguf",
+    "size": "17.1GB",
+    "description": "Qwen3.8 27B dense, vision + text, memory-efficient agentic tool calling and reasoning",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "mmproj-BF16.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/resolve/main/mmproj-BF16.gguf"
+    }
+  },
+  {
     "name": "Qwen3-Coder-Next-Q4_K_M",
     "file": "Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",
     "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M/Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",

--- a/crates/mesh-llm-node/src/catalog.json
+++ b/crates/mesh-llm-node/src/catalog.json
@@ -295,6 +295,19 @@
     }
   },
   {
+    "name": "Qwen3.8-27B-Q4_K_M",
+    "file": "Qwen3.8-27B-Q4_K_M.gguf",
+    "url": "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/resolve/main/Qwen3.8-27B-Q4_K_M.gguf",
+    "size": "17.1GB",
+    "description": "Qwen3.8 27B dense, vision + text, memory-efficient agentic tool calling and reasoning",
+    "draft": null,
+    "extra_files": [],
+    "mmproj": {
+      "file": "mmproj-BF16.gguf",
+      "url": "https://huggingface.co/unsloth/Qwen3.8-27B-GGUF/resolve/main/mmproj-BF16.gguf"
+    }
+  },
+  {
     "name": "Qwen3-Coder-Next-Q4_K_M",
     "file": "Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",
     "url": "https://huggingface.co/Qwen/Qwen3-Coder-Next-GGUF/resolve/main/Qwen3-Coder-Next-Q4_K_M/Qwen3-Coder-Next-Q4_K_M-00001-of-00004.gguf",


### PR DESCRIPTION
## Summary
- add the tested Qwen3.8 27B Q4_K_M artifact to both bundled recommended-model catalogs
- include the upstream BF16 vision projector
- keep draft-model acceleration disabled because the existing Qwen3 draft does not share Qwen3.8's tokenizer vocabulary

## Validation
- model URL: HTTP 200, 17,106,775,008 bytes
- projector URL: HTTP 200, 931,146,432 bytes
- both catalog JSON files parse and are byte-identical
- `cargo test -p mesh-llm-client`
- `cargo test -p mesh-llm-node`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Qwen3.8-27B-Q4_K_M model.
  * Included download details for the 17.1 GB model file and its BF16 multimodal projection file.
  * Identified support for text, vision, and agentic reasoning capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->