### PR TITLE
ci: cancel sibling PR lanes after failure

### DIFF
--- a/.agents/skills/manage-ci/SKILL.md
+++ b/.agents/skills/manage-ci/SKILL.md
@@ -175,10 +175,14 @@ owning source, and update the inventory and topology in the same change.
 - Cancel superseded PR runs. Do not cancel releases, deployments, cache
   warming, cleanup, or publishing unless their rollback semantics explicitly
   permit it.
-- Treat each focused PR workflow as an independent failure domain. A Quality
-  or Website failure must not cancel platform compilation, tests, products, or
-  smoke jobs, and a platform failure must not cancel another focused PR
-  workflow.
+- Keep the five focused PR workflows as separate visible checks, but stop
+  wasting capacity after the first definitive job failure for one exact PR
+  revision. The protected default-branch sibling monitor may cancel the other
+  queued or in-progress Quality, Website, Linux, macOS, and Windows workflow
+  runs for the same PR number, head SHA, and event epoch. It must preserve the
+  workflow containing the first failure so that lane can publish its stable
+  diagnostic result. This policy is PR-only; main, manual, release,
+  deployment, cleanup, cache-warming, and newer PR revisions are never targets.
 - Within a PR platform lane, compilation, functional-test, product, and smoke
   matrices fail fast so a required row failure cancels their queued and
   in-progress sibling rows. Keep this profile-derived: exhaustive main/manual
@@ -186,9 +190,11 @@ owning source, and update the inventory and topology in the same change.
   matrices continue all rows because they are independent diagnostics rather
   than producer/consumer gates.
 - Prefer declared `needs` edges to suppress impossible consumers after a
-  producer failure. Do not cancel an entire workflow run through the Actions
-  API on first failure: that prevents the stable lane summary from reporting a
-  terminal failure and discards unrelated failure-domain evidence.
+  producer failure. Cross-workflow PR cancellation is owned only by the
+  protected `workflow_run` monitor: ordinary PR-controlled workflows and
+  checked-out code must never receive `actions: write`. Cancelled sibling
+  checks are expected terminal evidence after another lane has already failed;
+  the preserved failed lane remains the root diagnostic.
 - Control fan-out in the graph. Use bounded matrices and `max-parallel` after
   eliminating irrelevant work; do not use additional runner capacity as a
   substitute for routing and composition.

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -13,6 +13,7 @@ Read it with `../SKILL.md` and `ci/ci.md` before editing CI.
 | `pr_linux.yml` (`PR · Linux`) | PR lifecycle | Canonical PR planning plus the protected reusable Linux lane |
 | `pr_macos.yml` (`PR · macOS`) | PR lifecycle | Canonical PR planning plus the protected reusable macOS lane |
 | `pr_windows.yml` (`PR · Windows`) | PR lifecycle | Canonical PR planning plus the protected reusable Windows lane |
+| `pr-cancel-sibling-runs.yml` (`PR · Cancel sibling lanes`) | protected `workflow_run` on `PR · Quality` entering progress | No-PR-checkout monitor that cancels other exact-revision PR validation lanes after the first definitive job failure |
 | `pr_builds.yml` | `workflow_call` only | Inert migration shim for the pre-merge protected runner-contract filename check; no PR event trigger |
 | `ci-orchestrator.yml` | `workflow_call` only | Inert migration shim for the pre-merge protected runner-contract filename check; no PR event trigger or lane calls |
 | `main_quality.yml` (`Main · Quality`) | push to `main` | Exhaustive main planning plus the same-commit reusable Quality lane |
@@ -44,8 +45,10 @@ target; prerelease tags are excluded so RC and final notes use the same stable
 baseline.
 
 The five PR lifecycle rows and five main push rows above are the complete
-allowed routine validation entry sets. Their separation and direct GitHub log
-visibility are contractual, not a presentation preference. `pr_builds.yml`,
+allowed routine validation entry sets. The protected sibling monitor is
+metadata/control infrastructure, not a sixth validation entrypoint or required
+check. Their separation and direct GitHub log visibility are contractual, not
+a presentation preference. `pr_builds.yml`,
 `ci-orchestrator.yml`, and `ci.yml` are reusable-only migration scaffolding;
 they must never regain event triggers or call the five lanes. They are
 removable after this branch's runner contract is active on protected main.
@@ -151,8 +154,15 @@ the pnpm store without racing to save it. Trusted main owns shared publication.
 
 PR Rust-test, host, native-runtime, product, and platform-check matrices receive
 `fail_fast: true`; main/manual pass `false`. Quality matrices remain
-non-fail-fast, failed producers suppress only declared consumers through
-`needs`, and focused PR workflows never cancel one another.
+non-fail-fast and failed producers suppress impossible consumers through
+`needs`. One protected, default-branch `workflow_run` monitor starts with
+`PR · Quality`, polls the five exact-PR/exact-SHA validation runs, preserves the
+run containing the first definitive failed job, and cancels its queued or
+in-progress siblings. It checks out only the default branch, owns the sole
+`actions: write` token for this operation, and never targets main, manual,
+release, deployment, cleanup, cache-warming, another PR event epoch, or a newer
+revision. PR-controlled workflows and executor jobs retain no Actions-write
+permission.
 
 ## Providers and variables
 

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -43,6 +43,14 @@ remain separate PR-associated workflows with directly drillable nested jobs
 and one stable `PR / <lane>` result each. Do not add path filters; planning owns
 skips so every stable result exists.
 
+The protected `workflow_run` sibling-failure monitor is control infrastructure,
+not a sixth PR validation entrypoint. It may cancel only queued or in-progress
+Quality, Website, Linux, macOS, and Windows runs for the same PR number, exact
+head SHA, and event epoch after preserving the workflow containing the first
+definitive job failure. Its Actions-write token must never enter a PR-controlled
+workflow, checkout, action, or process, and it must never target main or other
+workflow classes.
+
 Preserve the five-entry main shape as well. Routine pushes to `main` must use
 five focused native workflows with one stable `Main / <lane>` result each.
 They must not use path filters, cancel older main revisions, call detached

--- a/.github/actions/cancel-pr-sibling-runs/action.yml
+++ b/.github/actions/cancel-pr-sibling-runs/action.yml
@@ -1,0 +1,19 @@
+name: Cancel sibling PR validation runs
+description: Monitor one exact PR revision and cancel its other validation lanes after the first definitive job failure.
+
+inputs:
+  token:
+    description: Repository-scoped token with Actions write permission.
+    required: true
+  poll_seconds:
+    description: Seconds between read-only workflow/job status polls.
+    required: false
+    default: "30"
+  max_minutes:
+    description: Maximum monitoring duration before failing visibly.
+    required: false
+    default: "180"
+
+runs:
+  using: node24
+  main: index.js

--- a/.github/actions/cancel-pr-sibling-runs/index.js
+++ b/.github/actions/cancel-pr-sibling-runs/index.js
@@ -1,0 +1,296 @@
+"use strict";
+
+const fs = require("fs");
+
+const TARGET_WORKFLOWS = Object.freeze([
+  "PR · Quality",
+  "PR · Website",
+  "PR · Linux",
+  "PR · macOS",
+  "PR · Windows",
+]);
+const TARGET_WORKFLOW_SET = new Set(TARGET_WORKFLOWS);
+const FAILURE_CONCLUSIONS = new Set([
+  "action_required",
+  "failure",
+  "stale",
+  "startup_failure",
+  "timed_out",
+]);
+const CANCELLABLE_STATUSES = new Set([
+  "in_progress",
+  "pending",
+  "queued",
+  "requested",
+  "waiting",
+]);
+
+function fail(message) {
+  throw new Error(`PR sibling cancellation: ${message}`);
+}
+
+function positiveInteger(raw, name) {
+  if (!/^[1-9][0-9]*$/.test(raw || "")) {
+    fail(`${name} must be a positive integer`);
+  }
+  return Number(raw);
+}
+
+function parseRepository(repository) {
+  const match = /^([^/]+)\/([^/]+)$/.exec(repository || "");
+  if (!match) {
+    fail("GITHUB_REPOSITORY is malformed");
+  }
+  return { owner: match[1], repo: match[2] };
+}
+
+function parseTrigger(payload, repository) {
+  const workflowRun = payload?.workflow_run;
+  if (!workflowRun || workflowRun.event !== "pull_request") {
+    return null;
+  }
+  if (workflowRun.name !== "PR · Quality") {
+    fail("triggering workflow is not PR · Quality");
+  }
+  if (!Number.isSafeInteger(workflowRun.id) || workflowRun.id <= 0) {
+    fail("triggering workflow run ID is malformed");
+  }
+  if (!/^[0-9a-f]{40}$/.test(workflowRun.head_sha || "")) {
+    fail("triggering workflow head SHA is malformed");
+  }
+  const createdAt = Date.parse(workflowRun.created_at || "");
+  if (!Number.isFinite(createdAt)) {
+    fail("triggering workflow creation time is malformed");
+  }
+  const pullRequests = Array.isArray(workflowRun.pull_requests)
+    ? workflowRun.pull_requests
+    : [];
+  if (pullRequests.length !== 1) {
+    fail("triggering workflow must identify exactly one pull request");
+  }
+  const pullNumber = pullRequests[0]?.number;
+  if (!Number.isSafeInteger(pullNumber) || pullNumber <= 0) {
+    fail("pull request number is malformed");
+  }
+  const payloadRepository = payload?.repository?.full_name;
+  if (payloadRepository !== repository) {
+    fail("event repository does not match GITHUB_REPOSITORY");
+  }
+  return {
+    createdAt,
+    headSha: workflowRun.head_sha,
+    pullNumber,
+    triggerRunId: workflowRun.id,
+  };
+}
+
+function runBelongsToTrigger(run, trigger) {
+  if (!TARGET_WORKFLOW_SET.has(run?.name)) return false;
+  if (run.event !== "pull_request" || run.head_sha !== trigger.headSha) return false;
+  const createdAt = Date.parse(run.created_at || "");
+  if (!Number.isFinite(createdAt)) return false;
+  // All five focused workflows are created by one PR event. Exclude an older
+  // reopened/ready run of the same unchanged SHA from this cancellation set.
+  if (Math.abs(createdAt - trigger.createdAt) > 120_000) return false;
+  const pullRequests = Array.isArray(run.pull_requests) ? run.pull_requests : [];
+  return pullRequests.some((pull) => pull?.number === trigger.pullNumber);
+}
+
+function selectTargetRuns(runs, trigger) {
+  const selected = new Map();
+  for (const run of runs || []) {
+    if (!runBelongsToTrigger(run, trigger)) continue;
+    const existing = selected.get(run.name);
+    if (!existing || Number(run.id) > Number(existing.id)) {
+      selected.set(run.name, run);
+    }
+  }
+  const quality = selected.get("PR · Quality");
+  if (quality && quality.id !== trigger.triggerRunId) {
+    selected.delete("PR · Quality");
+  }
+  return TARGET_WORKFLOWS.flatMap((name) => {
+    const run = selected.get(name);
+    return run ? [run] : [];
+  });
+}
+
+function findEarliestFailure(runJobs) {
+  const failures = [];
+  for (const { run, jobs } of runJobs) {
+    for (const job of jobs || []) {
+      if (!FAILURE_CONCLUSIONS.has(job?.conclusion)) continue;
+      failures.push({
+        completedAt: Date.parse(job.completed_at || "") || Number.MAX_SAFE_INTEGER,
+        jobId: job.id,
+        jobName: job.name,
+        runId: run.id,
+        workflowName: run.name,
+      });
+    }
+  }
+  failures.sort((left, right) => {
+    if (left.completedAt !== right.completedAt) {
+      return left.completedAt - right.completedAt;
+    }
+    if (left.runId !== right.runId) return left.runId - right.runId;
+    return left.jobId - right.jobId;
+  });
+  return failures[0] || null;
+}
+
+function allTargetsTerminal(runs) {
+  return runs.length === TARGET_WORKFLOWS.length
+    && runs.every((run) => run.status === "completed");
+}
+
+function cancellableSiblingRuns(runs, preservedRunId) {
+  return runs.filter((run) => (
+    run.id !== preservedRunId && CANCELLABLE_STATUSES.has(run.status)
+  ));
+}
+
+function sleep(milliseconds) {
+  return new Promise((resolve) => setTimeout(resolve, milliseconds));
+}
+
+function githubApi(token, owner, repo) {
+  const base = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
+
+  async function request(path, options = {}) {
+    const response = await fetch(`${base}${path}`, {
+      method: options.method || "GET",
+      headers: {
+        Accept: "application/vnd.github+json",
+        Authorization: `Bearer ${token}`,
+        "User-Agent": "mesh-llm-pr-sibling-canceller",
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (!response.ok) {
+      const body = await response.text();
+      const detail = body.slice(0, 300).replace(/[\r\n]+/g, " ");
+      const error = new Error(`GitHub API ${response.status}: ${detail}`);
+      error.status = response.status;
+      throw error;
+    }
+    const body = await response.text();
+    return body ? JSON.parse(body) : null;
+  }
+
+  return {
+    async listRuns(headSha) {
+      const query = new URLSearchParams({
+        event: "pull_request",
+        head_sha: headSha,
+        per_page: "100",
+      });
+      const result = await request(`/actions/runs?${query}`);
+      return result.workflow_runs || [];
+    },
+    async listJobs(runId) {
+      const result = await request(`/actions/runs/${runId}/jobs?filter=latest&per_page=100`);
+      return result.jobs || [];
+    },
+    async cancelRun(runId) {
+      try {
+        await request(`/actions/runs/${runId}/cancel`, { method: "POST" });
+        return true;
+      } catch (error) {
+        // A sibling can finish between the status read and cancel request.
+        if (error.status === 409 || error.status === 422) return false;
+        throw error;
+      }
+    },
+  };
+}
+
+async function monitor({ api, trigger, pollSeconds, maxMinutes, log = console.log }) {
+  const maxPolls = Math.ceil((maxMinutes * 60) / pollSeconds);
+  let consecutiveErrors = 0;
+  let failure = null;
+  let failurePolls = 0;
+  for (let poll = 1; poll <= maxPolls; poll += 1) {
+    try {
+      const runs = selectTargetRuns(await api.listRuns(trigger.headSha), trigger);
+      if (!failure) {
+        const runJobs = [];
+        for (const run of runs) {
+          if (run.status !== "queued") {
+            runJobs.push({ run, jobs: await api.listJobs(run.id) });
+          }
+        }
+        failure = findEarliestFailure(runJobs);
+      }
+      if (failure) {
+        failurePolls += 1;
+        if (failurePolls === 1) {
+          log(`::notice::Preserving failed ${failure.workflowName} run ${failure.runId}; cancelling sibling PR lanes for the same revision.`);
+        }
+        for (const sibling of cancellableSiblingRuns(runs, failure.runId)) {
+          const cancelled = await api.cancelRun(sibling.id);
+          log(`::notice::${cancelled ? "Cancelled" : "Sibling already terminal"}: ${sibling.name} run ${sibling.id}.`);
+        }
+        // Workflow records normally appear together, but a planning failure
+        // can be nearly immediate. Poll for up to two additional minutes so a
+        // late-created sibling from the same event epoch is still cancelled.
+        if (runs.length === TARGET_WORKFLOWS.length || failurePolls >= 4) {
+          return { failure, runs };
+        }
+      }
+      if (!failure && allTargetsTerminal(runs)) {
+        log("::notice::All five PR validation lanes completed without a definitive job failure.");
+        return { failure: null, runs };
+      }
+      consecutiveErrors = 0;
+    } catch (error) {
+      consecutiveErrors += 1;
+      console.warn(`::warning::PR sibling monitor poll failed (${consecutiveErrors}/3): ${error.message}`);
+      if (consecutiveErrors >= 3) throw error;
+    }
+    if (poll < maxPolls) await sleep(pollSeconds * 1000);
+  }
+  fail(`monitor timed out after ${maxMinutes} minutes`);
+}
+
+async function main() {
+  const token = process.env.INPUT_TOKEN || "";
+  if (!token) fail("token input is required");
+  const pollSeconds = positiveInteger(process.env.INPUT_POLL_SECONDS, "poll_seconds");
+  const maxMinutes = positiveInteger(process.env.INPUT_MAX_MINUTES, "max_minutes");
+  const repository = process.env.GITHUB_REPOSITORY || "";
+  const { owner, repo } = parseRepository(repository);
+  const eventPath = process.env.GITHUB_EVENT_PATH || "";
+  if (!eventPath) fail("GITHUB_EVENT_PATH is missing");
+  const payload = JSON.parse(fs.readFileSync(eventPath, "utf8"));
+  const trigger = parseTrigger(payload, repository);
+  if (!trigger) {
+    console.log("::notice::Trigger is not a pull_request workflow run; no monitoring is required.");
+    return;
+  }
+  console.log(`::notice::Monitoring five PR validation lanes for PR #${trigger.pullNumber} at ${trigger.headSha}.`);
+  await monitor({
+    api: githubApi(token, owner, repo),
+    trigger,
+    pollSeconds,
+    maxMinutes,
+  });
+}
+
+module.exports = {
+  TARGET_WORKFLOWS,
+  allTargetsTerminal,
+  cancellableSiblingRuns,
+  findEarliestFailure,
+  githubApi,
+  monitor,
+  parseTrigger,
+  selectTargetRuns,
+};
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(`::error::${error.message}`);
+    process.exitCode = 1;
+  });
+}

--- a/.github/actions/cancel-pr-sibling-runs/index.js
+++ b/.github/actions/cancel-pr-sibling-runs/index.js
@@ -24,6 +24,9 @@ const CANCELLABLE_STATUSES = new Set([
   "requested",
   "waiting",
 ]);
+const REQUEST_TIMEOUT_MS = 30_000;
+const LATE_SIBLING_WINDOW_MS = 120_000;
+const PAGE_SIZE = 100;
 
 function fail(message) {
   throw new Error(`PR sibling cancellation: ${message}`);
@@ -160,6 +163,7 @@ function githubApi(token, owner, repo) {
   async function request(path, options = {}) {
     const response = await fetch(`${base}${path}`, {
       method: options.method || "GET",
+      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
       headers: {
         Accept: "application/vnd.github+json",
         Authorization: `Bearer ${token}`,
@@ -178,19 +182,36 @@ function githubApi(token, owner, repo) {
     return body ? JSON.parse(body) : null;
   }
 
+  async function listAll(pathForPage, field) {
+    const values = [];
+    for (let page = 1; ; page += 1) {
+      const result = await request(pathForPage(page));
+      const batch = result?.[field];
+      if (!Array.isArray(batch)) {
+        fail(`GitHub API response is missing ${field}`);
+      }
+      values.push(...batch);
+      if (batch.length < PAGE_SIZE) return values;
+    }
+  }
+
   return {
     async listRuns(headSha) {
-      const query = new URLSearchParams({
-        event: "pull_request",
-        head_sha: headSha,
-        per_page: "100",
-      });
-      const result = await request(`/actions/runs?${query}`);
-      return result.workflow_runs || [];
+      return listAll((page) => {
+        const query = new URLSearchParams({
+          event: "pull_request",
+          head_sha: headSha,
+          page: String(page),
+          per_page: String(PAGE_SIZE),
+        });
+        return `/actions/runs?${query}`;
+      }, "workflow_runs");
     },
     async listJobs(runId) {
-      const result = await request(`/actions/runs/${runId}/jobs?filter=latest&per_page=100`);
-      return result.jobs || [];
+      return listAll(
+        (page) => `/actions/runs/${runId}/jobs?filter=latest&per_page=${PAGE_SIZE}&page=${page}`,
+        "jobs",
+      );
     },
     async cancelRun(runId) {
       try {
@@ -205,11 +226,11 @@ function githubApi(token, owner, repo) {
   };
 }
 
-async function monitor({ api, trigger, pollSeconds, maxMinutes, log = console.log }) {
+async function monitor({ api, trigger, pollSeconds, maxMinutes, log = console.log, now = Date.now }) {
   const maxPolls = Math.ceil((maxMinutes * 60) / pollSeconds);
   let consecutiveErrors = 0;
   let failure = null;
-  let failurePolls = 0;
+  let failureDeadline = null;
   for (let poll = 1; poll <= maxPolls; poll += 1) {
     try {
       const runs = selectTargetRuns(await api.listRuns(trigger.headSha), trigger);
@@ -223,8 +244,8 @@ async function monitor({ api, trigger, pollSeconds, maxMinutes, log = console.lo
         failure = findEarliestFailure(runJobs);
       }
       if (failure) {
-        failurePolls += 1;
-        if (failurePolls === 1) {
+        if (failureDeadline === null) {
+          failureDeadline = now() + LATE_SIBLING_WINDOW_MS;
           log(`::notice::Preserving failed ${failure.workflowName} run ${failure.runId}; cancelling sibling PR lanes for the same revision.`);
         }
         for (const sibling of cancellableSiblingRuns(runs, failure.runId)) {
@@ -234,7 +255,7 @@ async function monitor({ api, trigger, pollSeconds, maxMinutes, log = console.lo
         // Workflow records normally appear together, but a planning failure
         // can be nearly immediate. Poll for up to two additional minutes so a
         // late-created sibling from the same event epoch is still cancelled.
-        if (runs.length === TARGET_WORKFLOWS.length || failurePolls >= 4) {
+        if (runs.length === TARGET_WORKFLOWS.length || now() >= failureDeadline) {
           return { failure, runs };
         }
       }

--- a/.github/actions/cancel-pr-sibling-runs/index.js
+++ b/.github/actions/cancel-pr-sibling-runs/index.js
@@ -161,9 +161,17 @@ function githubApi(token, owner, repo) {
   const base = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}`;
 
   async function request(path, options = {}) {
+    let timeoutMs = REQUEST_TIMEOUT_MS;
+    if (options.remainingMs) {
+      const remainingMs = Math.floor(options.remainingMs());
+      if (!Number.isFinite(remainingMs) || remainingMs <= 0) {
+        fail("monitor deadline elapsed");
+      }
+      timeoutMs = Math.min(timeoutMs, remainingMs);
+    }
     const response = await fetch(`${base}${path}`, {
       method: options.method || "GET",
-      signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+      signal: AbortSignal.timeout(timeoutMs),
       headers: {
         Accept: "application/vnd.github+json",
         Authorization: `Bearer ${token}`,
@@ -182,10 +190,10 @@ function githubApi(token, owner, repo) {
     return body ? JSON.parse(body) : null;
   }
 
-  async function listAll(pathForPage, field) {
+  async function listAll(pathForPage, field, options) {
     const values = [];
     for (let page = 1; ; page += 1) {
-      const result = await request(pathForPage(page));
+      const result = await request(pathForPage(page), options);
       const batch = result?.[field];
       if (!Array.isArray(batch)) {
         fail(`GitHub API response is missing ${field}`);
@@ -196,7 +204,7 @@ function githubApi(token, owner, repo) {
   }
 
   return {
-    async listRuns(headSha) {
+    async listRuns(headSha, options = {}) {
       return listAll((page) => {
         const query = new URLSearchParams({
           event: "pull_request",
@@ -205,17 +213,21 @@ function githubApi(token, owner, repo) {
           per_page: String(PAGE_SIZE),
         });
         return `/actions/runs?${query}`;
-      }, "workflow_runs");
+      }, "workflow_runs", options);
     },
-    async listJobs(runId) {
+    async listJobs(runId, options = {}) {
       return listAll(
         (page) => `/actions/runs/${runId}/jobs?filter=latest&per_page=${PAGE_SIZE}&page=${page}`,
         "jobs",
+        options,
       );
     },
-    async cancelRun(runId) {
+    async cancelRun(runId, options = {}) {
       try {
-        await request(`/actions/runs/${runId}/cancel`, { method: "POST" });
+        await request(`/actions/runs/${runId}/cancel`, {
+          ...options,
+          method: "POST",
+        });
         return true;
       } catch (error) {
         // A sibling can finish between the status read and cancel request.
@@ -226,19 +238,34 @@ function githubApi(token, owner, repo) {
   };
 }
 
-async function monitor({ api, trigger, pollSeconds, maxMinutes, log = console.log, now = Date.now }) {
-  const maxPolls = Math.ceil((maxMinutes * 60) / pollSeconds);
+async function monitor({
+  api,
+  trigger,
+  pollSeconds,
+  maxMinutes,
+  log = console.log,
+  now = Date.now,
+  sleepFn = sleep,
+}) {
+  const monitorDeadline = now() + maxMinutes * 60_000;
+  const requestOptions = { remainingMs: () => monitorDeadline - now() };
   let consecutiveErrors = 0;
   let failure = null;
   let failureDeadline = null;
-  for (let poll = 1; poll <= maxPolls; poll += 1) {
+  while (now() < monitorDeadline) {
     try {
-      const runs = selectTargetRuns(await api.listRuns(trigger.headSha), trigger);
+      const runs = selectTargetRuns(
+        await api.listRuns(trigger.headSha, requestOptions),
+        trigger,
+      );
       if (!failure) {
         const runJobs = [];
         for (const run of runs) {
           if (run.status !== "queued") {
-            runJobs.push({ run, jobs: await api.listJobs(run.id) });
+            runJobs.push({
+              run,
+              jobs: await api.listJobs(run.id, requestOptions),
+            });
           }
         }
         failure = findEarliestFailure(runJobs);
@@ -249,7 +276,7 @@ async function monitor({ api, trigger, pollSeconds, maxMinutes, log = console.lo
           log(`::notice::Preserving failed ${failure.workflowName} run ${failure.runId}; cancelling sibling PR lanes for the same revision.`);
         }
         for (const sibling of cancellableSiblingRuns(runs, failure.runId)) {
-          const cancelled = await api.cancelRun(sibling.id);
+          const cancelled = await api.cancelRun(sibling.id, requestOptions);
           log(`::notice::${cancelled ? "Cancelled" : "Sibling already terminal"}: ${sibling.name} run ${sibling.id}.`);
         }
         // Workflow records normally appear together, but a planning failure
@@ -269,7 +296,10 @@ async function monitor({ api, trigger, pollSeconds, maxMinutes, log = console.lo
       console.warn(`::warning::PR sibling monitor poll failed (${consecutiveErrors}/3): ${error.message}`);
       if (consecutiveErrors >= 3) throw error;
     }
-    if (poll < maxPolls) await sleep(pollSeconds * 1000);
+    const remainingMs = monitorDeadline - now();
+    if (remainingMs > 0) {
+      await sleepFn(Math.min(pollSeconds * 1000, remainingMs));
+    }
   }
   fail(`monitor timed out after ${maxMinutes} minutes`);
 }

--- a/.github/workflows/pr-cancel-sibling-runs.yml
+++ b/.github/workflows/pr-cancel-sibling-runs.yml
@@ -1,0 +1,32 @@
+name: PR · Cancel sibling lanes
+
+on:
+  workflow_run:
+    workflows: [PR · Quality]
+    types: [in_progress]
+
+permissions: {}
+
+concurrency:
+  group: pr-sibling-cancel-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  monitor:
+    name: Monitor PR lane failures
+    if: ${{ github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.pull_requests[0] != null }}
+    runs-on: ubuntu-24.04
+    timeout-minutes: 185
+    permissions:
+      actions: write
+      contents: read
+    steps:
+      - name: Check out protected cancellation policy
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+      - name: Cancel sibling lanes after the first job failure
+        uses: ./.github/actions/cancel-pr-sibling-runs
+        with:
+          token: ${{ github.token }}

--- a/.github/workflows/pr-cancel-sibling-runs.yml
+++ b/.github/workflows/pr-cancel-sibling-runs.yml
@@ -8,7 +8,7 @@ on:
 permissions: {}
 
 concurrency:
-  group: pr-sibling-cancel-${{ github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+  group: pr-sibling-cancel-${{ github.event.workflow_run.id }}
   cancel-in-progress: true
 
 jobs:

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -40,6 +40,10 @@ or cache identity.
   reusable PR/main calls and protected manual dispatch.
 - PRs and routine main pushes expose native lane jobs and five stable
   topic/platform results; dispatched manual-full lanes retain correlated checks.
+- One protected default-branch `workflow_run` monitor observes the five focused
+  runs for one exact PR event epoch. After the first definitive job failure it
+  preserves that workflow and cancels the other queued or in-progress sibling
+  lanes; PR-controlled jobs never receive Actions-write permission.
 - Existing static ABI, native SDK, Swift, smoke and HF workflows remain
   lower-level reusable producers/consumers.
 - Current PR routing is GitHub-hosted except for the documented uncredentialed
@@ -82,6 +86,7 @@ Routine main validation has the same acceptance invariant and exposes
   PR Linux entry --> plan --> protected Linux lane --> PR / Linux
   PR macOS entry --> plan --> protected macOS lane --> PR / macOS
   PR Windows entry --> plan --> protected Windows lane --> PR / Windows
+  PR Quality in-progress --> protected sibling monitor --> cancel other exact-revision lanes after first failure
 
   Main Quality/Website/Linux/macOS/Windows entries --> same-commit matching lanes
   Explicit manual-full entry --> protected controller --> five dispatched lanes
@@ -194,10 +199,13 @@ heavy job has a timeout and a deterministic row identity.
 
 PR platform matrices for compilation, Rust tests, products and functional
 platform checks fail fast. Main/manual matrices continue all rows for exhaustive
-diagnostics, and Quality remains non-fail-fast and independent. A failure never
-cancels another focused PR workflow; declared producer dependencies suppress
-only consumers that can no longer run. Whole-workflow API cancellation is
-forbidden because every lane must reach its stable summary.
+diagnostics, and Quality remains non-fail-fast within its own matrix. Declared
+producer dependencies suppress consumers that can no longer run. Across the
+five focused PR workflows, the protected sibling monitor preserves the lane
+with the first definitive job failure and cancels the other exact-PR,
+exact-SHA, same-epoch runs. Main/manual and unrelated workflows are never
+targets. The monitor is the only owner of Actions-write permission; checked-out
+PR code cannot invoke the cancellation API.
 
 PR caching is selective. Large Cargo target caches restore trusted main and do
 not publish per-PR copies; sccache remains job-local. Exact verified static,
@@ -379,7 +387,8 @@ the relevant xtask repo-consistency checks.
   source plan;
 - every consumer has a reachable producer and no consumer fallback build;
 - every lane summary passes unplanned skips and fails planned skips;
-- cancellation leaves no required summary stuck in a running state;
+- a failed PR lane retains its stable diagnostic while sibling runs become
+  terminal cancellations, with no required result stuck running;
 - GitHub fallback passes all slice fixtures;
 - no branch ruleset, runner group, Depot setting or external capacity change
   is included in this implementation PR.

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -14,6 +14,7 @@ and acceptance criteria are in `.omo/specs/pr-ci-optimization.md`.
 | `pr_linux.yml` (`PR · Linux`) | `pull_request` | Plans and calls the protected Linux lane |
 | `pr_macos.yml` (`PR · macOS`) | `pull_request` | Plans and calls the protected macOS lane |
 | `pr_windows.yml` (`PR · Windows`) | `pull_request` | Plans and calls the protected Windows lane |
+| `pr-cancel-sibling-runs.yml` (`PR · Cancel sibling lanes`) | protected `workflow_run` for `PR · Quality` | Watches one exact PR revision and cancels its other validation lanes after the first job failure |
 | `pr_builds.yml` | `workflow_call` only | Inert compatibility for the pre-migration protected runner-contract filename check |
 | `ci-orchestrator.yml` | `workflow_call` only | Inert compatibility for the pre-migration protected runner-contract filename check |
 | `main_quality.yml` (`Main · Quality`) | push to `main` | Plans and calls the same-commit Quality lane |
@@ -36,8 +37,9 @@ trusted-main caches, and independently cancel superseded synchronizations.
 
 The five-way split is a hard CI architecture invariant. Keep exactly these PR
 validation entry workflows: Quality, Website, Linux, macOS, and Windows. PR
-metadata, cleanup, and auto-assignment workflows such as `pr_cleanup.yml` and
-`pr_auto_assign.yml` are outside this validation census. Every validation
+metadata, cleanup, auto-assignment, and sibling-cancellation workflows such as
+`pr_cleanup.yml`, `pr_auto_assign.yml`, and `pr-cancel-sibling-runs.yml` are
+outside this validation census. Every validation
 workflow must call only its matching protected reusable lane and finish with
 its own stable `PR / <lane>` result. Add or refactor jobs inside the owning
 reusable lane; do not move multiple lanes into a shared PR entrypoint.
@@ -135,6 +137,7 @@ flowchart TD
     MAIN["five focused main entry workflows"] --> MAINPLAN["same-commit exhaustive planning"]
     MANUAL["explicit manual-full"] --> CONTROL["protected manual dispatcher"]
     PRPLAN --> PLAN["compute changes + plan-ci per focused entry"]
+    PR --> MONITOR["protected exact-revision failure monitor"]
     MAINPLAN --> PLAN
     CONTROL --> PLAN
     PLAN --> QUALITY["Quality graph"]
@@ -152,6 +155,11 @@ flowchart TD
     LC --> LINUXGATE["PR / Linux"]
     MC --> MACGATE["PR / macOS"]
     XC --> WINGATE["PR / Windows"]
+    MONITOR -. "first definitive job failure" .-> QUALITY
+    MONITOR -. "cancel remaining siblings" .-> WEB
+    MONITOR -. "cancel remaining siblings" .-> LINUX
+    MONITOR -. "cancel remaining siblings" .-> MAC
+    MONITOR -. "cancel remaining siblings" .-> WIN
     QC --> MQ["Main / Quality"]
     WC --> MW["Main / Website"]
     LC --> ML["Main / Linux"]
@@ -274,10 +282,23 @@ raw inputs and dated reports under `/tmp` or a tracking artifact, never in
 
 ### PR failure domains
 
-The five PR workflows are independent failure domains. Quality and Website
-continue when a platform compile or functional test fails, and platform lanes
-do not cancel one another. This preserves useful, directly visible diagnostics
-and prevents one topic from hiding another topic's result.
+The five PR workflows remain separate visible checks, but they share a PR-only
+failure budget. A protected `workflow_run` monitor starts when `PR · Quality`
+enters progress and polls the five validation runs associated with the same PR
+number, exact head SHA, and two-minute event epoch. When it observes the first
+definitive failed, timed-out, startup-failed, stale, or action-required job, it
+preserves that workflow as the root diagnostic and cancels the other queued or
+in-progress lane runs. A newer PR synchronization has a different SHA and
+supersedes the old monitor through its PR-number concurrency group.
+
+The monitor executes only the default-branch implementation, checks out only
+the default branch, and owns the narrowly scoped `actions: write` token.
+PR-controlled entrypoints, reusable executors, and checked-out source never
+receive that permission. Main, manual-full, release, deployment, cleanup,
+cache-warming, unrelated workflows, other PRs, and a different event epoch are
+not cancellation targets. The monitor costs one GitHub-hosted Linux slot while
+the PR runs; this bounded overhead replaces five per-lane polling jobs and is
+expected to recover more capacity whenever a lane fails early.
 
 Inside Linux, macOS, and Windows, PR-only `fail_fast` inputs are enabled for
 Rust-test, host, native-runtime, product, and platform-check matrices. The
@@ -289,10 +310,10 @@ unusable.
 
 Producer/consumer `needs` edges are the second cancellation layer. A failed UI,
 ABI, host, or runtime producer prevents its product and smoke consumers from
-starting. Do not add an Actions-API watcher that cancels the whole workflow on
-first failure. Whole-run cancellation would also cancel the stable lane
-summary, leaving reviewers with a cancelled required result instead of a
-precise terminal failure.
+starting. Only the protected monitor may use the Actions API for cross-workflow
+cancellation. The failed workflow is never cancelled, so its stable summary
+can report the precise terminal failure; cancelled siblings are expected
+terminal results that release their runner capacity.
 
 ## Artifact contract
 

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -288,8 +288,9 @@ enters progress and polls the five validation runs associated with the same PR
 number, exact head SHA, and two-minute event epoch. When it observes the first
 definitive failed, timed-out, startup-failed, stale, or action-required job, it
 preserves that workflow as the root diagnostic and cancels the other queued or
-in-progress lane runs. A newer PR synchronization has a different SHA and
-supersedes the old monitor through its PR-number concurrency group.
+in-progress lane runs. Each triggering Quality run owns a distinct monitor, so
+a newer synchronization cannot prevent an older exact-revision monitor from
+finishing its bounded cleanup.
 
 The monitor executes only the default-branch implementation, checks out only
 the default branch, and owns the narrowly scoped `actions: write` token.

--- a/scripts/tests/test_pr_sibling_cancellation.py
+++ b/scripts/tests/test_pr_sibling_cancellation.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+ACTION = ROOT / ".github" / "actions" / "cancel-pr-sibling-runs" / "index.js"
+WORKFLOW = ROOT / ".github" / "workflows" / "pr-cancel-sibling-runs.yml"
+
+
+class PrSiblingCancellationTests(unittest.TestCase):
+    def run_node(self, expression: str) -> object:
+        script = f"""
+const action = require(process.argv[1]);
+const result = (() => {{ {expression} }})();
+process.stdout.write(JSON.stringify(result));
+"""
+        completed = subprocess.run(
+            ["node", "-e", script, str(ACTION)],
+            check=True,
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        return json.loads(completed.stdout)
+
+    def run_node_async(self, expression: str) -> object:
+        script = f"""
+const action = require(process.argv[1]);
+(async () => {{
+  const result = await (async () => {{ {expression} }})();
+  process.stdout.write(JSON.stringify(result));
+}})().catch((error) => {{
+  console.error(error);
+  process.exitCode = 1;
+}});
+"""
+        completed = subprocess.run(
+            ["node", "-e", script, str(ACTION)],
+            check=True,
+            cwd=ROOT,
+            capture_output=True,
+            text=True,
+        )
+        return json.loads(completed.stdout)
+
+    def test_monitor_is_protected_and_pr_only(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+        self.assertIn("workflow_run:", workflow)
+        self.assertIn("workflows: [PR · Quality]", workflow)
+        self.assertIn("types: [in_progress]", workflow)
+        self.assertNotIn("pull_request_target:", workflow)
+        self.assertNotIn("\n  pull_request:\n", workflow)
+        self.assertIn("github.event.workflow_run.event == 'pull_request'", workflow)
+        self.assertIn("actions: write", workflow)
+        self.assertIn("permissions: {}", workflow)
+        self.assertIn(
+            "ref: ${{ github.event.repository.default_branch }}",
+            workflow,
+        )
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertNotIn("github.event.workflow_run.head_sha", workflow)
+        self.assertNotIn("secrets:", workflow)
+
+        for lane in ("quality", "website", "linux", "macos", "windows"):
+            pr_workflow = (
+                ROOT / ".github" / "workflows" / f"pr_{lane}.yml"
+            ).read_text(encoding="utf-8")
+            self.assertNotIn("actions: write", pr_workflow)
+
+    def test_trigger_requires_exact_quality_pr_identity(self) -> None:
+        result = self.run_node(
+            """
+const sha = "a".repeat(40);
+const payload = {
+  repository: {full_name: "Mesh-LLM/mesh-llm"},
+  workflow_run: {
+    id: 101,
+    name: "PR · Quality",
+    event: "pull_request",
+    head_sha: sha,
+    created_at: "2026-08-20T12:00:00Z",
+    pull_requests: [{number: 42}],
+  },
+};
+return action.parseTrigger(payload, "Mesh-LLM/mesh-llm");
+"""
+        )
+        self.assertEqual(42, result["pullNumber"])
+        self.assertEqual(101, result["triggerRunId"])
+        self.assertEqual("a" * 40, result["headSha"])
+
+    def test_target_selection_rejects_other_pr_sha_and_event_epoch(self) -> None:
+        result = self.run_node(
+            """
+const sha = "b".repeat(40);
+const trigger = {
+  createdAt: Date.parse("2026-08-20T12:00:00Z"),
+  headSha: sha,
+  pullNumber: 42,
+  triggerRunId: 201,
+};
+const base = {
+  event: "pull_request",
+  head_sha: sha,
+  created_at: "2026-08-20T12:00:20Z",
+  pull_requests: [{number: 42}],
+  status: "in_progress",
+};
+const runs = [
+  {...base, id: 201, name: "PR · Quality"},
+  {...base, id: 202, name: "PR · Linux"},
+  {...base, id: 203, name: "PR · Windows", head_sha: "c".repeat(40)},
+  {...base, id: 204, name: "PR · macOS", pull_requests: [{number: 43}]},
+  {...base, id: 205, name: "PR · Website", created_at: "2026-08-20T11:40:00Z"},
+  {...base, id: 206, name: "Release"},
+  {...base, id: 207, name: "PR · Quality"},
+];
+return action.selectTargetRuns(runs, trigger).map((run) => [run.id, run.name]);
+"""
+        )
+        self.assertEqual([[202, "PR · Linux"]], result)
+
+    def test_first_failure_is_preserved_and_only_active_siblings_cancel(self) -> None:
+        result = self.run_node(
+            """
+const runs = [
+  {id: 301, name: "PR · Quality", status: "in_progress"},
+  {id: 302, name: "PR · Website", status: "completed"},
+  {id: 303, name: "PR · Linux", status: "in_progress"},
+  {id: 304, name: "PR · macOS", status: "queued"},
+  {id: 305, name: "PR · Windows", status: "completed"},
+];
+const failure = action.findEarliestFailure([
+  {run: runs[2], jobs: [{id: 2, name: "later", conclusion: "failure", completed_at: "2026-08-20T12:02:00Z"}]},
+  {run: runs[0], jobs: [{id: 1, name: "first", conclusion: "failure", completed_at: "2026-08-20T12:01:00Z"}]},
+]);
+return {
+  failure,
+  cancellations: action.cancellableSiblingRuns(runs, failure.runId).map((run) => run.id),
+};
+"""
+        )
+        self.assertEqual(301, result["failure"]["runId"])
+        self.assertEqual([303, 304], result["cancellations"])
+
+    def test_all_five_runs_must_be_terminal_before_monitor_exits_cleanly(self) -> None:
+        result = self.run_node(
+            """
+const complete = action.TARGET_WORKFLOWS.map((name, index) => ({id: index + 1, name, status: "completed"}));
+return {
+  complete: action.allTargetsTerminal(complete),
+  missing: action.allTargetsTerminal(complete.slice(0, 4)),
+  active: action.allTargetsTerminal(complete.map((run, index) => index === 2 ? {...run, status: "in_progress"} : run)),
+};
+"""
+        )
+        self.assertEqual(
+            {"complete": True, "missing": False, "active": False},
+            result,
+        )
+
+    def test_cancel_api_accepts_empty_202_response(self) -> None:
+        result = self.run_node_async(
+            """
+global.fetch = async () => ({
+  ok: true,
+  status: 202,
+  text: async () => "",
+});
+return await action.githubApi("token", "owner", "repo").cancelRun(123);
+"""
+        )
+        self.assertTrue(result)
+
+    def test_monitor_cancels_siblings_created_after_early_failure(self) -> None:
+        result = self.run_node_async(
+            """
+const sha = "d".repeat(40);
+const trigger = {
+  createdAt: Date.parse("2026-08-20T12:00:00Z"),
+  headSha: sha,
+  pullNumber: 42,
+  triggerRunId: 401,
+};
+const base = {
+  event: "pull_request",
+  head_sha: sha,
+  created_at: "2026-08-20T12:00:05Z",
+  pull_requests: [{number: 42}],
+  status: "in_progress",
+};
+const quality = {...base, id: 401, name: "PR · Quality"};
+const allRuns = action.TARGET_WORKFLOWS.map((name, index) => ({
+  ...base,
+  id: 401 + index,
+  name,
+}));
+let polls = 0;
+const cancelled = [];
+const api = {
+  listRuns: async () => (++polls === 1 ? [quality] : allRuns),
+  listJobs: async (runId) => runId === 401 ? [{
+    id: 501,
+    name: "Plan",
+    conclusion: "failure",
+    completed_at: "2026-08-20T12:00:06Z",
+  }] : [],
+  cancelRun: async (runId) => { cancelled.push(runId); return true; },
+};
+const outcome = await action.monitor({
+  api,
+  trigger,
+  pollSeconds: 0,
+  maxMinutes: 1,
+  log: () => {},
+});
+return {cancelled, failedRun: outcome.failure.runId, polls};
+"""
+        )
+        self.assertEqual(401, result["failedRun"])
+        self.assertEqual(2, result["polls"])
+        self.assertEqual([402, 403, 404, 405], result["cancelled"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_pr_sibling_cancellation.py
+++ b/scripts/tests/test_pr_sibling_cancellation.py
@@ -5,6 +5,8 @@ from pathlib import Path
 import subprocess
 import unittest
 
+import yaml
+
 
 ROOT = Path(__file__).resolve().parents[2]
 ACTION = ROOT / ".github" / "actions" / "cancel-pr-sibling-runs" / "index.js"
@@ -12,6 +14,25 @@ WORKFLOW = ROOT / ".github" / "workflows" / "pr-cancel-sibling-runs.yml"
 
 
 class PrSiblingCancellationTests(unittest.TestCase):
+    def assert_actions_permission_denied(
+        self,
+        permissions: object,
+        scope: str,
+    ) -> None:
+        self.assertNotEqual("write-all", permissions, f"{scope} grants write-all")
+        if permissions is None:
+            return
+        self.assertIsInstance(
+            permissions,
+            dict,
+            f"{scope} permissions must be a mapping or omitted",
+        )
+        self.assertIn(
+            permissions.get("actions"),
+            (None, "none"),
+            f"{scope} must not grant Actions API access",
+        )
+
     def run_node(self, expression: str) -> object:
         script = f"""
 const action = require(process.argv[1]);
@@ -70,10 +91,19 @@ const action = require(process.argv[1]);
         self.assertNotIn("secrets:", workflow)
 
         for lane in ("quality", "website", "linux", "macos", "windows"):
-            pr_workflow = (
-                ROOT / ".github" / "workflows" / f"pr_{lane}.yml"
-            ).read_text(encoding="utf-8")
-            self.assertNotIn("actions: write", pr_workflow)
+            path = ROOT / ".github" / "workflows" / f"pr_{lane}.yml"
+            document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            with self.subTest(lane=lane, scope="workflow"):
+                self.assert_actions_permission_denied(
+                    document.get("permissions"),
+                    f"{path.name} workflow",
+                )
+            for job_name, job in (document.get("jobs") or {}).items():
+                with self.subTest(lane=lane, scope=f"job:{job_name}"):
+                    self.assert_actions_permission_denied(
+                        job.get("permissions"),
+                        f"{path.name} job {job_name}",
+                    )
 
     def test_trigger_requires_exact_quality_pr_identity(self) -> None:
         result = self.run_node(

--- a/scripts/tests/test_pr_sibling_cancellation.py
+++ b/scripts/tests/test_pr_sibling_cancellation.py
@@ -52,6 +52,10 @@ const action = require(process.argv[1]);
         self.assertIn("workflow_run:", workflow)
         self.assertIn("workflows: [PR · Quality]", workflow)
         self.assertIn("types: [in_progress]", workflow)
+        self.assertIn(
+            "group: pr-sibling-cancel-${{ github.event.workflow_run.id }}",
+            workflow,
+        )
         self.assertNotIn("pull_request_target:", workflow)
         self.assertNotIn("\n  pull_request:\n", workflow)
         self.assertIn("github.event.workflow_run.event == 'pull_request'", workflow)
@@ -176,6 +180,42 @@ return await action.githubApi("token", "owner", "repo").cancelRun(123);
         )
         self.assertTrue(result)
 
+    def test_api_paginates_workflow_runs_and_jobs(self) -> None:
+        result = self.run_node_async(
+            """
+const pages = [];
+global.fetch = async (rawUrl, options) => {
+  const url = new URL(rawUrl);
+  const page = Number(url.searchParams.get("page"));
+  const field = url.pathname.endsWith("/jobs") ? "jobs" : "workflow_runs";
+  pages.push([field, page, options.signal instanceof AbortSignal]);
+  const count = page === 1 ? 100 : 1;
+  return {
+    ok: true,
+    status: 200,
+    text: async () => JSON.stringify({
+      [field]: Array.from({length: count}, (_, index) => ({id: (page - 1) * 100 + index + 1})),
+    }),
+  };
+};
+const api = action.githubApi("token", "owner", "repo");
+const runs = await api.listRuns("e".repeat(40));
+const jobs = await api.listJobs(123);
+return {pages, runCount: runs.length, jobCount: jobs.length};
+"""
+        )
+        self.assertEqual(101, result["runCount"])
+        self.assertEqual(101, result["jobCount"])
+        self.assertEqual(
+            [
+                ["workflow_runs", 1, True],
+                ["workflow_runs", 2, True],
+                ["jobs", 1, True],
+                ["jobs", 2, True],
+            ],
+            result["pages"],
+        )
+
     def test_monitor_cancels_siblings_created_after_early_failure(self) -> None:
         result = self.run_node_async(
             """
@@ -224,6 +264,49 @@ return {cancelled, failedRun: outcome.failure.runId, polls};
         self.assertEqual(401, result["failedRun"])
         self.assertEqual(2, result["polls"])
         self.assertEqual([402, 403, 404, 405], result["cancelled"])
+
+    def test_late_sibling_window_uses_elapsed_time(self) -> None:
+        result = self.run_node_async(
+            """
+const sha = "f".repeat(40);
+const trigger = {
+  createdAt: Date.parse("2026-08-20T12:00:00Z"),
+  headSha: sha,
+  pullNumber: 42,
+  triggerRunId: 601,
+};
+const quality = {
+  id: 601,
+  name: "PR · Quality",
+  event: "pull_request",
+  head_sha: sha,
+  created_at: "2026-08-20T12:00:05Z",
+  pull_requests: [{number: 42}],
+  status: "in_progress",
+};
+let polls = 0;
+let clock = 0;
+const outcome = await action.monitor({
+  api: {
+    listRuns: async () => { polls += 1; return [quality]; },
+    listJobs: async () => [{
+      id: 701,
+      name: "Plan",
+      conclusion: "failure",
+      completed_at: "2026-08-20T12:00:06Z",
+    }],
+    cancelRun: async () => true,
+  },
+  trigger,
+  pollSeconds: 0,
+  maxMinutes: 1,
+  log: () => {},
+  now: () => { const value = clock; clock += 60_000; return value; },
+});
+return {failedRun: outcome.failure.runId, polls};
+"""
+        )
+        self.assertEqual({"failedRun": 601, "polls": 2}, result)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_pr_sibling_cancellation.py
+++ b/scripts/tests/test_pr_sibling_cancellation.py
@@ -298,15 +298,58 @@ const outcome = await action.monitor({
     cancelRun: async () => true,
   },
   trigger,
-  pollSeconds: 0,
-  maxMinutes: 1,
+  pollSeconds: 30,
+  maxMinutes: 10,
   log: () => {},
-  now: () => { const value = clock; clock += 60_000; return value; },
+  now: () => clock,
+  sleepFn: async (milliseconds) => { clock += milliseconds; },
 });
 return {failedRun: outcome.failure.runId, polls};
 """
         )
-        self.assertEqual({"failedRun": 601, "polls": 2}, result)
+        self.assertEqual({"failedRun": 601, "polls": 5}, result)
+
+    def test_monitor_caps_slow_successful_polls_at_absolute_deadline(self) -> None:
+        result = self.run_node_async(
+            """
+const trigger = {
+  createdAt: Date.parse("2026-08-20T12:00:00Z"),
+  headSha: "1".repeat(40),
+  pullNumber: 42,
+  triggerRunId: 801,
+};
+let clock = 0;
+let polls = 0;
+const sleeps = [];
+let error = null;
+try {
+  await action.monitor({
+    api: {
+      listRuns: async (_sha, options) => {
+        polls += 1;
+        if (options.remainingMs() <= 0) throw new Error("late API operation");
+        clock += 40_000;
+        return [];
+      },
+      listJobs: async () => [],
+      cancelRun: async () => true,
+    },
+    trigger,
+    pollSeconds: 30,
+    maxMinutes: 1,
+    log: () => {},
+    now: () => clock,
+    sleepFn: async (milliseconds) => { sleeps.push(milliseconds); clock += milliseconds; },
+  });
+} catch (caught) {
+  error = caught.message;
+}
+return {error, polls, sleeps};
+"""
+        )
+        self.assertIn("timed out after 1 minutes", result["error"])
+        self.assertEqual(1, result["polls"])
+        self.assertEqual([20_000], result["sleeps"])
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_pr_sibling_cancellation.py
+++ b/scripts/tests/test_pr_sibling_cancellation.py
@@ -18,14 +18,21 @@ class PrSiblingCancellationTests(unittest.TestCase):
         self,
         permissions: object,
         scope: str,
+        *,
+        inherited_permissions: object = None,
+        require_explicit: bool = False,
     ) -> None:
-        self.assertNotEqual("write-all", permissions, f"{scope} grants write-all")
         if permissions is None:
-            return
+            self.assertFalse(
+                require_explicit,
+                f"{scope} must declare an explicit permissions mapping",
+            )
+            permissions = inherited_permissions
+        self.assertNotEqual("write-all", permissions, f"{scope} grants write-all")
         self.assertIsInstance(
             permissions,
             dict,
-            f"{scope} permissions must be a mapping or omitted",
+            f"{scope} effective permissions must be a mapping",
         )
         self.assertIn(
             permissions.get("actions"),
@@ -93,16 +100,35 @@ const action = require(process.argv[1]);
         for lane in ("quality", "website", "linux", "macos", "windows"):
             path = ROOT / ".github" / "workflows" / f"pr_{lane}.yml"
             document = yaml.safe_load(path.read_text(encoding="utf-8")) or {}
+            workflow_permissions = document.get("permissions")
             with self.subTest(lane=lane, scope="workflow"):
                 self.assert_actions_permission_denied(
-                    document.get("permissions"),
+                    workflow_permissions,
                     f"{path.name} workflow",
+                    require_explicit=True,
                 )
             for job_name, job in (document.get("jobs") or {}).items():
                 with self.subTest(lane=lane, scope=f"job:{job_name}"):
                     self.assert_actions_permission_denied(
                         job.get("permissions"),
                         f"{path.name} job {job_name}",
+                        inherited_permissions=workflow_permissions,
+                    )
+
+    def test_permission_assertion_rejects_implicit_or_write_access(self) -> None:
+        with self.assertRaises(AssertionError):
+            self.assert_actions_permission_denied(
+                None,
+                "workflow",
+                require_explicit=True,
+            )
+        for permissions in ("write-all", "read-all", {"actions": "write"}):
+            with self.subTest(permissions=permissions):
+                with self.assertRaises(AssertionError):
+                    self.assert_actions_permission_denied(
+                        permissions,
+                        "job",
+                        inherited_permissions={"actions": "none"},
                     )
 
     def test_trigger_requires_exact_quality_pr_identity(self) -> None:


### PR DESCRIPTION
## Summary

- add a protected default-branch monitor for the five focused PR validation workflows
- preserve the workflow containing the first definitive failed job while cancelling its queued or running siblings for the same PR, head SHA, and event epoch
- keep `actions: write` outside PR-controlled workflows and update the normative CI topology and cancellation policy
- cover empty cancellation responses, late-created sibling runs, target selection, and failure preservation with focused tests

## Validation

- `just ci-validate` (482 tests, 7 expected skips)
- `python3 -m unittest scripts.tests.test_pr_sibling_cancellation scripts.tests.test_ci_lane_workflows scripts.tests.test_pr_builds_summary scripts.tests.test_pr_workflow_artifacts` (46 tests)
- `actionlint -config-file .github/actionlint.yaml`
- `node --check .github/actions/cancel-pr-sibling-runs/index.js`
- `git diff --check`

## Operational notes

- PR-only; main, manual, release, deployment, cleanup, cache-warming, unrelated workflows, and newer PR revisions are excluded.
- The monitor consumes one GitHub-hosted Linux slot while a PR is active.
- Because `workflow_run` executes the default-branch workflow definition, the new monitor itself becomes live only after merge; this PR validates its structure and local action behavior.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **CI Improvements**
  * Added protected monitoring for pull request validation workflows.
  * Preserves the first definitive failure for diagnostics while cancelling eligible sibling runs.
  * Limits cancellation to matching pull requests, revisions, and validation workflows; unrelated workflows remain unaffected.
  * Keeps workflow-cancellation permissions isolated from pull request code.

* **Documentation**
  * Updated CI policies, architecture references, and workflow inventory.

* **Tests**
  * Added coverage for filtering, failure preservation, cancellation behavior, permissions, pagination, and monitoring edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->