### PR TITLE
Fix blank responses from thinking models

### DIFF
--- a/crates/skippy-server/src/frontend/request.rs
+++ b/crates/skippy-server/src/frontend/request.rs
@@ -322,7 +322,7 @@ fn default_reasoning_budget_enabled(value: Option<EmbeddedReasoningBudget>) -> O
 }
 
 fn chat_reasoning_format(value: Option<EmbeddedReasoningFormat>) -> ChatReasoningFormat {
-    match value.unwrap_or(EmbeddedReasoningFormat::Hidden) {
+    match value.unwrap_or(EmbeddedReasoningFormat::Auto) {
         EmbeddedReasoningFormat::Auto => ChatReasoningFormat::Auto,
         EmbeddedReasoningFormat::None => ChatReasoningFormat::None,
         EmbeddedReasoningFormat::Deepseek => ChatReasoningFormat::Deepseek,

--- a/crates/skippy-server/src/frontend/tests/request.rs
+++ b/crates/skippy-server/src/frontend/tests/request.rs
@@ -327,11 +327,11 @@ fn canonical_reasoning_overrides_chat_template_thinking() {
     let options =
         chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default()).unwrap();
     assert_eq!(options.enable_thinking, Some(false));
-    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Hidden));
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Auto));
 }
 
 #[test]
-fn chat_template_options_default_to_hidden_reasoning_parser() {
+fn chat_template_options_default_to_auto_reasoning_parser() {
     let request: ChatCompletionRequest = serde_json::from_value(json!({
         "model": "jc-builds/SmolLM2-135M-Instruct-Q4_K_M-GGUF:Q4_K_M",
         "messages": [{"role": "user", "content": "hello"}]
@@ -342,7 +342,8 @@ fn chat_template_options_default_to_hidden_reasoning_parser() {
         .expect("template options");
 
     assert_eq!(options.enable_thinking, None);
-    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Hidden));
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Auto));
+    assert!(template_exposes_reasoning(&options));
 }
 
 #[test]
@@ -445,7 +446,7 @@ fn reasoning_effort_overrides_chat_template_thinking() {
     let options =
         chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default()).unwrap();
     assert_eq!(options.enable_thinking, Some(false));
-    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Hidden));
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Auto));
 }
 
 #[test]
@@ -460,7 +461,7 @@ fn top_level_reasoning_effort_overrides_chat_template_thinking() {
     let options =
         chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default()).unwrap();
     assert_eq!(options.enable_thinking, Some(false));
-    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Hidden));
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Auto));
 }
 
 #[test]
@@ -513,7 +514,7 @@ fn provider_enable_thinking_overrides_chat_template_thinking() {
     let options =
         chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default()).unwrap();
     assert_eq!(options.enable_thinking, Some(true));
-    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Hidden));
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Auto));
 }
 
 #[test]
@@ -528,7 +529,7 @@ fn chat_template_kwargs_enable_thinking_overrides_template() {
     let options =
         chat_template_options(&request, &EmbeddedOpenAiRequestDefaults::default()).unwrap();
     assert_eq!(options.enable_thinking, Some(false));
-    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Hidden));
+    assert_eq!(options.reasoning_format, Some(ChatReasoningFormat::Auto));
 }
 
 #[test]


### PR DESCRIPTION
## Problem

Thinking models can appear to return a blank response in Mesh. When `reasoning_format` is omitted, Mesh currently parses generated reasoning and then silently discards it. The model is producing tokens and the GPU is working, but clients receive no visible stream while the model is reasoning.

This differs from llama-server/LM Studio and from harness expectations, where the default is to pass model reasoning through.

## Fix

Default an omitted `reasoning_format` to `auto` instead of Mesh's `hidden` mode. Reasoning is now streamed to clients as `reasoning_content`, so the reproduced Qwen3.8 request no longer appears hung or empty.

Explicitly configured formats such as `hidden` and `none` keep their existing behavior. This does not change whether a model thinks; it fixes whether generated thinking is silently lost.

## Validation

- `cargo fmt --all --check`
- `cargo check -p skippy-server`
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `cargo test -p skippy-server --lib` (447 passed, 3 ignored)
