### PR TITLE
fix(packaging): retry transient HF artifact uploads

### DIFF
--- a/crates/model-package/src/script.rs
+++ b/crates/model-package/src/script.rs
@@ -199,6 +199,9 @@ mod tests {
         assert!(EMBEDDED_SCRIPT.contains("upload-package-artifact.py"));
         assert!(EMBEDDED_SCRIPT.contains("SKIPPY_PACKAGE_ARTIFACT_PATH"));
         assert!(EMBEDDED_SCRIPT.contains("SKIPPY_PACKAGE_ARTIFACT_RELATIVE_PATH"));
+        assert!(EMBEDDED_SCRIPT.contains("ARTIFACT_UPLOAD_ATTEMPTS"));
+        assert!(EMBEDDED_SCRIPT.contains("for attempt in range(1, max_attempts + 1)"));
+        assert!(EMBEDDED_SCRIPT.contains("Retrying in {delay}s"));
         assert!(EMBEDDED_SCRIPT.contains(r#"--after-artifact-command "$ARTIFACT_UPLOAD_HOOK""#));
         assert!(EMBEDDED_SCRIPT.contains("Uploaded and removed"));
         assert!(!EMBEDDED_SCRIPT.contains("api.upload_folder"));

--- a/crates/model-package/src/scripts/split-model-job.sh
+++ b/crates/model-package/src/scripts/split-model-job.sh
@@ -237,19 +237,39 @@ cat > "$ARTIFACT_UPLOAD_SCRIPT" <<'PYTHON'
 from huggingface_hub import HfApi
 from pathlib import Path
 import os
+import time
 
 path = Path(os.environ["SKIPPY_PACKAGE_ARTIFACT_PATH"])
 relative = os.environ["SKIPPY_PACKAGE_ARTIFACT_RELATIVE_PATH"]
 target_repo = os.environ["TARGET_REPO"]
+max_attempts = int(os.environ.get("ARTIFACT_UPLOAD_ATTEMPTS", "4"))
 
 api = HfApi(token=os.environ["HF_TOKEN"])
-api.upload_file(
-    repo_id=target_repo,
-    path_or_fileobj=str(path),
-    path_in_repo=relative,
-    repo_type="model",
-    commit_message=f"Add package artifact {relative}",
-)
+last_error = None
+for attempt in range(1, max_attempts + 1):
+    try:
+        api.upload_file(
+            repo_id=target_repo,
+            path_or_fileobj=str(path),
+            path_in_repo=relative,
+            repo_type="model",
+            commit_message=f"Add package artifact {relative}",
+        )
+        last_error = None
+        break
+    except Exception as err:
+        last_error = err
+        if attempt == max_attempts:
+            break
+        delay = min(60, 5 * attempt)
+        print(
+            f"  Upload failed for {relative} on attempt {attempt}/{max_attempts}: {err}. "
+            f"Retrying in {delay}s...",
+            flush=True,
+        )
+        time.sleep(delay)
+if last_error is not None:
+    raise last_error
 size = path.stat().st_size
 path.unlink()
 print(f"  Uploaded and removed {relative} ({size} bytes)")


### PR DESCRIPTION
## Summary

- retry individual Hugging Face package artifact uploads up to four times
- preserve the local artifact until the remote upload succeeds
- add an embedded-script regression assertion for the retry contract

## Why

The first 250 GB Nemotron Ultra `UD-IQ3_S` package run failed after 29 successful layer uploads when Hugging Face briefly rejected an LFS pointer because its object was not yet visible. The job runner previously made only one attempt and then discarded the whole job.

The same pinned source completed all 108 layers and published a verified 111-artifact manifest when rerun from this commit: https://huggingface.co/jobs/meshllm/6a8be6d073304676c8ecbb57

## Verification

At `8afb13c52420e07044a6789d62ebb3b5d553e6bf`:

- `cargo fmt --all --check`
- `cargo test -p model-package` (23 passed)
- `cargo clippy -p model-package --all-targets -- -D warnings`
- live package job completed (108 layers, 234.1 GiB)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Artifact uploads now automatically retry up to four times when failures occur.
  * Retry delays increase incrementally and are capped at 60 seconds.
  * Failed uploads remain available for subsequent attempts, while successful uploads continue to be cleaned up.
  * If all attempts fail, the final error is reported clearly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->