### PR TITLE
fix(split): let Iroh own transport path selection

### DIFF
--- a/crates/mesh-client/src/mesh/types.rs
+++ b/crates/mesh-client/src/mesh/types.rs
@@ -1,8 +1,8 @@
 use iroh::{EndpointAddr, EndpointId};
 pub use mesh_llm_types::mesh::{
-    DEMAND_TTL_SECS, MAX_SPLIT_RTT_MS, ModelDemand, ModelRuntimeDescriptor, ModelSourceKind,
-    ServedModelDescriptor, ServedModelIdentity, infer_available_model_descriptors,
-    infer_local_served_model_descriptor, infer_served_model_descriptors, merge_demand,
+    DEMAND_TTL_SECS, ModelDemand, ModelRuntimeDescriptor, ModelSourceKind, ServedModelDescriptor,
+    ServedModelIdentity, infer_available_model_descriptors, infer_local_served_model_descriptor,
+    infer_served_model_descriptors, merge_demand,
 };
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;

--- a/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
+++ b/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
@@ -1,6 +1,6 @@
 use super::MeshApi;
 use super::status::{ModelTargetCapacityAdvicePayload, ModelTargetCapacityAdviceState};
-use crate::mesh::{NodeRole, PeerInfo, SplitStagePathRejection, SplitStagePathSnapshot};
+use crate::mesh::{NodeRole, PeerInfo, SplitStagePathSnapshot};
 use serde::Serialize;
 
 const MIN_SPLIT_PARTICIPANTS: usize = 2;
@@ -241,11 +241,6 @@ fn split_node_exclusion_reason(
         return Some(SplitReadinessExclusionReason::StageProtocolGeneration);
     }
     if node.source == SplitReadinessNodeSource::Peer
-        && let Some(rejection) = node.stage_path.stage_path_rejection()
-    {
-        return Some(split_readiness_stage_path_rejection(rejection));
-    }
-    if node.source == SplitReadinessNodeSource::Peer
         && let Some(reason) = split_stage_source_exclusion_reason(model_ref, node)
     {
         return Some(reason);
@@ -264,22 +259,6 @@ fn split_participant(model_ref: &str, node: SplitReadinessNodeInput) -> SplitRea
         artifact_transfer_supported: node.artifact_transfer_supported,
         rtt_ms: node.stage_path.rtt_ms,
         model_source_state,
-    }
-}
-
-const fn split_readiness_stage_path_rejection(
-    rejection: SplitStagePathRejection,
-) -> SplitReadinessExclusionReason {
-    match rejection {
-        SplitStagePathRejection::MissingStagePath => {
-            SplitReadinessExclusionReason::MissingStagePath
-        }
-        SplitStagePathRejection::StagePathRelayOnly => {
-            SplitReadinessExclusionReason::StagePathRelayOnly
-        }
-        SplitStagePathRejection::StagePathTooSlow => {
-            SplitReadinessExclusionReason::StagePathTooSlow
-        }
     }
 }
 
@@ -513,33 +492,6 @@ fn split_readiness_recommendations(
                 .to_string(),
         );
     }
-    if exclusions
-        .iter()
-        .any(|item| item.reason == SplitReadinessExclusionReason::MissingStagePath.as_str())
-    {
-        recommendations.push(
-            "Wait for direct peer latency to be measured before split serving, or check that the nodes can establish a direct QUIC path."
-                .to_string(),
-        );
-    }
-    if exclusions
-        .iter()
-        .any(|item| item.reason == SplitReadinessExclusionReason::StagePathRelayOnly.as_str())
-    {
-        recommendations.push(
-            "Relay-only peers are not admitted for split serving; check firewall/NAT settings so the stage connection can use a direct QUIC path."
-                .to_string(),
-        );
-    }
-    if exclusions
-        .iter()
-        .any(|item| item.reason == SplitReadinessExclusionReason::StagePathTooSlow.as_str())
-    {
-        recommendations.push(format!(
-            "Use lower-latency peers for split serving; direct stage RTT must be at or below {}ms.",
-            crate::mesh::max_split_rtt_ms()
-        ));
-    }
     recommendations
 }
 
@@ -616,16 +568,13 @@ fn split_capacity_shortfall_blocker(
     })
 }
 
-const fn split_readiness_exclusion_reason_order() -> [SplitReadinessExclusionReason; 12] {
+const fn split_readiness_exclusion_reason_order() -> [SplitReadinessExclusionReason; 9] {
     [
         SplitReadinessExclusionReason::StageControlUnreachable,
         SplitReadinessExclusionReason::PackageManifestMismatch,
         SplitReadinessExclusionReason::ArtifactTransferUnavailable,
         SplitReadinessExclusionReason::StageInventoryEmpty,
         SplitReadinessExclusionReason::MissingModelSource,
-        SplitReadinessExclusionReason::MissingStagePath,
-        SplitReadinessExclusionReason::StagePathRelayOnly,
-        SplitReadinessExclusionReason::StagePathTooSlow,
         SplitReadinessExclusionReason::StageProtocolGeneration,
         SplitReadinessExclusionReason::MissingVram,
         SplitReadinessExclusionReason::MissingModelInterest,
@@ -765,9 +714,6 @@ enum SplitReadinessExclusionReason {
     MissingVram,
     MissingModelInterest,
     StageProtocolGeneration,
-    MissingStagePath,
-    StagePathRelayOnly,
-    StagePathTooSlow,
     StageControlUnreachable,
     ArtifactTransferUnavailable,
     StageInventoryEmpty,
@@ -782,9 +728,6 @@ impl SplitReadinessExclusionReason {
             Self::MissingVram => "missing_vram",
             Self::MissingModelInterest => "missing_model_interest",
             Self::StageProtocolGeneration => "stage_protocol_generation",
-            Self::MissingStagePath => "missing_stage_path",
-            Self::StagePathRelayOnly => "stage_path_relay_only",
-            Self::StagePathTooSlow => "stage_path_too_slow",
             Self::StageControlUnreachable => "stage_control_unreachable",
             Self::ArtifactTransferUnavailable => "artifact_transfer_unavailable",
             Self::StageInventoryEmpty => "stage_inventory_empty",
@@ -804,15 +747,6 @@ impl SplitReadinessExclusionReason {
             }
             Self::StageProtocolGeneration => {
                 "Upgrade this peer; its stage protocol generation is too old for split serving."
-            }
-            Self::MissingStagePath => {
-                "Wait for a measured direct path before admitting this peer to split serving."
-            }
-            Self::StagePathRelayOnly => {
-                "Establish a direct QUIC path before admitting this peer to split serving."
-            }
-            Self::StagePathTooSlow => {
-                "Use a lower-latency path or peer before admitting this peer to split serving."
             }
             Self::StageControlUnreachable => {
                 "Check stage-control connectivity and peer runtime logs before retrying."
@@ -1105,91 +1039,36 @@ mod tests {
     }
 
     #[test]
-    fn split_readiness_excludes_peer_without_measured_stage_path() {
-        let mut peer = node(
-            "peer000000000000000000000000000000000",
+    fn split_readiness_does_not_gate_on_transport_path_or_rtt() {
+        let mut unknown_path = node(
+            "unknown00000000000000000000000000000",
             SplitReadinessNodeRole::Worker,
             &["meshllm/Qwen3-8B-Q4_K_M-layers"],
         );
-        peer.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
-        peer.stage_path = crate::mesh::SplitStagePathSnapshot::unknown();
+        unknown_path.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
+        unknown_path.stage_path = crate::mesh::SplitStagePathSnapshot::unknown();
+
+        let mut relay_path = node(
+            "relay000000000000000000000000000000",
+            SplitReadinessNodeRole::Worker,
+            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
+        );
+        relay_path.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
+        relay_path.stage_path = crate::mesh::SplitStagePathSnapshot::relay(Some(u32::MAX));
 
         let report = build_split_readiness_report(SplitReadinessInput {
             model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
             local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
-            peers: vec![peer],
+            peers: vec![unknown_path, relay_path],
             capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
             active_topology_count: 0,
             active_stage_count: 0,
         });
 
-        assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
-        assert_eq!(report.participant_count, 1);
-        assert_eq!(report.exclusions[0].reason, "missing_stage_path");
-        assert_eq!(report.blockers[0].reason, "missing_stage_path");
-        assert_eq!(report.blockers[0].count, 1);
-        assert!(
-            report
-                .recommendations
-                .iter()
-                .any(|item| item.contains("direct peer latency"))
-        );
-    }
-
-    #[test]
-    fn split_readiness_excludes_peer_with_slow_stage_path() {
-        let mut peer = node(
-            "peer000000000000000000000000000000000",
-            SplitReadinessNodeRole::Worker,
-            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
-        );
-        peer.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
-        peer.stage_path =
-            crate::mesh::SplitStagePathSnapshot::direct(Some(crate::mesh::MAX_SPLIT_RTT_MS + 1));
-
-        let report = build_split_readiness_report(SplitReadinessInput {
-            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
-            local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
-            peers: vec![peer],
-            capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
-            active_topology_count: 0,
-            active_stage_count: 0,
-        });
-
-        assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
-        assert_eq!(report.participant_count, 1);
-        assert_eq!(report.exclusions[0].reason, "stage_path_too_slow");
-        assert!(
-            report
-                .recommendations
-                .iter()
-                .any(|item| item.contains(&format!("{}ms", crate::mesh::max_split_rtt_ms())))
-        );
-    }
-
-    #[test]
-    fn split_readiness_excludes_relay_only_peer() {
-        let mut peer = node(
-            "peer000000000000000000000000000000000",
-            SplitReadinessNodeRole::Worker,
-            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
-        );
-        peer.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
-        peer.stage_path = crate::mesh::SplitStagePathSnapshot::relay(Some(5));
-
-        let report = build_split_readiness_report(SplitReadinessInput {
-            model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
-            local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
-            peers: vec![peer],
-            capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
-            active_topology_count: 0,
-            active_stage_count: 0,
-        });
-
-        assert_eq!(report.verdict, SplitReadinessVerdict::WaitingForPeers);
-        assert_eq!(report.participant_count, 1);
-        assert_eq!(report.exclusions[0].reason, "stage_path_relay_only");
-        assert_eq!(report.blockers[0].reason, "stage_path_relay_only");
+        assert_eq!(report.verdict, SplitReadinessVerdict::Ready);
+        assert_eq!(report.participant_count, 3);
+        assert!(report.exclusions.is_empty());
+        assert!(report.blockers.is_empty());
     }
 
     #[test]
@@ -1206,19 +1085,10 @@ mod tests {
             &["meshllm/Qwen3-8B-Q4_K_M-layers"],
         );
         missing_source_b.artifact_transfer_supported = false;
-        let mut slow_path = node(
-            "slowpath000000000000000000000000000",
-            SplitReadinessNodeRole::Worker,
-            &["meshllm/Qwen3-8B-Q4_K_M-layers"],
-        );
-        slow_path.available_models = vec!["meshllm/Qwen3-8B-Q4_K_M-layers".to_string()];
-        slow_path.stage_path =
-            crate::mesh::SplitStagePathSnapshot::direct(Some(crate::mesh::MAX_SPLIT_RTT_MS + 1));
-
         let report = build_split_readiness_report(SplitReadinessInput {
             model_ref: "meshllm/Qwen3-8B-Q4_K_M-layers".to_string(),
             local: local_node(&["meshllm/Qwen3-8B-Q4_K_M-layers"]),
-            peers: vec![slow_path, missing_source_a, missing_source_b],
+            peers: vec![missing_source_a, missing_source_b],
             capacity_advice: Some(advice(ModelTargetCapacityAdviceState::SplitCandidate)),
             active_topology_count: 0,
             active_stage_count: 0,
@@ -1230,6 +1100,5 @@ mod tests {
             report.blockers[0].short_node_ids,
             vec!["missinga".to_string(), "missingb".to_string()]
         );
-        assert_eq!(report.blockers[1].reason, "stage_path_too_slow");
     }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/connections.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/connections.rs
@@ -1770,10 +1770,10 @@ impl Node {
                 .await;
         });
 
-        // Schedule a delayed RTT recheck: the first gossip often goes via relay
-        // (high RTT) because direct holepunch hasn't completed yet. After a few
-        // seconds the direct path is usually ready, so re-check path info to get
-        // the real RTT and potentially trigger a re-election for split mode.
+        // Schedule a delayed selected-path refresh: the first gossip often goes
+        // via relay because direct holepunch has not completed yet. Iroh may
+        // upgrade the connection after admission, and diagnostics should report
+        // the selected path it ultimately owns.
         self.schedule_selected_path_recheck(peer_id);
         self.finish_pending_connection(owner, PendingConnectionOutcome::Admitted)
             .await;

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -5,13 +5,10 @@
 //! mixed-version compatibility. Skippy activation transport remains on the
 //! latency-sensitive `skippy-stage/2` ALPN.
 
-#[cfg(test)]
-pub(crate) use mesh_llm_types::mesh::MAX_SPLIT_RTT_MS;
 pub use mesh_llm_types::mesh::{
     ModelDemand, ModelRuntimeDescriptor, ModelSourceKind, ServedModelDescriptor,
     ServedModelIdentity, ServedModelMetadata, infer_available_model_descriptors,
-    infer_local_served_model_descriptor, infer_served_model_descriptors, max_split_rtt_ms,
-    split_allow_relay_paths,
+    infer_local_served_model_descriptor, infer_served_model_descriptors,
 };
 
 use anyhow::{Context, Result};
@@ -165,7 +162,7 @@ pub(crate) use stage_transport::{
     unused_imports,
     reason = "public compatibility re-export for existing split-stage routing callers"
 )]
-pub use stage_transport::{InflightRequestGuard, SplitStagePathRejection, SplitStagePathSnapshot};
+pub use stage_transport::{InflightRequestGuard, SplitStagePathSnapshot};
 pub use stage_transport::{
     StageAssignment, StageEndpoint, StageRuntimeStatus, StageTopologyInstance, TunnelChannels,
 };

--- a/crates/mesh-llm-host-runtime/src/mesh/node.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node.rs
@@ -1484,16 +1484,14 @@ impl Node {
         if rtt_ms == 0 {
             return;
         }
-        let (updated_peer, old_rtt) = {
+        let updated_peer = {
             let mut state = self.state.lock().await;
             if let Some(peer) = state.peers.get_mut(&id) {
                 let prev = peer.rtt_ms;
-                // Only accept equal-or-lower RTT. Gossip round-trip timing
-                // can inflate the value when routed via relay, overwriting a
-                // good direct-path measurement. The RTT gate only cares about
-                // "fast enough for split", so keeping the best-seen value is
-                // correct — if the path truly degrades the peer will be
-                // unreachable and removed via the normal liveness path.
+                // Only accept equal-or-lower RTT for planner preference and display.
+                // Gossip round-trip timing can inflate the value when routed via
+                // relay, overwriting a better path measurement. Liveness remains
+                // responsible for detecting an unreachable peer.
                 if prev.is_some_and(|p| rtt_ms > p) {
                     // Store display_rtt regardless (for UI refresh), but don't update best RTT.
                     peer.display_rtt = Some(DirectLatencyObservation {
@@ -1507,29 +1505,13 @@ impl Node {
                     rtt_ms,
                     observed_at: std::time::Instant::now(),
                 });
-                (Some(peer.clone()), prev)
+                Some(peer.clone())
             } else {
-                (None, None)
+                None
             }
         };
         if let Some(peer) = updated_peer {
             tracing::info!("Peer {} RTT: {}ms", id.fmt_short(), rtt_ms);
-            // If RTT dropped from above the configured split threshold to below it
-            // (e.g. relay → direct), trigger a re-election so the peer can now
-            // be included in split mode.
-            let became_split_eligible = old_rtt
-                .map(|old| old > max_split_rtt_ms() && rtt_ms <= max_split_rtt_ms())
-                .unwrap_or(rtt_ms <= max_split_rtt_ms());
-            if became_split_eligible {
-                emit_mesh_info(format!(
-                    "📡 Peer {} RTT improved ({}ms → {}ms) — re-electing for split",
-                    id.fmt_short(),
-                    old_rtt.unwrap_or(0),
-                    rtt_ms
-                ));
-                let count = self.state.lock().await.peers.len();
-                let _ = self.peer_change_tx.send(count);
-            }
             self.emit_plugin_mesh_event(
                 crate::plugin::proto::mesh_event::Kind::PeerUpdated,
                 Some(&peer),
@@ -1767,78 +1749,5 @@ impl Node {
 
     pub async fn explicit_model_interests(&self) -> Vec<String> {
         self.explicit_model_interests.lock().await.clone()
-    }
-}
-
-#[cfg(test)]
-mod node_tests {
-    use super::*;
-
-    fn test_peer_announcement(addr: EndpointAddr) -> PeerAnnouncement {
-        PeerAnnouncement {
-            addr,
-            role: NodeRole::Worker,
-            first_joined_mesh_ts: None,
-            models: Vec::new(),
-            vram_bytes: 0,
-            model_source: None,
-            serving_models: Vec::new(),
-            hosted_models: None,
-            available_models: Vec::new(),
-            requested_models: Vec::new(),
-            explicit_model_interests: Vec::new(),
-            version: None,
-            model_demand: HashMap::new(),
-            mesh_id: None,
-            mesh_policy_hash: None,
-            gpu_name: None,
-            hostname: None,
-            is_soc: None,
-            gpu_vram: None,
-            gpu_reserved_bytes: None,
-            gpu_mem_bandwidth_gbps: None,
-            gpu_compute_tflops_fp32: None,
-            gpu_compute_tflops_fp16: None,
-            available_model_metadata: Vec::new(),
-            experts_summary: None,
-            available_model_sizes: HashMap::new(),
-            served_model_descriptors: Vec::new(),
-            served_model_runtime: Vec::new(),
-            owner_attestation: None,
-            genesis_policy: None,
-            release_attestation: None,
-            direct_admission_proof: None,
-            artifact_transfer_supported: false,
-            stage_protocol_generation_supported: false,
-            stage_status_list_supported: false,
-            advertised_model_throughput: Vec::new(),
-            latency_ms: None,
-            latency_source: None,
-            latency_age_ms: None,
-            latency_observer_id: None,
-            inference_admission_state: None,
-        }
-    }
-
-    #[tokio::test]
-    async fn update_peer_rtt_notifies_when_first_sample_is_split_eligible() {
-        let node = Node::new_for_tests(NodeRole::Worker).await.unwrap();
-        let peer_node = Node::new_for_tests(NodeRole::Worker).await.unwrap();
-        let peer_id = peer_node.id();
-        let peer = PeerInfo::from_announcement(
-            peer_id,
-            peer_node.endpoint_addr_for_advertisement(),
-            &test_peer_announcement(peer_node.endpoint_addr_for_advertisement()),
-            OwnershipSummary::default(),
-        );
-        node.insert_test_peer(peer).await;
-
-        let mut peer_changes = node.peer_change_rx.clone();
-        node.update_peer_rtt(peer_id, MAX_SPLIT_RTT_MS).await;
-
-        tokio::time::timeout(std::time::Duration::from_secs(1), peer_changes.changed())
-            .await
-            .expect("first split-eligible RTT should notify election watchers")
-            .expect("peer change channel should stay open");
     }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/stage_transport.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/stage_transport.rs
@@ -66,23 +66,6 @@ pub(crate) enum SplitStagePathKind {
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
-pub enum SplitStagePathRejection {
-    MissingStagePath,
-    StagePathRelayOnly,
-    StagePathTooSlow,
-}
-
-impl SplitStagePathRejection {
-    pub(crate) const fn as_str(self) -> &'static str {
-        match self {
-            Self::MissingStagePath => "missing_stage_path",
-            Self::StagePathRelayOnly => "stage_path_relay_only",
-            Self::StagePathTooSlow => "stage_path_too_slow",
-        }
-    }
-}
-
-#[derive(Clone, Copy, Debug, Eq, PartialEq)]
 pub struct SplitStagePathSnapshot {
     pub(crate) kind: SplitStagePathKind,
     pub(crate) rtt_ms: Option<u32>,
@@ -126,24 +109,6 @@ impl SplitStagePathSnapshot {
                 split_stage_path_snapshot_from_observation(observation)
             }
             _ => self,
-        }
-    }
-
-    pub(crate) fn stage_path_rejection(self) -> Option<SplitStagePathRejection> {
-        match self.kind {
-            SplitStagePathKind::Direct => match self.rtt_ms {
-                Some(rtt_ms) if rtt_ms <= super::max_split_rtt_ms() => None,
-                Some(_) => Some(SplitStagePathRejection::StagePathTooSlow),
-                None => Some(SplitStagePathRejection::MissingStagePath),
-            },
-            SplitStagePathKind::Relay => {
-                if super::split_allow_relay_paths() {
-                    None
-                } else {
-                    Some(SplitStagePathRejection::StagePathRelayOnly)
-                }
-            }
-            SplitStagePathKind::Unknown => Some(SplitStagePathRejection::MissingStagePath),
         }
     }
 }
@@ -194,19 +159,6 @@ pub(crate) fn split_stage_path_snapshot_from_connection(
         return SplitStagePathSnapshot::unknown();
     };
     split_stage_path_snapshot_from_observation(observation)
-}
-
-pub(crate) fn stage_transport_path_rejection(
-    conn: &Connection,
-    stream_type: u8,
-    fallback: Option<SelectedPathObservation>,
-) -> Option<SplitStagePathRejection> {
-    if stream_type != skippy_protocol::STAGE_STREAM_TRANSPORT {
-        return None;
-    }
-    split_stage_path_snapshot_from_connection(conn)
-        .with_peer_path_fallback(fallback)
-        .stage_path_rejection()
 }
 
 pub(crate) fn endpoint_id_capture_fields(id: EndpointId) -> serde_json::Value {
@@ -1052,33 +1004,6 @@ impl Node {
         skippy_protocol::validate_stage_transport_open(&open)
             .map_err(|e| anyhow::anyhow!("StageTransportOpen validation error: {e}"))?;
         let conn = self.stage_connection_to_peer(peer_id).await?;
-        // Do NOT re-apply the formation-time RTT/path eligibility ceiling
-        // (MAX_SPLIT_RTT_MS) to operational streams here. This function only runs
-        // from the post-formation stage-transport bridge, and split admission
-        // already gates path eligibility using gossiped, hysteresis-smoothed peer
-        // RTT plus re-election (see api/split_readiness.rs and node RTT handling).
-        //
-        // Re-checking the *instantaneous* per-connection RTT snapshot on every
-        // fresh stream caused transient failures under normal WAN jitter: pooled
-        // forward lanes (opened once at low RTT and reused) kept working, while
-        // per-request direct-prediction-return sinks — which open a fresh bridge
-        // stream each request — were rejected whenever the snapshot briefly read
-        // above the ceiling. That aborted the bridge task, dropped the accepted
-        // return-sink TCP connection, and surfaced as a ready-handshake timeout on
-        // stage 0, degrading/​502-ing an already-admitted split. A transiently slow
-        // or relay path still *works* (just slower); sustained degradation is
-        // handled by re-election, not by killing individual operational streams.
-        if let Some(rejection) = split_stage_path_snapshot_from_connection(&conn)
-            .with_peer_path_fallback(self.peer_stage_path_fallback(peer_id).await)
-            .stage_path_rejection()
-        {
-            tracing::warn!(
-                "stage transport path to {} reports {} on a formed split; proceeding \
-                 (operational streams tolerate transient path degradation)",
-                peer_id.fmt_short(),
-                rejection.as_str()
-            );
-        }
         let (mut send, recv) = conn.open_bi().await?;
         send.write_all(&[skippy_protocol::STAGE_STREAM_TRANSPORT])
             .await?;
@@ -1314,19 +1239,6 @@ impl Node {
                 return StageStreamAccept::Continue;
             }
         };
-        if let Some(rejection) = stage_transport_path_rejection(
-            conn,
-            stream_type,
-            self.peer_stage_path_fallback(remote).await,
-        ) {
-            tracing::warn!(
-                "Rejected skippy stage transport stream from {}: {}",
-                remote.fmt_short(),
-                rejection.as_str()
-            );
-            drop((send, recv));
-            return StageStreamAccept::Continue;
-        }
         StageStreamAccept::Dispatch((send, recv), stream_type)
     }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/admission/connectivity.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/admission/connectivity.rs
@@ -1,17 +1,14 @@
 use super::*;
 use tokio::sync::watch;
 
-/// RTT re-election: when a peer's RTT drops from above the 80ms split
-/// threshold to below it (e.g. relay → direct), update_peer_rtt must
-/// trigger a peer_change event so the election loop re-runs and can
-/// now include the peer in split mode.
+/// RTT changes do not affect split eligibility, so they must not trigger
+/// topology re-election.
 #[tokio::test]
-async fn test_rtt_drop_triggers_reelection() -> Result<()> {
+async fn test_rtt_improvement_does_not_trigger_reelection() -> Result<()> {
     let node = make_test_node(super::super::NodeRole::Worker).await?;
     let peer_key = SecretKey::generate();
     let peer_id = EndpointId::from(peer_key.public());
 
-    // Add a fake peer with high relay RTT
     {
         let mut state = node.state.lock().await;
         state
@@ -20,48 +17,11 @@ async fn test_rtt_drop_triggers_reelection() -> Result<()> {
     }
 
     let rx = node.peer_change_rx.clone();
-
-    // Update RTT to still-high value — should NOT trigger
-    node.update_peer_rtt(peer_id, 500).await;
-    assert!(
-        !rx.has_changed()
-            .expect("peer_change_rx closed unexpectedly"),
-        "RTT 2600→500 (both above threshold) should not trigger re-election"
-    );
-
-    // Update RTT to below threshold — SHOULD trigger
-    node.update_peer_rtt(peer_id, 15).await;
-    assert!(
-        rx.has_changed()
-            .expect("peer_change_rx closed unexpectedly"),
-        "RTT 500→15 (crossing threshold) must trigger re-election"
-    );
-
-    Ok(())
-}
-
-/// RTT re-election should NOT trigger when RTT was already below threshold.
-#[tokio::test]
-async fn test_rtt_below_threshold_no_reelection() -> Result<()> {
-    let node = make_test_node(super::super::NodeRole::Worker).await?;
-    let peer_key = SecretKey::generate();
-    let peer_id = EndpointId::from(peer_key.public());
-
-    {
-        let mut state = node.state.lock().await;
-        state
-            .peers
-            .insert(peer_id, make_test_peer(peer_id, Some(20), 16));
-    }
-
-    let rx = node.peer_change_rx.clone();
-
-    // Update RTT to another low value — should NOT trigger
     node.update_peer_rtt(peer_id, 15).await;
     assert!(
         !rx.has_changed()
             .expect("peer_change_rx closed unexpectedly"),
-        "RTT 20→15 (both below threshold) should not trigger re-election"
+        "RTT improvement must not trigger split re-election"
     );
 
     Ok(())

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/connections.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/connections.rs
@@ -99,144 +99,6 @@ fn quic_bind_addr_keeps_endpoint_default_on_non_windows() {
 }
 
 #[test]
-fn split_stage_path_allows_fast_direct_path() {
-    assert_eq!(
-        SplitStagePathSnapshot::direct(Some(MAX_SPLIT_RTT_MS)).stage_path_rejection(),
-        None
-    );
-}
-
-#[test]
-fn split_stage_path_rejects_missing_rtt() {
-    assert_eq!(
-        SplitStagePathSnapshot::direct(None).stage_path_rejection(),
-        Some(SplitStagePathRejection::MissingStagePath)
-    );
-}
-
-#[test]
-fn split_stage_path_accepts_direct_path_with_peer_rtt_fallback() {
-    assert_eq!(
-        SplitStagePathSnapshot::direct(None)
-            .with_direct_rtt_fallback(Some(MAX_SPLIT_RTT_MS))
-            .stage_path_rejection(),
-        None
-    );
-}
-
-#[test]
-fn split_stage_path_keeps_relay_rejection_with_peer_rtt_fallback() {
-    assert_eq!(
-        SplitStagePathSnapshot::relay(None)
-            .with_direct_rtt_fallback(Some(1))
-            .stage_path_rejection(),
-        Some(SplitStagePathRejection::StagePathRelayOnly)
-    );
-}
-
-#[test]
-fn split_stage_path_rejects_slow_peer_rtt_fallback() {
-    assert_eq!(
-        SplitStagePathSnapshot::direct(None)
-            .with_direct_rtt_fallback(Some(MAX_SPLIT_RTT_MS + 1))
-            .stage_path_rejection(),
-        Some(SplitStagePathRejection::StagePathTooSlow)
-    );
-}
-
-#[test]
-fn split_stage_path_rejects_relay_path() {
-    assert_eq!(
-        SplitStagePathSnapshot::relay(Some(1)).stage_path_rejection(),
-        Some(SplitStagePathRejection::StagePathRelayOnly)
-    );
-}
-
-#[test]
-fn split_stage_path_rejects_slow_direct_path() {
-    assert_eq!(
-        SplitStagePathSnapshot::direct(Some(MAX_SPLIT_RTT_MS + 1)).stage_path_rejection(),
-        Some(SplitStagePathRejection::StagePathTooSlow)
-    );
-}
-
-#[test]
-fn split_stage_path_rejects_unknown_path() {
-    assert_eq!(
-        SplitStagePathSnapshot::unknown().stage_path_rejection(),
-        Some(SplitStagePathRejection::MissingStagePath)
-    );
-}
-
-#[test]
-fn split_stage_path_uses_direct_peer_path_fallback_for_unknown_stage_path() {
-    let fallback = SelectedPathObservation {
-        path_type: "direct",
-        rtt_ms: Some(MAX_SPLIT_RTT_MS),
-        observed_direct_remote_addr: None,
-    };
-
-    assert_eq!(
-        SplitStagePathSnapshot::unknown()
-            .with_peer_path_fallback(Some(fallback))
-            .stage_path_rejection(),
-        None
-    );
-}
-
-#[test]
-fn split_stage_path_keeps_relay_peer_path_fallback_rejected() {
-    let fallback = SelectedPathObservation {
-        path_type: "relay",
-        rtt_ms: Some(1),
-        observed_direct_remote_addr: None,
-    };
-
-    assert_eq!(
-        SplitStagePathSnapshot::unknown()
-            .with_peer_path_fallback(Some(fallback))
-            .stage_path_rejection(),
-        Some(SplitStagePathRejection::StagePathRelayOnly)
-    );
-}
-
-#[test]
-fn split_stage_path_peer_fallback_does_not_convert_relay_rtt_to_direct() {
-    let mut peer = make_test_peer_info(make_test_endpoint_id(0x4a));
-    peer.rtt_ms = Some(1);
-    peer.selected_path = Some(SelectedPathObservation {
-        path_type: "relay",
-        rtt_ms: Some(1),
-        observed_direct_remote_addr: None,
-    });
-
-    assert_eq!(
-        SplitStagePathSnapshot::unknown()
-            .with_peer_path_fallback(peer.split_stage_path_fallback())
-            .stage_path_rejection(),
-        Some(SplitStagePathRejection::StagePathRelayOnly)
-    );
-}
-
-#[test]
-fn split_stage_path_peer_fallback_uses_best_direct_rtt() {
-    let mut peer = make_test_peer_info(make_test_endpoint_id(0x4b));
-    peer.rtt_ms = Some(MAX_SPLIT_RTT_MS);
-    peer.selected_path = Some(SelectedPathObservation {
-        path_type: "direct",
-        rtt_ms: None,
-        observed_direct_remote_addr: None,
-    });
-
-    assert_eq!(
-        SplitStagePathSnapshot::unknown()
-            .with_peer_path_fallback(peer.split_stage_path_fallback())
-            .stage_path_rejection(),
-        None
-    );
-}
-
-#[test]
 fn endpoint_addr_filter_for_bind_ip_keeps_selected_ip_relay_and_public_candidates() {
     let mut addr = EndpointAddr {
         id: make_test_endpoint_id(0x42),
@@ -488,10 +350,10 @@ async fn make_test_node_with_requirements(
         },
         activity_policy_guard: crate::runtime::activity_policy::ActivityPolicyGuard::new(
             &mesh_llm_config::RuntimeActivityConfig::default(),
-            ),
-            public_mesh: false,
-            drain_timeout_secs: mesh_llm_config::DEFAULT_DRAIN_TIMEOUT_SECS,
-            drain_timeout_max_secs: mesh_llm_config::DEFAULT_DRAIN_TIMEOUT_MAX_SECS,
+        ),
+        public_mesh: false,
+        drain_timeout_secs: mesh_llm_config::DEFAULT_DRAIN_TIMEOUT_SECS,
+        drain_timeout_max_secs: mesh_llm_config::DEFAULT_DRAIN_TIMEOUT_MAX_SECS,
         runtime_intents: Arc::new(std::sync::Mutex::new(Vec::new())),
         runtime_instance_lifecycles: Arc::new(std::sync::Mutex::new(HashMap::new())),
         owner_lifecycle_response_cache: OwnerLifecycleResponseCache::default(),

--- a/crates/mesh-llm-host-runtime/src/runtime/local_package.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local_package.rs
@@ -166,9 +166,6 @@ pub(super) enum SplitParticipantExclusionReason {
     MissingVram,
     MissingModelInterest,
     StageProtocolGeneration,
-    MissingStagePath,
-    StagePathRelayOnly,
-    StagePathTooSlow,
     StageControlUnreachable,
     ArtifactTransferUnavailable,
     StageInventoryEmpty,
@@ -183,9 +180,6 @@ impl SplitParticipantExclusionReason {
             Self::MissingVram => "missing_vram",
             Self::MissingModelInterest => "missing_model_interest",
             Self::StageProtocolGeneration => "stage_protocol_generation",
-            Self::MissingStagePath => "missing_stage_path",
-            Self::StagePathRelayOnly => "stage_path_relay_only",
-            Self::StagePathTooSlow => "stage_path_too_slow",
             Self::StageControlUnreachable => "stage_control_unreachable",
             Self::ArtifactTransferUnavailable => "artifact_transfer_unavailable",
             Self::StageInventoryEmpty => "stage_inventory_empty",
@@ -206,13 +200,6 @@ impl SplitParticipantExclusionReason {
             Self::StageProtocolGeneration => {
                 "Upgrade this peer so it advertises current stage protocol support."
             }
-            Self::MissingStagePath => {
-                "Wait for direct peer latency to be measured or fix direct QUIC connectivity."
-            }
-            Self::StagePathRelayOnly => {
-                "Fix firewall/NAT/direct-path connectivity; relay-only stage paths are not admitted."
-            }
-            Self::StagePathTooSlow => "Use a lower-latency peer or network path for split serving.",
             Self::StageControlUnreachable => {
                 "Check stage-control connectivity and peer runtime logs before retrying split serving."
             }
@@ -418,16 +405,13 @@ fn split_participant_blocker(
 }
 
 pub(super) const fn split_participant_exclusion_reason_order()
--> [SplitParticipantExclusionReason; 12] {
+-> [SplitParticipantExclusionReason; 9] {
     [
         SplitParticipantExclusionReason::StageControlUnreachable,
         SplitParticipantExclusionReason::PackageManifestMismatch,
         SplitParticipantExclusionReason::ArtifactTransferUnavailable,
         SplitParticipantExclusionReason::StageInventoryEmpty,
         SplitParticipantExclusionReason::MissingModelSource,
-        SplitParticipantExclusionReason::MissingStagePath,
-        SplitParticipantExclusionReason::StagePathRelayOnly,
-        SplitParticipantExclusionReason::StagePathTooSlow,
         SplitParticipantExclusionReason::StageProtocolGeneration,
         SplitParticipantExclusionReason::MissingVram,
         SplitParticipantExclusionReason::MissingModelInterest,
@@ -455,15 +439,6 @@ pub(super) async fn collect_split_participant_membership(
     let mut excluded = Vec::new();
     for peer in node.peers().await {
         if let Some(reason) = split_peer_preflight_exclusion_reason(&peer, model_name, model_ref) {
-            excluded.push(SplitParticipantExclusion {
-                node_id: peer.id,
-                reason,
-            });
-            continue;
-        }
-        if let Some(reason) =
-            split_peer_stage_path_exclusion_reason(node.split_stage_path_snapshot(peer.id).await)
-        {
             excluded.push(SplitParticipantExclusion {
                 node_id: peer.id,
                 reason,
@@ -501,15 +476,6 @@ pub(super) async fn collect_split_participants(
     let mut excluded = Vec::new();
     for peer in node.peers().await {
         if let Some(reason) = split_peer_preflight_exclusion_reason(&peer, model_name, model_ref) {
-            excluded.push(SplitParticipantExclusion {
-                node_id: peer.id,
-                reason,
-            });
-            continue;
-        }
-        if let Some(reason) =
-            split_peer_stage_path_exclusion_reason(node.split_stage_path_snapshot(peer.id).await)
-        {
             excluded.push(SplitParticipantExclusion {
                 node_id: peer.id,
                 reason,
@@ -574,22 +540,6 @@ pub(super) fn split_peer_preflight_exclusion_reason(
         return Some(SplitParticipantExclusionReason::StageProtocolGeneration);
     }
     None
-}
-
-pub(super) fn split_peer_stage_path_exclusion_reason(
-    snapshot: mesh::SplitStagePathSnapshot,
-) -> Option<SplitParticipantExclusionReason> {
-    match snapshot.stage_path_rejection()? {
-        mesh::SplitStagePathRejection::MissingStagePath => {
-            Some(SplitParticipantExclusionReason::MissingStagePath)
-        }
-        mesh::SplitStagePathRejection::StagePathRelayOnly => {
-            Some(SplitParticipantExclusionReason::StagePathRelayOnly)
-        }
-        mesh::SplitStagePathRejection::StagePathTooSlow => {
-            Some(SplitParticipantExclusionReason::StagePathTooSlow)
-        }
-    }
 }
 
 pub(super) fn split_peer_stage_host_exclusion_reason(

--- a/crates/mesh-llm-host-runtime/src/runtime/local_split/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local_split/tests.rs
@@ -307,7 +307,6 @@ fn split_participant_timeout_error_reports_blocker_summary() {
 #[test]
 fn split_peer_preflight_requires_current_stage_protocol_generation() {
     let mut peer = split_test_peer(0x61, "Qwen3-Coder", false);
-    peer.rtt_ms = Some(crate::mesh::MAX_SPLIT_RTT_MS);
 
     assert_eq!(
         split_peer_preflight_exclusion_reason(&peer, "Qwen3-Coder", "meshllm/Qwen3-Coder-layers"),
@@ -322,55 +321,9 @@ fn split_peer_preflight_requires_current_stage_protocol_generation() {
 }
 
 #[test]
-fn split_peer_preflight_requires_measured_stage_path() {
-    assert_eq!(
-        split_peer_stage_path_exclusion_reason(mesh::SplitStagePathSnapshot::unknown()),
-        Some(SplitParticipantExclusionReason::MissingStagePath)
-    );
-}
-
-#[test]
-fn split_peer_preflight_rejects_slow_stage_path() {
-    assert_eq!(
-        split_peer_stage_path_exclusion_reason(mesh::SplitStagePathSnapshot::direct(Some(
-            crate::mesh::MAX_SPLIT_RTT_MS + 1,
-        ))),
-        Some(SplitParticipantExclusionReason::StagePathTooSlow)
-    );
-}
-
-#[test]
-fn split_peer_preflight_rejects_relay_only_stage_path() {
-    assert_eq!(
-        split_peer_stage_path_exclusion_reason(mesh::SplitStagePathSnapshot::relay(Some(
-            crate::mesh::MAX_SPLIT_RTT_MS,
-        ))),
-        Some(SplitParticipantExclusionReason::StagePathRelayOnly)
-    );
-}
-
-#[test]
-fn split_peer_preflight_rejects_direct_stage_path_without_rtt() {
-    assert_eq!(
-        split_peer_stage_path_exclusion_reason(mesh::SplitStagePathSnapshot::direct(None)),
-        Some(SplitParticipantExclusionReason::MissingStagePath)
-    );
-}
-
-#[test]
-fn split_peer_preflight_allows_fast_stage_path() {
-    assert_eq!(
-        split_peer_stage_path_exclusion_reason(mesh::SplitStagePathSnapshot::direct(Some(
-            crate::mesh::MAX_SPLIT_RTT_MS,
-        ))),
-        None
-    );
-}
-
-#[test]
 fn split_peer_preflight_keeps_host_eligibility_separate_from_stage_path() {
     let mut peer = split_test_peer(0x66, "Qwen3-Coder", true);
-    peer.rtt_ms = Some(crate::mesh::MAX_SPLIT_RTT_MS + 1);
+    peer.rtt_ms = Some(u32::MAX);
 
     assert_eq!(
         split_peer_preflight_exclusion_reason(&peer, "Qwen3-Coder", "meshllm/Qwen3-Coder-layers"),

--- a/crates/mesh-llm-types/src/mesh/mod.rs
+++ b/crates/mesh-llm-types/src/mesh/mod.rs
@@ -10,23 +10,6 @@ pub struct ModelDemand {
 
 pub const DEMAND_TTL_SECS: u64 = 86400;
 
-pub const MAX_SPLIT_RTT_MS: u32 = 80;
-
-/// Split admission RTT ceiling in milliseconds. Defaults to
-/// [`MAX_SPLIT_RTT_MS`]; the `MESH_SPLIT_MAX_RTT_MS` environment variable
-/// overrides it for long-haul WAN experiments where the fixed ceiling would
-/// reject every peer.
-pub fn max_split_rtt_ms() -> u32 {
-    static VALUE: std::sync::OnceLock<u32> = std::sync::OnceLock::new();
-    *VALUE.get_or_init(|| {
-        std::env::var("MESH_SPLIT_MAX_RTT_MS")
-            .ok()
-            .and_then(|raw| raw.trim().parse().ok())
-            .filter(|ms| *ms > 0)
-            .unwrap_or(MAX_SPLIT_RTT_MS)
-    })
-}
-
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum ModelSourceKind {
@@ -432,16 +415,4 @@ fn identity_hash_for(input: &str) -> String {
     let mut hasher = Sha256::new();
     hasher.update(input.as_bytes());
     hex::encode(hasher.finalize())
-}
-
-/// Whether relay-only stage paths may participate in splits. Off by default;
-/// `MESH_SPLIT_ALLOW_RELAY=1` enables it for WAN experiments where NAT
-/// prevents direct QUIC paths between stage peers.
-pub fn split_allow_relay_paths() -> bool {
-    static VALUE: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *VALUE.get_or_init(|| {
-        std::env::var("MESH_SPLIT_ALLOW_RELAY")
-            .map(|raw| raw.trim() == "1")
-            .unwrap_or(false)
-    })
 }

--- a/docs/SKIPPY_SPLITS.md
+++ b/docs/SKIPPY_SPLITS.md
@@ -112,11 +112,11 @@ mesh-llm serve \
   --join <token>
 ```
 
-Use directly reachable, low-latency UDP paths. If a cloud provider remaps the
+Prefer directly reachable, low-latency UDP paths. If a cloud provider remaps the
 container UDP port to a different public port, confirm that the invite advertises
-the reachable public endpoint and that runtime diagnostics report a direct path
-before paying the model-load cost. A relay-only peer is deliberately excluded
-from the Inkling split plan.
+the reachable public endpoint. Iroh owns path selection and may use or upgrade
+between relay and direct paths; split admission does not second-guess that choice
+with path-kind or RTT gates.
 
 Current Inkling policy uses an F32 activation wire and Q4_0 K/V cache. F16 and
 Q8 activation wires are not interchangeable shortcuts: both failed the current


### PR DESCRIPTION
## Summary

- remove relay-only and maximum-RTT split admission gates
- stop rejecting stage streams or re-electing split topology based on path/RTT observations
- leave selected-path and RTT data as diagnostics/planning metadata while Iroh owns path selection and upgrades

## Validation

- `cargo test -p mesh-llm-host-runtime --lib` (2456 passed, 8 ignored)
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm-types --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- release product build (`just release-build`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Split readiness now considers otherwise eligible peers even when their network path is unknown, relay-only, or has high latency.
  * Transport connections remain usable without instantaneous path-quality validation.

* **Bug Fixes**
  * Prevented RTT improvements from unnecessarily triggering peer re-election or change notifications.

* **Documentation**
  * Updated split networking guidance to reflect automatic direct and relay path selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->