### PR TITLE
fix(xtask): regenerate console-print ratchet drifted 2 lines by #1376

### DIFF
--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -1937,47 +1937,47 @@
   ],
   "crates/mesh-llm-system/src/autoupdate.rs": [
     {
-      "line": 148,
+      "line": 150,
       "macro_name": "eprintln!"
     },
     {
-      "line": 173,
+      "line": 175,
       "macro_name": "eprintln!"
     },
     {
-      "line": 195,
+      "line": 197,
       "macro_name": "eprintln!"
     },
     {
-      "line": 199,
+      "line": 201,
       "macro_name": "eprintln!"
     },
     {
-      "line": 206,
+      "line": 208,
       "macro_name": "eprintln!"
     },
     {
-      "line": 295,
+      "line": 297,
       "macro_name": "eprintln!"
     },
     {
-      "line": 302,
+      "line": 304,
       "macro_name": "eprintln!"
     },
     {
-      "line": 318,
+      "line": 320,
       "macro_name": "eprintln!"
     },
     {
-      "line": 324,
+      "line": 326,
       "macro_name": "eprintln!"
     },
     {
-      "line": 327,
+      "line": 329,
       "macro_name": "eprintln!"
     },
     {
-      "line": 331,
+      "line": 333,
       "macro_name": "eprintln!"
     }
   ],


### PR DESCRIPTION
## Problem

`main` has been red since #1376 merged (3a0cfb308). `Main · Quality` fails on `CI contracts and consistency`:

```
console print ratchet is out of sync with the tree:
crates/mesh-llm-system/src/autoupdate.rs:148 eprintln!: approved occurrence is missing or was replaced
... (11 entries total)
```

Every one of the 11 allowlisted line numbers for `autoupdate.rs` in `tools/xtask/data/console_print_allowlist.json` is exactly 2 lines short of where the corresponding `eprintln!` actually landed (148→150, 173→175, 195→197, 199→201, 206→208, 295→297, 302→304, 318→320, 324→326, 327→329, 331→333). Both files were touched by #1376 itself, so the ratchet was captured against a tree state 2 lines shorter than what merged.

## Fix

`cargo run -p xtask -- repo-consistency no-console-print --regen`. Diff is scoped to exactly those 11 line-number corrections in the one file — no new/removed allowlist entries, no other file touched.

## Validation

- `just ci-validate` — clean (was failing on `no-console-print` before this change)

Found incidentally while starting the CI prebuilt-runner-images work in mesh-dev; unrelated to that effort, filed standalone since it blocks `just ci-validate` for every PR right now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal console-output allowlist references to match shifted source locations.
  * No user-facing behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->