### PR TITLE
perf(kv): keep exact-state recording off inference path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7541,6 +7541,7 @@ dependencies = [
  "clap",
  "futures-util",
  "libc",
+ "mesh-llm-events",
  "mesh-native-serving-plugin-api",
  "model-artifact",
  "openai-frontend",

--- a/crates/skippy-cache/src/disk_tier.rs
+++ b/crates/skippy-cache/src/disk_tier.rs
@@ -565,6 +565,17 @@ impl PrefixDiskTier {
         }))
     }
 
+    /// Mark an entry as recently used without mapping or verifying its payload.
+    pub fn touch(&mut self, page_id: &str) -> bool {
+        let Some(entry) = self.entries.get_mut(page_id) else {
+            return false;
+        };
+        self.use_clock = self.use_clock.saturating_add(1);
+        entry.last_used_secs = now_secs();
+        entry.use_sequence = self.use_clock;
+        true
+    }
+
     pub fn contains(&self, page_id: &str) -> bool {
         self.entries.contains_key(page_id)
     }

--- a/crates/skippy-cache/src/exact_state.rs
+++ b/crates/skippy-cache/src/exact_state.rs
@@ -206,6 +206,21 @@ impl<E: Clone + serde::Serialize> ExactStateCache<E> {
         self.misses.note_identity_mismatch();
     }
 
+    /// Mark an existing page as recently used without reconstructing or
+    /// replacing its payload.
+    ///
+    /// Page identities include the complete prefix identity, so an existing
+    /// entry is already the checkpoint the caller intends to record. This
+    /// lets record paths avoid exporting and re-hashing the same state.
+    pub fn touch(&mut self, page_id: &str) -> bool {
+        self.clock = self.clock.saturating_add(1);
+        if let Some(entry) = self.entries.get_mut(page_id) {
+            entry.last_used = self.clock;
+            return true;
+        }
+        self.disk.as_mut().is_some_and(|disk| disk.touch(page_id))
+    }
+
     pub fn disk_contains(&self, page_id: &str) -> bool {
         self.disk
             .as_ref()
@@ -513,6 +528,36 @@ mod tests {
         assert!(cache.lookup("first").is_none());
         assert!(cache.lookup("second").is_some());
         assert_eq!(cache.stats().entries, 1);
+    }
+
+    #[test]
+    fn touching_existing_page_refreshes_lru_without_replacing_payload() {
+        let mut cache = ExactStateCache::new(2, 0);
+        cache.record(
+            "first".to_string(),
+            2,
+            ExactStatePayload::full_state(vec![1, 2]),
+            (),
+        );
+        cache.record(
+            "second".to_string(),
+            2,
+            ExactStatePayload::full_state(vec![3, 4]),
+            (),
+        );
+
+        assert!(cache.touch("first"));
+        assert!(!cache.touch("missing"));
+        cache.record(
+            "third".to_string(),
+            2,
+            ExactStatePayload::full_state(vec![5, 6]),
+            (),
+        );
+
+        assert!(cache.lookup("first").is_some());
+        assert!(cache.lookup("second").is_none());
+        assert!(cache.lookup("third").is_some());
     }
 
     #[test]

--- a/crates/skippy-server/Cargo.toml
+++ b/crates/skippy-server/Cargo.toml
@@ -28,6 +28,7 @@ futures-util = "0.3"
 skippy-runtime = { path = "../skippy-runtime", version = "0.76.0-rc4"  }
 skippy-tokenizer = { path = "../skippy-tokenizer", version = "0.76.0-rc4" }
 model-artifact = { path = "../model-artifact", version = "0.76.0-rc4" }
+mesh-llm-events = { path = "../mesh-llm-events", version = "0.76.0-rc4" }
 mesh-native-serving-plugin-api = { path = "../mesh-native-serving-plugin-api", version = "0.76.0-rc4" }
 skippy-protocol = { path = "../skippy-protocol", version = "0.76.0-rc4"  }
 skippy-cache = { path = "../skippy-cache", version = "0.76.0-rc4"  }

--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -600,6 +600,18 @@ impl StageOpenAiBackend {
                     "skippy.exact_cache.reconstruct_blocks".to_string(),
                     json!(restored.reconstruct_blocks),
                 );
+                attrs.insert(
+                    "skippy.exact_cache.lookup_ms".to_string(),
+                    json!(restored.lookup_ms),
+                );
+                attrs.insert(
+                    "skippy.exact_cache.kv_import_ms".to_string(),
+                    json!(restored.kv_import_ms),
+                );
+                attrs.insert(
+                    "skippy.exact_cache.recurrent_import_ms".to_string(),
+                    json!(restored.recurrent_import_ms),
+                );
                 self.telemetry
                     .emit("stage.openai_kv_lookup_decision", attrs);
             }
@@ -1088,13 +1100,10 @@ impl StageOpenAiBackend {
                     "skippy.exact_cache.recorded_tokens".to_string(),
                     json!(record.token_count),
                 );
-                attrs.insert(
-                    "skippy.exact_cache.stored".to_string(),
-                    json!(record.stored),
-                );
+                attrs.insert("skippy.exact_cache.queued".to_string(), json!(true));
                 self.telemetry
                     .emit("stage.openai_kv_record_decision", attrs);
-                record.stored
+                true
             }
             Ok(None) => false,
             Err(error) => {

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -38,8 +38,8 @@ use skippy_runtime::ModelInfo;
 use skippy_topology::{STAGE_RUNTIME_LLAMA_FAMILY_EXPECTATIONS, infer_family_capability};
 
 use super::{
-    ExactStateExtra, KvStageIntegration, StageKvMode, StagePrefixCachePayload, disk_budget,
-    disk_budget::NodeBudget,
+    ExactStateExtra, KvStageIntegration, PendingExactStateRecord, StageKvMode,
+    StagePrefixCachePayload, disk_budget, disk_budget::NodeBudget,
 };
 
 impl KvStageIntegration {
@@ -78,16 +78,52 @@ impl KvStageIntegration {
         if let Some(opened) = disk {
             exact_states = exact_states.with_disk_tier(opened.tier);
         }
+        let exact_states = Arc::new(Mutex::new(exact_states));
+        let (exact_state_record_tx, exact_state_record_rx) =
+            std::sync::mpsc::sync_channel::<PendingExactStateRecord>(1);
+        let worker_exact_states = exact_states.clone();
+        let inflight_records = Arc::new(Mutex::new(BTreeSet::new()));
+        let worker_inflight_records = inflight_records.clone();
+        let exact_state_records_queued = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let exact_state_records_dropped = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let exact_state_records_pending = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let worker_exact_state_records_pending = exact_state_records_pending.clone();
+        std::thread::Builder::new()
+            .name(format!("skippy-exact-cache-{}", config.stage_id))
+            .spawn(move || {
+                while let Ok(pending) = exact_state_record_rx.recv() {
+                    let page_id = pending.page_id.clone();
+                    worker_exact_states
+                        .lock()
+                        .expect("exact state cache lock poisoned")
+                        .record(
+                            pending.page_id,
+                            pending.token_count,
+                            pending.payload,
+                            pending.extra,
+                        );
+                    worker_inflight_records
+                        .lock()
+                        .expect("kv inflight record lock poisoned")
+                        .remove(&page_id);
+                    worker_exact_state_records_pending
+                        .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                }
+            })?;
         Ok(Some(Self {
             mode,
             payload,
             correctness_mode: false,
             trust_local_writes: true,
             candidate_policy,
-            inflight_records: Arc::new(Mutex::new(BTreeSet::new())),
+            inflight_records,
             resident: Arc::new(Mutex::new(ResidentPrefixCache::new(resident_config))),
             activations: Arc::new(Mutex::new(ResidentActivationCache::new(resident_config))),
-            exact_states: Arc::new(Mutex::new(exact_states)),
+            exact_states,
+            exact_state_record_tx,
+            exact_state_records_queued,
+            exact_state_records_dropped,
+            exact_state_records_pending,
             first_tokens: Arc::new(Mutex::new(BTreeMap::new())),
             replay_tokens: Arc::new(Mutex::new(BTreeMap::new())),
             split_prefill_tokens: Arc::new(Mutex::new(BTreeMap::new())),

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -39,8 +39,8 @@ use skippy_runtime::ModelInfo;
 use skippy_topology::{STAGE_RUNTIME_LLAMA_FAMILY_EXPECTATIONS, infer_family_capability};
 
 use super::{
-    ExactStateExtra, KvStageIntegration, PendingExactStateRecord, StageKvMode,
-    StagePrefixCachePayload, disk_budget, disk_budget::NodeBudget,
+    EXACT_STATE_RECORD_CAPACITY, ExactStateExtra, KvStageIntegration, PendingExactStateRecord,
+    StageKvMode, StagePrefixCachePayload, disk_budget, disk_budget::NodeBudget,
 };
 
 impl KvStageIntegration {
@@ -81,7 +81,7 @@ impl KvStageIntegration {
         }
         let exact_states = Arc::new(Mutex::new(exact_states));
         let (exact_state_record_tx, exact_state_record_rx) =
-            std::sync::mpsc::sync_channel::<PendingExactStateRecord>(1);
+            std::sync::mpsc::sync_channel::<PendingExactStateRecord>(EXACT_STATE_RECORD_CAPACITY);
         let worker_exact_states = exact_states.clone();
         let inflight_records = Arc::new(Mutex::new(BTreeSet::new()));
         let worker_inflight_records = inflight_records.clone();
@@ -89,14 +89,16 @@ impl KvStageIntegration {
         let exact_state_records_dropped = Arc::new(std::sync::atomic::AtomicU64::new(0));
         let exact_state_records_pending = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let worker_exact_state_records_pending = exact_state_records_pending.clone();
+        let worker_disk_budget_reservation = disk_budget_reservation.clone();
         std::thread::Builder::new()
             .name(format!("skippy-exact-cache-{}", config.stage_id))
             .spawn(move || {
+                let _disk_budget_reservation = worker_disk_budget_reservation;
                 while let Ok(pending) = exact_state_record_rx.recv() {
                     let page_id = pending.page_id.clone();
                     worker_exact_states
                         .lock()
-                        .expect("exact state cache lock poisoned")
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
                         .record(
                             pending.page_id,
                             pending.token_count,
@@ -105,10 +107,10 @@ impl KvStageIntegration {
                         );
                     worker_inflight_records
                         .lock()
-                        .expect("kv inflight record lock poisoned")
+                        .unwrap_or_else(std::sync::PoisonError::into_inner)
                         .remove(&page_id);
                     worker_exact_state_records_pending
-                        .fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+                        .fetch_sub(1, std::sync::atomic::Ordering::Release);
                 }
             })?;
         Ok(Some(Self {

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -27,6 +27,7 @@ pub fn configure_kv_disk_cache(config: KvDiskCacheConfig) -> Result<(), KvDiskCa
 }
 
 use anyhow::Result;
+use mesh_llm_events::{OutputEvent, emit_event};
 use skippy_cache::{
     ExactStateCache, PrefixCandidatePolicy, PrefixDiskTier, ResidentActivationCache,
     ResidentCacheConfig, ResidentPrefixCache,
@@ -133,6 +134,13 @@ impl KvStageIntegration {
     }
 }
 
+fn emit_warning(message: String) {
+    let _ = emit_event(OutputEvent::Warning {
+        message,
+        context: None,
+    });
+}
+
 /// Open the KV disk tier for this stage. Host configuration wins; legacy
 /// environment variables remain compatibility input when no host configured it.
 struct OpenedDiskTier {
@@ -143,17 +151,19 @@ struct OpenedDiskTier {
 fn open_disk_tier(config: &StageConfig) -> Option<OpenedDiskTier> {
     let root = disk_tier_root(config);
     if !has_valid_content_digest(config) {
-        eprintln!(
+        emit_warning(format!(
             "skippy: KV disk tier disabled for stage {}: no valid content digest",
             config.stage_id
-        );
+        ));
         return None;
     }
     let reservation = stage_disk_budget(&root, config)?;
     match PrefixDiskTier::open(&root, reservation.bytes()) {
         Ok(tier) => Some(OpenedDiskTier { tier, reservation }),
         Err(error) => {
-            eprintln!("skippy: KV disk tier unavailable, continuing without it: {error}");
+            emit_warning(format!(
+                "skippy: KV disk tier unavailable, continuing without it: {error}"
+            ));
             None
         }
     }
@@ -185,12 +195,12 @@ fn stage_disk_budget(root: &Path, config: &StageConfig) -> Option<disk_budget::B
     };
     let budget = disk_budget::resolve_node_budget(explicit, enabled, free_bytes);
     if let NodeBudget::InsufficientSpace { free_bytes } = budget {
-        eprintln!(
+        emit_warning(format!(
             "skippy: KV disk tier disabled for stage {}: only {:.1} GiB free on {}",
             config.stage_id,
             free_bytes as f64 / (1024.0 * 1024.0 * 1024.0),
             probe.display(),
-        );
+        ));
         return None;
     }
     let node_bytes = budget.bytes()?;

--- a/crates/skippy-server/src/kv_integration/disk_budget.rs
+++ b/crates/skippy-server/src/kv_integration/disk_budget.rs
@@ -175,6 +175,16 @@ mod tests {
     }
 
     #[test]
+    fn reservation_clone_keeps_ownership_until_last_clone_drops() {
+        let reservation = BudgetReservation(Arc::new(ReservationInner { bytes: 600 }));
+        let worker_reservation = reservation.clone();
+        assert_eq!(Arc::strong_count(&reservation.0), 2);
+
+        drop(reservation);
+        assert_eq!(Arc::strong_count(&worker_reservation.0), 1);
+    }
+
+    #[test]
     fn reservation_is_reclaimed_on_drop() {
         let first = reserve(1000, 600).expect("first reservation");
         let second = reserve(1000, 600).expect("remaining reservation");

--- a/crates/skippy-server/src/kv_integration/exact_state.rs
+++ b/crates/skippy-server/src/kv_integration/exact_state.rs
@@ -1,11 +1,14 @@
+use std::time::Instant;
+
 use anyhow::{Context, Result};
 use skippy_cache::ExactStatePayload;
 
 use crate::runtime_state::RuntimeState;
 
 use super::{
-    ExactStateExtra, ExactStateRecord, ExactStateRestore, ExactStateSource, KvStageIntegration,
-    PrefillKvIdentity, StagePrefixCachePayload, records::add_reconstruct_stats,
+    ExactStateExtra, ExactStateRecord, ExactStateRecordAdmission, ExactStateRestore,
+    ExactStateSource, KvStageIntegration, PendingExactStateRecord, PrefillKvIdentity,
+    StagePrefixCachePayload, records::add_reconstruct_stats,
 };
 
 impl KvStageIntegration {
@@ -19,6 +22,7 @@ impl KvStageIntegration {
             return Ok(None);
         }
         for identity in identities {
+            let lookup_started = Instant::now();
             let lookup = {
                 let mut cache = self
                     .exact_states
@@ -44,10 +48,13 @@ impl KvStageIntegration {
             let Some(lookup) = lookup else {
                 continue;
             };
+            let lookup_ms = lookup_started.elapsed().as_secs_f64() * 1000.0;
             let from_disk = lookup.from_disk;
             let mut reconstruct_ms = 0.0;
             let mut reconstruct_bytes = 0u64;
             let mut reconstruct_blocks = 0usize;
+            let mut kv_import_ms = 0.0;
+            let mut recurrent_import_ms = 0.0;
             match lookup.payload.kind().into() {
                 StagePrefixCachePayload::FullState => {
                     let (full_state, stats) = lookup
@@ -60,11 +67,13 @@ impl KvStageIntegration {
                         &mut reconstruct_blocks,
                         stats,
                     );
+                    let import_started = Instant::now();
                     runtime.import_full_state_for_token_count(
                         session_id,
                         full_state.as_ref(),
                         lookup.token_count,
                     )?;
+                    kv_import_ms = import_started.elapsed().as_secs_f64() * 1000.0;
                 }
                 StagePrefixCachePayload::KvRecurrent => {
                     if let Some((kv, stats)) = lookup
@@ -79,7 +88,9 @@ impl KvStageIntegration {
                             stats,
                         );
                         if let Some(desc) = lookup.extra.kv_desc {
+                            let import_started = Instant::now();
                             runtime.import_kv_page(session_id, &desc, kv.as_ref())?;
+                            kv_import_ms = import_started.elapsed().as_secs_f64() * 1000.0;
                         } else if !kv.is_empty() {
                             continue;
                         }
@@ -94,11 +105,13 @@ impl KvStageIntegration {
                         &mut reconstruct_blocks,
                         stats,
                     );
+                    let import_started = Instant::now();
                     runtime.import_recurrent_state_for_token_count(
                         session_id,
                         recurrent.as_ref(),
                         lookup.token_count,
                     )?;
+                    recurrent_import_ms = import_started.elapsed().as_secs_f64() * 1000.0;
                 }
                 _ => continue,
             }
@@ -116,6 +129,9 @@ impl KvStageIntegration {
                 reconstruct_ms,
                 reconstruct_bytes,
                 reconstruct_blocks,
+                lookup_ms,
+                kv_import_ms,
+                recurrent_import_ms,
             }));
         }
         Ok(None)
@@ -137,60 +153,109 @@ impl KvStageIntegration {
         if !self.try_begin_record(&identity.page_id) {
             return Ok(None);
         }
-        if self
-            .exact_states
-            .lock()
-            .expect("exact state cache lock poisoned")
-            .touch(&identity.page_id)
-        {
+        let already_recorded = match try_touch_exact_state(&self.exact_states, &identity.page_id) {
+            Ok(Some(already_recorded)) => already_recorded,
+            Ok(None) => {
+                // Recording is optional. A background worker may hold this lock
+                // while hashing hundreds of MiB; never make inference wait for it.
+                self.finish_record(&identity.page_id);
+                return Ok(None);
+            }
+            Err(error) => {
+                self.finish_record(&identity.page_id);
+                return Err(error);
+            }
+        };
+        if already_recorded {
             self.finish_record(&identity.page_id);
             return Ok(None);
         }
-        let result = (|| {
-            let (payload, extra) = match self.payload {
-                StagePrefixCachePayload::FullState => (
-                    ExactStatePayload::full_state(runtime.export_full_state(session_id)?),
-                    ExactStateExtra::default(),
-                ),
-                StagePrefixCachePayload::KvRecurrent => {
-                    let kv = match runtime.export_kv_page(session_id, 0, token_count) {
-                        Ok(kv) => Some(kv),
-                        Err(error) if is_native_kv_unavailable(&error) => None,
-                        Err(error) => return Err(error),
-                    };
-                    let recurrent = runtime.export_recurrent_state(session_id)?;
+        let exported = match self.payload {
+            StagePrefixCachePayload::FullState => {
+                runtime.export_full_state(session_id).map(|state| {
                     (
-                        ExactStatePayload::kv_recurrent(
-                            kv.as_ref().map(|kv| kv.payload.clone()).unwrap_or_default(),
-                            recurrent,
-                        ),
-                        ExactStateExtra {
-                            kv_desc: kv.as_ref().map(|kv| kv.desc.clone()),
-                        },
+                        ExactStatePayload::full_state(state),
+                        ExactStateExtra::default(),
                     )
-                }
-                _ => return Ok(None),
-            };
-            let outcome = self
-                .exact_states
-                .lock()
-                .expect("exact state cache lock poisoned")
-                .record(identity.page_id.clone(), token_count, payload, extra);
-            Ok(Some(ExactStateRecord {
-                page_id: outcome.page_id,
-                token_count: outcome.token_count as usize,
-                payload_kind: self.payload.into(),
-                stored: outcome.stored,
-                logical_bytes: outcome.logical_bytes,
-                physical_bytes: outcome.physical_bytes,
-                entries: outcome.entries,
-                evicted_entries: outcome.evicted_entries,
-                evicted_logical_bytes: outcome.evicted_logical_bytes,
-                dedupe: outcome.dedupe,
-            }))
-        })();
-        self.finish_record(&identity.page_id);
-        result
+                })
+            }
+            StagePrefixCachePayload::KvRecurrent => (|| {
+                let kv = match runtime.export_kv_page(session_id, 0, token_count) {
+                    Ok(kv) => Some(kv),
+                    Err(error) if is_native_kv_unavailable(&error) => None,
+                    Err(error) => return Err(error),
+                };
+                let recurrent = runtime.export_recurrent_state(session_id)?;
+                Ok((
+                    ExactStatePayload::kv_recurrent(
+                        kv.as_ref().map(|kv| kv.payload.clone()).unwrap_or_default(),
+                        recurrent,
+                    ),
+                    ExactStateExtra {
+                        kv_desc: kv.as_ref().map(|kv| kv.desc.clone()),
+                    },
+                ))
+            })(),
+            StagePrefixCachePayload::Disabled | StagePrefixCachePayload::ResidentKv => {
+                self.finish_record(&identity.page_id);
+                return Ok(None);
+            }
+        };
+        let (payload, extra) = match exported {
+            Ok(exported) => exported,
+            Err(error) => {
+                self.finish_record(&identity.page_id);
+                return Err(error);
+            }
+        };
+        let payload_kind = payload.kind();
+        let logical_bytes = payload.byte_len();
+        match self.enqueue_exact_state_record(PendingExactStateRecord {
+            page_id: identity.page_id.clone(),
+            token_count,
+            payload,
+            extra,
+        }) {
+            ExactStateRecordAdmission::Queued => {
+                // Recording owns the exact-state mutex while it hashes a potentially
+                // multi-hundred-MiB payload. Telemetry must not turn that background
+                // work back into request latency by waiting for cache stats here.
+                let stats = self
+                    .exact_states
+                    .try_lock()
+                    .ok()
+                    .map(|states| states.stats())
+                    .unwrap_or_default();
+                Ok(Some(ExactStateRecord {
+                    page_id: identity.page_id.clone(),
+                    token_count: token_count as usize,
+                    payload_kind,
+                    stored: false,
+                    logical_bytes,
+                    physical_bytes: stats.physical_bytes,
+                    entries: stats.entries,
+                    evicted_entries: 0,
+                    evicted_logical_bytes: 0,
+                    dedupe: Default::default(),
+                }))
+            }
+            ExactStateRecordAdmission::DroppedFull | ExactStateRecordAdmission::WorkerStopped => {
+                Ok(None)
+            }
+        }
+    }
+}
+
+fn try_touch_exact_state(
+    exact_states: &std::sync::Mutex<skippy_cache::ExactStateCache<ExactStateExtra>>,
+    page_id: &str,
+) -> Result<Option<bool>> {
+    match exact_states.try_lock() {
+        Ok(mut exact_states) => Ok(Some(exact_states.touch(page_id))),
+        Err(std::sync::TryLockError::WouldBlock) => Ok(None),
+        Err(std::sync::TryLockError::Poisoned(_)) => {
+            Err(anyhow::anyhow!("exact state cache lock poisoned"))
+        }
     }
 }
 
@@ -231,5 +296,55 @@ impl From<StagePrefixCachePayload> for skippy_cache::ExactStatePayloadKind {
                 Self::FullState
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{
+        sync::{Arc, Mutex},
+        time::{Duration, Instant},
+    };
+
+    use skippy_cache::ExactStateCache;
+
+    use super::{ExactStateExtra, try_touch_exact_state};
+
+    #[test]
+    fn busy_exact_state_lock_skips_touch_without_waiting() {
+        let cache = Arc::new(Mutex::new(ExactStateCache::<ExactStateExtra>::new(1, 1024)));
+        let locked = cache.clone();
+        let (locked_tx, locked_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let holder = std::thread::spawn(move || {
+            let _guard = locked.lock().unwrap();
+            locked_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+        locked_rx.recv().unwrap();
+
+        let started = Instant::now();
+        assert_eq!(try_touch_exact_state(&cache, "busy").unwrap(), None);
+        assert!(started.elapsed() < Duration::from_millis(100));
+
+        release_tx.send(()).unwrap();
+        holder.join().unwrap();
+    }
+
+    #[test]
+    fn poisoned_exact_state_lock_is_an_error() {
+        let cache = Arc::new(Mutex::new(ExactStateCache::<ExactStateExtra>::new(1, 1024)));
+        let poisoned = cache.clone();
+        assert!(
+            std::thread::spawn(move || {
+                let _guard = poisoned.lock().unwrap();
+                panic!("poison exact-state cache for test");
+            })
+            .join()
+            .is_err()
+        );
+
+        let error = try_touch_exact_state(&cache, "poisoned").unwrap_err();
+        assert_eq!(error.to_string(), "exact state cache lock poisoned");
     }
 }

--- a/crates/skippy-server/src/kv_integration/exact_state.rs
+++ b/crates/skippy-server/src/kv_integration/exact_state.rs
@@ -27,7 +27,7 @@ impl KvStageIntegration {
                 let mut cache = self
                     .exact_states
                     .lock()
-                    .expect("exact state cache lock poisoned");
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
                 // Fall through to the disk tier on a RAM miss, so a demoted
                 // page is actually readable. Without this the tier is
                 // write-only: eviction pays to serialize every payload and
@@ -170,6 +170,13 @@ impl KvStageIntegration {
             self.finish_record(&identity.page_id);
             return Ok(None);
         }
+        // Avoid paying a potentially multi-hundred-MiB runtime export when the
+        // bounded worker queue is already occupied. Admission remains best-effort:
+        // another producer may win the race before `try_send` below.
+        if !self.has_exact_state_record_capacity() {
+            self.finish_record(&identity.page_id);
+            return Ok(None);
+        }
         let exported = match self.payload {
             StagePrefixCachePayload::FullState => {
                 runtime.export_full_state(session_id).map(|state| {
@@ -253,8 +260,8 @@ fn try_touch_exact_state(
     match exact_states.try_lock() {
         Ok(mut exact_states) => Ok(Some(exact_states.touch(page_id))),
         Err(std::sync::TryLockError::WouldBlock) => Ok(None),
-        Err(std::sync::TryLockError::Poisoned(_)) => {
-            Err(anyhow::anyhow!("exact state cache lock poisoned"))
+        Err(std::sync::TryLockError::Poisoned(poisoned)) => {
+            Ok(Some(poisoned.into_inner().touch(page_id)))
         }
     }
 }
@@ -332,7 +339,7 @@ mod tests {
     }
 
     #[test]
-    fn poisoned_exact_state_lock_is_an_error() {
+    fn poisoned_exact_state_lock_recovers_without_panicking() {
         let cache = Arc::new(Mutex::new(ExactStateCache::<ExactStateExtra>::new(1, 1024)));
         let poisoned = cache.clone();
         assert!(
@@ -344,7 +351,9 @@ mod tests {
             .is_err()
         );
 
-        let error = try_touch_exact_state(&cache, "poisoned").unwrap_err();
-        assert_eq!(error.to_string(), "exact state cache lock poisoned");
+        assert_eq!(
+            try_touch_exact_state(&cache, "poisoned").unwrap(),
+            Some(false)
+        );
     }
 }

--- a/crates/skippy-server/src/kv_integration/exact_state.rs
+++ b/crates/skippy-server/src/kv_integration/exact_state.rs
@@ -137,6 +137,15 @@ impl KvStageIntegration {
         if !self.try_begin_record(&identity.page_id) {
             return Ok(None);
         }
+        if self
+            .exact_states
+            .lock()
+            .expect("exact state cache lock poisoned")
+            .touch(&identity.page_id)
+        {
+            self.finish_record(&identity.page_id);
+            return Ok(None);
+        }
         let result = (|| {
             let (payload, extra) = match self.payload {
                 StagePrefixCachePayload::FullState => (

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -167,6 +167,8 @@ pub enum StagePrefixCachePayload {
     FullState,
 }
 
+pub(crate) const EXACT_STATE_RECORD_CAPACITY: usize = 1;
+
 #[derive(Debug)]
 pub(crate) struct PendingExactStateRecord {
     pub(crate) page_id: String,
@@ -182,6 +184,10 @@ pub(crate) enum ExactStateRecordAdmission {
     WorkerStopped,
 }
 
+fn has_exact_state_record_capacity(pending_count: &AtomicUsize) -> bool {
+    pending_count.load(std::sync::atomic::Ordering::Acquire) < EXACT_STATE_RECORD_CAPACITY
+}
+
 fn enqueue_exact_state_record(
     sender: &SyncSender<PendingExactStateRecord>,
     inflight_records: &Mutex<BTreeSet<String>>,
@@ -190,14 +196,14 @@ fn enqueue_exact_state_record(
     pending_count: &AtomicUsize,
     pending: PendingExactStateRecord,
 ) -> ExactStateRecordAdmission {
-    pending_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    pending_count.fetch_add(1, std::sync::atomic::Ordering::Release);
     match sender.try_send(pending) {
         Ok(()) => {
             queued.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
             ExactStateRecordAdmission::Queued
         }
         Err(TrySendError::Full(pending)) => {
-            pending_count.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            pending_count.fetch_sub(1, std::sync::atomic::Ordering::Release);
             inflight_records
                 .lock()
                 .expect("kv inflight record lock poisoned")
@@ -206,7 +212,7 @@ fn enqueue_exact_state_record(
             ExactStateRecordAdmission::DroppedFull
         }
         Err(TrySendError::Disconnected(pending)) => {
-            pending_count.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            pending_count.fetch_sub(1, std::sync::atomic::Ordering::Release);
             inflight_records
                 .lock()
                 .expect("kv inflight record lock poisoned")
@@ -257,6 +263,10 @@ impl KvStageIntegration {
             .lock()
             .expect("kv inflight record lock poisoned")
             .remove(page_id);
+    }
+
+    pub(crate) fn has_exact_state_record_capacity(&self) -> bool {
+        has_exact_state_record_capacity(&self.exact_state_records_pending)
     }
 
     pub(crate) fn enqueue_exact_state_record(
@@ -556,9 +566,7 @@ fn disk_tier_attrs(
         Err(std::sync::TryLockError::WouldBlock) => {
             return vec![("skippy.kv.disk_tier_stats_busy", json!(true))];
         }
-        Err(std::sync::TryLockError::Poisoned(_)) => {
-            return vec![("skippy.kv.disk_tier_stats_error", json!("lock_poisoned"))];
-        }
+        Err(std::sync::TryLockError::Poisoned(poisoned)) => poisoned.into_inner(),
     };
     let Some(stats) = exact_states.disk_stats() else {
         return vec![("skippy.kv.disk_tier_enabled", json!(false))];
@@ -614,8 +622,9 @@ mod exact_state_record_queue_tests {
     use skippy_cache::{ExactStateCache, ExactStatePayload};
 
     use super::{
-        BTreeSet, ExactStateExtra, ExactStateRecordAdmission, PendingExactStateRecord,
-        disk_tier_attrs, enqueue_exact_state_record,
+        BTreeSet, EXACT_STATE_RECORD_CAPACITY, ExactStateExtra, ExactStateRecordAdmission,
+        PendingExactStateRecord, disk_tier_attrs, enqueue_exact_state_record,
+        has_exact_state_record_capacity,
     };
 
     fn pending(page_id: &str) -> PendingExactStateRecord {
@@ -649,6 +658,15 @@ mod exact_state_record_queue_tests {
 
         release_tx.send(()).unwrap();
         holder.join().unwrap();
+    }
+
+    #[test]
+    fn pending_capacity_signal_rejects_work_before_export() {
+        let pending_count = AtomicUsize::new(0);
+        assert!(has_exact_state_record_capacity(&pending_count));
+
+        pending_count.store(EXACT_STATE_RECORD_CAPACITY, Ordering::Release);
+        assert!(!has_exact_state_record_capacity(&pending_count));
     }
 
     #[test]

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -1,13 +1,18 @@
 use std::{
     collections::{BTreeMap, BTreeSet},
-    sync::{Arc, Mutex, atomic::AtomicBool},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, AtomicU64, AtomicUsize},
+        mpsc::{SyncSender, TrySendError},
+    },
 };
 
 use anyhow::{Result, bail};
 use serde_json::{Value, json};
 use sha2::{Digest, Sha256};
 use skippy_cache::{
-    ExactStateCache, PrefixCandidatePolicy, ResidentActivationCache, ResidentPrefixCache,
+    ExactStateCache, ExactStatePayload, PrefixCandidatePolicy, ResidentActivationCache,
+    ResidentPrefixCache,
 };
 use skippy_metrics::attr as attr_key;
 use skippy_runtime::{ActivationFrame, RuntimeKvPageDesc};
@@ -139,6 +144,10 @@ pub struct KvStageIntegration {
     pub(crate) resident: Arc<Mutex<ResidentPrefixCache>>,
     pub(crate) activations: Arc<Mutex<ResidentActivationCache<ActivationFrame>>>,
     pub(crate) exact_states: Arc<Mutex<ExactStateCache<ExactStateExtra>>>,
+    pub(crate) exact_state_record_tx: SyncSender<PendingExactStateRecord>,
+    pub(crate) exact_state_records_queued: Arc<AtomicU64>,
+    pub(crate) exact_state_records_dropped: Arc<AtomicU64>,
+    pub(crate) exact_state_records_pending: Arc<AtomicUsize>,
     pub(crate) first_tokens: Arc<Mutex<BTreeMap<String, i32>>>,
     pub(crate) replay_tokens: Arc<Mutex<BTreeMap<String, Vec<i32>>>>,
     pub(crate) split_prefill_tokens: Arc<Mutex<BTreeMap<String, Vec<i32>>>>,
@@ -156,6 +165,56 @@ pub enum StagePrefixCachePayload {
     ResidentKv,
     KvRecurrent,
     FullState,
+}
+
+#[derive(Debug)]
+pub(crate) struct PendingExactStateRecord {
+    pub(crate) page_id: String,
+    pub(crate) token_count: u64,
+    pub(crate) payload: ExactStatePayload,
+    pub(crate) extra: ExactStateExtra,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum ExactStateRecordAdmission {
+    Queued,
+    DroppedFull,
+    WorkerStopped,
+}
+
+fn enqueue_exact_state_record(
+    sender: &SyncSender<PendingExactStateRecord>,
+    inflight_records: &Mutex<BTreeSet<String>>,
+    queued: &AtomicU64,
+    dropped: &AtomicU64,
+    pending_count: &AtomicUsize,
+    pending: PendingExactStateRecord,
+) -> ExactStateRecordAdmission {
+    pending_count.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    match sender.try_send(pending) {
+        Ok(()) => {
+            queued.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            ExactStateRecordAdmission::Queued
+        }
+        Err(TrySendError::Full(pending)) => {
+            pending_count.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            inflight_records
+                .lock()
+                .expect("kv inflight record lock poisoned")
+                .remove(&pending.page_id);
+            dropped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            ExactStateRecordAdmission::DroppedFull
+        }
+        Err(TrySendError::Disconnected(pending)) => {
+            pending_count.fetch_sub(1, std::sync::atomic::Ordering::Relaxed);
+            inflight_records
+                .lock()
+                .expect("kv inflight record lock poisoned")
+                .remove(&pending.page_id);
+            dropped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            ExactStateRecordAdmission::WorkerStopped
+        }
+    }
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
@@ -198,6 +257,20 @@ impl KvStageIntegration {
             .lock()
             .expect("kv inflight record lock poisoned")
             .remove(page_id);
+    }
+
+    pub(crate) fn enqueue_exact_state_record(
+        &self,
+        pending: PendingExactStateRecord,
+    ) -> ExactStateRecordAdmission {
+        enqueue_exact_state_record(
+            &self.exact_state_record_tx,
+            &self.inflight_records,
+            &self.exact_state_records_queued,
+            &self.exact_state_records_dropped,
+            &self.exact_state_records_pending,
+            pending,
+        )
     }
 
     pub async fn hello(&self) -> Result<()> {
@@ -283,6 +356,13 @@ impl KvStageIntegration {
             .lock()
             .expect("resident activation cache lock poisoned");
         let activations = activations.stats();
+        let exact_state_stats = self
+            .exact_states
+            .try_lock()
+            .ok()
+            .map(|states| states.stats());
+        let exact_state_stats_busy = exact_state_stats.is_none();
+        let exact_state_stats = exact_state_stats.unwrap_or_default();
         vec![
             ("skippy.kv.mode", json!(format!("{:?}", self.mode))),
             ("skippy.kv.payload", json!(format!("{:?}", self.payload))),
@@ -308,19 +388,44 @@ impl KvStageIntegration {
             ),
             (
                 "skippy.exact_cache.entries",
-                json!(self.exact_state_stats().entries),
+                json!(exact_state_stats.entries),
             ),
             (
                 "skippy.exact_cache.logical_bytes",
-                json!(self.exact_state_stats().logical_bytes),
+                json!(exact_state_stats.logical_bytes),
             ),
             (
                 "skippy.exact_cache.physical_bytes",
-                json!(self.exact_state_stats().physical_bytes),
+                json!(exact_state_stats.physical_bytes),
+            ),
+            (
+                "skippy.exact_cache.stats_busy",
+                json!(exact_state_stats_busy),
+            ),
+            (
+                "skippy.exact_cache.records_queued",
+                json!(
+                    self.exact_state_records_queued
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                ),
+            ),
+            (
+                "skippy.exact_cache.records_dropped",
+                json!(
+                    self.exact_state_records_dropped
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                ),
+            ),
+            (
+                "skippy.exact_cache.records_pending",
+                json!(
+                    self.exact_state_records_pending
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                ),
             ),
             (
                 "skippy.exact_cache.max_bytes",
-                json!(self.exact_state_stats().max_bytes),
+                json!(exact_state_stats.max_bytes),
             ),
             ("skippy.kv.correctness_mode", json!(self.correctness_mode)),
             (
@@ -353,40 +458,7 @@ impl KvStageIntegration {
     /// (full budget, every write failing, every entry quarantined) is
     /// indistinguishable from one that is simply never probed.
     pub fn disk_tier_attrs(&self) -> Vec<(&'static str, Value)> {
-        let Some(stats) = self
-            .exact_states
-            .lock()
-            .expect("exact state cache lock poisoned")
-            .disk_stats()
-        else {
-            return vec![("skippy.kv.disk_tier_enabled", json!(false))];
-        };
-        vec![
-            ("skippy.kv.disk_tier_enabled", json!(true)),
-            ("skippy.kv.disk_entries", json!(stats.entries)),
-            ("skippy.kv.disk_bytes", json!(stats.bytes)),
-            ("skippy.kv.disk_max_bytes", json!(stats.max_bytes)),
-            ("skippy.kv.disk_demotions", json!(stats.demotions)),
-            ("skippy.kv.disk_promotions", json!(stats.promotions)),
-            ("skippy.kv.disk_evictions", json!(stats.evictions)),
-            (
-                "skippy.kv.disk_pages_rejected_too_large",
-                json!(stats.pages_rejected_too_large),
-            ),
-            (
-                "skippy.kv.disk_last_rejected_page_bytes",
-                json!(stats.last_rejected_page_bytes),
-            ),
-            (
-                "skippy.kv.disk_corrupt_entries",
-                json!(stats.corrupt_entries),
-            ),
-            ("skippy.kv.disk_verifications", json!(stats.verifications)),
-            (
-                "skippy.kv.disk_verifications_skipped",
-                json!(stats.verifications_skipped),
-            ),
-        ]
+        disk_tier_attrs(&self.exact_states)
     }
 
     /// Attach the disk-tier counters to a decision event.
@@ -399,13 +471,6 @@ impl KvStageIntegration {
         for (key, value) in self.disk_tier_attrs() {
             attrs.insert(key.to_string(), value);
         }
-    }
-
-    fn exact_state_stats(&self) -> skippy_cache::ExactStateCacheStats {
-        self.exact_states
-            .lock()
-            .expect("exact state cache lock poisoned")
-            .stats()
     }
 
     fn record_candidate_token_counts(&self, token_count: u64) -> Vec<u64> {
@@ -483,6 +548,49 @@ impl KvStageIntegration {
     }
 }
 
+fn disk_tier_attrs(
+    exact_states: &Mutex<ExactStateCache<ExactStateExtra>>,
+) -> Vec<(&'static str, Value)> {
+    let exact_states = match exact_states.try_lock() {
+        Ok(exact_states) => exact_states,
+        Err(std::sync::TryLockError::WouldBlock) => {
+            return vec![("skippy.kv.disk_tier_stats_busy", json!(true))];
+        }
+        Err(std::sync::TryLockError::Poisoned(_)) => {
+            return vec![("skippy.kv.disk_tier_stats_error", json!("lock_poisoned"))];
+        }
+    };
+    let Some(stats) = exact_states.disk_stats() else {
+        return vec![("skippy.kv.disk_tier_enabled", json!(false))];
+    };
+    vec![
+        ("skippy.kv.disk_tier_enabled", json!(true)),
+        ("skippy.kv.disk_entries", json!(stats.entries)),
+        ("skippy.kv.disk_bytes", json!(stats.bytes)),
+        ("skippy.kv.disk_max_bytes", json!(stats.max_bytes)),
+        ("skippy.kv.disk_demotions", json!(stats.demotions)),
+        ("skippy.kv.disk_promotions", json!(stats.promotions)),
+        ("skippy.kv.disk_evictions", json!(stats.evictions)),
+        (
+            "skippy.kv.disk_pages_rejected_too_large",
+            json!(stats.pages_rejected_too_large),
+        ),
+        (
+            "skippy.kv.disk_last_rejected_page_bytes",
+            json!(stats.last_rejected_page_bytes),
+        ),
+        (
+            "skippy.kv.disk_corrupt_entries",
+            json!(stats.corrupt_entries),
+        ),
+        ("skippy.kv.disk_verifications", json!(stats.verifications)),
+        (
+            "skippy.kv.disk_verifications_skipped",
+            json!(stats.verifications_skipped),
+        ),
+    ]
+}
+
 fn local_trust_checksum(page_id: &str, byte_size: u64) -> Checksum {
     let mut digest = Sha256::new();
     digest.update(b"skippy-local-trust-v1");
@@ -491,6 +599,144 @@ fn local_trust_checksum(page_id: &str, byte_size: u64) -> Checksum {
     Checksum {
         algorithm: ChecksumAlgorithm::Sha256 as i32,
         digest: digest.finalize().to_vec(),
+    }
+}
+
+#[cfg(test)]
+mod exact_state_record_queue_tests {
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicU64, AtomicUsize, Ordering},
+        mpsc::sync_channel,
+    };
+    use std::time::{Duration, Instant};
+
+    use skippy_cache::{ExactStateCache, ExactStatePayload};
+
+    use super::{
+        BTreeSet, ExactStateExtra, ExactStateRecordAdmission, PendingExactStateRecord,
+        disk_tier_attrs, enqueue_exact_state_record,
+    };
+
+    fn pending(page_id: &str) -> PendingExactStateRecord {
+        PendingExactStateRecord {
+            page_id: page_id.to_string(),
+            token_count: 1,
+            payload: ExactStatePayload::full_state(vec![1]),
+            extra: ExactStateExtra::default(),
+        }
+    }
+
+    #[test]
+    fn busy_exact_state_lock_skips_disk_stats_without_waiting() {
+        let cache = Arc::new(Mutex::new(ExactStateCache::<ExactStateExtra>::new(1, 1024)));
+        let locked = cache.clone();
+        let (locked_tx, locked_rx) = std::sync::mpsc::channel();
+        let (release_tx, release_rx) = std::sync::mpsc::channel();
+        let holder = std::thread::spawn(move || {
+            let _guard = locked.lock().unwrap();
+            locked_tx.send(()).unwrap();
+            release_rx.recv().unwrap();
+        });
+        locked_rx.recv().unwrap();
+
+        let started = Instant::now();
+        assert_eq!(
+            disk_tier_attrs(&cache),
+            vec![("skippy.kv.disk_tier_stats_busy", serde_json::json!(true))]
+        );
+        assert!(started.elapsed() < Duration::from_millis(100));
+
+        release_tx.send(()).unwrap();
+        holder.join().unwrap();
+    }
+
+    #[test]
+    fn full_queue_drops_optional_record_and_releases_inflight_page() {
+        let (sender, _receiver) = sync_channel(1);
+        sender.send(pending("queued")).unwrap();
+        let inflight = Mutex::new(BTreeSet::from(["dropped".to_string()]));
+        let queued = AtomicU64::new(0);
+        let dropped = AtomicU64::new(0);
+        let pending_count = AtomicUsize::new(0);
+
+        assert_eq!(
+            enqueue_exact_state_record(
+                &sender,
+                &inflight,
+                &queued,
+                &dropped,
+                &pending_count,
+                pending("dropped"),
+            ),
+            ExactStateRecordAdmission::DroppedFull
+        );
+        assert!(!inflight.lock().unwrap().contains("dropped"));
+        assert_eq!(queued.load(Ordering::Relaxed), 0);
+        assert_eq!(dropped.load(Ordering::Relaxed), 1);
+        assert_eq!(pending_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn disconnected_worker_releases_inflight_page() {
+        let (sender, receiver) = sync_channel(1);
+        drop(receiver);
+        let inflight = Mutex::new(BTreeSet::from(["orphaned".to_string()]));
+        let queued = AtomicU64::new(0);
+        let dropped = AtomicU64::new(0);
+        let pending_count = AtomicUsize::new(0);
+
+        assert_eq!(
+            enqueue_exact_state_record(
+                &sender,
+                &inflight,
+                &queued,
+                &dropped,
+                &pending_count,
+                pending("orphaned"),
+            ),
+            ExactStateRecordAdmission::WorkerStopped
+        );
+        assert!(!inflight.lock().unwrap().contains("orphaned"));
+        assert_eq!(dropped.load(Ordering::Relaxed), 1);
+        assert_eq!(pending_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn worker_keeps_page_inflight_until_record_finishes() {
+        let (sender, receiver) = sync_channel(1);
+        let inflight = Arc::new(Mutex::new(BTreeSet::from(["page".to_string()])));
+        let worker_inflight = inflight.clone();
+        let queued = AtomicU64::new(0);
+        let dropped = AtomicU64::new(0);
+        let pending_count = Arc::new(AtomicUsize::new(0));
+        let worker_pending_count = pending_count.clone();
+
+        assert_eq!(
+            enqueue_exact_state_record(
+                &sender,
+                &inflight,
+                &queued,
+                &dropped,
+                &pending_count,
+                pending("page"),
+            ),
+            ExactStateRecordAdmission::Queued
+        );
+        assert!(inflight.lock().unwrap().contains("page"));
+
+        let worker = std::thread::spawn(move || {
+            let pending = receiver.recv().unwrap();
+            assert!(worker_inflight.lock().unwrap().contains(&pending.page_id));
+            worker_inflight.lock().unwrap().remove(&pending.page_id);
+            worker_pending_count.fetch_sub(1, Ordering::Relaxed);
+        });
+        worker.join().unwrap();
+
+        assert!(!inflight.lock().unwrap().contains("page"));
+        assert_eq!(queued.load(Ordering::Relaxed), 1);
+        assert_eq!(dropped.load(Ordering::Relaxed), 0);
+        assert_eq!(pending_count.load(Ordering::Relaxed), 0);
     }
 }
 

--- a/crates/skippy-server/src/kv_integration/records.rs
+++ b/crates/skippy-server/src/kv_integration/records.rs
@@ -103,6 +103,9 @@ pub struct ExactStateRestore {
     pub reconstruct_ms: f64,
     pub reconstruct_bytes: u64,
     pub reconstruct_blocks: usize,
+    pub lookup_ms: f64,
+    pub kv_import_ms: f64,
+    pub recurrent_import_ms: f64,
 }
 
 #[derive(Debug, Clone)]

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4347,20 +4347,6 @@
       "macro_name": "println!"
     }
   ],
-  "crates/skippy-server/src/kv_integration/config.rs": [
-    {
-      "line": 110,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 120,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 152,
-      "macro_name": "eprintln!"
-    }
-  ],
   "crates/skippy-server/src/main.rs": [
     {
       "line": 16,


### PR DESCRIPTION
## Summary

- skip export, hashing, and disk work when the complete exact-page identity is already present; an identical repeat only refreshes LRU recency
- move first-time exact-state hashing and archival onto one bounded background worker per stage
- fail open when optional recording or telemetry contends: inference never waits for the cache worker, and a full one-item queue drops optional work
- expose queue pressure and separate lookup/reconstruction/native-import timings
- route disk-cache warnings through structured `mesh_llm_events::emit_event` output and retire the three console-print ratchet entries

## Why this does not write forever or fill the disk

The new worker changes **when** a genuinely new page is recorded; it does not remove any storage limits.

1. **Identical prefixes do not rewrite.** Before native state export, `record_exact_state` checks the full content/config-derived page identity in RAM and on disk. If found, `touch` only updates LRU metadata and returns. Concurrent attempts for the same page are also coalesced by the in-flight page-id set. The disk tier independently refuses `store` when that page id already exists.
2. **Work is bounded.** Each stage has one worker and a `sync_channel(1)`. Admission uses `try_send`; if that single slot is occupied, optional recording is dropped rather than blocking inference or growing memory. `records_queued`, `records_dropped`, and `records_pending` expose pressure.
3. **Bytes are bounded node-wide and per stage.** Automatic policy is 20% of currently free space, capped at 64 GiB, and the tier is disabled below the 16 GiB free-space floor. An explicit budget is also refused unless that budget **plus** the 16 GiB reserve is free. Stage reservations share the node budget rather than each claiming it all.
4. **The tier enforces its cap.** It LRU-evicts until `bytes <= max_bytes`, and rejects a single page larger than the whole tier instead of evicting everything for it.
5. **Crashes/concurrency do not leak an unbounded second copy.** A cache directory has a nonblocking exclusive owner lock; a second process declines that tier. Page and index publication use temp-file + atomic rename, and crash-left temp/orphan files are reclaimed at next open. Payload and interpretation metadata are checksummed before reuse; corrupt entries are quarantined.

Relevant implementation: `crates/skippy-server/src/kv_integration/{exact_state.rs,mod.rs,config.rs,disk_budget.rs}` and `crates/skippy-cache/src/{exact_state.rs,disk_tier.rs}`.

## Scope / resource rationale

The PR is now 10 files, +592/-120 against current `main`; the accidental generated SDK/resource commit is gone. The larger pieces are the bounded record queue/worker, its deterministic lifecycle tests, nonblocking exact-cache paths, counters/timing telemetry, the event dependency, and the regenerated console-print ratchet. No UI/SDK generated resources are part of this diff.

## Verified at committed HEAD

Commit `ec79904708ee9f9fbd0ba5c166f0975bcc2a42ee`:

- `cargo run -p xtask -- repo-consistency no-console-print --regen` — passed; the three legacy `eprintln!` entries were removed
- `cargo test -p skippy-server --lib` — 493 passed, 0 failed, 3 ignored
- deterministic coverage includes existing-page touch/no replacement, full queue drop, disconnected worker, pending/in-flight lifecycle, busy exact-state touch, busy disk telemetry, poisoned lock, disk LRU budget enforcement, oversized-page rejection, exclusive directory ownership, checksum quarantine, and crash-temp reclamation

The macOS linker printed deployment-version warnings during the package test, but the suite completed successfully.

## Real model evidence and remaining product gate

A local Qwen3.8-27B cold/exact-repeat/changed-tail run on the patched branch produced valid `OK`, `OK`, `YES` responses. The exact repeat reported 21,022/21,023 cached prompt tokens and completed in ~0.139s. The changed-tail request reported 20,864/21,023 cached prompt tokens, only 158 suffix-prefill tokens, ~1.187s prefill, and ~1.799s wall time. These artifacts are kept outside the PR tree.

That run predates the final structured-warning commit, so it is supporting model evidence, **not** claimed as committed-HEAD Buzz certification. I am rerunning the exact commit through the authenticated Buzz agent/channel path and will add the observed events plus queue/dedupe telemetry before asking for merge or a human hand-test.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added cache entry touch support to refresh recency without reloading data.
  * Added bounded asynchronous exact-state recording with queue-capacity checks.
  * Added detailed timing metrics for cache lookup and state imports.

* **Bug Fixes**
  * Improved cache eviction behavior when entries are accessed.
  * Improved recovery from cache contention and worker shutdown conditions.
  * Replaced direct disk-tier warning output with application warning events.

* **Tests**
  * Added coverage for cache retention, queue capacity, lock recovery, and shared budget reservations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->