### PR TITLE
Fix chat-chain pipelined splits: verify-history accounting, early-stop replies, session leaks

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
@@ -1494,3 +1494,88 @@ fn integrated_invalid_fixture_fails_closed_for_request_defaults_and_single_stage
         .to_string();
     assert!(staged_only_error.contains("prefill chunk controls require staged serving"));
 }
+
+#[test]
+fn explicit_ngram_suffix_strategy_resolves_a_suffix_proposer() {
+    use crate::plugin::SpeculativeConfig;
+    let model_config: SpeculativeConfig = toml::from_str(
+        r#"
+strategy = "ngram-suffix"
+ngram_proposer = "suffix"
+ngram_min = 5
+ngram_max = 32
+ngram_max_proposal_tokens = 48
+verify_window_min_tokens = 1
+verify_window_max_tokens = 32
+verify_window_pipeline_depth = 2
+"#,
+    )
+    .expect("parse speculative config");
+    let resolved = super::speculative::resolve_speculative_config(
+        Some(&model_config),
+        None,
+        "meshllm/test-model",
+        std::path::Path::new("/nonexistent/test-model.gguf"),
+        None,
+    )
+    .expect("explicit ngram-suffix must resolve");
+    let decode = resolved.decode;
+    assert_eq!(decode.effective_strategy, "ngram-suffix", "effective strategy");
+    let ngram = decode.ngram.expect("suffix proposer must be present");
+    assert_eq!(ngram.min_ngram, 5);
+    assert_eq!(ngram.max_ngram, 32);
+    assert_eq!(decode.verify_window.pipeline_depth, 2);
+    assert_eq!(resolved.mode, "ngram", "resolved mode drives the embedded frontend");
+}
+
+#[test]
+fn explicit_ngram_suffix_survives_staged_openai_translation() {
+    use crate::plugin::SpeculativeConfig;
+    let model_config: SpeculativeConfig = toml::from_str(
+        r#"
+strategy = "ngram-suffix"
+ngram_proposer = "suffix"
+ngram_min = 5
+ngram_max = 32
+ngram_max_proposal_tokens = 48
+verify_window_min_tokens = 1
+verify_window_max_tokens = 32
+verify_window_pipeline_depth = 2
+"#,
+    )
+    .expect("parse speculative config");
+    let mesh_config = crate::plugin::MeshConfig {
+        defaults: Some(crate::plugin::ModelConfigDefaults {
+            speculative: Some(model_config),
+            ..Default::default()
+        }),
+        ..Default::default()
+    };
+    let resolved = super::resolve_skippy_config(super::SkippyConfigResolveRequest {
+        mesh_config: &mesh_config,
+        model_id: "meshllm/Qwen3-8B-Q4_K_M-layers",
+        model_path: std::path::Path::new("/nonexistent/model.gguf"),
+        model_bytes: 8_000_000_000,
+        allocatable_memory_bytes: None,
+        request_defaults: None,
+        package_generation: None,
+    })
+    .expect("resolve skippy config");
+    let ngram = resolved
+        .speculative
+        .decode
+        .ngram
+        .as_ref()
+        .expect("resolved decode plan must keep the suffix proposer");
+    assert_eq!(ngram.min_ngram, 5);
+    let args = resolved
+        .to_embedded_openai_args(4096, true)
+        .expect("staged translation");
+    let translated = args
+        .speculative
+        .ngram
+        .as_ref()
+        .expect("staged embedded args must keep the suffix proposer");
+    assert_eq!(translated.max_ngram, 32);
+    assert_eq!(args.speculative.verify_window.pipeline_depth, 2);
+}

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
@@ -1520,12 +1520,20 @@ verify_window_pipeline_depth = 2
     )
     .expect("explicit ngram-suffix must resolve");
     let decode = resolved.decode;
-    assert_eq!(decode.effective_strategy, "ngram-suffix", "effective strategy");
+    assert_eq!(
+        decode.effective_strategy, "ngram-suffix",
+        "effective strategy"
+    );
     let ngram = decode.ngram.expect("suffix proposer must be present");
+    assert_eq!(ngram.kind, skippy_server::NgramProposerKind::Suffix);
     assert_eq!(ngram.min_ngram, 5);
     assert_eq!(ngram.max_ngram, 32);
+    assert_eq!(ngram.max_proposal_tokens, 48);
     assert_eq!(decode.verify_window.pipeline_depth, 2);
-    assert_eq!(resolved.mode, "ngram", "resolved mode drives the embedded frontend");
+    assert_eq!(
+        resolved.mode, "ngram",
+        "resolved mode drives the embedded frontend"
+    );
 }
 
 #[test]
@@ -1567,7 +1575,9 @@ verify_window_pipeline_depth = 2
         .ngram
         .as_ref()
         .expect("resolved decode plan must keep the suffix proposer");
+    assert_eq!(ngram.kind, skippy_server::NgramProposerKind::Suffix);
     assert_eq!(ngram.min_ngram, 5);
+    assert_eq!(ngram.max_proposal_tokens, 48);
     let args = resolved
         .to_embedded_openai_args(4096, true)
         .expect("staged translation");
@@ -1576,6 +1586,9 @@ verify_window_pipeline_depth = 2
         .ngram
         .as_ref()
         .expect("staged embedded args must keep the suffix proposer");
+    assert_eq!(translated.kind, skippy_server::NgramProposerKind::Suffix);
+    assert_eq!(translated.min_ngram, 5);
     assert_eq!(translated.max_ngram, 32);
+    assert_eq!(translated.max_proposal_tokens, 48);
     assert_eq!(args.speculative.verify_window.pipeline_depth, 2);
 }

--- a/crates/skippy-server/src/frontend/embedded_generation/lifecycle.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation/lifecycle.rs
@@ -107,6 +107,11 @@ pub(super) fn compose_target_predictions(
     let boundary = prior_boundary_prediction.ok_or_else(|| {
         OpenAiError::backend("continuation verify window has no prior boundary prediction")
     })?;
+    if traversal_predictions.is_empty() {
+        return Err(OpenAiError::backend(
+            "continuation verify window returned no predictions",
+        ));
+    }
     let available = proposal_count.min(traversal_predictions.len());
     let mut predictions = Vec::with_capacity(available.saturating_add(1));
     predictions.push(boundary);
@@ -220,6 +225,19 @@ mod prediction_tests {
         let predictions = compose_target_predictions(false, 2, Some(11), &[12, 13]).unwrap();
 
         assert_eq!(predictions, [11, 12, 13]);
+    }
+
+    #[test]
+    fn early_stopped_replies_pass_through_short_prediction_arrays() {
+        let predictions = compose_target_predictions(false, 3, Some(11), &[12]).unwrap();
+
+        assert_eq!(predictions, [11, 12]);
+    }
+
+    #[test]
+    fn empty_replies_are_protocol_errors_on_both_paths() {
+        assert!(compose_target_predictions(true, 2, None, &[]).is_err());
+        assert!(compose_target_predictions(false, 2, Some(11), &[]).is_err());
     }
 
     #[test]

--- a/crates/skippy-server/src/frontend/embedded_generation/lifecycle.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation/lifecycle.rs
@@ -89,28 +89,28 @@ pub(super) fn compose_target_predictions(
     traversal_predictions: &[i32],
 ) -> OpenAiResult<Vec<i32>> {
     let required = proposal_count.saturating_add(1);
+    // Stateful chat sampling stops verifying at the first mismatched row and
+    // returns only the rows it sampled, so a shorter prediction array is a
+    // legitimate early rejection — pass through what arrived and let window
+    // classification reject at the divergence. An empty reply is still a
+    // protocol error.
     if starts_epoch {
-        if traversal_predictions.len() < required {
-            return Err(OpenAiError::backend(format!(
-                "epoch-start verify window returned {} predictions; expected {required}",
-                traversal_predictions.len()
-            )));
+        if traversal_predictions.is_empty() {
+            return Err(OpenAiError::backend(
+                "epoch-start verify window returned no predictions",
+            ));
         }
-        return Ok(traversal_predictions[..required].to_vec());
+        let available = required.min(traversal_predictions.len());
+        return Ok(traversal_predictions[..available].to_vec());
     }
 
     let boundary = prior_boundary_prediction.ok_or_else(|| {
         OpenAiError::backend("continuation verify window has no prior boundary prediction")
     })?;
-    if traversal_predictions.len() < proposal_count {
-        return Err(OpenAiError::backend(format!(
-            "continuation verify window returned {} predictions; expected {proposal_count}",
-            traversal_predictions.len()
-        )));
-    }
-    let mut predictions = Vec::with_capacity(required);
+    let available = proposal_count.min(traversal_predictions.len());
+    let mut predictions = Vec::with_capacity(available.saturating_add(1));
     predictions.push(boundary);
-    predictions.extend_from_slice(&traversal_predictions[..proposal_count]);
+    predictions.extend_from_slice(&traversal_predictions[..available]);
     Ok(predictions)
 }
 

--- a/crates/skippy-server/src/frontend/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/prefix_cache.rs
@@ -814,6 +814,9 @@ impl StageOpenAiBackend {
             return Ok(None);
         };
         if restore.restored_tokens < request.prompt_token_ids.len() {
+            // A partial restore leaves the session holding a lane; drop it so
+            // retries do not exhaust the execution lanes (502 cascade).
+            self.drop_embedded_split_restore(request, session_key, downstream);
             return Ok(None);
         }
         let mut attrs = self.openai_attrs(request.ids);
@@ -1001,6 +1004,11 @@ impl StageOpenAiBackend {
             return Ok(None);
         };
         if local_restore.token_count < prefill_tokens.len() {
+            // Same lane-leak guard as the chain-restore paths: a partial local
+            // restore must not keep the session resident.
+            if let Ok(mut runtime) = self.runtime.lock() {
+                let _ = runtime.drop_session_timed(session_key);
+            }
             return Ok(None);
         }
         reply_stats.kv_lookup_hits += 1;

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -241,14 +241,23 @@ fn infer_cache_payload(config: &StageConfig) -> StagePrefixCachePayload {
     StagePrefixCachePayload::Disabled
 }
 
+/// Either kill-switch variable resolving to `off` disables the cache, so an
+/// explicit `SKIPPY_KV_CACHE=on` cannot mask `SKIPPY_PREFIX_CACHE=off`.
+fn cache_disabled_by_env(kv_cache: Option<&str>, prefix_cache: Option<&str>) -> bool {
+    [kv_cache, prefix_cache]
+        .into_iter()
+        .flatten()
+        .any(|value| parse_cache_mode(value) == Some(StageKvCacheMode::Disabled))
+}
+
 fn effective_cache_config(config: &StageConfig) -> Option<StageKvCacheConfig> {
     // An explicit environment kill-switch beats the planned stage config so
     // benches and incident response can turn the prefix cache off without
     // replanning the topology.
-    if let Ok(value) =
-        std::env::var("SKIPPY_KV_CACHE").or_else(|_| std::env::var("SKIPPY_PREFIX_CACHE"))
-        && parse_cache_mode(&value) == Some(StageKvCacheMode::Disabled)
-    {
+    if cache_disabled_by_env(
+        std::env::var("SKIPPY_KV_CACHE").ok().as_deref(),
+        std::env::var("SKIPPY_PREFIX_CACHE").ok().as_deref(),
+    ) {
         return None;
     }
     if let Some(cache) = config.kv_cache.clone() {
@@ -320,6 +329,16 @@ fn parse_cache_mode(value: &str) -> Option<StageKvCacheMode> {
 mod tests {
     use super::*;
     use skippy_protocol::FlashAttentionType;
+
+    #[test]
+    fn either_cache_kill_switch_disables_the_cache() {
+        assert!(!cache_disabled_by_env(None, None));
+        assert!(!cache_disabled_by_env(Some("on"), None));
+        assert!(cache_disabled_by_env(Some("off"), None));
+        assert!(cache_disabled_by_env(None, Some("off")));
+        assert!(cache_disabled_by_env(Some("on"), Some("off")));
+        assert!(cache_disabled_by_env(Some("off"), Some("on")));
+    }
 
     #[test]
     fn recurrent_tensor_names_require_exact_state_cache() {

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -242,6 +242,15 @@ fn infer_cache_payload(config: &StageConfig) -> StagePrefixCachePayload {
 }
 
 fn effective_cache_config(config: &StageConfig) -> Option<StageKvCacheConfig> {
+    // An explicit environment kill-switch beats the planned stage config so
+    // benches and incident response can turn the prefix cache off without
+    // replanning the topology.
+    if let Ok(value) =
+        std::env::var("SKIPPY_KV_CACHE").or_else(|_| std::env::var("SKIPPY_PREFIX_CACHE"))
+        && parse_cache_mode(&value) == Some(StageKvCacheMode::Disabled)
+    {
+        return None;
+    }
     if let Some(cache) = config.kv_cache.clone() {
         return Some(cache);
     }

--- a/third_party/llama.cpp/patches/0026-skippy-fix-verify-history-accounting-for-activation-.patch
+++ b/third_party/llama.cpp/patches/0026-skippy-fix-verify-history-accounting-for-activation-.patch
@@ -1,0 +1,58 @@
+From 76314ca963e6b2b2a594cc7ebd500f3b7148e947 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Sat, 22 Aug 2026 14:29:39 +1000
+Subject: [PATCH] skippy: fix verify history accounting for activation-input
+ stages
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Batch decode only eagerly records tokens into token_history when the
+batch has no activation input, but include_output verification always
+subtracted token_count and truncated the history as if the eager append
+had happened. On stages fed by an upstream stage this silently dropped
+real history rows (corrupting the chat sampler's absorbed history) and,
+once the sampler caught up, tripped 'sampled verification history is
+behind sampler state' — killing every request on pipelined splits.
+
+Only subtract and truncate for token-batch verification; activation-frame
+verification's history already ends at the pre-batch position.
+---
+ src/skippy/verification.cpp | 18 +++++++++++++-----
+ 1 file changed, 13 insertions(+), 5 deletions(-)
+
+diff --git a/src/skippy/verification.cpp b/src/skippy/verification.cpp
+index b140efbb0..9ab6b0712 100644
+--- a/src/skippy/verification.cpp
++++ b/src/skippy/verification.cpp
+@@ -185,14 +185,22 @@ enum skippy_status skippy_verify_tokens_frame_sampled(
+     }
+ 
+     if (session->stage_model->config.include_output) {
+-        // Native verification decodes and records the complete batch before
+-        // sampling. Remove that eager append, then expose each input exactly
+-        // once and in causal order as its row is sampled.
+-        if (session->token_history.size() < token_count) {
++        // Token-batch verification (no activation input) eagerly decodes and
++        // records the complete batch before sampling; that eager append must
++        // be removed so each input is exposed exactly once and in causal
++        // order as its row is sampled. Activation-frame verification
++        // (`skippy_verify_activation_frame`, used on stages fed by an
++        // upstream stage) never records the batch, so its history already
++        // ends at the pre-batch position and must not be truncated — doing
++        // so silently drops real history rows and leaves the sampler ahead
++        // of the rewritten history.
++        if (!activation_input && session->token_history.size() < token_count) {
+             skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "sampled verification token history underflow");
+             return SKIPPY_STATUS_RUNTIME_ERROR;
+         }
+-        const size_t history_size_before_verification = session->token_history.size() - token_count;
++        const size_t history_size_before_verification = activation_input
++                ? session->token_history.size()
++                : session->token_history.size() - token_count;
+         if (session->sampling_accepted_token_count > history_size_before_verification) {
+             skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "sampled verification history is behind sampler state");
+             return SKIPPY_STATUS_RUNTIME_ERROR;
+-- 
+2.50.1 (Apple Git-155)
+

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4287,7 +4287,7 @@
   ],
   "crates/skippy-server/src/frontend/embedded_generation/lifecycle.rs": [
     {
-      "line": 155,
+      "line": 160,
       "macro_name": "eprintln!"
     }
   ],


### PR DESCRIPTION
# Fix chat-chain pipelined splits: verify-history accounting, early-stop replies, session leaks

Pipelined verify windows (`verify_window_pipeline_depth >= 2`) with chat
sampling are currently broken on main for any staged split: requests fail with
`sampled verification history is behind sampler state` (reliably at depth 3,
intermittently at depth 2), and windows that do pass silently corrupt the chat
sampler's absorbed history. Bisected + instrumented on a 2-process loopback
Qwen3-8B split (standalone suffix, temperature 0).

## What broke

`execution-batch.cpp` only eagerly records decoded tokens into
`token_history` when the batch has no activation input:

```cpp
session->n_past += 1;
if (!activation_input) {
    skippy_record_tokens(session, &token_ids[i], 1);
}
```

but `verification.cpp`'s `include_output` block unconditionally removes that
eager append (`history.size() - token_count` + truncate) before re-recording
rows as they are sampled. On any stage fed by an upstream stage
(`skippy_verify_activation_frame`), the append never happened, so:

1. each passing window drops real history rows and re-records sampled rows at
   wrong logical positions — the chat sampler absorbs corrupted history;
2. once `sampling_accepted_token_count` catches up to `token_history.size()`,
   the next contiguous window trips the invariant and the request dies.

Instrumented trip: `n_past=372 history=339 accepted=339 token_count=33` —
n_past advanced by the batch, history did not.

## Fixes

- **llama patch 0026**: in the `include_output` block, only subtract/truncate
  for token-batch verification; activation-frame verification's history
  already ends at the pre-batch position.
- **Early-stopped verify replies**: stateful chat sampling stops at the first
  mismatched row and returns only the sampled rows; the pipelined composer
  treated any short prediction array as a protocol error. Pass through the
  available rows — window classification already rejects at the divergence.
- **Prefix-cache session leaks**: two partial-restore early-outs
  (full-prompt-first-token chain restore, local prefill restore) returned
  without dropping the session, so identical-prompt retries exhausted the
  execution lanes and cascaded into 502s. Same fix shape as the existing
  `drop_embedded_split_restore` call sites.
- **`SKIPPY_KV_CACHE=off`** now overrides the planned stage kv-cache config
  (explicit disabled value only), so benches/incident response can turn the
  prefix cache off without replanning a topology.

## Validation

- 2-process loopback split (Qwen3-8B Q4_K_M, runtime-slice 0..18/18..36,
  embedded stage-0 OpenAI, standalone suffix 5/32/48, window 32, temp 0):
  previously every request failed at depth >= 2; with these fixes depth 2/3
  run to completion with exact outputs (accept 0.89, ~90-100 tok/s loopback).
- skippy-server suite, mesh-llm-config, skippy-protocol, and the
  mesh-llm-host-runtime suite green; clippy clean; `check-release` and
  crate-list consistency pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring suffix-based speculative decoding with n-gram mode.

* **Bug Fixes**
  * Improved handling of empty and partial prediction results during generation.
  * Prevented stale execution sessions after incomplete prefix-cache restores.
  * Ensured caching is disabled when either cache setting is turned off.
  * Corrected token verification history tracking for more reliable decoding.

* **Tests**
  * Added coverage for n-gram decoding, prediction edge cases, and cache configuration combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->