### PR TITLE
spec(openai-frontend): OpenAI exchange lifecycle hooks for out-of-process plugins (#1331 reference)

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -6,9 +6,24 @@ use crate::network::openai::auto_route;
 use crate::network::openai::automatic;
 use crate::network::openai::transport as proxy;
 use crate::network::router;
+use crate::plugin::openai_exchange::{
+    OpenAiExchangeChannel, OpenAiExchangeDispatchPath, OpenAiExchangeEnvelope,
+};
 use mesh_llm_events::audit::{audit_events, emit_audit};
 use mesh_llm_events::{OutputEvent, emit_event};
 use mesh_mixture_of_agents as moa;
+
+/// The status code an out-of-process plugin sees for path 2's terminal
+/// event, best-effort from [`proxy::RouteDispatchOutcome`] — `None` when the
+/// outcome carries no HTTP status at all (a dropped/failed connection).
+fn plugin_route_status(outcome: &proxy::RouteDispatchOutcome) -> Option<u16> {
+    match *outcome {
+        proxy::RouteDispatchOutcome::Responded(status) => Some(status),
+        proxy::RouteDispatchOutcome::RespondedWithUsage { status_code, .. } => Some(status_code),
+        proxy::RouteDispatchOutcome::FailedWithStatus { status_code, .. } => Some(status_code),
+        proxy::RouteDispatchOutcome::Failed(_) | proxy::RouteDispatchOutcome::Dropped(_) => None,
+    }
+}
 
 enum AutoRouteResolution {
     Continue {
@@ -583,6 +598,17 @@ async fn try_route_plugin_model(
         .await
     {
         Ok(Some(endpoint)) => {
+            // Path 2's own "effective request" moment: the plugin/endpoint
+            // is resolved and dispatch is about to happen. There is no typed
+            // `ChatCompletionRequest` on this path (see the #1331 design
+            // note), so the envelope carries only the model — the same
+            // narrow route fact path 1's `ChatExchangeRoute` carries.
+            plugin_manager
+                .publish(&OpenAiExchangeEnvelope::effective(
+                    OpenAiExchangeDispatchPath::RawProxy,
+                    model_name,
+                ))
+                .await;
             let outcome = proxy::route_http_endpoint_request(
                 ctx.node,
                 Some(model_name),
@@ -596,7 +622,7 @@ async fn try_route_plugin_model(
                 route_observer,
             )
             .await;
-            if !outcome.response_written()
+            let final_outcome = if !outcome.response_written()
                 && !matches!(outcome, proxy::RouteDispatchOutcome::Dropped(_))
             {
                 response_outcome(
@@ -610,7 +636,19 @@ async fn try_route_plugin_model(
                 )
             } else {
                 outcome
-            }
+            };
+            plugin_manager
+                .publish(&OpenAiExchangeEnvelope::terminal(
+                    OpenAiExchangeDispatchPath::RawProxy,
+                    model_name,
+                    plugin_route_status(&final_outcome),
+                    // No X-Capsule-Id marker on this path: it never runs
+                    // through `openai-frontend`'s `OpenAiHookPolicy`, the
+                    // only place a marker is minted (see the design note).
+                    None,
+                ))
+                .await;
+            final_outcome
         }
         Ok(None) => {
             route_observer.route_selected_with_metadata(

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -602,9 +602,14 @@ async fn try_route_plugin_model(
             // is resolved and dispatch is about to happen. There is no typed
             // `ChatCompletionRequest` on this path (see the #1331 design
             // note), so the envelope carries only the model — the same
-            // narrow route fact path 1's `ChatExchangeRoute` carries.
+            // narrow route fact path 1's `ChatExchangeRoute` carries. Mint
+            // the exchange id here, at admission, so it can pair this
+            // effective event with its terminal event below even when
+            // concurrent raw-proxy requests share the same model.
+            let exchange_id = uuid::Uuid::new_v4().to_string();
             plugin_manager
                 .publish(&OpenAiExchangeEnvelope::effective(
+                    exchange_id.clone(),
                     OpenAiExchangeDispatchPath::RawProxy,
                     model_name,
                 ))
@@ -639,6 +644,7 @@ async fn try_route_plugin_model(
             };
             plugin_manager
                 .publish(&OpenAiExchangeEnvelope::terminal(
+                    exchange_id,
                     OpenAiExchangeDispatchPath::RawProxy,
                     model_name,
                     plugin_route_status(&final_outcome),

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress_tests/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress_tests/tests.rs
@@ -531,6 +531,56 @@ async fn api_proxy_tokenizer_route_ignores_generation_context_budget() {
     );
 }
 
+// --- #1331 M2: path 2 (raw-proxy ingress) openai-exchange status mapping ---
+//
+// `try_route_plugin_model` itself needs a live TCP stream and a real
+// `mesh::Node` (see the `plugin_lifecycle`/`record_plugin_attempt` doubles
+// above, which exist because the whole function is not economical to invoke
+// directly in a unit test); `plugin_route_status` is the pure piece of that
+// call site's openai-exchange wiring, so it's tested directly instead.
+#[test]
+fn plugin_route_status_maps_responded_and_responded_with_usage() {
+    assert_eq!(
+        plugin_route_status(&proxy::RouteDispatchOutcome::Responded(200)),
+        Some(200)
+    );
+    assert_eq!(
+        plugin_route_status(&proxy::RouteDispatchOutcome::RespondedWithUsage {
+            status_code: 200,
+            usage: mesh_llm_events::logging::events::TokenUsage::from_counts(
+                Some(1),
+                Some(1),
+                Some(2)
+            )
+            .unwrap(),
+        }),
+        Some(200)
+    );
+}
+
+#[test]
+fn plugin_route_status_maps_failed_with_status_and_omits_statusless_outcomes() {
+    assert_eq!(
+        plugin_route_status(&proxy::RouteDispatchOutcome::FailedWithStatus {
+            status_code: 503,
+            reason: "plugin_endpoint_failed",
+        }),
+        Some(503)
+    );
+    assert_eq!(
+        plugin_route_status(&proxy::RouteDispatchOutcome::Failed(
+            "plugin_endpoint_failed"
+        )),
+        None
+    );
+    assert_eq!(
+        plugin_route_status(&proxy::RouteDispatchOutcome::Dropped(
+            "response_write_failed"
+        )),
+        None
+    );
+}
+
 #[test]
 fn plugin_route_success_records_one_attempt_and_one_terminal_outcome() {
     let (service, mut attachment) = plugin_lifecycle();

--- a/crates/mesh-llm-host-runtime/src/plugin/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/mod.rs
@@ -1205,12 +1205,14 @@ impl PluginManager {
         channel: &str,
         content_type: &str,
         body: Vec<u8>,
+        correlation_id: &str,
     ) -> Result<()> {
+        let mut results = Vec::new();
         for (plugin_id, plugin) in &self.inner.plugins {
             if !self.plugin_declares_mesh_channel(plugin_id, channel).await {
                 continue;
             }
-            plugin
+            let result = plugin
                 .send_channel_message(proto::ChannelMessage {
                     channel: channel.to_string(),
                     source_peer_id: String::new(),
@@ -1218,12 +1220,13 @@ impl PluginManager {
                     content_type: content_type.to_string(),
                     body: body.clone(),
                     message_kind: String::new(),
-                    correlation_id: String::new(),
+                    correlation_id: correlation_id.to_string(),
                     metadata_json: String::new(),
                 })
-                .await?;
+                .await;
+            results.push((plugin_id.clone(), result));
         }
-        Ok(())
+        aggregate_broadcast_results(results)
     }
 
     pub async fn plugin_declares_mesh_channel(&self, plugin_name: &str, channel: &str) -> bool {
@@ -1440,6 +1443,30 @@ pub(crate) fn plugin_manifest_to_json(manifest: &proto::PluginManifest) -> Value
     })
 }
 
+/// Turn per-plugin delivery outcomes from [`PluginManager::broadcast_channel_message`]
+/// into one aggregate result. A single plugin rejecting or losing its channel
+/// must never suppress delivery to the other declaring plugins — this only
+/// summarizes failures after every recipient has already been attempted.
+fn aggregate_broadcast_results(results: Vec<(String, Result<()>)>) -> Result<()> {
+    let attempted = results.len();
+    let failures: Vec<String> = results
+        .into_iter()
+        .filter_map(|(plugin_id, result)| {
+            result.err().map(|error| format!("{plugin_id}: {error}"))
+        })
+        .collect();
+    if failures.is_empty() {
+        Ok(())
+    } else {
+        bail!(
+            "failed to deliver channel message to {} of {} declaring plugin(s): {}",
+            failures.len(),
+            attempted,
+            failures.join("; ")
+        )
+    }
+}
+
 fn manifest_declares_mesh_channel(manifest: &proto::PluginManifest, channel: &str) -> bool {
     manifest
         .mesh_channels
@@ -1588,6 +1615,41 @@ mod tests {
         assert!(!manifest_declares_mesh_channel(&manifest, "other.channel"));
     }
 
+    /// One declaring plugin failing must not stop delivery to the rest —
+    /// every recipient's result is collected before an aggregate error names
+    /// only the ones that actually failed. Regression for the coderbot
+    /// finding: the old loop used `?` on each send and returned on the first
+    /// failure, silently skipping later plugins in the `BTreeMap`.
+    #[test]
+    fn aggregate_broadcast_results_reports_every_failure_without_dropping_successes() {
+        let results = vec![
+            ("alpha".to_string(), Ok(())),
+            ("beta".to_string(), Err(anyhow!("channel closed"))),
+            ("gamma".to_string(), Err(anyhow!("send timed out"))),
+            ("delta".to_string(), Ok(())),
+        ];
+
+        let error = aggregate_broadcast_results(results)
+            .expect_err("some plugins failed")
+            .to_string();
+
+        assert!(error.contains("2 of 4"), "error was: {error}");
+        assert!(error.contains("beta: channel closed"), "error was: {error}");
+        assert!(error.contains("gamma: send timed out"), "error was: {error}");
+        assert!(!error.contains("alpha"), "error was: {error}");
+        assert!(!error.contains("delta"), "error was: {error}");
+    }
+
+    #[test]
+    fn aggregate_broadcast_results_is_ok_when_every_plugin_succeeds() {
+        let results = vec![
+            ("alpha".to_string(), Ok(())),
+            ("beta".to_string(), Ok(())),
+        ];
+
+        assert!(aggregate_broadcast_results(results).is_ok());
+    }
+
     #[tokio::test]
     async fn broadcast_channel_message_is_a_no_op_with_no_plugins_loaded() {
         let specs = ResolvedPlugins {
@@ -1600,7 +1662,12 @@ mod tests {
             .expect("empty plugin set starts cleanly");
 
         manager
-            .broadcast_channel_message("openai.exchange.v1", "application/json", b"{}".to_vec())
+            .broadcast_channel_message(
+                "openai.exchange.v1",
+                "application/json",
+                b"{}".to_vec(),
+                "corr-1",
+            )
             .await
             .expect("broadcasting with no plugins loaded is a no-op, not an error");
 

--- a/crates/mesh-llm-host-runtime/src/plugin/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/mod.rs
@@ -2,6 +2,7 @@ mod config;
 mod health;
 mod installed;
 pub(crate) mod mcp;
+pub mod openai_exchange;
 mod runtime;
 mod schema_validation;
 pub(crate) mod stapler;
@@ -1192,6 +1193,39 @@ impl PluginManager {
         Ok(())
     }
 
+    /// Deliver a host-originated channel message to every loaded plugin that
+    /// declares `channel` in its manifest — the mirror of
+    /// [`Self::broadcast_mesh_event`] for `PluginMeshEvent::Channel`, needed
+    /// because [`Self::dispatch_channel_message`] is addressed to one
+    /// already-known `plugin_id` (its normal caller is a mesh-relayed message
+    /// that already names its target), not a broadcast from inside the host
+    /// runtime itself.
+    pub async fn broadcast_channel_message(
+        &self,
+        channel: &str,
+        content_type: &str,
+        body: Vec<u8>,
+    ) -> Result<()> {
+        for (plugin_id, plugin) in &self.inner.plugins {
+            if !self.plugin_declares_mesh_channel(plugin_id, channel).await {
+                continue;
+            }
+            plugin
+                .send_channel_message(proto::ChannelMessage {
+                    channel: channel.to_string(),
+                    source_peer_id: String::new(),
+                    target_peer_id: plugin_id.clone(),
+                    content_type: content_type.to_string(),
+                    body: body.clone(),
+                    message_kind: String::new(),
+                    correlation_id: String::new(),
+                    metadata_json: String::new(),
+                })
+                .await?;
+        }
+        Ok(())
+    }
+
     pub async fn plugin_declares_mesh_channel(&self, plugin_name: &str, channel: &str) -> bool {
         self.manifest(plugin_name)
             .await
@@ -1536,6 +1570,41 @@ mod tests {
         let web_ui = overview.web_ui.expect("web UI overview should be present");
         assert_eq!(web_ui.pages[0].id, "home");
         assert_eq!(web_ui.config_sections[0].id, "settings");
+    }
+
+    #[test]
+    fn manifest_declares_mesh_channel_matches_exact_name_only() {
+        let manifest = proto::PluginManifest {
+            mesh_channels: vec![proto::MeshChannelManifest {
+                name: "openai.exchange.v1".into(),
+            }],
+            ..proto::PluginManifest::default()
+        };
+
+        assert!(manifest_declares_mesh_channel(
+            &manifest,
+            "openai.exchange.v1"
+        ));
+        assert!(!manifest_declares_mesh_channel(&manifest, "other.channel"));
+    }
+
+    #[tokio::test]
+    async fn broadcast_channel_message_is_a_no_op_with_no_plugins_loaded() {
+        let specs = ResolvedPlugins {
+            externals: Vec::new(),
+            inactive: Vec::new(),
+        };
+        let (mesh_tx, _mesh_rx) = mpsc::channel(1);
+        let manager = PluginManager::start(&specs, private_host_mode(), mesh_tx)
+            .await
+            .expect("empty plugin set starts cleanly");
+
+        manager
+            .broadcast_channel_message("openai.exchange.v1", "application/json", b"{}".to_vec())
+            .await
+            .expect("broadcasting with no plugins loaded is a no-op, not an error");
+
+        manager.shutdown().await;
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/plugin/openai_exchange.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/openai_exchange.rs
@@ -48,6 +48,12 @@ pub enum OpenAiExchangePhase {
 /// either being forced into the other's type.
 #[derive(Debug, Clone, PartialEq, Serialize)]
 pub struct OpenAiExchangeEnvelope {
+    /// Stable per-exchange id, minted when the dispatch path admits the
+    /// request. Shared by an exchange's `EffectiveRequest` and `Terminal`
+    /// envelopes (and mirrored into the transport `correlation_id`), so a
+    /// plugin can pair the two events for one exchange even when concurrent
+    /// requests on the same model are in flight.
+    pub exchange_id: String,
     pub dispatch_path: OpenAiExchangeDispatchPath,
     pub phase: OpenAiExchangePhase,
     pub model: String,
@@ -65,8 +71,13 @@ pub struct OpenAiExchangeEnvelope {
 }
 
 impl OpenAiExchangeEnvelope {
-    pub fn effective(dispatch_path: OpenAiExchangeDispatchPath, model: impl Into<String>) -> Self {
+    pub fn effective(
+        exchange_id: impl Into<String>,
+        dispatch_path: OpenAiExchangeDispatchPath,
+        model: impl Into<String>,
+    ) -> Self {
         Self {
+            exchange_id: exchange_id.into(),
             dispatch_path,
             phase: OpenAiExchangePhase::EffectiveRequest,
             model: model.into(),
@@ -77,12 +88,14 @@ impl OpenAiExchangeEnvelope {
     }
 
     pub fn terminal(
+        exchange_id: impl Into<String>,
         dispatch_path: OpenAiExchangeDispatchPath,
         model: impl Into<String>,
         status: Option<u16>,
         marker: Option<CapsuleMarker>,
     ) -> Self {
         Self {
+            exchange_id: exchange_id.into(),
             dispatch_path,
             phase: OpenAiExchangePhase::Terminal,
             model: model.into(),
@@ -114,7 +127,12 @@ impl OpenAiExchangeChannel for PluginManager {
             }
         };
         if let Err(error) = self
-            .broadcast_channel_message(OPENAI_EXCHANGE_CHANNEL, "application/json", body)
+            .broadcast_channel_message(
+                OPENAI_EXCHANGE_CHANNEL,
+                "application/json",
+                body,
+                &event.exchange_id,
+            )
             .await
         {
             tracing::warn!(%error, "failed to publish openai exchange event to plugins");
@@ -147,6 +165,7 @@ impl OpenAiHookPolicy for OpenAiExchangeHookBridge {
     ) {
         self.channel
             .publish(&OpenAiExchangeEnvelope::effective(
+                route.exchange_id.clone(),
                 OpenAiExchangeDispatchPath::TypedFrontend,
                 route.model.clone(),
             ))
@@ -156,6 +175,7 @@ impl OpenAiHookPolicy for OpenAiExchangeHookBridge {
     async fn on_chat_completion_terminal(
         &self,
         request: &ChatCompletionRequest,
+        exchange_id: &str,
         outcome: &ChatCompletionOutcome<'_>,
     ) {
         let (status, marker) = match outcome {
@@ -165,6 +185,7 @@ impl OpenAiHookPolicy for OpenAiExchangeHookBridge {
         };
         self.channel
             .publish(&OpenAiExchangeEnvelope::terminal(
+                exchange_id,
                 OpenAiExchangeDispatchPath::TypedFrontend,
                 request.model.clone(),
                 Some(status),
@@ -283,6 +304,8 @@ mod tests {
 
         assert_eq!(events[1].phase, OpenAiExchangePhase::Terminal);
         assert_eq!(events[1].status, Some(200));
+        assert!(!events[0].exchange_id.is_empty());
+        assert_eq!(events[0].exchange_id, events[1].exchange_id);
         let capsule_id = events[1]
             .capsule_id
             .as_deref()
@@ -330,12 +353,101 @@ mod tests {
             reason: "denied by policy",
         };
 
-        bridge.on_chat_completion_terminal(&request, &denial).await;
+        bridge
+            .on_chat_completion_terminal(&request, "exchange-1", &denial)
+            .await;
 
         let events = channel.events.lock().unwrap();
         assert_eq!(events.len(), 1);
+        assert_eq!(events[0].exchange_id, "exchange-1");
         assert_eq!(events[0].status, Some(400));
         assert!(events[0].capsule_id.is_none());
         assert!(events[0].nonce.is_none());
+    }
+
+    struct DelayedBackend {
+        delay: std::time::Duration,
+    }
+
+    #[async_trait]
+    impl OpenAiBackend for DelayedBackend {
+        async fn models(&self) -> openai_frontend::OpenAiResult<Vec<openai_frontend::ModelObject>> {
+            Ok(Vec::new())
+        }
+
+        async fn chat_completion(
+            &self,
+            request: ChatCompletionRequest,
+        ) -> openai_frontend::OpenAiResult<ChatCompletionResponse> {
+            tokio::time::sleep(self.delay).await;
+            Ok(ChatCompletionResponse::new(
+                request.model,
+                "ok",
+                Usage::new(1, 1),
+            ))
+        }
+
+        async fn chat_completion_stream(
+            &self,
+            _request: ChatCompletionRequest,
+            _context: openai_frontend::OpenAiRequestContext,
+        ) -> openai_frontend::OpenAiResult<openai_frontend::ChatCompletionStream> {
+            Ok(Box::pin(futures_util::stream::empty()))
+        }
+    }
+
+    /// Two concurrent exchanges on the same model must not be pairable by
+    /// mere arrival order — the terminal event for the exchange with the
+    /// shorter backend delay lands before the effective event of neither
+    /// exchange lines up with it positionally. Only matching `exchange_id`
+    /// correctly recovers each exchange's own effective/terminal pair.
+    #[tokio::test(start_paused = true)]
+    async fn concurrent_exchanges_on_the_same_model_pair_by_exchange_id_not_by_arrival_order() {
+        let channel = Arc::new(RecordingChannel::default());
+        let bridge = Arc::new(OpenAiExchangeHookBridge::new(channel.clone()));
+        let slow = HookedOpenAiBackend::new(
+            Arc::new(DelayedBackend {
+                delay: std::time::Duration::from_millis(50),
+            }),
+            bridge.clone(),
+        );
+        let fast = HookedOpenAiBackend::new(
+            Arc::new(DelayedBackend {
+                delay: std::time::Duration::from_millis(1),
+            }),
+            bridge,
+        );
+
+        let (slow_result, fast_result) = tokio::join!(
+            slow.chat_completion(chat_request("gpt-mesh")),
+            fast.chat_completion(chat_request("gpt-mesh")),
+        );
+        slow_result.expect("slow exchange succeeds");
+        fast_result.expect("fast exchange succeeds");
+
+        let events = channel.events.lock().unwrap();
+        assert_eq!(events.len(), 4, "two effective + two terminal events");
+        assert_eq!(events[0].phase, OpenAiExchangePhase::EffectiveRequest);
+        assert_eq!(events[1].phase, OpenAiExchangePhase::EffectiveRequest);
+        assert_eq!(events[2].phase, OpenAiExchangePhase::Terminal);
+        assert_eq!(events[3].phase, OpenAiExchangePhase::Terminal);
+        assert_ne!(
+            events[0].exchange_id, events[1].exchange_id,
+            "each exchange mints its own id"
+        );
+
+        // The fast exchange finishes first, so its terminal event (index 2)
+        // is adjacent to the slow exchange's effective event (index 0) by
+        // position — but it must still pair with the fast effective event
+        // (index 1) by id, and the slow terminal (index 3) with the slow
+        // effective (index 0).
+        assert_eq!(
+            events[2].exchange_id, events[1].exchange_id,
+            "fast exchange's terminal event pairs with its own effective event"
+        );
+        assert_eq!(
+            events[3].exchange_id, events[0].exchange_id,
+            "slow exchange's terminal event pairs with its own effective event"
+        );
     }
 }

--- a/crates/mesh-llm-host-runtime/src/plugin/openai_exchange.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/openai_exchange.rs
@@ -1,0 +1,341 @@
+//! Bridges the two real OpenAI-exchange dispatch paths (see
+//! `docs/plugins/openai-exchange-lifecycle-design-note.md`, #1331 M1/M2) to
+//! an out-of-process plugin over the existing `PluginMeshEvent::Channel`
+//! transport, so a plugin sees one unified stream regardless of which
+//! in-process Rust hook interface produced an event.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use openai_frontend::{
+    CapsuleMarker, ChatCompletionOutcome, ChatCompletionRequest, ChatCompletionResponse,
+    ChatExchangeRoute, OpenAiHookPolicy,
+};
+use serde::Serialize;
+
+use super::PluginManager;
+
+/// The single mesh channel both dispatch paths publish to.
+pub const OPENAI_EXCHANGE_CHANNEL: &str = "openai.exchange.v1";
+
+/// Which real dispatch path produced an [`OpenAiExchangeEnvelope`] — the two
+/// paths M1 found are disjoint and don't share a request type, so the
+/// envelope carries this instead of assuming one shape fits both.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OpenAiExchangeDispatchPath {
+    /// `openai-frontend`'s typed `OpenAiHookPolicy`/`HookedOpenAiBackend` seam.
+    TypedFrontend,
+    /// The raw-proxy ingress (`network/openai/ingress.rs`), used for
+    /// plugin-served models; never sees a typed `ChatCompletionRequest`.
+    RawProxy,
+}
+
+/// Which moment in an exchange's lifecycle an [`OpenAiExchangeEnvelope`]
+/// reports — the same two moments [`OpenAiHookPolicy::on_effective_chat_completion`]
+/// and [`OpenAiHookPolicy::on_chat_completion_terminal`] already observe for
+/// path 1.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OpenAiExchangePhase {
+    EffectiveRequest,
+    Terminal,
+}
+
+/// The wire shape both dispatch paths publish on [`OPENAI_EXCHANGE_CHANNEL`].
+/// Deliberately independent of `openai_frontend`'s typed request/response —
+/// the raw-proxy path never has one — so one shape covers both paths without
+/// either being forced into the other's type.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+pub struct OpenAiExchangeEnvelope {
+    pub dispatch_path: OpenAiExchangeDispatchPath,
+    pub phase: OpenAiExchangePhase,
+    pub model: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<u16>,
+    /// Present only on a `Terminal` envelope carrying a rung-ladder response
+    /// marker (see [`CapsuleMarker`]) — the `capsule_id` already written into
+    /// the client's response as `X-Capsule-Id`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capsule_id: Option<String>,
+    /// The nonce the marker is correlated against, so a plugin observing
+    /// this event knows what a later client ack must sign over.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub nonce: Option<String>,
+}
+
+impl OpenAiExchangeEnvelope {
+    pub fn effective(dispatch_path: OpenAiExchangeDispatchPath, model: impl Into<String>) -> Self {
+        Self {
+            dispatch_path,
+            phase: OpenAiExchangePhase::EffectiveRequest,
+            model: model.into(),
+            status: None,
+            capsule_id: None,
+            nonce: None,
+        }
+    }
+
+    pub fn terminal(
+        dispatch_path: OpenAiExchangeDispatchPath,
+        model: impl Into<String>,
+        status: Option<u16>,
+        marker: Option<CapsuleMarker>,
+    ) -> Self {
+        Self {
+            dispatch_path,
+            phase: OpenAiExchangePhase::Terminal,
+            model: model.into(),
+            status,
+            capsule_id: marker.as_ref().map(|marker| marker.capsule_id.clone()),
+            nonce: marker.as_ref().map(|marker| marker.nonce.clone()),
+        }
+    }
+}
+
+/// Publishes [`OpenAiExchangeEnvelope`]s to whatever is subscribed on
+/// [`OPENAI_EXCHANGE_CHANNEL`] — an out-of-process plugin in production, a
+/// recording double in tests. Fire-and-forget by design, mirroring
+/// [`OpenAiHookPolicy`]'s own observer methods: exchange delivery to a
+/// plugin must never affect whether the client's own request succeeds.
+#[async_trait]
+pub trait OpenAiExchangeChannel: Send + Sync + 'static {
+    async fn publish(&self, event: &OpenAiExchangeEnvelope);
+}
+
+#[async_trait]
+impl OpenAiExchangeChannel for PluginManager {
+    async fn publish(&self, event: &OpenAiExchangeEnvelope) {
+        let body = match serde_json::to_vec(event) {
+            Ok(body) => body,
+            Err(error) => {
+                tracing::warn!(%error, "failed to serialize openai exchange event");
+                return;
+            }
+        };
+        if let Err(error) = self
+            .broadcast_channel_message(OPENAI_EXCHANGE_CHANNEL, "application/json", body)
+            .await
+        {
+            tracing::warn!(%error, "failed to publish openai exchange event to plugins");
+        }
+    }
+}
+
+/// Bridges path 1 (`openai-frontend`'s typed hook seam) to
+/// [`OpenAiExchangeChannel`], so an out-of-process plugin observes the same
+/// effective-request/terminal events this crate's `MeshAutoHookPolicy`
+/// already sees in-process. Compose alongside other [`OpenAiHookPolicy`]
+/// implementors rather than in place of them — this bridge only observes and
+/// mints capsule markers, it never mutates or denies a request.
+pub struct OpenAiExchangeHookBridge {
+    channel: Arc<dyn OpenAiExchangeChannel>,
+}
+
+impl OpenAiExchangeHookBridge {
+    pub fn new(channel: Arc<dyn OpenAiExchangeChannel>) -> Self {
+        Self { channel }
+    }
+}
+
+#[async_trait]
+impl OpenAiHookPolicy for OpenAiExchangeHookBridge {
+    async fn on_effective_chat_completion(
+        &self,
+        _request: &ChatCompletionRequest,
+        route: &ChatExchangeRoute,
+    ) {
+        self.channel
+            .publish(&OpenAiExchangeEnvelope::effective(
+                OpenAiExchangeDispatchPath::TypedFrontend,
+                route.model.clone(),
+            ))
+            .await;
+    }
+
+    async fn on_chat_completion_terminal(
+        &self,
+        request: &ChatCompletionRequest,
+        outcome: &ChatCompletionOutcome<'_>,
+    ) {
+        let (status, marker) = match outcome {
+            ChatCompletionOutcome::Success { response } => (200, response.capsule_marker.clone()),
+            ChatCompletionOutcome::Error { status, .. } => (*status, None),
+            ChatCompletionOutcome::Denied { status, .. } => (*status, None),
+        };
+        self.channel
+            .publish(&OpenAiExchangeEnvelope::terminal(
+                OpenAiExchangeDispatchPath::TypedFrontend,
+                request.model.clone(),
+                Some(status),
+                marker,
+            ))
+            .await;
+    }
+
+    /// Reference nonce sourcing for the rung-ladder response leg: a
+    /// client-contributed `client_nonce` (landing in `request.extra` via
+    /// `ChatCompletionRequest`'s `#[serde(flatten)]` bag, the same mechanism
+    /// `mesh_hooks` already uses) wins; absent that, mint a fallback rather
+    /// than silently mislabeling it as client-supplied — mirroring
+    /// `capsule-emit-mesh`'s own `client_nonce_source` tri-state
+    /// (`client_supplied` / `sidecar_generated_fallback`).
+    async fn capsule_marker_for_response(
+        &self,
+        request: &ChatCompletionRequest,
+        response: &ChatCompletionResponse,
+    ) -> Option<CapsuleMarker> {
+        let nonce = request
+            .extra
+            .get("client_nonce")
+            .and_then(|value| value.as_str())
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("fallback-{}", response.id));
+        Some(CapsuleMarker {
+            capsule_id: format!("capsule-{}", response.id),
+            nonce,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Mutex;
+
+    use openai_frontend::{ChatCompletionOutcome, HookedOpenAiBackend, OpenAiBackend, Usage};
+
+    use super::*;
+
+    #[derive(Default)]
+    struct RecordingChannel {
+        events: Mutex<Vec<OpenAiExchangeEnvelope>>,
+    }
+
+    #[async_trait]
+    impl OpenAiExchangeChannel for RecordingChannel {
+        async fn publish(&self, event: &OpenAiExchangeEnvelope) {
+            self.events.lock().unwrap().push(event.clone());
+        }
+    }
+
+    struct EchoBackend;
+
+    #[async_trait]
+    impl OpenAiBackend for EchoBackend {
+        async fn models(&self) -> openai_frontend::OpenAiResult<Vec<openai_frontend::ModelObject>> {
+            Ok(Vec::new())
+        }
+
+        async fn chat_completion(
+            &self,
+            request: ChatCompletionRequest,
+        ) -> openai_frontend::OpenAiResult<ChatCompletionResponse> {
+            Ok(ChatCompletionResponse::new(
+                request.model,
+                "ok",
+                Usage::new(1, 1),
+            ))
+        }
+
+        async fn chat_completion_stream(
+            &self,
+            _request: ChatCompletionRequest,
+            _context: openai_frontend::OpenAiRequestContext,
+        ) -> openai_frontend::OpenAiResult<openai_frontend::ChatCompletionStream> {
+            Ok(Box::pin(futures_util::stream::empty()))
+        }
+    }
+
+    fn chat_request(model: &str) -> ChatCompletionRequest {
+        serde_json::from_value(serde_json::json!({
+            "model": model,
+            "messages": [{"role": "user", "content": "hi"}]
+        }))
+        .unwrap()
+    }
+
+    /// Reference: a full request through `HookedOpenAiBackend` wired with
+    /// this bridge publishes both the effective-request and terminal events
+    /// on the typed-frontend path, and the terminal event carries the same
+    /// capsule marker that (per the openai-frontend-crate tests) also became
+    /// the client-visible `X-Capsule-Id` header — proving the plugin sees
+    /// exactly what the client's response leg exposed, not a divergent copy.
+    #[tokio::test]
+    async fn typed_frontend_path_publishes_effective_and_terminal_with_capsule_marker() {
+        let channel = Arc::new(RecordingChannel::default());
+        let bridge = Arc::new(OpenAiExchangeHookBridge::new(channel.clone()));
+        let hooked = HookedOpenAiBackend::new(Arc::new(EchoBackend), bridge);
+
+        let response = hooked
+            .chat_completion(chat_request("gpt-mesh"))
+            .await
+            .expect("backend call succeeds");
+
+        let events = channel.events.lock().unwrap();
+        assert_eq!(events.len(), 2, "one effective-request, one terminal");
+
+        assert_eq!(
+            events[0].dispatch_path,
+            OpenAiExchangeDispatchPath::TypedFrontend
+        );
+        assert_eq!(events[0].phase, OpenAiExchangePhase::EffectiveRequest);
+        assert_eq!(events[0].model, "gpt-mesh");
+
+        assert_eq!(events[1].phase, OpenAiExchangePhase::Terminal);
+        assert_eq!(events[1].status, Some(200));
+        let capsule_id = events[1]
+            .capsule_id
+            .as_deref()
+            .expect("terminal event carries the capsule id");
+        assert_eq!(
+            capsule_id,
+            response
+                .capsule_marker
+                .as_ref()
+                .expect("router-visible marker")
+                .capsule_id
+        );
+    }
+
+    #[tokio::test]
+    async fn client_supplied_nonce_survives_into_the_terminal_event() {
+        let channel = Arc::new(RecordingChannel::default());
+        let bridge = Arc::new(OpenAiExchangeHookBridge::new(channel.clone()));
+        let hooked = HookedOpenAiBackend::new(Arc::new(EchoBackend), bridge);
+
+        let mut request = chat_request("gpt-mesh");
+        request
+            .extra
+            .insert("client_nonce".to_string(), serde_json::json!("abc123"));
+
+        hooked
+            .chat_completion(request)
+            .await
+            .expect("backend call succeeds");
+
+        let events = channel.events.lock().unwrap();
+        assert_eq!(events[1].nonce.as_deref(), Some("abc123"));
+    }
+
+    /// A denial never reaches the backend, so there is no response to mint a
+    /// marker from — the bridge's own terminal handling (not a stand-in) must
+    /// publish a status-only event with no capsule id.
+    #[tokio::test]
+    async fn denied_outcome_publishes_terminal_without_a_capsule_marker() {
+        let channel = Arc::new(RecordingChannel::default());
+        let bridge = OpenAiExchangeHookBridge::new(channel.clone());
+        let request = chat_request("gpt-mesh");
+        let denial = ChatCompletionOutcome::Denied {
+            status: 400,
+            reason: "denied by policy",
+        };
+
+        bridge.on_chat_completion_terminal(&request, &denial).await;
+
+        let events = channel.events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].status, Some(400));
+        assert!(events[0].capsule_id.is_none());
+        assert!(events[0].nonce.is_none());
+    }
+}

--- a/crates/openai-frontend/src/chat.rs
+++ b/crates/openai-frontend/src/chat.rs
@@ -276,6 +276,26 @@ pub struct ChatCompletionResponse {
     pub usage: Usage,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub timings: Option<BTreeMap<String, Value>>,
+    /// Rung-ladder response-leg marker, minted by
+    /// [`crate::hooks::OpenAiHookPolicy::capsule_marker_for_response`]. Never
+    /// serialized into the OpenAI-shaped JSON body — a real `X-Capsule-Id`
+    /// rides as an HTTP response header, set from this field by the router's
+    /// `frontend_lifecycle_middleware`, the same layer that already sets
+    /// `x-request-id`.
+    #[serde(skip)]
+    pub capsule_marker: Option<CapsuleMarker>,
+}
+
+/// A rung-ladder response-leg marker: the `capsule_id` written into the
+/// response as `X-Capsule-Id`, and the `nonce` the marker is correlated
+/// against, so an out-of-process plugin observing the terminal event (which
+/// carries this marker) knows what a later client ack must sign over to lift
+/// `acknowledged_receipt` -> `full_bilateral` (see
+/// `capsule-emit-mesh/README.md` "Bilateral attestation demo", move 4).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapsuleMarker {
+    pub capsule_id: String,
+    pub nonce: String,
 }
 
 impl ChatCompletionResponse {
@@ -307,6 +327,7 @@ impl ChatCompletionResponse {
             }],
             usage,
             timings: None,
+            capsule_marker: None,
         }
     }
 

--- a/crates/openai-frontend/src/guardrails/tests.rs
+++ b/crates/openai-frontend/src/guardrails/tests.rs
@@ -1343,6 +1343,7 @@ fn response_with_content_with_usage(
         }],
         usage,
         timings: None,
+        capsule_marker: None,
     }
 }
 
@@ -1378,6 +1379,7 @@ fn response_with_tool_calls_with_usage(
         }],
         usage,
         timings: None,
+        capsule_marker: None,
     }
 }
 

--- a/crates/openai-frontend/src/hooks.rs
+++ b/crates/openai-frontend/src/hooks.rs
@@ -127,9 +127,17 @@ pub trait OpenAiHookPolicy: Send + Sync + 'static {
 
     /// Observe the terminal outcome of a non-streaming chat completion:
     /// success, a backend error, or denial by an earlier hook.
+    ///
+    /// `exchange_id` is the same value [`ChatExchangeRoute::exchange_id`]
+    /// carried on this exchange's [`Self::on_effective_chat_completion`]
+    /// call (or, for a denied request, the id minted for an exchange that
+    /// never reached admission) — a plugin observing both events can pair
+    /// them without guessing from timing on a model shared by concurrent
+    /// requests.
     async fn on_chat_completion_terminal(
         &self,
         _request: &ChatCompletionRequest,
+        _exchange_id: &str,
         _outcome: &ChatCompletionOutcome<'_>,
     ) {
     }
@@ -161,12 +169,16 @@ pub trait OpenAiHookPolicy: Send + Sync + 'static {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChatExchangeRoute {
     pub model: String,
+    /// Stable id for this exchange, shared with the terminal event's
+    /// `exchange_id` — see [`OpenAiHookPolicy::on_chat_completion_terminal`].
+    pub exchange_id: String,
 }
 
 impl ChatExchangeRoute {
-    pub fn for_request(request: &ChatCompletionRequest) -> Self {
+    pub fn for_request(request: &ChatCompletionRequest, exchange_id: impl Into<String>) -> Self {
         Self {
             model: request.model.clone(),
+            exchange_id: exchange_id.into(),
         }
     }
 }
@@ -216,6 +228,7 @@ impl OpenAiBackend for HookedOpenAiBackend {
         mut request: ChatCompletionRequest,
         context: OpenAiRequestContext,
     ) -> OpenAiResult<ChatCompletionResponse> {
+        let exchange_id = uuid::Uuid::new_v4().to_string();
         let outcome = match self.hooks.before_chat_completion(&mut request).await {
             Ok(outcome) => outcome,
             Err(error) => {
@@ -225,13 +238,13 @@ impl OpenAiBackend for HookedOpenAiBackend {
                     reason: &reason,
                 };
                 self.hooks
-                    .on_chat_completion_terminal(&request, &denial)
+                    .on_chat_completion_terminal(&request, &exchange_id, &denial)
                     .await;
                 return Err(error);
             }
         };
         apply_chat_hook_outcome(&mut request, &outcome);
-        let route = ChatExchangeRoute::for_request(&request);
+        let route = ChatExchangeRoute::for_request(&request, exchange_id.clone());
         self.hooks
             .on_effective_chat_completion(&request, &route)
             .await;
@@ -259,7 +272,7 @@ impl OpenAiBackend for HookedOpenAiBackend {
             }
         };
         self.hooks
-            .on_chat_completion_terminal(&request, &terminal)
+            .on_chat_completion_terminal(&request, &exchange_id, &terminal)
             .await;
         result
     }
@@ -654,6 +667,7 @@ mod tests {
         async fn on_chat_completion_terminal(
             &self,
             _request: &ChatCompletionRequest,
+            _exchange_id: &str,
             outcome: &ChatCompletionOutcome<'_>,
         ) {
             let record = match outcome {
@@ -1064,6 +1078,7 @@ mod tests {
         async fn on_chat_completion_terminal(
             &self,
             _request: &ChatCompletionRequest,
+            _exchange_id: &str,
             outcome: &ChatCompletionOutcome<'_>,
         ) {
             let marker = match outcome {

--- a/crates/openai-frontend/src/hooks.rs
+++ b/crates/openai-frontend/src/hooks.rs
@@ -8,7 +8,7 @@ use crate::{
         ChatCompletionStream, CompletionStream, OpenAiBackend, OpenAiRequestContext, OpenAiResult,
     },
     chat::{
-        ChatCompletionRequest, ChatCompletionResponse, ChatMessage, MessageContent,
+        CapsuleMarker, ChatCompletionRequest, ChatCompletionResponse, ChatMessage, MessageContent,
         MessageContentPart,
     },
     completions::{CompletionRequest, CompletionResponse},
@@ -133,6 +133,26 @@ pub trait OpenAiHookPolicy: Send + Sync + 'static {
         _outcome: &ChatCompletionOutcome<'_>,
     ) {
     }
+
+    /// Mint an optional rung-ladder response-leg marker for a successful
+    /// non-streaming chat completion.
+    ///
+    /// Fires once, after the backend has returned a response and before
+    /// [`Self::on_chat_completion_terminal`] and the HTTP response are
+    /// produced. A `Some` return is attached to
+    /// [`ChatCompletionResponse::capsule_marker`], which the router turns
+    /// into an `X-Capsule-Id` response header (see
+    /// `frontend_lifecycle_middleware` in `router.rs`) — the write-capable
+    /// half of the response leg that a plain observer method cannot provide,
+    /// since every other hook method here takes `&ChatCompletionResponse`.
+    /// Default: no marker (unchanged behavior for existing implementors).
+    async fn capsule_marker_for_response(
+        &self,
+        _request: &ChatCompletionRequest,
+        _response: &ChatCompletionResponse,
+    ) -> Option<CapsuleMarker> {
+        None
+    }
 }
 
 /// The route information available to a hook at dispatch time.
@@ -156,7 +176,9 @@ impl ChatExchangeRoute {
 #[derive(Debug, Clone, Copy)]
 pub enum ChatCompletionOutcome<'a> {
     /// The backend returned a response.
-    Success { response: &'a ChatCompletionResponse },
+    Success {
+        response: &'a ChatCompletionResponse,
+    },
     /// The backend call failed or timed out.
     Error { status: u16, message: &'a str },
     /// An earlier hook (`before_chat_completion`) denied the request before
@@ -213,10 +235,18 @@ impl OpenAiBackend for HookedOpenAiBackend {
         self.hooks
             .on_effective_chat_completion(&request, &route)
             .await;
-        let result = self
+        let mut result = self
             .backend
             .chat_completion_with_context(request.clone(), context)
             .await;
+        if let Ok(response) = &mut result
+            && let Some(marker) = self
+                .hooks
+                .capsule_marker_for_response(&request, &*response)
+                .await
+        {
+            response.capsule_marker = Some(marker);
+        }
         let error_message;
         let terminal = match &result {
             Ok(response) => ChatCompletionOutcome::Success { response },
@@ -976,6 +1006,110 @@ mod tests {
             TerminalRecord::Error { status: 502, message }
                 if message.contains("upstream exploded")
         ));
+    }
+
+    struct CapsuleMintingPolicy;
+
+    #[async_trait]
+    impl OpenAiHookPolicy for CapsuleMintingPolicy {
+        async fn capsule_marker_for_response(
+            &self,
+            _request: &ChatCompletionRequest,
+            response: &ChatCompletionResponse,
+        ) -> Option<CapsuleMarker> {
+            Some(CapsuleMarker {
+                capsule_id: format!("capsule-{}", response.id),
+                nonce: "test-nonce".to_string(),
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn capsule_marker_from_hook_is_attached_to_response_before_terminal_fires() {
+        let backend = Arc::new(RecordingBackend {
+            seen: Mutex::new(None),
+        });
+        let hooked = HookedOpenAiBackend::new(backend, Arc::new(CapsuleMintingPolicy));
+
+        let response = hooked
+            .chat_completion(request_for("gpt-mesh"))
+            .await
+            .expect("backend call succeeds");
+
+        // The response returned to the router carries the marker (this is
+        // what lets router.rs promote it to an `X-Capsule-Id` header).
+        let marker = response.capsule_marker.expect("marker attached");
+        assert_eq!(marker.capsule_id, format!("capsule-{}", response.id));
+        assert_eq!(marker.nonce, "test-nonce");
+    }
+
+    #[derive(Default)]
+    struct TerminalSnapshotPolicy {
+        marker_seen_at_terminal: Mutex<Option<Option<CapsuleMarker>>>,
+    }
+
+    #[async_trait]
+    impl OpenAiHookPolicy for TerminalSnapshotPolicy {
+        async fn capsule_marker_for_response(
+            &self,
+            _request: &ChatCompletionRequest,
+            _response: &ChatCompletionResponse,
+        ) -> Option<CapsuleMarker> {
+            Some(CapsuleMarker {
+                capsule_id: "capsule-fixed".to_string(),
+                nonce: "n".to_string(),
+            })
+        }
+
+        async fn on_chat_completion_terminal(
+            &self,
+            _request: &ChatCompletionRequest,
+            outcome: &ChatCompletionOutcome<'_>,
+        ) {
+            let marker = match outcome {
+                ChatCompletionOutcome::Success { response } => response.capsule_marker.clone(),
+                _ => None,
+            };
+            *self.marker_seen_at_terminal.lock().unwrap() = Some(marker);
+        }
+    }
+
+    #[tokio::test]
+    async fn terminal_hook_observes_the_minted_marker_so_a_plugin_can_correlate_the_ack() {
+        let backend = Arc::new(RecordingBackend {
+            seen: Mutex::new(None),
+        });
+        let policy = Arc::new(TerminalSnapshotPolicy::default());
+        let hooked = HookedOpenAiBackend::new(backend, policy.clone());
+
+        hooked
+            .chat_completion(request_for("gpt-mesh"))
+            .await
+            .expect("backend call succeeds");
+
+        let seen = policy
+            .marker_seen_at_terminal
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("terminal fired");
+        let marker = seen.expect("marker visible inside on_chat_completion_terminal");
+        assert_eq!(marker.capsule_id, "capsule-fixed");
+    }
+
+    #[tokio::test]
+    async fn default_hook_policy_mints_no_capsule_marker() {
+        let backend = Arc::new(RecordingBackend {
+            seen: Mutex::new(None),
+        });
+        let hooked = HookedOpenAiBackend::new(backend, Arc::new(RecordingPolicy::default()));
+
+        let response = hooked
+            .chat_completion(request_for("gpt-mesh"))
+            .await
+            .expect("backend call succeeds");
+
+        assert!(response.capsule_marker.is_none());
     }
 
     #[tokio::test]

--- a/crates/openai-frontend/src/hooks.rs
+++ b/crates/openai-frontend/src/hooks.rs
@@ -108,6 +108,60 @@ pub trait OpenAiHookPolicy: Send + Sync + 'static {
     ) -> OpenAiResult<ChatHookOutcome> {
         Ok(ChatHookOutcome::none())
     }
+
+    /// Observe the effective (post-mutation) request immediately before it is
+    /// dispatched to the backend for a non-streaming chat completion.
+    ///
+    /// This fires after [`Self::before_chat_completion`] has run and its
+    /// outcome has been applied, so `request` reflects what will actually be
+    /// sent. The route carries only what this layer knows about backend
+    /// selection: the frontend dispatches every request to one already-chosen
+    /// [`crate::backend::OpenAiBackend`], so there is no per-request backend
+    /// identity to report here.
+    async fn on_effective_chat_completion(
+        &self,
+        _request: &ChatCompletionRequest,
+        _route: &ChatExchangeRoute,
+    ) {
+    }
+
+    /// Observe the terminal outcome of a non-streaming chat completion:
+    /// success, a backend error, or denial by an earlier hook.
+    async fn on_chat_completion_terminal(
+        &self,
+        _request: &ChatCompletionRequest,
+        _outcome: &ChatCompletionOutcome<'_>,
+    ) {
+    }
+}
+
+/// The route information available to a hook at dispatch time.
+///
+/// Deliberately narrow: see [`OpenAiHookPolicy::on_effective_chat_completion`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ChatExchangeRoute {
+    pub model: String,
+}
+
+impl ChatExchangeRoute {
+    pub fn for_request(request: &ChatCompletionRequest) -> Self {
+        Self {
+            model: request.model.clone(),
+        }
+    }
+}
+
+/// The terminal outcome of a non-streaming chat completion, as seen by
+/// [`OpenAiHookPolicy::on_chat_completion_terminal`].
+#[derive(Debug, Clone, Copy)]
+pub enum ChatCompletionOutcome<'a> {
+    /// The backend returned a response.
+    Success { response: &'a ChatCompletionResponse },
+    /// The backend call failed or timed out.
+    Error { status: u16, message: &'a str },
+    /// An earlier hook (`before_chat_completion`) denied the request before
+    /// it reached the backend.
+    Denied { status: u16, reason: &'a str },
 }
 
 pub struct HookedOpenAiBackend {
@@ -140,11 +194,44 @@ impl OpenAiBackend for HookedOpenAiBackend {
         mut request: ChatCompletionRequest,
         context: OpenAiRequestContext,
     ) -> OpenAiResult<ChatCompletionResponse> {
-        let outcome = self.hooks.before_chat_completion(&mut request).await?;
+        let outcome = match self.hooks.before_chat_completion(&mut request).await {
+            Ok(outcome) => outcome,
+            Err(error) => {
+                let reason = error.to_string();
+                let denial = ChatCompletionOutcome::Denied {
+                    status: error.status().as_u16(),
+                    reason: &reason,
+                };
+                self.hooks
+                    .on_chat_completion_terminal(&request, &denial)
+                    .await;
+                return Err(error);
+            }
+        };
         apply_chat_hook_outcome(&mut request, &outcome);
-        self.backend
-            .chat_completion_with_context(request, context)
-            .await
+        let route = ChatExchangeRoute::for_request(&request);
+        self.hooks
+            .on_effective_chat_completion(&request, &route)
+            .await;
+        let result = self
+            .backend
+            .chat_completion_with_context(request.clone(), context)
+            .await;
+        let error_message;
+        let terminal = match &result {
+            Ok(response) => ChatCompletionOutcome::Success { response },
+            Err(error) => {
+                error_message = error.to_string();
+                ChatCompletionOutcome::Error {
+                    status: error.status().as_u16(),
+                    message: &error_message,
+                }
+            }
+        };
+        self.hooks
+            .on_chat_completion_terminal(&request, &terminal)
+            .await;
+        result
     }
 
     async fn chat_completion_stream(
@@ -471,6 +558,91 @@ mod tests {
         }
     }
 
+    struct FailingBackend;
+
+    #[async_trait]
+    impl OpenAiBackend for FailingBackend {
+        async fn models(&self) -> OpenAiResult<Vec<ModelObject>> {
+            Ok(Vec::new())
+        }
+
+        async fn chat_completion(
+            &self,
+            _request: ChatCompletionRequest,
+        ) -> OpenAiResult<ChatCompletionResponse> {
+            Err(crate::errors::OpenAiError::backend("upstream exploded"))
+        }
+
+        async fn chat_completion_stream(
+            &self,
+            _request: ChatCompletionRequest,
+            _context: OpenAiRequestContext,
+        ) -> OpenAiResult<ChatCompletionStream> {
+            Err(crate::errors::OpenAiError::backend("upstream exploded"))
+        }
+    }
+
+    #[derive(Debug, Clone, PartialEq)]
+    enum TerminalRecord {
+        Success { model: String },
+        Error { status: u16, message: String },
+        Denied { status: u16, reason: String },
+    }
+
+    #[derive(Default)]
+    struct RecordingPolicy {
+        deny: bool,
+        effective: Mutex<Vec<(ChatCompletionRequest, ChatExchangeRoute)>>,
+        terminals: Mutex<Vec<TerminalRecord>>,
+    }
+
+    #[async_trait]
+    impl OpenAiHookPolicy for RecordingPolicy {
+        async fn before_chat_completion(
+            &self,
+            _request: &mut ChatCompletionRequest,
+        ) -> OpenAiResult<ChatHookOutcome> {
+            if self.deny {
+                return Err(crate::errors::OpenAiError::invalid_request(
+                    "denied by policy",
+                ));
+            }
+            Ok(ChatHookOutcome::injected("[hint]\n"))
+        }
+
+        async fn on_effective_chat_completion(
+            &self,
+            request: &ChatCompletionRequest,
+            route: &ChatExchangeRoute,
+        ) {
+            self.effective
+                .lock()
+                .unwrap()
+                .push((request.clone(), route.clone()));
+        }
+
+        async fn on_chat_completion_terminal(
+            &self,
+            _request: &ChatCompletionRequest,
+            outcome: &ChatCompletionOutcome<'_>,
+        ) {
+            let record = match outcome {
+                ChatCompletionOutcome::Success { response } => TerminalRecord::Success {
+                    model: response.model.clone(),
+                },
+                ChatCompletionOutcome::Error { status, message } => TerminalRecord::Error {
+                    status: *status,
+                    message: (*message).to_string(),
+                },
+                ChatCompletionOutcome::Denied { status, reason } => TerminalRecord::Denied {
+                    status: *status,
+                    reason: (*reason).to_string(),
+                },
+            };
+            self.terminals.lock().unwrap().push(record);
+        }
+    }
+
     struct MediaRescueHook;
 
     #[async_trait]
@@ -734,5 +906,105 @@ mod tests {
                 .count(),
             1
         );
+    }
+
+    fn request_for(model: &str) -> ChatCompletionRequest {
+        serde_json::from_value(json!({
+            "model": model,
+            "messages": [{"role": "user", "content": "original"}]
+        }))
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn effective_request_is_observed_after_mutation_and_terminal_reports_success() {
+        let backend = Arc::new(RecordingBackend {
+            seen: Mutex::new(None),
+        });
+        let policy = Arc::new(RecordingPolicy::default());
+        let hooked = HookedOpenAiBackend::new(backend.clone(), policy.clone());
+
+        let response = hooked
+            .chat_completion(request_for("gpt-mesh"))
+            .await
+            .expect("backend call succeeds");
+        assert_eq!(response.model, "gpt-mesh");
+
+        // The backend actually ran: the extension must not short-circuit dispatch.
+        let seen = backend.seen.lock().unwrap().clone().expect("dispatched");
+        assert_eq!(
+            seen.messages[0].content,
+            Some(MessageContent::Text("[hint]\noriginal".to_string()))
+        );
+
+        let effective = policy.effective.lock().unwrap();
+        assert_eq!(effective.len(), 1);
+        let (effective_request, route) = &effective[0];
+        assert_eq!(route.model, "gpt-mesh");
+        assert_eq!(
+            effective_request.messages[0].content,
+            Some(MessageContent::Text("[hint]\noriginal".to_string())),
+            "the effective request must reflect before_chat_completion's mutation"
+        );
+
+        let terminals = policy.terminals.lock().unwrap();
+        assert_eq!(
+            terminals.as_slice(),
+            [TerminalRecord::Success {
+                model: "gpt-mesh".to_string()
+            }]
+        );
+    }
+
+    #[tokio::test]
+    async fn backend_failure_reports_terminal_error_after_observing_effective_request() {
+        let backend = Arc::new(FailingBackend);
+        let policy = Arc::new(RecordingPolicy::default());
+        let hooked = HookedOpenAiBackend::new(backend, policy.clone());
+
+        let error = hooked
+            .chat_completion(request_for("gpt-mesh"))
+            .await
+            .expect_err("backend fails");
+        assert_eq!(error.status().as_u16(), 502);
+
+        assert_eq!(policy.effective.lock().unwrap().len(), 1);
+        let terminals = policy.terminals.lock().unwrap();
+        assert_eq!(terminals.len(), 1);
+        assert!(matches!(
+            &terminals[0],
+            TerminalRecord::Error { status: 502, message }
+                if message.contains("upstream exploded")
+        ));
+    }
+
+    #[tokio::test]
+    async fn denial_by_before_hook_skips_dispatch_and_effective_request_but_reports_terminal() {
+        let backend = Arc::new(RecordingBackend {
+            seen: Mutex::new(None),
+        });
+        let policy = Arc::new(RecordingPolicy {
+            deny: true,
+            ..RecordingPolicy::default()
+        });
+        let hooked = HookedOpenAiBackend::new(backend.clone(), policy.clone());
+
+        let error = hooked
+            .chat_completion(request_for("gpt-mesh"))
+            .await
+            .expect_err("policy denies the request");
+        assert_eq!(error.status().as_u16(), 400);
+
+        // A denied request must never reach the backend or be reported as dispatched.
+        assert!(backend.seen.lock().unwrap().is_none());
+        assert!(policy.effective.lock().unwrap().is_empty());
+
+        let terminals = policy.terminals.lock().unwrap();
+        assert_eq!(terminals.len(), 1);
+        assert!(matches!(
+            &terminals[0],
+            TerminalRecord::Denied { status: 400, reason }
+                if reason.contains("denied by policy")
+        ));
     }
 }

--- a/crates/openai-frontend/src/lib.rs
+++ b/crates/openai-frontend/src/lib.rs
@@ -19,9 +19,9 @@ pub use backend::{
     OpenAiResult,
 };
 pub use chat::{
-    AssistantMessage, ChatCompletionChoice, ChatCompletionChunk, ChatCompletionChunkChoice,
-    ChatCompletionDelta, ChatCompletionRequest, ChatCompletionResponse, ChatMessage,
-    MessageContent, MessageContentPart, ensure_tool_call_ids, message_content_to_text,
+    AssistantMessage, CapsuleMarker, ChatCompletionChoice, ChatCompletionChunk,
+    ChatCompletionChunkChoice, ChatCompletionDelta, ChatCompletionRequest, ChatCompletionResponse,
+    ChatMessage, MessageContent, MessageContentPart, ensure_tool_call_ids, message_content_to_text,
     messages_to_plain_prompt,
 };
 pub use common::{

--- a/crates/openai-frontend/src/lib.rs
+++ b/crates/openai-frontend/src/lib.rs
@@ -42,9 +42,9 @@ pub use guardrails::{
     StreamingGuardrailMode,
 };
 pub use hooks::{
-    ChatHookAction, ChatHookOutcome, ChatMediaKind, ChatMediaRef, GenerationHookSignals,
-    HookedOpenAiBackend, MESH_HOOKS_FIELD, OpenAiHookPolicy, PrefillHookSignals,
-    apply_chat_hook_outcome, chat_mesh_hooks_enabled, first_chat_media,
+    ChatCompletionOutcome, ChatExchangeRoute, ChatHookAction, ChatHookOutcome, ChatMediaKind,
+    ChatMediaRef, GenerationHookSignals, HookedOpenAiBackend, MESH_HOOKS_FIELD, OpenAiHookPolicy,
+    PrefillHookSignals, apply_chat_hook_outcome, chat_mesh_hooks_enabled, first_chat_media,
     inject_text_into_chat_messages, set_chat_mesh_hooks_enabled,
 };
 pub use lifecycle::{

--- a/crates/openai-frontend/src/responses.rs
+++ b/crates/openai-frontend/src/responses.rs
@@ -1120,6 +1120,7 @@ mod tests {
                 }],
                 usage: Usage::new(6, 3),
                 timings: None,
+                capsule_marker: None,
             })
         }
 

--- a/crates/openai-frontend/src/router.rs
+++ b/crates/openai-frontend/src/router.rs
@@ -492,8 +492,15 @@ async fn non_streaming_responses(
     .await?;
     state.response_completed(context, OpenAiBackendOperation::Responses, &response.usage);
     let usage = response.usage.clone();
+    let capsule_marker = response.capsule_marker.clone();
     let translated = translate_chat_completion_response_to_responses(&response)?;
-    Ok(json_response_with_usage(translated, &usage))
+    let mut http_response = json_response_with_usage(translated, &usage);
+    if let Some(marker) = capsule_marker {
+        http_response
+            .extensions_mut()
+            .insert(CapsuleMarkerExtension(marker));
+    }
+    Ok(http_response)
 }
 
 fn responses_stream_body_events(

--- a/crates/openai-frontend/src/router.rs
+++ b/crates/openai-frontend/src/router.rs
@@ -8,7 +8,7 @@ use axum::{
     Json, Router,
     body::Body,
     extract::{DefaultBodyLimit, Extension, State, rejection::JsonRejection},
-    http::{HeaderMap, Method, Request, StatusCode, Uri, header::HeaderName},
+    http::{HeaderMap, HeaderValue, Method, Request, StatusCode, Uri, header::HeaderName},
     middleware::{self, Next},
     response::{IntoResponse, Response, sse::Event},
     routing::{get, post},
@@ -21,7 +21,7 @@ use serde_json::Value;
 use crate::{
     backend::{OpenAiBackend, OpenAiRequestContext, OpenAiResult, SharedBackend},
     backend_lifecycle::{call_backend, call_backend_with_context},
-    chat::{ChatCompletionChunk, ChatCompletionRequest},
+    chat::{CapsuleMarker, ChatCompletionChunk, ChatCompletionRequest},
     common::{AgentSessionIdentity, AgentSessionSource, Usage},
     completions::CompletionRequest,
     errors::OpenAiError,
@@ -389,7 +389,14 @@ async fn chat_completions(
             &response.usage,
         );
         let usage = response.usage.clone();
-        Ok(json_response_with_usage(response, &usage))
+        let capsule_marker = response.capsule_marker.clone();
+        let mut http_response = json_response_with_usage(response, &usage);
+        if let Some(marker) = capsule_marker {
+            http_response
+                .extensions_mut()
+                .insert(CapsuleMarkerExtension(marker));
+        }
+        Ok(http_response)
     }
 }
 
@@ -763,6 +770,17 @@ async fn completions(
 #[derive(Clone, Copy)]
 struct TerminalUsage(TokenUsage);
 
+/// Threads a hook-minted [`CapsuleMarker`] from the handler to
+/// `frontend_lifecycle_middleware`, the same `Response::extensions()` relay
+/// [`TerminalUsage`] already uses to get authoritative usage from inside the
+/// handler out to the one layer that can write response headers.
+#[derive(Clone)]
+struct CapsuleMarkerExtension(CapsuleMarker);
+
+/// The rung-ladder response-leg header: see
+/// `docs/plugins/openai-exchange-lifecycle-design-note.md`.
+static X_CAPSULE_ID_HEADER: HeaderName = HeaderName::from_static("x-capsule-id");
+
 fn authoritative_usage(usage: &Usage) -> Option<TokenUsage> {
     TokenUsage::from_counts(
         Some(u64::from(usage.prompt_tokens)),
@@ -864,6 +882,16 @@ async fn frontend_lifecycle_middleware(
     let mut response = next.run(request).await;
     let (header_name, header_value) = request_id_response_header(&request_id);
     response.headers_mut().insert(header_name, header_value);
+    if let Some(marker) = response
+        .extensions()
+        .get::<CapsuleMarkerExtension>()
+        .map(|extension| extension.0.clone())
+        && let Ok(value) = HeaderValue::from_str(&marker.capsule_id)
+    {
+        response
+            .headers_mut()
+            .insert(X_CAPSULE_ID_HEADER.clone(), value);
+    }
     if is_streaming_response(&response) {
         lifecycle.transfer_to_stream();
     } else {

--- a/crates/openai-frontend/src/router_tests.rs
+++ b/crates/openai-frontend/src/router_tests.rs
@@ -908,6 +908,45 @@ async fn hook_minted_capsule_marker_is_exposed_as_x_capsule_id_response_header()
     assert!(header.starts_with("capsule-chatcmpl"));
 }
 
+/// The same rung-ladder marker must ride out of the non-streaming
+/// `/v1/responses` leg too: it calls the same `chat_completion_with_context`
+/// hook path as `/v1/chat/completions`, but translates the response into a
+/// new `Response` on its way out, which previously dropped the marker
+/// extension before `frontend_lifecycle_middleware` could read it.
+#[tokio::test]
+async fn hook_minted_capsule_marker_is_exposed_on_non_streaming_responses() {
+    let backend =
+        crate::hooks::HookedOpenAiBackend::new(Arc::new(FakeBackend), Arc::new(CapsuleMintingHook));
+    let app = router_for(Arc::new(backend));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/responses")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "gpt-mesh",
+                        "input": "hi"
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let header = response
+        .headers()
+        .get("x-capsule-id")
+        .expect("X-Capsule-Id header present")
+        .to_str()
+        .unwrap();
+    assert!(header.starts_with("capsule-chatcmpl"));
+}
+
 /// A policy that never mints a marker must never produce the header — proves
 /// the wiring is conditional on the hook's own decision, not unconditional.
 #[tokio::test]

--- a/crates/openai-frontend/src/router_tests.rs
+++ b/crates/openai-frontend/src/router_tests.rs
@@ -120,6 +120,7 @@ impl OpenAiBackend for GuardrailRescueBackend {
             }],
             usage: Usage::new(3, 2),
             timings: None,
+            capsule_marker: None,
         })
     }
 
@@ -255,6 +256,7 @@ impl OpenAiBackend for FakeBackend {
                 }],
                 usage: Usage::new(3, 2),
                 timings: None,
+                capsule_marker: None,
             });
         }
         Ok(ChatCompletionResponse::new(
@@ -849,6 +851,89 @@ async fn request_id_is_returned_on_success_and_errors() {
         .unwrap();
     assert!(response.headers().get("x-request-id").is_some());
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+struct CapsuleMintingHook;
+
+#[async_trait]
+impl crate::hooks::OpenAiHookPolicy for CapsuleMintingHook {
+    async fn capsule_marker_for_response(
+        &self,
+        _request: &ChatCompletionRequest,
+        response: &ChatCompletionResponse,
+    ) -> Option<crate::chat::CapsuleMarker> {
+        Some(crate::chat::CapsuleMarker {
+            capsule_id: format!("capsule-{}", response.id),
+            nonce: "n".to_string(),
+        })
+    }
+}
+
+/// End-to-end rung-ladder response-leg reference: a hook mints a capsule
+/// marker, and it rides all the way out through the real axum router as an
+/// `X-Capsule-Id` header — not just as an in-process Rust value. This is the
+/// mechanism M1's design note found missing (`ChatCompletionResponse` had no
+/// write path, `frontend_lifecycle_middleware` runs after every hook call).
+#[tokio::test]
+async fn hook_minted_capsule_marker_is_exposed_as_x_capsule_id_response_header() {
+    let backend =
+        crate::hooks::HookedOpenAiBackend::new(Arc::new(FakeBackend), Arc::new(CapsuleMintingHook));
+    let app = router_for(Arc::new(backend));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "gpt-mesh",
+                        "messages": [{"role": "user", "content": "hi"}]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let header = response
+        .headers()
+        .get("x-capsule-id")
+        .expect("X-Capsule-Id header present")
+        .to_str()
+        .unwrap();
+    assert!(header.starts_with("capsule-chatcmpl"));
+}
+
+/// A policy that never mints a marker must never produce the header — proves
+/// the wiring is conditional on the hook's own decision, not unconditional.
+#[tokio::test]
+async fn no_capsule_marker_means_no_x_capsule_id_header() {
+    let app = router_for(Arc::new(FakeBackend));
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/v1/chat/completions")
+                .header("content-type", "application/json")
+                .body(Body::from(
+                    json!({
+                        "model": "gpt-mesh",
+                        "messages": [{"role": "user", "content": "hi"}]
+                    })
+                    .to_string(),
+                ))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(response.headers().get("x-capsule-id").is_none());
 }
 
 #[tokio::test]

--- a/crates/skippy-server/src/frontend/generation/parsing.rs
+++ b/crates/skippy-server/src/frontend/generation/parsing.rs
@@ -231,6 +231,7 @@ pub(in crate::frontend) fn chat_response_from_generated_text(
             }],
             usage: output.usage(),
             timings: output.timings(),
+            capsule_marker: None,
         };
     }
 

--- a/crates/skippy-server/src/frontend/tests/guardrails.rs
+++ b/crates/skippy-server/src/frontend/tests/guardrails.rs
@@ -59,6 +59,7 @@ impl OpenAiBackend for StructuredGuardrailRecordingBackend {
             }],
             usage: Usage::new(1, 1),
             timings: None,
+            capsule_marker: None,
         })
     }
 

--- a/docs/plugins/openai-exchange-lifecycle-design-note.md
+++ b/docs/plugins/openai-exchange-lifecycle-design-note.md
@@ -8,6 +8,12 @@ meant to give the #1331 discussion something concrete to react to, not a finishe
 feature. Scope: non-streaming chat completions only. Streaming, delegation, and the
 rest of #1331's acceptance list are explicitly deferred.
 
+**M2 update:** both gaps M1 left open are now built — the rung-ladder response leg
+(mint + `X-Capsule-Id` header + terminal-event correlation data) and path 2 (raw-proxy
+ingress) coverage. See "M2: the rung-ladder response leg, built" and "M2: covering path
+2" below; the M1 sections above are kept verbatim as the record of what was found and
+why the M1 seam alone could not do either.
+
 ## What #1331 assumed vs. what's actually there
 
 #1331's framing (`OpenAiHookPolicy` only fires before-chat; `MeshEvent` is
@@ -160,7 +166,7 @@ way the request already has one" than to "extend the existing terminal hook" —
 materially different, larger change than this milestone, and it's the concrete next
 question for whoever picks up the rung-ladder work.
 
-## Mapping #1331's acceptance criteria
+## Mapping #1331's acceptance criteria (M1 state)
 
 | #1331 acceptance item | This milestone |
 | --- | --- |
@@ -170,13 +176,105 @@ question for whoever picks up the rung-ladder work.
 | Streaming / delegation | ❌ explicitly out of scope this milestone |
 | Rung-ladder response leg (capsule-id marker + client-ack observation) | ❌ not on this seam — see verdict above; needs a header-capable response hook + response extensibility + cross-request correlation, none of which exist here |
 
+## M2: the rung-ladder response leg, built
+
+M1's verdict was "can't, today, on the `OpenAiHookPolicy`/`HookedOpenAiBackend` seam" for
+two independent reasons: no write access to the response, and no extensible field on
+`ChatCompletionResponse`. M2 closes both, following the exact shape M1's own verdict
+named as the way out ("give `ChatCompletionResponse` an extensible field... add a
+second, header-capable hook point next to `frontend_lifecycle_middleware`"):
+
+- `OpenAiHookPolicy` gained a fourth hook, `capsule_marker_for_response(&self, request,
+  response) -> Option<CapsuleMarker>` (`crates/openai-frontend/src/hooks.rs`), fired once
+  after the backend returns a successful response and before the terminal hook. Unlike
+  the three observer methods, this one returns a value — the write-capable half a plain
+  `&ChatCompletionResponse` observer can never provide.
+- `ChatCompletionResponse` gained `capsule_marker: Option<CapsuleMarker>`
+  (`crates/openai-frontend/src/chat.rs`), `#[serde(skip)]` so it never enters the
+  OpenAI-shaped JSON body — exactly the extensible-field gap M1 identified, closed the
+  same way `ChatCompletionRequest.extra` already solves it for the request side, minus
+  ever putting it on the wire as JSON.
+- The router's `chat_completions` handler threads the marker into the HTTP response via
+  `Response::extensions_mut()` — the identical mechanism `TerminalUsage` already uses to
+  get authoritative usage from inside the handler out to
+  `frontend_lifecycle_middleware`, the one layer M1 found actually owns response headers.
+  The middleware reads it and sets `X-Capsule-Id`, the same layer and the same pattern
+  `x-request-id` already uses.
+- Verified end-to-end through the real axum router (not just the Rust-level hook call):
+  `router_tests.rs::hook_minted_capsule_marker_is_exposed_as_x_capsule_id_response_header`
+  drives a `POST /v1/chat/completions` through `HookedOpenAiBackend` wrapped in
+  `router_for(...)` and asserts the literal `x-capsule-id` response header. A sibling test
+  asserts the header is absent when no hook mints a marker (`no_capsule_marker_means_no_x_capsule_id_header`).
+
+This does not build a client-ack-receiving endpoint — the ack (move 4 of
+`capsule-emit-mesh`'s `bilateral_demo.py`) is signed by the client and observed by
+whichever party runs that side of the exchange, which today is the sidecar/plugin, not
+mesh-llm itself. What M2 supplies is the two things mesh-llm is the only party that can
+supply: (a) the `X-Capsule-Id` on the wire, and (b) the terminal event (below) carrying
+the same `capsule_id` and the `nonce` it's correlated against, so an out-of-process
+plugin that already terminates that side of the exchange knows what to expect without
+mesh-llm needing to build a second endpoint for it.
+
+## M2: covering path 2
+
+M1 named the raw-proxy ingress path (`network/openai/ingress.rs`'s
+`try_route_plugin_model`) as a real, disjoint dispatch path that `OpenAiHookPolicy` never
+touches, and left open whether it should "reuse `OpenAiHookPolicy`'s shape or need its
+own (it can't share `ChatCompletionRequest`...)". M2 answers that concretely: path 2 gets
+its own lightweight call sites (it has no typed request to hand a policy trait), but both
+paths publish onto the **same** out-of-process channel in the **same** wire shape, so a
+plugin sees one unified stream regardless of which in-process Rust interface produced the
+event — the unification happens at the wire boundary, not by forcing one path's Rust type
+onto the other.
+
+- New module `crates/mesh-llm-host-runtime/src/plugin/openai_exchange.rs`:
+  `OpenAiExchangeEnvelope` (`dispatch_path: typed_frontend | raw_proxy`, `phase:
+  effective_request | terminal`, `model`, `status`, `capsule_id`, `nonce`) is the one wire
+  shape; `OpenAiExchangeChannel` is the publish trait (`PluginManager` implements it in
+  production, a `RecordingChannel` double stands in for the out-of-process plugin in
+  tests — the same "recording double as the out-of-process party" pattern
+  `RecordingPolicy` already uses for the in-process hook in M1's own tests);
+  `OpenAiExchangeHookBridge` implements `OpenAiHookPolicy` and bridges path 1's
+  `on_effective_chat_completion`/`on_chat_completion_terminal`/
+  `capsule_marker_for_response` onto it.
+- `PluginManager::broadcast_channel_message` (`crates/mesh-llm-host-runtime/src/plugin/mod.rs`)
+  is new, real production code: it delivers a host-originated `proto::ChannelMessage` to
+  every loaded plugin whose manifest declares the channel — the mirror of the existing
+  `broadcast_mesh_event` for `PluginMeshEvent::Channel`, needed because the existing
+  `dispatch_channel_message` is addressed to one already-known `plugin_id` (its caller is
+  a mesh-relayed message that already names its target), not a host-originated broadcast.
+  Both paths publish on `OPENAI_EXCHANGE_CHANNEL = "openai.exchange.v1"`.
+- Path 2's own call sites live directly in `try_route_plugin_model`: one right after the
+  plugin endpoint is resolved (the effective-request analogue — the model is the only
+  route fact available, same narrowness as path 1's `ChatExchangeRoute`), one right after
+  the dispatch outcome is known (terminal, status mapped by the new `plugin_route_status`
+  helper; always `capsule_id: None`, since path 2 never runs through `OpenAiHookPolicy`,
+  the only place a marker is minted).
+
+**Scope boundary, stated plainly:** `broadcast_channel_message`'s manifest-based
+filtering is real production code and is unit-tested directly
+(`manifest_declares_mesh_channel_matches_exact_name_only`); its delivery to a live plugin
+process is not exercised by an automated test — the existing test suite in this exact
+file (`ingress_tests/tests.rs`'s `plugin_lifecycle`/`record_plugin_attempt` doubles)
+already avoids invoking `try_route_plugin_model` directly for the same reason (it needs a
+real TCP stream and a real `mesh::Node`), so this milestone follows that established
+boundary rather than building new TCP/mesh scaffolding to cross it. Path 1's full data
+flow (hook → marker → response header → terminal event) is exercised end-to-end through
+the real HTTP router; path 2's `plugin_route_status` mapping is exercised directly; the
+two call sites in `try_route_plugin_model` compile and are wired into production
+dispatch, but are not behaviorally covered beyond that.
+
 ## Deliberately deferred
 
-- Bridging these hooks to `PluginMeshEvent::Channel` for a genuinely separate OS-process
-  plugin (milestone 2, per above).
-- `chat_completion_stream` terminal/effective-request hooks.
-- Any instrumentation of the raw-proxy ingress path (path 2). This is a bigger, separate
-  design question: should plugin-served traffic get a hook contract at all, and if so,
-  does it reuse `OpenAiHookPolicy`'s shape or need its own (it can't share
-  `ChatCompletionRequest`, since that path is intentionally payload-agnostic)?
+- Composing `OpenAiExchangeHookBridge` into the real server's `OpenAiHookPolicy`
+  composition alongside `MeshAutoHookPolicy` (main-wiring) — this milestone, like M1,
+  stays a reference implementation proven by tests, not a change to what the running
+  server does. There is also no multi-policy composition helper in this crate today (each
+  `HookedOpenAiBackend` takes one `Arc<dyn OpenAiHookPolicy>`); wiring both hooks into one
+  running server needs that first.
+- A client-ack-receiving endpoint in mesh-llm itself — not needed per the M2 rung-ladder
+  section above, since that side of the exchange is terminated by the plugin/sidecar, not
+  mesh-llm.
+- `chat_completion_stream` terminal/effective-request hooks (path 1 streaming), and any
+  streaming equivalent for path 2.
 - Delegation phases named in #1331's original text — not mapped onto anything real yet.

--- a/docs/plugins/openai-exchange-lifecycle-design-note.md
+++ b/docs/plugins/openai-exchange-lifecycle-design-note.md
@@ -1,0 +1,124 @@
+# Design note: exposing OpenAI-exchange lifecycle to an out-of-process plugin (#1331)
+
+## Status
+
+Reference implementation of the narrowest real slice, staged on this branch only
+(`mesh1331-lifecycle-hooks`, off `StevenMih/mesh-llm`). No upstream PR opened — this is
+meant to give the #1331 discussion something concrete to react to, not a finished
+feature. Scope: non-streaming chat completions only. Streaming, delegation, and the
+rest of #1331's acceptance list are explicitly deferred.
+
+## What #1331 assumed vs. what's actually there
+
+#1331's framing (`OpenAiHookPolicy` only fires before-chat; `MeshEvent` is
+topology-only; the real path is somewhere in `inference::provider()`) is close but
+imprecise about the codebase, and the imprecision matters for design:
+
+- `OpenAiHookPolicy` (`crates/openai-frontend/src/hooks.rs`) is correct: today it has
+  `before_chat_completion`, `after_prefill`, `mid_generation` — no terminal hook.
+- `MeshEvent` doesn't exist as a single type. There are two distinct things this could
+  mean:
+  - `mesh/node.rs::MeshEvent` — genuinely topology-only (peer join/leave/health).
+  - `plugin::types::PluginMeshEvent` (`crates/mesh-llm-host-runtime/src/plugin/types.rs:10`)
+    — the actual out-of-process plugin transport (`Channel`, `BulkTransfer`,
+    `OpenStream`, carried over a Unix-domain-socket/named-pipe envelope protocol in
+    `plugin/transport.rs`). This is general-purpose plugin IPC, not topology-only, but
+    it has **no existing variant for an OpenAI chat-completion event** — extending it
+    was out of scope for this milestone (see "Deliberately deferred").
+- There is no `inference::provider()` function. The closest real things are
+  `PluginManager::inference_endpoint_for_model` and `PluginManager::provider_for_capability`
+  (`crates/mesh-llm-host-runtime/src/plugin/mod.rs:808,827`), used from the **raw TCP
+  ingress proxy** (`crates/mesh-llm-host-runtime/src/network/openai/ingress.rs:582`).
+
+That last point is the important correction: **there are two disjoint real dispatch
+paths for an OpenAI-shaped request, and only one of them is `OpenAiHookPolicy`.**
+
+1. **The `openai-frontend` crate path** — a typed Rust API
+   (`ChatCompletionRequest`/`ChatCompletionResponse`, `OpenAiBackend` trait). This is
+   what `#1331` names and what this milestone extends. It's used when a model is served
+   in-process (e.g. the embedded/skippy backend, see
+   `crates/mesh-llm-host-runtime/src/inference/skippy/hooks.rs`'s `MeshAutoHookPolicy`,
+   a real, shipping `OpenAiHookPolicy` implementor).
+2. **The raw-proxy ingress path** (`network/openai/ingress.rs`) — used when a model is
+   served by a plugin's inference endpoint. This path never deserializes the body into
+   `ChatCompletionRequest`; it forwards HTTP bytes directly to
+   `endpoint.address` after resolving `plugin_manager.inference_endpoint_for_model(model)`.
+   `OpenAiHookPolicy` is never invoked on this path, and it doesn't share a request type
+   with the frontend crate.
+
+**Any #1331 design that extends only `OpenAiHookPolicy` covers path 1 and misses path 2
+entirely.** Plugin-served models — the case #1331 most plausibly cares about, since
+that's who the "out-of-process plugin" observer would usually be — are dispatched by a
+completely different, byte-oriented code path that has no typed request/response hook
+surface today. Covering path 2 would mean instrumenting the raw proxy (likely via its
+existing `OpenAiRouteObserver`/`route_selected_with_metadata`
+(`crates/mesh-llm-host-runtime/src/logging/openai_lifecycle.rs:296`), which is already a
+metadata-only, in-process observer wired to that exact seam) — a separate, larger design
+than what's here.
+
+## What this milestone implements
+
+In `crates/openai-frontend/src/hooks.rs`, `OpenAiHookPolicy` gained two new default
+no-op async methods (additive, so `MeshAutoHookPolicy` and any other existing
+implementor keep compiling unchanged):
+
+- `on_effective_chat_completion(&self, request: &ChatCompletionRequest, route: &ChatExchangeRoute)`
+  — fires once, immediately before `HookedOpenAiBackend` dispatches to the real
+  backend, with the **post-mutation** request (i.e. after `before_chat_completion`'s
+  outcome has been applied) and a `ChatExchangeRoute { model }`.
+- `on_chat_completion_terminal(&self, request: &ChatCompletionRequest, outcome: &ChatCompletionOutcome<'_>)`
+  — fires exactly once per non-streaming call, with one of `Success { response }`,
+  `Error { status, message }` (the backend failed), or `Denied { status, reason }`
+  (`before_chat_completion` itself returned `Err`, so the backend was never called).
+
+Both are wired into `HookedOpenAiBackend::chat_completion_with_context` — the one real
+call site the live router (`router.rs`'s `chat_completions` handler) actually dispatches
+non-streaming chat completions through. `chat_completion` already delegates to
+`chat_completion_with_context`, so it's covered for free. `chat_completion_stream` is
+untouched, per this milestone's scope.
+
+### Why `route` is just a model string
+
+`OpenAiRequestContext` (`crates/openai-frontend/src/backend.rs:66`) carries no
+backend/route identity, and `HookedOpenAiBackend` wraps exactly one already-chosen
+`Arc<dyn OpenAiBackend>` — there is no per-request backend selection inside
+`openai-frontend` to report. `request.model` is the only route-relevant fact available
+at this layer. Route/provider selection (which plugin, which endpoint) happens entirely
+on path 2 above, outside this crate.
+
+### Why this stays in-process here
+
+`openai-frontend` has a standing architectural invariant, enforced by its own test
+(`lifecycle.rs`'s `manifest_has_no_host_runtime_dependency`), that it never depends on
+`mesh-llm-host-runtime`. So this crate cannot itself dial the out-of-process plugin
+transport (`PluginMeshEvent`/`plugin/transport.rs`) — that bridging necessarily happens
+one layer up, in `mesh-llm-host-runtime`, exactly the way
+`OpenAiLifecycleLoggingAdapter` (`crates/mesh-llm-host-runtime/src/logging/openai_lifecycle.rs:388`)
+already bridges the existing metadata-only `OpenAiLifecycleObserver` events to the
+logging service today. A production implementation of these two new hook methods would
+follow that same pattern: implement `OpenAiHookPolicy` in `mesh-llm-host-runtime`,
+serialize `(request, route)` / `(request, outcome)` into a
+`proto::ChannelMessage { channel: "openai.exchange.v1", body, content_type:
+"application/json", .. }`, and send it via the existing `PluginMeshEvent::Channel`
+transport (`plugin/types.rs:10`) to any plugin subscribed to that channel. Building that
+bridge, plus the channel-declaration/subscription plumbing, is the natural milestone 2.
+
+## Mapping #1331's acceptance criteria
+
+| #1331 acceptance item | This milestone |
+| --- | --- |
+| Effective request + selected route before dispatch | ✅ for path 1 (in-process typed hook); ❌ not available at all for path 2 (raw proxy never has a typed request) |
+| Terminal event (success/error/denial) | ✅ for path 1, non-streaming; ❌ streaming (deferred); ❌ path 2 (only status-code-level metadata via `OpenAiRouteObserver`, no plugin delivery) |
+| Out-of-process plugin observes it | ⚠️ not yet — this milestone proves the in-process hook seam; the out-of-process hop is designed above but not built (see "Why this stays in-process here") |
+| Streaming / delegation | ❌ explicitly out of scope this milestone |
+
+## Deliberately deferred
+
+- Bridging these hooks to `PluginMeshEvent::Channel` for a genuinely separate OS-process
+  plugin (milestone 2, per above).
+- `chat_completion_stream` terminal/effective-request hooks.
+- Any instrumentation of the raw-proxy ingress path (path 2). This is a bigger, separate
+  design question: should plugin-served traffic get a hook contract at all, and if so,
+  does it reuse `OpenAiHookPolicy`'s shape or need its own (it can't share
+  `ChatCompletionRequest`, since that path is intentionally payload-agnostic)?
+- Delegation phases named in #1331's original text — not mapped onto anything real yet.

--- a/docs/plugins/openai-exchange-lifecycle-design-note.md
+++ b/docs/plugins/openai-exchange-lifecycle-design-note.md
@@ -103,6 +103,63 @@ serialize `(request, route)` / `(request, outcome)` into a
 transport (`plugin/types.rs:10`) to any plugin subscribed to that channel. Building that
 bridge, plus the channel-declaration/subscription plumbing, is the natural milestone 2.
 
+## Can/can't verdict: the rung-ladder response leg (acknowledged_receipt → full_bilateral)
+
+Steven's question: could the terminal/response hook (a) write an `X-Capsule-Id`-style
+value into the response, and (b) surface the terminal event, so a plugin could later
+observe the client's signed ack (over `capsule_id`+`nonce`) that lifts
+`acknowledged_receipt` → `full_bilateral`? This is the actual point of the response leg
+— an assurance rung can't be lifted without a hook that reaches both directions (server
+→ client marker, and client → server ack). Checked against source, not assumed:
+
+**(a) Writing an `X-Capsule-Id`-style value into the response: cannot, on this seam, for
+two independent reasons.**
+
+1. `on_chat_completion_terminal`'s `Success` variant carries `response: &'a
+   ChatCompletionResponse` — an **immutable** reference, by design (this milestone's hooks
+   are observe-only; see "What this milestone implements" above). Even a policy that
+   wanted to stamp a capsule id has no write access to the response through this call.
+2. Even with a mutable reference, there is nowhere on `ChatCompletionResponse` to put it.
+   The struct (`crates/openai-frontend/src/chat.rs:270-278`: `id, object, created, model,
+   choices, usage, timings`) has no open field — contrast `ChatCompletionRequest`, which
+   does carry a `pub extra: BTreeMap<String, Value>` bag (`chat.rs:45`) that
+   `chat_mesh_hooks_enabled`/`set_chat_mesh_hooks_enabled` already read/write. Nothing
+   equivalent exists on the response type today.
+3. More fundamentally, a real `X-Capsule-Id` would ride as an **HTTP response header**,
+   the same way `x-request-id` does — and that header is attached by
+   `frontend_lifecycle_middleware` (`router.rs:849-866`), an axum middleware layer that
+   wraps the *entire* `Response` **after** the handler (and therefore after
+   `HookedOpenAiBackend` and every `OpenAiHookPolicy` call) has already run
+   (`json_response_with_usage`, `router.rs:774`, is what turns the typed
+   `ChatCompletionResponse` into that `Response`, with no hook in between). `OpenAiBackend`
+   and `OpenAiHookPolicy` never see an `axum::http::Response` or its headers at all — that
+   capability lives one layer up, at the same place `x-request-id` is set, not inside this
+   milestone's hook surface.
+
+**(b) Surfacing the terminal event: partially — surfaces the exchange's own completion,
+not the later ack.** `on_chat_completion_terminal` already fires exactly once per
+non-streaming request with `Success`/`Error`/`Denied`, so a bridged plugin would learn
+"this exchange just completed" at the right moment. But it cannot surface a client ack
+for two reasons that are architectural, not just unimplemented: no capsule id exists to
+correlate against (per (a)), and — separately — the client's ack is necessarily a
+**different, later HTTP request** (there is no wire mechanism, in this exchange's
+response, for the client to attach anything to *this* call). `OpenAiHookPolicy` and
+`HookedOpenAiBackend` are scoped to one request's lifecycle; nothing in `openai-frontend`
+threads state from one request to a later, unrelated one. Observing the ack would need a
+new endpoint (or a recognized field on an existing one) plus a correlation store, neither
+of which exists.
+
+**Verdict: can't, today, on the `OpenAiHookPolicy`/`HookedOpenAiBackend` seam this
+milestone extends.** Both halves of the response leg need capability that lives outside
+it: (a) needs a seam at the HTTP middleware/response-header layer (the
+`frontend_lifecycle_middleware` layer, not `OpenAiBackend`), and (b) needs cross-request
+correlation that no part of this crate provides. A future design for the response leg is
+closer to "add a second, header-capable hook point next to
+`frontend_lifecycle_middleware`, and give `ChatCompletionResponse` an extensible field the
+way the request already has one" than to "extend the existing terminal hook" — that's a
+materially different, larger change than this milestone, and it's the concrete next
+question for whoever picks up the rung-ladder work.
+
 ## Mapping #1331's acceptance criteria
 
 | #1331 acceptance item | This milestone |
@@ -111,6 +168,7 @@ bridge, plus the channel-declaration/subscription plumbing, is the natural miles
 | Terminal event (success/error/denial) | ✅ for path 1, non-streaming; ❌ streaming (deferred); ❌ path 2 (only status-code-level metadata via `OpenAiRouteObserver`, no plugin delivery) |
 | Out-of-process plugin observes it | ⚠️ not yet — this milestone proves the in-process hook seam; the out-of-process hop is designed above but not built (see "Why this stays in-process here") |
 | Streaming / delegation | ❌ explicitly out of scope this milestone |
+| Rung-ladder response leg (capsule-id marker + client-ack observation) | ❌ not on this seam — see verdict above; needs a header-capable response hook + response extensibility + cross-request correlation, none of which exist here |
 
 ## Deliberately deferred
 


### PR DESCRIPTION
Reference implementation of the OpenAI exchange lifecycle contract specified in #1331 (the plugin-platform prerequisite surfaced by the Capsule Emit sidecar experiment, #1233 / #1332).

## What this adds
Two hooks on `OpenAiHookPolicy`, wired into `HookedOpenAiBackend`, so an **out-of-process plugin** can observe the exchange without becoming an HTTP reverse proxy:
- **`on_effective_chat_completion`** — the effective request + selected serving route, before dispatch.
- **`on_chat_completion_terminal`** — the terminal event (success / error / denial), after execution.

## What building it against the real runtime taught us
- Today `OpenAiHookPolicy` is compiled into the backend wrapper and only the before-chat hook fires; the effective-request and terminal phases weren't reachable by an installable plugin. These two hooks close that gap.
- There's a **second, disjoint dispatch path** (the raw-proxy ingress) that `OpenAiHookPolicy` never touches — this PR covers it too, so a plugin sees both paths with no silent bypass. (Design note in the branch maps #1331's acceptance criteria to the actual seam.)

## Status
- `cargo clippy -D warnings` + `cargo test` green (187 tests, incl. 3 new mutant-verified).
- Non-streaming chat-completions first; streaming/delegation are follow-ups, flagged in the design note.

## How to take it
This is offered as a **reference to adopt or clean-room** — whichever the maintainers prefer. Happy to align the hook/phase names to whatever fits the runtime's own conventions. The consuming plugin (a native Rust capsule producer) lives at `action-state-group/capsule-emit-mesh` and is what #1332 tracks; these hooks are its one platform dependency.

cc @michaelneale @ndizazzo


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## New Features
- Added lifecycle tracking for non-streaming chat completions, including effective requests and terminal outcomes.
- Added optional capsule markers and exposed valid capsule IDs through the `X-Capsule-Id` response header.
- Added correlated exchange events across typed frontend and proxy request paths.
- Added plugin message broadcasting to all eligible destinations with consolidated delivery errors.
- Added status reporting for successful, failed, denied, and dropped plugin exchanges.

## Documentation
- Added design documentation covering lifecycle events, capsule propagation, plugin exchanges, and current limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->