### PR TITLE
perf(skippy): coalesce native KV page transfers

### DIFF
--- a/third_party/llama.cpp/patches/0021-skippy-coalesce-native-KV-page-transfers.patch
+++ b/third_party/llama.cpp/patches/0021-skippy-coalesce-native-KV-page-transfers.patch
@@ -1,0 +1,142 @@
+From 7dd4eed6111f1d324b499d447ea899d57c167753 Mon Sep 17 00:00:00 2001
+From: Jimmy
+ <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a02b36a8@meshllm.communities.buzz.xyz>
+Date: Tue, 18 Aug 2026 16:15:48 +1000
+Subject: [PATCH] skippy: coalesce native KV page transfers
+
+Co-authored-by: Jimmy <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a02b36a8@meshllm.communities.buzz.xyz>
+Signed-off-by: Jimmy <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a02b36a8@meshllm.communities.buzz.xyz>
+---
+ src/llama-kv-cache.cpp | 68 +++++++++++++++++++++++++++++-------------
+ 1 file changed, 48 insertions(+), 20 deletions(-)
+
+diff --git a/src/llama-kv-cache.cpp b/src/llama-kv-cache.cpp
+index 9af3c442e..1d0e25cc1 100644
+--- a/src/llama-kv-cache.cpp
++++ b/src/llama-kv-cache.cpp
+@@ -1446,6 +1446,26 @@ const llama_kv_cells & llama_kv_cache::get_cells(llama_seq_id seq_id) const {
+     return v_cells[seq_to_stream[seq_id]];
+ }
+ 
++struct llama_kv_cache_cell_run {
++    uint32_t first;
++    uint32_t count;
++};
++
++static std::vector<llama_kv_cache_cell_run> llama_kv_cache_cell_runs(const std::vector<uint32_t> & cell_idxs) {
++    std::vector<llama_kv_cache_cell_run> runs;
++    runs.reserve(cell_idxs.size());
++
++    for (uint32_t cell_idx : cell_idxs) {
++        if (!runs.empty() && cell_idx == runs.back().first + runs.back().count) {
++            ++runs.back().count;
++        } else {
++            runs.push_back({ cell_idx, 1 });
++        }
++    }
++
++    return runs;
++}
++
+ bool llama_kv_cache::stage_export_kv_page(
+         llama_seq_id seq_id,
+         int32_t layer_start,
+@@ -1606,12 +1626,14 @@ bool llama_kv_cache::stage_export_kv_page(
+         return false;
+     }
+ 
++    const auto cell_runs = llama_kv_cache_cell_runs(cell_idxs);
+     char * dst = static_cast<char *>(output);
+     for (const auto * layer : selected) {
+         auto * k = layer->k_stream[strm];
+-        for (uint32_t cell_idx : cell_idxs) {
+-            ggml_backend_tensor_get(k, dst, static_cast<size_t>(cell_idx) * k_row_bytes, k_row_bytes);
+-            dst += k_row_bytes;
++        for (const auto & run : cell_runs) {
++            const size_t run_bytes = static_cast<size_t>(run.count) * k_row_bytes;
++            ggml_backend_tensor_get(k, dst, static_cast<size_t>(run.first) * k_row_bytes, run_bytes);
++            dst += run_bytes;
+         }
+     }
+ 
+@@ -1621,9 +1643,10 @@ bool llama_kv_cache::stage_export_kv_page(
+                 continue;
+             }
+             auto * v = layer->v_stream[strm];
+-            for (uint32_t cell_idx : cell_idxs) {
+-                ggml_backend_tensor_get(v, dst, static_cast<size_t>(cell_idx) * v_row_bytes, v_row_bytes);
+-                dst += v_row_bytes;
++            for (const auto & run : cell_runs) {
++                const size_t run_bytes = static_cast<size_t>(run.count) * v_row_bytes;
++                ggml_backend_tensor_get(v, dst, static_cast<size_t>(run.first) * v_row_bytes, run_bytes);
++                dst += run_bytes;
+             }
+         }
+     } else {
+@@ -1634,10 +1657,11 @@ bool llama_kv_cache::stage_export_kv_page(
+             auto * v = layer->v_stream[strm];
+             const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(layer->il);
+             for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
+-                for (uint32_t cell_idx : cell_idxs) {
+-                    const size_t src_offset = (static_cast<size_t>(cell_idx) + static_cast<size_t>(j) * cells.size()) * v_element_bytes;
+-                    ggml_backend_tensor_get(v, dst, src_offset, v_element_bytes);
+-                    dst += v_element_bytes;
++                for (const auto & run : cell_runs) {
++                    const size_t run_bytes = static_cast<size_t>(run.count) * v_element_bytes;
++                    const size_t src_offset = (static_cast<size_t>(run.first) + static_cast<size_t>(j) * cells.size()) * v_element_bytes;
++                    ggml_backend_tensor_get(v, dst, src_offset, run_bytes);
++                    dst += run_bytes;
+                 }
+             }
+         }
+@@ -1816,12 +1840,14 @@ bool llama_kv_cache::stage_import_kv_page(
+     }
+     apply_ubatch(sinfo, ubatch);
+ 
++    const auto cell_runs = llama_kv_cache_cell_runs(sinfo.idxs[0]);
+     const char * src = static_cast<const char *>(input);
+     for (const auto * layer : selected) {
+         auto * k = layer->k_stream[strm];
+-        for (uint32_t i = 0; i < n_tokens; ++i) {
+-            ggml_backend_tensor_set(k, src, static_cast<size_t>(sinfo.idxs[0][i]) * desc.k_row_bytes, desc.k_row_bytes);
+-            src += desc.k_row_bytes;
++        for (const auto & run : cell_runs) {
++            const size_t run_bytes = static_cast<size_t>(run.count) * desc.k_row_bytes;
++            ggml_backend_tensor_set(k, src, static_cast<size_t>(run.first) * desc.k_row_bytes, run_bytes);
++            src += run_bytes;
+         }
+     }
+ 
+@@ -1832,9 +1858,10 @@ bool llama_kv_cache::stage_import_kv_page(
+                 continue;
+             }
+             auto * v = layer->v_stream[strm];
+-            for (uint32_t i = 0; i < n_tokens; ++i) {
+-                ggml_backend_tensor_set(v, src, static_cast<size_t>(sinfo.idxs[0][i]) * desc.v_row_bytes, desc.v_row_bytes);
+-                src += desc.v_row_bytes;
++            for (const auto & run : cell_runs) {
++                const size_t run_bytes = static_cast<size_t>(run.count) * desc.v_row_bytes;
++                ggml_backend_tensor_set(v, src, static_cast<size_t>(run.first) * desc.v_row_bytes, run_bytes);
++                src += run_bytes;
+             }
+         }
+     } else {
+@@ -1845,10 +1872,11 @@ bool llama_kv_cache::stage_import_kv_page(
+             auto * v = layer->v_stream[strm];
+             const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(layer->il);
+             for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
+-                for (uint32_t i = 0; i < n_tokens; ++i) {
+-                    const size_t dst_offset = (static_cast<size_t>(sinfo.idxs[0][i]) + static_cast<size_t>(j) * cells.size()) * desc.v_element_bytes;
+-                    ggml_backend_tensor_set(v, src, dst_offset, desc.v_element_bytes);
+-                    src += desc.v_element_bytes;
++                for (const auto & run : cell_runs) {
++                    const size_t run_bytes = static_cast<size_t>(run.count) * desc.v_element_bytes;
++                    const size_t dst_offset = (static_cast<size_t>(run.first) + static_cast<size_t>(j) * cells.size()) * desc.v_element_bytes;
++                    ggml_backend_tensor_set(v, src, dst_offset, run_bytes);
++                    src += run_bytes;
+                 }
+             }
+         }
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
## Summary

- coalesce Skippy KV-page K and non-transposed-V copies over contiguous physical cache-cell runs
- coalesce transposed-V copies to one backend transfer per embedding row and contiguous run
- apply the same transfer layout to export and import without changing cache/session semantics or the Skippy ABI

## Why

The exact-state cache path issued one synchronous CUDA transfer per layer per token (and per V element when transposed). A 26k-token Qwen3.8 cache page therefore spent seconds in millions of tiny transfers despite moving only ~1.87 GB. This keeps exact-state correctness and bounded-memory behavior, but makes the existing primitive bulk-transfer efficiently for every caller.

## Validation

- clean patch replay from pinned llama.cpp upstream: patched SHA `1b009977ce399501346ae4bd9489e42f7d9977db` on CUDA; local replay produced the same queue shape before the CUDA run
- local Apple CPU build: `test-skippy-kv-page-export` passed
- CUDA 13 / RTX 5090 native runtime build for sm_120 succeeded
- live A/B with the same rc3 host, same Qwen3.8-27B UD-Q4_K_XL model, 131072 context, q8_0 K/V, flash attention, one lane, 26,352-token cold prompt + 12-word suffix + 5 output tokens:

| request | rc3 baseline | patched | speedup | cached tokens |
|---|---:|---:|---:|---:|
| cold 26,352-token prompt | 29.86 s | 13.31 s | 2.24x | 0 |
| growing turn (+12 words) | 17.89 s | 3.71 s | 4.82x | 26,112 |
| exact repeat | 8.09 s | 1.60 s | 5.04x | 26,363 |

Patched runtime evidence: llama patched SHA `1b009977ce399501346ae4bd9489e42f7d9977db`, `libllama.so` SHA-256 `e5472134442d88f1b87ce9312eea836cef650f0250b4e163b9fddbb2e83ffdc6`.

The benchmark intentionally leaves MTP disabled, matching the rc3 reproduction and isolating KV-page transfer behavior. The live CUDA box remains running; this PR did not stop or destroy any Vast instance.

## Follow-up

The existing native unit test is K-only and one token. Broader multi-token contiguous/fragmented and transposed-V round-trip coverage should follow; the live Qwen3.8 test exercises multi-token K/V with flash-attention's non-transposed V layout.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved KV cache transfer efficiency by combining contiguous data into larger operations.
  * Optimized both export and import workflows across supported cache layouts.
  * Preserved existing source and destination positioning during transfers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Apple Metal control

An isolated M5 Metal A/B used the same Qwen3.8-27B Q4_K_M model, 65,536 context, q8_0 K/V, flash attention, one lane, and MTP disabled. The order was baseline → patched → baseline → patched, with separate process state and runtime caches for every arm.

| request | baseline runs | patched runs | result |
|---|---:|---:|---:|
| cold, 21,571 prompt tokens | 52.43 / 53.19 s | 56.16 / 52.91 s | no effect separable from M5 drift |
| growing, 21,536 cached tokens | 1.545 / 1.523 s | 1.602 / 1.501 s | no effect larger than ~5% |
| exact repeat, 21,582 cached tokens | 0.657 / 0.655 s | 0.684 / 0.664 s | no effect larger than ~5% |

Both arms restored exactly the same token counts. With only two observations per cell and known M5 run-to-run drift, these data do not support a point estimate below ~5%; they do rule out a CUDA-sized gain.

The backend comparison explains the null result: Metal baseline exact-repeat was already **0.656 s for 21.5k tokens**, while the CUDA baseline was **8.09 s for 26.4k tokens** in this PR's matched rc3 A/B (and approximately 3.5 s in Nick's later 26.4k measurement). Metal unified memory was therefore not paying the synchronous device-transfer cost this patch removes; the relevant optimization headroom is a CUDA/backend-transfer property, not a universal cache-path cost.

Metal artifacts: baseline mesh `084105d14447351d4cefcf4fa9d0fe0427fc279a`, baseline `libllama.dylib` SHA-256 `b8b9f1ab9f66fd71b6113a0b1bffdcb6e9e10c5a0fea40f25f81e598f4a43e07`; patched mesh `6293ca3fa05665243c9772eb8eac886d2fc7fb92`, patched `libllama.dylib` SHA-256 `e424871f56e407a4dc3d27aed35c0f7c36e4bf9e08cad452dba29e1875a1d0b0`.
