### PR TITLE
fix(openai): restore authenticated observability custody

### DIFF
--- a/crates/mesh-llm-host-runtime/src/logging/openai_lifecycle.rs
+++ b/crates/mesh-llm-host-runtime/src/logging/openai_lifecycle.rs
@@ -409,6 +409,7 @@ struct ActiveRequest {
     /// embedded frontend still emits the legacy custody projection, but must
     /// not register or terminalize a second canonical request.
     guard: Option<LifecycleGuard>,
+    legacy: Arc<LegacyCustody>,
     started_at: Instant,
     operation: OpenAiBackendOperation,
     agent_session_id: Option<String>,
@@ -416,14 +417,128 @@ struct ActiveRequest {
     backend_operation: Option<OpenAiBackendOperation>,
     backend_attempt: Option<(OpenAiBackendOperation, AttemptId)>,
     backend_stream_first_item: bool,
-    legacy_started: bool,
     usage: Option<OpenAiUsage>,
+}
+
+type LegacyAction = Box<dyn FnOnce() + Send + 'static>;
+
+#[derive(Default)]
+struct LegacyCustody {
+    state: Mutex<LegacyCustodyState>,
+}
+
+#[derive(Default)]
+struct LegacyCustodyState {
+    actions: VecDeque<LegacyAction>,
+    draining: bool,
+    started: bool,
+    terminalized: bool,
+}
+
+impl LegacyCustody {
+    /// Queue the two events that establish legacy custody as one atomic
+    /// per-request action sequence. The caller may hold the adapter's map
+    /// mutex while this method queues; logging itself is always drained after
+    /// that lock is released.
+    fn start(
+        &self,
+        request_id: RequestId,
+        operation: OpenAiBackendOperation,
+        agent_session_id: Option<String>,
+        agent_session_source: Option<String>,
+    ) -> bool {
+        let backend_session_id = agent_session_id.clone();
+        let backend_session_source = agent_session_source.clone();
+        self.start_with(
+            Box::new(move || {
+                log_legacy_request_started(
+                    request_id,
+                    operation,
+                    agent_session_id.as_deref(),
+                    agent_session_source.as_deref(),
+                );
+            }),
+            Box::new(move || {
+                log_legacy_backend_started(
+                    request_id,
+                    operation,
+                    backend_session_id.as_deref(),
+                    backend_session_source.as_deref(),
+                );
+            }),
+        )
+    }
+
+    fn start_with(&self, request_started: LegacyAction, backend_started: LegacyAction) -> bool {
+        let mut state = lock_recover(&self.state);
+        if state.started || state.terminalized {
+            return false;
+        }
+        state.started = true;
+        state.actions.push_back(request_started);
+        state.actions.push_back(backend_started);
+        Self::begin_draining(&mut state)
+    }
+
+    fn enqueue<F>(&self, action: F) -> bool
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let mut state = lock_recover(&self.state);
+        if state.terminalized {
+            return false;
+        }
+        state.actions.push_back(Box::new(action));
+        Self::begin_draining(&mut state)
+    }
+
+    fn finish<F>(&self, action: F) -> bool
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        let mut state = lock_recover(&self.state);
+        if state.terminalized {
+            return false;
+        }
+        state.terminalized = true;
+        if !state.started {
+            return false;
+        }
+        state.actions.push_back(Box::new(action));
+        Self::begin_draining(&mut state)
+    }
+
+    fn begin_draining(state: &mut LegacyCustodyState) -> bool {
+        if state.draining {
+            false
+        } else {
+            state.draining = true;
+            true
+        }
+    }
+
+    fn drain(&self) {
+        loop {
+            let action = {
+                let mut state = lock_recover(&self.state);
+                match state.actions.pop_front() {
+                    Some(action) => action,
+                    None => {
+                        state.draining = false;
+                        return;
+                    }
+                }
+            };
+            action();
+        }
+    }
 }
 
 impl ActiveRequest {
     fn new(guard: Option<LifecycleGuard>, context: &OpenAiLifecycleContext) -> Self {
         Self {
             guard,
+            legacy: Arc::new(LegacyCustody::default()),
             started_at: Instant::now(),
             operation: route_operation(context.route),
             agent_session_id: context.agent_session_id.clone(),
@@ -431,7 +546,6 @@ impl ActiveRequest {
             backend_operation: None,
             backend_attempt: None,
             backend_stream_first_item: false,
-            legacy_started: false,
             usage: None,
         }
     }
@@ -524,7 +638,7 @@ impl OpenAiLifecycleLoggingAdapter {
             self.service.start_attempt(request_id, guard)
         });
 
-        let legacy_start = {
+        let legacy_drain = {
             let mut tracked = lock_recover(&self.tracked);
             let Some(TrackedRequest::Active(active)) = tracked.requests.get_mut(&request_id) else {
                 return;
@@ -535,40 +649,18 @@ impl OpenAiLifecycleLoggingAdapter {
             active.operation = operation;
             active.backend_operation = Some(operation);
             active.backend_attempt = attempt_id.map(|attempt_id| (operation, attempt_id));
-            if active.legacy_started {
-                None
-            } else {
-                active.legacy_started = true;
-                Some((
-                    active.agent_session_id.clone(),
-                    active.agent_session_source.clone(),
-                ))
-            }
-        };
-        if let Some((agent_session_id, agent_session_source)) = legacy_start {
-            log_legacy_request_started(
+            let legacy = Arc::clone(&active.legacy);
+            let should_drain = legacy.start(
                 request_id,
                 operation,
-                agent_session_id.as_deref(),
-                agent_session_source.as_deref(),
-            );
-        }
-        let session = {
-            let tracked = lock_recover(&self.tracked);
-            let Some(TrackedRequest::Active(active)) = tracked.requests.get(&request_id) else {
-                return;
-            };
-            (
                 active.agent_session_id.clone(),
                 active.agent_session_source.clone(),
-            )
+            );
+            (legacy, should_drain)
         };
-        log_legacy_backend_started(
-            request_id,
-            operation,
-            session.0.as_deref(),
-            session.1.as_deref(),
-        );
+        if legacy_drain.1 {
+            legacy_drain.0.drain();
+        }
     }
 
     fn backend_terminal(
@@ -585,17 +677,56 @@ impl OpenAiLifecycleLoggingAdapter {
             if active.backend_operation == Some(operation) {
                 active.backend_operation = None;
                 let backend_attempt = active.backend_attempt.take();
+                let elapsed = active.started_at.elapsed();
+                let agent_session_id = active.agent_session_id.clone();
+                let agent_session_source = active.agent_session_source.clone();
+                let legacy = Arc::clone(&active.legacy);
+                let should_drain = match result {
+                    OpenAiTerminalResult::Completed { .. }
+                    | OpenAiTerminalResult::CompletedWithUsage { .. } => {
+                        legacy.enqueue(move || {
+                            log_legacy_backend_returned(
+                                request_id,
+                                operation,
+                                elapsed,
+                                agent_session_id.as_deref(),
+                                agent_session_source.as_deref(),
+                            );
+                        })
+                    }
+                    OpenAiTerminalResult::Failed { failure, .. }
+                        if failure == OpenAiFailure::Timeout =>
+                    {
+                        legacy.enqueue(move || {
+                            log_legacy_backend_timeout(
+                                request_id,
+                                operation,
+                                elapsed,
+                                agent_session_id.as_deref(),
+                                agent_session_source.as_deref(),
+                            );
+                        })
+                    }
+                    OpenAiTerminalResult::Failed { .. } => legacy.enqueue(move || {
+                        log_legacy_backend_error(
+                            request_id,
+                            operation,
+                            elapsed,
+                            agent_session_id.as_deref(),
+                            agent_session_source.as_deref(),
+                        );
+                    }),
+                };
                 Some((
                     backend_attempt.map(|(_, attempt_id)| attempt_id),
-                    active.started_at.elapsed(),
-                    active.agent_session_id.clone(),
-                    active.agent_session_source.clone(),
+                    legacy,
+                    should_drain,
                 ))
             } else {
                 None
             }
         };
-        let Some((attempt_id, elapsed, agent_session_id, agent_session_source)) = attempt else {
+        let Some((attempt_id, legacy, should_drain)) = attempt else {
             return;
         };
         match result {
@@ -605,13 +736,6 @@ impl OpenAiLifecycleLoggingAdapter {
                     self.service
                         .complete_attempt(request_id, attempt_id, Some(status_code));
                 }
-                log_legacy_backend_returned(
-                    request_id,
-                    operation,
-                    elapsed,
-                    agent_session_id.as_deref(),
-                    agent_session_source.as_deref(),
-                );
             }
             OpenAiTerminalResult::Failed { failure, .. } => {
                 if let Some(attempt_id) = attempt_id {
@@ -621,24 +745,10 @@ impl OpenAiLifecycleLoggingAdapter {
                         failure_label(failure).to_owned(),
                     );
                 }
-                if failure == OpenAiFailure::Timeout {
-                    log_legacy_backend_timeout(
-                        request_id,
-                        operation,
-                        elapsed,
-                        agent_session_id.as_deref(),
-                        agent_session_source.as_deref(),
-                    );
-                } else {
-                    log_legacy_backend_error(
-                        request_id,
-                        operation,
-                        elapsed,
-                        agent_session_id.as_deref(),
-                        agent_session_source.as_deref(),
-                    );
-                }
             }
+        }
+        if should_drain {
+            legacy.drain();
         }
     }
 
@@ -652,25 +762,29 @@ impl OpenAiLifecycleLoggingAdapter {
                 None
             } else {
                 active.backend_stream_first_item = true;
-                Some((
-                    active.guard.is_some(),
-                    active.started_at.elapsed(),
-                    active.agent_session_id.clone(),
-                    active.agent_session_source.clone(),
-                ))
+                let elapsed = active.started_at.elapsed();
+                let agent_session_id = active.agent_session_id.clone();
+                let agent_session_source = active.agent_session_source.clone();
+                let legacy = Arc::clone(&active.legacy);
+                let should_drain = legacy.enqueue(move || {
+                    log_legacy_stream_first_item(
+                        request_id,
+                        operation,
+                        elapsed,
+                        agent_session_id.as_deref(),
+                        agent_session_source.as_deref(),
+                    );
+                });
+                Some((active.guard.is_some(), legacy, should_drain))
             }
         };
-        if let Some((canonical, elapsed, agent_session_id, agent_session_source)) = first_item {
+        if let Some((canonical, legacy, should_drain)) = first_item {
             if canonical {
                 self.enqueue_operation_event(request_id, LifecycleEvent::BackendStreamFirstItem);
             }
-            log_legacy_stream_first_item(
-                request_id,
-                operation,
-                elapsed,
-                agent_session_id.as_deref(),
-                agent_session_source.as_deref(),
-            );
+            if should_drain {
+                legacy.drain();
+            }
         }
     }
 
@@ -684,22 +798,25 @@ impl OpenAiLifecycleLoggingAdapter {
                 None
             } else {
                 active.usage = Some(usage);
-                Some((
-                    active.started_at.elapsed(),
-                    active.operation,
-                    active.agent_session_id.clone(),
-                    active.agent_session_source.clone(),
-                ))
+                let elapsed = active.started_at.elapsed();
+                let operation = active.operation;
+                let agent_session_id = active.agent_session_id.clone();
+                let agent_session_source = active.agent_session_source.clone();
+                let legacy = Arc::clone(&active.legacy);
+                let should_drain = legacy.enqueue(move || {
+                    log_legacy_response_completed(
+                        request_id,
+                        operation,
+                        elapsed,
+                        usage,
+                        agent_session_id.as_deref(),
+                        agent_session_source.as_deref(),
+                    );
+                });
+                Some((active.guard.is_some(), legacy, should_drain))
             }
         };
-        if let Some((elapsed, operation, agent_session_id, agent_session_source)) = metadata {
-            let canonical = {
-                let tracked = lock_recover(&self.tracked);
-                matches!(
-                    tracked.requests.get(&request_id),
-                    Some(TrackedRequest::Active(active)) if active.guard.is_some()
-                )
-            };
+        if let Some((canonical, legacy, should_drain)) = metadata {
             if canonical {
                 self.enqueue_operation_event(
                     request_id,
@@ -711,31 +828,41 @@ impl OpenAiLifecycleLoggingAdapter {
                     },
                 );
             }
-            log_legacy_response_completed(
-                request_id,
-                operation,
-                elapsed,
-                usage,
-                agent_session_id.as_deref(),
-                agent_session_source.as_deref(),
-            );
+            if should_drain {
+                legacy.drain();
+            }
         }
     }
 
     fn stream_terminal(&self, request_id: RequestId, result: OpenAiTerminalResult) {
-        let (usage, canonical, operation, elapsed, agent_session_id, agent_session_source) = {
+        let (usage, canonical, legacy, should_drain) = {
             let tracked = lock_recover(&self.tracked);
             let Some(TrackedRequest::Active(active)) = tracked.requests.get(&request_id) else {
                 return;
             };
-            (
-                active.usage,
-                active.guard.is_some(),
-                active.operation,
-                active.started_at.elapsed(),
-                active.agent_session_id.clone(),
-                active.agent_session_source.clone(),
-            )
+            let usage = active.usage;
+            let canonical = active.guard.is_some();
+            let legacy = Arc::clone(&active.legacy);
+            let should_drain = match result {
+                OpenAiTerminalResult::Failed { .. } => {
+                    let elapsed = active.started_at.elapsed();
+                    let operation = active.operation;
+                    let agent_session_id = active.agent_session_id.clone();
+                    let agent_session_source = active.agent_session_source.clone();
+                    legacy.enqueue(move || {
+                        log_legacy_stream_item_error(
+                            request_id,
+                            operation,
+                            elapsed,
+                            agent_session_id.as_deref(),
+                            agent_session_source.as_deref(),
+                        );
+                    })
+                }
+                OpenAiTerminalResult::Completed { .. }
+                | OpenAiTerminalResult::CompletedWithUsage { .. } => false,
+            };
+            (usage, canonical, legacy, should_drain)
         };
         match result {
             OpenAiTerminalResult::Completed { .. } => {
@@ -776,14 +903,10 @@ impl OpenAiLifecycleLoggingAdapter {
                         },
                     );
                 }
-                log_legacy_stream_item_error(
-                    request_id,
-                    operation,
-                    elapsed,
-                    agent_session_id.as_deref(),
-                    agent_session_source.as_deref(),
-                );
             }
+        }
+        if should_drain {
+            legacy.drain();
         }
     }
 
@@ -793,13 +916,21 @@ impl OpenAiLifecycleLoggingAdapter {
             let Some(TrackedRequest::Active(active)) = tracked.requests.get(&request_id) else {
                 return;
             };
-            (
-                active.guard.is_some(),
-                active.operation,
-                active.started_at.elapsed(),
-                active.agent_session_id.clone(),
-                active.agent_session_source.clone(),
-            )
+            let legacy = Arc::clone(&active.legacy);
+            let operation = active.operation;
+            let elapsed = active.started_at.elapsed();
+            let agent_session_id = active.agent_session_id.clone();
+            let agent_session_source = active.agent_session_source.clone();
+            let should_drain = legacy.enqueue(move || {
+                log_legacy_stream_item_error(
+                    request_id,
+                    operation,
+                    elapsed,
+                    agent_session_id.as_deref(),
+                    agent_session_source.as_deref(),
+                );
+            });
+            (active.guard.is_some(), legacy, should_drain)
         };
         if metadata.0 {
             self.enqueue_operation_event(
@@ -809,13 +940,9 @@ impl OpenAiLifecycleLoggingAdapter {
                 },
             );
         }
-        log_legacy_stream_item_error(
-            request_id,
-            metadata.1,
-            metadata.2,
-            metadata.3.as_deref(),
-            metadata.4.as_deref(),
-        );
+        if metadata.2 {
+            metadata.1.drain();
+        }
     }
 
     fn enqueue_operation_event(&self, request_id: RequestId, event: LifecycleEvent) {
@@ -827,7 +954,7 @@ impl OpenAiLifecycleLoggingAdapter {
     }
 
     fn terminal(&self, request_id: RequestId, outcome: TerminalOutcome) {
-        let (guard, elapsed, operation, legacy_started, agent_session_id, agent_session_source) = {
+        let (guard, legacy, should_drain) = {
             let mut tracked = lock_recover(&self.tracked);
             let Some(entry) = tracked.requests.get_mut(&request_id) else {
                 return;
@@ -836,28 +963,28 @@ impl OpenAiLifecycleLoggingAdapter {
                 return;
             };
             let guard = active.guard.clone();
-            let metadata = (
-                active.started_at.elapsed(),
-                active.operation,
-                active.legacy_started,
-                active.agent_session_id.clone(),
-                active.agent_session_source.clone(),
-            );
+            let elapsed = active.started_at.elapsed();
+            let operation = active.operation;
+            let agent_session_id = active.agent_session_id.clone();
+            let agent_session_source = active.agent_session_source.clone();
+            let legacy = Arc::clone(&active.legacy);
+            let outcome_label = legacy_outcome(&outcome);
+            let should_drain = legacy.finish(move || {
+                log_legacy_request_finished(
+                    request_id,
+                    operation,
+                    elapsed,
+                    outcome_label,
+                    agent_session_id.as_deref(),
+                    agent_session_source.as_deref(),
+                );
+            });
             *entry = TrackedRequest::Terminal;
-            (
-                guard, metadata.0, metadata.1, metadata.2, metadata.3, metadata.4,
-            )
+            (guard, legacy, should_drain)
         };
 
-        if legacy_started {
-            log_legacy_request_finished(
-                request_id,
-                operation,
-                elapsed,
-                legacy_outcome(&outcome),
-                agent_session_id.as_deref(),
-                agent_session_source.as_deref(),
-            );
+        if should_drain {
+            legacy.drain();
         }
 
         // A stale or externally-terminalized guard is harmless: request
@@ -1483,6 +1610,81 @@ mod tests {
             Arc::new(RawMeshLifecycleOwners::default()),
         );
         (service, adapter)
+    }
+
+    #[test]
+    fn legacy_custody_serializes_dispatch_and_terminal_race() {
+        use std::thread;
+
+        let custody = Arc::new(LegacyCustody::default());
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let gate = Arc::new(std::sync::Barrier::new(2));
+        let first_gate = Arc::clone(&gate);
+        let first_order = Arc::clone(&order);
+        assert!(custody.start_with(
+            Box::new(move || {
+                first_order.lock().unwrap().push("request_started");
+                first_gate.wait();
+            }),
+            Box::new({
+                let order = Arc::clone(&order);
+                move || order.lock().unwrap().push("backend_started")
+            }),
+        ));
+
+        let drain_custody = Arc::clone(&custody);
+        let drain_thread = thread::spawn(move || drain_custody.drain());
+        gate.wait();
+
+        let finish_order = Arc::clone(&order);
+        assert!(!custody.finish(move || { finish_order.lock().unwrap().push("request_finished") }));
+        drain_thread.join().unwrap();
+        assert_eq!(
+            *order.lock().unwrap(),
+            vec!["request_started", "backend_started", "request_finished"]
+        );
+    }
+
+    #[test]
+    fn legacy_custody_serializes_response_and_terminal_race() {
+        use std::thread;
+
+        let custody = Arc::new(LegacyCustody::default());
+        let order = Arc::new(Mutex::new(Vec::new()));
+        let gate = Arc::new(std::sync::Barrier::new(2));
+        let first_gate = Arc::clone(&gate);
+        let first_order = Arc::clone(&order);
+        assert!(custody.start_with(
+            Box::new(move || {
+                first_order.lock().unwrap().push("request_started");
+                first_gate.wait();
+            }),
+            Box::new({
+                let order = Arc::clone(&order);
+                move || order.lock().unwrap().push("backend_started")
+            }),
+        ));
+
+        let drain_custody = Arc::clone(&custody);
+        let drain_thread = thread::spawn(move || drain_custody.drain());
+        gate.wait();
+
+        let response_order = Arc::clone(&order);
+        assert!(
+            !custody.enqueue(move || { response_order.lock().unwrap().push("response_completed") })
+        );
+        let finish_order = Arc::clone(&order);
+        assert!(!custody.finish(move || { finish_order.lock().unwrap().push("request_finished") }));
+        drain_thread.join().unwrap();
+        assert_eq!(
+            *order.lock().unwrap(),
+            vec![
+                "request_started",
+                "backend_started",
+                "response_completed",
+                "request_finished"
+            ]
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/logging/openai_lifecycle.rs
+++ b/crates/mesh-llm-host-runtime/src/logging/openai_lifecycle.rs
@@ -399,31 +399,39 @@ struct TrackedRequests {
 }
 
 enum TrackedRequest {
+    Admitting,
     Active(ActiveRequest),
     Terminal,
 }
 
 struct ActiveRequest {
-    guard: LifecycleGuard,
+    /// `None` means raw Mesh ingress owns canonical lifecycle state. The
+    /// embedded frontend still emits the legacy custody projection, but must
+    /// not register or terminalize a second canonical request.
+    guard: Option<LifecycleGuard>,
     started_at: Instant,
     operation: OpenAiBackendOperation,
     agent_session_id: Option<String>,
     agent_session_source: Option<String>,
+    backend_operation: Option<OpenAiBackendOperation>,
     backend_attempt: Option<(OpenAiBackendOperation, AttemptId)>,
     backend_stream_first_item: bool,
+    legacy_started: bool,
     usage: Option<OpenAiUsage>,
 }
 
 impl ActiveRequest {
-    fn new(guard: LifecycleGuard, context: &OpenAiLifecycleContext) -> Self {
+    fn new(guard: Option<LifecycleGuard>, context: &OpenAiLifecycleContext) -> Self {
         Self {
             guard,
             started_at: Instant::now(),
             operation: route_operation(context.route),
             agent_session_id: context.agent_session_id.clone(),
             agent_session_source: context.agent_session_source.clone(),
+            backend_operation: None,
             backend_attempt: None,
             backend_stream_first_item: false,
+            legacy_started: false,
             usage: None,
         }
     }
@@ -443,27 +451,48 @@ impl OpenAiLifecycleLoggingAdapter {
 
     fn admit(&self, context: &OpenAiLifecycleContext) {
         let request_id = context.request_id;
-        // A raw mesh ingress request owns its lifecycle before it reaches an
-        // embedded frontend. Direct frontend loopback traffic never claims this
-        // registry and remains owned by this adapter.
-        if self.raw_mesh_owners.is_claimed(request_id) {
-            return;
-        }
-        let mut tracked = lock_recover(&self.tracked);
-        if tracked.requests.contains_key(&request_id) || !tracked.make_room() {
-            return;
+        // Both local raw ownership and remote-tunnel suppression mean that a
+        // canonical parent already exists elsewhere. Retain a legacy-only
+        // record here so the target's authenticated frontend events remain
+        // observable without creating a second canonical lifecycle.
+        let raw_mesh_owned = self.raw_mesh_owners.is_claimed(request_id);
+
+        // Reserve the request under the small state mutex, then perform
+        // service registration outside it. This prevents persistence and
+        // tracing work from blocking every other OpenAI request.
+        {
+            let mut tracked = lock_recover(&self.tracked);
+            if tracked.requests.contains_key(&request_id) || !tracked.make_room() {
+                return;
+            }
+            tracked
+                .requests
+                .insert(request_id, TrackedRequest::Admitting);
+            tracked.insertion_order.push_back(request_id);
         }
 
-        let (guard, _) = self.service.register_request_with_metadata(
-            request_id,
-            RequestSummaryMetadata::from_openai_frontend_route(context.route),
-        );
-        tracked.requests.insert(
-            request_id,
-            TrackedRequest::Active(ActiveRequest::new(guard, context)),
-        );
-        tracked.insertion_order.push_back(request_id);
-        log_legacy_request_started(context, route_operation(context.route));
+        let guard = if raw_mesh_owned {
+            None
+        } else {
+            Some(
+                self.service
+                    .register_request_with_metadata(
+                        request_id,
+                        RequestSummaryMetadata::from_openai_frontend_route(context.route),
+                    )
+                    .0,
+            )
+        };
+        let active = ActiveRequest::new(guard, context);
+
+        let mut tracked = lock_recover(&self.tracked);
+        let Some(entry) = tracked.requests.get_mut(&request_id) else {
+            return;
+        };
+        if !matches!(entry, TrackedRequest::Admitting) {
+            return;
+        }
+        *entry = TrackedRequest::Active(active);
     }
 
     fn backend_dispatched(&self, request_id: RequestId, operation: OpenAiBackendOperation) {
@@ -481,21 +510,65 @@ impl OpenAiLifecycleLoggingAdapter {
             Some("openai_frontend"),
             Some(operation_label(operation)),
         );
-        self.service
-            .merge_request_metadata(request_id, metadata.clone());
-        let event = LifecycleEvent::RouteSelected {
-            model: None,
-            provider: metadata.provider().map(str::to_owned),
-            engine: metadata.engine().map(str::to_owned),
-        };
-        self.enqueue_operation_event(request_id, event);
-        let attempt_id = self.service.start_attempt(request_id, &guard);
-        let mut tracked = lock_recover(&self.tracked);
-        if let Some(TrackedRequest::Active(active)) = tracked.requests.get_mut(&request_id) {
+        let attempt_id = guard.as_ref().map(|guard| {
+            self.service
+                .merge_request_metadata(request_id, metadata.clone());
+            self.enqueue_operation_event(
+                request_id,
+                LifecycleEvent::RouteSelected {
+                    model: None,
+                    provider: metadata.provider().map(str::to_owned),
+                    engine: metadata.engine().map(str::to_owned),
+                },
+            );
+            self.service.start_attempt(request_id, guard)
+        });
+
+        let legacy_start = {
+            let mut tracked = lock_recover(&self.tracked);
+            let Some(TrackedRequest::Active(active)) = tracked.requests.get_mut(&request_id) else {
+                return;
+            };
+            if active.backend_operation.is_some() {
+                return;
+            }
             active.operation = operation;
-            active.backend_attempt = Some((operation, attempt_id));
-            log_legacy_backend_started(request_id, operation, active);
+            active.backend_operation = Some(operation);
+            active.backend_attempt = attempt_id.map(|attempt_id| (operation, attempt_id));
+            if active.legacy_started {
+                None
+            } else {
+                active.legacy_started = true;
+                Some((
+                    active.agent_session_id.clone(),
+                    active.agent_session_source.clone(),
+                ))
+            }
+        };
+        if let Some((agent_session_id, agent_session_source)) = legacy_start {
+            log_legacy_request_started(
+                request_id,
+                operation,
+                agent_session_id.as_deref(),
+                agent_session_source.as_deref(),
+            );
         }
+        let session = {
+            let tracked = lock_recover(&self.tracked);
+            let Some(TrackedRequest::Active(active)) = tracked.requests.get(&request_id) else {
+                return;
+            };
+            (
+                active.agent_session_id.clone(),
+                active.agent_session_source.clone(),
+            )
+        };
+        log_legacy_backend_started(
+            request_id,
+            operation,
+            session.0.as_deref(),
+            session.1.as_deref(),
+        );
     }
 
     fn backend_terminal(
@@ -509,17 +582,17 @@ impl OpenAiLifecycleLoggingAdapter {
             let Some(TrackedRequest::Active(active)) = tracked.requests.get_mut(&request_id) else {
                 return;
             };
-            match active.backend_attempt {
-                Some((attempt_operation, attempt_id)) if attempt_operation == operation => {
-                    active.backend_attempt = None;
-                    Some((
-                        attempt_id,
-                        active.started_at.elapsed(),
-                        active.agent_session_id.clone(),
-                        active.agent_session_source.clone(),
-                    ))
-                }
-                _ => None,
+            if active.backend_operation == Some(operation) {
+                active.backend_operation = None;
+                let backend_attempt = active.backend_attempt.take();
+                Some((
+                    backend_attempt.map(|(_, attempt_id)| attempt_id),
+                    active.started_at.elapsed(),
+                    active.agent_session_id.clone(),
+                    active.agent_session_source.clone(),
+                ))
+            } else {
+                None
             }
         };
         let Some((attempt_id, elapsed, agent_session_id, agent_session_source)) = attempt else {
@@ -528,8 +601,10 @@ impl OpenAiLifecycleLoggingAdapter {
         match result {
             OpenAiTerminalResult::Completed { status_code }
             | OpenAiTerminalResult::CompletedWithUsage { status_code, .. } => {
-                self.service
-                    .complete_attempt(request_id, attempt_id, Some(status_code));
+                if let Some(attempt_id) = attempt_id {
+                    self.service
+                        .complete_attempt(request_id, attempt_id, Some(status_code));
+                }
                 log_legacy_backend_returned(
                     request_id,
                     operation,
@@ -539,18 +614,30 @@ impl OpenAiLifecycleLoggingAdapter {
                 );
             }
             OpenAiTerminalResult::Failed { failure, .. } => {
-                self.service.fail_attempt(
-                    request_id,
-                    attempt_id,
-                    failure_label(failure).to_owned(),
-                );
-                log_legacy_backend_error(
-                    request_id,
-                    operation,
-                    elapsed,
-                    agent_session_id.as_deref(),
-                    agent_session_source.as_deref(),
-                );
+                if let Some(attempt_id) = attempt_id {
+                    self.service.fail_attempt(
+                        request_id,
+                        attempt_id,
+                        failure_label(failure).to_owned(),
+                    );
+                }
+                if failure == OpenAiFailure::Timeout {
+                    log_legacy_backend_timeout(
+                        request_id,
+                        operation,
+                        elapsed,
+                        agent_session_id.as_deref(),
+                        agent_session_source.as_deref(),
+                    );
+                } else {
+                    log_legacy_backend_error(
+                        request_id,
+                        operation,
+                        elapsed,
+                        agent_session_id.as_deref(),
+                        agent_session_source.as_deref(),
+                    );
+                }
             }
         }
     }
@@ -566,14 +653,17 @@ impl OpenAiLifecycleLoggingAdapter {
             } else {
                 active.backend_stream_first_item = true;
                 Some((
+                    active.guard.is_some(),
                     active.started_at.elapsed(),
                     active.agent_session_id.clone(),
                     active.agent_session_source.clone(),
                 ))
             }
         };
-        if let Some((elapsed, agent_session_id, agent_session_source)) = first_item {
-            self.enqueue_operation_event(request_id, LifecycleEvent::BackendStreamFirstItem);
+        if let Some((canonical, elapsed, agent_session_id, agent_session_source)) = first_item {
+            if canonical {
+                self.enqueue_operation_event(request_id, LifecycleEvent::BackendStreamFirstItem);
+            }
             log_legacy_stream_first_item(
                 request_id,
                 operation,
@@ -603,15 +693,24 @@ impl OpenAiLifecycleLoggingAdapter {
             }
         };
         if let Some((elapsed, operation, agent_session_id, agent_session_source)) = metadata {
-            self.enqueue_operation_event(
-                request_id,
-                LifecycleEvent::UsageRecorded {
-                    prompt_tokens: Some(u64::from(usage.prompt_tokens)),
-                    cached_prompt_tokens: Some(u64::from(usage.cached_tokens)),
-                    completion_tokens: Some(u64::from(usage.completion_tokens)),
-                    total_tokens: Some(u64::from(usage.total_tokens)),
-                },
-            );
+            let canonical = {
+                let tracked = lock_recover(&self.tracked);
+                matches!(
+                    tracked.requests.get(&request_id),
+                    Some(TrackedRequest::Active(active)) if active.guard.is_some()
+                )
+            };
+            if canonical {
+                self.enqueue_operation_event(
+                    request_id,
+                    LifecycleEvent::UsageRecorded {
+                        prompt_tokens: Some(u64::from(usage.prompt_tokens)),
+                        cached_prompt_tokens: Some(u64::from(usage.cached_tokens)),
+                        completion_tokens: Some(u64::from(usage.completion_tokens)),
+                        total_tokens: Some(u64::from(usage.total_tokens)),
+                    },
+                );
+            }
             log_legacy_response_completed(
                 request_id,
                 operation,
@@ -624,12 +723,19 @@ impl OpenAiLifecycleLoggingAdapter {
     }
 
     fn stream_terminal(&self, request_id: RequestId, result: OpenAiTerminalResult) {
-        let usage = {
+        let (usage, canonical, operation, elapsed, agent_session_id, agent_session_source) = {
             let tracked = lock_recover(&self.tracked);
             let Some(TrackedRequest::Active(active)) = tracked.requests.get(&request_id) else {
                 return;
             };
-            active.usage
+            (
+                active.usage,
+                active.guard.is_some(),
+                active.operation,
+                active.started_at.elapsed(),
+                active.agent_session_id.clone(),
+                active.agent_session_source.clone(),
+            )
         };
         match result {
             OpenAiTerminalResult::Completed { .. } => {
@@ -640,36 +746,62 @@ impl OpenAiLifecycleLoggingAdapter {
                         Some(u64::from(value.total_tokens)),
                     )
                 });
-                self.enqueue_operation_event(
-                    request_id,
-                    LifecycleEvent::StreamCompleted {
-                        tokens: usage.map(|value| u64::from(value.completion_tokens)),
-                        usage: terminal_usage,
-                    },
-                );
+                if canonical {
+                    self.enqueue_operation_event(
+                        request_id,
+                        LifecycleEvent::StreamCompleted {
+                            tokens: usage.map(|value| u64::from(value.completion_tokens)),
+                            usage: terminal_usage,
+                        },
+                    );
+                }
             }
             OpenAiTerminalResult::CompletedWithUsage { usage, .. } => {
-                self.enqueue_operation_event(
-                    request_id,
-                    LifecycleEvent::StreamCompleted {
-                        tokens: usage.completion_tokens,
-                        usage: Some(usage),
-                    },
-                );
+                if canonical {
+                    self.enqueue_operation_event(
+                        request_id,
+                        LifecycleEvent::StreamCompleted {
+                            tokens: usage.completion_tokens,
+                            usage: Some(usage),
+                        },
+                    );
+                }
             }
             OpenAiTerminalResult::Failed { failure, .. } => {
-                self.enqueue_operation_event(
+                if canonical {
+                    self.enqueue_operation_event(
+                        request_id,
+                        LifecycleEvent::StreamError {
+                            error: Some(failure_label(failure).to_owned()),
+                        },
+                    );
+                }
+                log_legacy_stream_item_error(
                     request_id,
-                    LifecycleEvent::StreamError {
-                        error: Some(failure_label(failure).to_owned()),
-                    },
+                    operation,
+                    elapsed,
+                    agent_session_id.as_deref(),
+                    agent_session_source.as_deref(),
                 );
             }
         }
     }
 
     fn stream_interrupted(&self, request_id: RequestId, label: &'static str) {
-        if lock_recover(&self.tracked).is_active(request_id) {
+        let metadata = {
+            let tracked = lock_recover(&self.tracked);
+            let Some(TrackedRequest::Active(active)) = tracked.requests.get(&request_id) else {
+                return;
+            };
+            (
+                active.guard.is_some(),
+                active.operation,
+                active.started_at.elapsed(),
+                active.agent_session_id.clone(),
+                active.agent_session_source.clone(),
+            )
+        };
+        if metadata.0 {
             self.enqueue_operation_event(
                 request_id,
                 LifecycleEvent::StreamError {
@@ -677,6 +809,13 @@ impl OpenAiLifecycleLoggingAdapter {
                 },
             );
         }
+        log_legacy_stream_item_error(
+            request_id,
+            metadata.1,
+            metadata.2,
+            metadata.3.as_deref(),
+            metadata.4.as_deref(),
+        );
     }
 
     fn enqueue_operation_event(&self, request_id: RequestId, event: LifecycleEvent) {
@@ -688,7 +827,7 @@ impl OpenAiLifecycleLoggingAdapter {
     }
 
     fn terminal(&self, request_id: RequestId, outcome: TerminalOutcome) {
-        let (guard, elapsed, operation, agent_session_id, agent_session_source) = {
+        let (guard, elapsed, operation, legacy_started, agent_session_id, agent_session_source) = {
             let mut tracked = lock_recover(&self.tracked);
             let Some(entry) = tracked.requests.get_mut(&request_id) else {
                 return;
@@ -700,27 +839,32 @@ impl OpenAiLifecycleLoggingAdapter {
             let metadata = (
                 active.started_at.elapsed(),
                 active.operation,
+                active.legacy_started,
                 active.agent_session_id.clone(),
                 active.agent_session_source.clone(),
             );
             *entry = TrackedRequest::Terminal;
-            (guard, metadata.0, metadata.1, metadata.2, metadata.3)
+            (
+                guard, metadata.0, metadata.1, metadata.2, metadata.3, metadata.4,
+            )
         };
 
-        log_legacy_request_finished(
-            request_id,
-            operation,
-            elapsed,
-            legacy_outcome(&outcome),
-            agent_session_id.as_deref(),
-            agent_session_source.as_deref(),
-        );
+        if legacy_started {
+            log_legacy_request_finished(
+                request_id,
+                operation,
+                elapsed,
+                legacy_outcome(&outcome),
+                agent_session_id.as_deref(),
+                agent_session_source.as_deref(),
+            );
+        }
 
         // A stale or externally-terminalized guard is harmless: request
         // serving and later frontend events must never depend on this write.
-        let _ = self
-            .service
-            .transition_terminal(request_id, &guard, outcome);
+        if let Some(guard) = guard.as_ref() {
+            let _ = self.service.transition_terminal(request_id, guard, outcome);
+        }
     }
 
     #[cfg(test)]
@@ -853,16 +997,20 @@ const fn route_operation(route: openai_frontend::OpenAiFrontendRoute) -> OpenAiB
     }
 }
 
-fn log_legacy_request_started(context: &OpenAiLifecycleContext, operation: OpenAiBackendOperation) {
+fn log_legacy_request_started(
+    request_id: RequestId,
+    operation: OpenAiBackendOperation,
+    agent_session_id: Option<&str>,
+    agent_session_source: Option<&str>,
+) {
     let operation = operation_label(operation);
-    if let (Some(agent_session_id), Some(agent_session_source)) = (
-        context.agent_session_id.as_deref(),
-        context.agent_session_source.as_deref(),
-    ) {
+    if let (Some(agent_session_id), Some(agent_session_source)) =
+        (agent_session_id, agent_session_source)
+    {
         tracing::info!(
             target: LEGACY_OBSERVABILITY_TARGET,
             event = "request_started",
-            request_id = %context.request_id.as_ref(),
+            request_id = %request_id.as_ref(),
             operation,
             agent_session_id,
             agent_session_source,
@@ -872,7 +1020,7 @@ fn log_legacy_request_started(context: &OpenAiLifecycleContext, operation: OpenA
         tracing::info!(
             target: LEGACY_OBSERVABILITY_TARGET,
             event = "request_started",
-            request_id = %context.request_id.as_ref(),
+            request_id = %request_id.as_ref(),
             operation,
             "OpenAI request accepted"
         );
@@ -882,14 +1030,14 @@ fn log_legacy_request_started(context: &OpenAiLifecycleContext, operation: OpenA
 fn log_legacy_backend_started(
     request_id: RequestId,
     operation: OpenAiBackendOperation,
-    active: &ActiveRequest,
+    agent_session_id: Option<&str>,
+    agent_session_source: Option<&str>,
 ) {
     let operation = operation_label(operation);
     let request_id = request_id.as_ref();
-    if let (Some(agent_session_id), Some(agent_session_source)) = (
-        active.agent_session_id.as_deref(),
-        active.agent_session_source.as_deref(),
-    ) {
+    if let (Some(agent_session_id), Some(agent_session_source)) =
+        (agent_session_id, agent_session_source)
+    {
         tracing::info!(
             target: LEGACY_OBSERVABILITY_TARGET,
             event = "backend_started",
@@ -944,6 +1092,23 @@ fn log_legacy_backend_error(
     );
 }
 
+fn log_legacy_backend_timeout(
+    request_id: RequestId,
+    operation: OpenAiBackendOperation,
+    elapsed: std::time::Duration,
+    agent_session_id: Option<&str>,
+    agent_session_source: Option<&str>,
+) {
+    log_legacy_backend_result(
+        "backend_timeout",
+        request_id,
+        operation,
+        elapsed,
+        agent_session_id,
+        agent_session_source,
+    );
+}
+
 fn log_legacy_backend_result(
     event: &'static str,
     request_id: RequestId,
@@ -966,6 +1131,16 @@ fn log_legacy_backend_result(
             elapsed_us,
             "OpenAI backend operation returned"
         ),
+        ("backend_timeout", Some(agent_session_id), Some(agent_session_source)) => tracing::warn!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event,
+            request_id = %request_id,
+            operation,
+            agent_session_id,
+            agent_session_source,
+            elapsed_us,
+            "OpenAI backend operation timed out"
+        ),
         ("backend_error", Some(agent_session_id), Some(agent_session_source)) => tracing::warn!(
             target: LEGACY_OBSERVABILITY_TARGET,
             event,
@@ -983,6 +1158,14 @@ fn log_legacy_backend_result(
             operation,
             elapsed_us,
             "OpenAI backend operation returned"
+        ),
+        ("backend_timeout", _, _) => tracing::warn!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event,
+            request_id = %request_id,
+            operation,
+            elapsed_us,
+            "OpenAI backend operation timed out"
         ),
         _ => tracing::warn!(
             target: LEGACY_OBSERVABILITY_TARGET,
@@ -1015,6 +1198,7 @@ fn log_legacy_stream_first_item(
             operation,
             agent_session_id,
             agent_session_source,
+            elapsed_us = time_to_first_item_us,
             time_to_first_item_us,
             "OpenAI stream emitted its first item"
         );
@@ -1024,9 +1208,42 @@ fn log_legacy_stream_first_item(
             event = "stream_first_item",
             request_id = %request_id,
             operation,
+            elapsed_us = time_to_first_item_us,
             time_to_first_item_us,
             "OpenAI stream emitted its first item"
         );
+    }
+}
+
+fn log_legacy_stream_item_error(
+    request_id: RequestId,
+    operation: OpenAiBackendOperation,
+    elapsed: std::time::Duration,
+    agent_session_id: Option<&str>,
+    agent_session_source: Option<&str>,
+) {
+    let operation = operation_label(operation);
+    let request_id = request_id.as_ref();
+    let elapsed_us = elapsed.as_micros() as u64;
+    match (agent_session_id, agent_session_source) {
+        (Some(agent_session_id), Some(agent_session_source)) => tracing::warn!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event = "stream_item_error",
+            request_id = %request_id,
+            operation,
+            agent_session_id,
+            agent_session_source,
+            elapsed_us,
+            "OpenAI stream item failed"
+        ),
+        _ => tracing::warn!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event = "stream_item_error",
+            request_id = %request_id,
+            operation,
+            elapsed_us,
+            "OpenAI stream item failed"
+        ),
     }
 }
 
@@ -1416,6 +1633,108 @@ mod tests {
     }
 
     #[test]
+    fn legacy_observability_uses_timeout_and_stream_error_events() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_target(true)
+            .with_writer(TraceWriter(Arc::clone(&output)))
+            .finish();
+        let (_service, adapter) = adapter();
+        let request_id = RequestId::new();
+        let mut context = context(request_id);
+        context.agent_session_id = Some("cacheline-eval-developer-session-1".to_owned());
+        context.agent_session_source = Some("trusted_header".to_owned());
+        let operation = OpenAiBackendOperation::ChatCompletionStream;
+
+        tracing::subscriber::with_default(subscriber, || {
+            adapter.observe(&OpenAiLifecycleEvent::Admitted {
+                context: context.clone(),
+            });
+            adapter.observe(&OpenAiLifecycleEvent::BackendDispatched {
+                context: context.clone(),
+                operation,
+            });
+            adapter.observe(&OpenAiLifecycleEvent::BackendTerminal {
+                context: context.clone(),
+                operation,
+                result: OpenAiTerminalResult::Failed {
+                    status_code: 504,
+                    failure: OpenAiFailure::Timeout,
+                },
+            });
+            adapter.observe(&OpenAiLifecycleEvent::StreamTerminal {
+                context,
+                result: OpenAiTerminalResult::Failed {
+                    status_code: 504,
+                    failure: OpenAiFailure::Timeout,
+                },
+            });
+        });
+
+        let lines = String::from_utf8(output.lock().unwrap().clone()).unwrap();
+        let records = lines
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .filter(|record| record["target"] == LEGACY_OBSERVABILITY_TARGET)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            records
+                .iter()
+                .map(|record| record["fields"]["event"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec![
+                "request_started",
+                "backend_started",
+                "backend_timeout",
+                "stream_item_error",
+                "request_finished",
+            ]
+        );
+        for record in records {
+            assert_eq!(record["fields"]["agent_session_source"], "trusted_header");
+            if matches!(
+                record["fields"]["event"].as_str(),
+                Some("backend_timeout" | "stream_item_error" | "request_finished")
+            ) {
+                assert!(record["fields"]["elapsed_us"].is_u64());
+            }
+        }
+    }
+
+    #[test]
+    fn pre_dispatch_rejection_does_not_create_legacy_custody() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_target(true)
+            .with_writer(TraceWriter(Arc::clone(&output)))
+            .finish();
+        let (_service, adapter) = adapter();
+        let request_id = RequestId::new();
+        let context = context(request_id);
+
+        tracing::subscriber::with_default(subscriber, || {
+            adapter.observe(&OpenAiLifecycleEvent::Admitted {
+                context: context.clone(),
+            });
+            adapter.observe(&OpenAiLifecycleEvent::Rejected {
+                context,
+                status_code: 404,
+                rejection: OpenAiRejection::NotFound,
+            });
+        });
+
+        let lines = String::from_utf8(output.lock().unwrap().clone()).unwrap();
+        assert!(
+            lines
+                .lines()
+                .filter_map(|line| serde_json::from_str::<serde_json::Value>(line).ok())
+                .all(|record| record["target"] != LEGACY_OBSERVABILITY_TARGET)
+        );
+    }
+
+    #[test]
     fn backend_stream_and_usage_events_map_to_canonical_children_once() {
         let (service, adapter) = adapter();
         let request_id = RequestId::new();
@@ -1577,7 +1896,9 @@ mod tests {
             context: context(request_id),
         });
 
-        assert_eq!(adapter.tracked_len(), 0);
+        // Raw ingress owns canonical state, while this adapter retains a
+        // legacy-only record for authenticated custody.
+        assert_eq!(adapter.tracked_len(), 1);
         assert_eq!(
             service
                 .bus_ref()
@@ -1612,7 +1933,8 @@ mod tests {
         adapter.observe(&OpenAiLifecycleEvent::Admitted {
             context: context(request_id),
         });
-        assert_eq!(adapter.tracked_len(), 0);
+        // The raw parent remains canonical; the adapter's entry is legacy-only.
+        assert_eq!(adapter.tracked_len(), 1);
 
         let observer = attachment.route_observer();
         observer.route_selected(Some("safe-model"));
@@ -1660,7 +1982,7 @@ mod tests {
     }
 
     #[test]
-    fn remote_tunnel_suppression_skips_only_the_active_frontend_admission() {
+    fn remote_tunnel_suppression_skips_canonical_parent_but_retains_legacy() {
         let service = Arc::new(LoggingService::new_disabled(Default::default()));
         let raw_mesh_owners = Arc::new(RawMeshLifecycleOwners::default());
         let adapter =
@@ -1675,7 +1997,9 @@ mod tests {
         adapter.observe(&OpenAiLifecycleEvent::Admitted {
             context: context(request_id),
         });
-        assert_eq!(adapter.tracked_len(), 0);
+        // Suppression skips a second canonical parent, but the adapter retains
+        // a legacy-only record for the target's custody events.
+        assert_eq!(adapter.tracked_len(), 1);
 
         drop(lease);
         adapter.observe(&OpenAiLifecycleEvent::Admitted {

--- a/crates/mesh-llm-host-runtime/src/logging/openai_lifecycle.rs
+++ b/crates/mesh-llm-host-runtime/src/logging/openai_lifecycle.rs
@@ -6,6 +6,7 @@
 use std::{
     collections::{HashMap, VecDeque},
     sync::{Arc, Mutex},
+    time::Instant,
 };
 
 use mesh_llm_events::logging::{
@@ -26,6 +27,7 @@ use super::{
 
 /// Fixed upper bound for requests owned by one embedded frontend observer.
 const MAX_TRACKED_REQUESTS: usize = 1_024;
+const LEGACY_OBSERVABILITY_TARGET: &str = "mesh_openai_observability";
 
 /// The host-owned lifecycle attachment for one parsed OpenAI ingress request.
 ///
@@ -403,15 +405,23 @@ enum TrackedRequest {
 
 struct ActiveRequest {
     guard: LifecycleGuard,
+    started_at: Instant,
+    operation: OpenAiBackendOperation,
+    agent_session_id: Option<String>,
+    agent_session_source: Option<String>,
     backend_attempt: Option<(OpenAiBackendOperation, AttemptId)>,
     backend_stream_first_item: bool,
     usage: Option<OpenAiUsage>,
 }
 
 impl ActiveRequest {
-    fn new(guard: LifecycleGuard) -> Self {
+    fn new(guard: LifecycleGuard, context: &OpenAiLifecycleContext) -> Self {
         Self {
             guard,
+            started_at: Instant::now(),
+            operation: route_operation(context.route),
+            agent_session_id: context.agent_session_id.clone(),
+            agent_session_source: context.agent_session_source.clone(),
             backend_attempt: None,
             backend_stream_first_item: false,
             usage: None,
@@ -450,9 +460,10 @@ impl OpenAiLifecycleLoggingAdapter {
         );
         tracked.requests.insert(
             request_id,
-            TrackedRequest::Active(ActiveRequest::new(guard)),
+            TrackedRequest::Active(ActiveRequest::new(guard, context)),
         );
         tracked.insertion_order.push_back(request_id);
+        log_legacy_request_started(context, route_operation(context.route));
     }
 
     fn backend_dispatched(&self, request_id: RequestId, operation: OpenAiBackendOperation) {
@@ -481,7 +492,9 @@ impl OpenAiLifecycleLoggingAdapter {
         let attempt_id = self.service.start_attempt(request_id, &guard);
         let mut tracked = lock_recover(&self.tracked);
         if let Some(TrackedRequest::Active(active)) = tracked.requests.get_mut(&request_id) {
+            active.operation = operation;
             active.backend_attempt = Some((operation, attempt_id));
+            log_legacy_backend_started(request_id, operation, active);
         }
     }
 
@@ -491,7 +504,7 @@ impl OpenAiLifecycleLoggingAdapter {
         operation: OpenAiBackendOperation,
         result: OpenAiTerminalResult,
     ) {
-        let attempt_id = {
+        let attempt = {
             let mut tracked = lock_recover(&self.tracked);
             let Some(TrackedRequest::Active(active)) = tracked.requests.get_mut(&request_id) else {
                 return;
@@ -499,12 +512,17 @@ impl OpenAiLifecycleLoggingAdapter {
             match active.backend_attempt {
                 Some((attempt_operation, attempt_id)) if attempt_operation == operation => {
                     active.backend_attempt = None;
-                    Some(attempt_id)
+                    Some((
+                        attempt_id,
+                        active.started_at.elapsed(),
+                        active.agent_session_id.clone(),
+                        active.agent_session_source.clone(),
+                    ))
                 }
                 _ => None,
             }
         };
-        let Some(attempt_id) = attempt_id else {
+        let Some((attempt_id, elapsed, agent_session_id, agent_session_source)) = attempt else {
             return;
         };
         match result {
@@ -512,6 +530,13 @@ impl OpenAiLifecycleLoggingAdapter {
             | OpenAiTerminalResult::CompletedWithUsage { status_code, .. } => {
                 self.service
                     .complete_attempt(request_id, attempt_id, Some(status_code));
+                log_legacy_backend_returned(
+                    request_id,
+                    operation,
+                    elapsed,
+                    agent_session_id.as_deref(),
+                    agent_session_source.as_deref(),
+                );
             }
             OpenAiTerminalResult::Failed { failure, .. } => {
                 self.service.fail_attempt(
@@ -519,42 +544,65 @@ impl OpenAiLifecycleLoggingAdapter {
                     attempt_id,
                     failure_label(failure).to_owned(),
                 );
+                log_legacy_backend_error(
+                    request_id,
+                    operation,
+                    elapsed,
+                    agent_session_id.as_deref(),
+                    agent_session_source.as_deref(),
+                );
             }
         }
     }
 
-    fn backend_stream_first_item(&self, request_id: RequestId) {
-        let should_emit = {
+    fn backend_stream_first_item(&self, request_id: RequestId, operation: OpenAiBackendOperation) {
+        let first_item = {
             let mut tracked = lock_recover(&self.tracked);
             let Some(TrackedRequest::Active(active)) = tracked.requests.get_mut(&request_id) else {
                 return;
             };
             if active.backend_stream_first_item {
-                false
+                None
             } else {
                 active.backend_stream_first_item = true;
-                true
+                Some((
+                    active.started_at.elapsed(),
+                    active.agent_session_id.clone(),
+                    active.agent_session_source.clone(),
+                ))
             }
         };
-        if should_emit {
+        if let Some((elapsed, agent_session_id, agent_session_source)) = first_item {
             self.enqueue_operation_event(request_id, LifecycleEvent::BackendStreamFirstItem);
+            log_legacy_stream_first_item(
+                request_id,
+                operation,
+                elapsed,
+                agent_session_id.as_deref(),
+                agent_session_source.as_deref(),
+            );
         }
     }
 
     fn response_completed(&self, request_id: RequestId, usage: OpenAiUsage) {
-        let should_emit = {
+        let metadata = {
             let mut tracked = lock_recover(&self.tracked);
             let Some(TrackedRequest::Active(active)) = tracked.requests.get_mut(&request_id) else {
                 return;
             };
             if active.usage.is_some() {
-                false
+                None
             } else {
                 active.usage = Some(usage);
-                true
+                Some((
+                    active.started_at.elapsed(),
+                    active.operation,
+                    active.agent_session_id.clone(),
+                    active.agent_session_source.clone(),
+                ))
             }
         };
-        if should_emit {
+        if let Some((elapsed, operation, agent_session_id, agent_session_source)) = metadata {
             self.enqueue_operation_event(
                 request_id,
                 LifecycleEvent::UsageRecorded {
@@ -563,6 +611,14 @@ impl OpenAiLifecycleLoggingAdapter {
                     completion_tokens: Some(u64::from(usage.completion_tokens)),
                     total_tokens: Some(u64::from(usage.total_tokens)),
                 },
+            );
+            log_legacy_response_completed(
+                request_id,
+                operation,
+                elapsed,
+                usage,
+                agent_session_id.as_deref(),
+                agent_session_source.as_deref(),
             );
         }
     }
@@ -632,7 +688,7 @@ impl OpenAiLifecycleLoggingAdapter {
     }
 
     fn terminal(&self, request_id: RequestId, outcome: TerminalOutcome) {
-        let guard = {
+        let (guard, elapsed, operation, agent_session_id, agent_session_source) = {
             let mut tracked = lock_recover(&self.tracked);
             let Some(entry) = tracked.requests.get_mut(&request_id) else {
                 return;
@@ -641,9 +697,24 @@ impl OpenAiLifecycleLoggingAdapter {
                 return;
             };
             let guard = active.guard.clone();
+            let metadata = (
+                active.started_at.elapsed(),
+                active.operation,
+                active.agent_session_id.clone(),
+                active.agent_session_source.clone(),
+            );
             *entry = TrackedRequest::Terminal;
-            guard
+            (guard, metadata.0, metadata.1, metadata.2, metadata.3)
         };
+
+        log_legacy_request_finished(
+            request_id,
+            operation,
+            elapsed,
+            legacy_outcome(&outcome),
+            agent_session_id.as_deref(),
+            agent_session_source.as_deref(),
+        );
 
         // A stale or externally-terminalized guard is harmless: request
         // serving and later frontend events must never depend on this write.
@@ -694,9 +765,9 @@ impl OpenAiLifecycleObserver for OpenAiLifecycleLoggingAdapter {
                 operation,
                 result,
             } => self.backend_terminal(context.request_id, *operation, *result),
-            OpenAiLifecycleEvent::StreamFirstItem { context, .. } => {
-                self.backend_stream_first_item(context.request_id)
-            }
+            OpenAiLifecycleEvent::StreamFirstItem {
+                context, operation, ..
+            } => self.backend_stream_first_item(context.request_id, *operation),
             OpenAiLifecycleEvent::ResponseCompleted { context, usage, .. } => {
                 self.response_completed(context.request_id, *usage)
             }
@@ -769,6 +840,295 @@ const fn operation_label(operation: OpenAiBackendOperation) -> &'static str {
     }
 }
 
+const fn route_operation(route: openai_frontend::OpenAiFrontendRoute) -> OpenAiBackendOperation {
+    match route {
+        openai_frontend::OpenAiFrontendRoute::Completions => OpenAiBackendOperation::Completion,
+        openai_frontend::OpenAiFrontendRoute::Responses => OpenAiBackendOperation::Responses,
+        openai_frontend::OpenAiFrontendRoute::Models
+        | openai_frontend::OpenAiFrontendRoute::Health
+        | openai_frontend::OpenAiFrontendRoute::Healthz
+        | openai_frontend::OpenAiFrontendRoute::Readyz => OpenAiBackendOperation::Models,
+        openai_frontend::OpenAiFrontendRoute::ChatCompletions
+        | openai_frontend::OpenAiFrontendRoute::Unknown => OpenAiBackendOperation::ChatCompletion,
+    }
+}
+
+fn log_legacy_request_started(context: &OpenAiLifecycleContext, operation: OpenAiBackendOperation) {
+    let operation = operation_label(operation);
+    if let (Some(agent_session_id), Some(agent_session_source)) = (
+        context.agent_session_id.as_deref(),
+        context.agent_session_source.as_deref(),
+    ) {
+        tracing::info!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event = "request_started",
+            request_id = %context.request_id.as_ref(),
+            operation,
+            agent_session_id,
+            agent_session_source,
+            "OpenAI request accepted"
+        );
+    } else {
+        tracing::info!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event = "request_started",
+            request_id = %context.request_id.as_ref(),
+            operation,
+            "OpenAI request accepted"
+        );
+    }
+}
+
+fn log_legacy_backend_started(
+    request_id: RequestId,
+    operation: OpenAiBackendOperation,
+    active: &ActiveRequest,
+) {
+    let operation = operation_label(operation);
+    let request_id = request_id.as_ref();
+    if let (Some(agent_session_id), Some(agent_session_source)) = (
+        active.agent_session_id.as_deref(),
+        active.agent_session_source.as_deref(),
+    ) {
+        tracing::info!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event = "backend_started",
+            request_id = %request_id,
+            operation,
+            agent_session_id,
+            agent_session_source,
+            "OpenAI backend operation started"
+        );
+    } else {
+        tracing::info!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event = "backend_started",
+            request_id = %request_id,
+            operation,
+            "OpenAI backend operation started"
+        );
+    }
+}
+
+fn log_legacy_backend_returned(
+    request_id: RequestId,
+    operation: OpenAiBackendOperation,
+    elapsed: std::time::Duration,
+    agent_session_id: Option<&str>,
+    agent_session_source: Option<&str>,
+) {
+    log_legacy_backend_result(
+        "backend_returned",
+        request_id,
+        operation,
+        elapsed,
+        agent_session_id,
+        agent_session_source,
+    );
+}
+
+fn log_legacy_backend_error(
+    request_id: RequestId,
+    operation: OpenAiBackendOperation,
+    elapsed: std::time::Duration,
+    agent_session_id: Option<&str>,
+    agent_session_source: Option<&str>,
+) {
+    log_legacy_backend_result(
+        "backend_error",
+        request_id,
+        operation,
+        elapsed,
+        agent_session_id,
+        agent_session_source,
+    );
+}
+
+fn log_legacy_backend_result(
+    event: &'static str,
+    request_id: RequestId,
+    operation: OpenAiBackendOperation,
+    elapsed: std::time::Duration,
+    agent_session_id: Option<&str>,
+    agent_session_source: Option<&str>,
+) {
+    let operation = operation_label(operation);
+    let request_id = request_id.as_ref();
+    let elapsed_us = elapsed.as_micros() as u64;
+    match (event, agent_session_id, agent_session_source) {
+        ("backend_returned", Some(agent_session_id), Some(agent_session_source)) => tracing::info!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event,
+            request_id = %request_id,
+            operation,
+            agent_session_id,
+            agent_session_source,
+            elapsed_us,
+            "OpenAI backend operation returned"
+        ),
+        ("backend_error", Some(agent_session_id), Some(agent_session_source)) => tracing::warn!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event,
+            request_id = %request_id,
+            operation,
+            agent_session_id,
+            agent_session_source,
+            elapsed_us,
+            "OpenAI backend operation failed"
+        ),
+        ("backend_returned", _, _) => tracing::info!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event,
+            request_id = %request_id,
+            operation,
+            elapsed_us,
+            "OpenAI backend operation returned"
+        ),
+        _ => tracing::warn!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event,
+            request_id = %request_id,
+            operation,
+            elapsed_us,
+            "OpenAI backend operation failed"
+        ),
+    }
+}
+
+fn log_legacy_stream_first_item(
+    request_id: RequestId,
+    operation: OpenAiBackendOperation,
+    elapsed: std::time::Duration,
+    agent_session_id: Option<&str>,
+    agent_session_source: Option<&str>,
+) {
+    let request_id = request_id.as_ref();
+    let operation = operation_label(operation);
+    let time_to_first_item_us = elapsed.as_micros() as u64;
+    if let (Some(agent_session_id), Some(agent_session_source)) =
+        (agent_session_id, agent_session_source)
+    {
+        tracing::info!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event = "stream_first_item",
+            request_id = %request_id,
+            operation,
+            agent_session_id,
+            agent_session_source,
+            time_to_first_item_us,
+            "OpenAI stream emitted its first item"
+        );
+    } else {
+        tracing::info!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event = "stream_first_item",
+            request_id = %request_id,
+            operation,
+            time_to_first_item_us,
+            "OpenAI stream emitted its first item"
+        );
+    }
+}
+
+fn log_legacy_response_completed(
+    request_id: RequestId,
+    operation: OpenAiBackendOperation,
+    elapsed: std::time::Duration,
+    usage: OpenAiUsage,
+    agent_session_id: Option<&str>,
+    agent_session_source: Option<&str>,
+) {
+    let operation = operation_label(operation);
+    let request_id = request_id.as_ref();
+    let elapsed_us = elapsed.as_micros() as u64;
+    if let (Some(agent_session_id), Some(agent_session_source)) =
+        (agent_session_id, agent_session_source)
+    {
+        tracing::info!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event = "response_completed",
+            request_id = %request_id,
+            operation,
+            agent_session_id,
+            agent_session_source,
+            elapsed_us,
+            prompt_tokens = usage.prompt_tokens,
+            cached_tokens = usage.cached_tokens,
+            completion_tokens = usage.completion_tokens,
+            total_tokens = usage.total_tokens,
+            "OpenAI response completed"
+        );
+    } else {
+        tracing::info!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event = "response_completed",
+            request_id = %request_id,
+            operation,
+            elapsed_us,
+            prompt_tokens = usage.prompt_tokens,
+            cached_tokens = usage.cached_tokens,
+            completion_tokens = usage.completion_tokens,
+            total_tokens = usage.total_tokens,
+            "OpenAI response completed"
+        );
+    }
+}
+
+fn log_legacy_request_finished(
+    request_id: RequestId,
+    operation: OpenAiBackendOperation,
+    elapsed: std::time::Duration,
+    outcome: &'static str,
+    agent_session_id: Option<&str>,
+    agent_session_source: Option<&str>,
+) {
+    let operation = operation_label(operation);
+    let request_id = request_id.as_ref();
+    let elapsed_us = elapsed.as_micros() as u64;
+    if let (Some(agent_session_id), Some(agent_session_source)) =
+        (agent_session_id, agent_session_source)
+    {
+        tracing::info!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event = "request_finished",
+            request_id = %request_id,
+            operation,
+            agent_session_id,
+            agent_session_source,
+            outcome,
+            elapsed_us,
+            "OpenAI request finished"
+        );
+    } else {
+        tracing::info!(
+            target: LEGACY_OBSERVABILITY_TARGET,
+            event = "request_finished",
+            request_id = %request_id,
+            operation,
+            outcome,
+            elapsed_us,
+            "OpenAI request finished"
+        );
+    }
+}
+
+fn legacy_outcome(outcome: &TerminalOutcome) -> &'static str {
+    match outcome {
+        TerminalOutcome::Completed
+        | TerminalOutcome::CompletedWithStatus(_)
+        | TerminalOutcome::CompletedWithUsage { .. } => "success",
+        TerminalOutcome::Failed(error) | TerminalOutcome::FailedWithStatus { error, .. }
+            if error == "timeout" =>
+        {
+            "timeout"
+        }
+        TerminalOutcome::Failed(_) | TerminalOutcome::FailedWithStatus { .. } => "backend_error",
+        TerminalOutcome::Rejected(_) | TerminalOutcome::RejectedWithStatus { .. } => "client_error",
+        TerminalOutcome::Cancelled(_) => "cancelled",
+        TerminalOutcome::Dropped(_) => "client_disconnect",
+    }
+}
+
 const fn rejection_label(rejection: OpenAiRejection) -> &'static str {
     match rejection {
         OpenAiRejection::InvalidRequest => "invalid_request",
@@ -796,7 +1156,10 @@ fn lock_recover<T>(mutex: &Mutex<T>) -> std::sync::MutexGuard<'_, T> {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
+    use std::{
+        io::Write,
+        sync::{Arc, Mutex},
+    };
 
     use mesh_llm_events::logging::{events::LifecycleEvent, identifiers::RequestId};
     use openai_frontend::{
@@ -874,6 +1237,28 @@ mod tests {
         )
     }
 
+    #[derive(Clone)]
+    struct TraceWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for TraceWriter {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for TraceWriter {
+        type Writer = Self;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
     fn adapter() -> (Arc<LoggingService>, OpenAiLifecycleLoggingAdapter) {
         let service = Arc::new(LoggingService::new_disabled(Default::default()));
         let adapter = OpenAiLifecycleLoggingAdapter::new(
@@ -937,6 +1322,97 @@ mod tests {
             1
         );
         assert_eq!(adapter.tracked_len(), 1);
+    }
+
+    #[test]
+    fn legacy_observability_retains_authenticated_request_custody() {
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let subscriber = tracing_subscriber::fmt()
+            .json()
+            .with_target(true)
+            .with_writer(TraceWriter(Arc::clone(&output)))
+            .finish();
+        let (service, adapter) = adapter();
+        let request_id = RequestId::new();
+        let mut context = context(request_id);
+        context.agent_session_id = Some("cacheline-eval-developer-session-1".to_owned());
+        context.agent_session_source = Some("trusted_header".to_owned());
+        let operation = OpenAiBackendOperation::ChatCompletion;
+        let usage = OpenAiUsage {
+            prompt_tokens: 21,
+            cached_tokens: 13,
+            completion_tokens: 8,
+            total_tokens: 29,
+        };
+
+        tracing::subscriber::with_default(subscriber, || {
+            adapter.observe(&OpenAiLifecycleEvent::Admitted {
+                context: context.clone(),
+            });
+            adapter.observe(&OpenAiLifecycleEvent::BackendDispatched {
+                context: context.clone(),
+                operation,
+            });
+            adapter.observe(&OpenAiLifecycleEvent::BackendTerminal {
+                context: context.clone(),
+                operation,
+                result: OpenAiTerminalResult::Completed { status_code: 200 },
+            });
+            adapter.observe(&OpenAiLifecycleEvent::ResponseCompleted {
+                context: context.clone(),
+                operation,
+                usage,
+            });
+            adapter.observe(&OpenAiLifecycleEvent::NonStreamTerminal {
+                context,
+                result: OpenAiTerminalResult::CompletedWithUsage {
+                    status_code: 200,
+                    usage: TokenUsage {
+                        prompt_tokens: Some(21),
+                        completion_tokens: Some(8),
+                        total_tokens: Some(29),
+                    },
+                },
+            });
+        });
+
+        let lines = String::from_utf8(output.lock().unwrap().clone()).unwrap();
+        let records = lines
+            .lines()
+            .map(|line| serde_json::from_str::<serde_json::Value>(line).unwrap())
+            .filter(|record| record["target"] == LEGACY_OBSERVABILITY_TARGET)
+            .collect::<Vec<_>>();
+        assert_eq!(
+            records
+                .iter()
+                .map(|record| record["fields"]["event"].as_str().unwrap())
+                .collect::<Vec<_>>(),
+            vec![
+                "request_started",
+                "backend_started",
+                "backend_returned",
+                "response_completed",
+                "request_finished",
+            ]
+        );
+        for record in records {
+            assert_eq!(record["fields"]["operation"], "chat_completion");
+            assert_eq!(
+                record["fields"]["agent_session_id"],
+                "cacheline-eval-developer-session-1"
+            );
+            assert_eq!(record["fields"]["agent_session_source"], "trusted_header");
+            assert_eq!(
+                record["fields"]["request_id"],
+                request_id.as_uuid().to_string()
+            );
+        }
+        assert!(
+            service
+                .registry_ref()
+                .get_recent(&request_id.as_uuid().to_string())
+                .is_some()
+        );
     }
 
     #[test]

--- a/crates/openai-frontend/src/common.rs
+++ b/crates/openai-frontend/src/common.rs
@@ -66,7 +66,10 @@ impl AgentSessionSource {
     #[must_use]
     pub(crate) fn label(&self) -> &str {
         match self {
-            Self::TrustedHeader(header) => header,
+            // The custody contract identifies the trust mechanism, not the
+            // operator-selected header name. The latter is configuration
+            // detail and must not become part of the durable provenance ABI.
+            Self::TrustedHeader(_) => "trusted_header",
             Self::ResponsesConversation => "responses.conversation",
         }
     }

--- a/crates/openai-frontend/src/lifecycle.rs
+++ b/crates/openai-frontend/src/lifecycle.rs
@@ -21,6 +21,11 @@ pub struct OpenAiLifecycleContext {
     pub request_id: RequestId,
     pub method: OpenAiRequestMethod,
     pub route: OpenAiFrontendRoute,
+    /// Stable session metadata supplied by the configured trusted ingress
+    /// header. This is retained only as bounded lifecycle metadata; request
+    /// and response payloads never cross this boundary.
+    pub agent_session_id: Option<String>,
+    pub agent_session_source: Option<String>,
 }
 
 impl OpenAiLifecycleContext {
@@ -33,7 +38,24 @@ impl OpenAiLifecycleContext {
             request_id,
             method,
             route,
+            agent_session_id: None,
+            agent_session_source: None,
         }
+    }
+
+    /// Attach a validated session identity to lifecycle metadata.
+    pub(crate) fn with_agent_session(
+        mut self,
+        agent_session_id: Option<&str>,
+        agent_session_source: Option<&str>,
+    ) -> Self {
+        self.agent_session_id = agent_session_id.map(ToOwned::to_owned);
+        self.agent_session_source = self
+            .agent_session_id
+            .as_ref()
+            .and(agent_session_source)
+            .map(ToOwned::to_owned);
+        self
     }
 }
 

--- a/crates/openai-frontend/src/router.rs
+++ b/crates/openai-frontend/src/router.rs
@@ -856,6 +856,12 @@ async fn frontend_lifecycle_middleware(
     let uri = request.uri().clone();
     let context =
         OpenAiLifecycleContext::new(request_id, lifecycle_method(&method), lifecycle_route(&uri));
+    let context = match agent_session_from_header(&state.config, request.headers()) {
+        Ok(Some(identity)) => {
+            context.with_agent_session(Some(identity.id()), Some(identity.source().label()))
+        }
+        _ => context,
+    };
     request.extensions_mut().insert(request_id);
     request.extensions_mut().insert(context.clone());
     let mut lifecycle =

--- a/crates/openai-frontend/src/router_tests.rs
+++ b/crates/openai-frontend/src/router_tests.rs
@@ -720,10 +720,7 @@ async fn configured_trusted_header_reaches_backend_as_agent_session_identity() {
     assert_eq!(response.status(), StatusCode::OK);
     let requests = backend.requests.lock().unwrap();
     assert_eq!(requests[0].agent_session(), Some("agent-thread-42"));
-    assert_eq!(
-        requests[0].agent_session_source(),
-        Some("x-litellm-session-id")
-    );
+    assert_eq!(requests[0].agent_session_source(), Some("trusted_header"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## What changed

Restore the target-specific `mesh_openai_observability` lifecycle projection alongside the canonical lifecycle events. The projection carries the request lifecycle, trusted agent-session identity, authoritative usage counts, terminal outcome, and elapsed timing that Cacheline uses for model-performance custody.

## Root cause

The lifecycle refactor removed the old target-specific events. Mesh continued serving requests and emitting canonical JSON, but Cacheline’s custody collector correctly rejected those records because the canonical presentation intentionally omits session identity. The benchmark therefore stopped after source-only with an empty observability artifact.

## Validation

- `cargo check -p openai-frontend -p mesh-llm-host-runtime`
- `cargo test -p mesh-llm-host-runtime logging::openai_lifecycle::tests::legacy_observability_retains_authenticated_request_custody --lib`
- `cargo test -p mesh-llm-host-runtime logging::openai_lifecycle --lib`
- `cargo test -p openai-frontend lifecycle --lib`

The corresponding Cacheline benchmark pin should be updated only after this commit lands in the private Mesh main.