### PR TITLE
Treat max_tokens as a ceiling, not a context reservation

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/routing_rank.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/routing_rank.rs
@@ -4,6 +4,11 @@ use crate::network::router;
 
 pub(super) const REQUEST_TOKEN_MARGIN: u32 = 256;
 
+/// Decode headroom Skippy admission reserves, as a `u32` for token arithmetic.
+fn decode_headroom_tokens() -> u32 {
+    saturating_u32(skippy_server::DECODE_BATCH_HEADROOM_TOKENS)
+}
+
 fn saturating_u32(value: usize) -> u32 {
     value.try_into().unwrap_or(u32::MAX)
 }
@@ -27,6 +32,14 @@ fn request_budget_tokens(body: &serde_json::Value) -> Option<u32> {
     request_budget_tokens_from_parts(serialized.len(), completion_tokens)
 }
 
+/// Context a request needs from a target, in tokens.
+///
+/// The completion term is deliberately *not* the client's `max_tokens`. That
+/// value is an upper bound, and clients commonly send an enormous one to mean
+/// "no limit" (Buzz Agent Desktop defaults to 65,536). Skippy admission only
+/// ever reserves `min(max_tokens, DECODE_BATCH_HEADROOM_TOKENS)`, so counting
+/// the full ceiling here made routing refuse requests the server would have
+/// served — issue #1350. Both layers now apply the same bound.
 pub(crate) fn request_budget_tokens_from_parts(
     body_len_bytes: usize,
     completion_tokens: Option<u32>,
@@ -35,7 +48,7 @@ pub(crate) fn request_budget_tokens_from_parts(
         return None;
     }
     let prompt_tokens = ceil_div_u32(saturating_u32(body_len_bytes), 4);
-    let completion_tokens = completion_tokens.unwrap_or(0);
+    let completion_tokens = completion_tokens.unwrap_or(0).min(decode_headroom_tokens());
     let requested_tokens = prompt_tokens.saturating_add(completion_tokens);
     Some(
         prompt_tokens
@@ -406,6 +419,76 @@ mod tests {
 
         assert_eq!(budget, 2_500 + 512 + REQUEST_TOKEN_MARGIN);
     }
+    #[test]
+    fn test_request_budget_tokens_bounds_generous_client_ceiling() {
+        // Regression for #1350: Buzz Agent Desktop defaults max_completion_tokens
+        // to 65,536, which meant a ~35.6 KB request "needed" 74,703 tokens and was
+        // refused by every 65,536-context target, even though Skippy admission
+        // would only have reserved prompt + 512.
+        let prompt_tokens = ceil_div_u32(35_644, 4);
+        let budget = request_budget_tokens_from_parts(35_644, Some(65_536)).unwrap();
+
+        assert_eq!(
+            budget,
+            prompt_tokens + 512 + request_token_margin(prompt_tokens + 512)
+        );
+        assert!(
+            budget <= 65_536,
+            "generous client ceiling should still fit a 65,536-token target: {budget}"
+        );
+    }
+
+    #[test]
+    fn test_request_budget_tokens_matches_skippy_decode_headroom() {
+        // Routing and Skippy admission must apply the same completion bound or
+        // routing can refuse requests the backend would serve (#1350).
+        let huge = request_budget_tokens_from_parts(4_096, Some(u32::MAX)).unwrap();
+        let headroom = request_budget_tokens_from_parts(
+            4_096,
+            Some(skippy_server::DECODE_BATCH_HEADROOM_TOKENS as u32),
+        )
+        .unwrap();
+
+        assert_eq!(huge, headroom);
+    }
+
+    #[test]
+    fn test_request_budget_tokens_still_counts_full_prompt() {
+        // Only the completion term is bounded. An oversized prompt must still be
+        // excluded from an undersized target.
+        let budget = request_budget_tokens_from_parts(400_000, None).unwrap();
+
+        assert!(budget > 65_536, "oversized prompt must not be bounded away");
+    }
+
+    #[test]
+    fn test_request_budget_tokens_bounds_all_completion_limit_aliases() {
+        let expected = request_budget_tokens_from_parts(1_024, Some(512)).unwrap();
+        for key in [
+            "max_completion_tokens",
+            "max_tokens",
+            "max_output_tokens",
+            "n_predict",
+        ] {
+            let body = serde_json::json!({ key: 65_536u64 });
+            let padded_len = 1_024;
+            let completion = body.get(key).and_then(|v| v.as_u64()).map(|v| v as u32);
+            assert_eq!(
+                request_budget_tokens_from_parts(padded_len, completion).unwrap(),
+                expected,
+                "{key} should be bounded like every other completion alias"
+            );
+        }
+    }
+
+    #[test]
+    fn test_request_budget_tokens_absent_completion_limit_reserves_nothing() {
+        let prompt_tokens = ceil_div_u32(1_024, 4);
+        let budget = request_budget_tokens_from_parts(1_024, None).unwrap();
+
+        assert_eq!(budget, prompt_tokens + request_token_margin(prompt_tokens));
+    }
+
     #[test]
     fn test_reorder_candidates_by_context_prefers_known_fit_then_unknown() {
         let ordered = reorder_candidates_by_context_and_throughput(

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -29,6 +29,7 @@ use self::{
     decode_scheduler::*, native_mtp::*, request::*, speculative::*, util::*, wire_messages::*,
 };
 
+pub use self::admission::DECODE_BATCH_HEADROOM_TOKENS;
 use self::generation::*;
 pub use self::generation::{
     CONTEXT_BUDGET_MAX_TOKENS, DEFAULT_EMBEDDED_MAX_TOKENS, EmbeddedOpenAiArgs,

--- a/crates/skippy-server/src/frontend/admission.rs
+++ b/crates/skippy-server/src/frontend/admission.rs
@@ -9,7 +9,17 @@ use std::sync::Mutex;
 use std::time::Duration;
 use std::time::Instant;
 
-const DECODE_BATCH_HEADROOM_TOKENS: usize = 512;
+/// Decode headroom this server actually reserves per in-flight request.
+///
+/// A client's `max_tokens` is a *ceiling*, not a reservation: most replies are
+/// far shorter, so reserving each request's full ceiling would let a couple of
+/// clients with generous defaults exhaust the KV budget. Admission therefore
+/// reserves `min(max_tokens, DECODE_BATCH_HEADROOM_TOKENS)`.
+///
+/// Exported because host-runtime routing must use the same rule when it decides
+/// whether a target's context can fit a request. Two different rules here mean
+/// routing can refuse a request the server would have served (see issue #1350).
+pub const DECODE_BATCH_HEADROOM_TOKENS: usize = 512;
 
 #[derive(Debug)]
 pub(super) struct GenerationTokenBudget {

--- a/crates/skippy-server/src/frontend/generation/queue.rs
+++ b/crates/skippy-server/src/frontend/generation/queue.rs
@@ -2,7 +2,6 @@ use crate::frontend::generation::CONTEXT_BUDGET_MAX_TOKENS;
 use crate::frontend::generation::GENERATION_RETRY_AFTER_SECS;
 use crate::frontend::generation::PhaseTimer;
 use crate::frontend::util::context_budget_completion_tokens;
-use crate::frontend::util::ensure_context_capacity;
 use crate::runtime_state::RuntimeState;
 use crate::telemetry::Telemetry;
 use crate::telemetry::lifecycle_attrs;
@@ -162,8 +161,19 @@ impl GenerationTokenLimit {
     ) -> OpenAiResult<u32> {
         match self {
             Self::Explicit(max_tokens) => {
-                ensure_context_capacity(prompt_token_count, max_tokens, ctx_size)?;
-                Ok(max_tokens)
+                // Client-asserted ceiling. `max_tokens` is an upper bound on
+                // the reply, not a reservation the server must be able to
+                // honour in full: OpenAI-compatible clients routinely send a
+                // very large value to mean "no limit" (Buzz Agent Desktop
+                // defaults to 65,536). Clamp to the remaining context and let
+                // generation stop with `finish_reason: "length"`. A prompt that
+                // overflows the window on its own is still a real error.
+                //
+                // Rejecting a ceiling that wouldn't fit made routing and the
+                // backend disagree about a request the server could serve
+                // comfortably — issue #1350.
+                let remaining = context_budget_completion_tokens(prompt_token_count, ctx_size)?;
+                Ok(remaining.min(max_tokens))
             }
             Self::Default(default_max_tokens) => {
                 // Server-picked default. Always clamp to the remaining

--- a/crates/skippy-server/src/frontend/tests/generation.rs
+++ b/crates/skippy-server/src/frontend/tests/generation.rs
@@ -376,10 +376,10 @@ fn model_matching_normalizes_default_revision() {
 }
 
 #[test]
-fn rejects_requests_that_exceed_context_window() {
-    ensure_context_capacity(4, 4, 8).unwrap();
+fn rejects_requests_whose_prompt_alone_exceeds_context_window() {
+    assert_eq!(context_budget_completion_tokens(4, 8).unwrap(), 4);
 
-    let error = ensure_context_capacity(5, 4, 8).unwrap_err();
+    let error = context_budget_completion_tokens(9, 8).unwrap_err();
     assert_eq!(
         error.body().error.code.as_deref(),
         Some("context_length_exceeded")
@@ -432,13 +432,19 @@ fn omitted_max_tokens_errors_only_when_prompt_already_exceeds_ctx() {
 }
 
 #[test]
-fn explicit_max_tokens_still_errors_when_too_large_for_ctx() {
-    // Client-asserted max_tokens that won't fit is still a hard error.
-    // The clamping behavior applies only to the server-picked default.
+fn explicit_max_tokens_clamps_to_remaining_context() {
+    // `max_tokens` is a ceiling, not a reservation. A client asking for more
+    // than fits gets the remaining context and stops at `length`, matching the
+    // server-picked default path. Only a prompt that overflows on its own is
+    // an error. See issue #1350.
     let limit = GenerationTokenLimit::from_request(Some(4), 999);
     assert_eq!(limit.resolve(4, 8).unwrap(), 4);
+    assert_eq!(limit.resolve(5, 8).unwrap(), 3);
 
-    let error = limit.resolve(5, 8).unwrap_err();
+    let limit = GenerationTokenLimit::from_request(Some(65_536), 999);
+    assert_eq!(limit.resolve(8_911, 65_536).unwrap(), 65_536 - 8_911);
+
+    let error = limit.resolve(65_537, 65_536).unwrap_err();
     assert_eq!(
         error.body().error.code.as_deref(),
         Some("context_length_exceeded")

--- a/crates/skippy-server/src/frontend/util.rs
+++ b/crates/skippy-server/src/frontend/util.rs
@@ -161,20 +161,6 @@ pub(super) fn finish_reason_for_generation(exhausted_max_tokens: bool) -> Finish
     }
 }
 
-pub(super) fn ensure_context_capacity(
-    prompt_token_count: usize,
-    max_tokens: u32,
-    ctx_size: usize,
-) -> OpenAiResult<()> {
-    let requested_tokens = prompt_token_count.saturating_add(max_tokens as usize);
-    if requested_tokens > ctx_size {
-        return Err(OpenAiError::context_length_exceeded(format!(
-            "requested prompt plus completion tokens ({requested_tokens}) exceed context window ({ctx_size})"
-        )));
-    }
-    Ok(())
-}
-
 pub(super) fn context_budget_completion_tokens(
     prompt_token_count: usize,
     ctx_size: usize,

--- a/crates/skippy-server/src/lib.rs
+++ b/crates/skippy-server/src/lib.rs
@@ -29,14 +29,15 @@ pub use embedded::{
     start_openai_backend_with_tokenizer_and_lifecycle_observer, start_stage_http,
 };
 pub use frontend::{
-    CONTEXT_BUDGET_MAX_TOKENS, DEFAULT_EMBEDDED_MAX_TOKENS, EmbeddedOpenAiArgs,
-    EmbeddedOpenAiBackend, EmbeddedOpenAiRequestDefaults, EmbeddedReasoningBudget,
-    EmbeddedReasoningEnabled, EmbeddedReasoningFormat, LinearProposal, LinearProposalDiscardReason,
-    LinearProposalDisposition, LinearProposalIngress, LinearProposalQuery, LinearProposalReceipt,
-    LinearProposalSourceOutcome, LinearProposalSourceResponse, LinearProposalSourceTelemetry,
-    NativeMtpProposalConfig, NgramExtensionConfig, NgramProposalConfig, NgramProposerKind,
-    OpaqueProposalDecisionId, OpenAiGuardrailsConfig, OpenAiGuardrailsStatus,
-    OpenAiGuardrailsTarget, SpeculativeDecodeConfig, VerifyWindowConfig, embedded_openai_backend,
+    CONTEXT_BUDGET_MAX_TOKENS, DECODE_BATCH_HEADROOM_TOKENS, DEFAULT_EMBEDDED_MAX_TOKENS,
+    EmbeddedOpenAiArgs, EmbeddedOpenAiBackend, EmbeddedOpenAiRequestDefaults,
+    EmbeddedReasoningBudget, EmbeddedReasoningEnabled, EmbeddedReasoningFormat, LinearProposal,
+    LinearProposalDiscardReason, LinearProposalDisposition, LinearProposalIngress,
+    LinearProposalQuery, LinearProposalReceipt, LinearProposalSourceOutcome,
+    LinearProposalSourceResponse, LinearProposalSourceTelemetry, NativeMtpProposalConfig,
+    NgramExtensionConfig, NgramProposalConfig, NgramProposerKind, OpaqueProposalDecisionId,
+    OpenAiGuardrailsConfig, OpenAiGuardrailsStatus, OpenAiGuardrailsTarget,
+    SpeculativeDecodeConfig, VerifyWindowConfig, embedded_openai_backend,
 };
 pub use kv_integration::{KvDiskCacheBudget, KvDiskCacheConfig, configure_kv_disk_cache};
 pub use skippy_protocol::StageConfig;


### PR DESCRIPTION
A request that Skippy would serve comfortably was returning `503` before it reached any backend, because routing and the runtime disagreed by 128x about how much context a completion limit needs.

`max_completion_tokens` is a *ceiling*, but two places treated it as a *reservation*. Buzz Agent Desktop 0.5.14 defaults it to 65,536 when `BUZZ_AGENT_MAX_OUTPUT_TOKENS` is unset — a client saying "no limit", not a request for 65,536 tokens. A ~9k-token prompt therefore "needed" 74,703 tokens, every 65,536-context target was filtered out, and the caller got a 503.

Skippy admission never reserves that: `min(max_tokens, DECODE_BATCH_HEADROOM_TOKENS)` = 512.

## Changes

**`routing_rank.rs` — bound the completion term.** `request_budget_tokens_from_parts` now applies the same bound admission does. The prompt term is untouched, so a genuinely oversized prompt is still excluded from an undersized target — #753's goal is preserved.

**`generation/queue.rs` — `Explicit` clamps instead of rejecting.** Without this the routing fix alone only moves the failure from a 503 to a 400: the request escapes routing and then trips `prompt + 65,536 > ctx_size` at the backend. `Explicit` now clamps to remaining context like the adjacent `Default` arm already did, and generation stops with `finish_reason: "length"`. A prompt that overflows the window on its own is still an error.

**One shared constant.** `DECODE_BATCH_HEADROOM_TOKENS` is exported from `skippy-server` and consumed by host-runtime, so the two layers cannot drift into two hand-maintained numbers. A test asserts the routing estimate for an unbounded ceiling equals the estimate computed from the exported headroom.

`ensure_context_capacity` had no remaining callers after this and is removed; `context_budget_completion_tokens` covers both arms.

## Behaviour change, called out explicitly

This reverses a deliberate, test-locked decision. `explicit_max_tokens_still_errors_when_too_large_for_ctx` carried the comment *"Client-asserted max_tokens that won't fit is still a hard error. The clamping behavior applies only to the server-picked default."* That test is inverted here.

The argument for inverting it: `max_tokens` is an upper bound in the OpenAI API, clients send large values to mean "unlimited", and refusing them costs a servable request. The argument against: a client that genuinely wants 65,536 tokens now silently gets fewer. I think the former dominates in practice, but it is a product call and a reviewer should push back if they disagree — the routing half of this PR stands on its own if the `queue.rs` half is rejected.

## Regression provenance

The 503 is a regression from `c0f8990b` ("Reject known-too-small context targets", #753, 2026-05-30), which changed the no-adequate-target case from "fall back to the full candidate list and try anyway" to `return Vec::new()`. The over-reservation arithmetic predates it — it dates to `5454baac`, the Skippy landing — but was harmless while it only affected *ranking*. #753 made it a filter, and the overcount became load-bearing.

Related: `b4c36ef3` (#581) hit the same class of complaint on the Skippy side and fixed it by splitting `Default` off from `Explicit` and clamping only `Default`. This PR extends that reasoning to `Explicit`.

## Validation

- `cargo test -p skippy-server --lib` — 445 passed
- `cargo test -p mesh-llm-host-runtime --lib` — 2493 passed, 8 ignored
- `cargo clippy -p skippy-server -p mesh-llm-host-runtime --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `cargo check --workspace --all-targets` — clean

Both new assertions were verified to **fail** against the pre-fix bodies, reconstructed in place rather than by stash: routing 3 of 8 budget tests fail; `explicit_max_tokens_clamps_to_remaining_context` fails with `context_length_exceeded`.

Not exercised: no live serve. The end-to-end claim (503 becomes a served 200 finishing at `length`) is inferred from the two unit-tested expressions, not observed.

Closes #1350.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved token budgeting for completion requests.
  * Large requested completion limits are now safely capped to available context capacity.
  * Prompts that exceed the context window continue to return clear errors.
  * Requests without explicit completion limits now receive consistent budgeting.

* **Tests**
  * Added coverage for oversized limits, alternate limit fields, prompt preservation, headroom handling, and missing limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->