### PR TITLE
Fix release builds failing in the containerized smoke job

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -84,6 +84,16 @@ jobs:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
 
+      # The container runs as root while the host-mounted workspace is owned
+      # by the runner uid, so git refuses every command in it as "dubious
+      # ownership". release-version.sh enumerates manifests with `git
+      # ls-files`, which then returns nothing and the script exits 1. Same
+      # step every containerized release job already carries (release.yml,
+      # native-sdk-artifact.yml, node-sdk-addon-artifact.yml).
+      - name: Trust checkout directory
+        if: job.container.id != ''
+        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
       - name: Prepare dispatched release version
         if: inputs.release_tag != ''
         run: scripts/release-version.sh "${{ inputs.release_tag }}"


### PR DESCRIPTION
Release dispatches now get past the smoke job again. `v0.76.0-rc6` failed 8 seconds into `inference_smoke_tests / Skippy Inference Smoke Tests` with:

```
fatal: detected dubious ownership in repository at '/__w/mesh-llm/mesh-llm'
no Cargo.toml manifests found under crates/ or tools/
```

## Cause

#1380 containerized the hosted smoke job (`smoke.yml` `container.image`). The image's `public` stage runs as root while the Actions workspace is mounted owned by the host runner uid, so git refuses every command in it. `scripts/release-version.sh:223` enumerates manifests with `git ls-files`, gets nothing, and the empty-array guard at `:229` exits 1.

Every other containerized job that shells out to git already adds `git config --global --add safe.directory "$GITHUB_WORKSPACE"` — `release.yml` has 8, `native-sdk-artifact.yml` and `node-sdk-addon-artifact.yml` one each. The newly containerized `smoke.yml` had none.

The step is gated `if: inputs.release_tag != ''`, which is only non-empty on the release lane, so PR and main CI stayed green and could not have caught this.

## Change

One step in `smoke.yml`, before `Prepare dispatched release version`, gated on `job.container.id != ''` so the bare-metal `gpu-nvidia` row is untouched.

## Validation

Structural audit of `.github/workflows/*.yml`: every job that both declares a container image and calls `release-version.sh` now carries the trust step (11 jobs; `smoke.yml smoke_tests` was the only one missing it). `swift-sdk-artifact.yml` calls the script but does not containerize, so it is unaffected.

Runtime proof requires a release dispatch — the next rc6 attempt is the check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved container-based release workflows by ensuring the checked-out project is recognized as trusted before version preparation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->