### PR TITLE
fix: redact plugin provider health details

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/routes/plugins.rs
+++ b/crates/mesh-llm-host-runtime/src/api/routes/plugins.rs
@@ -209,7 +209,13 @@ async fn handle_endpoints(stream: &mut TcpStream, state: &MeshApi) -> anyhow::Re
 
 async fn handle_providers(stream: &mut TcpStream, state: &MeshApi) -> anyhow::Result<()> {
     match state.plugin_capability_providers().await {
-        Ok(providers) => respond_json(stream, 200, &providers).await?,
+        Ok(providers) => {
+            let providers = providers
+                .into_iter()
+                .map(|provider| provider.redacted_for_network())
+                .collect::<Vec<_>>();
+            respond_json(stream, 200, &providers).await?
+        }
         Err(err) => respond_error(stream, 500, &err.to_string()).await?,
     }
     Ok(())
@@ -225,7 +231,7 @@ async fn handle_provider(
         .map(|value| value.into_owned())
         .unwrap_or_else(|_| capability.to_string());
     match state.plugin_provider_for_capability(&capability).await {
-        Ok(Some(provider)) => respond_json(stream, 200, &provider).await?,
+        Ok(Some(provider)) => respond_json(stream, 200, &provider.redacted_for_network()).await?,
         Ok(None) => {
             respond_error(
                 stream,
@@ -969,6 +975,33 @@ mod tests {
             .await
             .unwrap();
         String::from_utf8(response_bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn provider_routes_redact_credentials_from_health_details() {
+        let plugin_manager = plugin::PluginManager::for_test_summaries(Vec::new());
+        plugin_manager.set_test_capability_providers(vec![
+            crate::plugin::PluginCapabilityProvider {
+                capability: "chat".into(),
+                plugin_name: "demo".into(),
+                plugin_status: "running".into(),
+                endpoint_id: Some("chat".into()),
+                available: true,
+                detail: Some(
+                    "GET https://alice:s3cret@host/v1/models?api_key=abc123 -> 200 OK".into(),
+                ),
+            },
+        ]);
+        let state = build_test_api_with_plugin_manager(plugin_manager).await;
+
+        for path in ["/api/plugins/providers", "/api/plugins/providers/chat"] {
+            let response = call_plugins_route(&state, "GET", path, "").await;
+            assert!(response.starts_with("HTTP/1.1 200 OK"), "{response}");
+            let body = response_body(&response);
+            assert!(!body.contains("alice:s3cret"), "userinfo leaked: {body}");
+            assert!(!body.contains("abc123"), "api_key leaked: {body}");
+            assert!(body.contains("host"), "host lost: {body}");
+        }
     }
 
     fn response_body(response: &str) -> &str {

--- a/crates/mesh-llm-host-runtime/src/logging/policy.rs
+++ b/crates/mesh-llm-host-runtime/src/logging/policy.rs
@@ -206,8 +206,7 @@ pub(crate) fn redact_urls_in_text(text: &str) -> String {
                 let url_start = cursor + relative_start;
                 redacted.push_str(&word[cursor..url_start]);
 
-                let scheme_len = if word[url_start..]
-                    .as_bytes()
+                let scheme_len = if word.as_bytes()[url_start..]
                     .get(..b"https://".len())
                     .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"https://"))
                 {

--- a/crates/mesh-llm-host-runtime/src/logging/policy.rs
+++ b/crates/mesh-llm-host-runtime/src/logging/policy.rs
@@ -219,7 +219,10 @@ pub(crate) fn redact_urls_in_text(text: &str) -> String {
                     .map_or(word.len(), |next_start| after_scheme + next_start);
                 let url_with_separator = &word[url_start..url_end];
                 let url_len = url_with_separator
-                    .trim_end_matches(['(', ')', '[', ']', '{', '}', ',', ';'])
+                    .trim_end_matches(|character: char| {
+                        character.is_ascii_punctuation()
+                            && !matches!(character, '=' | '&' | '?' | '#')
+                    })
                     .len();
                 let (url, separator) = url_with_separator.split_at(url_len);
                 redacted.push_str(&redact_url_query(url));
@@ -768,6 +771,18 @@ mod redaction_corpus_tests {
         assert_eq!(
             cleaned,
             "(https://host/v1?token=[REDACTED]),(https://host/v2?token=[REDACTED])"
+        );
+        assert!(!cleaned.contains("first"));
+        assert!(!cleaned.contains("second"));
+    }
+
+    #[test]
+    fn arbitrary_punctuation_between_query_bearing_urls_is_preserved() {
+        let text = "https://host/v1?token=first).https://host/v2?token=second";
+        let cleaned = redact_urls_in_text(text);
+        assert_eq!(
+            cleaned,
+            "https://host/v1?token=[REDACTED]).https://host/v2?token=[REDACTED]"
         );
         assert!(!cleaned.contains("first"));
         assert!(!cleaned.contains("second"));

--- a/crates/mesh-llm-host-runtime/src/logging/policy.rs
+++ b/crates/mesh-llm-host-runtime/src/logging/policy.rs
@@ -200,12 +200,29 @@ fn http_url_start(value: &str) -> Option<usize> {
 pub(crate) fn redact_urls_in_text(text: &str) -> String {
     text.split_whitespace()
         .map(|word| {
-            if let Some(url_start) = http_url_start(word) {
-                let (prefix, url) = word.split_at(url_start);
-                format!("{prefix}{}", redact_url_query(url))
-            } else {
-                word.to_string()
+            let mut redacted = String::with_capacity(word.len());
+            let mut cursor = 0;
+            while let Some(relative_start) = http_url_start(&word[cursor..]) {
+                let url_start = cursor + relative_start;
+                redacted.push_str(&word[cursor..url_start]);
+
+                let scheme_len = if word[url_start..]
+                    .as_bytes()
+                    .get(..b"https://".len())
+                    .is_some_and(|prefix| prefix.eq_ignore_ascii_case(b"https://"))
+                {
+                    b"https://".len()
+                } else {
+                    b"http://".len()
+                };
+                let after_scheme = url_start + scheme_len;
+                let url_end = http_url_start(&word[after_scheme..])
+                    .map_or(word.len(), |next_start| after_scheme + next_start);
+                redacted.push_str(&redact_url_query(&word[url_start..url_end]));
+                cursor = url_end;
             }
+            redacted.push_str(&word[cursor..]);
+            redacted
         })
         .collect::<Vec<_>>()
         .join(" ")
@@ -725,6 +742,18 @@ mod redaction_corpus_tests {
     fn url_without_query_passes_through() {
         let url = "https://example.com/path/to/resource";
         assert_eq!(redact_url_query(url), url);
+    }
+
+    #[test]
+    fn every_punctuation_adjacent_url_is_redacted() {
+        let text = "(https://alice:first@host/v1),(https://bob:second@host/v2)";
+        let cleaned = redact_urls_in_text(text);
+        assert_eq!(
+            cleaned,
+            "(https://[REDACTED]@host/v1),(https://[REDACTED]@host/v2)"
+        );
+        assert!(!cleaned.contains("alice:first"));
+        assert!(!cleaned.contains("bob:second"));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/logging/policy.rs
+++ b/crates/mesh-llm-host-runtime/src/logging/policy.rs
@@ -177,18 +177,32 @@ pub fn sanitize_lifecycle_event(event: LifecycleEvent) -> LifecycleEvent {
 /// let such an address bypass credential redaction, so every redaction gate
 /// must use this helper rather than a bare `starts_with("http://")`.
 pub(crate) fn is_http_url(value: &str) -> bool {
+    http_url_start(value) == Some(0)
+}
+
+fn http_url_start(value: &str) -> Option<usize> {
     let bytes = value.as_bytes();
     let starts_ci = |prefix: &[u8]| {
         bytes.len() >= prefix.len() && bytes[..prefix.len()].eq_ignore_ascii_case(prefix)
     };
-    starts_ci(b"http://") || starts_ci(b"https://")
+    if starts_ci(b"http://") || starts_ci(b"https://") {
+        return Some(0);
+    }
+    (1..bytes.len()).find(|&index| {
+        let suffix = &bytes[index..];
+        (suffix.len() >= b"http://".len()
+            && suffix[..b"http://".len()].eq_ignore_ascii_case(b"http://"))
+            || (suffix.len() >= b"https://".len()
+                && suffix[..b"https://".len()].eq_ignore_ascii_case(b"https://"))
+    })
 }
 
 pub(crate) fn redact_urls_in_text(text: &str) -> String {
     text.split_whitespace()
         .map(|word| {
-            if is_http_url(word) {
-                redact_url_query(word)
+            if let Some(url_start) = http_url_start(word) {
+                let (prefix, url) = word.split_at(url_start);
+                format!("{prefix}{}", redact_url_query(url))
             } else {
                 word.to_string()
             }

--- a/crates/mesh-llm-host-runtime/src/logging/policy.rs
+++ b/crates/mesh-llm-host-runtime/src/logging/policy.rs
@@ -220,8 +220,7 @@ pub(crate) fn redact_urls_in_text(text: &str) -> String {
                 let url_with_separator = &word[url_start..url_end];
                 let url_len = url_with_separator
                     .trim_end_matches(|character: char| {
-                        character.is_ascii_punctuation()
-                            && !matches!(character, '=' | '&' | '?' | '#')
+                        character.is_ascii_punctuation() && character != '='
                     })
                     .len();
                 let (url, separator) = url_with_separator.split_at(url_len);
@@ -786,6 +785,23 @@ mod redaction_corpus_tests {
         );
         assert!(!cleaned.contains("first"));
         assert!(!cleaned.contains("second"));
+    }
+
+    #[test]
+    fn url_syntax_punctuation_between_adjacent_urls_is_preserved() {
+        for separator in ['?', '&', '#'] {
+            let text =
+                format!("https://host/v1?token=first{separator}https://host/v2?token=second");
+            let cleaned = redact_urls_in_text(&text);
+            assert_eq!(
+                cleaned,
+                format!(
+                    "https://host/v1?token=[REDACTED]{separator}https://host/v2?token=[REDACTED]"
+                )
+            );
+            assert!(!cleaned.contains("first"));
+            assert!(!cleaned.contains("second"));
+        }
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/logging/policy.rs
+++ b/crates/mesh-llm-host-runtime/src/logging/policy.rs
@@ -217,7 +217,13 @@ pub(crate) fn redact_urls_in_text(text: &str) -> String {
                 let after_scheme = url_start + scheme_len;
                 let url_end = http_url_start(&word[after_scheme..])
                     .map_or(word.len(), |next_start| after_scheme + next_start);
-                redacted.push_str(&redact_url_query(&word[url_start..url_end]));
+                let url_with_separator = &word[url_start..url_end];
+                let url_len = url_with_separator
+                    .trim_end_matches(['(', ')', '[', ']', '{', '}', ',', ';'])
+                    .len();
+                let (url, separator) = url_with_separator.split_at(url_len);
+                redacted.push_str(&redact_url_query(url));
+                redacted.push_str(separator);
                 cursor = url_end;
             }
             redacted.push_str(&word[cursor..]);
@@ -753,6 +759,18 @@ mod redaction_corpus_tests {
         );
         assert!(!cleaned.contains("alice:first"));
         assert!(!cleaned.contains("bob:second"));
+    }
+
+    #[test]
+    fn punctuation_between_query_bearing_urls_is_preserved() {
+        let text = "(https://host/v1?token=first),(https://host/v2?token=second)";
+        let cleaned = redact_urls_in_text(text);
+        assert_eq!(
+            cleaned,
+            "(https://host/v1?token=[REDACTED]),(https://host/v2?token=[REDACTED])"
+        );
+        assert!(!cleaned.contains("first"));
+        assert!(!cleaned.contains("second"));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/plugin/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/mod.rs
@@ -583,6 +583,11 @@ impl PluginManager {
     }
 
     #[cfg(test)]
+    pub fn set_test_capability_providers(&self, providers: Vec<PluginCapabilityProvider>) {
+        self.publish_plugin_providers("__test__", providers);
+    }
+
+    #[cfg(test)]
     pub async fn set_test_inference_endpoints(&self, endpoints: Vec<InferenceEndpointRoute>) {
         *self.inner.test_inference_endpoints.lock().await = endpoints;
     }

--- a/crates/mesh-llm-host-runtime/src/plugin/types.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/types.rs
@@ -290,4 +290,26 @@ mod tests {
         assert!(!detail.contains("abc123"), "api_key leaked: {detail}");
         assert!(detail.contains("host"), "host lost: {detail}");
     }
+
+    #[test]
+    fn punctuation_delimited_detail_url_credentials_are_redacted_for_network() {
+        let provider = PluginCapabilityProvider {
+            capability: "chat".into(),
+            plugin_name: "demo".into(),
+            plugin_status: "running".into(),
+            endpoint_id: Some("chat".into()),
+            available: true,
+            detail: Some("GET (https://alice:s3cret@host/v1) -> 200 OK".into()),
+        }
+        .redacted_for_network();
+        let detail = provider.detail.expect("detail present");
+        assert!(
+            !detail.contains("alice:s3cret"),
+            "userinfo leaked: {detail}"
+        );
+        assert!(
+            detail.contains("(https://[REDACTED]@host/v1)"),
+            "URL punctuation lost: {detail}"
+        );
+    }
 }

--- a/crates/mesh-llm-host-runtime/src/plugin/types.rs
+++ b/crates/mesh-llm-host-runtime/src/plugin/types.rs
@@ -168,6 +168,21 @@ pub struct PluginCapabilityProvider {
     pub detail: Option<String>,
 }
 
+impl PluginCapabilityProvider {
+    /// Return a copy safe to serialize across a network boundary.
+    ///
+    /// Provider health details can echo the HTTP endpoint URL that was
+    /// probed, including URL userinfo or sensitive query parameters. The
+    /// provider projection has no address of its own, so only the embedded
+    /// URLs in `detail` need redaction.
+    pub(crate) fn redacted_for_network(mut self) -> Self {
+        if let Some(detail) = self.detail.as_deref() {
+            self.detail = Some(crate::logging::policy::redact_urls_in_text(detail));
+        }
+        self
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct InferenceEndpointRoute {
     pub plugin_name: String,
@@ -254,5 +269,25 @@ mod tests {
         let address = "/usr/local/bin/my-mcp-server --flag value";
         let redacted = summary_with(Some(address), None).redacted_for_network();
         assert_eq!(redacted.address.as_deref(), Some(address));
+    }
+
+    #[test]
+    fn provider_health_detail_url_credentials_are_redacted_for_network() {
+        let provider = PluginCapabilityProvider {
+            capability: "chat".into(),
+            plugin_name: "demo".into(),
+            plugin_status: "running".into(),
+            endpoint_id: Some("chat".into()),
+            available: true,
+            detail: Some("GET https://alice:s3cret@host/v1/models?api_key=abc123 -> 200 OK".into()),
+        }
+        .redacted_for_network();
+        let detail = provider.detail.expect("detail present");
+        assert!(
+            !detail.contains("alice:s3cret"),
+            "userinfo leaked: {detail}"
+        );
+        assert!(!detail.contains("abc123"), "api_key leaked: {detail}");
+        assert!(detail.contains("host"), "host lost: {detail}");
     }
 }


### PR DESCRIPTION
## Summary

- redact credential-bearing URLs embedded in plugin capability provider health details
- apply the network-safe projection to provider list and capability-specific routes
- add type-level and route-level regression coverage

## Validation

- cargo fmt --all --check
- just with-lld cargo test -p mesh-llm-host-runtime (2553 passed, 8 ignored; audit test passed)

This addresses release-validation finding D-001.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Provider details shared over the network now omit credentials, API keys, and other sensitive URL information.
  * Health information continues to include provider hosts while protecting private URL data.

* **Bug Fixes**
  * Improved protection of sensitive provider information in provider lists and individual provider responses.
  * Sensitive URLs in surrounding text, including multiple punctuation-adjacent URLs, are now detected and safely redacted.

* **Tests**
  * Added coverage for credential redaction and preservation of non-sensitive host information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->