### PR TITLE
skippy: address #1402 review follow-up (dead comparison + Inkling test coverage)

### DIFF
--- a/third_party/llama.cpp/patches/0010-Add-Skippy-tokenization-and-stage-chat.patch
+++ b/third_party/llama.cpp/patches/0010-Add-Skippy-tokenization-and-stage-chat.patch
@@ -1482,7 +1482,7 @@ index c4670da85..e1790ecce 100644
                  "</tool_call>\n";
  
              bool got_runtime_error = false;
-@@ -6815,6 +7003,63 @@ static void test_template_generation_prompt() {
+@@ -6815,6 +7003,65 @@ static void test_template_generation_prompt() {
          check(tmpls, continuation_content(),   "<|im_start|>assistant\n<think>\nI'm thinking\n</think>\n\nHello, ");
          check(tmpls, continuation_reasoning(), "<|im_start|>assistant\n<think>\nI'm");
      }
@@ -1542,11 +1542,13 @@ index c4670da85..e1790ecce 100644
 +        assert_contains(qwen, "<think>\n\n</think>\n\n");
 +        const auto gpt_oss = render_disabled("models/templates/openai-gpt-oss-120b.jinja");
 +        assert_contains(gpt_oss, "Reasoning: 0");
++        const auto inkling = render_disabled("models/templates/Inkling.jinja");
++        assert_contains(inkling, "Thinking effort level: 0");
 +    }
  }
  
  // Test the developer role to system workaround with a simple mock template
-@@ -7157,6 +7402,7 @@ static void test_msg_diffs_compute() {
+@@ -7157,6 +7404,7 @@ static void test_msg_diffs_compute() {
  int main(int argc, char ** argv) {
      bool detailed_debug    = false;
      bool only_run_filtered = false;
@@ -1554,7 +1556,7 @@ index c4670da85..e1790ecce 100644
  
      // Check for --template and --detailed flags
      for (int i = 1; i < argc; i++) {
-@@ -7174,9 +7420,19 @@ int main(int argc, char ** argv) {
+@@ -7174,9 +7422,19 @@ int main(int argc, char ** argv) {
              g_force_reconstruction_test = true;
              only_run_filtered          = true;
          }

--- a/third_party/llama.cpp/patches/0012-skippy-retain-and-execute-final-stage-MTP-tensors.patch
+++ b/third_party/llama.cpp/patches/0012-skippy-retain-and-execute-final-stage-MTP-tensors.patch
@@ -114,9 +114,9 @@ index dd21a313f..4a2c64239 100644
      }
  
      llama_model_params model_params = llama_model_default_params();
-+    // The explicitly external model backs an LLAMA_CONTEXT_TYPE_MTP draft
-+    // context, so retain its optional NextN/MTP tensors.
-+    model_params.load_mtp = config->mtp_source == SKIPPY_MTP_SOURCE_EXTERNAL;
++    // The guard above already established an external MTP source, so this model
++    // backs an LLAMA_CONTEXT_TYPE_MTP draft context and must retain MTP tensors.
++    model_params.load_mtp = true;
      if (config != nullptr) {
          model_params.n_gpu_layers = config->n_gpu_layers;
          skippy_apply_model_load_memory_config(config, model_params);


### PR DESCRIPTION
Follow-up to the review of #1402 (merged as the 15-patch Skippy queue). I triaged all seven review findings against the **merged** state; only two are live and fixed here. The rest are documented as no-change with rationale.

## Fixed

**F5 — dead comparison (patch 0012, `skippy_model_attach_mtp_draft_model`)**
`model_params.load_mtp = config->mtp_source == SKIPPY_MTP_SOURCE_EXTERNAL` is tautological: the guard added earlier in the function already returns `INVALID_ARGUMENT` unless `config != nullptr && mtp_source == EXTERNAL`. Assign `true` directly with a comment explaining why.

**F1 — Inkling thinking-disabled test coverage (patch 0010, `test-chat.cpp`)**
The `render_disabled` test covered Qwen and gpt-oss but not Inkling. Added an Inkling case asserting a thinking-disabled render yields `Thinking effort level: 0`. Note: the feared *max-effort fallthrough* does **not** occur — the Inkling template float-coerces a numeric `0` (`reasoning_effort_text` → `eff | float` → `0.0`), so this locks in correct behaviour rather than fixing a live miscompute.

## Triaged as no-change (with rationale)

- **F2** (attach hard-errors on default config): not a bug — both Rust callers pass `MtpSource::External` (`draft_runner.rs:164`, `mtp_attach.rs`). The guard is correct.
- **F3** (`llama_kv_cache_cell_runs` sorted-input assumption): the review is mistaken. The function is **order-preserving** — the consumer advances the payload pointer per run while reading from `run.first`, so any `cell_idxs` permutation is handled correctly. The export path legitimately produces unsorted indices (token-position → cell-index after cache fragmentation), so a `GGML_ASSERT(std::is_sorted(...))` would **false-fire and crash on valid input**. Declined.
- **F4** (Metal `lightning_indexer` link risk): resolved — the pipeline getter is **defined in-tree** at `ggml/src/ggml-metal/ggml-metal-device.cpp` (via patch 0002), not relying on upstream.
- **F6** (DeepSeek4 in `llm_arch_supports_rs_rollback`): DeepSeek4 *is* in the switch (`llama-arch.cpp`). Whether it *should* support bounded RS rollback is a domain decision (the review itself flagged it unverifiable in CI); left for a deliberate call rather than a speculative revert.
- **F7** (0013 subject/scope mismatch): cosmetic commit-message hygiene on already-merged history.

## Validation

Full patch queue re-applies cleanly via `scripts/prepare-llama.sh pinned` (all 15 patches `git am` onto upstream `3af988f`), and the edits are confirmed present in the applied source. I could not run `test-chat` locally (this box's C++ toolchain is missing libc++ headers — `#include <array>` fails); the new Inkling assertion mirrors the existing `off → "Thinking effort level: 0"` assertion in the same test, which the template provably renders. CI will build and run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added tokenization, detokenization, end-of-generation detection, and native model access.
  * Improved chat template handling and response parsing, including specialized formats and reasoning fields.
  * Added support for flexible tool-argument ordering with validation for missing or duplicate required arguments.
  * Added configurable handling for integrated, external, or disabled draft-model tensors.

* **Bug Fixes**
  * Preserved distinctions between omitted, null, and empty message content.
  * Improved template fallback detection and response-trigger handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->