### PR TITLE
Learned low-rank activation codec for split boundaries

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
@@ -448,6 +448,10 @@ impl StageControlState {
             downstream_wire_condition: super::benchmark_downstream_wire_condition()?,
             downstream_connect_timeout_secs: 30,
             native_mtp_enabled: effective_load.native_mtp_enabled,
+            // Boundary-codec config plumbing is env-only for now: full model
+            // config / package-manifest integration is tracked in the lowrank
+            // codec plan.
+            boundary_codec: boundary_codec_from_env()?,
             openai: None,
         });
         self.stages.insert(
@@ -770,6 +774,22 @@ fn probe_binary_stage_ready(
         .context(format!(
             "binary stage did not become ready at {bind_addr} before timeout"
         )))
+}
+
+/// Optional boundary codec for the lowrank activation wire dtype, loaded from
+/// `MESH_LLM_BOUNDARY_CODEC` (a path to a fitted `.skbc` file).
+fn boundary_codec_from_env() -> Result<
+    Option<std::sync::Arc<skippy_server::binary_transport::boundary_codec::BoundaryCodec>>,
+> {
+    match std::env::var_os("MESH_LLM_BOUNDARY_CODEC") {
+        Some(path) => {
+            let path = std::path::PathBuf::from(path);
+            let codec = skippy_server::binary_transport::boundary_codec::BoundaryCodec::load(&path)
+                .with_context(|| format!("load boundary codec {}", path.display()))?;
+            Ok(Some(std::sync::Arc::new(codec)))
+        }
+        None => Ok(None),
+    }
 }
 
 fn stage_config(

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
@@ -778,9 +778,8 @@ fn probe_binary_stage_ready(
 
 /// Optional boundary codec for the lowrank activation wire dtype, loaded from
 /// `MESH_LLM_BOUNDARY_CODEC` (a path to a fitted `.skbc` file).
-fn boundary_codec_from_env() -> Result<
-    Option<std::sync::Arc<skippy_server::binary_transport::boundary_codec::BoundaryCodec>>,
-> {
+fn boundary_codec_from_env()
+-> Result<Option<std::sync::Arc<skippy_server::binary_transport::boundary_codec::BoundaryCodec>>> {
     match std::env::var_os("MESH_LLM_BOUNDARY_CODEC") {
         Some(path) => {
             let path = std::path::PathBuf::from(path);

--- a/crates/mesh-llm-host-runtime/src/protocol/convert.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/convert.rs
@@ -17,7 +17,7 @@ fn skippy_stage_subprotocols(
     let mut features = vec![skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL.to_string()];
     if stage_protocol_generation_supported {
         features.push(
-            skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V5.to_string(),
+            skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V6.to_string(),
         );
     }
     if artifact_transfer_supported {
@@ -50,7 +50,7 @@ fn supports_skippy_status_list(subprotocols: &[crate::proto::node::MeshSubprotoc
 fn supports_skippy_stage_generation(subprotocols: &[crate::proto::node::MeshSubprotocol]) -> bool {
     supports_skippy_stage_feature(
         subprotocols,
-        skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V5,
+        skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V6,
     ) && supports_skippy_stage_feature(
         subprotocols,
         skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL,

--- a/crates/mesh-llm-host-runtime/src/protocol/tests/announcements.rs
+++ b/crates/mesh-llm-host-runtime/src/protocol/tests/announcements.rs
@@ -82,7 +82,7 @@ fn owner_fields_roundtrip_through_proto_announcement() {
             .any(|feature| feature == skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST)
     );
     assert!(skippy.features.iter().any(|feature| feature
-        == skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V5));
+        == skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V6));
     assert_eq!(
         proto_pa
             .owner_attestation
@@ -310,7 +310,7 @@ fn proto_announcement_without_stage_control_is_not_stage_compatible() {
             name: skippy_protocol::STAGE_SUBPROTOCOL_NAME.to_string(),
             major: skippy_protocol::STAGE_SUBPROTOCOL_MAJOR,
             features: vec![
-                skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V5.to_string(),
+                skippy_protocol::STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V6.to_string(),
             ],
         }],
         ..Default::default()

--- a/crates/skippy-protocol/src/binary/activation.rs
+++ b/crates/skippy-protocol/src/binary/activation.rs
@@ -41,7 +41,33 @@ pub fn activation_wire_bytes_with_state_flags(
             .checked_mul(4)
             .and_then(|scales| scales.checked_add(elements))
             .ok_or_else(|| invalid_data("activation byte count overflow")),
+        // The rank is not knowable from (dtype, n_embd) alone; use
+        // `lowrank_activation_wire_bytes` with the rank from the state header.
+        WireActivationDType::Lowrank => Err(invalid_data(
+            "lowrank activation size requires the frame's rank",
+        )),
     }
+}
+
+/// Wire byte count of a lowrank frame: a per-token f32 scale followed by
+/// `token_count * k` int8 coefficients.
+pub fn lowrank_activation_wire_bytes(
+    token_count: i32,
+    k: usize,
+    state_flag_bits: i32,
+) -> io::Result<usize> {
+    if token_count < 0 {
+        return Err(invalid_data("negative activation dimensions"));
+    }
+    let token_count = (token_count as usize)
+        .checked_mul(activation_payload_multiplier_from_state_flags(
+            state_flag_bits,
+        ))
+        .ok_or_else(|| invalid_data("activation token count overflow"))?;
+    token_count
+        .checked_mul(4)
+        .and_then(|scales| token_count.checked_mul(k)?.checked_add(scales))
+        .ok_or_else(|| invalid_data("activation byte count overflow"))
 }
 
 pub(crate) fn activation_decoded_f32_bytes_with_state_flags(
@@ -96,6 +122,9 @@ pub fn encode_f32_activation_payload_with_state_flags(
                 .ok_or_else(|| invalid_data("Q8 activation token count overflow"))?;
             encode_f32_to_q8_bytes(f32_payload, token_count, n_embd)
         }
+        WireActivationDType::Lowrank => Err(invalid_data(
+            "lowrank activation requires a boundary codec to encode",
+        )),
     }
 }
 

--- a/crates/skippy-protocol/src/binary/codec.rs
+++ b/crates/skippy-protocol/src/binary/codec.rs
@@ -9,6 +9,7 @@ use super::{
     WireReplyKind,
     activation::{
         activation_decoded_f32_bytes_with_state_flags, activation_wire_bytes_with_state_flags,
+        lowrank_activation_wire_bytes,
     },
     invalid_data, invalid_input,
 };
@@ -268,7 +269,13 @@ pub fn write_stage_message(
     )?;
 
     let mut state = message.state;
-    state.reserved = dtype as i32;
+    // A lowrank frame's reserved field carries the rank alongside the dtype
+    // tag; preserve it instead of clobbering it with the bare tag.
+    if dtype == WireActivationDType::Lowrank {
+        state.lowrank_k().map_err(io::Error::other)?;
+    } else {
+        state.reserved = dtype as i32;
+    }
     if message.sampling.is_some() {
         state.flags |= super::state_flags::SAMPLING;
     } else {
@@ -421,6 +428,8 @@ pub fn read_stage_message(mut reader: impl Read, n_embd: i32) -> io::Result<Stag
     let activation_bytes =
         if state.source_stage_index < 0 || kind.is_activationless_prefix_cache_control() {
             0
+        } else if dtype == WireActivationDType::Lowrank {
+            lowrank_activation_wire_bytes(token_count, state.lowrank_k()?, state.flags)?
         } else {
             activation_wire_bytes_with_state_flags(dtype, token_count, n_embd, state.flags)?
         };

--- a/crates/skippy-protocol/src/binary/codec.rs
+++ b/crates/skippy-protocol/src/binary/codec.rs
@@ -272,7 +272,7 @@ pub fn write_stage_message(
     // A lowrank frame's reserved field carries the rank alongside the dtype
     // tag; preserve it instead of clobbering it with the bare tag.
     if dtype == WireActivationDType::Lowrank {
-        state.lowrank_k().map_err(io::Error::other)?;
+        state.validate_lowrank().map_err(io::Error::other)?;
     } else {
         state.reserved = dtype as i32;
     }

--- a/crates/skippy-protocol/src/binary/types.rs
+++ b/crates/skippy-protocol/src/binary/types.rs
@@ -336,8 +336,23 @@ impl StageStateHeader {
 
     pub fn dtype(self) -> io::Result<WireActivationDType> {
         // The low byte carries the dtype tag; Lowrank packs its rank into the
-        // high bits (existing dtypes always have zero high bits).
-        WireActivationDType::try_from(self.reserved & 0xFF)
+        // high bits. Every other dtype must still leave the high bits zero:
+        // before the rank was packed here, `reserved` was exactly the tag, and
+        // masking alone would silently accept a frame whose high bits are
+        // garbage instead of rejecting it as this field always has.
+        let dtype = WireActivationDType::try_from(self.reserved & 0xFF)?;
+        if dtype != WireActivationDType::Lowrank && self.reserved >> 8 != 0 {
+            return Err(invalid_data(
+                "activation wire dtype has unexpected reserved high bits",
+            ));
+        }
+        Ok(dtype)
+    }
+
+    /// Checks that this header carries a well-formed `Lowrank` rank, for
+    /// callers that only want the validation and discard the value.
+    pub fn validate_lowrank(self) -> io::Result<()> {
+        self.lowrank_k().map(|_| ())
     }
 
     /// The low-rank codec rank carried by a `Lowrank` frame.
@@ -768,5 +783,40 @@ fn expected_phase(kind: WireMessageKind) -> WireStagePhase {
         WireStagePhase::DecodeLight
     } else {
         WireStagePhase::Decode
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn only_lowrank_may_carry_reserved_high_bits() {
+        let mut header =
+            StageStateHeader::new(WireMessageKind::DecodeEmbd, WireActivationDType::F32);
+
+        assert_eq!(
+            header.dtype().expect("plain dtype"),
+            WireActivationDType::F32
+        );
+
+        // Before the rank was packed into `reserved`, this field was exactly
+        // the dtype tag and anything else was rejected. Masking alone would
+        // have accepted this as F32.
+        header.reserved = 0x0100;
+        assert!(
+            header.dtype().is_err(),
+            "high bits on a non-lowrank dtype must fail"
+        );
+
+        header
+            .set_lowrank(512)
+            .expect("a lowrank rank packs into the high bits");
+        assert_eq!(
+            header.dtype().expect("lowrank dtype"),
+            WireActivationDType::Lowrank
+        );
+        assert_eq!(header.lowrank_k().expect("rank"), 512);
+        header.validate_lowrank().expect("validation accepts it");
     }
 }

--- a/crates/skippy-protocol/src/binary/types.rs
+++ b/crates/skippy-protocol/src/binary/types.rs
@@ -29,6 +29,10 @@ pub enum WireActivationDType {
     F32 = 0,
     F16 = 1,
     Q8 = 2,
+    /// Learned low-rank projection at a split boundary. The rank `k` rides in
+    /// the high bits of `StageStateHeader::reserved`; both stages must hold
+    /// byte-identical codec tensors to use it.
+    Lowrank = 3,
 }
 
 impl TryFrom<i32> for WireActivationDType {
@@ -39,6 +43,7 @@ impl TryFrom<i32> for WireActivationDType {
             0 => Ok(Self::F32),
             1 => Ok(Self::F16),
             2 => Ok(Self::Q8),
+            3 => Ok(Self::Lowrank),
             _ => Err(invalid_data("unknown activation wire dtype")),
         }
     }
@@ -330,7 +335,31 @@ impl StageStateHeader {
     }
 
     pub fn dtype(self) -> io::Result<WireActivationDType> {
-        WireActivationDType::try_from(self.reserved)
+        // The low byte carries the dtype tag; Lowrank packs its rank into the
+        // high bits (existing dtypes always have zero high bits).
+        WireActivationDType::try_from(self.reserved & 0xFF)
+    }
+
+    /// The low-rank codec rank carried by a `Lowrank` frame.
+    pub fn lowrank_k(self) -> io::Result<usize> {
+        if self.dtype()? != WireActivationDType::Lowrank {
+            return Err(invalid_data("state header is not a lowrank frame"));
+        }
+        let k = (self.reserved >> 8) as usize;
+        if k == 0 {
+            return Err(invalid_data("lowrank frame has zero rank"));
+        }
+        Ok(k)
+    }
+
+    /// Tags this header as a `Lowrank` frame of rank `k`.
+    pub fn set_lowrank(&mut self, k: usize) -> io::Result<()> {
+        let k = i32::try_from(k).map_err(|_| invalid_data("lowrank rank exceeds i32"))?;
+        if k <= 0 || k > (i32::MAX >> 8) {
+            return Err(invalid_data("lowrank rank out of range"));
+        }
+        self.reserved = WireActivationDType::Lowrank as i32 | (k << 8);
+        Ok(())
     }
 
     pub fn matches_kind(self, kind: WireMessageKind) -> bool {
@@ -556,6 +585,9 @@ impl StageWireMessage {
                 n_embd,
                 self.state.flags,
             ),
+            WireActivationDType::Lowrank => Err(invalid_data(
+                "lowrank activation requires a boundary codec to decode",
+            )),
         }
     }
 
@@ -579,6 +611,9 @@ impl StageWireMessage {
                 n_embd,
                 self.state.flags,
             ),
+            WireActivationDType::Lowrank => Err(invalid_data(
+                "lowrank activation requires a boundary codec to decode",
+            )),
         }
     }
 }

--- a/crates/skippy-protocol/src/lib.rs
+++ b/crates/skippy-protocol/src/lib.rs
@@ -33,7 +33,7 @@ pub use validation::{
     SCHEMA_VERSION, STAGE_ALPN_V2, STAGE_PROTOCOL_GENERATION, STAGE_STREAM_ARTIFACT_TRANSFER,
     STAGE_STREAM_CONTROL, STAGE_STREAM_TRANSPORT, STAGE_SUBPROTOCOL_FEATURE_ARTIFACT_TRANSFER,
     STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL, STAGE_SUBPROTOCOL_FEATURE_STAGE_GENERATION,
-    STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V5, STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST,
+    STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V6, STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST,
     STAGE_SUBPROTOCOL_MAJOR, STAGE_SUBPROTOCOL_NAME, StageFrameError,
     validate_stage_artifact_transfer_request, validate_stage_artifact_transfer_response,
     validate_stage_control_request, validate_stage_control_response, validate_stage_transport_open,
@@ -53,7 +53,7 @@ mod tests {
         stage_control_response,
     };
     use super::{
-        STAGE_PROTOCOL_GENERATION, STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V5,
+        STAGE_PROTOCOL_GENERATION, STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V6,
         StageFrameError, validate_stage_artifact_transfer_request,
         validate_stage_artifact_transfer_response, validate_stage_control_request,
         validate_stage_control_response, validate_stage_transport_open,
@@ -62,7 +62,7 @@ mod tests {
     #[test]
     fn stage_protocol_generation_feature_names_current_generation() {
         assert_eq!(
-            STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V5,
+            STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V6,
             format!("stage-generation-{STAGE_PROTOCOL_GENERATION}")
         );
     }

--- a/crates/skippy-protocol/src/validation.rs
+++ b/crates/skippy-protocol/src/validation.rs
@@ -6,13 +6,13 @@ pub const STAGE_ALPN_V2: &[u8] = b"skippy-stage/2";
 pub const STAGE_SUBPROTOCOL_NAME: &str = "skippy-stage";
 pub const STAGE_SUBPROTOCOL_MAJOR: u32 = 2;
 pub const STAGE_SUBPROTOCOL_FEATURE_STAGE_CONTROL: &str = "stage-control";
-pub const STAGE_PROTOCOL_GENERATION: u32 = 5;
+pub const STAGE_PROTOCOL_GENERATION: u32 = 6;
 /// Generation-scoped stage capability. A peer can advertise `stage-control`
 /// while still rejecting current-generation frames, so split planning gates on
 /// this exact token before sending current-generation control requests.
-pub const STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V5: &str = "stage-generation-5";
+pub const STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V6: &str = "stage-generation-6";
 pub const STAGE_SUBPROTOCOL_FEATURE_STAGE_GENERATION: &str =
-    STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V5;
+    STAGE_SUBPROTOCOL_FEATURE_STAGE_PROTOCOL_GENERATION_V6;
 pub const STAGE_SUBPROTOCOL_FEATURE_ARTIFACT_TRANSFER: &str = "artifact-transfer";
 pub const STAGE_SUBPROTOCOL_FEATURE_STATUS_LIST: &str = "status-list";
 pub const STAGE_STREAM_CONTROL: u8 = 0x01;

--- a/crates/skippy-server/README.md
+++ b/crates/skippy-server/README.md
@@ -15,7 +15,7 @@ mesh/openai-frontend; diagnostic and benchmark clients may connect directly to
 the first stage.
 
 The full request/reply path is tip-to-tip: token IDs enter at the driver-facing
-tip, and activations flow through the stage chain. Stage protocol generation 5
+tip, and activations flow through the stage chain. Stage protocol generation 6
 is a compatibility-breaking contract: prediction-bearing replies return
 directly from the final/readout tip to the driver-facing stage instead of being
 relayed back through intermediate stages. Middle-out is the prefill optimization
@@ -103,11 +103,15 @@ deadline handling.
 ## Notes
 
 - `serve-binary` is the tuned binary stage-to-stage path.
-- `serve-binary` participates in the breaking generation-5 stage protocol.
-  Stage compatibility requires `stage-generation-5`; direct prediction return,
+- `serve-binary` participates in the breaking generation-6 stage protocol.
+  Stage compatibility requires `stage-generation-6`; direct prediction return,
   exact verify-checkpoint retirement, and the `DiscardStaleWindows` control
   frame are part of that generation's contract, so older peers are rejected
-  during split planning instead of being mixed into a generation-5 topology.
+  during split planning instead of being mixed into a generation-6 topology.
+  Generation 6 additionally redefines `StageStateHeader::reserved`, which
+  used to be exactly the activation dtype tag and now packs a low-rank codec
+  rank into its high bits. A generation-5 peer predates that change, so the
+  boundary codec claims its own generation rather than riding on 5.
 - That rejection happens in mesh split planning. A manually wired
   `serve-binary --downstream host:port` pair performs no generation
   handshake, so **the contract for the standalone path is that all stages are
@@ -130,7 +134,7 @@ deadline handling.
   `/v1/completions` using the shared `openai-frontend` crate for a local
   final/single-stage config with no downstream peer. Split serving uses
   embedded stage-0 OpenAI serving from `serve-binary --openai-bind-addr` because
-  generation-5 prediction returns flow directly from the final stage to stage 0.
+  generation-6 prediction returns flow directly from the final stage to stage 0.
   The older standalone `serve-openai --first-stage-addr` adapter is no longer
   supported. `--model-id` is the exact served model id to advertise
   and accept, for example `org/repo:Q4_K_M`; it is not parsed as stage topology.

--- a/crates/skippy-server/src/binary_transport.rs
+++ b/crates/skippy-server/src/binary_transport.rs
@@ -1,6 +1,7 @@
 mod activation_cache;
 mod binary_kv;
 mod binary_messaging;
+pub mod boundary_codec;
 pub(crate) mod direct_return;
 pub(crate) mod forwarding;
 mod kv_eviction;

--- a/crates/skippy-server/src/binary_transport/binary_messaging.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging.rs
@@ -183,6 +183,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
         downstream_wire_condition,
         downstream_connect_timeout_secs,
         native_mtp_enabled,
+        boundary_codec,
         openai,
     } = options;
     let native_mtp_enabled = native_mtp_enabled && config.native_mtp_enabled;
@@ -344,6 +345,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
             let worker_shutdown = shutdown.clone();
             let prediction_returns = prediction_returns.clone();
             let prediction_return_sinks = prediction_return_sinks.clone();
+            let boundary_codec = boundary_codec.clone();
             let worker_control = Arc::new(ConnectionWorkerControl::default());
             worker_control
                 .track(&upstream)
@@ -402,6 +404,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
                         downstream_wire_condition,
                         downstream_connect_timeout_secs,
                         native_mtp_enabled,
+                        boundary_codec.as_deref(),
                         &prediction_return_sinks,
                         first_message,
                     )

--- a/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
@@ -41,7 +41,7 @@ use crate::binary_transport::stage_execution::binary_message_session_id;
 use crate::binary_transport::stage_execution::decode_record_tokens_sideband;
 use crate::binary_transport::stage_execution::elapsed_ms;
 use crate::binary_transport::stage_execution::empty_activation_frame;
-use crate::binary_transport::stage_execution::input_activation_frame;
+use crate::binary_transport::stage_execution::input_activation_frame_with_codec;
 use crate::binary_transport::stage_execution::is_decode_frame_batch_candidate;
 use crate::binary_transport::stage_execution::nanos_delta_ms;
 use crate::binary_transport::stage_execution::runtime_sampling_config;
@@ -88,6 +88,7 @@ pub(super) fn handle_binary_connection(
     downstream_wire_condition: WireCondition,
     downstream_connect_timeout_secs: u64,
     native_mtp_enabled: bool,
+    boundary_codec: Option<&crate::binary_transport::boundary_codec::BoundaryCodec>,
     prediction_return_sinks: &PredictionReturnSinks,
     first_message: StageWireMessage,
 ) -> Result<()> {
@@ -108,6 +109,7 @@ pub(super) fn handle_binary_connection(
         downstream_wire_condition,
         downstream_connect_timeout_secs,
         native_mtp_enabled,
+        boundary_codec,
         prediction_return_sinks,
         first_message,
         &mut session_tracker,
@@ -138,6 +140,7 @@ fn handle_binary_connection_messages(
     downstream_wire_condition: WireCondition,
     downstream_connect_timeout_secs: u64,
     native_mtp_enabled: bool,
+    boundary_codec: Option<&crate::binary_transport::boundary_codec::BoundaryCodec>,
     prediction_return_sinks: &PredictionReturnSinks,
     first_message: StageWireMessage,
     session_tracker: &mut ConnectionSessionTracker,
@@ -478,7 +481,13 @@ fn handle_binary_connection_messages(
             } else {
                 let input_decode_started = Instant::now();
                 let input = suffix_activation_frame(
-                    input_activation_frame(config, topology, &mut message, activation_width)?,
+                    input_activation_frame_with_codec(
+                        config,
+                        topology,
+                        &mut message,
+                        activation_width,
+                        boundary_codec,
+                    )?,
                     executable_prefill_start,
                 )?;
                 input_activation_decode_ms = if input_activation_bytes == 0 {
@@ -754,13 +763,31 @@ fn handle_binary_connection_messages(
             if output.payload.is_empty() {
                 bail!("stage has downstream but produced an empty activation payload");
             }
-            let forwarded = forwarded_stage_message_timed(
-                config,
-                &message,
-                &output,
-                wire_dtype,
-                activation_width,
-            )?;
+            if output.desc.dtype == skippy_runtime::RuntimeActivationDType::F32 {
+                crate::binary_transport::boundary_codec::maybe_capture_boundary_activations(
+                    &output.payload,
+                );
+            }
+            let forwarded = if wire_dtype == WireActivationDType::Lowrank {
+                let codec = boundary_codec.context(
+                    "lowrank activation wire dtype requires a boundary codec on this stage",
+                )?;
+                crate::binary_transport::forwarding::forwarded_stage_message_lowrank_timed(
+                    config,
+                    &message,
+                    &output,
+                    codec,
+                    activation_width,
+                )?
+            } else {
+                forwarded_stage_message_timed(
+                    config,
+                    &message,
+                    &output,
+                    wire_dtype,
+                    activation_width,
+                )?
+            };
             forward_activation_encode_ms += forwarded.activation_encode_ms;
             forward_activation_bytes = forwarded.message.activation.len();
             let mut downstream_write_attrs = BTreeMap::new();

--- a/crates/skippy-server/src/binary_transport/boundary_codec.rs
+++ b/crates/skippy-server/src/binary_transport/boundary_codec.rs
@@ -83,8 +83,8 @@ impl BoundaryCodec {
             }
             let mut max_abs = 0.0_f32;
             for (component_index, coeff) in coeffs.iter_mut().enumerate() {
-                let component = &self.components
-                    [component_index * self.d..(component_index + 1) * self.d];
+                let component =
+                    &self.components[component_index * self.d..(component_index + 1) * self.d];
                 let mut dot = 0.0_f32;
                 for (value, weight) in centered.iter().zip(component) {
                     dot += value * weight;
@@ -133,8 +133,8 @@ impl BoundaryCodec {
                 if coeff == 0.0 {
                     continue;
                 }
-                let component = &self.components
-                    [component_index * self.d..(component_index + 1) * self.d];
+                let component =
+                    &self.components[component_index * self.d..(component_index + 1) * self.d];
                 for (value, weight) in row.iter_mut().zip(component) {
                     *value += coeff * weight;
                 }
@@ -154,7 +154,10 @@ impl BoundaryCodec {
             bail!("boundary codec dimensions out of range: d={d} k={k}");
         }
         if samples.is_empty() || !samples.len().is_multiple_of(d) {
-            bail!("calibration sample length {} is not a multiple of d {d}", samples.len());
+            bail!(
+                "calibration sample length {} is not a multiple of d {d}",
+                samples.len()
+            );
         }
         let n = samples.len() / d;
         if n < k {
@@ -195,8 +198,7 @@ impl BoundaryCodec {
                         continue;
                     }
                     let target = &mut next[component_index * d..(component_index + 1) * d];
-                    for ((accumulator, value), mean_value) in
-                        target.iter_mut().zip(row).zip(&mean)
+                    for ((accumulator, value), mean_value) in target.iter_mut().zip(row).zip(&mean)
                     {
                         *accumulator += coeff * (value - mean_value);
                     }
@@ -223,8 +225,8 @@ impl BoundaryCodec {
     }
 
     pub fn load(path: &Path) -> Result<Self> {
-        let file =
-            fs::File::open(path).with_context(|| format!("open boundary codec {}", path.display()))?;
+        let file = fs::File::open(path)
+            .with_context(|| format!("open boundary codec {}", path.display()))?;
         let mut reader = io::BufReader::new(file);
         let mut magic = [0_u8; 8];
         reader.read_exact(&mut magic).context("read codec magic")?;
@@ -234,7 +236,10 @@ impl BoundaryCodec {
         let d = read_u32(&mut reader)? as usize;
         let k = read_u32(&mut reader)? as usize;
         if d == 0 || k == 0 || k > d || d > MAX_CODEC_DIM {
-            bail!("boundary codec {} has invalid dimensions d={d} k={k}", path.display());
+            bail!(
+                "boundary codec {} has invalid dimensions d={d} k={k}",
+                path.display()
+            );
         }
         let mean = read_f32_vec(&mut reader, d)?;
         let components = read_f32_vec(&mut reader, k * d)?;
@@ -384,7 +389,10 @@ mod tests {
     }
 
     fn payload_bytes(values: &[f32]) -> Vec<u8> {
-        values.iter().flat_map(|value| value.to_le_bytes()).collect()
+        values
+            .iter()
+            .flat_map(|value| value.to_le_bytes())
+            .collect()
     }
 
     fn payload_values(bytes: &[u8]) -> Vec<f32> {

--- a/crates/skippy-server/src/binary_transport/boundary_codec.rs
+++ b/crates/skippy-server/src/binary_transport/boundary_codec.rs
@@ -126,6 +126,11 @@ impl BoundaryCodec {
                     .try_into()
                     .expect("slice length"),
             );
+            // A NaN or infinite scale would propagate into the model as NaN
+            // activations rather than failing the frame here.
+            if !scale.is_finite() {
+                return Err(invalid_data("lowrank token scale is not finite"));
+            }
             row.copy_from_slice(&self.mean);
             let coeff_offset = scale_bytes + token_index * self.k;
             for component_index in 0..self.k {

--- a/crates/skippy-server/src/binary_transport/boundary_codec.rs
+++ b/crates/skippy-server/src/binary_transport/boundary_codec.rs
@@ -1,0 +1,450 @@
+//! Learned low-rank activation codec for split boundaries.
+//!
+//! A codec is a per-boundary orthonormal projection fitted offline (PCA over
+//! calibration activations). Encoding projects each d-wide activation row to
+//! k coefficients and int8-quantizes them with a per-row scale; decoding
+//! reconstructs `x̂ = Qᵀ·y + μ`. Both stages of a boundary must load
+//! byte-identical codec files.
+
+use std::fs;
+use std::io::{self, Read};
+use std::path::Path;
+
+use anyhow::{Context, Result, bail};
+
+const CODEC_MAGIC: &[u8; 8] = b"SKBC0001";
+
+/// Maximum supported width/rank; a codec file above this is rejected as
+/// corrupt rather than allocating unbounded memory.
+const MAX_CODEC_DIM: usize = 65_536;
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct BoundaryCodec {
+    d: usize,
+    k: usize,
+    /// Mean activation, length `d`.
+    mean: Vec<f32>,
+    /// `k` orthonormal component rows, each of length `d` (row-major).
+    components: Vec<f32>,
+}
+
+impl BoundaryCodec {
+    pub fn new(d: usize, k: usize, mean: Vec<f32>, components: Vec<f32>) -> Result<Self> {
+        if d == 0 || k == 0 || k > d || d > MAX_CODEC_DIM {
+            bail!("boundary codec dimensions out of range: d={d} k={k}");
+        }
+        if mean.len() != d {
+            bail!("boundary codec mean length {} != d {d}", mean.len());
+        }
+        if components.len() != k * d {
+            bail!(
+                "boundary codec component length {} != k*d {}",
+                components.len(),
+                k * d
+            );
+        }
+        Ok(Self {
+            d,
+            k,
+            mean,
+            components,
+        })
+    }
+
+    pub fn d(&self) -> usize {
+        self.d
+    }
+
+    pub fn k(&self) -> usize {
+        self.k
+    }
+
+    /// Encodes `token_count` f32 rows (little-endian, `token_count * d`
+    /// values) into the lowrank wire layout:
+    /// `[token_count f32 scales][token_count * k i8 coefficients]`.
+    pub fn encode(&self, f32_payload: &[u8], token_count: usize) -> io::Result<Vec<u8>> {
+        let expected = token_count
+            .checked_mul(self.d)
+            .and_then(|elements| elements.checked_mul(4))
+            .ok_or_else(|| invalid_data("lowrank source byte count overflow"))?;
+        if f32_payload.len() != expected {
+            return Err(invalid_data("lowrank source payload size mismatch"));
+        }
+        let mut scales = Vec::with_capacity(token_count * 4);
+        let mut packed = Vec::with_capacity(token_count * self.k);
+        let mut centered = vec![0.0_f32; self.d];
+        let mut coeffs = vec![0.0_f32; self.k];
+        for token_index in 0..token_count {
+            let row_offset = token_index * self.d * 4;
+            let row = &f32_payload[row_offset..row_offset + self.d * 4];
+            for (index, chunk) in row.chunks_exact(4).enumerate() {
+                let value = f32::from_le_bytes(chunk.try_into().expect("chunks_exact size"));
+                centered[index] = value - self.mean[index];
+            }
+            let mut max_abs = 0.0_f32;
+            for (component_index, coeff) in coeffs.iter_mut().enumerate() {
+                let component = &self.components
+                    [component_index * self.d..(component_index + 1) * self.d];
+                let mut dot = 0.0_f32;
+                for (value, weight) in centered.iter().zip(component) {
+                    dot += value * weight;
+                }
+                *coeff = dot;
+                max_abs = max_abs.max(dot.abs());
+            }
+            let scale = if max_abs > 0.0 { max_abs / 127.0 } else { 1.0 };
+            scales.extend_from_slice(&scale.to_le_bytes());
+            for coeff in &coeffs {
+                packed.push((coeff / scale).round().clamp(-127.0, 127.0) as i8 as u8);
+            }
+        }
+        scales.extend_from_slice(&packed);
+        Ok(scales)
+    }
+
+    /// Decodes a lowrank wire payload back into `token_count * d` f32 values
+    /// (little-endian bytes).
+    pub fn decode(&self, payload: &[u8], token_count: usize) -> io::Result<Vec<u8>> {
+        let scale_bytes = token_count
+            .checked_mul(4)
+            .ok_or_else(|| invalid_data("lowrank scale byte count overflow"))?;
+        let coeff_bytes = token_count
+            .checked_mul(self.k)
+            .ok_or_else(|| invalid_data("lowrank coefficient byte count overflow"))?;
+        let expected = scale_bytes
+            .checked_add(coeff_bytes)
+            .ok_or_else(|| invalid_data("lowrank payload byte count overflow"))?;
+        if payload.len() != expected {
+            return Err(invalid_data("lowrank payload size mismatch"));
+        }
+        let mut out = Vec::with_capacity(token_count * self.d * 4);
+        let mut row = vec![0.0_f32; self.d];
+        for token_index in 0..token_count {
+            let scale_offset = token_index * 4;
+            let scale = f32::from_le_bytes(
+                payload[scale_offset..scale_offset + 4]
+                    .try_into()
+                    .expect("slice length"),
+            );
+            row.copy_from_slice(&self.mean);
+            let coeff_offset = scale_bytes + token_index * self.k;
+            for component_index in 0..self.k {
+                let coeff = (payload[coeff_offset + component_index] as i8) as f32 * scale;
+                if coeff == 0.0 {
+                    continue;
+                }
+                let component = &self.components
+                    [component_index * self.d..(component_index + 1) * self.d];
+                for (value, weight) in row.iter_mut().zip(component) {
+                    *value += coeff * weight;
+                }
+            }
+            for value in &row {
+                out.extend_from_slice(&value.to_le_bytes());
+            }
+        }
+        Ok(out)
+    }
+
+    /// Fits a codec by PCA over calibration rows (`samples.len() / d` rows)
+    /// using orthogonal iteration. Deterministic: the starting subspace is
+    /// seeded from a fixed splitmix64 stream.
+    pub fn fit(samples: &[f32], d: usize, k: usize, iterations: usize) -> Result<Self> {
+        if d == 0 || k == 0 || k > d || d > MAX_CODEC_DIM {
+            bail!("boundary codec dimensions out of range: d={d} k={k}");
+        }
+        if samples.is_empty() || !samples.len().is_multiple_of(d) {
+            bail!("calibration sample length {} is not a multiple of d {d}", samples.len());
+        }
+        let n = samples.len() / d;
+        if n < k {
+            bail!("need at least k={k} calibration rows, got {n}");
+        }
+        let mut mean = vec![0.0_f32; d];
+        for row in samples.chunks_exact(d) {
+            for (accumulator, value) in mean.iter_mut().zip(row) {
+                *accumulator += value;
+            }
+        }
+        for value in &mut mean {
+            *value /= n as f32;
+        }
+
+        // Orthogonal iteration on the covariance action: Z = Aᵀ(A·Q).
+        let mut q = deterministic_matrix(d, k);
+        orthonormalize(&mut q, d, k);
+        let mut projected = vec![0.0_f32; n * k];
+        for _ in 0..iterations.max(1) {
+            // projected = centered · Qᵀ  (n×k)
+            for (row_index, row) in samples.chunks_exact(d).enumerate() {
+                for component_index in 0..k {
+                    let component = &q[component_index * d..(component_index + 1) * d];
+                    let mut dot = 0.0_f32;
+                    for ((value, mean_value), weight) in row.iter().zip(&mean).zip(component) {
+                        dot += (value - mean_value) * weight;
+                    }
+                    projected[row_index * k + component_index] = dot;
+                }
+            }
+            // q = projectedᵀ · centered  (k×d)
+            let mut next = vec![0.0_f32; k * d];
+            for (row_index, row) in samples.chunks_exact(d).enumerate() {
+                for component_index in 0..k {
+                    let coeff = projected[row_index * k + component_index];
+                    if coeff == 0.0 {
+                        continue;
+                    }
+                    let target = &mut next[component_index * d..(component_index + 1) * d];
+                    for ((accumulator, value), mean_value) in
+                        target.iter_mut().zip(row).zip(&mean)
+                    {
+                        *accumulator += coeff * (value - mean_value);
+                    }
+                }
+            }
+            q = next;
+            orthonormalize(&mut q, d, k);
+        }
+        Self::new(d, k, mean, q)
+    }
+
+    pub fn save(&self, path: &Path) -> Result<()> {
+        let mut bytes = Vec::with_capacity(16 + (self.d + self.k * self.d) * 4);
+        bytes.extend_from_slice(CODEC_MAGIC);
+        bytes.extend_from_slice(&(self.d as u32).to_le_bytes());
+        bytes.extend_from_slice(&(self.k as u32).to_le_bytes());
+        for value in &self.mean {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        for value in &self.components {
+            bytes.extend_from_slice(&value.to_le_bytes());
+        }
+        fs::write(path, bytes).with_context(|| format!("write boundary codec {}", path.display()))
+    }
+
+    pub fn load(path: &Path) -> Result<Self> {
+        let file =
+            fs::File::open(path).with_context(|| format!("open boundary codec {}", path.display()))?;
+        let mut reader = io::BufReader::new(file);
+        let mut magic = [0_u8; 8];
+        reader.read_exact(&mut magic).context("read codec magic")?;
+        if &magic != CODEC_MAGIC {
+            bail!("{} is not a boundary codec file", path.display());
+        }
+        let d = read_u32(&mut reader)? as usize;
+        let k = read_u32(&mut reader)? as usize;
+        if d == 0 || k == 0 || k > d || d > MAX_CODEC_DIM {
+            bail!("boundary codec {} has invalid dimensions d={d} k={k}", path.display());
+        }
+        let mean = read_f32_vec(&mut reader, d)?;
+        let components = read_f32_vec(&mut reader, k * d)?;
+        Self::new(d, k, mean, components)
+    }
+}
+
+fn invalid_data(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+fn read_u32(reader: &mut impl Read) -> Result<u32> {
+    let mut bytes = [0_u8; 4];
+    reader.read_exact(&mut bytes).context("read codec u32")?;
+    Ok(u32::from_le_bytes(bytes))
+}
+
+fn read_f32_vec(reader: &mut impl Read, len: usize) -> Result<Vec<f32>> {
+    let mut bytes = vec![0_u8; len * 4];
+    reader
+        .read_exact(&mut bytes)
+        .context("read codec tensor data")?;
+    Ok(bytes
+        .chunks_exact(4)
+        .map(|chunk| f32::from_le_bytes(chunk.try_into().expect("chunks_exact size")))
+        .collect())
+}
+
+/// Deterministic pseudo-random starting subspace (splitmix64 → uniform).
+fn deterministic_matrix(d: usize, k: usize) -> Vec<f32> {
+    let mut out = Vec::with_capacity(k * d);
+    let mut state = 0x1234_5678_9ABC_DEF0_u64;
+    for _ in 0..k * d {
+        state = state.wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let mut z = state;
+        z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+        z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+        z ^= z >> 31;
+        out.push(((z >> 11) as f64 / (1u64 << 53) as f64) as f32 - 0.5);
+    }
+    out
+}
+
+/// Modified Gram-Schmidt over `k` row vectors of width `d`.
+fn orthonormalize(rows: &mut [f32], d: usize, k: usize) {
+    for row_index in 0..k {
+        for prior_index in 0..row_index {
+            let mut dot = 0.0_f32;
+            for column in 0..d {
+                dot += rows[row_index * d + column] * rows[prior_index * d + column];
+            }
+            for column in 0..d {
+                rows[row_index * d + column] -= dot * rows[prior_index * d + column];
+            }
+        }
+        let mut norm = 0.0_f32;
+        for column in 0..d {
+            norm += rows[row_index * d + column] * rows[row_index * d + column];
+        }
+        let norm = norm.sqrt();
+        if norm > 1e-12 {
+            for column in 0..d {
+                rows[row_index * d + column] /= norm;
+            }
+        }
+    }
+}
+
+/// CLI entry: fits a codec from a raw f32 activation dump and writes it out.
+pub fn fit_boundary_codec_cli(args: &crate::cli::FitBoundaryCodecArgs) -> Result<()> {
+    let bytes = fs::read(&args.input)
+        .with_context(|| format!("read calibration dump {}", args.input.display()))?;
+    if !bytes.len().is_multiple_of(4) {
+        bail!("calibration dump is not a whole number of f32 values");
+    }
+    let samples: Vec<f32> = bytes
+        .chunks_exact(4)
+        .map(|chunk| f32::from_le_bytes(chunk.try_into().expect("chunks_exact size")))
+        .collect();
+    let rows = samples.len() / args.width.max(1);
+    eprintln!(
+        "fitting boundary codec: {} rows of width {}, rank {}, {} iterations",
+        rows, args.width, args.rank, args.iterations
+    );
+    let codec = BoundaryCodec::fit(&samples, args.width, args.rank, args.iterations)?;
+    codec.save(&args.output)?;
+    eprintln!(
+        "wrote {} ({}x compression vs f16 at the boundary)",
+        args.output.display(),
+        (args.width * 2) as f64 / (args.rank as f64 + 4.0 / 1.0f64.max(1.0)),
+    );
+    Ok(())
+}
+
+/// Appends f32 activation rows to the capture file named by
+/// `SKIPPY_CAPTURE_BOUNDARY_ACTIVATIONS`, bounded by
+/// `SKIPPY_CAPTURE_BOUNDARY_MAX_MB` (default 512). Failures are logged and
+/// ignored: capture must never break serving.
+pub(crate) fn maybe_capture_boundary_activations(payload: &[u8]) {
+    use std::io::Write as _;
+    let Some(path) = std::env::var_os("SKIPPY_CAPTURE_BOUNDARY_ACTIVATIONS") else {
+        return;
+    };
+    let max_bytes = std::env::var("SKIPPY_CAPTURE_BOUNDARY_MAX_MB")
+        .ok()
+        .and_then(|value| value.parse::<u64>().ok())
+        .unwrap_or(512)
+        .saturating_mul(1024 * 1024);
+    let path = std::path::PathBuf::from(path);
+    if let Ok(metadata) = fs::metadata(&path)
+        && metadata.len().saturating_add(payload.len() as u64) > max_bytes
+    {
+        return;
+    }
+    let result = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+        .and_then(|mut file| file.write_all(payload));
+    if let Err(error) = result {
+        eprintln!("boundary activation capture failed: {error}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn low_rank_samples(n: usize, d: usize, rank: usize) -> Vec<f32> {
+        // Rows are combinations of `rank` fixed basis directions plus a mean
+        // offset, so a rank-k codec should reconstruct them almost exactly.
+        let basis = deterministic_matrix(d, rank);
+        let coefficients = deterministic_matrix(rank, n);
+        let mut out = Vec::with_capacity(n * d);
+        for row_index in 0..n {
+            for column in 0..d {
+                let mut value = 0.5; // constant mean offset
+                for basis_index in 0..rank {
+                    value += coefficients[row_index * rank + basis_index]
+                        * basis[basis_index * d + column]
+                        * 3.0;
+                }
+                out.push(value);
+            }
+        }
+        out
+    }
+
+    fn payload_bytes(values: &[f32]) -> Vec<u8> {
+        values.iter().flat_map(|value| value.to_le_bytes()).collect()
+    }
+
+    fn payload_values(bytes: &[u8]) -> Vec<f32> {
+        bytes
+            .chunks_exact(4)
+            .map(|chunk| f32::from_le_bytes(chunk.try_into().unwrap()))
+            .collect()
+    }
+
+    #[test]
+    fn fit_encode_decode_roundtrips_low_rank_data() {
+        let (n, d, rank) = (64, 32, 4);
+        let samples = low_rank_samples(n, d, rank);
+        let codec = BoundaryCodec::fit(&samples, d, rank, 12).unwrap();
+
+        let token_count = 3;
+        let original = &samples[..token_count * d];
+        let encoded = codec.encode(&payload_bytes(original), token_count).unwrap();
+        assert_eq!(encoded.len(), token_count * 4 + token_count * rank);
+
+        let decoded = payload_values(&codec.decode(&encoded, token_count).unwrap());
+        assert_eq!(decoded.len(), original.len());
+        let mut max_error = 0.0_f32;
+        let mut max_abs = 0.0_f32;
+        for (reconstructed, value) in decoded.iter().zip(original) {
+            max_error = max_error.max((reconstructed - value).abs());
+            max_abs = max_abs.max(value.abs());
+        }
+        // Exactly-low-rank data must reconstruct to int8 quantization noise.
+        assert!(
+            max_error <= max_abs * 0.02,
+            "max_error {max_error} vs max_abs {max_abs}"
+        );
+    }
+
+    #[test]
+    fn save_load_roundtrips_exactly() {
+        let samples = low_rank_samples(32, 16, 3);
+        let codec = BoundaryCodec::fit(&samples, 16, 3, 8).unwrap();
+        let dir = std::env::temp_dir().join("skippy-boundary-codec-test");
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("codec.skbc");
+        codec.save(&path).unwrap();
+        let loaded = BoundaryCodec::load(&path).unwrap();
+        assert_eq!(codec, loaded);
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn encode_rejects_mismatched_payload_sizes() {
+        let samples = low_rank_samples(32, 16, 3);
+        let codec = BoundaryCodec::fit(&samples, 16, 3, 4).unwrap();
+        assert!(codec.encode(&[0_u8; 12], 1).is_err());
+        assert!(codec.decode(&[0_u8; 5], 1).is_err());
+    }
+
+    #[test]
+    fn fit_rejects_degenerate_shapes() {
+        assert!(BoundaryCodec::fit(&[], 4, 2, 4).is_err());
+        assert!(BoundaryCodec::fit(&[0.0; 8], 4, 8, 4).is_err());
+        assert!(BoundaryCodec::fit(&[0.0; 9], 4, 2, 4).is_err());
+    }
+}

--- a/crates/skippy-server/src/binary_transport/forwarding.rs
+++ b/crates/skippy-server/src/binary_transport/forwarding.rs
@@ -25,6 +25,62 @@ pub(crate) struct ForwardedStageMessage {
     pub activation_encode_ms: f64,
 }
 
+/// Lowrank-aware forward builder: projects the stage's f32 output activation
+/// through the boundary codec and tags the state header with the codec rank.
+pub(crate) fn forwarded_stage_message_lowrank_timed(
+    config: &StageConfig,
+    incoming: &StageWireMessage,
+    output: &ActivationFrame,
+    codec: &crate::binary_transport::boundary_codec::BoundaryCodec,
+    activation_width: i32,
+) -> Result<ForwardedStageMessage> {
+    if output.desc.dtype != RuntimeActivationDType::F32 {
+        bail!(
+            "lowrank encoding requires an F32 output activation frame, got {:?}",
+            output.desc.dtype
+        );
+    }
+    if activation_width.max(0) as usize != codec.d() {
+        bail!(
+            "boundary codec width {} does not match activation width {activation_width}",
+            codec.d()
+        );
+    }
+    let mut state = incoming.state;
+    state.source_stage_index = config.stage_index as i32;
+    state
+        .set_lowrank(codec.k())
+        .map_err(anyhow::Error::from)
+        .context("tag lowrank state header")?;
+    state.flags |= activation_state_flags_from_frame_flags(output.desc.flags);
+    let multiplier =
+        skippy_protocol::binary::activation_payload_multiplier_from_state_flags(state.flags);
+    let token_count = (incoming.token_count.max(0) as usize)
+        .checked_mul(multiplier)
+        .context("lowrank token count overflow")?;
+    let encode_started = Instant::now();
+    let activation = codec
+        .encode(&output.payload, token_count)
+        .context("encode lowrank activation payload")?;
+    Ok(ForwardedStageMessage {
+        message: StageWireMessage {
+            kind: incoming.kind,
+            pos_start: incoming.pos_start,
+            token_count: incoming.token_count,
+            state,
+            request_id: incoming.request_id,
+            session_id: incoming.session_id,
+            sampling: incoming.sampling.clone(),
+            chat_sampling_metadata: None,
+            tokens: incoming.tokens.clone(),
+            positions: incoming.positions.clone(),
+            activation,
+            raw_bytes: Vec::new(),
+        },
+        activation_encode_ms: encode_started.elapsed().as_secs_f64() * 1000.0,
+    })
+}
+
 pub(crate) fn forwarded_stage_message_timed(
     config: &StageConfig,
     incoming: &StageWireMessage,

--- a/crates/skippy-server/src/binary_transport/options.rs
+++ b/crates/skippy-server/src/binary_transport/options.rs
@@ -27,6 +27,7 @@ pub struct BinaryStageOptions {
     pub downstream_wire_condition: WireCondition,
     pub downstream_connect_timeout_secs: u64,
     pub native_mtp_enabled: bool,
+    pub boundary_codec: Option<std::sync::Arc<crate::binary_transport::boundary_codec::BoundaryCodec>>,
     pub openai: Option<EmbeddedOpenAiStageOptions>,
 }
 
@@ -64,6 +65,16 @@ impl BinaryStageOptions {
             bail!("--openai-prefill-chunk-size must be greater than zero");
         }
         let wire_dtype = parse_wire_dtype(&args.activation_wire_dtype)?;
+        let boundary_codec = match (&args.boundary_codec, wire_dtype) {
+            (Some(path), _) => Some(std::sync::Arc::new(
+                crate::binary_transport::boundary_codec::BoundaryCodec::load(path)
+                    .with_context(|| format!("load boundary codec {}", path.display()))?,
+            )),
+            (None, WireActivationDType::Lowrank) => {
+                bail!("--activation-wire-dtype lowrank requires --boundary-codec");
+            }
+            (None, _) => None,
+        };
         let downstream_wire_condition = WireCondition::with_jitter(
             args.downstream_wire_delay_ms,
             args.downstream_wire_mbps,
@@ -127,6 +138,7 @@ impl BinaryStageOptions {
             downstream_wire_condition,
             downstream_connect_timeout_secs: args.downstream_connect_timeout_secs,
             native_mtp_enabled,
+            boundary_codec,
             openai,
         })
     }
@@ -154,6 +166,7 @@ pub fn parse_wire_dtype(value: &str) -> Result<WireActivationDType> {
         "fp32" | "f32" => Ok(WireActivationDType::F32),
         "fp16" | "f16" => Ok(WireActivationDType::F16),
         "q8" | "int8" | "i8" => Ok(WireActivationDType::Q8),
+        "lowrank" => Ok(WireActivationDType::Lowrank),
         _ => bail!("unsupported activation wire dtype {value}"),
     }
 }

--- a/crates/skippy-server/src/binary_transport/options.rs
+++ b/crates/skippy-server/src/binary_transport/options.rs
@@ -27,7 +27,8 @@ pub struct BinaryStageOptions {
     pub downstream_wire_condition: WireCondition,
     pub downstream_connect_timeout_secs: u64,
     pub native_mtp_enabled: bool,
-    pub boundary_codec: Option<std::sync::Arc<crate::binary_transport::boundary_codec::BoundaryCodec>>,
+    pub boundary_codec:
+        Option<std::sync::Arc<crate::binary_transport::boundary_codec::BoundaryCodec>>,
     pub openai: Option<EmbeddedOpenAiStageOptions>,
 }
 

--- a/crates/skippy-server/src/binary_transport/stage_execution.rs
+++ b/crates/skippy-server/src/binary_transport/stage_execution.rs
@@ -807,7 +807,10 @@ pub(in crate::binary_transport) fn input_activation_frame_with_codec(
     if message.activation.is_empty() {
         return Ok(None);
     }
-    let payload = if message.state.dtype().context("read activation wire dtype")?
+    let payload = if message
+        .state
+        .dtype()
+        .context("read activation wire dtype")?
         == skippy_protocol::binary::WireActivationDType::Lowrank
     {
         let codec = boundary_codec

--- a/crates/skippy-server/src/binary_transport/stage_execution.rs
+++ b/crates/skippy-server/src/binary_transport/stage_execution.rs
@@ -794,12 +794,47 @@ pub(in crate::binary_transport) fn input_activation_frame(
     message: &mut StageWireMessage,
     activation_width: i32,
 ) -> Result<Option<ActivationFrame>> {
+    input_activation_frame_with_codec(config, topology, message, activation_width, None)
+}
+
+pub(in crate::binary_transport) fn input_activation_frame_with_codec(
+    config: &StageConfig,
+    topology: Option<&StageTopology>,
+    message: &mut StageWireMessage,
+    activation_width: i32,
+    boundary_codec: Option<&crate::binary_transport::boundary_codec::BoundaryCodec>,
+) -> Result<Option<ActivationFrame>> {
     if message.activation.is_empty() {
         return Ok(None);
     }
-    let payload = message
-        .take_activation_f32_payload(activation_width)
-        .context("decode wire activation payload")?;
+    let payload = if message.state.dtype().context("read activation wire dtype")?
+        == skippy_protocol::binary::WireActivationDType::Lowrank
+    {
+        let codec = boundary_codec
+            .context("lowrank activation frame arrived on a stage without a boundary codec")?;
+        let k = message.state.lowrank_k().context("read lowrank rank")?;
+        if k != codec.k() {
+            bail!(
+                "lowrank frame rank {k} does not match loaded codec rank {}",
+                codec.k()
+            );
+        }
+        let multiplier = skippy_protocol::binary::activation_payload_multiplier_from_state_flags(
+            message.state.flags,
+        );
+        let token_count = (message.token_count.max(0) as usize)
+            .checked_mul(multiplier)
+            .context("lowrank token count overflow")?;
+        let decoded = codec
+            .decode(&message.activation, token_count)
+            .context("decode lowrank activation payload")?;
+        message.activation = Vec::new();
+        decoded
+    } else {
+        message
+            .take_activation_f32_payload(activation_width)
+            .context("decode wire activation payload")?
+    };
     let (layer_start, layer_end) = upstream_layer_range(config, topology, message);
     Ok(Some(ActivationFrame {
         desc: ActivationDesc {

--- a/crates/skippy-server/src/cli.rs
+++ b/crates/skippy-server/src/cli.rs
@@ -17,6 +17,28 @@ pub enum Command {
     #[command(name = "serve-openai")]
     ServeOpenAi(ServeOpenAiArgs),
     ExampleConfig,
+    /// Fit a low-rank boundary codec from captured boundary activations.
+    FitBoundaryCodec(FitBoundaryCodecArgs),
+}
+
+#[derive(Parser)]
+pub struct FitBoundaryCodecArgs {
+    /// Raw little-endian f32 file of concatenated activation rows, as written
+    /// by SKIPPY_CAPTURE_BOUNDARY_ACTIVATIONS.
+    #[arg(long)]
+    pub input: PathBuf,
+    /// Activation width (the split boundary's embedding dimension).
+    #[arg(long)]
+    pub width: usize,
+    /// Codec rank: coefficients kept per token.
+    #[arg(long)]
+    pub rank: usize,
+    /// Orthogonal-iteration refinement passes.
+    #[arg(long, default_value_t = 8)]
+    pub iterations: usize,
+    /// Output .skbc codec file.
+    #[arg(long)]
+    pub output: PathBuf,
 }
 
 #[derive(Parser)]
@@ -96,6 +118,11 @@ pub struct ServeBinaryArgs {
         help = "Probability in [0, 1] that a downstream message is hit by --downstream-wire-stall-ms."
     )]
     pub downstream_wire_stall_p: f64,
+    #[arg(
+        long,
+        help = "Path to a fitted boundary codec (.skbc) enabling the lowrank activation wire dtype."
+    )]
+    pub boundary_codec: Option<PathBuf>,
     #[arg(long, default_value_t = 60)]
     pub downstream_connect_timeout_secs: u64,
     #[arg(

--- a/crates/skippy-server/src/frontend/tests/multimodal.rs
+++ b/crates/skippy-server/src/frontend/tests/multimodal.rs
@@ -349,6 +349,7 @@ async fn real_multimodal_split_smoke_when_fixture_is_set() -> Result<()> {
             downstream_wire_condition: WireCondition::new(0.0, None)?,
             downstream_connect_timeout_secs: 5,
             native_mtp_enabled: true,
+            boundary_codec: None,
             openai: None,
         });
     let ready = connect_endpoint_ready(&stage1_addr.to_string(), 120);

--- a/crates/skippy-server/src/main.rs
+++ b/crates/skippy-server/src/main.rs
@@ -16,5 +16,8 @@ async fn main() -> Result<()> {
             println!("{}", serde_json::to_string_pretty(&example_config())?);
             Ok(())
         }
+        Command::FitBoundaryCodec(args) => {
+            skippy_server::binary_transport::boundary_codec::fit_boundary_codec_cli(&args)
+        }
     }
 }

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -848,8 +848,8 @@ cached and a worker does not:
   to open `skippy-stage/2`, then Skippy artifact-transfer stream 0x03, to
   fetch only its assigned package files before the normal HF fallback path.
 - Current/released mixed mesh: a released coordinator without advertised
-  `skippy-stage/2` `artifact-transfer`, `stage-generation-5`, and
-  `direct-prediction-return` support must not be selected for a generation-5
+  `skippy-stage/2` `artifact-transfer`, `stage-generation-6`, and
+  `direct-prediction-return` support must not be selected for a generation-6
   split topology; the worker must fall back to local/HF package resolution.
 - Default public-mesh safety: with `MESH_LLM_ARTIFACT_TRANSFER` unset, the node
   must advertise no `artifact-transfer` feature, reject inbound artifact

--- a/docs/skippy/DATA_FLOW.md
+++ b/docs/skippy/DATA_FLOW.md
@@ -40,11 +40,11 @@ activation links and then crossed three reply links before stage 0 could emit
 the token. On a topology with a fixed 10 ms delay per inter-stage hop, the reply
 chain alone makes the hot path six hops, or about 60 ms before compute.
 
-## Generation 5 Direct Prediction Return and Verify Retirement
+## Generation 6 Direct Prediction Return and Verify Retirement
 
-Stage protocol generation 5 is a compatibility-breaking change. A peer is stage
+Stage protocol generation 6 is a compatibility-breaking change. A peer is stage
 compatible only when it advertises both `skippy-stage/2` and
-`stage-generation-5`. Prediction-bearing messages return
+`stage-generation-6`. Prediction-bearing messages return
 directly from the final/readout stage to the driver-facing stage. Intermediate stages
 continue to forward activations and may handle cold-path control acknowledgments,
 but they are not part of the decode-token prediction return path.

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4245,15 +4245,15 @@
   ],
   "crates/skippy-server/src/binary_transport/boundary_codec.rs": [
     {
-      "line": 323,
+      "line": 328,
       "macro_name": "eprintln!"
     },
     {
-      "line": 329,
+      "line": 334,
       "macro_name": "eprintln!"
     },
     {
-      "line": 363,
+      "line": 368,
       "macro_name": "eprintln!"
     }
   ],

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4205,27 +4205,27 @@
   ],
   "crates/skippy-server/src/binary_transport/binary_messaging.rs": [
     {
-      "line": 301,
+      "line": 302,
       "macro_name": "eprintln!"
     },
     {
-      "line": 311,
+      "line": 312,
       "macro_name": "println!"
     },
     {
-      "line": 334,
+      "line": 335,
       "macro_name": "eprintln!"
     },
     {
-      "line": 354,
+      "line": 356,
       "macro_name": "eprintln!"
     },
     {
-      "line": 362,
+      "line": 364,
       "macro_name": "eprintln!"
     },
     {
-      "line": 416,
+      "line": 419,
       "macro_name": "eprintln!"
     }
   ],
@@ -4240,6 +4240,20 @@
     },
     {
       "line": 78,
+      "macro_name": "eprintln!"
+    }
+  ],
+  "crates/skippy-server/src/binary_transport/boundary_codec.rs": [
+    {
+      "line": 323,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 329,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 363,
       "macro_name": "eprintln!"
     }
   ],


### PR DESCRIPTION
# Draft: learned low-rank activation codec for split boundaries

A per-boundary PCA codec targeting ~8x vs f16 on the inter-stage wire
(4096-wide f16 = 8 KB/token -> rank-512 int8 ~ 0.5 KB, rank-1024 ~ 1 KB):

- `WireActivationDType::Lowrank`: the rank rides in the high bits of the
  state header's reserved field, so frame sizes stay derivable at read time
  and existing dtypes are byte-identical.
- `BoundaryCodec`: orthogonal-iteration PCA (deterministic seed), per-token
  int8 quantized coefficients, `.skbc` file format with dimension sanity
  bounds. Fit offline with the new `fit-boundary-codec` subcommand from
  activations captured via `SKIPPY_CAPTURE_BOUNDARY_ACTIVATIONS`.
- `serve-binary --boundary-codec` + `--activation-wire-dtype lowrank`
  enable it on the standalone stage path; embedded stages can load a codec
  via `MESH_LLM_BOUNDARY_CODEC`.

**Draft because**: protocol + tooling are complete and unit-tested
(roundtrip error bounds on synthetic low-rank data), but there are no
real-model quality gates yet (perplexity delta, suffix accept-rate delta),
no package-manifest shipping of codec tensors, and `auto` dtype resolution
deliberately does not select lowrank until the embedded forward path is
wired. Codec identity is keyed informally for now — package-hash keying is
the planned follow-up.
