### PR TITLE
fix(ci): select static-abi in pr-draft when its matrix consumers are planned

### DIFF
--- a/ci/slices.yml
+++ b/ci/slices.yml
@@ -3,7 +3,7 @@
   "profiles": {
     "pr-draft": {
       "base_slices": ["quality"],
-      "control_slices": ["quality", "runner-contract"],
+      "control_slices": ["quality", "runner-contract", "static-abi"],
       "all_rows": false,
       "budgets": {
         "linux_max_parallel": 7,

--- a/scripts/tests/test_plan_ci.py
+++ b/scripts/tests/test_plan_ci.py
@@ -248,6 +248,40 @@ class PlanCiTests(unittest.TestCase):
             plan["reasons"]["runner-contract"],
         )
 
+    def test_control_plane_changes_select_static_abi_for_its_matrix_gated_consumers(
+        self,
+    ) -> None:
+        # static_abi is the only lane job gated on required_slices while its
+        # consumers (rust_tests, kotlin_sdk_input) are gated on the matrices
+        # force_all_rows populates. If either matrix comes back non-empty,
+        # static-abi must be selected too, or the consumer can never run.
+        cases = (
+            ("pr-draft", "pull_request", "runtime.json"),
+            ("pr-ready", "pull_request", "runtime.json"),
+            ("main", "push", "main.json"),
+            ("manual-full", "workflow_dispatch", "main.json"),
+        )
+        for profile, event_name, fixture_name in cases:
+            with self.subTest(profile=profile):
+                payload = fixture(fixture_name)
+                payload.update(
+                    {
+                        "profile": profile,
+                        "event_name": event_name,
+                        "changed_files": [".github/workflows/pr_linux.yml"],
+                        "affected_crates": [],
+                    }
+                )
+
+                plan = PLANNER.build_plan(payload, root=ROOT)
+
+                kotlin_planned = "kotlin" in {
+                    row["id"] for row in plan["matrices"]["sdk"]
+                }
+                rust_tests_planned = bool(plan["matrices"]["rust_tests"])
+                if kotlin_planned or rust_tests_planned:
+                    self.assertIn("static-abi", plan["required_slices"])
+
     def test_macos_consumer_rows_reject_multiple_architectures(self) -> None:
         slices = json.loads((ROOT / "ci" / "slices.yml").read_text())
         extra = copy.deepcopy(

--- a/scripts/tests/test_plan_ci.py
+++ b/scripts/tests/test_plan_ci.py
@@ -279,6 +279,11 @@ class PlanCiTests(unittest.TestCase):
                     row["id"] for row in plan["matrices"]["sdk"]
                 }
                 rust_tests_planned = bool(plan["matrices"]["rust_tests"])
+                # This fixture always plans kotlin via force_all_rows, so
+                # assert the concrete case directly rather than relying on
+                # readers to trace that through -- the conditional below
+                # keeps the invariant general for any future payload.
+                self.assertIn("static-abi", plan["required_slices"])
                 if kotlin_planned or rust_tests_planned:
                     self.assertIn("static-abi", plan["required_slices"])
 


### PR DESCRIPTION
## What

`pr-draft`'s `control_slices` in `ci/slices.yml` omitted `static-abi`, unlike
`pr-ready`/`main`/`manual-full`. One-line fix:

```diff
- "control_slices": ["quality", "runner-contract"],
+ "control_slices": ["quality", "runner-contract", "static-abi"],
```

## Why

`static_abi` is the only Linux-lane job gated on `required_slices` while its
consumers (`rust_tests`, `kotlin_sdk_input`) are gated on the matrices that
`force_all_rows` populates for control-plane changes. Any `pr-draft` PR that
touches only ci-control-domain files (any workflow/scripts edit) triggers
`force_all_rows`, which force-includes the full sdk matrix including
`kotlin` — but `static-abi` was never selected, so `static_abi` skips,
`kotlin_sdk_input`'s `needs: [static_abi]` guard then also skips it, and
`validate-ci-lane-results.py` fails the lane because the sdk matrix still
expects `kotlin_sdk_input` to succeed:

```
ERROR: planned job 'kotlin_sdk_input' finished with 'skipped'
```

This breaks the fail-open invariant documented in `ci/ci.md:182-184`:
control-plane changes are supposed to land on "a successful required slice
instead of an empty reusable workflow reported as skipped." `rust_tests`
doesn't hit this because its matrix is already slice-gated
(`plan-ci.py:822`); the row matrices (sdk, runtime, smoke) never got the
same guard, and `static-abi`'s absence from `pr-draft` is where that surfaces.

## Testing

- New regression test `test_control_plane_changes_select_static_abi_for_its_matrix_gated_consumers`
  in `scripts/tests/test_plan_ci.py`, encoding the general invariant: for any
  profile, if `matrices.sdk` contains `kotlin` or `matrices.rust_tests` is
  non-empty, `static-abi` must be in `required_slices`. Subtested over
  `pr-draft`/`pr-ready`/`main`/`manual-full` x a ci-control change.
  Confirmed it fails on `pr-draft` only before this change, passes on all
  four after.
- Re-ran the original repro:
  `echo '{"profile":"pr-draft",...,"changed_files":[".github/workflows/ci-linux-lane.yml"]}' | python3 scripts/plan-ci.py`
  — `required_slices` now includes `static-abi`, `matrices.rust_tests` stays
  `[]` (correctly still unselected).
- Full `python3 -m unittest scripts.tests.test_plan_ci` — 24/24 pass.

## Scope note

Opened standalone against `main`, not folded into #1380 (the PR whose red
"PR / Linux" check surfaced this): `pr_linux.yml`'s plan job checks out
`ref: ${{ github.event.repository.default_branch }}`, so `plan-ci.py` and
`ci/slices.yml` are read from `main`, not the PR head — a fix living inside
#1380 would have zero effect on #1380's own CI. Opened **ready**, not draft:
under `pr-draft` this same PR's own diff (`ci/slices.yml` + `tooling` domain)
would reproduce the bug it fixes against a `main` that doesn't have the fix
yet, with no way to clear it.

Follow-ups intentionally deferred (see mesh-dev channel thread for the full
design discussion): the structural fix moving `static_abi`'s gate onto the
matrix vocabulary, the undeclared `sdk -> static-abi` dependency edge in
`ci/slices.yml`, and `force_all_rows` bypassing `pr-draft`'s smoke-row
pruning.

Related to Mesh-LLM/mesh-llm#1380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added static ABI validation to pull request draft checks alongside existing quality and runner-contract checks.

* **Tests**
  * Expanded CI plan regression coverage to verify static ABI validation is selected across tested profiles.
  * Retained checks for conditional Kotlin and Rust consumer coverage in applicable test plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->