### PR TITLE
fix(release): compare release bases, not raw tag SHAs, in provenance check

### DIFF
--- a/.agents/agents/release-validation.md
+++ b/.agents/agents/release-validation.md
@@ -50,11 +50,12 @@ Never infer authorization to use a lab, cloud, rented, or production host.
 2. Inspect the latest published GitHub release, its tag, notes, assets,
    checksums, publication metadata, and applicable release workflow result.
 3. Before collecting inventory, resolve the candidate SHA and previous-release
-   tag commit and require that the candidate is reachable from `origin/main`
-   and the previous-release commit is an ancestor of the candidate. Use
-   `git merge-base --is-ancestor <candidate-sha> origin/main` and
-   `git merge-base --is-ancestor <previous-release-commit> <candidate-sha>`;
-   stop if `origin/main` is unavailable or either check fails.
+   tag commit and derive each release base from its merge-base with
+   `origin/main`. Allow zero commits above a release base, or exactly one commit
+   whose subject is the tag-specific `<tag>: prepare release source`. Require
+   the previous-release base to be an ancestor of the candidate base. Stop if
+   `origin/main` is unavailable or any subject, commit-count, or base-ordering
+   check fails.
 4. Reconcile GitHub compare data, merged pull requests, commits, linked issues,
    changed files, tests, docs, migrations, generated artifacts, and implemented
    user-visible or operational behavior.

--- a/.agents/agents/release-validation.md
+++ b/.agents/agents/release-validation.md
@@ -51,11 +51,13 @@ Never infer authorization to use a lab, cloud, rented, or production host.
    checksums, publication metadata, and applicable release workflow result.
 3. Before collecting inventory, resolve the candidate SHA and previous-release
    tag commit and derive each release base from its merge-base with
-   `origin/main`. Allow zero commits above a release base, or exactly one commit
-   whose subject is the tag-specific `<tag>: prepare release source`. Require
-   the previous-release base to be an ancestor of the candidate base. Stop if
-   `origin/main` is unavailable or any subject, commit-count, or base-ordering
-   check fails.
+   `origin/main`. An off-main candidate must be passed as its explicit release
+   tag or have exactly one local tag pointing at its SHA; use that canonical tag
+   for the subject check and stop if it is absent or ambiguous. Allow zero
+   commits above a release base, or exactly one commit whose subject is the
+   tag-specific `<tag>: prepare release source`. Require the previous-release
+   base to be an ancestor of the candidate base. Stop if `origin/main` is
+   unavailable or any tag, subject, commit-count, or base-ordering check fails.
 4. Reconcile GitHub compare data, merged pull requests, commits, linked issues,
    changed files, tests, docs, migrations, generated artifacts, and implemented
    user-visible or operational behavior.

--- a/.agents/skills/release-validation/SKILL.md
+++ b/.agents/skills/release-validation/SKILL.md
@@ -61,11 +61,13 @@ Read each applicable skill completely before acting:
    prerelease, draft, and manually superseded releases.
 4. Before collecting inventory, resolve the candidate SHA and previous-release
    tag commit and derive each release base from its merge-base with
-   `origin/main`. Allow zero commits above a release base, or exactly one commit
-   whose subject is the tag-specific `<tag>: prepare release source`. Require
-   the previous-release base to be an ancestor of the candidate base. Fail
-   closed if `origin/main` is unavailable or any subject, commit-count, or base
-   ordering check fails.
+   `origin/main`. An off-main candidate must be passed as its explicit release
+   tag or have exactly one local tag pointing at its SHA; use that canonical tag
+   for the subject check and fail closed if it is absent or ambiguous. Allow
+   zero commits above a release base, or exactly one commit whose subject is the
+   tag-specific `<tag>: prepare release source`. Require the previous-release
+   base to be an ancestor of the candidate base. Fail closed if `origin/main` is
+   unavailable or any tag, subject, commit-count, or base ordering check fails.
 5. Run `scripts/collect-release-inventory.py` from this skill to capture a raw
    JSON evidence manifest. If its exact release tag is missing locally, verify
    the configured remote URL and fetch that tag before rerunning. The script

--- a/.agents/skills/release-validation/SKILL.md
+++ b/.agents/skills/release-validation/SKILL.md
@@ -60,10 +60,11 @@ Read each applicable skill completely before acting:
    publication time, and release workflow conclusion. Distinguish stable,
    prerelease, draft, and manually superseded releases.
 4. Before collecting inventory, resolve the candidate SHA and previous-release
-   tag commit and require that the candidate SHA is reachable from `origin/main`
-   and the previous-release commit is an ancestor of the candidate. Fail closed
-   if `origin/main` is unavailable or either `git merge-base --is-ancestor`
-   check fails.
+   tag commit and require that each one's release base — its merge-base with
+   `origin/main`, tolerating only the documented `<tag>: prepare release
+   source` commit on top — precedes the other's in the expected order. Fail
+   closed if `origin/main` is unavailable, an unexpected commit sits between a
+   tag and its release base, or the base ordering check fails.
 5. Run `scripts/collect-release-inventory.py` from this skill to capture a raw
    JSON evidence manifest. If its exact release tag is missing locally, verify
    the configured remote URL and fetch that tag before rerunning. The script

--- a/.agents/skills/release-validation/SKILL.md
+++ b/.agents/skills/release-validation/SKILL.md
@@ -60,11 +60,12 @@ Read each applicable skill completely before acting:
    publication time, and release workflow conclusion. Distinguish stable,
    prerelease, draft, and manually superseded releases.
 4. Before collecting inventory, resolve the candidate SHA and previous-release
-   tag commit and require that each one's release base — its merge-base with
-   `origin/main`, tolerating only the documented `<tag>: prepare release
-   source` commit on top — precedes the other's in the expected order. Fail
-   closed if `origin/main` is unavailable, an unexpected commit sits between a
-   tag and its release base, or the base ordering check fails.
+   tag commit and derive each release base from its merge-base with
+   `origin/main`. Allow zero commits above a release base, or exactly one commit
+   whose subject is the tag-specific `<tag>: prepare release source`. Require
+   the previous-release base to be an ancestor of the candidate base. Fail
+   closed if `origin/main` is unavailable or any subject, commit-count, or base
+   ordering check fails.
 5. Run `scripts/collect-release-inventory.py` from this skill to capture a raw
    JSON evidence manifest. If its exact release tag is missing locally, verify
    the configured remote URL and fetch that tag before rerunning. The script

--- a/.agents/skills/release-validation/scripts/collect-release-inventory.py
+++ b/.agents/skills/release-validation/scripts/collect-release-inventory.py
@@ -70,10 +70,11 @@ def require_local_tag(tag: str) -> str:
 # tags that prepared-source commit directly without pushing it to origin/main, so
 # every release tag -- prerelease or stable -- sits one documented commit ahead
 # of its main-line ancestor by design.
-RELEASE_PREPARE_SUBJECT_SUFFIX = ": prepare release source"
+def release_prepare_subject(tag: str) -> str:
+    return f"{tag}: prepare release source"
 
 
-def require_release_base(origin_main: str, tag_sha: str) -> str:
+def require_release_base(origin_main: str, tag: str, tag_sha: str) -> str:
     """Return the main-line commit a release tag was prepared from.
 
     Fails closed unless every commit between that point and the tag itself is
@@ -81,24 +82,24 @@ def require_release_base(origin_main: str, tag_sha: str) -> str:
     """
     release_base = git("merge-base", origin_main, tag_sha)
     if release_base != tag_sha:
-        unexpected = [
-            commit
-            for commit in collect_commits(release_base, tag_sha)
-            if not commit["subject"].endswith(RELEASE_PREPARE_SUBJECT_SUFFIX)
-        ]
-        if unexpected:
-            detail = "; ".join(f"{c['sha'][:12]} {c['subject']!r}" for c in unexpected)
+        commits = collect_commits(release_base, tag_sha)
+        expected_subject = release_prepare_subject(tag)
+        if len(commits) != 1 or commits[0]["subject"] != expected_subject:
+            detail = "; ".join(f"{c['sha'][:12]} {c['subject']!r}" for c in commits)
             raise RuntimeError(
-                f"{tag_sha} diverges from origin/main (base {release_base}) with commits "
-                f"beyond the documented release-prepare step: {detail}"
+                f"release {tag!r} ({tag_sha}) diverges from origin/main (base "
+                f"{release_base}); expected zero commits or exactly one commit with "
+                f"subject {expected_subject!r}, found: {detail or 'no commits'}"
             )
     return release_base
 
 
-def require_release_provenance(base_sha: str, head_sha: str) -> None:
+def require_release_provenance(
+    base_tag: str, base_sha: str, head_ref: str, head_sha: str
+) -> None:
     origin_main = git("rev-parse", "--verify", "origin/main^{commit}")
-    base_release_base = require_release_base(origin_main, base_sha)
-    head_release_base = require_release_base(origin_main, head_sha)
+    base_release_base = require_release_base(origin_main, base_tag, base_sha)
+    head_release_base = require_release_base(origin_main, head_ref, head_sha)
     if subprocess.run(
         ["git", "merge-base", "--is-ancestor", base_release_base, head_release_base],
         check=False,
@@ -220,7 +221,7 @@ def main() -> int:
         release = latest_release(args.repo, args.release_tag)
         base_sha = require_local_tag(release["tagName"])
         head_sha = git("rev-parse", f"{args.head}^{{commit}}")
-        require_release_provenance(base_sha, head_sha)
+        require_release_provenance(release["tagName"], base_sha, args.head, head_sha)
         manifest = {
             "schema_version": 1,
             "collected_at": datetime.now(timezone.utc).isoformat(),

--- a/.agents/skills/release-validation/scripts/collect-release-inventory.py
+++ b/.agents/skills/release-validation/scripts/collect-release-inventory.py
@@ -94,12 +94,39 @@ def require_release_base(origin_main: str, tag: str, tag_sha: str) -> str:
     return release_base
 
 
+def canonical_candidate_tag(origin_main: str, head_ref: str, head_sha: str) -> str | None:
+    """Resolve the tag that names an off-main release-prepare commit."""
+    if git("merge-base", origin_main, head_sha) == head_sha:
+        return None
+
+    explicit_tag = head_ref.removeprefix("refs/tags/")
+    try:
+        explicit_tag_sha = git("rev-parse", "--verify", f"refs/tags/{explicit_tag}^{{commit}}")
+    except RuntimeError:
+        explicit_tag_sha = None
+    if explicit_tag_sha == head_sha:
+        return explicit_tag
+
+    tags = [tag for tag in git("tag", "--points-at", head_sha).splitlines() if tag]
+    if len(tags) != 1:
+        detail = ", ".join(repr(tag) for tag in tags) or "none"
+        raise RuntimeError(
+            f"candidate {head_ref!r} ({head_sha}) is off origin/main and must be named "
+            "by an explicit release tag or have exactly one tag pointing at it; "
+            f"found: {detail}"
+        )
+    return tags[0]
+
+
 def require_release_provenance(
     base_tag: str, base_sha: str, head_ref: str, head_sha: str
-) -> None:
+) -> str | None:
     origin_main = git("rev-parse", "--verify", "origin/main^{commit}")
     base_release_base = require_release_base(origin_main, base_tag, base_sha)
-    head_release_base = require_release_base(origin_main, head_ref, head_sha)
+    candidate_tag = canonical_candidate_tag(origin_main, head_ref, head_sha)
+    head_release_base = require_release_base(
+        origin_main, candidate_tag or head_ref, head_sha
+    )
     if subprocess.run(
         ["git", "merge-base", "--is-ancestor", base_release_base, head_release_base],
         check=False,
@@ -108,6 +135,7 @@ def require_release_provenance(
             f"previous release commit {base_sha} (base {base_release_base}) is not an "
             f"ancestor of candidate {head_sha} (base {head_release_base})"
         )
+    return candidate_tag
 
 
 def collect_commits(base: str, head: str) -> list[dict]:
@@ -221,7 +249,9 @@ def main() -> int:
         release = latest_release(args.repo, args.release_tag)
         base_sha = require_local_tag(release["tagName"])
         head_sha = git("rev-parse", f"{args.head}^{{commit}}")
-        require_release_provenance(release["tagName"], base_sha, args.head, head_sha)
+        candidate_tag = require_release_provenance(
+            release["tagName"], base_sha, args.head, head_sha
+        )
         manifest = {
             "schema_version": 1,
             "collected_at": datetime.now(timezone.utc).isoformat(),
@@ -229,6 +259,7 @@ def main() -> int:
             "remote_urls": git("remote", "-v").splitlines(),
             "candidate": {
                 "ref": args.head,
+                "tag": candidate_tag,
                 "sha": head_sha,
                 "branch": git("branch", "--show-current"),
                 "dirty": dirty_state(),

--- a/.agents/skills/release-validation/scripts/collect-release-inventory.py
+++ b/.agents/skills/release-validation/scripts/collect-release-inventory.py
@@ -64,17 +64,48 @@ def require_local_tag(tag: str) -> str:
         ) from error
 
 
+# scripts/release.sh and RELEASE.md's manual publish path both write this exact
+# subject for the commit that bakes built/generated release artifacts (console
+# dist, SwiftPM manifest, version bump) onto the tag. The workflow_dispatch path
+# tags that prepared-source commit directly without pushing it to origin/main, so
+# every release tag -- prerelease or stable -- sits one documented commit ahead
+# of its main-line ancestor by design.
+RELEASE_PREPARE_SUBJECT_SUFFIX = ": prepare release source"
+
+
+def require_release_base(origin_main: str, tag_sha: str) -> str:
+    """Return the main-line commit a release tag was prepared from.
+
+    Fails closed unless every commit between that point and the tag itself is
+    the documented release-prepare commit.
+    """
+    release_base = git("merge-base", origin_main, tag_sha)
+    if release_base != tag_sha:
+        unexpected = [
+            commit
+            for commit in collect_commits(release_base, tag_sha)
+            if not commit["subject"].endswith(RELEASE_PREPARE_SUBJECT_SUFFIX)
+        ]
+        if unexpected:
+            detail = "; ".join(f"{c['sha'][:12]} {c['subject']!r}" for c in unexpected)
+            raise RuntimeError(
+                f"{tag_sha} diverges from origin/main (base {release_base}) with commits "
+                f"beyond the documented release-prepare step: {detail}"
+            )
+    return release_base
+
+
 def require_release_provenance(base_sha: str, head_sha: str) -> None:
     origin_main = git("rev-parse", "--verify", "origin/main^{commit}")
+    base_release_base = require_release_base(origin_main, base_sha)
+    head_release_base = require_release_base(origin_main, head_sha)
     if subprocess.run(
-        ["git", "merge-base", "--is-ancestor", head_sha, origin_main], check=False
-    ).returncode != 0:
-        raise RuntimeError(f"candidate {head_sha} is not reachable from origin/main")
-    if subprocess.run(
-        ["git", "merge-base", "--is-ancestor", base_sha, head_sha], check=False
+        ["git", "merge-base", "--is-ancestor", base_release_base, head_release_base],
+        check=False,
     ).returncode != 0:
         raise RuntimeError(
-            f"previous release commit {base_sha} is not an ancestor of candidate {head_sha}"
+            f"previous release commit {base_sha} (base {base_release_base}) is not an "
+            f"ancestor of candidate {head_sha} (base {head_release_base})"
         )
 
 


### PR DESCRIPTION
## Problem

`collect-release-inventory.py`'s `require_release_provenance()` rejects every release tag this repo has ever produced — rc7 and rc6 included — with `candidate <sha> is not reachable from origin/main`. This surfaced as D-004 in the rc7 release-validation report and blocks the release-validation skill's inventory step on every future RC.

## Root cause

Both `scripts/release.sh`'s `workflow_dispatch` path and `RELEASE.md`'s manual publish path write a `<tag>: prepare release source` commit that bakes built/generated artifacts (console dist, SwiftPM manifest, version bump) onto the release tag. The `workflow_dispatch` path — the one actually used to cut RCs — tags that prepared-source commit directly without pushing it to `origin/main`.

That means **every** release tag, prerelease or stable, sits one documented, off-main commit ahead of its true main-line ancestor. Verified this holds for all six `v0.76.0-rc*` tags available locally and for the last stable release, `v0.75.1`:

```
$ git log --oneline $(git merge-base origin/main v0.76.0-rc7)..v0.76.0-rc7
5d07a20b6 v0.76.0-rc7: prepare release source

$ git log --oneline $(git merge-base origin/main v0.75.1)..v0.75.1
3295c902d v0.75.1: prepare release source
```

The old check compared raw tag SHAs directly: it required the candidate SHA itself to be reachable from `origin/main`, and the previous-release SHA to be an ancestor of the candidate SHA. Both fail unconditionally given the above — neither tag SHA is actually on main, and two different tags' private prepare commits are never ancestors of each other.

## Fix

Derive each tag's "release base" — its `git merge-base` with `origin/main` — and:

1. Fail closed if anything other than the documented `<tag>: prepare release source` commit sits between a tag and its release base (still catches a genuinely rogue/untracked candidate).
2. Compare release bases, not raw tag SHAs, for the previous-release-precedes-candidate ancestry check.

Also updated the release-validation skill's step 4 to describe the corrected rule.

## Verification

Ran `require_release_provenance()` directly against real repo history (no mocking):

- `v0.75.1 → v0.76.0-rc7` (real previous-release/candidate pair): **passes** (was failing before this fix)
- `v0.75.1 → origin/main HEAD`: **passes**
- `v0.76.0-rc6 → v0.76.0-rc7`: **passes**
- `v0.76.0-rc7 → v0.75.1` (reversed direction): **correctly fails**
- `v0.75.1 → a real feature branch one non-prepare commit ahead of main`: **correctly fails**, naming the offending commit

Also ran the full script end-to-end against the real candidate:

```
$ python3 .agents/skills/release-validation/scripts/collect-release-inventory.py --head v0.76.0-rc7
```

which now produces a complete manifest (120 commits, 1619 changed files, 112 merged PRs vs. `v0.75.1`) instead of failing at the provenance check.

No existing test harness covers this script (no pytest/test infra anywhere in the repo for `.agents/skills/*/scripts/*.py`), so verification here is against real repository history rather than a new unit-test suite — flagging that gap rather than adding ad hoc test infra out of scope for this fix.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release validation to support releases with zero or one documented preparation commit.
  - Added stricter checks for release tags, commit subjects, commit counts, ancestry, base ordering, and unavailable release history.
  - Improved validation for off-main release candidates by requiring an explicit or uniquely identifiable release tag.
  - Release validation now compares candidate and previous releases against verified main-line bases and reports relevant tags and intervening commits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->