### PR TITLE
Reject non-protobuf content types on OTLP/HTTP ingestion

### DIFF
--- a/crates/metrics-server/src/api.rs
+++ b/crates/metrics-server/src/api.rs
@@ -3,7 +3,7 @@ use axum::{
     Json,
     body::Bytes,
     extract::{Path, State},
-    http::header,
+    http::{HeaderMap, StatusCode, header},
     response::IntoResponse,
 };
 use opentelemetry_proto::tonic::collector::{
@@ -71,10 +71,49 @@ pub(crate) async fn artifacts(Path(run_id): Path<String>) -> Json<ArtifactsRespo
     })
 }
 
+/// OTLP/HTTP requires protobuf export bodies to be sent as
+/// `application/x-protobuf` (OTLP spec, "OTLP/HTTP" section).
+const OTLP_PROTOBUF_CONTENT_TYPE: &str = "application/x-protobuf";
+
+/// Reject OTLP/HTTP export requests that do not declare the protobuf content
+/// type.
+///
+/// The listener binds loopback, but loopback is not an authentication boundary
+/// for browsers: a hostile web page can issue a "simple" cross-origin `POST`
+/// with a CORS-safelisted `Content-Type` (`text/plain`, `application/
+/// x-www-form-urlencoded`, `multipart/form-data`) and no preflight, and the
+/// browser will still deliver the body even though script cannot read the
+/// response. Because these handlers accept a raw `Bytes` body and protobuf-
+/// decode it directly, such a drive-by request could inject or poison spans,
+/// metrics, and runs in the local store.
+///
+/// Requiring `application/x-protobuf` — which every conforming OTLP/HTTP
+/// exporter already sends — takes the request out of the CORS-safelisted set,
+/// so a cross-origin browser request must first pass a preflight the attacker
+/// page cannot satisfy. Legitimate exporters are unaffected.
+fn require_otlp_protobuf(headers: &HeaderMap) -> Result<(), AppError> {
+    let content_type = headers
+        .get(header::CONTENT_TYPE)
+        .and_then(|value| value.to_str().ok())
+        .unwrap_or_default();
+    // The header may carry parameters, e.g. `application/x-protobuf; charset=…`.
+    let media_type = content_type.split(';').next().unwrap_or_default().trim();
+    if media_type.eq_ignore_ascii_case(OTLP_PROTOBUF_CONTENT_TYPE) {
+        Ok(())
+    } else {
+        Err(AppError::status(
+            StatusCode::UNSUPPORTED_MEDIA_TYPE,
+            format!("OTLP/HTTP requires Content-Type: {OTLP_PROTOBUF_CONTENT_TYPE}"),
+        ))
+    }
+}
+
 pub(crate) async fn otlp_http_traces(
     State(state): State<AppState>,
+    headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, AppError> {
+    require_otlp_protobuf(&headers)?;
     let request = ExportTraceServiceRequest::decode(body.as_ref())
         .context("decode OTLP/HTTP trace export request")?;
     state.store.ingest_traces(request)?;
@@ -85,8 +124,10 @@ pub(crate) async fn otlp_http_traces(
 
 pub(crate) async fn otlp_http_metrics(
     State(state): State<AppState>,
+    headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, AppError> {
+    require_otlp_protobuf(&headers)?;
     let request = ExportMetricsServiceRequest::decode(body.as_ref())
         .context("decode OTLP/HTTP metric export request")?;
     state.store.ingest_metrics(request)?;
@@ -97,8 +138,10 @@ pub(crate) async fn otlp_http_metrics(
 
 pub(crate) async fn otlp_http_logs(
     State(state): State<AppState>,
+    headers: HeaderMap,
     body: Bytes,
 ) -> Result<impl IntoResponse, AppError> {
+    require_otlp_protobuf(&headers)?;
     let request = ExportLogsServiceRequest::decode(body.as_ref())
         .context("decode OTLP/HTTP log export request")?;
     state.store.ingest_logs(request)?;

--- a/crates/metrics-server/src/lib.rs
+++ b/crates/metrics-server/src/lib.rs
@@ -30,7 +30,12 @@ mod tests {
         store::Store,
         util::now_unix_nanos,
     };
-    use axum::{body::Bytes, extract::State, http::StatusCode, response::IntoResponse};
+    use axum::{
+        body::Bytes,
+        extract::State,
+        http::{HeaderMap, HeaderValue, StatusCode, header},
+        response::IntoResponse,
+    };
     use opentelemetry_proto::tonic::metrics::v1::{
         Gauge, ResourceMetrics, ScopeMetrics as MetricScopeMetrics,
     };
@@ -247,6 +252,15 @@ mod tests {
         assert!(raw_json.is_empty());
     }
 
+    fn protobuf_headers() -> HeaderMap {
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/x-protobuf"),
+        );
+        headers
+    }
+
     #[tokio::test]
     async fn otlp_http_trace_ingest_accepts_protobuf() {
         let store = in_memory_store(false);
@@ -255,7 +269,7 @@ mod tests {
         };
         let body = Bytes::from(fixture_request("run-http").encode_to_vec());
 
-        let response = otlp_http_traces(State(state), body)
+        let response = otlp_http_traces(State(state), protobuf_headers(), body)
             .await
             .unwrap()
             .into_response();
@@ -263,5 +277,77 @@ mod tests {
 
         let report = store.report("run-http").unwrap();
         assert_eq!(report.counts["spans"], 1);
+    }
+
+    #[tokio::test]
+    async fn otlp_http_trace_ingest_accepts_protobuf_with_charset_parameter() {
+        let store = in_memory_store(false);
+        let state = AppState {
+            store: store.clone(),
+        };
+        let body = Bytes::from(fixture_request("run-http-charset").encode_to_vec());
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("application/x-protobuf; charset=utf-8"),
+        );
+
+        let response = otlp_http_traces(State(state), headers, body)
+            .await
+            .unwrap()
+            .into_response();
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let report = store.report("run-http-charset").unwrap();
+        assert_eq!(report.counts["spans"], 1);
+    }
+
+    /// A drive-by web page can only send CORS-safelisted content types without
+    /// a preflight. Sending `text/plain` protobuf bytes must be rejected and
+    /// must not create a run, closing the cross-origin injection path (#886).
+    #[tokio::test]
+    async fn otlp_http_trace_ingest_rejects_cors_safelisted_content_type() {
+        let store = in_memory_store(false);
+        let state = AppState {
+            store: store.clone(),
+        };
+        let body = Bytes::from(fixture_request("run-driveby").encode_to_vec());
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain;charset=UTF-8"),
+        );
+
+        let status = match otlp_http_traces(State(state), headers, body).await {
+            Ok(_) => panic!("text/plain OTLP export must be rejected"),
+            Err(error) => error.into_response().status(),
+        };
+        assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+
+        assert!(
+            store.report("run-driveby").is_err(),
+            "rejected drive-by request must not create a run"
+        );
+    }
+
+    /// A request with no `Content-Type` at all must also be rejected.
+    #[tokio::test]
+    async fn otlp_http_trace_ingest_rejects_missing_content_type() {
+        let store = in_memory_store(false);
+        let state = AppState {
+            store: store.clone(),
+        };
+        let body = Bytes::from(fixture_request("run-no-ct").encode_to_vec());
+
+        let status = match otlp_http_traces(State(state), HeaderMap::new(), body).await {
+            Ok(_) => panic!("OTLP export without a content type must be rejected"),
+            Err(error) => error.into_response().status(),
+        };
+        assert_eq!(status, StatusCode::UNSUPPORTED_MEDIA_TYPE);
+
+        assert!(
+            store.report("run-no-ct").is_err(),
+            "rejected request must not create a run"
+        );
     }
 }

--- a/crates/metrics-server/src/server.rs
+++ b/crates/metrics-server/src/server.rs
@@ -31,22 +31,39 @@ pub(crate) struct AppState {
 }
 
 #[derive(Debug)]
-pub(crate) struct AppError(anyhow::Error);
+pub(crate) struct AppError {
+    status: StatusCode,
+    error: anyhow::Error,
+}
+
+impl AppError {
+    /// Build an error that responds with a specific HTTP status code and
+    /// message instead of the default `500 Internal Server Error`.
+    pub(crate) fn status(status: StatusCode, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            error: anyhow::Error::msg(message.into()),
+        }
+    }
+}
 
 impl<E> From<E> for AppError
 where
     E: Into<anyhow::Error>,
 {
     fn from(error: E) -> Self {
-        Self(error.into())
+        Self {
+            status: StatusCode::INTERNAL_SERVER_ERROR,
+            error: error.into(),
+        }
     }
 }
 
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         (
-            StatusCode::INTERNAL_SERVER_ERROR,
-            Json(json!({ "error": self.0.to_string() })),
+            self.status,
+            Json(json!({ "error": self.error.to_string() })),
         )
             .into_response()
     }


### PR DESCRIPTION
## What this fixes

The bundled `metrics-server` exposes OTLP/HTTP ingestion endpoints (`/v1/traces`, `/v1/metrics`, `/v1/logs`) on a loopback listener. These handlers accepted a raw request body and protobuf-decoded it **without checking `Content-Type`, `Origin`, or any credential**.

Loopback is not an authentication boundary for browsers. A hostile web page you happen to have open can issue a "simple" cross-origin `POST` with a CORS-safelisted content type (`text/plain`, `application/x-www-form-urlencoded`, `multipart/form-data`) and **no preflight** — the browser still delivers the body even though script can't read the response. That let a drive-by page POST valid protobuf bytes and inject or poison spans, metrics, and runs (including a chosen `run_id`) in your local metrics store, corrupting benchmark reports and consuming disk.

## The fix

Require `Content-Type: application/x-protobuf` on the three OTLP/HTTP export handlers. Every conforming OTLP/HTTP exporter already sends this, so legitimate ingestion is unaffected. Because `application/x-protobuf` is **not** in the CORS-safelisted set, a cross-origin browser request must now pass a preflight the attacker page cannot satisfy — closing the drive-by path. Requests with a missing or non-protobuf content type get `415 Unsupported Media Type`, and content-type parameters (e.g. `; charset=utf-8`) are tolerated.

`create_run` (`POST /v1/runs`) was already safe: it uses axum's `Json` extractor, which enforces `application/json` and is therefore not CORS-safelisted.

## Validation

- New regression tests: drive-by `text/plain` protobuf is rejected with `415` and creates no run; missing content type is rejected; `application/x-protobuf` (with and without a charset parameter) is still accepted.
- `cargo test -p metrics-server --lib` → 9 passed.
- `cargo clippy -p metrics-server --all-targets -- -D warnings` clean; `cargo fmt --all --check` clean.

Fixes project-loupe/audit-mesh-llm#886.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OTLP/HTTP trace, metric, and log ingestion now validates the `Content-Type` header before processing requests.
  * Requests using `application/x-protobuf`, including charset parameters, are accepted.
  * Requests with missing or unsupported content types now receive a clear `415 Unsupported Media Type` response.
  * HTTP errors now return their appropriate status codes instead of defaulting to `500 Internal Server Error`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->