### PR TITLE
Cap remotely advertised model lists to protect the console from a hostile peer

### DIFF
--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -715,6 +715,36 @@ pub(crate) fn build_gossip_frame(
     }
 }
 
+/// Upper bound on the number of model-name entries accepted from a single
+/// remote peer announcement.
+///
+/// Peer gossip carries `serving_models` / `hosted_models` (and the other
+/// model-name lists) straight through `/api/status` into the console, where
+/// they are sorted and rendered one DOM element per entry. The wire frame is
+/// only bounded by the generic 8 MiB control-frame ceiling, which still allows
+/// hundreds of thousands of short names. Capping the list length at the trust
+/// boundary stops a hostile peer from freezing another operator's dashboard
+/// with an oversized (or rapidly re-advertised) model list (#860). A real node
+/// serves at most a handful of models, so this ceiling is far above any
+/// legitimate value.
+const MAX_REMOTE_MODEL_LIST_LEN: usize = 256;
+
+/// Upper bound on the byte length of a single remotely-advertised model name.
+/// Legitimate model references (including HuggingFace repo + revision) are well
+/// under this; anything larger is dropped rather than rendered.
+const MAX_REMOTE_MODEL_NAME_BYTES: usize = 512;
+
+/// Sanitize a remotely-supplied list of model names: drop entries that exceed
+/// the per-name byte cap and keep at most `MAX_REMOTE_MODEL_LIST_LEN` of them.
+fn cap_remote_model_names(names: &[String]) -> Vec<String> {
+    names
+        .iter()
+        .filter(|name| name.len() <= MAX_REMOTE_MODEL_NAME_BYTES)
+        .take(MAX_REMOTE_MODEL_LIST_LEN)
+        .cloned()
+        .collect()
+}
+
 pub(crate) fn proto_ann_to_local(
     pa: &crate::proto::node::PeerAnnouncement,
 ) -> Option<(EndpointAddr, PeerAnnouncement)> {
@@ -749,7 +779,7 @@ pub(crate) fn proto_ann_to_local(
     let hosted_models = pa
         .hosted_models_known
         .unwrap_or(!pa.hosted_models.is_empty())
-        .then(|| pa.hosted_models.clone());
+        .then(|| cap_remote_model_names(&pa.hosted_models));
     let hardware = pa.hardware.as_ref();
     let legacy_gpu_fields = proto_gpu_info_to_legacy_fields(
         hardware
@@ -760,14 +790,14 @@ pub(crate) fn proto_ann_to_local(
         addr: addr.clone(),
         role,
         first_joined_mesh_ts: pa.first_joined_mesh_ts,
-        models: pa.catalog_models.clone(),
+        models: cap_remote_model_names(&pa.catalog_models),
         vram_bytes: pa.vram_bytes,
         model_source: pa.model_source.clone(),
-        serving_models: pa.serving_models.clone(),
+        serving_models: cap_remote_model_names(&pa.serving_models),
         hosted_models,
         available_models: Vec::new(),
-        requested_models: pa.requested_models.clone(),
-        explicit_model_interests: pa.explicit_model_interests.clone(),
+        requested_models: cap_remote_model_names(&pa.requested_models),
+        explicit_model_interests: cap_remote_model_names(&pa.explicit_model_interests),
         version: pa.version.clone(),
         model_demand,
         mesh_id: pa.mesh_id.clone(),
@@ -1176,5 +1206,50 @@ mod tests {
             peer_release_attestation_status(ann.release_attestation.as_ref()),
             crate::PeerReleaseAttestationStatus::Unsigned
         );
+    }
+
+    #[test]
+    fn proto_ann_to_local_caps_oversized_remote_model_lists() {
+        let flood: Vec<String> = (0..10_000).map(|i| format!("model-{i}")).collect();
+        let proto = crate::proto::node::PeerAnnouncement {
+            endpoint_id: vec![1; 32],
+            role: crate::proto::node::NodeRole::Worker as i32,
+            serving_models: flood.clone(),
+            catalog_models: flood.clone(),
+            requested_models: flood.clone(),
+            explicit_model_interests: flood.clone(),
+            hosted_models: flood.clone(),
+            hosted_models_known: Some(true),
+            ..Default::default()
+        };
+
+        let (_addr, ann) = proto_ann_to_local(&proto).expect("announcement should decode");
+
+        assert_eq!(ann.serving_models.len(), MAX_REMOTE_MODEL_LIST_LEN);
+        assert_eq!(ann.models.len(), MAX_REMOTE_MODEL_LIST_LEN);
+        assert_eq!(ann.requested_models.len(), MAX_REMOTE_MODEL_LIST_LEN);
+        assert_eq!(
+            ann.explicit_model_interests.len(),
+            MAX_REMOTE_MODEL_LIST_LEN
+        );
+        assert_eq!(
+            ann.hosted_models.as_ref().map(Vec::len),
+            Some(MAX_REMOTE_MODEL_LIST_LEN)
+        );
+    }
+
+    #[test]
+    fn proto_ann_to_local_drops_oversized_remote_model_names() {
+        let huge_name = "x".repeat(MAX_REMOTE_MODEL_NAME_BYTES + 1);
+        let proto = crate::proto::node::PeerAnnouncement {
+            endpoint_id: vec![1; 32],
+            role: crate::proto::node::NodeRole::Worker as i32,
+            serving_models: vec!["ok-model".to_string(), huge_name],
+            ..Default::default()
+        };
+
+        let (_addr, ann) = proto_ann_to_local(&proto).expect("announcement should decode");
+
+        assert_eq!(ann.serving_models, vec!["ok-model".to_string()]);
     }
 }


### PR DESCRIPTION
## What this fixes

A mesh peer advertises the models it serves via gossip (`serving_models`, `hosted_models`, and the other model-name lists). These lists flow untouched through `/api/status` into the web console, where each name is sorted (locale-aware, `O(n log n)`) and rendered as its own DOM element.

Nothing bounded the list length at ingest: the only limit was the generic 8 MiB control-frame ceiling, which still permits hundreds of thousands of short names. A malicious mesh participant could therefore advertise an oversized model list — and repeatedly re-advertise it — to exhaust memory and freeze or crash another operator's dashboard browser, denying access to the local management UI. This is a genuinely remote vector: it needs only a hostile peer on the mesh, no co-resident user or browser trust assumption.

## The fix

Sanitize peer-supplied model-name lists at the trust boundary — `proto_ann_to_local`, where an inbound wire protobuf `PeerAnnouncement` is converted into the local struct. Each remotely-advertised list (`serving_models`, `hosted_models`, `catalog_models`, `requested_models`, `explicit_model_interests`) now:

- drops any entry longer than 512 bytes, and
- keeps at most 256 names.

A real node serves a handful of models, so these ceilings sit far above any legitimate value and no honest peer is affected. Capping at the trust boundary also protects every downstream consumer (routing, `/api/status`, the console) at once, rather than relying on the UI to defend itself.

## Protocol

No wire-format change. This only bounds how much of an existing, additive gossip field the receiver retains, so mixed-version meshes are unaffected: older and newer nodes still exchange the same fields, and a node that advertises a normal number of models sees identical behavior. An over-advertising peer simply has its list truncated locally.

## Validation

- New regression tests in `protocol::convert`: an announcement carrying 10,000 names per list is capped to 256 each; an over-length model name is dropped while a valid sibling is kept.
- `cargo test -p mesh-llm-host-runtime --lib` → 2495 passed, 0 failed.
- `cargo check -p mesh-llm-host-runtime` clean; `cargo fmt --all --check` clean.

Fixes project-loupe/audit-mesh-llm#860.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added safeguards for remote model-name lists.
  * Oversized names are ignored, and excessively long lists are capped to maintain reliable processing.
  * Applies across catalog, serving, requested, interest, and hosted-model listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->