### PR TITLE
ci(quality): install just before the CI-contracts python tests run

### DIFF
--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -128,6 +128,7 @@ jobs:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
       - uses: ./.github/actions/install-actionlint
+      - uses: taiki-e/install-action@3d23c1bbdafe696dfccad2664945a04f47d03dc3 # just
       - name: Validate GitHub Actions
         run: actionlint -config-file .github/actionlint.yaml
       - name: Test CI, packaging, and SDK contracts
@@ -147,7 +148,6 @@ jobs:
             exit 1
           fi
 
-      - uses: taiki-e/install-action@3d23c1bbdafe696dfccad2664945a04f47d03dc3 # just
       - name: Check console print drift
         run: just no-console-print
 


### PR DESCRIPTION
`ci-quality-slice.yml`'s `quality_contracts` job installed `just` (`taiki-e/install-action`) *after* the step that runs `python3 -m unittest discover -s scripts/tests`. #1405 adds a test (`test_justfile_release_runtime.py`) that shells out to the real `just` binary to run Justfile release recipes verbatim, so that job now fails: `FileNotFoundError: [Errno 2] No such file or directory: 'just'`.

Moves the install-action step ahead of the python test step it now serves. No other change.

**Why this can't land via #1405 itself:** `pr_quality.yml` pins the required Quality lane to `Mesh-LLM/mesh-llm/.github/workflows/ci-quality-lane.yml@main`, so a PR's own branch controls what its checks look at (via `source_sha`) but not the step order those checks run — that always comes from `main`. #1405's CI-contracts check can't go green until this lands on `main` first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the quality-check workflow to install the required tooling before validation.
  * Removed a redundant setup step, streamlining automated checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->