### PR TITLE
Stop aborting healthy long prefills at five minutes

### DIFF
--- a/crates/openai-frontend/README.md
+++ b/crates/openai-frontend/README.md
@@ -49,7 +49,7 @@ For the concrete benchy command and contract, see
 | OpenAI-style HTTP fallbacks | Supported | Unknown routes, unsupported methods, invalid JSON, and oversized JSON return the shared error envelope. |
 | Request body limit | Supported | Configurable via `OpenAiFrontendConfig`; defaults to 4 MiB. |
 | Request IDs | Supported | Reuses only a valid UUID `x-request-id`; missing or invalid values are replaced with a generated UUID. Every response returns the canonical hyphenated UUID and the frontend emits a tracing event with method, URI, status, and request ID. |
-| Backend timeout | Supported | Configurable via `OpenAiFrontendConfig`; defaults to 300 seconds and maps timeouts to OpenAI-shaped 504 errors. |
+| Backend timeout | Supported | Configurable via `OpenAiFrontendConfig` or the `MESH_OPENAI_BACKEND_TIMEOUT_SECS` environment variable; defaults to 600 seconds (`0` disables it) and maps timeouts to OpenAI-shaped 504 errors. |
 | Agent session header | Supported | Set `MESH_AGENT_SESSION_HEADER` to accept a trusted upstream header as the stable agent-session identity. |
 | embeddings/rerank/infill/audio/vision | Out of scope | Not needed for staged text benchmark entrypoints. |
 

--- a/crates/openai-frontend/src/router.rs
+++ b/crates/openai-frontend/src/router.rs
@@ -48,6 +48,45 @@ use crate::{
 };
 
 const AGENT_SESSION_HEADER_ENV: &str = "MESH_AGENT_SESSION_HEADER";
+const BACKEND_TIMEOUT_SECS_ENV: &str = "MESH_OPENAI_BACKEND_TIMEOUT_SECS";
+
+/// Backend timeout override, in whole seconds. `0` disables the timeout.
+///
+/// Returning `None` means "no override configured", which leaves
+/// [`OpenAiFrontendConfig::DEFAULT_BACKEND_TIMEOUT`] in place. Returning
+/// `Some(None)` means the operator explicitly disabled the timeout.
+fn configured_backend_timeout() -> Option<Option<Duration>> {
+    let value = match std::env::var(BACKEND_TIMEOUT_SECS_ENV) {
+        Ok(value) => value,
+        Err(std::env::VarError::NotPresent) => return None,
+        Err(std::env::VarError::NotUnicode(_)) => {
+            tracing::warn!(
+                env = BACKEND_TIMEOUT_SECS_ENV,
+                "ignoring non-UTF-8 backend timeout configuration"
+            );
+            return None;
+        }
+    };
+    match parse_backend_timeout_secs(&value) {
+        Some(timeout) => Some(timeout),
+        None => {
+            tracing::warn!(
+                env = BACKEND_TIMEOUT_SECS_ENV,
+                value = %value,
+                "ignoring invalid backend timeout configuration; expected whole seconds"
+            );
+            None
+        }
+    }
+}
+
+fn parse_backend_timeout_secs(value: &str) -> Option<Option<Duration>> {
+    match value.trim().parse::<u64>() {
+        Ok(0) => Some(None),
+        Ok(secs) => Some(Some(Duration::from_secs(secs))),
+        Err(_) => None,
+    }
+}
 
 fn parse_agent_session_header(value: &str) -> Option<HeaderName> {
     HeaderName::from_bytes(value.as_bytes()).ok()
@@ -139,7 +178,14 @@ impl std::fmt::Debug for OpenAiFrontendConfig {
 
 impl OpenAiFrontendConfig {
     pub const DEFAULT_MAX_REQUEST_BODY_BYTES: usize = 4 * 1024 * 1024;
-    pub const DEFAULT_BACKEND_TIMEOUT: Duration = Duration::from_secs(300);
+    /// Safety net for a wedged backend, not a latency budget.
+    ///
+    /// A cold prefill of a large prompt on a single local machine is measured
+    /// in minutes: a 60k-token prompt takes ~250s on an M5 Max. A tighter
+    /// budget here makes the frontend give up while the runtime is still
+    /// legitimately working. This matches the proxy's own local first-byte
+    /// safety net so neither layer aborts a healthy long prefill.
+    pub const DEFAULT_BACKEND_TIMEOUT: Duration = Duration::from_secs(600);
 
     pub fn with_max_request_body_bytes(mut self, max_request_body_bytes: usize) -> Self {
         self.max_request_body_bytes = max_request_body_bytes;
@@ -172,7 +218,8 @@ impl Default for OpenAiFrontendConfig {
     fn default() -> Self {
         Self {
             max_request_body_bytes: Self::DEFAULT_MAX_REQUEST_BODY_BYTES,
-            backend_timeout: Some(Self::DEFAULT_BACKEND_TIMEOUT),
+            backend_timeout: configured_backend_timeout()
+                .unwrap_or(Some(Self::DEFAULT_BACKEND_TIMEOUT)),
             agent_session_header: configured_agent_session_header(),
             lifecycle_observer: None,
         }

--- a/crates/openai-frontend/src/router_tests.rs
+++ b/crates/openai-frontend/src/router_tests.rs
@@ -25,6 +25,37 @@ fn trusted_agent_session_header_parser_accepts_valid_names() {
 fn trusted_agent_session_header_parser_rejects_invalid_names() {
     assert!(parse_agent_session_header("not a header").is_none());
 }
+
+#[test]
+fn backend_timeout_parser_accepts_whole_seconds() {
+    assert_eq!(
+        parse_backend_timeout_secs("900"),
+        Some(Some(Duration::from_secs(900)))
+    );
+    assert_eq!(
+        parse_backend_timeout_secs(" 900 "),
+        Some(Some(Duration::from_secs(900)))
+    );
+}
+
+#[test]
+fn backend_timeout_parser_treats_zero_as_disabled() {
+    assert_eq!(parse_backend_timeout_secs("0"), Some(None));
+}
+
+#[test]
+fn backend_timeout_parser_rejects_non_numeric_values() {
+    assert!(parse_backend_timeout_secs("10m").is_none());
+    assert!(parse_backend_timeout_secs("-1").is_none());
+    assert!(parse_backend_timeout_secs("").is_none());
+}
+
+#[test]
+fn default_backend_timeout_exceeds_a_cold_large_prompt_prefill() {
+    // A 60k-token cold prefill on a single Apple-silicon host measures ~250s.
+    // The default must leave headroom above that, not abort it.
+    assert!(OpenAiFrontendConfig::DEFAULT_BACKEND_TIMEOUT >= Duration::from_secs(600));
+}
 use crate::{
     FinishReason,
     backend::{


### PR DESCRIPTION
Long prompts no longer fail with a gateway timeout while the runtime is still working.

Sending a large prompt to a single-machine mesh endpoint used to return
`504 chat_completion timed out after 300000 ms` even though nothing was wrong —
the model was mid-prefill and would have answered fine given a few more seconds.
The frontend gave up first.

Reproduced and fixed on a live endpoint. Same binary, same config, an 88,318-token
cold prompt on an M5 Max:

```text
before  HTTP 504   300.02s   chat_completion timed out after 300000 ms
after   HTTP 200   503.17s   prompt=88318 cached=0  (176 tok/s prefill)
```

A cold prefill at this size is legitimately an eight-minute operation on one
machine. Agent harnesses that send a whole conversation in a single
non-streaming request are exactly the shape that hits this.

Operators who need a different budget can now set it:

```bash
# raise to 20 minutes
MESH_OPENAI_BACKEND_TIMEOUT_SECS=1200 mesh-llm serve --config ...

# disable the timeout entirely
MESH_OPENAI_BACKEND_TIMEOUT_SECS=0 mesh-llm serve --config ...
```

Invalid or non-numeric values are ignored with a warning and the default applies.

## Architecture

The 300s cap was the only layer in the stack with a budget that tight. The proxy's
own local first-byte safety net (`network/openai/response/probe.rs:199`) already
allows 10 minutes, with a comment explaining that it is a wedged-runtime backstop
rather than a latency budget. The frontend's 300s contradicted that and won,
so a healthy long prefill was aborted by the inner layer while the outer layer
was still willing to wait. Raising the default to 600s makes the two agree.

`OpenAiFrontendConfig::with_backend_timeout` already existed but nothing on the
serve path called it, so there was no way to change this without a rebuild. The
environment variable is read in `OpenAiFrontendConfig::default`, alongside the
existing `MESH_AGENT_SESSION_HEADER` handling, so every construction path picks
it up — including `router_for`, which does not take a config.

## Protocol

No protocol change. Timeout behavior and the OpenAI-shaped 504 error body are
unchanged; only the default budget and its configurability differ. Older and
newer nodes interoperate exactly as before.

## Validation

```text
cargo fmt --all --check                                  clean
cargo test -p openai-frontend --lib                      178 passed
cargo clippy -p openai-frontend --all-targets -D warnings clean
cargo clippy -p mesh-llm --all-targets -D warnings        clean
```

Live: `just release-build` at this branch, swapped into a running launchd serve
job (one line of the plist changed — the host binary path), same config, same
port 9447. Result is the 200 shown above; the identical probe against the
previous build returned the 504.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable backend timeout support through the `MESH_OPENAI_BACKEND_TIMEOUT_SECS` environment variable.
  * Timeout defaults are now 600 seconds, and setting the value to `0` disables the timeout.
  * Timeout responses continue to use OpenAI-compatible 504 errors.

* **Documentation**
  * Updated configuration documentation with the new timeout behavior and environment variable.

* **Tests**
  * Added coverage for valid, invalid, whitespace-trimmed, zero, and default timeout values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->