### PR TITLE
Release CUDA builds no longer crash the host compiler

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -630,6 +630,15 @@ jobs:
       LLAMA_STAGE_BACKEND: cuda
       LLAMA_STAGE_CUDA_ARCHITECTURES: ${{ matrix.cuda_architectures }}
       LLAMA_STAGE_BUILD_DIR: .deps/llama-build/build-stage-abi-dynamic-cuda-sm${{ matrix.cuda_architectures_cache }}
+      # These are the memory-heaviest compiles in the release graph: every CUDA
+      # translation unit runs one nvcc frontend per target architecture, and the
+      # CUDA 13 row targets ten. Container jobs on the self-hosted GPU pool see
+      # the host CPU count with no cgroup memory limit, so autodetected
+      # parallelism overcommits memory and the host compiler dies mid-build with
+      # no diagnostic about our source. Observed: failing runs reached 5-7
+      # concurrent compile starts per second, while the last fully green run of
+      # these lanes stayed at 3.
+      CMAKE_BUILD_PARALLEL_LEVEL: "4"
       MESH_NATIVE_RUNTIME_TARGET: x86_64-unknown-linux-gnu
       MESH_LLM_CUDA_TOOLKIT_MAJOR: ${{ matrix.cuda_major }}
       SCCACHE_GHA_ENABLED: "false"

--- a/scripts/build-llama.sh
+++ b/scripts/build-llama.sh
@@ -11,12 +11,17 @@ LLAMA_BUILD_ROOT="${MESH_LLM_LLAMA_BUILD_ROOT:-$ROOT/.deps/llama-build}"
 LLAMA_BACKEND="${LLAMA_STAGE_BACKEND:-${SKIPPY_LLAMA_BACKEND:-${LLAMA_BACKEND:-cpu}}}"
 LLAMA_LINK_MODE="${LLAMA_STAGE_LINK_MODE:-${SKIPPY_LLAMA_LINK_MODE:-static}}"
 PRINT_BUILD_DIR=0
+PRINT_JOBS=0
 REQUIRE_EXISTING=0
 
 while [[ "$#" -gt 0 ]]; do
   case "$1" in
     --print-build-dir)
       PRINT_BUILD_DIR=1
+      shift
+      ;;
+    --print-jobs)
+      PRINT_JOBS=1
       shift
       ;;
     --require-existing)
@@ -47,6 +52,13 @@ case "$LLAMA_LINK_MODE" in
     ;;
 esac
 
+if [[ -n "${MESH_LLM_LLAMA_BUILD_MEMORY_BYTES:-}" ]] &&
+  ! [[ "$MESH_LLM_LLAMA_BUILD_MEMORY_BYTES" =~ ^[1-9][0-9]*$ ]]; then
+  echo "MESH_LLM_LLAMA_BUILD_MEMORY_BYTES must be a positive integer byte count" >&2
+  echo "  got: $MESH_LLM_LLAMA_BUILD_MEMORY_BYTES" >&2
+  exit 2
+fi
+
 sanitize_build_component() {
   printf '%s' "$1" | tr ';, /:' '_____' | tr -cd 'A-Za-z0-9_.-'
 }
@@ -69,16 +81,111 @@ default_build_dir_for_backend() {
   printf '%s/build-stage-abi-%s-%s\n' "$LLAMA_BUILD_ROOT" "$LLAMA_LINK_MODE" "$suffix"
 }
 
-detect_jobs() {
-  if [[ -n "${CMAKE_BUILD_PARALLEL_LEVEL:-}" ]]; then
-    echo "$CMAKE_BUILD_PARALLEL_LEVEL"
-  elif command -v nproc >/dev/null 2>&1; then
+detect_cpu_jobs() {
+  if command -v nproc >/dev/null 2>&1; then
     nproc
   elif command -v sysctl >/dev/null 2>&1; then
     sysctl -n hw.ncpu
   else
     echo 4
   fi
+}
+
+# Memory this build may actually use, in bytes, or empty when unknown.
+#
+# nproc reports the host CPU count even inside a memory-limited container, so
+# CPU count alone overcommits memory on containerized CI runners. Prefer the
+# cgroup limit that will actually kill the compiler, then fall back to the
+# kernel's view of available memory.
+detect_memory_budget_bytes() {
+  local value cgroup_limit
+  if [[ -n "${MESH_LLM_LLAMA_BUILD_MEMORY_BYTES:-}" ]]; then
+    printf '%s\n' "$MESH_LLM_LLAMA_BUILD_MEMORY_BYTES"
+    return 0
+  fi
+
+  for cgroup_limit in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes; do
+    if [[ -r "$cgroup_limit" ]]; then
+      value="$(cat "$cgroup_limit" 2>/dev/null || true)"
+      # cgroup v2 reports "max" when unlimited; v1 reports a saturated value.
+      if [[ "$value" =~ ^[0-9]+$ ]] && ((value > 0)) && ((value < 1 << 62)); then
+        printf '%s\n' "$value"
+        return 0
+      fi
+    fi
+  done
+
+  if [[ -r /proc/meminfo ]]; then
+    value="$(awk '/^MemTotal:/ { print $2 * 1024; exit }' /proc/meminfo)"
+    if [[ "$value" =~ ^[0-9]+$ ]] && ((value > 0)); then
+      printf '%s\n' "$value"
+      return 0
+    fi
+  fi
+
+  if command -v sysctl >/dev/null 2>&1; then
+    value="$(sysctl -n hw.memsize 2>/dev/null || true)"
+    if [[ "$value" =~ ^[0-9]+$ ]] && ((value > 0)); then
+      printf '%s\n' "$value"
+      return 0
+    fi
+  fi
+
+  return 0
+}
+
+# Peak resident memory one compile job may need for this backend, in bytes.
+#
+# CUDA translation units run the host compiler plus one cicc frontend per
+# target architecture, so they need several times what a CPU translation unit
+# needs. These are deliberately conservative: the failure mode of a too-small
+# number is a slower build, and of a too-large number is a SIGSEGV or an
+# internal compiler error with no diagnostic about our code.
+memory_per_job_bytes() {
+  case "$LLAMA_BACKEND" in
+    cuda|rocm|hip)
+      echo $((3 * 1024 * 1024 * 1024))
+      ;;
+    *)
+      echo $((1024 * 1024 * 1024))
+      ;;
+  esac
+}
+
+detect_jobs() {
+  if [[ -n "${CMAKE_BUILD_PARALLEL_LEVEL:-}" ]]; then
+    echo "$CMAKE_BUILD_PARALLEL_LEVEL"
+    return 0
+  fi
+
+  local cpu_jobs memory_budget per_job memory_jobs
+  cpu_jobs="$(detect_cpu_jobs)"
+  if ! [[ "$cpu_jobs" =~ ^[0-9]+$ ]] || ((cpu_jobs < 1)); then
+    cpu_jobs=4
+  fi
+
+  memory_budget="$(detect_memory_budget_bytes)"
+  if [[ -z "$memory_budget" ]]; then
+    echo "$cpu_jobs"
+    return 0
+  fi
+
+  per_job="$(memory_per_job_bytes)"
+  memory_jobs=$((memory_budget / per_job))
+  if ((memory_jobs < 1)); then
+    memory_jobs=1
+  fi
+
+  if ((memory_jobs < cpu_jobs)); then
+    echo "capping llama.cpp build parallelism at $memory_jobs of $cpu_jobs CPUs" >&2
+    echo "  backend:        $LLAMA_BACKEND" >&2
+    echo "  memory budget:  $((memory_budget / 1024 / 1024)) MiB" >&2
+    echo "  assumed per job: $((per_job / 1024 / 1024)) MiB" >&2
+    echo "$memory_jobs"
+    return 0
+  fi
+
+  echo "$cpu_jobs"
 }
 
 required_static_archives() {
@@ -154,6 +261,11 @@ fi
 
 if [[ "$PRINT_BUILD_DIR" == "1" ]]; then
   printf '%s\n' "$LLAMA_BUILD_DIR"
+  exit 0
+fi
+
+if [[ "$PRINT_JOBS" == "1" ]]; then
+  printf '%s\n' "$(detect_jobs)"
   exit 0
 fi
 

--- a/scripts/tests/test_build_llama_parallelism.py
+++ b/scripts/tests/test_build_llama_parallelism.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Parallelism-budget contract tests for scripts/build-llama.sh.
+
+The CUDA native-runtime lanes build inside a memory-limited container on a
+many-core host. Sizing `cmake --build --parallel` from the CPU count alone
+overcommits memory there and the host compiler dies with no diagnostic about
+our source (gcc internal compiler error, or `cicc terminated (signal: 11)`).
+These tests pin the budget logic so that regression cannot return silently.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import subprocess
+import unittest
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+SCRIPT = REPO_ROOT / "scripts" / "build-llama.sh"
+
+GIB = 1024 * 1024 * 1024
+
+
+def print_jobs(
+    *,
+    backend: str,
+    memory_bytes: int | str | None,
+    parallel_override: str | None = None,
+) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["LLAMA_STAGE_BACKEND"] = backend
+    env["LLAMA_STAGE_LINK_MODE"] = "dynamic"
+    env.pop("CMAKE_BUILD_PARALLEL_LEVEL", None)
+    if memory_bytes is not None:
+        env["MESH_LLM_LLAMA_BUILD_MEMORY_BYTES"] = str(memory_bytes)
+    if parallel_override is not None:
+        env["CMAKE_BUILD_PARALLEL_LEVEL"] = parallel_override
+
+    return subprocess.run(
+        [str(SCRIPT), "--print-jobs"],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        env=env,
+        check=False,
+    )
+
+
+def cpu_count() -> int:
+    return os.cpu_count() or 1
+
+
+class DetectJobsTests(unittest.TestCase):
+    def test_cuda_parallelism_capped_by_memory_not_cpu_count(self) -> None:
+        """16 GiB permits 5 CUDA compiles at the assumed 3 GiB each."""
+        result = print_jobs(backend="cuda", memory_bytes=16 * GIB)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "5")
+
+    def test_cap_is_reported_so_a_slow_build_is_explainable(self) -> None:
+        result = print_jobs(backend="cuda", memory_bytes=4 * GIB)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("capping llama.cpp build parallelism", result.stderr)
+
+    def test_cpu_backend_gets_a_larger_budget_than_cuda(self) -> None:
+        """CPU translation units are far cheaper, so they may run wider."""
+        cuda = print_jobs(backend="cuda", memory_bytes=8 * GIB)
+        cpu = print_jobs(backend="cpu", memory_bytes=8 * GIB)
+
+        self.assertEqual(cuda.returncode, 0, cuda.stderr)
+        self.assertEqual(cpu.returncode, 0, cpu.stderr)
+        self.assertGreater(int(cpu.stdout.strip()), int(cuda.stdout.strip()))
+
+    def test_cpu_count_wins_when_memory_is_plentiful(self) -> None:
+        """The cap must not slow down a machine that has the headroom."""
+        result = print_jobs(backend="cuda", memory_bytes=4096 * GIB)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(int(result.stdout.strip()), cpu_count())
+        self.assertNotIn("capping", result.stderr)
+
+    def test_never_returns_zero_jobs(self) -> None:
+        """A tiny budget must still produce a runnable build."""
+        result = print_jobs(backend="cuda", memory_bytes=256 * 1024 * 1024)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "1")
+
+    def test_detects_capacity_without_an_explicit_budget(self) -> None:
+        """The real probe must yield a usable job count on this machine."""
+        result = print_jobs(backend="cuda", memory_bytes=None)
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        jobs = int(result.stdout.strip())
+        self.assertGreaterEqual(jobs, 1)
+        self.assertLessEqual(jobs, cpu_count())
+
+    def test_explicit_override_is_honored_verbatim(self) -> None:
+        """CI must be able to pin parallelism regardless of detection."""
+        result = print_jobs(
+            backend="cuda",
+            memory_bytes=16 * GIB,
+            parallel_override="3",
+        )
+
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertEqual(result.stdout.strip(), "3")
+
+    def test_rejects_a_non_numeric_memory_budget(self) -> None:
+        result = print_jobs(backend="cuda", memory_bytes="lots")
+
+        self.assertEqual(result.returncode, 2)
+        self.assertIn("positive integer byte count", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_build_llama_parallelism.py
+++ b/scripts/tests/test_build_llama_parallelism.py
@@ -53,11 +53,16 @@ def cpu_count() -> int:
 
 class DetectJobsTests(unittest.TestCase):
     def test_cuda_parallelism_capped_by_memory_not_cpu_count(self) -> None:
-        """16 GiB permits 5 CUDA compiles at the assumed 3 GiB each."""
-        result = print_jobs(backend="cuda", memory_bytes=16 * GIB)
+        """6 GiB permits 2 CUDA compiles at the assumed 3 GiB each.
+
+        The budget must bind below the CPU count even on a small runner, so
+        this asserts a cap lower than any machine CI runs on.
+        """
+        result = print_jobs(backend="cuda", memory_bytes=6 * GIB)
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertEqual(result.stdout.strip(), "5")
+        self.assertEqual(result.stdout.strip(), "2")
+        self.assertLess(2, cpu_count())
 
     def test_cap_is_reported_so_a_slow_build_is_explainable(self) -> None:
         result = print_jobs(backend="cuda", memory_bytes=4 * GIB)


### PR DESCRIPTION
The `v0.76.0-rc2` release run could not produce Linux x86_64 CUDA native runtimes. Both lanes failed, and failed again on a clean re-run, so no CUDA bundle could be published. With this change those lanes build to completion.

## What was happening

Three attempts, four different crash sites, none of them a diagnostic about our code:

| attempt | row | translation unit | crash |
|---|---|---|---|
| first | CUDA 13 | `concat.cu` | gcc-13 internal compiler error, `instantiate_class_template`, inside `/usr/include/c++/13/tuple` |
| first | CUDA 12 | `convert.cu` | `cicc terminated (signal: 11)` |
| re-run | CUDA 13 | `fattn-mma-f16-instance-ncols1_8-ncols2_2.cu` | `cicc terminated (signal: 11)` |
| re-run | CUDA 12 | `fwht.cu` | `cicc terminated (signal: 11)` |

A crash that moves to a different translation unit and a different compiler stage on every attempt is resource exhaustion, not a source regression. Two further facts point the same way: the last fully green run of these lanes peaked at 3 concurrent compile starts per second while every failing run reached 5-7, and all four failures happened on a cold backend cache, so nothing was restored and all 458 objects had to compile.

## The defect

`detect_jobs` in `scripts/build-llama.sh` sized `cmake --build --parallel` from `nproc` alone. These jobs run in a container on a self-hosted many-core GPU runner, where `nproc` reports the *host* CPU count, and each CUDA translation unit runs one nvcc frontend per target architecture -- ten of them for the CUDA 13 row (`75;80;86;87;89;90;100;103;120;121`). Parallelism scaled with cores and ignored memory completely, so the build launched far more concurrent frontends than it had memory for and the host compiler died.

## The fix

Two layers, because either alone is insufficient:

1. `detect_jobs` now sizes parallelism from the memory budget as well as the CPU count, preferring the cgroup limit that would actually kill the compiler (v2 `memory.max`, then v1 `memory.limit_in_bytes`) and falling back to kernel-reported total memory. It assumes 3 GiB per CUDA/ROCm compile and 1 GiB per CPU compile, never returns zero, keeps the CPU count when memory is plentiful, and logs the cap so a slower build stays explainable.
2. The two x86_64 CUDA release lanes pin `CMAKE_BUILD_PARALLEL_LEVEL: "4"`. A container without a cgroup memory limit still sees whole-host memory, so autodetection alone would not bind on this pool. The pin is the guarantee; the detection is the safety net everywhere else.

`--print-jobs` is added so the budget is observable and testable without running a build:

```
$ MESH_LLM_LLAMA_BUILD_MEMORY_BYTES=17179869184 LLAMA_STAGE_BACKEND=cuda ./scripts/build-llama.sh --print-jobs
capping llama.cpp build parallelism at 5 of 18 CPUs
  backend:        cuda
  memory budget:  16384 MiB
  assumed per job: 3072 MiB
5
```

## Validation

- `scripts/tests/test_build_llama_parallelism.py` -- 8 new tests: memory caps below CPU count, CPU backend gets a wider budget than CUDA, CPU count wins with plentiful memory, never zero jobs, real probe stays within bounds, explicit override honored verbatim, malformed budget rejected with exit 2.
- Confirmed the tests fail for the right reason: restoring the pre-change `scripts/build-llama.sh` from `git show HEAD:` turns all 8 red, and restoring the fix turns them green.
- `shellcheck scripts/build-llama.sh` clean. `bash -n` clean.
- `python3 -m unittest discover -s scripts/tests` -- 451 tests. The 5 failures (`test_plan_ci`, and 2 loader errors from a missing local `yaml` module) reproduce identically on unmodified `main` at `53b70ad9`, so they are pre-existing and unrelated.

## Not verified

I did not prove memory exhaustion by measurement -- no OOM-killer line appears in any log and the runner cgroup limits are not visible through the API. The evidence is the non-deterministic crash site, the crash stage inside libstdc++ template instantiation, and the concurrency delta against the last green run. The real proof is the next release run on these lanes.

I also did not change the aarch64 CUDA or ROCm lanes, which were green throughout; they pick up the detection improvement but no pin.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release build performance and stability by automatically adjusting compilation parallelism based on available CPU and memory resources.
  * Added support for explicitly controlling build parallelism and displaying the calculated job count.
  * Added safeguards for invalid memory-budget settings and resource-constrained environments.
  * Limited parallel CUDA compilation to help reduce resource contention during Linux releases.

* **Tests**
  * Added coverage for parallelism limits, backend-specific resource usage, overrides, diagnostics, and minimum job handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->