### PR TITLE
fix(mesh): close the iroh endpoint on shutdown instead of dropping it

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/node.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node.rs
@@ -11,6 +11,40 @@ use startup::{
 };
 pub(crate) use startup::{default_plugin_event_source, hardware_snapshot_for_start};
 
+/// Upper bound on how long shutdown waits for one iroh endpoint to close.
+///
+/// `Endpoint::close` queues connection-close frames and then waits for peers to
+/// acknowledge them, which iroh documents as up to roughly 3s when connectivity
+/// is bad or a peer has already gone away; it then waits for the endpoint and
+/// connection drivers to stop. Shutdown must stay bounded, so an unresponsive
+/// peer costs this budget and nothing more.
+const ENDPOINT_CLOSE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Await `Endpoint::close` under [`ENDPOINT_CLOSE_TIMEOUT`].
+///
+/// Returning early on an already-closed endpoint keeps this idempotent, so a
+/// shutdown path may call it without tracking whether an earlier one did.
+///
+/// On timeout iroh has still *started* closing, which downgrades the drop-time
+/// `abort()` to a no-op, but the endpoint is not marked closed and the
+/// ungraceful-drop ERROR can still be logged. The warning is what tells those
+/// two cases apart in a log.
+async fn close_endpoint_gracefully(endpoint: &Endpoint, label: &str) {
+    if endpoint.is_closed() {
+        return;
+    }
+    if tokio::time::timeout(ENDPOINT_CLOSE_TIMEOUT, endpoint.close())
+        .await
+        .is_err()
+    {
+        tracing::warn!(
+            endpoint = label,
+            timeout_secs = ENDPOINT_CLOSE_TIMEOUT.as_secs(),
+            "iroh endpoint did not finish closing within the shutdown budget; peers may time its connections out instead of seeing them close"
+        );
+    }
+}
+
 /// Lightweight routing table for passive nodes (clients + standby GPU).
 /// Contains just enough info to route requests to the right host.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -656,8 +690,29 @@ impl Node {
                 .store(true, std::sync::atomic::Ordering::Release);
             lifecycle.shutdown.notify_waiters();
             let _ = lifecycle.task.await;
-            lifecycle.endpoint.close().await;
+            close_endpoint_gracefully(&lifecycle.endpoint, "owner-control").await;
         }
+    }
+
+    /// Close the main mesh QUIC endpoint as the last step of runtime shutdown.
+    ///
+    /// iroh only releases an endpoint gracefully when `Endpoint::close` is
+    /// awaited. Dropping it instead makes `EndpointInner::drop` log
+    ///
+    /// ```text
+    /// ERROR iroh::socket: Endpoint dropped without calling `Endpoint::close`. Aborting ungracefully.
+    /// ```
+    ///
+    /// and abort the socket, which also denies peers the connection-close
+    /// frames — they are left to time the connections out and report this node
+    /// as failed rather than as cleanly departed.
+    ///
+    /// Call this only after every subsystem that speaks over the mesh endpoint
+    /// (control listener, plugins, loaded models and their stage connections,
+    /// the final gossip updates) has finished. `accept_loop` observes the close
+    /// as `Endpoint::accept` returning `None` and exits on its own.
+    pub async fn close_endpoint(&self) {
+        close_endpoint_gracefully(&self.endpoint, "mesh").await;
     }
 
     #[expect(

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/endpoint_shutdown.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/endpoint_shutdown.rs
@@ -1,0 +1,90 @@
+// Regression coverage for #1338.
+//
+// iroh's `EndpointInner::drop` logs
+// `Endpoint dropped without calling `Endpoint::close`. Aborting ungracefully.`
+// at ERROR unless the endpoint was closed first, and it then aborts the socket
+// instead of flushing the queued connection-close frames — so peers time the
+// connections out rather than seeing this node depart. A node owns two
+// endpoints (the mesh endpoint and, for a verified owner, the control
+// listener), and shutdown has to close both.
+//
+// The observable invariant these tests pin is iroh's own `is_closed()` flag,
+// because that is precisely the condition `EndpointInner::drop` checks before
+// logging. Asserting on the log line instead would couple the tests to an
+// upstream message string.
+
+#[tokio::test]
+async fn close_endpoint_closes_the_mesh_endpoint() -> anyhow::Result<()> {
+    let node = Node::new_for_tests(super::NodeRole::Worker).await?;
+    assert!(
+        !node.endpoint.is_closed(),
+        "a freshly bound endpoint should be open"
+    );
+
+    node.close_endpoint().await;
+
+    assert!(
+        node.endpoint.is_closed(),
+        "shutdown must leave the mesh endpoint closed, or iroh aborts it on drop"
+    );
+    Ok(())
+}
+
+#[tokio::test]
+async fn close_endpoint_is_idempotent() -> anyhow::Result<()> {
+    let node = Node::new_for_tests(super::NodeRole::Worker).await?;
+
+    node.close_endpoint().await;
+    // A second call must not re-enter iroh's close path or wait out the
+    // shutdown budget; shutdown callers should not have to track whether an
+    // earlier stage already closed the endpoint.
+    tokio::time::timeout(std::time::Duration::from_secs(1), node.close_endpoint())
+        .await
+        .expect("closing an already-closed endpoint should return immediately");
+
+    assert!(node.endpoint.is_closed());
+    Ok(())
+}
+
+#[tokio::test]
+async fn accept_loop_exits_once_the_endpoint_is_closed() -> anyhow::Result<()> {
+    let node = Node::new_for_tests(super::NodeRole::Worker).await?;
+    let accepting = node.clone();
+    let accept_loop = tokio::spawn(async move { accepting.accept_loop().await });
+    node.start_accepting();
+
+    node.close_endpoint().await;
+
+    // `Endpoint::accept` yields `None` once the endpoint closes, which is the
+    // only signal the accept loop has. If closing ever stopped terminating it,
+    // the loop would outlive shutdown holding a `Node` clone.
+    tokio::time::timeout(std::time::Duration::from_secs(5), accept_loop)
+        .await
+        .expect("accept loop should exit when the endpoint closes")?;
+    Ok(())
+}
+
+#[tokio::test]
+async fn shutdown_control_listener_closes_the_control_endpoint() -> anyhow::Result<()> {
+    let (node, secret_key) = Node::new_for_tests_with_secret(super::NodeRole::Worker).await?;
+    *node.owner_summary.lock().await = verified_owner_summary("owner-a");
+    node.maybe_start_control_listener(secret_key, None, None)
+        .await?;
+
+    let control_endpoint = node
+        .control_listener
+        .lock()
+        .await
+        .as_ref()
+        .map(|listener| listener.endpoint.clone())
+        .expect("a verified owner should start a control listener");
+    assert!(!control_endpoint.is_closed());
+
+    node.shutdown_control_listener().await;
+
+    assert!(
+        control_endpoint.is_closed(),
+        "the owner-control endpoint is a second iroh endpoint and needs the same graceful close"
+    );
+    Ok(())
+}

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/mod.rs
@@ -7,6 +7,7 @@ mod control_listener;
 
 include!("connections.rs");
 include!("admission/helpers.rs");
+include!("endpoint_shutdown.rs");
 include!("protocol_compat.rs");
 include!("owner_control.rs");
 include!("stage_transport.rs");

--- a/crates/mesh-llm-host-runtime/src/runtime/control_loop.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/control_loop.rs
@@ -420,6 +420,14 @@ pub(super) async fn shutdown_run_auto_runtime(ctx: RunAutoShutdownContext<'_>) {
 
     node.set_serving_models(Vec::new()).await;
     node.set_hosted_models(Vec::new()).await;
+
+    // Last mesh-facing step: every subsystem that speaks over the mesh endpoint
+    // has now stopped, so close it explicitly. Dropping it instead makes iroh
+    // log `Endpoint dropped without calling `Endpoint::close`. Aborting
+    // ungracefully.` and abandon the connection-close frames, leaving peers to
+    // time this node out rather than seeing it depart.
+    node.close_endpoint().await;
+
     cleanup_run_auto_runtime_dir(runtime);
 }
 


### PR DESCRIPTION
Fixes #1338.

## Root cause

The runtime binds the main mesh endpoint in `mesh/node/startup.rs::bind_mesh_endpoint` and never closes it. iroh 1.0.3 reacts to that in `EndpointInner::drop` (`src/socket.rs:220`):

```rust
impl Drop for EndpointInner {
    fn drop(&mut self) {
        if self.sock.is_closed() { return; }
        tracing::error!("Endpoint dropped without calling `Endpoint::close`. Aborting ungracefully.");
        self.abort();
    }
}
```

A node owns **two** iroh endpoints. The owner-control listener was already closed correctly in `shutdown_control_listener`. The mesh endpoint — the one carrying `ALPN_V1` and `STAGE_ALPN_V2` — was not closed anywhere: `shutdown_run_auto_runtime` ran `broadcast_leaving`, then services, then models, and then simply dropped it.

**This is not purely cosmetic.** `abort()` skips `noq_endpoint().close()` and `wait_all_draining()`, so the queued connection-close frames are never flushed. Peers do not learn the node departed; they time its connections out and mark it failed. The ERROR line is the visible tell, not the whole cost.

## Fix

`Node::close_endpoint()`, called as the last mesh-facing step of `shutdown_run_auto_runtime` — after plugins, models and the final gossip updates. `accept_loop` already terminates on `Endpoint::accept` returning `None`, so nothing outlives the close.

The close is **bounded at 5s**. iroh documents `Endpoint::close` as taking up to ~3s when a peer is unresponsive, and it then waits on the endpoint and connection drivers; an unbounded await would hand a remote peer control of local shutdown latency, which is the wrong trade in a shutdown path. On expiry we log a warn.

One honest limitation, called out because it shaped the design: iroh sets its `is_closed` flag only at the *end* of a completed close, and `Drop` checks that flag — so a close future abandoned on timeout can still emit the ERROR. The timeout guarantees bounded shutdown, not silence. The normal path is clean; the pathological path is no worse than today rather than a new hang.

The owner-control endpoint now shares the same bounded helper, so neither endpoint can stall shutdown.

## Validation

**A/B against the real binary on one host**, `RUST_LOG=error,iroh::socket=trace`, `serve --debug --headless --log-format json --disable-iroh-relays`, SIGINT:

| build | ungraceful-drop ERRORs | iroh socket trace | exit |
|---|---|---|---|
| call disabled (control) | **1** | `socket aborting...` → `socket closed` | 2s |
| this branch | **0** | `socket closing...` → `wait_all_draining start` → `wait_all_draining done` → `socket closed` | 2s |

The control was built from this same tree with only the one call commented out, so the two runs differ by exactly this change.

**With a live peer attached** — two local nodes, B joined A via invite token, A's `/api/status` confirming `peers: 1`, then SIGTERM to A: graceful close, `wait_all_draining` completed in under a millisecond, both nodes exited in 2s, zero ungraceful drops on either side. So the drain path does not hang when there is a real connection to close.

**Tests.** Four added in `mesh/tests/endpoint_shutdown.rs`, pinning iroh's `is_closed()` flag rather than the upstream log string:

- `close_endpoint_closes_the_mesh_endpoint`
- `close_endpoint_is_idempotent`
- `accept_loop_exits_once_the_endpoint_is_closed`
- `shutdown_control_listener_closes_the_control_endpoint`

Full `cargo test -p mesh-llm-host-runtime`: **2555 passed, 0 failed, 8 ignored**. `cargo fmt --all --check` clean. Clippy clean for the touched crate — the two `chunks_exact_to_as_chunks` hits in this workspace are pre-existing on `main` (verified with `git show origin/main:…`) and come from a newer local toolchain.

## Scope

Deliberately limited to the normal shutdown path, which is what #1338 reports. Startup **error** paths in `run_auto` (the `?` sites between `build_run_auto_node_setup` and the runtime loop) still drop the endpoint without closing it and would log the same ERROR. Covering those means restructuring that function's error handling, which does not belong in this fix — worth a follow-up if we care about clean teardown on failed startup.

Related: this touches the same shutdown lifecycle as #1103, and the release-validation run found a split **stage** node that fails to exit on SIGTERM. This change does not address that; it is a separate defect in the same area.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Mesh nodes now shut down network connections gracefully, allowing peers to detect departures promptly.
  * Added bounded shutdown handling to prevent endpoints from hanging during closure.
  * Repeated shutdown requests now complete safely without re-entering the shutdown process.

* **Tests**
  * Added coverage verifying graceful closure of mesh and control connections, including shutdown completion and listener termination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->