### PR TITLE
fix(build): link libvendor-hash.a and test Rust on llama.cpp pin bumps

### DIFF
--- a/.github/actions/prepare-static-abi-input/action.yml
+++ b/.github/actions/prepare-static-abi-input/action.yml
@@ -93,6 +93,7 @@ runs:
           "ggml/src/libggml.a"
           "ggml/src/libggml-base.a"
           "tools/mtmd/libmtmd.a"
+          "vendor/hash/libvendor-hash.a"
         )
         test -s "$build_stamp"
         test -s "$patched_sha_file"

--- a/crates/skippy-ffi/build.rs
+++ b/crates/skippy-ffi/build.rs
@@ -56,6 +56,7 @@ fn main() {
 
     let search_dirs = [
         build_dir.join("tools/mtmd"),
+        build_dir.join("vendor/hash"),
         build_dir.join("common"),
         build_dir.join("src"),
         build_dir.join("ggml/src"),
@@ -78,6 +79,10 @@ fn main() {
     for (unix_archive, msvc_archive) in [
         ("src/libllama.a", "src/llama.lib"),
         ("tools/mtmd/libmtmd.a", "tools/mtmd/mtmd.lib"),
+        (
+            "vendor/hash/libvendor-hash.a",
+            "vendor/hash/vendor-hash.lib",
+        ),
         ("common/libllama-common.a", "common/llama-common.lib"),
         (
             "common/libllama-common-base.a",
@@ -122,6 +127,16 @@ fn main() {
 
     if static_archive_exists(&build_dir, "tools/mtmd/libmtmd.a", "tools/mtmd/mtmd.lib") {
         println!("cargo:rustc-link-lib=static=mtmd");
+        // Upstream links mtmd against vendor::hash PRIVATE, so the archive is
+        // not propagated to consumers. It must follow libmtmd.a on the link
+        // line or hash_sha256_hex stays undefined.
+        if static_archive_exists(
+            &build_dir,
+            "vendor/hash/libvendor-hash.a",
+            "vendor/hash/vendor-hash.lib",
+        ) {
+            println!("cargo:rustc-link-lib=static=vendor-hash");
+        }
     }
     println!("cargo:rustc-link-lib=static=llama-common");
     println!("cargo:rustc-link-lib=static=llama-common-base");

--- a/crates/skippy-ffi/build.rs
+++ b/crates/skippy-ffi/build.rs
@@ -129,14 +129,23 @@ fn main() {
         println!("cargo:rustc-link-lib=static=mtmd");
         // Upstream links mtmd against vendor::hash PRIVATE, so the archive is
         // not propagated to consumers. It must follow libmtmd.a on the link
-        // line or hash_sha256_hex stays undefined.
-        if static_archive_exists(
+        // line or hash_sha256_hex stays undefined. mtmd without vendor-hash is
+        // not a degraded configuration to link anyway -- it is a guaranteed
+        // undefined symbol, so fail here with the cause rather than emitting a
+        // link line we know cannot resolve.
+        if !static_archive_exists(
             &build_dir,
             "vendor/hash/libvendor-hash.a",
             "vendor/hash/vendor-hash.lib",
         ) {
-            println!("cargo:rustc-link-lib=static=vendor-hash");
+            panic!(
+                "libmtmd is present in {} but vendor/hash/libvendor-hash.a is not; \
+                 mtmd requires vendor::hash for hash_sha256_hex. The llama.cpp \
+                 build or the restored static ABI artifact is incomplete.",
+                build_dir.display()
+            );
         }
+        println!("cargo:rustc-link-lib=static=vendor-hash");
     }
     println!("cargo:rustc-link-lib=static=llama-common");
     println!("cargo:rustc-link-lib=static=llama-common-base");

--- a/scripts/affected-crates.sh
+++ b/scripts/affected-crates.sh
@@ -168,10 +168,16 @@ main() {
       continue
     fi
 
-    # Escalation patterns. Native llama.cpp inputs are routed by
+    # Escalation patterns. Most native llama.cpp inputs are routed by
     # .github/actions/compute-changes as backend builds, not as all-Rust crate
-    # test fanout.
-    if [[ "$file" =~ ^Cargo\.lock$ ]] || \
+    # test fanout. The upstream pin and the patch queue are the exception: they
+    # can change which archives the native build emits, and the static link
+    # line in crates/skippy-ffi/build.rs is hand-maintained, so only the Rust
+    # test batches can prove the link still closes. Advancing the pin without
+    # this escalation is how an undefined hash_sha256_hex reached main.
+    if [[ "$file" =~ ^third_party/llama\.cpp/upstream\.txt$ ]] || \
+       [[ "$file" =~ ^third_party/llama\.cpp/patches/ ]] || \
+       [[ "$file" =~ ^Cargo\.lock$ ]] || \
        [[ "$file" =~ ^Cargo\.toml$ ]] || \
             [[ "$file" =~ ^scripts/(build-llama|prepare-llama|build-linux|build-linux-rocm|build-mac|build-windows|skippy-ci-smoke|ci-install-native-runtime|ci-prepare-native-runtime|ci-smoke-test|ci-compat-smoke|ci-client-auto-test|ci-two-node-client-serving-smoke|ci-two-node-split-smoke)\. ]] || \
        [[ "$file" =~ ^\.github/cache-version\.txt$ ]] || \

--- a/scripts/build-llama.sh
+++ b/scripts/build-llama.sh
@@ -88,7 +88,8 @@ required_static_archives() {
     "$LLAMA_BUILD_DIR/common/libllama-common-base.a" \
     "$LLAMA_BUILD_DIR/ggml/src/libggml.a" \
     "$LLAMA_BUILD_DIR/ggml/src/libggml-base.a" \
-    "$LLAMA_BUILD_DIR/tools/mtmd/libmtmd.a"
+    "$LLAMA_BUILD_DIR/tools/mtmd/libmtmd.a" \
+    "$LLAMA_BUILD_DIR/vendor/hash/libvendor-hash.a"
 }
 
 required_static_archives_exist() {

--- a/scripts/restore-static-abi-input.sh
+++ b/scripts/restore-static-abi-input.sh
@@ -87,6 +87,7 @@ required_archives=(
     "$restored_dir/ggml/src/libggml.a"
     "$restored_dir/ggml/src/libggml-base.a"
     "$restored_dir/tools/mtmd/libmtmd.a"
+    "$restored_dir/vendor/hash/libvendor-hash.a"
 )
 test -s "$manifest"
 test -s "$build_stamp"

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -1198,6 +1198,7 @@ class CiArtifactActionTests(unittest.TestCase):
             "libggml.a",
             "libggml-base.a",
             "libggml-cpu.a",
+            "libvendor-hash.a",
         ):
             self.assertIn(archive, producer_action)
         self.assertIn(

--- a/scripts/tests/test_static_abi_artifacts.py
+++ b/scripts/tests/test_static_abi_artifacts.py
@@ -70,6 +70,7 @@ class StaticAbiArtifactTests(unittest.TestCase):
             "libggml.a",
             "libggml-base.a",
             "libggml-cpu.a",
+            "libvendor-hash.a",
         ):
             self.assertIn(archive, build_script)
         self.assertIn("--require-prebuilt-llama", package_script)
@@ -131,6 +132,7 @@ class StaticAbiArtifactTests(unittest.TestCase):
             "ggml/src/libggml-base.a",
             "ggml/src/ggml-cpu/libggml-cpu.a",
             "tools/mtmd/libmtmd.a",
+            "vendor/hash/libvendor-hash.a",
         ):
             if relative == omit_archive:
                 continue

--- a/scripts/tests/test_static_abi_artifacts.py
+++ b/scripts/tests/test_static_abi_artifacts.py
@@ -296,19 +296,26 @@ class StaticAbiArtifactTests(unittest.TestCase):
             self.assertIn("link-mode mismatch", result.stderr)
 
     def test_restore_rejects_incomplete_link_closure(self) -> None:
-        with tempfile.TemporaryDirectory() as directory:
-            root = Path(directory)
-            download = self.write_artifact(
-                root,
-                omit_archive="common/libllama-common-base.a",
-            )
+        # Every required archive is load-bearing for the link, so omitting any
+        # one of them must fail the restore. vendor-hash is listed explicitly:
+        # it was added after the others and only the Rust link line consumes
+        # it, so a silent drop reappears as an undefined hash_sha256_hex far
+        # from here.
+        for omitted in (
+            "common/libllama-common-base.a",
+            "vendor/hash/libvendor-hash.a",
+        ):
+            with self.subTest(omitted=omitted):
+                with tempfile.TemporaryDirectory() as directory:
+                    root = Path(directory)
+                    download = self.write_artifact(root, omit_archive=omitted)
 
-            result = self.restore(
-                download,
-                root / "restored" / "build-stage-abi-static",
-            )
+                    result = self.restore(
+                        download,
+                        root / "restored" / "build-stage-abi-static",
+                    )
 
-            self.assertNotEqual(result.returncode, 0)
+                    self.assertNotEqual(result.returncode, 0)
 
     def test_restore_rejects_toolchain_epoch_mismatch(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/sdk/swift/Sources/MeshLLM/Generated/mesh_ffi.swift
+++ b/sdk/swift/Sources/MeshLLM/Generated/mesh_ffi.swift
@@ -4704,151 +4704,151 @@ private let initializationResult: InitializationResult = {
     if bindings_contract_version != scaffolding_contract_version {
         return InitializationResult.contractVersionMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_create_auto_client() != 12517) {
+    if (uniffi_meshllm_ffi_checksum_func_create_auto_client() != 16973) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_create_auto_node() != 33432) {
+    if (uniffi_meshllm_ffi_checksum_func_create_auto_node() != 45845) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_create_client() != 53219) {
+    if (uniffi_meshllm_ffi_checksum_func_create_client() != 49213) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_create_node() != 11855) {
+    if (uniffi_meshllm_ffi_checksum_func_create_node() != 26976) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_current_mesh_version() != 42923) {
+    if (uniffi_meshllm_ffi_checksum_func_current_mesh_version() != 33957) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_current_skippy_abi_version() != 11242) {
+    if (uniffi_meshllm_ffi_checksum_func_current_skippy_abi_version() != 21058) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_discover_public_meshes() != 52961) {
+    if (uniffi_meshllm_ffi_checksum_func_discover_public_meshes() != 33302) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_generate_owner_keypair_hex() != 63994) {
+    if (uniffi_meshllm_ffi_checksum_func_generate_owner_keypair_hex() != 2785) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_install_native_runtime() != 25162) {
+    if (uniffi_meshllm_ffi_checksum_func_install_native_runtime() != 2951) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_installed_native_runtimes() != 21851) {
+    if (uniffi_meshllm_ffi_checksum_func_installed_native_runtimes() != 28322) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_prune_native_runtimes() != 18336) {
+    if (uniffi_meshllm_ffi_checksum_func_prune_native_runtimes() != 53652) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_func_remove_native_runtime() != 48639) {
+    if (uniffi_meshllm_ffi_checksum_func_remove_native_runtime() != 19262) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_consolehandle_stop() != 13931) {
+    if (uniffi_meshllm_ffi_checksum_method_consolehandle_stop() != 31371) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_consolehandle_url() != 15682) {
+    if (uniffi_meshllm_ffi_checksum_method_consolehandle_url() != 55833) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_cancel() != 60947) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_cancel() != 22097) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_chat() != 50040) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_chat() != 13614) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_inference_list_models() != 8792) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_inference_list_models() != 16388) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_reconnect() != 10889) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_reconnect() != 818) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_responses() != 28930) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_responses() != 28958) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_start() != 44515) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_start() != 65171) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_status() != 41037) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_status() != 26002) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_stop() != 1554) {
+    if (uniffi_meshllm_ffi_checksum_method_meshclienthandle_stop() != 47420) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_cancel() != 56505) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_cancel() != 310) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_chat() != 37264) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_chat() != 42393) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_cleanup_models() != 58526) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_cleanup_models() != 63183) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_delete_model() != 51823) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_delete_model() != 14553) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_download_model() != 26002) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_download_model() != 38255) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_inference_list_models() != 32433) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_inference_list_models() != 18715) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_installed_models() != 28122) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_installed_models() != 60028) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_load_serving_model() != 39783) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_load_serving_model() != 37197) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_model_cache_status() != 29059) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_model_cache_status() != 36857) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_prune_derived_cache() != 45852) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_prune_derived_cache() != 31455) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_recommended_models() != 28368) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_recommended_models() != 46303) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_reconnect() != 64634) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_reconnect() != 53825) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_responses() != 43033) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_responses() != 49381) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_search_models() != 26120) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_search_models() != 45752) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_served_models() != 18883) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_served_models() != 1478) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_serving_status() != 35990) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_serving_status() != 34534) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_set_device_policy() != 30969) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_set_device_policy() != 42711) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_show_model() != 41215) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_show_model() != 59120) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_start() != 22769) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_start() != 37489) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_start_console() != 35615) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_start_console() != 62311) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_status() != 44385) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_status() != 55890) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_stop() != 24422) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_stop() != 57983) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_instance() != 65198) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_instance() != 41330) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_model() != 48491) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_model() != 61320) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_model_by_id() != 21862) {
+    if (uniffi_meshllm_ffi_checksum_method_meshnodehandle_unload_serving_model_by_id() != 13409) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_eventlistener_on_event() != 56769) {
+    if (uniffi_meshllm_ffi_checksum_method_eventlistener_on_event() != 9933) {
         return InitializationResult.apiChecksumMismatch
     }
-    if (uniffi_meshllm_ffi_checksum_method_nativeruntimeprogresslistener_on_progress() != 1578) {
+    if (uniffi_meshllm_ffi_checksum_method_nativeruntimeprogresslistener_on_progress() != 289) {
         return InitializationResult.apiChecksumMismatch
     }
 


### PR DESCRIPTION
## What is broken

`main` has not built since #1402 (`33185235`, 2026-08-22 20:47Z) advanced the llama.cpp pin `030ebb55` -> `3af988fa`. Every commit since fails `Rust tests (batch-2)` and `(batch-3)`:

```
rust-lld: error: undefined symbol: hash_sha256_hex[abi:cxx11](void const*, unsigned long)
error: could not compile `skippy-runtime` (lib test)
error: could not compile `skippy-server` (lib test)
```

Upstream moved SHA256 into a new static library `vendor::hash` (`vendor/CMakeLists.txt` -> `vendor/hash`) and links it into `mtmd` as **PRIVATE** (`tools/mtmd/CMakeLists.txt:82`). PRIVATE means the archive is not propagated to consumers. Our static link line is a hand-maintained list, so `libmtmd.a`'s call to `hash_sha256_hex` (`tools/mtmd/mtmd-helper.cpp:368`) has nothing to resolve against.

The C++ build and the inference smoke tests still pass — the symbol resolves inside CMake's own link. Only the Rust link line is short an archive.

## The fix

Add `vendor/hash/libvendor-hash.a` to all four places that enumerate static ABI archives:

- `scripts/build-llama.sh` (`required_static_archives`)
- `crates/skippy-ffi/build.rs` (search dir, rerun-if-changed, and `rustc-link-lib` emitted **after** `mtmd` so archive order resolves)
- `scripts/restore-static-abi-input.sh`
- `.github/actions/prepare-static-abi-input/action.yml`

plus the two contract tests that assert on those lists.

Of the five vendor libraries upstream added, `hash` is the only one producing an archive — `miniaudio`, `stb`, `sheredom`, `nlohmann` are all `add_library(... INTERFACE)`.

## Why CI did not catch it

`scripts/affected-crates.sh:171-181` escalates to a full-workspace test run for `Cargo.lock`, `Cargo.toml`, `rust-toolchain`, `.github/cache-version.txt` and the llama build scripts. It does **not** escalate on the llama.cpp pin or patch queue — there is a comment saying those are routed as backend builds instead.

#1402 changed 26 files, **all** under `third_party/llama.cpp/`. So it built the native libraries, ran the smoke tests green, and reported `Rust tests: skipped`. The one input that can change which archives the native build emits is the one input excluded from the only job that exercises the link line.

This also explains why a PR can be green and main red at the same commit content: a PR run tests change-scoped packages, main tests all of them. PR #1364's head ran 8 packages (not including `skippy-runtime`); the main run of the same tree ran 36 (including it).

Fix: escalate on `third_party/llama.cpp/upstream.txt` and `third_party/llama.cpp/patches/`.

## Verification

- `python3 -m unittest discover -s scripts/tests` — the two touched suites (`test_static_abi_artifacts`, `test_ci_artifact_actions`, 55 tests) pass. Remaining failures in `test_plan_ci` and the `yaml`-importing modules are **pre-existing and environment-local**: identical set with this diff stashed on the same worktree, and `PyYAML` is absent locally.
- Escalation verified by differential, not by reading: `printf 'third_party/llama.cpp/upstream.txt\n' | bash scripts/affected-crates.sh --stdin` now returns `all_rust=true` with 61 crates including `skippy-runtime`; the same input against `git show origin/main:scripts/affected-crates.sh` falls through to the dependency-graph path.
- `rustfmt --edition 2024 --check crates/skippy-ffi/build.rs` clean; `bash -n` clean on both scripts.
- **Not locally link-verified.** I have no CUDA/Linux static ABI build here — CI's `Rust tests` batches on this PR are the real proof, and they will now run because the escalation covers this PR's own changes to `build-llama.sh`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved static builds by ensuring the vendor hash library is included in native linking and ABI archives.
  * Builds and artifact restoration now detect missing vendor hash archives earlier, reducing incomplete-package failures.

* **Tests**
  * Expanded static ABI artifact validation to cover the vendor hash library and incomplete archive sets.
  * Updated change detection so relevant native source and patch updates trigger comprehensive Rust validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

## Second, independent main breakage also fixed here: stale Swift UniFFI checksums

`macOS / Swift SDK input` also fails on `main`, at the step `Verify committed Swift binding source is current`. It is unrelated to archives, but `main` is not green until both are fixed, so it is in this PR rather than a follow-up.

Bisected by check-run history down `main`: green through `65035345a`, failing from `277de2adf` (#1396, "refactor: complete codebase audit / cleanup") onward. That PR moved every `uniffi::export` out of `crates/mesh-llm-ffi/src/lib.rs` and `crates/skippy-ffi/src/lib.rs` into submodules. UniFFI hashes `module_path!()` into each API checksum, so all 49 committed checksums in `sdk/swift/Sources/MeshLLM/Generated/mesh_ffi.swift` went stale and the `git diff --exit-code` gate has failed since 2026-08-21.

Regenerated by running the repo's own `sdk/swift/scripts/build-host-macos-xcframework.sh` end to end on an arm64 Mac — a real Metal llama.cpp build, a real `cargo build --release -p mesh-llm-ffi`, and the script's own `otool -tvV` checksum sync. Not hand-edited and not taken from bindgen alone: running `generate-swift-bindings.sh` on its own produces *different* values (e.g. `create_auto_client` 12117), because the authoritative checksums come from the compiled staticlib. The committed values match what CI computed (`create_auto_client` 12517 -> **16973**, identical to the diff in the failing job log), and re-running the sync against the regenerated file is a no-op, which is exactly what the gate checks.

Side benefit: that full macOS build also exercised the `vendor-hash` change on Metal/macOS, not just Linux.
