### PR TITLE
CI recognizes Apple provider paths

### DIFF
--- a/ci/ownership.yml
+++ b/ci/ownership.yml
@@ -217,7 +217,8 @@
       "patterns": [
         "scripts/build-mac.sh",
         "scripts/ci-swift-sdk-smoke.sh",
-        ".github/workflows/swift-sdk-artifact.yml"
+        ".github/workflows/swift-sdk-artifact.yml",
+        "providers/apple/**"
       ]
     },
     {


### PR DESCRIPTION
Adds `providers/apple/**` to the `platform-macos` ownership rules.

The PR planner validates changed paths against `main`'s ownership manifest, so the Apple runtime stack currently fails before any build/test jobs run. This prerequisite lets #1249 and its dependent Apple PRs plan successfully once merged.

Validation:
- `python3 scripts/tests/test_plan_ci.py` (23 passed)
- `python3 scripts/tests/test_ci_workflow_artifacts.py` (13 passed)
- `python3 scripts/tests/test_ci_lane_workflows.py` (19 passed)
- `cargo run -p xtask -- repo-consistency release-targets`
- `cargo run -p xtask -- repo-consistency ci-crate-lists`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ownership rules so changes to Apple provider components are routed to the appropriate platform team.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->