### PR TITLE
Unblock release dispatches after the config schema module split

### DIFF
--- a/scripts/release-version.sh
+++ b/scripts/release-version.sh
@@ -149,6 +149,10 @@ update_known_mesh_versions() {
     local next="$2"
     local before
     local after
+    if ! grep -q 'fn known_mesh_llm_versions()' "$file"; then
+        echo "known_mesh_llm_versions() is not defined in $file; update known_versions_file in $0" >&2
+        exit 1
+    fi
     before="$(cat "$file")"
     if perl -0777 -ne '
         BEGIN {
@@ -293,7 +297,7 @@ for relative_file in "${literal_version_files[@]}"; do
     versioned_files+=("$file")
 done
 
-known_versions_file="$REPO_ROOT/crates/mesh-llm-config/src/model/built_in_schema.rs"
+known_versions_file="$REPO_ROOT/crates/mesh-llm-config/src/model/built_in_schema/setting_schema.rs"
 require_file "$known_versions_file"
 update_known_mesh_versions "$known_versions_file" "$version"
 versioned_files+=("$known_versions_file")

--- a/scripts/tests/test_release_version_script.py
+++ b/scripts/tests/test_release_version_script.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import re
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+RELEASE_VERSION_SCRIPT = ROOT / "scripts" / "release-version.sh"
+
+
+def known_versions_file() -> Path:
+    script = RELEASE_VERSION_SCRIPT.read_text(encoding="utf-8")
+    match = re.search(
+        r'^known_versions_file="\$REPO_ROOT/(?P<path>[^"]+)"$',
+        script,
+        re.MULTILINE,
+    )
+    assert match is not None, "release-version.sh no longer assigns known_versions_file"
+    return ROOT / match.group("path")
+
+
+# Run update_known_mesh_versions in isolation. The script cannot be sourced --
+# it validates its own arguments and performs a full release bump at load time
+# -- so extract just the function definition and evaluate that.
+_INVOKE_HELPER = """
+set -euo pipefail
+eval "$(sed -n '/^update_known_mesh_versions()/,/^}/p' "$1")"
+update_known_mesh_versions "$2" "$3"
+"""
+
+class ReleaseVersionScriptTests(unittest.TestCase):
+    def test_known_versions_file_defines_the_function_the_script_edits(self) -> None:
+        """The script rewrites known_mesh_llm_versions() by regex.
+
+        If the function moves to another module the substitution silently
+        matches nothing and the release fails in the metadata job, after the
+        tag has been chosen. Keep the path and the definition together.
+        """
+        target = known_versions_file()
+        self.assertTrue(target.is_file(), f"missing {target}")
+        self.assertIn(
+            "fn known_mesh_llm_versions()",
+            target.read_text(encoding="utf-8"),
+        )
+
+    def test_update_known_mesh_versions_prepends_the_new_version(self) -> None:
+        source = known_versions_file().read_text(encoding="utf-8")
+        with tempfile.TemporaryDirectory() as tmp:
+            sample = Path(tmp) / "setting_schema.rs"
+            sample.write_text(source, encoding="utf-8")
+            subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    _INVOKE_HELPER,
+                    "bash",
+                    str(RELEASE_VERSION_SCRIPT),
+                    str(sample),
+                    "99.99.99-rc1",
+                ],
+                check=True,
+                capture_output=True,
+            )
+            updated = sample.read_text(encoding="utf-8")
+        self.assertIn('"99.99.99-rc1",', updated)
+
+    def test_update_known_mesh_versions_fails_loudly_on_a_wrong_file(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            sample = Path(tmp) / "elsewhere.rs"
+            sample.write_text("// no version list here\n", encoding="utf-8")
+            result = subprocess.run(
+                [
+                    "bash",
+                    "-c",
+                    _INVOKE_HELPER,
+                    "bash",
+                    str(RELEASE_VERSION_SCRIPT),
+                    str(sample),
+                    "99.99.99-rc1",
+                ],
+                capture_output=True,
+                text=True,
+            )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("known_mesh_llm_versions()", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What this fixes

Cutting a release currently fails. The `v0.76.0-rc7` dispatch ([run 32704132957](https://github.com/Mesh-LLM/mesh-llm/actions/runs/32704132957)) aborted in its first job with:

```
failed to add 0.76.0-rc7 to known mesh-llm versions in .../crates/mesh-llm-config/src/model/built_in_schema.rs
```

`scripts/release-version.sh` rewrites `known_mesh_llm_versions()` with a regex against a hard-coded file path. #1396 moved that function into `crates/mesh-llm-config/src/model/built_in_schema/setting_schema.rs`, leaving `built_in_schema.rs` as a module root with no version list. The substitution matched nothing, and the script's "no change" guard turned that into a hard failure.

This is a release-blocking regression on `main`: every `workflow_dispatch` of `release.yml` fails after the tag has already been resolved.

## Change

- Point `known_versions_file` at `built_in_schema/setting_schema.rs`.
- Fail with a message that names the missing `known_mesh_llm_versions()` function, so the next move of this list reports the actual cause instead of a failed substitution.
- Add `scripts/tests/test_release_version_script.py`, which asserts the configured path actually defines the function, exercises the successful bump, and asserts the loud failure on a file without the list.

## Validation

- `python3 -m unittest scripts.tests.test_release_version_script` — 3 passed.
- Verified the new tests fail against `origin/main`'s `scripts/release-version.sh` (path assertion and both behavior tests), then pass with the fix.
- `bash scripts/release-version.sh 0.76.0-rc7` on a clean worktree prepends `"0.76.0-rc7"` to the list and updates the rest of the version surface; the only remaining error is `cargo: command not found` in my local shell, unrelated to this change. That trial bump was reverted and is not part of this branch.
- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — identical pre-existing failures with and without this branch (`test_plan_ci` ownership/crate-list errors plus several loader errors), and the 3 new tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release version updates by validating the expected known-versions definition before making changes.
  * Updated the release process to target the correct known-versions file.
  * Added clearer errors when the expected file structure is missing.

* **Tests**
  * Added automated coverage for successful version insertion and invalid input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->