### PR TITLE
Return a visible error when streaming prompts exceed context

### DIFF
--- a/crates/openai-frontend/src/router_tests.rs
+++ b/crates/openai-frontend/src/router_tests.rs
@@ -241,6 +241,11 @@ impl OpenAiBackend for FakeBackend {
         if request.model == "missing" {
             return Err(OpenAiError::model_not_found(request.model));
         }
+        if request.model == "context-overflow" {
+            return Err(OpenAiError::context_length_exceeded(
+                "prompt tokens plus requested completion exceed context window",
+            ));
+        }
         if request.model == "stream-error" {
             return Ok(Box::pin(stream::iter(vec![Err(OpenAiError::backend(
                 "stream backend failed",
@@ -963,6 +968,23 @@ async fn chat_completion_stream_suppresses_usage_unless_requested() {
     assert!(!body.contains(r#""total_tokens":5"#));
     assert!(body.contains("data: [DONE]"));
     assert_stream_terminal_usage(&observer, 3, 2, 5);
+}
+
+#[tokio::test]
+async fn chat_completion_stream_maps_pre_stream_context_overflow() {
+    let response = post_json(
+        "/v1/chat/completions",
+        json!({
+            "model": "context-overflow",
+            "messages": [{"role": "user", "content": "hi"}],
+            "max_completion_tokens": 768,
+            "stream": true
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let body = response_body_json(response).await;
+    assert_eq!(body["error"]["code"], "context_length_exceeded");
 }
 
 #[tokio::test]

--- a/crates/skippy-server/src/frontend/backend.rs
+++ b/crates/skippy-server/src/frontend/backend.rs
@@ -745,6 +745,7 @@ impl StageOpenAiBackend {
             let output = backend.generate_text(
                 prompt,
                 max_tokens,
+                None,
                 stop.as_ref(),
                 sampling,
                 hook_request,
@@ -782,6 +783,22 @@ impl StageOpenAiBackend {
         context: OpenAiRequestContext,
         ids: OpenAiGenerationIds,
     ) -> OpenAiResult<GenerationStream> {
+        let prepared_text = if prompt.has_media() {
+            None
+        } else {
+            let backend = self.clone();
+            let prompt_for_tokenize = prompt.clone();
+            let ids_for_tokenize = ids.clone();
+            Some(
+                task::spawn_blocking(move || {
+                    backend.prepare_text_prompt(&prompt_for_tokenize, max_tokens, &ids_for_tokenize)
+                })
+                .await
+                .map_err(|error| {
+                    OpenAiError::backend(format!("prompt tokenization task failed: {error}"))
+                })??,
+            )
+        };
         let admit_timer = PhaseTimer::start();
         let cancellation = context.cancellation_token();
         let (permit, session_permit) = self
@@ -815,6 +832,7 @@ impl StageOpenAiBackend {
             let result = backend.generate_text(
                 prompt,
                 max_tokens,
+                prepared_text,
                 stop.as_ref(),
                 sampling,
                 hook_request,

--- a/crates/skippy-server/src/frontend/generation/types.rs
+++ b/crates/skippy-server/src/frontend/generation/types.rs
@@ -133,6 +133,11 @@ pub(in crate::frontend) struct GenerationMetrics {
     pub(in crate::frontend) eog_check_ms: f64,
 }
 
+pub(in crate::frontend) struct PreparedTextPrompt {
+    pub(in crate::frontend) token_ids: Vec<i32>,
+    pub(in crate::frontend) max_tokens: u32,
+}
+
 pub(in crate::frontend) struct LocalGeneration<'a> {
     pub(in crate::frontend) prompt_token_ids: &'a [i32],
     pub(in crate::frontend) max_tokens: u32,

--- a/crates/skippy-server/src/frontend/generation_flow/text_generation.rs
+++ b/crates/skippy-server/src/frontend/generation_flow/text_generation.rs
@@ -2,7 +2,7 @@ use crate::frontend::admission::GenerationTokenBudgetRequest;
 use crate::frontend::generation::{
     EmbeddedStageZeroGeneration, GENERATION_ADMISSION_TIMEOUT, GeneratedText, GenerationTokenLimit,
     LocalGeneration, OpenAiBackendMode, OpenAiGenerationIds, PhaseTimer, PreparedGenerationPrompt,
-    StageOpenAiBackend, TextGenerationCollector, emulation_generation_active,
+    PreparedTextPrompt, StageOpenAiBackend, TextGenerationCollector, emulation_generation_active,
 };
 use crate::frontend::util::{generation_stop_values, openai_backend_error};
 use openai_frontend::{ChatCompletionRequest, OpenAiError, OpenAiResult};
@@ -10,11 +10,40 @@ use serde_json::json;
 use skippy_runtime::SamplingConfig;
 
 impl StageOpenAiBackend {
+    pub(in crate::frontend) fn prepare_text_prompt(
+        &self,
+        prompt: &PreparedGenerationPrompt,
+        max_tokens: GenerationTokenLimit,
+        ids: &OpenAiGenerationIds,
+    ) -> OpenAiResult<PreparedTextPrompt> {
+        let tokenize_timer = PhaseTimer::start();
+        let token_ids = self.tokenize(&prompt.text)?;
+        let mut tokenize_attrs = self.openai_attrs(ids);
+        tokenize_attrs.insert(
+            "llama_stage.prompt_chars".to_string(),
+            json!(prompt.text.len()),
+        );
+        tokenize_attrs.insert(
+            "llama_stage.prompt_token_count".to_string(),
+            json!(token_ids.len()),
+        );
+        self.emit_openai_phase("stage.openai_tokenize", tokenize_timer, tokenize_attrs);
+        if token_ids.is_empty() {
+            return Err(OpenAiError::invalid_request("prompt produced no tokens"));
+        }
+        let max_tokens = max_tokens.resolve(token_ids.len(), self.ctx_size)?;
+        Ok(PreparedTextPrompt {
+            token_ids,
+            max_tokens,
+        })
+    }
+
     #[allow(clippy::too_many_arguments)]
     pub(in crate::frontend) fn generate_text(
         &self,
         prompt: PreparedGenerationPrompt,
         max_tokens: GenerationTokenLimit,
+        prepared_text: Option<PreparedTextPrompt>,
         stop: Option<&openai_frontend::StopSequence>,
         sampling: SamplingConfig,
         hook_request: Option<ChatCompletionRequest>,
@@ -51,25 +80,16 @@ impl StageOpenAiBackend {
             .iter()
             .map(String::as_str)
             .collect::<Vec<_>>();
-        let tokenize_timer = PhaseTimer::start();
-        let prompt_token_ids = self.tokenize(&prompt.text)?;
+        let PreparedTextPrompt {
+            token_ids: prompt_token_ids,
+            max_tokens,
+        } = match prepared_text {
+            Some(prepared) => prepared,
+            None => self.prepare_text_prompt(&prompt, max_tokens, &ids)?,
+        };
         if cancellation.is_some_and(openai_frontend::CancellationToken::is_cancelled) {
             return Err(OpenAiError::backend("request cancelled"));
         }
-        let mut tokenize_attrs = self.openai_attrs(&ids);
-        tokenize_attrs.insert(
-            "llama_stage.prompt_chars".to_string(),
-            json!(prompt.text.len()),
-        );
-        tokenize_attrs.insert(
-            "llama_stage.prompt_token_count".to_string(),
-            json!(prompt_token_ids.len()),
-        );
-        self.emit_openai_phase("stage.openai_tokenize", tokenize_timer, tokenize_attrs);
-        if prompt_token_ids.is_empty() {
-            return Err(OpenAiError::invalid_request("prompt produced no tokens"));
-        }
-        let max_tokens = max_tokens.resolve(prompt_token_ids.len(), self.ctx_size)?;
         let token_admit_timer = PhaseTimer::start();
         let token_budget_reservation = self.generation_token_budget.reserve_cancellable(
             GenerationTokenBudgetRequest::new(prompt_token_ids.len(), max_tokens),


### PR DESCRIPTION
Streaming requests whose tokenized prompt plus explicit completion limit exceeds the model context now fail visibly with `400 context_length_exceeded`, instead of committing `200 text/event-stream` and producing an empty/failed turn.

The Skippy backend now tokenizes and resolves the context budget before returning a stream to `openai-frontend`. Valid requests reuse those prepared tokens in the generation worker, so the prompt is not tokenized twice. Multimodal requests retain their existing prefill-time validation path because media embeddings determine their effective position.

part of #1350.

## Validation

- `cargo test -p openai-frontend --lib` — 174 passed
- `cargo test -p skippy-server --lib` — 445 passed
- `cargo check -p skippy-server`
- `cargo clippy -p openai-frontend --all-targets -- -D warnings`
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `cargo fmt --all --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of prompts that exceed the model’s context limit.
  * Context-length errors are now returned as clear OpenAI-compatible `400` errors before streaming begins.
  * Improved error handling for prompt preparation and generation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->