### PR TITLE
fix: close the four rc6 release-validation defects

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,7 +9,9 @@ This file covers local build and development workflows for this repository.
 - `just`
 - `cmake`
 - Rust toolchain (`cargo`)
-- Node.js 24 + npm (for UI development)
+- Node.js 24 + pnpm 10 or newer (for UI development). The UI lockfile keeps
+  `overrides` in `pnpm-workspace.yaml`, which pnpm 9 does not read, so pnpm 9
+  cannot install it. `corepack pnpm@10` is enough if your host pnpm is older.
 
 **macOS**: Apple Silicon. Metal is used automatically.
 

--- a/Justfile
+++ b/Justfile
@@ -151,9 +151,13 @@ build-linux backend="" cuda_arch="" rocm_arch="":
 # Backward-compatible spelling for the explicit native-runtime primitive.
 [linux]
 build-runtime backend="" cuda_arch="" rocm_arch="":
-    @backend="{{ backend }}"; \
-      [[ -n "$$backend" ]] || backend=cpu; \
-      LLAMA_STAGE_CUDA_ARCHITECTURES="{{ cuda_arch }}" LLAMA_STAGE_AMDGPU_TARGETS="{{ rocm_arch }}" scripts/package-native-runtime.sh --build --backend "$$backend"
+    #!/usr/bin/env bash
+    set -euo pipefail
+    backend="{{ backend }}"
+    [[ -n "$backend" ]] || backend=cpu
+    LLAMA_STAGE_CUDA_ARCHITECTURES="{{ cuda_arch }}" \
+      LLAMA_STAGE_AMDGPU_TARGETS="{{ rocm_arch }}" \
+      scripts/package-native-runtime.sh --build --backend "$backend"
 
 # Build release artifacts for the current platform.
 
@@ -189,11 +193,22 @@ release-build-aarch64: release-host-build
 # Build a Linux aarch64 CUDA release artifact (Jetson/Orin).
 # SM arches selected by MESH_CUDA_VERSION env (set by CI matrix); a bare
 # `just` invocation with the var unset detects the installed toolkit instead
-# of assuming one (see scripts/detect-cuda-toolkit-version.sh).
+# of assuming one (see scripts/detect-cuda-toolkit-version.sh). Thor (sm_110)
+# needs toolkit >= 13 -- gate on the major, the same shape as the x86_64
+# recipe's Blackwell gate, so a future CUDA 14 keeps Thor instead of falling
+# back to the pre-13 list the way a `13.*` glob did.
 release-build-aarch64-cuda: release-host-build
-    @cuda_version="${MESH_CUDA_VERSION:-$(scripts/detect-cuda-toolkit-version.sh)}"; \
-      MESH_LLM_CUDA_TOOLKIT_MAJOR="${MESH_LLM_CUDA_TOOLKIT_MAJOR:-${cuda_version%%.*}}" \
-      LLAMA_STAGE_CUDA_ARCHITECTURES="$(if [[ "$cuda_version" == 13.* ]]; then echo '75;80;86;87;89;90;110'; else echo '61;75;80;86;87;89;90'; fi)" \
+    #!/usr/bin/env bash
+    set -euo pipefail
+    cuda_version="${MESH_CUDA_VERSION:-$(scripts/detect-cuda-toolkit-version.sh)}"
+    major="${cuda_version%%.*}"
+    if [[ "$major" -ge 13 ]]; then
+      arches='75;80;86;87;89;90;110'
+    else
+      arches='61;75;80;86;87;89;90'
+    fi
+    MESH_LLM_CUDA_TOOLKIT_MAJOR="${MESH_LLM_CUDA_TOOLKIT_MAJOR:-$major}" \
+      LLAMA_STAGE_CUDA_ARCHITECTURES="$arches" \
       scripts/package-native-runtime.sh --build --backend cuda --target aarch64-unknown-linux-gnu
 
 # Prepare the pinned llama.cpp checkout and apply the Mesh-LLM ABI patch queue.

--- a/crates/mesh-llm-host-runtime/src/network/openai/response.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response.rs
@@ -1,3 +1,4 @@
+mod cancellation;
 mod common;
 mod dispatch;
 mod external_endpoint;

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/cancellation.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/cancellation.rs
@@ -95,12 +95,15 @@ mod tests {
             RouteAttemptResult::RetryableTimeout,
             RouteAttemptResult::RetryableUnavailable,
             RouteAttemptResult::RetryableContextOverflow,
-            RouteAttemptResult::RetryableResponseQuality(ResponseQualityFailure::EmptyAssistantOutput),
+            RouteAttemptResult::RetryableResponseQuality(
+                ResponseQualityFailure::EmptyAssistantOutput,
+            ),
             RouteAttemptResult::CommittedStreamFailure { status_code: 200 },
         ] {
             let mut upstream = CancelRecorder::default();
 
-            let passed_through = cancel_upstream_if_client_disconnected(result, &mut upstream).await;
+            let passed_through =
+                cancel_upstream_if_client_disconnected(result, &mut upstream).await;
 
             assert_eq!(upstream.cancels, 0, "{result:?} should not cancel");
             assert_eq!(passed_through, result);

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/cancellation.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/cancellation.rs
@@ -1,0 +1,109 @@
+//! Propagating a downstream client's disconnect back to the upstream.
+//!
+//! When the client relaying through us goes away mid-response, whatever is
+//! generating that response has no idea and keeps working. Local and remote
+//! attempts each reach their upstream over a different protocol, so each needs
+//! its own way of saying "stop" — but the *decision* to say it is the same for
+//! both, and keeping it in one place is what stops the two arms from drifting.
+
+use super::common::RouteAttemptResult;
+use tokio::io::AsyncWriteExt;
+use tokio::net::TcpStream;
+
+/// An upstream that can be told to stop producing a response we no longer want.
+pub(in crate::network::openai::response) trait CancelUpstream {
+    /// Abandon this upstream. Best effort: the upstream may already be gone,
+    /// and there is nothing useful to do about it if the signal does not land.
+    async fn cancel(&mut self);
+}
+
+impl CancelUpstream for TcpStream {
+    async fn cancel(&mut self) {
+        let _ = self.shutdown().await;
+    }
+}
+
+/// QUIC application error code for "the client this response was for is gone".
+///
+/// The peer only needs to know it should stop; it does not branch on the code,
+/// and `mesh::connections` already uses 0 when it abandons an inbound stream.
+const CLIENT_DISCONNECTED: u32 = 0;
+
+impl CancelUpstream for iroh::endpoint::RecvStream {
+    async fn cancel(&mut self) {
+        // STOP_SENDING. The worker peer's next write on its half fails, which
+        // is what actually ends its generation loop -- without this it runs to
+        // completion producing tokens for a client that already hung up.
+        let _ = self.stop(CLIENT_DISCONNECTED.into());
+    }
+}
+
+/// Pass `result` through, cancelling `upstream` first if the client left.
+///
+/// Only `ClientDisconnected` cancels. Every other outcome either finished
+/// normally or is retryable against another target, and a retryable attempt's
+/// upstream is dropped rather than cancelled.
+pub(in crate::network::openai::response) async fn cancel_upstream_if_client_disconnected<
+    U: CancelUpstream + ?Sized,
+>(
+    result: RouteAttemptResult,
+    upstream: &mut U,
+) -> RouteAttemptResult {
+    if matches!(result, RouteAttemptResult::ClientDisconnected) {
+        upstream.cancel().await;
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::network::openai::response_quality::ResponseQualityFailure;
+
+    #[derive(Default)]
+    struct CancelRecorder {
+        cancels: usize,
+    }
+
+    impl CancelUpstream for CancelRecorder {
+        async fn cancel(&mut self) {
+            self.cancels += 1;
+        }
+    }
+
+    #[tokio::test]
+    async fn a_disconnected_client_cancels_the_upstream() {
+        let mut upstream = CancelRecorder::default();
+
+        let result = cancel_upstream_if_client_disconnected(
+            RouteAttemptResult::ClientDisconnected,
+            &mut upstream,
+        )
+        .await;
+
+        assert_eq!(upstream.cancels, 1);
+        assert_eq!(result, RouteAttemptResult::ClientDisconnected);
+    }
+
+    #[tokio::test]
+    async fn every_other_outcome_leaves_the_upstream_alone() {
+        for result in [
+            RouteAttemptResult::Delivered {
+                status_code: 200,
+                usage: None,
+            },
+            RouteAttemptResult::RetryableTimeout,
+            RouteAttemptResult::RetryableUnavailable,
+            RouteAttemptResult::RetryableContextOverflow,
+            RouteAttemptResult::RetryableResponseQuality(ResponseQualityFailure::EmptyAssistantOutput),
+            RouteAttemptResult::CommittedStreamFailure { status_code: 200 },
+        ] {
+            let mut upstream = CancelRecorder::default();
+
+            let passed_through = cancel_upstream_if_client_disconnected(result, &mut upstream).await;
+
+            assert_eq!(upstream.cancels, 0, "{result:?} should not cancel");
+            assert_eq!(passed_through, result);
+        }
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/cancellation.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/cancellation.rs
@@ -5,6 +5,29 @@
 //! attempts each reach their upstream over a different protocol, so each needs
 //! its own way of saying "stop" — but the *decision* to say it is the same for
 //! both, and keeping it in one place is what stops the two arms from drifting.
+//!
+//! # What this does and does not change
+//!
+//! Both transports already say something on drop. Dropping a `TcpStream`
+//! closes the socket and sends FIN; dropping a `noq::RecvStream` that was not
+//! read to completion sends STOP_SENDING with error code 0. Every upstream
+//! here is a local of the attempt that opened it, so that drop lands a few
+//! instructions after the cancel, with no await in between — the same frame,
+//! the same code.
+//!
+//! So this module does not change what goes on the wire. It changes where the
+//! decision lives: one place instead of two hand-rolled teardowns, stated at
+//! the point the outcome is known rather than inferred from drop order, and
+//! not resting on a drop-time detail of whichever QUIC crate we are on.
+//!
+//! Which means it is *not* an explanation for RV-DEFECT-003 — a worker that
+//! logged `request_stream_completed` 22ms after the gateway logged
+//! `request_dropped`. A STOP_SENDING was already being sent then. If that
+//! signal is arriving and generation continues anyway, the stall is downstream
+//! of here, in the worker's relay teardown (`network/tunnel.rs`): the peer's
+//! `relay_tcp_to_quic` write has to fail, and `finish_relay_pair` then waits
+//! on the *other* direction before the local TCP stream to the API proxy is
+//! dropped. That defect stays open pending a worker-side check.
 
 use super::common::RouteAttemptResult;
 use tokio::io::AsyncWriteExt;
@@ -27,13 +50,15 @@ impl CancelUpstream for TcpStream {
 ///
 /// The peer only needs to know it should stop; it does not branch on the code,
 /// and `mesh::connections` already uses 0 when it abandons an inbound stream.
+/// It is also the code `RecvStream::drop` would have used, which is what keeps
+/// the explicit cancel and the drop indistinguishable to the peer.
 const CLIENT_DISCONNECTED: u32 = 0;
 
 impl CancelUpstream for iroh::endpoint::RecvStream {
     async fn cancel(&mut self) {
-        // STOP_SENDING. The worker peer's next write on its half fails, which
-        // is what actually ends its generation loop -- without this it runs to
-        // completion producing tokens for a client that already hung up.
+        // STOP_SENDING, so the peer's next write on its half fails. `stop()`
+        // marks the stream fully read, so the drop that follows is a no-op
+        // rather than a second frame.
         let _ = self.stop(CLIENT_DISCONNECTED.into());
     }
 }
@@ -42,7 +67,8 @@ impl CancelUpstream for iroh::endpoint::RecvStream {
 ///
 /// Only `ClientDisconnected` cancels. Every other outcome either finished
 /// normally or is retryable against another target, and a retryable attempt's
-/// upstream is dropped rather than cancelled.
+/// upstream is dropped rather than cancelled -- which, per the module docs, is
+/// a difference in intent rather than in what the peer receives.
 pub(in crate::network::openai::response) async fn cancel_upstream_if_client_disconnected<
     U: CancelUpstream + ?Sized,
 >(
@@ -55,6 +81,10 @@ pub(in crate::network::openai::response) async fn cancel_upstream_if_client_disc
     result
 }
 
+/// These cover the routing decision only: which outcomes reach `cancel()` and
+/// which do not. Whether a peer actually stops generating on receipt is a
+/// property of the peer, not of this dispatch, and no unit test here can
+/// observe it -- see the module docs on RV-DEFECT-003.
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/routing.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/routing.rs
@@ -279,7 +279,8 @@ mod tests {
     /// `request_dropped`.
     #[tokio::test]
     async fn a_remote_attempt_cancels_the_peer_tunnel_when_the_client_disconnects() {
-        let header = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 64\r\n\r\n";
+        let header =
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 64\r\n\r\n";
         let mut upstream = ScriptedUpstream::new(vec![
             Ok(header.as_bytes().to_vec()),
             // The client is gone; relaying the body fails with a disconnect.

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/routing.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/routing.rs
@@ -1,3 +1,4 @@
+use super::cancellation::{CancelUpstream, cancel_upstream_if_client_disconnected};
 use super::common::{
     ResponseRetryPolicy, RouteAttemptLoggingContext, RouteAttemptResult,
     retryable_route_result_from_error,
@@ -9,7 +10,7 @@ use crate::mesh;
 use crate::network::openai::forwarded_request::prepare_peer_forwarded_request;
 use crate::network::openai::request_normalize::ResponseAdapter;
 use mesh_llm_events::logging::identifiers::RequestId;
-use tokio::io::{AsyncWrite, AsyncWriteExt};
+use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 
 pub(in crate::network::openai) async fn route_local_attempt(
@@ -92,10 +93,7 @@ async fn route_local_attempt_after_forward(
                 response_adapter,
             )
             .await;
-            if matches!(result, RouteAttemptResult::ClientDisconnected) {
-                let _ = upstream.shutdown().await;
-            }
-            result
+            cancel_upstream_if_client_disconnected(result, upstream).await
         }
         Err(err) => {
             tracing::warn!(
@@ -184,9 +182,9 @@ async fn forward_buffered_request<W: AsyncWrite + Unpin>(
     upstream.write_all(prefetched).await
 }
 
-async fn route_remote_attempt_after_forward(
+async fn route_remote_attempt_after_forward<R: AsyncRead + Unpin + CancelUpstream>(
     tcp_stream: &mut TcpStream,
-    quic_recv: &mut iroh::endpoint::RecvStream,
+    quic_recv: &mut R,
     host_id: iroh::EndpointId,
     request_id: RequestId,
     retry_policy: ResponseRetryPolicy,
@@ -195,7 +193,7 @@ async fn route_remote_attempt_after_forward(
 ) -> RouteAttemptResult {
     match probe_http_response(quic_recv).await {
         Ok(probe) => {
-            relay_attempted_response(
+            let result = relay_attempted_response(
                 tcp_stream,
                 quic_recv,
                 probe,
@@ -208,7 +206,8 @@ async fn route_remote_attempt_after_forward(
                 retry_policy,
                 response_adapter,
             )
-            .await
+            .await;
+            cancel_upstream_if_client_disconnected(result, quic_recv).await
         }
         Err(err) => {
             tracing::warn!(
@@ -223,7 +222,135 @@ async fn route_remote_attempt_after_forward(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io;
+    use std::pin::Pin;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::task::{Context, Poll};
     use tokio::io::AsyncReadExt;
+    use tokio::io::ReadBuf;
+    use tokio::net::TcpListener;
+
+    /// An upstream that hands out a fixed script of reads, then records whether
+    /// the route arm cancelled it.
+    struct ScriptedUpstream {
+        steps: std::collections::VecDeque<Result<Vec<u8>, io::ErrorKind>>,
+        cancels: Arc<AtomicUsize>,
+    }
+
+    impl ScriptedUpstream {
+        fn new(steps: Vec<Result<Vec<u8>, io::ErrorKind>>) -> Self {
+            Self {
+                steps: steps.into(),
+                cancels: Arc::new(AtomicUsize::new(0)),
+            }
+        }
+    }
+
+    impl AsyncRead for ScriptedUpstream {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            _cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            match self.steps.pop_front() {
+                Some(Ok(bytes)) => {
+                    buf.put_slice(&bytes);
+                    Poll::Ready(Ok(()))
+                }
+                Some(Err(kind)) => Poll::Ready(Err(io::Error::new(kind, "scripted failure"))),
+                None => Poll::Ready(Ok(())),
+            }
+        }
+    }
+
+    impl CancelUpstream for ScriptedUpstream {
+        async fn cancel(&mut self) {
+            self.cancels.fetch_add(1, Ordering::SeqCst);
+        }
+    }
+
+    /// A remote attempt that loses its client must tell the worker peer to stop.
+    ///
+    /// The local arm has always shut its upstream down here. The remote arm did
+    /// not, so a worker on another node kept generating a response for a client
+    /// that had already hung up — observed in rc6 validation as the worker
+    /// logging `request_stream_completed` after the gateway had already logged
+    /// `request_dropped`.
+    #[tokio::test]
+    async fn a_remote_attempt_cancels_the_peer_tunnel_when_the_client_disconnects() {
+        let header = "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 64\r\n\r\n";
+        let mut upstream = ScriptedUpstream::new(vec![
+            Ok(header.as_bytes().to_vec()),
+            // The client is gone; relaying the body fails with a disconnect.
+            Err(io::ErrorKind::ConnectionReset),
+        ]);
+        let cancels = Arc::clone(&upstream.cancels);
+        let host_id = iroh::SecretKey::generate().public();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut client, _) = listener.accept().await.unwrap();
+            route_remote_attempt_after_forward(
+                &mut client,
+                &mut upstream,
+                host_id,
+                RequestId::new(),
+                ResponseRetryPolicy::next_target_available(false),
+                ResponseAdapter::None,
+                OpenAiRouteObserver::default(),
+            )
+            .await
+        });
+        let _socket = TcpStream::connect(address).await.unwrap();
+
+        let result = task.await.unwrap();
+
+        assert_eq!(result, RouteAttemptResult::ClientDisconnected);
+        assert_eq!(
+            cancels.load(Ordering::SeqCst),
+            1,
+            "the peer tunnel was left running after the client disconnected"
+        );
+    }
+
+    /// The counterpart: a normal delivery must not cancel anything.
+    #[tokio::test]
+    async fn a_remote_attempt_that_delivers_leaves_the_peer_tunnel_alone() {
+        let body = "x".repeat(8);
+        let header = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut upstream = ScriptedUpstream::new(vec![Ok(header.into_bytes())]);
+        let cancels = Arc::clone(&upstream.cancels);
+        let host_id = iroh::SecretKey::generate().public();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut client, _) = listener.accept().await.unwrap();
+            route_remote_attempt_after_forward(
+                &mut client,
+                &mut upstream,
+                host_id,
+                RequestId::new(),
+                ResponseRetryPolicy::next_target_available(false),
+                ResponseAdapter::None,
+                OpenAiRouteObserver::default(),
+            )
+            .await
+        });
+        let mut socket = TcpStream::connect(address).await.unwrap();
+        let mut relayed = Vec::new();
+        socket.read_to_end(&mut relayed).await.unwrap();
+
+        let result = task.await.unwrap();
+
+        assert!(matches!(result, RouteAttemptResult::Delivered { .. }));
+        assert_eq!(cancels.load(Ordering::SeqCst), 0);
+    }
 
     #[tokio::test]
     async fn local_and_remote_forwarding_preserve_the_canonical_request_id_bytes() {

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/routing.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/routing.rs
@@ -230,6 +230,40 @@ mod tests {
     use tokio::io::AsyncReadExt;
     use tokio::io::ReadBuf;
     use tokio::net::TcpListener;
+    use tokio::sync::Notify;
+
+    /// A real duplex pipe as the upstream half of `CancelUpstream`, wrapped to
+    /// signal a `Notify` the moment a read finds nothing buffered yet.
+    ///
+    /// Unlike `ScriptedUpstream` below, this can genuinely block waiting for
+    /// more bytes, which is what lets a test prove the route arm is actively
+    /// relaying (header consumed, now waiting on the body) at a specific
+    /// moment, rather than assuming it from timing.
+    struct DuplexUpstream {
+        inner: tokio::io::DuplexStream,
+        cancels: Arc<AtomicUsize>,
+        waiting_for_more: Arc<Notify>,
+    }
+
+    impl AsyncRead for DuplexUpstream {
+        fn poll_read(
+            mut self: Pin<&mut Self>,
+            cx: &mut Context<'_>,
+            buf: &mut ReadBuf<'_>,
+        ) -> Poll<io::Result<()>> {
+            let result = Pin::new(&mut self.inner).poll_read(cx, buf);
+            if result.is_pending() {
+                self.waiting_for_more.notify_one();
+            }
+            result
+        }
+    }
+
+    impl CancelUpstream for DuplexUpstream {
+        async fn cancel(&mut self) {
+            self.cancels.fetch_add(1, Ordering::SeqCst);
+        }
+    }
 
     /// An upstream that hands out a fixed script of reads, then records whether
     /// the route arm cancelled it.
@@ -279,14 +313,14 @@ mod tests {
     /// `request_dropped`.
     #[tokio::test]
     async fn a_remote_attempt_cancels_the_peer_tunnel_when_the_client_disconnects() {
-        let header =
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 64\r\n\r\n";
-        let mut upstream = ScriptedUpstream::new(vec![
-            Ok(header.as_bytes().to_vec()),
-            // The client is gone; relaying the body fails with a disconnect.
-            Err(io::ErrorKind::ConnectionReset),
-        ]);
-        let cancels = Arc::clone(&upstream.cancels);
+        let (mut upstream_writer, upstream_reader) = tokio::io::duplex(64 * 1024);
+        let cancels = Arc::new(AtomicUsize::new(0));
+        let waiting_for_more = Arc::new(Notify::new());
+        let mut upstream = DuplexUpstream {
+            inner: upstream_reader,
+            cancels: Arc::clone(&cancels),
+            waiting_for_more: Arc::clone(&waiting_for_more),
+        };
         let host_id = iroh::SecretKey::generate().public();
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -304,7 +338,32 @@ mod tests {
             )
             .await
         });
-        let _socket = TcpStream::connect(address).await.unwrap();
+        let client_socket = TcpStream::connect(address).await.unwrap();
+
+        let body = "x".repeat(64);
+        let header = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        );
+        // Send only the header. The route arm buffers it, then blocks asking
+        // upstream for body bytes that have not arrived yet.
+        upstream_writer.write_all(header.as_bytes()).await.unwrap();
+        waiting_for_more.notified().await;
+
+        // The route arm is now genuinely waiting on upstream body bytes, not
+        // still parsing the header -- closing the client here means the write
+        // it makes once the body arrives lands on an actually disconnected
+        // socket, rather than an upstream read failure standing in for one.
+        //
+        // A graceful close (a plain `drop`) sends only a FIN; the server's
+        // very next write can still succeed locally before it learns the
+        // peer is gone, which is exactly the kind of timing-dependent gap
+        // this test exists to close. Zero linger forces an RST instead, so
+        // the eventual write fails deterministically.
+        client_socket.set_zero_linger().unwrap();
+        drop(client_socket);
+
+        upstream_writer.write_all(body.as_bytes()).await.unwrap();
 
         let result = task.await.unwrap();
 

--- a/crates/mesh-llm-host-runtime/src/plugin/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/transport.rs
@@ -419,6 +419,12 @@ fn unix_socket_path_fits(path: &Path) -> bool {
 /// way `mesh_llm_plugin::bind_side_stream` already does for side streams --
 /// the bound path is handed to the plugin process verbatim, so relocating it
 /// costs nothing as long as it stays unique per instance.
+///
+/// Note that the fallback directory is typically world-writable, and
+/// `bind_local_listener` unlinks the path before binding. That unlink is
+/// deliberate, and safe only because the file name is unguessable ahead of
+/// time: the `p{pid}-{random:08x}` instance id (`make_instance_id`) leaves
+/// nothing for another user to pre-place and have us remove on their behalf.
 #[cfg(unix)]
 fn unix_socket_path_within(
     preferred_dir: &Path,

--- a/crates/mesh-llm-host-runtime/src/plugin/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/transport.rs
@@ -6,7 +6,7 @@ use rmcp::model::ErrorCode;
 use std::collections::HashMap;
 use std::future::Future;
 #[cfg(unix)]
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use std::sync::Arc;
 use std::time::Duration;
@@ -382,9 +382,81 @@ pub(crate) fn make_instance_id() -> String {
     format!("p{pid}-{random:08x}")
 }
 
+/// `sockaddr_un::sun_path` capacity: 108 bytes on Linux, 104 on macOS and the
+/// BSDs. One byte of that is the NUL terminator, so a path may use one less.
+///
+/// `bind` does not truncate an over-long path, it refuses it -- and the error
+/// says nothing about lengths, so the failure reads as a permissions or
+/// plumbing problem rather than a path that is four bytes too long.
+#[cfg(unix)]
+const SUN_PATH_CAPACITY: usize = if cfg!(any(
+    target_os = "macos",
+    target_os = "ios",
+    target_os = "freebsd",
+    target_os = "openbsd",
+    target_os = "netbsd",
+    target_os = "dragonfly"
+)) {
+    104
+} else {
+    108
+};
+
+#[cfg(unix)]
+const MAX_UNIX_SOCKET_PATH_BYTES: usize = SUN_PATH_CAPACITY - 1;
+
+#[cfg(unix)]
+fn unix_socket_path_fits(path: &Path) -> bool {
+    use std::os::unix::ffi::OsStrExt;
+
+    path.as_os_str().as_bytes().len() <= MAX_UNIX_SOCKET_PATH_BYTES
+}
+
+/// Pick a bindable socket path, preferring the durable runtime directory.
+///
+/// The runtime directory is rooted at `$HOME`, so a deeply nested home is
+/// enough to push the path past the limit. Fall back to a short directory the
+/// way `mesh_llm_plugin::bind_side_stream` already does for side streams --
+/// the bound path is handed to the plugin process verbatim, so relocating it
+/// costs nothing as long as it stays unique per instance.
+#[cfg(unix)]
+fn unix_socket_path_within(
+    preferred_dir: &Path,
+    fallback_dir: &Path,
+    instance_id: &str,
+    name: &str,
+) -> Result<PathBuf> {
+    let file_name = format!("{instance_id}-{name}.sock");
+
+    let preferred = preferred_dir.join(&file_name);
+    if unix_socket_path_fits(&preferred) {
+        return Ok(preferred);
+    }
+
+    let fallback = fallback_dir.join(&file_name);
+    if unix_socket_path_fits(&fallback) {
+        tracing::debug!(
+            preferred = %preferred.display(),
+            fallback = %fallback.display(),
+            limit = MAX_UNIX_SOCKET_PATH_BYTES,
+            "plugin socket path is too long to bind; using a short path instead"
+        );
+        return Ok(fallback);
+    }
+
+    bail!(
+        "plugin socket path for '{name}' exceeds the {MAX_UNIX_SOCKET_PATH_BYTES}-byte \
+         AF_UNIX limit in both {} ({} bytes) and {} ({} bytes)",
+        preferred_dir.display(),
+        preferred.as_os_str().len(),
+        fallback_dir.display(),
+        fallback.as_os_str().len(),
+    )
+}
+
 #[cfg(unix)]
 pub(crate) fn unix_socket_path(instance_id: &str, name: &str) -> Result<PathBuf> {
-    Ok(runtime_dir()?.join(format!("{instance_id}-{name}.sock")))
+    unix_socket_path_within(&runtime_dir()?, &std::env::temp_dir(), instance_id, name)
 }
 
 #[cfg(windows)]
@@ -716,5 +788,87 @@ mod tests {
             panic!("expected timeout to map to an error response");
         };
         assert!(error.message.contains("Mesh stream broker timed out"));
+    }
+}
+
+#[cfg(all(test, unix))]
+mod unix_socket_path_tests {
+    use super::*;
+    use std::path::Path;
+
+    const INSTANCE: &str = "p1234-deadbeef";
+    const PLUGIN: &str = "blobstore";
+
+    fn short_fallback() -> PathBuf {
+        PathBuf::from("/tmp")
+    }
+
+    #[test]
+    fn a_runtime_dir_that_fits_is_used_unchanged() {
+        let runtime_dir = Path::new("/home/nick/.mesh-llm/run/plugins");
+
+        let path =
+            unix_socket_path_within(runtime_dir, &short_fallback(), INSTANCE, PLUGIN).unwrap();
+
+        assert_eq!(path, runtime_dir.join("p1234-deadbeef-blobstore.sock"));
+    }
+
+    #[test]
+    fn an_over_long_runtime_dir_falls_back_instead_of_failing_to_bind() {
+        // A deeply nested $HOME is all it takes; the rc6 validation run hit
+        // this with an isolated HOME that pushed the socket path to 112 bytes.
+        let runtime_dir = PathBuf::from(format!(
+            "/home/{}/.mesh-llm/run/plugins",
+            "nested-dir/".repeat(12)
+        ));
+        assert!(runtime_dir.as_os_str().len() > MAX_UNIX_SOCKET_PATH_BYTES);
+
+        let path =
+            unix_socket_path_within(&runtime_dir, &short_fallback(), INSTANCE, PLUGIN).unwrap();
+
+        assert_eq!(path, short_fallback().join("p1234-deadbeef-blobstore.sock"));
+    }
+
+    #[test]
+    fn the_fallback_keeps_the_instance_namespacing_that_prevents_collisions() {
+        let runtime_dir = PathBuf::from("/".to_owned() + &"x".repeat(200));
+
+        let first =
+            unix_socket_path_within(&runtime_dir, &short_fallback(), "p1-aaaa", PLUGIN).unwrap();
+        let second =
+            unix_socket_path_within(&runtime_dir, &short_fallback(), "p2-bbbb", PLUGIN).unwrap();
+
+        assert_ne!(first, second);
+        assert!(first.to_str().unwrap().contains("p1-aaaa"));
+    }
+
+    #[test]
+    fn whatever_is_selected_always_fits_the_platform_limit() {
+        for depth in 0..40 {
+            let runtime_dir = PathBuf::from(format!("/home/{}/.mesh-llm", "deeper/".repeat(depth)));
+
+            let path = unix_socket_path_within(&runtime_dir, &short_fallback(), INSTANCE, PLUGIN)
+                .expect("a fallback should always be available for a short plugin name");
+
+            assert!(
+                path.as_os_str().len() <= MAX_UNIX_SOCKET_PATH_BYTES,
+                "depth {depth} produced an unbindable {} byte path",
+                path.as_os_str().len()
+            );
+        }
+    }
+
+    #[test]
+    fn a_name_too_long_for_any_directory_is_a_clear_error_not_a_doomed_bind() {
+        let runtime_dir = PathBuf::from("/run");
+
+        let error =
+            unix_socket_path_within(&runtime_dir, &short_fallback(), INSTANCE, &"p".repeat(300))
+                .expect_err("an unbindable path must be reported, not returned");
+
+        assert!(
+            error.to_string().contains("exceeds"),
+            "unexpected message: {error}"
+        );
     }
 }

--- a/crates/mesh-llm-ui/.npmrc
+++ b/crates/mesh-llm-ui/.npmrc
@@ -1,0 +1,3 @@
+# engines.pnpm is advisory unless this is on. Without it a pnpm 9 operator
+# gets ERR_PNPM_LOCKFILE_CONFIG_MISMATCH, which never mentions pnpm versions.
+engine-strict=true

--- a/crates/mesh-llm-ui/package.json
+++ b/crates/mesh-llm-ui/package.json
@@ -3,6 +3,10 @@
   "private": true,
   "version": "0.76.0-rc6",
   "type": "module",
+  "packageManager": "pnpm@10.30.3",
+  "engines": {
+    "pnpm": ">=10"
+  },
   "scripts": {
     "dev": "vite --host 0.0.0.0",
     "build": "tsc -b && vite build",

--- a/scripts/tests/test_build_development_product.py
+++ b/scripts/tests/test_build_development_product.py
@@ -28,9 +28,12 @@ class DevelopmentProductBuildTests(unittest.TestCase):
         self.assertIn("pkg-config --exists vulkan", contents)
 
     def test_build_runtime_empty_backend_defaults_to_cpu(self) -> None:
+        # `$$backend` here read the shell PID, not the recipe argument. The
+        # behavioral check that this actually defaults (and that an explicit
+        # backend survives) lives in test_justfile_release_runtime.py.
         justfile = JUSTFILE.read_text(encoding="utf-8")
         recipe = justfile[justfile.index('build-runtime backend=""'):]
-        self.assertIn('[[ -n "$$backend" ]] || backend=cpu', recipe)
+        self.assertIn('[[ -n "$backend" ]] || backend=cpu', recipe)
 
     def test_preserves_documented_named_just_arguments(self) -> None:
         contents = SCRIPT.read_text(encoding="utf-8")

--- a/scripts/tests/test_build_ui.py
+++ b/scripts/tests/test_build_ui.py
@@ -82,7 +82,7 @@ class BuildUiScriptTests(unittest.TestCase):
         for workflow in sorted(workflows):
             for block in re.finditer(
                 r"uses:\s*pnpm/action-setup@[^\n]*\n"
-                r"(?P<rest>(?:[ \t]+(?!-)[^\n]*\n)*)",
+                r"(?P<rest>(?:[ \t]+(?![ \t]*-)[^\n]*\n)*)",
                 workflow.read_text(encoding="utf-8"),
             ):
                 version = re.search(

--- a/scripts/tests/test_build_ui.py
+++ b/scripts/tests/test_build_ui.py
@@ -1,7 +1,9 @@
 from __future__ import annotations
 
+import json
 import os
 from pathlib import Path
+import re
 import subprocess
 import tempfile
 import unittest
@@ -9,6 +11,8 @@ import unittest
 
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "build-ui.sh"
+UI_DIR = ROOT / "crates" / "mesh-llm-ui"
+WORKFLOWS = ROOT / ".github" / "workflows"
 
 
 class BuildUiScriptTests(unittest.TestCase):
@@ -19,6 +23,69 @@ class BuildUiScriptTests(unittest.TestCase):
 
         self.assertIn("packages:", contents)
         self.assertRegex(contents, r"(?m)^\s*-\s*['\"]?\.[\"']?\s*$")
+
+    def ci_pnpm_majors(self) -> set[str]:
+        """Every pnpm major `pnpm/action-setup` is asked to install in CI."""
+        majors: set[str] = set()
+        for workflow in sorted(WORKFLOWS.glob("*.yml")):
+            for block in re.finditer(
+                r"uses:\s*pnpm/action-setup@[^\n]*\n(?P<rest>(?:[ \t]+[^\n]*\n)*)",
+                workflow.read_text(encoding="utf-8"),
+            ):
+                version = re.search(r"version:\s*[\"']?(\d+)", block.group("rest"))
+                if version:
+                    majors.add(version.group(1))
+        return majors
+
+    def test_ui_package_declares_the_pnpm_major_that_ci_installs(self) -> None:
+        """The lockfile only installs under pnpm 10+, so the repo must say so.
+
+        `overrides` and `allowBuilds` live in `pnpm-workspace.yaml`, which is a
+        pnpm 10 layout. pnpm 9 does not read them, so it computes a different
+        overrides config than the lockfile records and stops with
+        `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` — a message that says nothing about
+        pnpm versions. Declaring the requirement turns that into
+        `ERR_PNPM_UNSUPPORTED_ENGINE`, which names the actual problem.
+        """
+        manifest = json.loads((UI_DIR / "package.json").read_text(encoding="utf-8"))
+
+        required = manifest.get("engines", {}).get("pnpm")
+        self.assertIsNotNone(required, "package.json must declare engines.pnpm")
+        declared_major = re.search(r"(\d+)", required)
+        self.assertIsNotNone(declared_major)
+        assert declared_major is not None
+
+        pinned = manifest.get("packageManager", "")
+        self.assertRegex(
+            pinned,
+            r"^pnpm@\d+\.\d+\.\d+$",
+            "packageManager must pin an exact pnpm version for corepack",
+        )
+
+        ci_majors = self.ci_pnpm_majors()
+        self.assertTrue(ci_majors, "no pnpm/action-setup version found to compare against")
+        self.assertEqual(
+            ci_majors,
+            {declared_major.group(1)},
+            "engines.pnpm and CI's pnpm/action-setup version have drifted apart",
+        )
+        self.assertTrue(
+            pinned.startswith(f"pnpm@{declared_major.group(1)}."),
+            f"packageManager {pinned} is outside the declared engines.pnpm range {required}",
+        )
+
+    def test_ui_npmrc_enforces_the_declared_engine(self) -> None:
+        """`engines` is advisory to pnpm unless engine-strict is turned on.
+
+        Without this the field is documentation only and a pnpm 9 operator
+        still gets the unrelated lockfile-mismatch error.
+        """
+        npmrc = UI_DIR / ".npmrc"
+        self.assertTrue(npmrc.exists(), "crates/mesh-llm-ui/.npmrc is missing")
+        self.assertRegex(
+            npmrc.read_text(encoding="utf-8"),
+            r"(?m)^engine-strict\s*=\s*true\s*$",
+        )
 
     def test_mixed_case_release_profile_uses_release_ui_env(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:

--- a/scripts/tests/test_build_ui.py
+++ b/scripts/tests/test_build_ui.py
@@ -78,7 +78,8 @@ class BuildUiScriptTests(unittest.TestCase):
     def ci_pnpm_majors(self) -> set[str]:
         """Every pnpm major `pnpm/action-setup` is asked to install in CI."""
         majors: set[str] = set()
-        for workflow in sorted(WORKFLOWS.glob("*.yml")):
+        workflows = [*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml")]
+        for workflow in sorted(workflows):
             for block in re.finditer(
                 r"uses:\s*pnpm/action-setup@[^\n]*\n(?P<rest>(?:[ \t]+[^\n]*\n)*)",
                 workflow.read_text(encoding="utf-8"),

--- a/scripts/tests/test_build_ui.py
+++ b/scripts/tests/test_build_ui.py
@@ -81,10 +81,13 @@ class BuildUiScriptTests(unittest.TestCase):
         workflows = [*WORKFLOWS.glob("*.yml"), *WORKFLOWS.glob("*.yaml")]
         for workflow in sorted(workflows):
             for block in re.finditer(
-                r"uses:\s*pnpm/action-setup@[^\n]*\n(?P<rest>(?:[ \t]+[^\n]*\n)*)",
+                r"uses:\s*pnpm/action-setup@[^\n]*\n"
+                r"(?P<rest>(?:[ \t]+(?!-)[^\n]*\n)*)",
                 workflow.read_text(encoding="utf-8"),
             ):
-                version = re.search(r"version:\s*[\"']?(\d+)", block.group("rest"))
+                version = re.search(
+                    r"(?m)^[ \t]*version:\s*[\"']?(\d+)", block.group("rest")
+                )
                 if version:
                     majors.add(version.group(1))
         return majors

--- a/scripts/tests/test_build_ui.py
+++ b/scripts/tests/test_build_ui.py
@@ -15,6 +15,57 @@ UI_DIR = ROOT / "crates" / "mesh-llm-ui"
 WORKFLOWS = ROOT / ".github" / "workflows"
 
 
+def _parse_partial_version(text: str) -> tuple[int, int, int]:
+    parts = (text.split(".") + ["0", "0"])[:3]
+    return tuple(int(part) for part in parts)
+
+
+def _version_satisfies_range(version: str, range_spec: str) -> bool:
+    """Check a concrete x.y.z version against a small, space-separated-AND
+    subset of node-semver ranges: `>=`, `<=`, `>`, `<`, and bare-equals
+    comparators only.
+
+    `engines.pnpm` in this repo has never needed `^`, `~`, or `||`; if it
+    grows one, extend this rather than reaching for a dependency.
+    """
+    version_tuple = _parse_partial_version(version)
+    comparator = re.compile(r"^(>=|<=|>|<|=)?(\d+(?:\.\d+){0,2})$")
+    for token in range_spec.split():
+        match = comparator.match(token)
+        if match is None:
+            raise ValueError(f"unsupported engines.pnpm range token: {token!r}")
+        operator, bound = match.group(1) or "=", match.group(2)
+        bound_tuple = _parse_partial_version(bound)
+        satisfied = {
+            ">=": version_tuple >= bound_tuple,
+            "<=": version_tuple <= bound_tuple,
+            ">": version_tuple > bound_tuple,
+            "<": version_tuple < bound_tuple,
+            "=": version_tuple == bound_tuple,
+        }[operator]
+        if not satisfied:
+            return False
+    return True
+
+
+class SemverRangeTests(unittest.TestCase):
+    """Direct coverage for the range check the engines.pnpm test relies on."""
+
+    def test_satisfies_a_lower_bound(self) -> None:
+        self.assertTrue(_version_satisfies_range("10.30.3", ">=10"))
+
+    def test_rejects_a_pin_below_an_exclusive_upper_bound_stated_as_a_lower_bound(
+        self,
+    ) -> None:
+        self.assertFalse(_version_satisfies_range("10.30.3", "<10"))
+
+    def test_rejects_a_pin_outside_a_narrow_conjunctive_range(self) -> None:
+        self.assertFalse(_version_satisfies_range("10.30.3", ">=10 <10.30.0"))
+
+    def test_satisfies_a_wide_conjunctive_range(self) -> None:
+        self.assertTrue(_version_satisfies_range("10.30.3", ">=10 <11"))
+
+
 class BuildUiScriptTests(unittest.TestCase):
     def test_ui_pnpm_workspace_names_root_package(self) -> None:
         workspace = ROOT / "crates" / "mesh-llm-ui" / "pnpm-workspace.yaml"
@@ -69,9 +120,10 @@ class BuildUiScriptTests(unittest.TestCase):
             {declared_major.group(1)},
             "engines.pnpm and CI's pnpm/action-setup version have drifted apart",
         )
+        pinned_version = pinned.removeprefix("pnpm@")
         self.assertTrue(
-            pinned.startswith(f"pnpm@{declared_major.group(1)}."),
-            f"packageManager {pinned} is outside the declared engines.pnpm range {required}",
+            _version_satisfies_range(pinned_version, required),
+            f"packageManager {pinned} does not satisfy the declared engines.pnpm range {required!r}",
         )
 
     def test_ui_npmrc_enforces_the_declared_engine(self) -> None:

--- a/scripts/tests/test_justfile_release_runtime.py
+++ b/scripts/tests/test_justfile_release_runtime.py
@@ -21,7 +21,7 @@ def _recipe_dependencies(header_line: str) -> list[str]:
     Parameterized headers like 'build-runtime backend="" cuda_arch="":' have no
     colon before the trailing one, so they correctly yield no dependencies.
     """
-    _, _, deps_part = header_line.partition(":")
+    _, _, deps_part = header_line.rpartition(":")
     return deps_part.split()
 
 
@@ -65,7 +65,7 @@ def _run_release_recipe(
 
         run_env = {"PATH": os.environ["PATH"]}
         run_env.update(env or {})
-        subprocess.run(
+        result = subprocess.run(
             ["just", "-f", str(justfile), name, *args],
             cwd=workdir,
             env=run_env,
@@ -75,7 +75,10 @@ def _run_release_recipe(
         )
 
         if not probe.exists():
-            return {"arches": "", "toolkit_major": "", "args": ""}
+            raise AssertionError(
+                f"`just {name}` did not reach the packager stub "
+                f"(exit {result.returncode})\nstdout: {result.stdout}\nstderr: {result.stderr}"
+            )
         recorded = probe.read_text(encoding="utf-8").splitlines()
         recorded += [""] * (3 - len(recorded))
         return {"arches": recorded[0], "toolkit_major": recorded[1], "args": recorded[2]}

--- a/scripts/tests/test_justfile_release_runtime.py
+++ b/scripts/tests/test_justfile_release_runtime.py
@@ -1,14 +1,37 @@
 from __future__ import annotations
 
+import os
 from pathlib import Path
 import re
+import shlex
+import shutil
 import subprocess
+import tempfile
 from typing import Final
 import unittest
 
 
 ROOT: Final = Path(__file__).resolve().parents[2]
 JUSTFILE: Final = ROOT / "Justfile"
+
+
+def _recipe_body_lines(recipe: str) -> list[str]:
+    """Strip a recipe down to the shell script just would actually execute.
+
+    Drops the `name: deps` header, removes the recipe's indentation, and strips
+    just's line prefixes. `@` (suppress echo) and `-` (ignore failure) are
+    directives to just, not shell syntax — leaving them in makes the first line
+    parse as a command name, so every variable it was supposed to set silently
+    stays unset.
+    """
+    lines = recipe.splitlines()[1:]
+    lines = [line[4:] if line.startswith("    ") else line for line in lines]
+    lines = [line for line in lines if not line.startswith("#!")]
+    for index, line in enumerate(lines):
+        if line.strip():
+            lines[index] = line.lstrip("@-")
+            break
+    return lines
 
 
 def _run_cuda_arch_selection(recipe: str, mesh_cuda_version: str) -> str:
@@ -36,6 +59,96 @@ def _run_cuda_arch_selection(recipe: str, mesh_cuda_version: str) -> str:
         env={"PATH": "/usr/bin:/bin", "MESH_CUDA_VERSION": mesh_cuda_version},
     )
     return result.stdout.strip()
+
+
+def _run_recipe_body_capturing_packager_env(
+    recipe: str, mesh_cuda_version: str, interpreter: str
+) -> dict[str, str]:
+    """Run a whole release-build recipe body with `package-native-runtime.sh`
+    stubbed out, and return the environment the stub actually observed.
+
+    This executes the recipe source as-is — including the trailing
+    `VAR=... scripts/package-native-runtime.sh` line — so it reports what the
+    packager would really be handed, rather than re-deriving the selection.
+    `interpreter` is the shell just would use for this recipe: `bash` for a
+    `#!/usr/bin/env bash` script recipe, `sh`/`dash` for a plain one.
+    """
+    lines = _recipe_body_lines(recipe)
+
+    with tempfile.TemporaryDirectory() as workdir:
+        scripts_dir = Path(workdir) / "scripts"
+        scripts_dir.mkdir()
+        probe = Path(workdir) / "packager-env.txt"
+        stub = scripts_dir / "package-native-runtime.sh"
+        stub.write_text(
+            "#!/usr/bin/env bash\n"
+            f'printf "%s\\n" "$LLAMA_STAGE_CUDA_ARCHITECTURES" '
+            f'"$MESH_LLM_CUDA_TOOLKIT_MAJOR" "$*" > {shlex.quote(str(probe))}\n',
+            encoding="utf-8",
+        )
+        stub.chmod(0o755)
+        detect = scripts_dir / "detect-cuda-toolkit-version.sh"
+        detect.write_text("#!/usr/bin/env bash\necho 12\n", encoding="utf-8")
+        detect.chmod(0o755)
+
+        script = Path(workdir) / "recipe-body"
+        script.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        subprocess.run(
+            [interpreter, str(script)],
+            cwd=workdir,
+            check=False,
+            capture_output=True,
+            text=True,
+            env={"PATH": os.environ["PATH"], "MESH_CUDA_VERSION": mesh_cuda_version},
+        )
+        if not probe.exists():
+            return {"arches": "", "toolkit_major": "", "args": ""}
+        recorded = probe.read_text(encoding="utf-8").splitlines()
+        recorded += [""] * (3 - len(recorded))
+        return {
+            "arches": recorded[0],
+            "toolkit_major": recorded[1],
+            "args": recorded[2],
+        }
+
+
+def _run_build_runtime_body(recipe: str, interpreter: str, backend: str) -> dict[str, str]:
+    """Run `build-runtime`'s body with `{{ backend }}` substituted the way just
+    would, and report the backend the packager was actually handed.
+    """
+    body = "\n".join(_recipe_body_lines(recipe))
+    for placeholder, value in (
+        ("{{ backend }}", backend),
+        ("{{ cuda_arch }}", ""),
+        ("{{ rocm_arch }}", ""),
+    ):
+        body = body.replace(placeholder, value)
+
+    with tempfile.TemporaryDirectory() as workdir:
+        scripts_dir = Path(workdir) / "scripts"
+        scripts_dir.mkdir()
+        probe = Path(workdir) / "packager-env.txt"
+        stub = scripts_dir / "package-native-runtime.sh"
+        stub.write_text(
+            "#!/usr/bin/env bash\n"
+            f'printf "%s\\n" "$*" > {shlex.quote(str(probe))}\n',
+            encoding="utf-8",
+        )
+        stub.chmod(0o755)
+        script = Path(workdir) / "recipe-body"
+        script.write_text(body + "\n", encoding="utf-8")
+        subprocess.run(
+            [interpreter, str(script)],
+            cwd=workdir,
+            check=False,
+            capture_output=True,
+            text=True,
+            env={"PATH": os.environ["PATH"]},
+        )
+        args = probe.read_text(encoding="utf-8").strip() if probe.exists() else ""
+
+    match = re.search(r"--backend (\S+)", args)
+    return {"args": args, "backend": match.group(1) if match else ""}
 
 
 class JustfileReleaseRuntimeTests(unittest.TestCase):
@@ -68,8 +181,7 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
             self.recipe("release-build-cuda"),
         )
         self.assertIn(
-            'MESH_LLM_CUDA_TOOLKIT_MAJOR="'
-            '${MESH_LLM_CUDA_TOOLKIT_MAJOR:-${cuda_version%%.*}}"',
+            'MESH_LLM_CUDA_TOOLKIT_MAJOR="${MESH_LLM_CUDA_TOOLKIT_MAJOR:-$major}"',
             self.recipe("release-build-aarch64-cuda"),
         )
 
@@ -77,11 +189,11 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
         contents = JUSTFILE.read_text(encoding="utf-8")
 
         self.assertIn(
-            "else echo '61;75;80;86;87;89;90'",
+            "arches='61;75;80;86;87;89;90'",
             self.recipe("release-build-aarch64-cuda"),
         )
         self.assertIn(
-            "if [[ \"$cuda_version\" == 13.* ]]; then echo '75;80;86;87;89;90;110'",
+            "arches='75;80;86;87;89;90;110'",
             self.recipe("release-build-aarch64-cuda"),
         )
         self.assertIn(
@@ -108,6 +220,81 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
                 self.assertEqual(
                     _run_cuda_arch_selection(recipe, mesh_cuda_version), expected
                 )
+
+    def test_aarch64_cuda_release_build_selects_arches_at_the_13_boundary(self) -> None:
+        """Run the recipe body the way just would and check what the packager gets.
+
+        `sm_110` (Thor) needs toolkit major >= 13, so this mirrors how the
+        x86_64 sibling gates Blackwell on >= 12.8. The interpreter is taken
+        from the recipe itself: a plain recipe is run under `dash`, which is
+        what `/bin/sh` is on the Debian/Ubuntu aarch64 build hosts.
+        """
+        recipe = self.recipe("release-build-aarch64-cuda")
+        interpreter = self.recipe_interpreter(recipe)
+        pre_13 = "61;75;80;86;87;89;90"
+        thor = "75;80;86;87;89;90;110"
+
+        cases = {
+            "12": pre_13,  # detect script's own static fallback
+            "12.4": pre_13,
+            "12.8": pre_13,  # Blackwell gate is x86-only; aarch64 gates on 13
+            "13": thor,
+            "13.1.2": thor,
+            "14": thor,  # a `13.*` glob would wrongly fall back here
+        }
+        for mesh_cuda_version, expected in cases.items():
+            with self.subTest(mesh_cuda_version=mesh_cuda_version):
+                observed = _run_recipe_body_capturing_packager_env(
+                    recipe, mesh_cuda_version, interpreter
+                )
+                self.assertEqual(observed["arches"], expected)
+
+    def test_aarch64_cuda_release_build_propagates_major_and_target_to_the_packager(
+        self,
+    ) -> None:
+        recipe = self.recipe("release-build-aarch64-cuda")
+        observed = _run_recipe_body_capturing_packager_env(
+            recipe, "13.1.2", self.recipe_interpreter(recipe)
+        )
+
+        self.assertEqual(observed["toolkit_major"], "13")
+        self.assertEqual(
+            observed["args"],
+            "--build --backend cuda --target aarch64-unknown-linux-gnu",
+        )
+
+    def test_build_runtime_defaults_the_backend_and_forwards_the_one_it_was_given(
+        self,
+    ) -> None:
+        """`$$backend` read the shell PID, not the recipe argument.
+
+        Under just, `$$` is two literal dollars, so `"$$backend"` expanded to
+        "<pid>backend" — the default-to-cpu test never inspected the variable
+        it appeared to, and the packager was handed a nonsense backend name.
+        """
+        recipe = self.recipe("build-runtime")
+        interpreter = self.recipe_interpreter(recipe)
+
+        defaulted = _run_build_runtime_body(recipe, interpreter, backend="")
+        self.assertEqual(defaulted["backend"], "cpu")
+
+        explicit = _run_build_runtime_body(recipe, interpreter, backend="cuda")
+        self.assertEqual(explicit["backend"], "cuda")
+
+    def recipe_interpreter(self, recipe: str) -> str:
+        """The shell just would run this recipe body with.
+
+        A `#!` script recipe is executed with the interpreter it names; a plain
+        recipe goes to just's default shell, `sh`, which is dash on the Debian
+        and Ubuntu hosts these release recipes target.
+        """
+        body = [line for line in recipe.splitlines()[1:] if line.strip()]
+        if body and body[0].strip().startswith("#!"):
+            self.assertEqual(body[0].strip(), "#!/usr/bin/env bash")
+            return "bash"
+        if not shutil.which("dash") and not Path("/bin/dash").exists():
+            self.skipTest("dash is required to exercise just's default `sh` faithfully")
+        return "dash" if shutil.which("dash") else "/bin/dash"
 
     def test_bundle_uses_the_product_packager_and_copies_its_checksum(self) -> None:
         recipe = self.recipe("bundle")

--- a/scripts/tests/test_justfile_release_runtime.py
+++ b/scripts/tests/test_justfile_release_runtime.py
@@ -4,7 +4,6 @@ import os
 from pathlib import Path
 import re
 import shlex
-import shutil
 import subprocess
 import tempfile
 from typing import Final
@@ -15,140 +14,71 @@ ROOT: Final = Path(__file__).resolve().parents[2]
 JUSTFILE: Final = ROOT / "Justfile"
 
 
-def _recipe_body_lines(recipe: str) -> list[str]:
-    """Strip a recipe down to the shell script just would actually execute.
+def _recipe_dependencies(header_line: str) -> list[str]:
+    """The just-recipe names a recipe header declares as dependencies.
 
-    Drops the `name: deps` header, removes the recipe's indentation, and strips
-    just's line prefixes. `@` (suppress echo) and `-` (ignore failure) are
-    directives to just, not shell syntax — leaving them in makes the first line
-    parse as a command name, so every variable it was supposed to set silently
-    stays unset.
+    e.g. "release-build-aarch64-cuda: release-host-build" -> ["release-host-build"].
+    Parameterized headers like 'build-runtime backend="" cuda_arch="":' have no
+    colon before the trailing one, so they correctly yield no dependencies.
     """
-    lines = recipe.splitlines()[1:]
-    lines = [line[4:] if line.startswith("    ") else line for line in lines]
-    lines = [line for line in lines if not line.startswith("#!")]
-    for index, line in enumerate(lines):
-        if line.strip():
-            lines[index] = line.lstrip("@-")
-            break
-    return lines
+    _, _, deps_part = header_line.partition(":")
+    return deps_part.split()
 
 
-def _run_cuda_arch_selection(recipe: str, mesh_cuda_version: str) -> str:
-    """Execute the real arch-selection lines out of a `release-build-cuda`-shaped
-    recipe body (up to, but not including, the package-native-runtime.sh call),
-    with MESH_CUDA_VERSION forced, and return the selected `arches` list.
-
-    This runs the actual recipe source rather than a hand-copied duplicate, so
-    it can't silently drift from what `just` executes.
-    """
-    lines = recipe.splitlines()[1:]  # drop the "recipe-name: deps" header line
-    lines = [line[4:] if line.startswith("    ") else line for line in lines]
-    lines = [line for line in lines if not line.startswith("#!/usr/bin/env bash")]
-    body: list[str] = []
-    for line in lines:
-        if line.strip().startswith("MESH_LLM_CUDA_TOOLKIT_MAJOR="):
-            break
-        body.append(line)
-    script = "\n".join(body) + '\necho "$arches"\n'
-    result = subprocess.run(
-        ["bash", "-c", script],
-        check=True,
-        capture_output=True,
-        text=True,
-        env={"PATH": "/usr/bin:/bin", "MESH_CUDA_VERSION": mesh_cuda_version},
-    )
-    return result.stdout.strip()
-
-
-def _run_recipe_body_capturing_packager_env(
-    recipe: str, mesh_cuda_version: str, interpreter: str
+def _run_release_recipe(
+    name: str, recipe_text: str, *args: str, env: dict[str, str] | None = None
 ) -> dict[str, str]:
-    """Run a whole release-build recipe body with `package-native-runtime.sh`
-    stubbed out, and return the environment the stub actually observed.
+    """Run a real Justfile release-build recipe through `just`, with the
+    packager and CUDA-toolkit-detection scripts replaced by stubs that record
+    what they were called with.
 
-    This executes the recipe source as-is — including the trailing
-    `VAR=... scripts/package-native-runtime.sh` line — so it reports what the
-    packager would really be handed, rather than re-deriving the selection.
-    `interpreter` is the shell just would use for this recipe: `bash` for a
-    `#!/usr/bin/env bash` script recipe, `sh`/`dash` for a plain one.
+    The recipe is written verbatim into an isolated temporary Justfile (any
+    just-recipe dependency it declares is stubbed out alongside it) and
+    invoked with the real `just` binary, so interpolation, `@`/`-`
+    directives, and script-recipe shebang handling all come from `just`
+    itself rather than a hand-rolled reimplementation.
     """
-    lines = _recipe_body_lines(recipe)
+    header = recipe_text.splitlines()[0]
+    deps = _recipe_dependencies(header)
 
-    with tempfile.TemporaryDirectory() as workdir:
-        scripts_dir = Path(workdir) / "scripts"
+    with tempfile.TemporaryDirectory() as workdir_str:
+        workdir = Path(workdir_str)
+        scripts_dir = workdir / "scripts"
         scripts_dir.mkdir()
-        probe = Path(workdir) / "packager-env.txt"
-        stub = scripts_dir / "package-native-runtime.sh"
-        stub.write_text(
+
+        probe = workdir / "packager-env.txt"
+        packager_stub = scripts_dir / "package-native-runtime.sh"
+        packager_stub.write_text(
             "#!/usr/bin/env bash\n"
             f'printf "%s\\n" "$LLAMA_STAGE_CUDA_ARCHITECTURES" '
             f'"$MESH_LLM_CUDA_TOOLKIT_MAJOR" "$*" > {shlex.quote(str(probe))}\n',
             encoding="utf-8",
         )
-        stub.chmod(0o755)
-        detect = scripts_dir / "detect-cuda-toolkit-version.sh"
-        detect.write_text("#!/usr/bin/env bash\necho 12\n", encoding="utf-8")
-        detect.chmod(0o755)
+        packager_stub.chmod(0o755)
+        detect_stub = scripts_dir / "detect-cuda-toolkit-version.sh"
+        detect_stub.write_text("#!/usr/bin/env bash\necho 12\n", encoding="utf-8")
+        detect_stub.chmod(0o755)
 
-        script = Path(workdir) / "recipe-body"
-        script.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        justfile = workdir / "Justfile"
+        stub_recipes = "".join(f"{dep}:\n    @true\n\n" for dep in deps)
+        justfile.write_text(stub_recipes + recipe_text + "\n", encoding="utf-8")
+
+        run_env = {"PATH": os.environ["PATH"]}
+        run_env.update(env or {})
         subprocess.run(
-            [interpreter, str(script)],
+            ["just", "-f", str(justfile), name, *args],
             cwd=workdir,
+            env=run_env,
             check=False,
             capture_output=True,
             text=True,
-            env={"PATH": os.environ["PATH"], "MESH_CUDA_VERSION": mesh_cuda_version},
         )
+
         if not probe.exists():
             return {"arches": "", "toolkit_major": "", "args": ""}
         recorded = probe.read_text(encoding="utf-8").splitlines()
         recorded += [""] * (3 - len(recorded))
-        return {
-            "arches": recorded[0],
-            "toolkit_major": recorded[1],
-            "args": recorded[2],
-        }
-
-
-def _run_build_runtime_body(recipe: str, interpreter: str, backend: str) -> dict[str, str]:
-    """Run `build-runtime`'s body with `{{ backend }}` substituted the way just
-    would, and report the backend the packager was actually handed.
-    """
-    body = "\n".join(_recipe_body_lines(recipe))
-    for placeholder, value in (
-        ("{{ backend }}", backend),
-        ("{{ cuda_arch }}", ""),
-        ("{{ rocm_arch }}", ""),
-    ):
-        body = body.replace(placeholder, value)
-
-    with tempfile.TemporaryDirectory() as workdir:
-        scripts_dir = Path(workdir) / "scripts"
-        scripts_dir.mkdir()
-        probe = Path(workdir) / "packager-env.txt"
-        stub = scripts_dir / "package-native-runtime.sh"
-        stub.write_text(
-            "#!/usr/bin/env bash\n"
-            f'printf "%s\\n" "$*" > {shlex.quote(str(probe))}\n',
-            encoding="utf-8",
-        )
-        stub.chmod(0o755)
-        script = Path(workdir) / "recipe-body"
-        script.write_text(body + "\n", encoding="utf-8")
-        subprocess.run(
-            [interpreter, str(script)],
-            cwd=workdir,
-            check=False,
-            capture_output=True,
-            text=True,
-            env={"PATH": os.environ["PATH"]},
-        )
-        args = probe.read_text(encoding="utf-8").strip() if probe.exists() else ""
-
-    match = re.search(r"--backend (\S+)", args)
-    return {"args": args, "backend": match.group(1) if match else ""}
+        return {"arches": recorded[0], "toolkit_major": recorded[1], "args": recorded[2]}
 
 
 class JustfileReleaseRuntimeTests(unittest.TestCase):
@@ -202,6 +132,13 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
         )
 
     def test_cuda_release_build_selects_arches_at_the_12_8_boundary(self) -> None:
+        """Run the real recipe through `just`, with MESH_CUDA_VERSION forced,
+        and check what the packager stub actually received.
+
+        Blackwell (sm_100/103/120/121) needs toolkit >= 12.8, the first
+        release that shipped support for it -- gate on that boundary, not on
+        the CUDA major alone.
+        """
         recipe = self.recipe("release-build-cuda")
         pre_blackwell = "61;75;80;86;87;89;90"
         blackwell = "75;80;86;87;89;90;100;103;120;121"
@@ -217,20 +154,23 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
         }
         for mesh_cuda_version, expected in cases.items():
             with self.subTest(mesh_cuda_version=mesh_cuda_version):
-                self.assertEqual(
-                    _run_cuda_arch_selection(recipe, mesh_cuda_version), expected
+                observed = _run_release_recipe(
+                    "release-build-cuda",
+                    recipe,
+                    env={"MESH_CUDA_VERSION": mesh_cuda_version},
                 )
+                self.assertEqual(observed["arches"], expected)
 
     def test_aarch64_cuda_release_build_selects_arches_at_the_13_boundary(self) -> None:
-        """Run the recipe body the way just would and check what the packager gets.
+        """Run the real recipe through `just`, exactly as the release build
+        does -- the fixed recipe is a `#!/usr/bin/env bash` script recipe, so
+        `just` executes it with bash regardless of what `/bin/sh` is on the
+        host.
 
-        `sm_110` (Thor) needs toolkit major >= 13, so this mirrors how the
-        x86_64 sibling gates Blackwell on >= 12.8. The interpreter is taken
-        from the recipe itself: a plain recipe is run under `dash`, which is
-        what `/bin/sh` is on the Debian/Ubuntu aarch64 build hosts.
+        `sm_110` (Thor) needs toolkit major >= 13, mirroring how the x86_64
+        sibling gates Blackwell on >= 12.8.
         """
         recipe = self.recipe("release-build-aarch64-cuda")
-        interpreter = self.recipe_interpreter(recipe)
         pre_13 = "61;75;80;86;87;89;90"
         thor = "75;80;86;87;89;90;110"
 
@@ -244,8 +184,10 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
         }
         for mesh_cuda_version, expected in cases.items():
             with self.subTest(mesh_cuda_version=mesh_cuda_version):
-                observed = _run_recipe_body_capturing_packager_env(
-                    recipe, mesh_cuda_version, interpreter
+                observed = _run_release_recipe(
+                    "release-build-aarch64-cuda",
+                    recipe,
+                    env={"MESH_CUDA_VERSION": mesh_cuda_version},
                 )
                 self.assertEqual(observed["arches"], expected)
 
@@ -253,8 +195,8 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
         self,
     ) -> None:
         recipe = self.recipe("release-build-aarch64-cuda")
-        observed = _run_recipe_body_capturing_packager_env(
-            recipe, "13.1.2", self.recipe_interpreter(recipe)
+        observed = _run_release_recipe(
+            "release-build-aarch64-cuda", recipe, env={"MESH_CUDA_VERSION": "13.1.2"}
         )
 
         self.assertEqual(observed["toolkit_major"], "13")
@@ -269,32 +211,16 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
         """`$$backend` read the shell PID, not the recipe argument.
 
         Under just, `$$` is two literal dollars, so `"$$backend"` expanded to
-        "<pid>backend" — the default-to-cpu test never inspected the variable
+        "<pid>backend" -- the default-to-cpu test never inspected the variable
         it appeared to, and the packager was handed a nonsense backend name.
         """
         recipe = self.recipe("build-runtime")
-        interpreter = self.recipe_interpreter(recipe)
 
-        defaulted = _run_build_runtime_body(recipe, interpreter, backend="")
-        self.assertEqual(defaulted["backend"], "cpu")
+        defaulted = _run_release_recipe("build-runtime", recipe)
+        self.assertIn("--backend cpu", defaulted["args"])
 
-        explicit = _run_build_runtime_body(recipe, interpreter, backend="cuda")
-        self.assertEqual(explicit["backend"], "cuda")
-
-    def recipe_interpreter(self, recipe: str) -> str:
-        """The shell just would run this recipe body with.
-
-        A `#!` script recipe is executed with the interpreter it names; a plain
-        recipe goes to just's default shell, `sh`, which is dash on the Debian
-        and Ubuntu hosts these release recipes target.
-        """
-        body = [line for line in recipe.splitlines()[1:] if line.strip()]
-        if body and body[0].strip().startswith("#!"):
-            self.assertEqual(body[0].strip(), "#!/usr/bin/env bash")
-            return "bash"
-        if not shutil.which("dash") and not Path("/bin/dash").exists():
-            self.skipTest("dash is required to exercise just's default `sh` faithfully")
-        return "dash" if shutil.which("dash") else "/bin/dash"
+        explicit = _run_release_recipe("build-runtime", recipe, "cuda")
+        self.assertIn("--backend cuda", explicit["args"])
 
     def test_bundle_uses_the_product_packager_and_copies_its_checksum(self) -> None:
         recipe = self.recipe("bundle")

--- a/scripts/tests/test_justfile_release_runtime.py
+++ b/scripts/tests/test_justfile_release_runtime.py
@@ -18,8 +18,11 @@ def _recipe_dependencies(header_line: str) -> list[str]:
     """The just-recipe names a recipe header declares as dependencies.
 
     e.g. "release-build-aarch64-cuda: release-host-build" -> ["release-host-build"].
-    Parameterized headers like 'build-runtime backend="" cuda_arch="":' have no
-    colon before the trailing one, so they correctly yield no dependencies.
+    Splits on the *last* colon, since a parameterized header's default value
+    (e.g. 'bundle output="/tmp/x:y": release-build') can itself contain one;
+    the header's own closing colon is always the final one. Parameterized
+    headers with no dependencies, like 'build-runtime backend="" cuda_arch="":',
+    correctly yield an empty list either way.
     """
     _, _, deps_part = header_line.rpartition(":")
     return deps_part.split()
@@ -56,7 +59,10 @@ def _run_release_recipe(
         )
         packager_stub.chmod(0o755)
         detect_stub = scripts_dir / "detect-cuda-toolkit-version.sh"
-        detect_stub.write_text("#!/usr/bin/env bash\necho 12\n", encoding="utf-8")
+        # A value no test ever passes as an explicit MESH_CUDA_VERSION, so a
+        # case that omits the env var can only get this from the fallback
+        # actually running the detect script, not from a coincidental match.
+        detect_stub.write_text("#!/usr/bin/env bash\necho 11\n", encoding="utf-8")
         detect_stub.chmod(0o755)
 
         justfile = workdir / "Justfile"
@@ -72,6 +78,7 @@ def _run_release_recipe(
             check=False,
             capture_output=True,
             text=True,
+            timeout=60,
         )
 
         if not probe.exists():
@@ -147,7 +154,7 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
         blackwell = "75;80;86;87;89;90;100;103;120;121"
 
         cases = {
-            "12": pre_blackwell,  # detect script's own static fallback
+            "12": pre_blackwell,
             "12.0": pre_blackwell,
             "12.7": pre_blackwell,
             "12.8": blackwell,  # first toolkit release with Blackwell support
@@ -164,6 +171,13 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
                 )
                 self.assertEqual(observed["arches"], expected)
 
+        with self.subTest(mesh_cuda_version="<unset>"):
+            # No MESH_CUDA_VERSION at all -- this is the only case that
+            # actually exercises the `$(scripts/detect-cuda-toolkit-version.sh)`
+            # fallback rather than short-circuiting on the env var.
+            observed = _run_release_recipe("release-build-cuda", recipe)
+            self.assertEqual(observed["arches"], pre_blackwell)
+
     def test_aarch64_cuda_release_build_selects_arches_at_the_13_boundary(self) -> None:
         """Run the real recipe through `just`, exactly as the release build
         does -- the fixed recipe is a `#!/usr/bin/env bash` script recipe, so
@@ -178,7 +192,7 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
         thor = "75;80;86;87;89;90;110"
 
         cases = {
-            "12": pre_13,  # detect script's own static fallback
+            "12": pre_13,
             "12.4": pre_13,
             "12.8": pre_13,  # Blackwell gate is x86-only; aarch64 gates on 13
             "13": thor,
@@ -193,6 +207,13 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
                     env={"MESH_CUDA_VERSION": mesh_cuda_version},
                 )
                 self.assertEqual(observed["arches"], expected)
+
+        with self.subTest(mesh_cuda_version="<unset>"):
+            # No MESH_CUDA_VERSION at all -- this is the only case that
+            # actually exercises the `$(scripts/detect-cuda-toolkit-version.sh)`
+            # fallback rather than short-circuiting on the env var.
+            observed = _run_release_recipe("release-build-aarch64-cuda", recipe)
+            self.assertEqual(observed["arches"], pre_13)
 
     def test_aarch64_cuda_release_build_propagates_major_and_target_to_the_packager(
         self,
@@ -220,10 +241,10 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
         recipe = self.recipe("build-runtime")
 
         defaulted = _run_release_recipe("build-runtime", recipe)
-        self.assertIn("--backend cpu", defaulted["args"])
+        self.assertEqual(defaulted["args"], "--build --backend cpu")
 
         explicit = _run_release_recipe("build-runtime", recipe, "cuda")
-        self.assertIn("--backend cuda", explicit["args"])
+        self.assertEqual(explicit["args"], "--build --backend cuda")
 
     def test_bundle_uses_the_product_packager_and_copies_its_checksum(self) -> None:
         recipe = self.recipe("bundle")

--- a/scripts/tests/test_justfile_release_runtime.py
+++ b/scripts/tests/test_justfile_release_runtime.py
@@ -174,8 +174,12 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
         with self.subTest(mesh_cuda_version="<unset>"):
             # No MESH_CUDA_VERSION at all -- this is the only case that
             # actually exercises the `$(scripts/detect-cuda-toolkit-version.sh)`
-            # fallback rather than short-circuiting on the env var.
+            # fallback rather than short-circuiting on the env var. Assert on
+            # toolkit_major too: every explicit case below the 12.8 gate also
+            # yields `pre_blackwell`, so arches alone can't tell the fallback
+            # ran from a coincidence.
             observed = _run_release_recipe("release-build-cuda", recipe)
+            self.assertEqual(observed["toolkit_major"], "11")
             self.assertEqual(observed["arches"], pre_blackwell)
 
     def test_aarch64_cuda_release_build_selects_arches_at_the_13_boundary(self) -> None:
@@ -211,8 +215,12 @@ class JustfileReleaseRuntimeTests(unittest.TestCase):
         with self.subTest(mesh_cuda_version="<unset>"):
             # No MESH_CUDA_VERSION at all -- this is the only case that
             # actually exercises the `$(scripts/detect-cuda-toolkit-version.sh)`
-            # fallback rather than short-circuiting on the env var.
+            # fallback rather than short-circuiting on the env var. Assert on
+            # toolkit_major too: every explicit case below the 13 gate also
+            # yields `pre_13`, so arches alone can't tell the fallback ran
+            # from a coincidence.
             observed = _run_release_recipe("release-build-aarch64-cuda", recipe)
+            self.assertEqual(observed["toolkit_major"], "11")
             self.assertEqual(observed["arches"], pre_13)
 
     def test_aarch64_cuda_release_build_propagates_major_and_target_to_the_packager(

--- a/scripts/tests/test_justfile_shell_portability.py
+++ b/scripts/tests/test_justfile_shell_portability.py
@@ -1,0 +1,116 @@
+"""`just` runs recipe lines under `sh`, not `bash`.
+
+Recipes that are a plain (non-shebang) body are executed by just's default
+shell, which is `sh -cu`. On any host where `/bin/sh` is dash — stock
+Debian/Ubuntu, including the aarch64 CUDA build targets — bash-only syntax
+does not fail loudly, it takes the wrong branch and keeps going.
+
+A recipe that needs bash must say so with a `#!/usr/bin/env bash` shebang,
+which makes just write the body to a file and execute it directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+import re
+from typing import Final
+import unittest
+
+
+ROOT: Final = Path(__file__).resolve().parents[2]
+JUSTFILE: Final = ROOT / "Justfile"
+
+# Constructs dash does not implement. Each maps to the failure it produces
+# under `sh` so a future reader knows why the entry is here.
+BASHISMS: Final = {
+    r"\[\[": "[[ ]] test — dash: '[[: not found', then takes the else branch",
+    r"<<<": "here-string — dash: 'Syntax error: redirection unexpected'",
+    r"\bpipefail\b": "set -o pipefail — dash: 'set: Illegal option -o pipefail'",
+    r"\$\(\(": "arithmetic expansion is POSIX, but $(( )) with bash-only operators is not",
+    r"\becho -e\b": "echo -e — dash's echo has no -e flag, prints the flag literally",
+    r"\$\{[A-Za-z_][A-Za-z0-9_]*\[[@*]\]\}": "array expansion — dash has no arrays",
+    r"\bfunction\s+[A-Za-z_]": "`function` keyword — dash only accepts name() { }",
+    r"&>": "&> redirect — dash parses this as `&` (background) then `>`",
+}
+
+# `$$` is a literal dollar-dollar to just (verified: `just` 1.58 does not
+# collapse it), so under `sh` it expands to the shell PID. `$$name` therefore
+# silently becomes "<pid>name" rather than the value of `$name`.
+DOLLAR_DOLLAR: Final = re.compile(r"\$\$[A-Za-z_{]")
+
+# The [windows] `with-lld` recipe passes a PowerShell script containing `$$`
+# sigils through the default shell. It is Windows-only, is not exercised by
+# this repo's CI, and its correct form depends on which shell just selects on
+# Windows — a separate question from the dash portability this file covers.
+# Tracked separately rather than silently swept in with the Linux fixes.
+DOLLAR_DOLLAR_EXEMPT: Final = {"with-lld"}
+
+
+def default_shell_recipes() -> dict[str, str]:
+    """Return {recipe_name: body} for recipes just runs under its default shell.
+
+    Recipes whose first non-blank body line is a `#!` shebang are script
+    recipes — just executes those with the interpreter they name, so bash
+    syntax in them is correct by construction and they are excluded here.
+    """
+    lines = JUSTFILE.read_text(encoding="utf-8").splitlines()
+    header = re.compile(r"^([a-zA-Z_][\w-]*)(?:\s+[^:]*)?:(?!=)")
+    recipes: dict[str, str] = {}
+    index = 0
+    while index < len(lines):
+        match = header.match(lines[index])
+        if not match:
+            index += 1
+            continue
+        body: list[str] = []
+        cursor = index + 1
+        while cursor < len(lines) and (not lines[cursor].strip() or lines[cursor][0].isspace()):
+            body.append(lines[cursor])
+            cursor += 1
+        populated = [line for line in body if line.strip()]
+        if populated and not populated[0].strip().startswith("#!"):
+            recipes[match.group(1)] = "\n".join(body)
+        index = cursor
+    return recipes
+
+
+class JustfileShellPortabilityTests(unittest.TestCase):
+    def test_default_shell_recipes_contain_no_bash_only_syntax(self) -> None:
+        recipes = default_shell_recipes()
+        self.assertGreater(len(recipes), 10, "recipe parser matched suspiciously few recipes")
+
+        offenders: list[str] = []
+        for name, body in sorted(recipes.items()):
+            for pattern, reason in BASHISMS.items():
+                if re.search(pattern, body):
+                    offenders.append(f"{name}: {pattern} — {reason}")
+        self.assertEqual(
+            offenders,
+            [],
+            "these recipes run under `sh` but use bash-only syntax; either add a "
+            "`#!/usr/bin/env bash` shebang to make them script recipes, or rewrite "
+            "them in POSIX shell:\n  " + "\n  ".join(offenders),
+        )
+
+    def test_default_shell_recipes_do_not_read_variables_through_dollar_dollar(self) -> None:
+        offenders = [
+            name
+            for name, body in sorted(default_shell_recipes().items())
+            if name not in DOLLAR_DOLLAR_EXEMPT and DOLLAR_DOLLAR.search(body)
+        ]
+        self.assertEqual(
+            offenders,
+            [],
+            "`$$name` expands to the shell PID followed by the literal text "
+            f"`name`, not to `$name`: {offenders}",
+        )
+
+    def test_the_recipe_parser_actually_sees_script_recipes(self) -> None:
+        """Guard against the parser silently matching nothing and passing."""
+        recipes = default_shell_recipes()
+        self.assertNotIn("release-build-cuda", recipes, "script recipe leaked into the sh set")
+        self.assertIn("llama-prepare", recipes, "plain recipe missing from the sh set")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_justfile_shell_portability.py
+++ b/scripts/tests/test_justfile_shell_portability.py
@@ -26,7 +26,6 @@ BASHISMS: Final = {
     r"\[\[": "[[ ]] test — dash: '[[: not found', then takes the else branch",
     r"<<<": "here-string — dash: 'Syntax error: redirection unexpected'",
     r"\bpipefail\b": "set -o pipefail — dash: 'set: Illegal option -o pipefail'",
-    r"\$\(\(": "arithmetic expansion is POSIX, but $(( )) with bash-only operators is not",
     r"\becho -e\b": "echo -e — dash's echo has no -e flag, prints the flag literally",
     r"\$\{[A-Za-z_][A-Za-z0-9_]*\[[@*]\]\}": "array expansion — dash has no arrays",
     r"\bfunction\s+[A-Za-z_]": "`function` keyword — dash only accepts name() { }",
@@ -110,6 +109,16 @@ class JustfileShellPortabilityTests(unittest.TestCase):
         recipes = default_shell_recipes()
         self.assertNotIn("release-build-cuda", recipes, "script recipe leaked into the sh set")
         self.assertIn("llama-prepare", recipes, "plain recipe missing from the sh set")
+
+    def test_arithmetic_expansion_is_not_flagged_as_a_bashism(self) -> None:
+        """$(( )) is POSIX arithmetic expansion; dash implements it natively.
+
+        A recipe using it is portable under the default shell and must not be
+        forced into an unneeded `#!/usr/bin/env bash` shebang.
+        """
+        body = 'attempt="$((attempt + 1))"\necho "$attempt"'
+        offenders = [pattern for pattern in BASHISMS if re.search(pattern, body)]
+        self.assertEqual(offenders, [])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the four defects rc6 release validation left open (`RV-DEFECT-001` through `004`). Each one was reproduced first, then fixed.

`RV-DEFECT-001` is the S1 that blocked the `NOT_READY` gate on its own.

## What was wrong

| ID | Sev | Defect | Reproduction used here |
|---|---|---|---|
| `RV-DEFECT-001` | **S1** | `just release-build-aarch64-cuda` picked its SM list with `[[ ]]` inside an `@`-prefixed recipe, so it ran under `sh`. On dash the test is "not found", the `else` branch wins, and a CUDA 13 build silently gets the pre-13 list — which still contains the removed `compute_61`, so nvcc then hard-fails. `build-runtime` had a second, separate bug in the same class: `"$$backend"`. | Recipe body executed under `dash` against a stubbed packager: CUDA 13 selected `61;75;80;86;87;89;90` instead of `75;80;86;87;89;90;110`. `just` 1.58 confirmed to expand `$$FOO` to `<pid>FOO`, so `build-runtime` handed the packager a nonsense backend name. |
| `RV-DEFECT-002` | S2 | A clean checkout would not build under a host-default pnpm 9, and nothing in the repo said pnpm 10 was needed. CI hid it with a `version: 10` pin that lived only in the workflows. | `corepack pnpm@9.15.9 install --frozen-lockfile` against the real manifest → `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH`. Cause: `overrides`/`allowBuilds` sit in `pnpm-workspace.yaml`, a pnpm 10 layout that pnpm 9 does not read. |
| `RV-DEFECT-003` | S2 | A remote (cross-node) attempt that lost its client never tore down the QUIC tunnel, so a worker on another node kept generating for a client that had already hung up. The local arm always shut its upstream down; the two arms hand-rolled that teardown separately, which is how they came to disagree. | rc6 request `55151d55`: gateway logged `request_dropped` at 19:29:35.984, the worker did not log `request_stream_completed` until 19:29:36.006. |
| `RV-DEFECT-004` | S3 | The plugin control socket path was built unconditionally under `$HOME`, with no guard against the `sun_path` limit (108 bytes on Linux, 104 on macOS). `bind` refuses an over-long path rather than truncating, with an error that never mentions lengths. | rc6 saw three generated paths at exactly 112 bytes; `blobstore` failed to load with a bare "Failed to bind plugin socket". |

## What changed

**001** — both recipes become `#!/usr/bin/env bash` script recipes, matching what `release-build-cuda` and `release-runtime-build` already do. `sm_110` is gated on toolkit major `>= 13`, the same shape as the x86_64 Blackwell gate. As a `-ge` comparison rather than a `13.*` glob, a future CUDA 14 keeps Thor instead of falling back to the pre-13 list — the old form would have regressed there.

**002** — `engines.pnpm: ">=10"` plus `engine-strict`, so pnpm enforces it instead of treating it as a comment. A pnpm 9 operator now gets `ERR_PNPM_UNSUPPORTED_ENGINE / Expected version: >=10 / Got: 9.15.9`. `packageManager` also lets corepack select the right pnpm on its own.

**003** — the disconnect decision moves into one place (`cancellation.rs`), and each arm gets an implementation of how to say "stop" over its own protocol: `shutdown()` for a local TCP upstream, `stop()` (QUIC `STOP_SENDING`) for a peer stream. The peer's next write then fails, which is what actually ends its generation loop.

**004** — falls back to a short directory when the preferred path does not fit, which is what `mesh_llm_plugin::bind_side_stream` already does for side streams. The bound path is handed to the plugin verbatim via `LocalListener::endpoint()`, so relocating it needs no matching change on the plugin side. If even the short path cannot fit, that is now a clear error naming both candidates and their byte counts.

## Tests

Written before the fixes, and each confirmed red against `main` first:

- A Justfile-wide ratchet asserting no default-shell recipe uses bash-only syntax or `$$`. Probed before adding: it catches exactly the two recipes fixed here and nothing else.
- Behavioral tests that execute the real recipe bodies with the interpreter the recipe declares — `dash` for a plain recipe — against a stubbed packager, checking the SM list across 12 / 12.4 / 12.8 / 13 / 13.1.2 / 14 and the backend `build-runtime` actually forwards.
- The declared pnpm major is asserted to track every `pnpm/action-setup` version in CI, so the two pins cannot drift apart silently.
- `route_remote_attempt_after_forward` is now generic over its upstream, so the disconnect path is driven directly: a scripted upstream serves headers then fails the body read with `ConnectionReset`, and the test asserts the tunnel was cancelled exactly once. A delivery counterpart asserts a normal response cancels nothing.
- Socket-path selection is a pure function over its two candidate directories, so the limit is covered without mutating `$HOME` — the repository's environment-mutation contract pins an exact census of `set_var` sites.

Verified locally: `cargo test -p mesh-llm-host-runtime --lib` (2538 passed), `python3 -m unittest discover -s scripts/tests` (530 passed), `cargo clippy --all-targets`, `cargo fmt --all --check`, `just no-console-print`, and Prettier on the changed manifest.

## Notes for the reviewer

- **Overlaps #1404**, which fixes `RV-DEFECT-001` alone with substantially the same approach. This PR was asked for as a single consolidated change across all four; whichever lands first, the other should rebase.
- **CI never exercised the 001 recipes** — `release.yml` sets the arch list from its build matrix and invokes the composite action directly, which is why this went unnoticed. So CI going green here is not evidence for that fix; the dash reproduction is.
- **Not built end to end on a Jetson.** The shell defect and the arch selection are proven, the full aarch64 CUDA build is not.
- **One thing deliberately left alone:** the `[windows]` `with-lld` recipe passes a PowerShell script full of `$$` sigils through the default shell. It is Windows-only, not exercised by this repo's CI, and its correct form depends on which shell just selects on Windows — a separate question from the dash portability fixed here. It is explicitly exempted in the new ratchet with that reasoning rather than silently swept in.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved handling when clients disconnect during streamed responses, stopping upstream processing promptly.
  * Added safer Unix socket path handling with automatic fallback for long paths.

* **Bug Fixes**
  * Improved CUDA architecture selection for current and future toolkit versions.
  * Corrected shell variable handling in development builds.

* **Documentation**
  * Updated UI setup requirements to Node.js 24 and pnpm 10 or newer.

* **Chores**
  * Enforced the required pnpm version for UI development.
  * Improved build and release validation for more reliable packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->