### PR TITLE
fix(build): stop aarch64 CUDA and build-runtime recipes running bashisms under sh

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -151,9 +151,11 @@ build-linux backend="" cuda_arch="" rocm_arch="":
 # Backward-compatible spelling for the explicit native-runtime primitive.
 [linux]
 build-runtime backend="" cuda_arch="" rocm_arch="":
-    @backend="{{ backend }}"; \
-      [[ -n "$$backend" ]] || backend=cpu; \
-      LLAMA_STAGE_CUDA_ARCHITECTURES="{{ cuda_arch }}" LLAMA_STAGE_AMDGPU_TARGETS="{{ rocm_arch }}" scripts/package-native-runtime.sh --build --backend "$$backend"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    backend="{{ backend }}"
+    [[ -n "$backend" ]] || backend=cpu
+    LLAMA_STAGE_CUDA_ARCHITECTURES="{{ cuda_arch }}" LLAMA_STAGE_AMDGPU_TARGETS="{{ rocm_arch }}" scripts/package-native-runtime.sh --build --backend "$backend"
 
 # Build release artifacts for the current platform.
 
@@ -189,11 +191,21 @@ release-build-aarch64: release-host-build
 # Build a Linux aarch64 CUDA release artifact (Jetson/Orin).
 # SM arches selected by MESH_CUDA_VERSION env (set by CI matrix); a bare
 # `just` invocation with the var unset detects the installed toolkit instead
-# of assuming one (see scripts/detect-cuda-toolkit-version.sh).
+# of assuming one (see scripts/detect-cuda-toolkit-version.sh). Thor (sm_110)
+# needs toolkit >= 13.0 -- gate on that boundary the same way the x86_64
+# recipe gates Blackwell.
 release-build-aarch64-cuda: release-host-build
-    @cuda_version="${MESH_CUDA_VERSION:-$(scripts/detect-cuda-toolkit-version.sh)}"; \
-      MESH_LLM_CUDA_TOOLKIT_MAJOR="${MESH_LLM_CUDA_TOOLKIT_MAJOR:-${cuda_version%%.*}}" \
-      LLAMA_STAGE_CUDA_ARCHITECTURES="$(if [[ "$cuda_version" == 13.* ]]; then echo '75;80;86;87;89;90;110'; else echo '61;75;80;86;87;89;90'; fi)" \
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cuda_version="${MESH_CUDA_VERSION:-$(scripts/detect-cuda-toolkit-version.sh)}"
+    major="${cuda_version%%.*}"
+    if [[ "$major" -ge 13 ]]; then
+      arches='75;80;86;87;89;90;110'
+    else
+      arches='61;75;80;86;87;89;90'
+    fi
+    MESH_LLM_CUDA_TOOLKIT_MAJOR="${MESH_LLM_CUDA_TOOLKIT_MAJOR:-$major}" \
+      LLAMA_STAGE_CUDA_ARCHITECTURES="$arches" \
       scripts/package-native-runtime.sh --build --backend cuda --target aarch64-unknown-linux-gnu
 
 # Prepare the pinned llama.cpp checkout and apply the Mesh-LLM ABI patch queue.


### PR DESCRIPTION
Closes the S1 found in rc6 release validation (`RV-DEFECT-001`).

`release-build-aarch64-cuda` and `build-runtime` are `@`-prefixed shell lines, so `just` runs them with the default `sh`. On any host where `/bin/sh` is dash (stock Debian/Ubuntu — including the Jetson target the rc6 validation used), the `[[ ... ]]` tests fail:

```
$ /bin/dash -c 'cuda_version=13.0; echo "$(if [[ "$cuda_version" == 13.* ]]; then echo NEW; else echo OLD; fi)"'
/bin/dash: 1: [[: not found
OLD
```

So the aarch64 CUDA recipe's arch-list command substitution errors and the CUDA 13 build gets the wrong (pre-CUDA-13) SM list before hard-failing. CI never catches it: `release.yml` sets `LLAMA_STAGE_CUDA_ARCHITECTURES` from the job matrix and never invokes this recipe.

`release-build-cuda` (x86_64) was already converted to a `#!/usr/bin/env bash` script recipe with a proper toolkit-version gate; this brings the aarch64 sibling and `build-runtime` in line.

- aarch64: gate `sm_110` (Thor) on toolkit major >= 13, mirroring how x86_64 gates Blackwell on >= 12.8.
- `build-runtime`: converted to a script recipe; the `$$backend` escaping bug goes with it (under `sh` that expanded to a PID, so the emptiness test was never checking the variable it appeared to check).

Verification: `just --summary` parses; the version gate was exercised for 12.4 / 12.8 / 13 / 13.1.2 and selects the expected list in each case. Not run end-to-end on a Jetson — the shell-compatibility defect is reproduced above, but the full aarch64 CUDA build is untested here.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native runtime build reliability with stricter error handling.
  * Preserved backend and architecture configuration during runtime builds.
  * Updated ARM64 CUDA release builds to support CUDA toolkit versions 13 and newer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->