### PR TITLE
docs(skippy): remove stale disk cache defaults

### DIFF
--- a/docs/skippy/KV_DISK_TIER_FORMAT.md
+++ b/docs/skippy/KV_DISK_TIER_FORMAT.md
@@ -10,19 +10,6 @@ migrated. Every recovery path in this document ends in "discard and recompute",
 because a cache that starts empty is merely slow while a cache that serves the
 wrong bytes is numerically wrong.
 
-## Enabling it
-
-The tier is opt-in and off by default.
-
-| Variable | Effect |
-|---|---|
-| `SKIPPY_KV_DISK_TIER=1` | Enable with the default node budget |
-| `SKIPPY_KV_DISK_TIER_MIB=<mib>` | Enable with an explicit node-total budget |
-| `SKIPPY_KV_DISK_TIER_DIR=<path>` | Override the cache base directory |
-
-The budget is a **node total**, shared out across stages, not a per-stage
-allowance. See `crates/skippy-server/src/kv_integration/disk_budget.rs`.
-
 The tier also declines to open at all when the stage configuration carries no
 valid content digest (`manifest_sha256` or `source_model_sha256`). A page that
 outlives its process must be anchored to the weights' *content*, never to the

--- a/docs/skippy/KV_RETENTION_PLAN.md
+++ b/docs/skippy/KV_RETENTION_PLAN.md
@@ -824,13 +824,6 @@ topology.
 - Miss-reason stats are collected but **not yet exported** as OTLP metrics, so
   W2 cannot yet answer the W4/W5 go/no-go question in production.
 
-### Operational notes
-
-The tier is **opt-in**: `SKIPPY_KV_DISK_TIER_MIB=<size>` (or
-`SKIPPY_KV_DISK_TIER=1`), with `SKIPPY_KV_DISK_TIER_DIR` overriding the
-location. Default-off means the serving path is unchanged apart from the
-identity hash and ladder depth.
-
 Cache directories are per stage-shape and hold an exclusive lock; a second
 instance on the same directory declines the tier rather than sharing it, because
 the index is last-writer-wins and orphan reclaim would delete the other


### PR DESCRIPTION
## Summary

- remove stale claims that the KV disk cache is opt-in/default-off
- keep runtime defaults owned by CLI help and typed configuration instead of duplicating them in internal format/design docs

The current implementation defaults `--kv-cache-disk` to `auto`; the removed prose contradicted that code and caused operational confusion.

## Validation

- `git diff --check`
- searched `docs/skippy` for the removed opt-in/default-off claims

Documentation-only deletion; no runtime behavior changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Removed outdated operational notes about disk-tier configuration, cache directory overrides, default behavior, locking, and retention semantics.
  - Removed the disk-tier enablement section from the format documentation.
  - No runtime behavior or configuration changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->