### PR TITLE
fix: drain hosted split stages on shutdown

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
@@ -68,9 +68,9 @@ pub(crate) use resolver::{
 pub(crate) use skippy_server::OpenAiGuardrailsStatus as SkippyOpenAiGuardrailsStatus;
 pub(crate) use stage::{
     LayerRange, SourceModelKind, StageCancelPrepareRequest, StageControlCommand,
-    StageControlRequest, StageControlResponse, StageCoordinatorClaim, StageCoordinatorClaimAck,
-    StageInventoryRequest, StageLayerInventory, StageLoadRequest, StagePackagePrefetcher,
-    StagePeerDescriptor, StagePreparationState, StagePreparationStatus,
+    StageControlHandle, StageControlRequest, StageControlResponse, StageCoordinatorClaim,
+    StageCoordinatorClaimAck, StageInventoryRequest, StageLayerInventory, StageLoadRequest,
+    StagePackagePrefetcher, StagePeerDescriptor, StagePreparationState, StagePreparationStatus,
     StagePrepareAcceptedResponse, StagePrepareRequest, StageReadyResponse, StageRuntimeState,
     StageStatusAck, StageStatusFilter, StageStatusSnapshot, StageStopRequest, StageWireDType,
     spawn_stage_control_loop, stage_load_timeout,

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
@@ -14,7 +14,7 @@ use skippy_coordinator::{ClaimDecision, ClaimFence, LoadClaimRef};
 use skippy_protocol::{FlashAttentionType, LoadMode, PeerConfig, StageConfig};
 use skippy_server::{EmbeddedServerHandle, binary_transport::BinaryStageOptions};
 use tokio::{
-    sync::{Mutex, mpsc},
+    sync::{Mutex, mpsc, oneshot},
     task::JoinHandle,
 };
 
@@ -49,6 +49,25 @@ struct StagePreparationTask {
     handle: JoinHandle<()>,
 }
 
+pub(crate) struct StageControlHandle {
+    sender: mpsc::UnboundedSender<StageControlCommand>,
+    shutdown: Option<oneshot::Sender<()>>,
+    task: JoinHandle<Result<()>>,
+}
+
+impl StageControlHandle {
+    pub(crate) fn sender(&self) -> mpsc::UnboundedSender<StageControlCommand> {
+        self.sender.clone()
+    }
+
+    pub(crate) async fn shutdown(mut self) -> Result<()> {
+        if let Some(shutdown) = self.shutdown.take() {
+            let _ = shutdown.send(());
+        }
+        self.task.await.context("join stage control loop")?
+    }
+}
+
 #[async_trait::async_trait]
 pub(crate) trait StagePackagePrefetcher: Send + Sync {
     async fn prefetch_stage_package(&self, request: &StagePrepareRequest) -> Result<()>;
@@ -57,23 +76,56 @@ pub(crate) trait StagePackagePrefetcher: Send + Sync {
 pub(crate) fn spawn_stage_control_loop(
     package_prefetcher: Option<Arc<dyn StagePackagePrefetcher>>,
     telemetry: super::SkippyTelemetryOptions,
-) -> mpsc::UnboundedSender<StageControlCommand> {
+) -> StageControlHandle {
     let (tx, mut rx) = mpsc::unbounded_channel::<StageControlCommand>();
-    tokio::spawn(async move {
+    let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
+    let task = tokio::spawn(async move {
         let mut state = StageControlState {
             package_prefetcher,
             telemetry,
             ..Default::default()
         };
-        while let Some(command) = rx.recv().await {
-            let result = state.handle(command.request).await;
-            let _ = command.resp.send(result);
+        loop {
+            tokio::select! {
+                biased;
+                _ = &mut shutdown_rx => break,
+                command = rx.recv() => {
+                    let Some(command) = command else { break };
+                    let result = state.handle(command.request).await;
+                    let _ = command.resp.send(result);
+                }
+            }
         }
+        state.shutdown().await
     });
-    tx
+    StageControlHandle {
+        sender: tx,
+        shutdown: Some(shutdown_tx),
+        task,
+    }
 }
 
 impl StageControlState {
+    async fn shutdown(&mut self) -> Result<()> {
+        for (_, task) in self.preparation_tasks.drain() {
+            task.cancelled.store(true, Ordering::Release);
+            task.handle.abort();
+            let _ = task.handle.await;
+        }
+        let mut first_error = None;
+        for (_, stage) in self.stages.drain() {
+            if let Err(error) = stage.server.shutdown().await
+                && first_error.is_none()
+            {
+                first_error = Some(error);
+            }
+        }
+        if let Some(error) = first_error {
+            return Err(error);
+        }
+        Ok(())
+    }
+
     async fn handle(&mut self, request: StageControlRequest) -> Result<StageControlResponse> {
         match request {
             StageControlRequest::Claim(claim) => self

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
@@ -40,6 +40,7 @@ struct StageControlState {
     coordinator_claims: ClaimFence,
     preparations: Arc<Mutex<HashMap<String, StagePreparationStatus>>>,
     preparation_tasks: HashMap<String, StagePreparationTask>,
+    readiness_probe: Option<StageReadinessProbe>,
     package_prefetcher: Option<Arc<dyn StagePackagePrefetcher>>,
     telemetry: super::SkippyTelemetryOptions,
 }
@@ -47,6 +48,11 @@ struct StageControlState {
 struct StagePreparationTask {
     cancelled: Arc<AtomicBool>,
     handle: JoinHandle<()>,
+}
+
+struct StageReadinessProbe {
+    cancelled: Arc<AtomicBool>,
+    handle: JoinHandle<Result<()>>,
 }
 
 pub(crate) struct StageControlHandle {
@@ -119,6 +125,10 @@ impl StageControlState {
             task.cancelled.store(true, Ordering::Release);
             task.handle.abort();
             let _ = task.handle.await;
+        }
+        if let Some(mut probe) = self.readiness_probe.take() {
+            probe.cancelled.store(true, Ordering::Release);
+            let _ = (&mut probe.handle).await;
         }
         let mut first_error = None;
         for (_, stage) in self.stages.drain() {
@@ -450,9 +460,21 @@ impl StageControlState {
                 _materialized_pin: None,
             },
         );
-        if let Err(error) =
-            wait_for_binary_stage_ready(bind_addr, stage_load_timeout(&effective_load)).await
-        {
+        self.readiness_probe = Some(start_binary_stage_ready_probe(
+            bind_addr,
+            stage_load_timeout(&effective_load),
+        ));
+        let readiness_result = {
+            let probe = self
+                .readiness_probe
+                .as_mut()
+                .expect("binary stage readiness probe must remain registered while pending");
+            (&mut probe.handle)
+                .await
+                .context("join binary stage readiness probe")
+        };
+        self.readiness_probe.take();
+        if let Err(error) = readiness_result.and_then(|result| result) {
             let stage = self
                 .stages
                 .remove(&key)
@@ -645,10 +667,13 @@ fn materialize_stage_bind_addr(bind_addr: SocketAddr) -> Result<SocketAddr> {
         .context("read reserved ephemeral stage bind address")
 }
 
-async fn wait_for_binary_stage_ready(bind_addr: SocketAddr, timeout: Duration) -> Result<()> {
-    tokio::task::spawn_blocking(move || probe_binary_stage_ready(bind_addr, timeout))
-        .await
-        .context("join binary stage readiness probe")?
+fn start_binary_stage_ready_probe(bind_addr: SocketAddr, timeout: Duration) -> StageReadinessProbe {
+    let cancelled = Arc::new(AtomicBool::new(false));
+    let probe_cancelled = Arc::clone(&cancelled);
+    let handle = tokio::task::spawn_blocking(move || {
+        probe_binary_stage_ready(bind_addr, timeout, &probe_cancelled)
+    });
+    StageReadinessProbe { cancelled, handle }
 }
 
 pub(crate) fn stage_load_timeout(load: &StageLoadRequest) -> Duration {
@@ -704,15 +729,23 @@ fn stage_load_failure_context(
     )
 }
 
-fn probe_binary_stage_ready(bind_addr: SocketAddr, timeout: Duration) -> Result<()> {
+fn probe_binary_stage_ready(
+    bind_addr: SocketAddr,
+    timeout: Duration,
+    cancelled: &AtomicBool,
+) -> Result<()> {
+    const PROBE_IO_TIMEOUT: Duration = Duration::from_secs(2);
     let deadline = std::time::Instant::now() + timeout;
     let mut last_error = None;
     while std::time::Instant::now() < deadline {
-        match std::net::TcpStream::connect(bind_addr) {
+        if cancelled.load(Ordering::Acquire) {
+            return Err(anyhow!("binary stage readiness probe cancelled"));
+        }
+        match std::net::TcpStream::connect_timeout(&bind_addr, PROBE_IO_TIMEOUT) {
             Ok(mut stream) => {
                 stream.set_nodelay(true).ok();
-                stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
-                stream.set_write_timeout(Some(Duration::from_secs(2))).ok();
+                stream.set_read_timeout(Some(PROBE_IO_TIMEOUT)).ok();
+                stream.set_write_timeout(Some(PROBE_IO_TIMEOUT)).ok();
                 match skippy_protocol::binary::recv_ready(&mut stream) {
                     Ok(()) => return Ok(()),
                     Err(error) => {
@@ -725,7 +758,12 @@ fn probe_binary_stage_ready(bind_addr: SocketAddr, timeout: Duration) -> Result<
                 last_error = Some(anyhow!(error).context("connect binary stage listener"));
             }
         }
-        std::thread::sleep(Duration::from_millis(250));
+        for _ in 0..25 {
+            if cancelled.load(Ordering::Acquire) {
+                return Err(anyhow!("binary stage readiness probe cancelled"));
+            }
+            std::thread::sleep(Duration::from_millis(10));
+        }
     }
     Err(last_error
         .unwrap_or_else(|| anyhow!("timed out waiting for binary stage ready at {bind_addr}"))

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/mod.rs
@@ -77,22 +77,30 @@ pub(crate) fn spawn_stage_control_loop(
     package_prefetcher: Option<Arc<dyn StagePackagePrefetcher>>,
     telemetry: super::SkippyTelemetryOptions,
 ) -> StageControlHandle {
+    spawn_stage_control_loop_with_state(StageControlState {
+        package_prefetcher,
+        telemetry,
+        ..Default::default()
+    })
+}
+
+fn spawn_stage_control_loop_with_state(mut state: StageControlState) -> StageControlHandle {
     let (tx, mut rx) = mpsc::unbounded_channel::<StageControlCommand>();
     let (shutdown_tx, mut shutdown_rx) = oneshot::channel();
     let task = tokio::spawn(async move {
-        let mut state = StageControlState {
-            package_prefetcher,
-            telemetry,
-            ..Default::default()
-        };
         loop {
             tokio::select! {
                 biased;
                 _ = &mut shutdown_rx => break,
                 command = rx.recv() => {
                     let Some(command) = command else { break };
-                    let result = state.handle(command.request).await;
-                    let _ = command.resp.send(result);
+                    tokio::select! {
+                        biased;
+                        _ = &mut shutdown_rx => break,
+                        result = state.handle(command.request) => {
+                            let _ = command.resp.send(result);
+                        }
+                    }
                 }
             }
         }
@@ -432,21 +440,8 @@ impl StageControlState {
             native_mtp_enabled: effective_load.native_mtp_enabled,
             openai: None,
         });
-        if let Err(error) =
-            wait_for_binary_stage_ready(bind_addr, stage_load_timeout(&effective_load)).await
-        {
-            let last_error = server.status().last_error;
-            let context = stage_load_failure_context(
-                &effective_load,
-                "binary stage did not become ready",
-                last_error.as_deref(),
-            );
-            let _ = server.shutdown().await;
-            return Err(error.context(context));
-        }
-
         self.stages.insert(
-            key,
+            key.clone(),
             RunningStage {
                 load: effective_load.clone(),
                 server,
@@ -455,6 +450,23 @@ impl StageControlState {
                 _materialized_pin: None,
             },
         );
+        if let Err(error) =
+            wait_for_binary_stage_ready(bind_addr, stage_load_timeout(&effective_load)).await
+        {
+            let stage = self
+                .stages
+                .remove(&key)
+                .expect("newly started stage must remain registered while readiness is pending");
+            let last_error = stage.server.status().last_error;
+            let context = stage_load_failure_context(
+                &effective_load,
+                "binary stage did not become ready",
+                last_error.as_deref(),
+            );
+            let _ = stage.server.shutdown().await;
+            return Err(error.context(context));
+        }
+
         let status = self
             .statuses(&StageStatusFilter {
                 topology_id: Some(effective_load.topology_id.clone()),

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/tests.rs
@@ -35,6 +35,33 @@ async fn stage_control_shutdown_closes_and_joins_the_control_loop() {
     );
 }
 
+#[tokio::test]
+async fn stage_control_shutdown_interrupts_an_active_request() {
+    let state = StageControlState::default();
+    let preparations = Arc::clone(&state.preparations);
+    let preparations_guard = preparations.lock().await;
+    let handle = spawn_stage_control_loop_with_state(state);
+    let (resp, _rx) = oneshot::channel();
+    handle
+        .sender()
+        .send(StageControlCommand {
+            request: StageControlRequest::StatusUpdate(preparation_status_from_load(
+                &load_request(),
+                StagePreparationState::Assigned,
+                None,
+            )),
+            resp,
+        })
+        .expect("control command accepted");
+    tokio::time::sleep(Duration::from_millis(25)).await;
+
+    tokio::time::timeout(Duration::from_secs(1), handle.shutdown())
+        .await
+        .expect("shutdown must interrupt the active request")
+        .expect("stage control shutdown should succeed");
+    drop(preparations_guard);
+}
+
 fn load_request() -> StageLoadRequest {
     StageLoadRequest {
         topology_id: "topology-a".to_string(),

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/tests.rs
@@ -408,10 +408,45 @@ async fn binary_stage_ready_probe_waits_for_wire_handshake() {
     });
 
     let started = Instant::now();
-    wait_for_binary_stage_ready(bind_addr, Duration::from_secs(2))
+    let mut probe = start_binary_stage_ready_probe(bind_addr, Duration::from_secs(2));
+    (&mut probe.handle)
         .await
+        .expect("join readiness probe")
         .unwrap();
     assert!(started.elapsed() >= Duration::from_millis(50));
+    server.join().unwrap();
+}
+
+#[tokio::test]
+async fn stage_control_shutdown_cancels_and_joins_an_active_readiness_probe() {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    let bind_addr = listener.local_addr().unwrap();
+    let (accepted_tx, accepted_rx) = std::sync::mpsc::channel();
+    let (release_tx, release_rx) = std::sync::mpsc::channel();
+    let server = std::thread::spawn(move || {
+        let (_stream, _) = listener.accept().unwrap();
+        accepted_tx.send(()).unwrap();
+        let _ = release_rx.recv_timeout(Duration::from_secs(5));
+    });
+
+    let state = StageControlState {
+        readiness_probe: Some(start_binary_stage_ready_probe(
+            bind_addr,
+            Duration::from_secs(900),
+        )),
+        ..Default::default()
+    };
+    let handle = spawn_stage_control_loop_with_state(state);
+    accepted_rx
+        .recv_timeout(Duration::from_secs(1))
+        .expect("readiness probe connected to silent stage");
+
+    tokio::time::timeout(Duration::from_secs(3), handle.shutdown())
+        .await
+        .expect("shutdown must not wait for the readiness deadline")
+        .expect("stage control shutdown should succeed");
+
+    release_tx.send(()).unwrap();
     server.join().unwrap();
 }
 

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/stage/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/stage/tests.rs
@@ -10,6 +10,31 @@ use anyhow::{Result, anyhow};
 use skippy_protocol::{FlashAttentionType, LoadMode, StageDevice};
 use tokio::sync::{Mutex as TokioMutex, oneshot};
 
+#[tokio::test]
+async fn stage_control_shutdown_closes_and_joins_the_control_loop() {
+    let handle = spawn_stage_control_loop(None, super::super::SkippyTelemetryOptions::default());
+    let sender = handle.sender();
+
+    tokio::time::timeout(Duration::from_secs(1), handle.shutdown())
+        .await
+        .expect("stage control shutdown should be bounded")
+        .expect("stage control shutdown should succeed");
+    let (resp, _rx) = oneshot::channel();
+    assert!(
+        sender
+            .send(StageControlCommand {
+                request: StageControlRequest::Status(StageStatusFilter {
+                    topology_id: None,
+                    run_id: None,
+                    stage_id: None,
+                }),
+                resp,
+            })
+            .is_err(),
+        "shutdown must close the stage control command channel"
+    );
+}
+
 fn load_request() -> StageLoadRequest {
     StageLoadRequest {
         topology_id: "topology-a".to_string(),

--- a/crates/mesh-llm-host-runtime/src/mesh/node.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node.rs
@@ -95,6 +95,8 @@ pub struct Node {
             >,
         >,
     >,
+    pub(crate) stage_control_lifecycle:
+        Arc<Mutex<Option<crate::inference::skippy::StageControlHandle>>>,
     pub(crate) stage_transport_bridges: Arc<Mutex<HashMap<String, StageTransportBridge>>>,
     pub(crate) stage_transport_aliases: Arc<Mutex<HashMap<String, String>>>,
     pub(crate) stage_topologies: Arc<Mutex<StageTopologyState>>,
@@ -658,6 +660,17 @@ impl Node {
             let _ = lifecycle.task.await;
             lifecycle.endpoint.close().await;
         }
+        self.shutdown_stage_control().await;
+    }
+
+    async fn shutdown_stage_control(&self) {
+        *self.stage_control_tx.lock().await = None;
+        let lifecycle = self.stage_control_lifecycle.lock().await.take();
+        if let Some(lifecycle) = lifecycle
+            && let Err(error) = lifecycle.shutdown().await
+        {
+            tracing::warn!("stage control shutdown failed: {error:#}");
+        }
     }
 
     #[expect(
@@ -814,6 +827,7 @@ impl Node {
             tunnel_http_tx,
             stage_transport_tx,
             stage_control_tx: Arc::new(Mutex::new(None)),
+            stage_control_lifecycle: Arc::new(Mutex::new(None)),
             stage_transport_bridges: Arc::new(Mutex::new(HashMap::new())),
             stage_transport_aliases: Arc::new(Mutex::new(HashMap::new())),
             stage_topologies: Arc::new(Mutex::new(StageTopologyState::default())),
@@ -990,6 +1004,7 @@ impl Node {
             tunnel_http_tx,
             stage_transport_tx,
             stage_control_tx: Arc::new(Mutex::new(None)),
+            stage_control_lifecycle: Arc::new(Mutex::new(None)),
             stage_transport_bridges: Arc::new(Mutex::new(HashMap::new())),
             stage_transport_aliases: Arc::new(Mutex::new(HashMap::new())),
             stage_topologies: Arc::new(Mutex::new(StageTopologyState::default())),

--- a/crates/mesh-llm-host-runtime/src/mesh/stage_transport.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/stage_transport.rs
@@ -684,6 +684,15 @@ impl Node {
         self.inflight_change_tx.subscribe()
     }
 
+    pub(crate) async fn set_stage_control_handle(
+        &self,
+        lifecycle: crate::inference::skippy::StageControlHandle,
+    ) {
+        *self.stage_control_tx.lock().await = Some(lifecycle.sender());
+        *self.stage_control_lifecycle.lock().await = Some(lifecycle);
+    }
+
+    #[cfg(test)]
     pub(crate) async fn set_stage_control_sender(
         &self,
         tx: tokio::sync::mpsc::UnboundedSender<crate::inference::skippy::StageControlCommand>,

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/connections.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/connections.rs
@@ -318,6 +318,7 @@ async fn make_test_node_with_requirements(
         tunnel_http_tx,
         stage_transport_tx,
         stage_control_tx: Arc::new(Mutex::new(None)),
+        stage_control_lifecycle: Arc::new(Mutex::new(None)),
         stage_transport_bridges: Arc::new(Mutex::new(HashMap::new())),
         stage_transport_aliases: Arc::new(Mutex::new(HashMap::new())),
         stage_topologies: Arc::new(Mutex::new(StageTopologyState::default())),

--- a/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
@@ -734,7 +734,7 @@ pub(super) async fn start_run_auto_node_and_plugins(
     .await?;
     node.set_swarm_capture_recorder(swarm_capture);
     attach_local_release_attestation(&node).await?;
-    node.set_stage_control_sender(skippy::spawn_stage_control_loop(
+    node.set_stage_control_handle(skippy::spawn_stage_control_loop(
         Some(Arc::new(node.clone())),
         skippy_telemetry_options(options),
     ))

--- a/crates/skippy-server/src/binary_transport/binary_messaging.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging.rs
@@ -18,7 +18,7 @@ use super::{
     decode_batcher::DecodeFrameBatcher,
     direct_return::{PredictionReturnHub, PredictionReturnSinks},
     options::BinaryStageOptions,
-    preconnect::spawn_downstream_preconnector,
+    preconnect::DownstreamPreconnector,
 };
 use crate::{
     cli::ServeBinaryArgs,
@@ -196,9 +196,6 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
     );
     telemetry.emit("stage.binary_server_start", lifecycle_attrs(&config));
     let warm_downstream = Arc::new(Mutex::new(None));
-    if warm_downstream_preconnect_enabled() {
-        spawn_downstream_preconnector(config.clone(), warm_downstream.clone(), shutdown.clone());
-    }
     let runtime = load_runtime_with_overrides(
         &config,
         &RuntimeLaunchOverrides {
@@ -292,6 +289,12 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
             }
         });
     }
+    let _downstream_preconnector = warm_downstream_preconnect_enabled()
+        .then(|| {
+            DownstreamPreconnector::spawn(config.clone(), warm_downstream.clone(), shutdown.clone())
+        })
+        .transpose()
+        .context("spawn downstream preconnector")?;
     println!(
         "skippy-server listening: binary={} stage_id={} layer_range={}..{} activation_width={} dtype={:?}",
         bind_addr,

--- a/crates/skippy-server/src/binary_transport/binary_messaging.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging.rs
@@ -97,18 +97,19 @@ impl ConnectionWorkers {
         self.0.push(worker);
     }
 
-    fn reap_finished(&mut self) {
+    fn reap_finished(&mut self) -> Result<()> {
         let mut index = 0;
         while index < self.0.len() {
             if self.0[index].task.is_finished() {
                 let worker = self.0.swap_remove(index);
                 if worker.task.join().is_err() {
-                    eprintln!("binary stage connection worker panicked");
+                    bail!("binary stage connection worker panicked");
                 }
             } else {
                 index += 1;
             }
         }
+        Ok(())
     }
 
     fn shutdown(mut self) -> Result<()> {
@@ -303,7 +304,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
 
     let accept_result = (|| -> Result<()> {
         while !shutdown.load(Ordering::SeqCst) {
-            connection_workers.reap_finished();
+            connection_workers.reap_finished()?;
             let (mut upstream, _) = match listener.accept() {
                 Ok(conn) => conn,
                 Err(error) if error.kind() == io::ErrorKind::WouldBlock => {

--- a/crates/skippy-server/src/binary_transport/binary_messaging.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging.rs
@@ -424,6 +424,7 @@ mod shutdown_tests {
         sync::{
             Arc,
             atomic::{AtomicBool, Ordering},
+            mpsc,
         },
         thread,
         time::Duration,
@@ -470,9 +471,17 @@ mod shutdown_tests {
         let mut workers = ConnectionWorkers::default();
         workers.push(ConnectionWorker { control, task });
 
-        let error = finish_connection_workers(Err(anyhow!("accept failed")), workers)
-            .expect_err("accept failure must be returned after worker cleanup");
+        let (cleanup_tx, cleanup_rx) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let result = finish_connection_workers(Err(anyhow!("accept failed")), workers);
+            let _ = cleanup_tx.send(result);
+        });
+
+        let result = cleanup_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("active worker cleanup must complete within one second");
         assert!(finished.load(Ordering::Acquire));
+        let error = result.expect_err("accept failure must be returned after worker cleanup");
         assert!(format!("{error:#}").contains("accept failed"));
         drop(client);
     }

--- a/crates/skippy-server/src/binary_transport/binary_messaging.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging.rs
@@ -326,6 +326,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
             let kv = kv.clone();
             let telemetry = telemetry.clone();
             let warm_downstream = warm_downstream.clone();
+            let worker_shutdown = shutdown.clone();
             let prediction_returns = prediction_returns.clone();
             let prediction_return_sinks = prediction_return_sinks.clone();
             let worker_control = Arc::new(ConnectionWorkerControl::default());
@@ -363,6 +364,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
                         &config,
                         &warm_downstream,
                         downstream_connect_timeout_secs,
+                        &worker_shutdown,
                     )?;
                     if let Some(stream) = downstream.as_ref() {
                         task_control
@@ -409,6 +411,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
         }
         Ok(())
     })();
+    shutdown.store(true, Ordering::SeqCst);
     finish_connection_workers(accept_result, connection_workers)
 }
 
@@ -446,9 +449,14 @@ mod shutdown_tests {
         let mut workers = ConnectionWorkers::default();
         workers.push(ConnectionWorker { control, task });
 
-        let started = std::time::Instant::now();
-        workers.shutdown().unwrap();
-        assert!(started.elapsed() < Duration::from_secs(1));
+        let (cleanup_tx, cleanup_rx) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            let _ = cleanup_tx.send(workers.shutdown());
+        });
+        cleanup_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("active worker cleanup must complete within one second")
+            .unwrap();
         drop(client);
     }
 

--- a/crates/skippy-server/src/binary_transport/binary_messaging.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging.rs
@@ -6,7 +6,7 @@ use std::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
     },
-    thread,
+    thread::{self, JoinHandle},
     time::{Duration, Instant},
 };
 
@@ -44,6 +44,87 @@ mod summary;
 mod telemetry;
 
 use self::connection::handle_binary_connection;
+
+#[derive(Default)]
+struct ConnectionWorkerControl {
+    shutting_down: AtomicBool,
+    sockets: Mutex<Vec<std::net::TcpStream>>,
+}
+
+impl ConnectionWorkerControl {
+    fn track(&self, stream: &std::net::TcpStream) -> io::Result<()> {
+        let tracked = stream.try_clone()?;
+        let mut sockets = self
+            .sockets
+            .lock()
+            .expect("connection sockets lock poisoned");
+        if self.shutting_down.load(Ordering::Acquire) {
+            let _ = tracked.shutdown(std::net::Shutdown::Both);
+        }
+        sockets.push(tracked);
+        Ok(())
+    }
+
+    fn shutdown(&self) {
+        self.shutting_down.store(true, Ordering::Release);
+        let sockets = self
+            .sockets
+            .lock()
+            .expect("connection sockets lock poisoned");
+        for socket in sockets.iter() {
+            let _ = socket.shutdown(std::net::Shutdown::Both);
+        }
+    }
+
+    fn clear(&self) {
+        self.sockets
+            .lock()
+            .expect("connection sockets lock poisoned")
+            .clear();
+    }
+}
+
+struct ConnectionWorker {
+    control: Arc<ConnectionWorkerControl>,
+    task: JoinHandle<()>,
+}
+
+#[derive(Default)]
+struct ConnectionWorkers(Vec<ConnectionWorker>);
+
+impl ConnectionWorkers {
+    fn push(&mut self, worker: ConnectionWorker) {
+        self.0.push(worker);
+    }
+
+    fn reap_finished(&mut self) {
+        let mut index = 0;
+        while index < self.0.len() {
+            if self.0[index].task.is_finished() {
+                let worker = self.0.swap_remove(index);
+                if worker.task.join().is_err() {
+                    eprintln!("binary stage connection worker panicked");
+                }
+            } else {
+                index += 1;
+            }
+        }
+    }
+
+    fn shutdown(mut self) -> Result<()> {
+        for worker in &self.0 {
+            worker.control.shutdown();
+        }
+        let mut panicked = false;
+        for worker in self.0.drain(..) {
+            panicked |= worker.task.join().is_err();
+        }
+        if panicked {
+            bail!("binary stage connection worker panicked during shutdown");
+        }
+        Ok(())
+    }
+}
 
 pub async fn serve_binary(args: ServeBinaryArgs) -> Result<()> {
     serve_binary_stage(BinaryStageOptions::from_cli_args(args)?).await
@@ -142,6 +223,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
     let kv = KvStageIntegration::from_config(&config)?.map(Arc::new);
     let prediction_returns = Arc::new(PredictionReturnHub::default());
     let prediction_return_sinks = Arc::new(PredictionReturnSinks::default());
+    let mut connection_workers = ConnectionWorkers::default();
     let listener = TcpListener::bind(bind_addr)?;
     listener.set_nonblocking(true)?;
     if let Some(openai_options) = openai {
@@ -206,6 +288,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
     );
 
     while !shutdown.load(Ordering::SeqCst) {
+        connection_workers.reap_finished();
         let (mut upstream, _) = match listener.accept() {
             Ok(conn) => conn,
             Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
@@ -229,7 +312,12 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
         let warm_downstream = warm_downstream.clone();
         let prediction_returns = prediction_returns.clone();
         let prediction_return_sinks = prediction_return_sinks.clone();
-        thread::spawn(move || {
+        let worker_control = Arc::new(ConnectionWorkerControl::default());
+        worker_control
+            .track(&upstream)
+            .context("track upstream binary stage connection")?;
+        let task_control = worker_control.clone();
+        let task = thread::spawn(move || {
             let connection_result = (|| -> Result<()> {
                 eprintln!(
                     "binary sending ready: stage_id={} peer={peer_addr:?}",
@@ -260,6 +348,11 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
                     &warm_downstream,
                     downstream_connect_timeout_secs,
                 )?;
+                if let Some(stream) = downstream.as_ref() {
+                    task_control
+                        .track(stream)
+                        .context("track downstream binary stage connection")?;
+                }
                 handle_binary_connection(
                     &config,
                     topology.as_ref(),
@@ -291,7 +384,46 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
                 eprintln!("{error:#}");
                 telemetry.emit("stage.binary_connection_error", attrs);
             }
+            task_control.clear();
+        });
+        connection_workers.push(ConnectionWorker {
+            control: worker_control,
+            task,
         });
     }
-    Ok(())
+    connection_workers.shutdown()
+}
+
+#[cfg(test)]
+mod shutdown_tests {
+    use super::{ConnectionWorker, ConnectionWorkerControl, ConnectionWorkers};
+    use std::{
+        io::Read,
+        net::{TcpListener, TcpStream},
+        sync::Arc,
+        thread,
+        time::Duration,
+    };
+
+    #[test]
+    fn shutdown_closes_and_joins_an_active_connection_worker() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (mut server, _) = listener.accept().unwrap();
+        let control = Arc::new(ConnectionWorkerControl::default());
+        control.track(&server).unwrap();
+        let task_control = control.clone();
+        let task = thread::spawn(move || {
+            let mut byte = [0u8; 1];
+            let _ = server.read(&mut byte);
+            task_control.clear();
+        });
+        let mut workers = ConnectionWorkers::default();
+        workers.push(ConnectionWorker { control, task });
+
+        let started = std::time::Instant::now();
+        workers.shutdown().unwrap();
+        assert!(started.elapsed() < Duration::from_secs(1));
+        drop(client);
+    }
 }

--- a/crates/skippy-server/src/binary_transport/binary_messaging.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging.rs
@@ -126,6 +126,20 @@ impl ConnectionWorkers {
     }
 }
 
+fn finish_connection_workers(
+    accept_result: Result<()>,
+    connection_workers: ConnectionWorkers,
+) -> Result<()> {
+    let shutdown_result = connection_workers.shutdown();
+    match (accept_result, shutdown_result) {
+        (Ok(()), result) => result,
+        (Err(error), Ok(())) => Err(error),
+        (Err(error), Err(shutdown_error)) => Err(error.context(format!(
+            "connection worker shutdown also failed: {shutdown_error:#}"
+        ))),
+    }
+}
+
 pub async fn serve_binary(args: ServeBinaryArgs) -> Result<()> {
     serve_binary_stage(BinaryStageOptions::from_cli_args(args)?).await
 }
@@ -287,120 +301,129 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
         wire_dtype,
     );
 
-    while !shutdown.load(Ordering::SeqCst) {
-        connection_workers.reap_finished();
-        let (mut upstream, _) = match listener.accept() {
-            Ok(conn) => conn,
-            Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
-                thread::sleep(Duration::from_millis(50));
-                continue;
-            }
-            Err(error) => return Err(error).context("accept binary stage connection"),
-        };
-        prepare_binary_stage_connection(&upstream)?;
-        let peer_addr = upstream.peer_addr().ok();
-        eprintln!(
-            "binary accepted connection: stage_id={} peer={peer_addr:?}",
-            config.stage_id
-        );
-        let config = config.clone();
-        let topology = topology.clone();
-        let runtime = runtime.clone();
-        let decode_frame_batcher = decode_frame_batcher.clone();
-        let kv = kv.clone();
-        let telemetry = telemetry.clone();
-        let warm_downstream = warm_downstream.clone();
-        let prediction_returns = prediction_returns.clone();
-        let prediction_return_sinks = prediction_return_sinks.clone();
-        let worker_control = Arc::new(ConnectionWorkerControl::default());
-        worker_control
-            .track(&upstream)
-            .context("track upstream binary stage connection")?;
-        let task_control = worker_control.clone();
-        let task = thread::spawn(move || {
-            let connection_result = (|| -> Result<()> {
-                eprintln!(
-                    "binary sending ready: stage_id={} peer={peer_addr:?}",
-                    config.stage_id
-                );
-                consume_optional_client_ready_hello(&mut upstream)
-                    .context("consume optional client ready hello")?;
-                send_ready(&mut upstream).context("failed to send binary ready")?;
-                upstream.flush().ok();
-                eprintln!(
-                    "binary sent ready: stage_id={} peer={peer_addr:?}",
-                    config.stage_id
-                );
-                let first_message = match read_stage_message(&mut upstream, activation_width) {
-                    Ok(message) => message,
-                    Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
-                    Err(error) => return Err(error.into()),
-                };
-                if first_message.kind == WireMessageKind::PredictionReturnOpen {
-                    if config.stage_index == 0 {
-                        return prediction_returns
-                            .handle_return_connection(first_message, upstream);
+    let accept_result = (|| -> Result<()> {
+        while !shutdown.load(Ordering::SeqCst) {
+            connection_workers.reap_finished();
+            let (mut upstream, _) = match listener.accept() {
+                Ok(conn) => conn,
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(50));
+                    continue;
+                }
+                Err(error) => return Err(error).context("accept binary stage connection"),
+            };
+            prepare_binary_stage_connection(&upstream)?;
+            let peer_addr = upstream.peer_addr().ok();
+            eprintln!(
+                "binary accepted connection: stage_id={} peer={peer_addr:?}",
+                config.stage_id
+            );
+            let config = config.clone();
+            let topology = topology.clone();
+            let runtime = runtime.clone();
+            let decode_frame_batcher = decode_frame_batcher.clone();
+            let kv = kv.clone();
+            let telemetry = telemetry.clone();
+            let warm_downstream = warm_downstream.clone();
+            let prediction_returns = prediction_returns.clone();
+            let prediction_return_sinks = prediction_return_sinks.clone();
+            let worker_control = Arc::new(ConnectionWorkerControl::default());
+            worker_control
+                .track(&upstream)
+                .context("track upstream binary stage connection")?;
+            let task_control = worker_control.clone();
+            let task = thread::spawn(move || {
+                let connection_result = (|| -> Result<()> {
+                    eprintln!(
+                        "binary sending ready: stage_id={} peer={peer_addr:?}",
+                        config.stage_id
+                    );
+                    consume_optional_client_ready_hello(&mut upstream)
+                        .context("consume optional client ready hello")?;
+                    send_ready(&mut upstream).context("failed to send binary ready")?;
+                    upstream.flush().ok();
+                    eprintln!(
+                        "binary sent ready: stage_id={} peer={peer_addr:?}",
+                        config.stage_id
+                    );
+                    let first_message = match read_stage_message(&mut upstream, activation_width) {
+                        Ok(message) => message,
+                        Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
+                        Err(error) => return Err(error.into()),
+                    };
+                    if first_message.kind == WireMessageKind::PredictionReturnOpen {
+                        if config.stage_index == 0 {
+                            return prediction_returns
+                                .handle_return_connection(first_message, upstream);
+                        }
+                        return prediction_return_sinks.insert_opened_sink(first_message, upstream);
                     }
-                    return prediction_return_sinks.insert_opened_sink(first_message, upstream);
+                    let downstream = take_ready_downstream(
+                        &config,
+                        &warm_downstream,
+                        downstream_connect_timeout_secs,
+                    )?;
+                    if let Some(stream) = downstream.as_ref() {
+                        task_control
+                            .track(stream)
+                            .context("track downstream binary stage connection")?;
+                    }
+                    handle_binary_connection(
+                        &config,
+                        topology.as_ref(),
+                        &runtime,
+                        &decode_frame_batcher,
+                        kv.as_ref(),
+                        &telemetry,
+                        &mut upstream,
+                        downstream,
+                        activation_width,
+                        wire_dtype,
+                        max_inflight,
+                        reply_credit_limit,
+                        async_prefill_forward,
+                        downstream_wire_condition,
+                        downstream_connect_timeout_secs,
+                        native_mtp_enabled,
+                        &prediction_return_sinks,
+                        first_message,
+                    )
+                })()
+                .context("binary stage connection failed");
+                if let Err(error) = connection_result {
+                    let mut attrs = lifecycle_attrs(&config);
+                    if let Some(peer_addr) = peer_addr {
+                        attrs.insert("llama_stage.peer_addr".to_string(), json!(peer_addr));
+                    }
+                    attrs.insert("llama_stage.error".to_string(), json!(error.to_string()));
+                    eprintln!("{error:#}");
+                    telemetry.emit("stage.binary_connection_error", attrs);
                 }
-                let downstream = take_ready_downstream(
-                    &config,
-                    &warm_downstream,
-                    downstream_connect_timeout_secs,
-                )?;
-                if let Some(stream) = downstream.as_ref() {
-                    task_control
-                        .track(stream)
-                        .context("track downstream binary stage connection")?;
-                }
-                handle_binary_connection(
-                    &config,
-                    topology.as_ref(),
-                    &runtime,
-                    &decode_frame_batcher,
-                    kv.as_ref(),
-                    &telemetry,
-                    &mut upstream,
-                    downstream,
-                    activation_width,
-                    wire_dtype,
-                    max_inflight,
-                    reply_credit_limit,
-                    async_prefill_forward,
-                    downstream_wire_condition,
-                    downstream_connect_timeout_secs,
-                    native_mtp_enabled,
-                    &prediction_return_sinks,
-                    first_message,
-                )
-            })()
-            .context("binary stage connection failed");
-            if let Err(error) = connection_result {
-                let mut attrs = lifecycle_attrs(&config);
-                if let Some(peer_addr) = peer_addr {
-                    attrs.insert("llama_stage.peer_addr".to_string(), json!(peer_addr));
-                }
-                attrs.insert("llama_stage.error".to_string(), json!(error.to_string()));
-                eprintln!("{error:#}");
-                telemetry.emit("stage.binary_connection_error", attrs);
-            }
-            task_control.clear();
-        });
-        connection_workers.push(ConnectionWorker {
-            control: worker_control,
-            task,
-        });
-    }
-    connection_workers.shutdown()
+                task_control.clear();
+            });
+            connection_workers.push(ConnectionWorker {
+                control: worker_control,
+                task,
+            });
+        }
+        Ok(())
+    })();
+    finish_connection_workers(accept_result, connection_workers)
 }
 
 #[cfg(test)]
 mod shutdown_tests {
-    use super::{ConnectionWorker, ConnectionWorkerControl, ConnectionWorkers};
+    use super::{
+        ConnectionWorker, ConnectionWorkerControl, ConnectionWorkers, finish_connection_workers,
+    };
+    use anyhow::anyhow;
     use std::{
         io::Read,
         net::{TcpListener, TcpStream},
-        sync::Arc,
+        sync::{
+            Arc,
+            atomic::{AtomicBool, Ordering},
+        },
         thread,
         time::Duration,
     };
@@ -424,6 +447,32 @@ mod shutdown_tests {
         let started = std::time::Instant::now();
         workers.shutdown().unwrap();
         assert!(started.elapsed() < Duration::from_secs(1));
+        drop(client);
+    }
+
+    #[test]
+    fn accept_error_still_closes_and_joins_active_connection_worker() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
+        let (mut server, _) = listener.accept().unwrap();
+        let control = Arc::new(ConnectionWorkerControl::default());
+        control.track(&server).unwrap();
+        let task_control = control.clone();
+        let finished = Arc::new(AtomicBool::new(false));
+        let task_finished = finished.clone();
+        let task = thread::spawn(move || {
+            let mut byte = [0u8; 1];
+            let _ = server.read(&mut byte);
+            task_control.clear();
+            task_finished.store(true, Ordering::Release);
+        });
+        let mut workers = ConnectionWorkers::default();
+        workers.push(ConnectionWorker { control, task });
+
+        let error = finish_connection_workers(Err(anyhow!("accept failed")), workers)
+            .expect_err("accept failure must be returned after worker cleanup");
+        assert!(finished.load(Ordering::Acquire));
+        assert!(format!("{error:#}").contains("accept failed"));
         drop(client);
     }
 }

--- a/crates/skippy-server/src/binary_transport/preconnect.rs
+++ b/crates/skippy-server/src/binary_transport/preconnect.rs
@@ -1,4 +1,5 @@
 use std::{
+    io,
     net::TcpStream,
     sync::{
         Arc, Mutex,
@@ -10,24 +11,48 @@ use std::{
 
 use skippy_protocol::StageConfig;
 
-use super::stage_execution::connect_binary_downstream;
+use super::stage_execution::connect_binary_downstream_cancellable;
 
 const WARM_DOWNSTREAM_RETRY_SLEEP: Duration = Duration::from_millis(500);
 const WARM_DOWNSTREAM_SLOT_POLL: Duration = Duration::from_millis(50);
 const WARM_DOWNSTREAM_CONNECT_TIMEOUT: Duration = Duration::from_secs(2);
 
-pub(super) fn spawn_downstream_preconnector(
-    config: StageConfig,
-    warm_downstream: Arc<Mutex<Option<TcpStream>>>,
+pub(super) struct DownstreamPreconnector {
     shutdown: Arc<AtomicBool>,
-) {
-    if config.downstream.is_none() {
-        return;
+    task: Option<thread::JoinHandle<()>>,
+}
+
+impl DownstreamPreconnector {
+    pub(super) fn spawn(
+        config: StageConfig,
+        warm_downstream: Arc<Mutex<Option<TcpStream>>>,
+        shutdown: Arc<AtomicBool>,
+    ) -> io::Result<Self> {
+        if config.downstream.is_none() {
+            return Ok(Self {
+                shutdown,
+                task: None,
+            });
+        }
+        let thread_name = format!("skippy-warm-downstream-{}", config.stage_index);
+        let task_shutdown = shutdown.clone();
+        let task = thread::Builder::new()
+            .name(thread_name)
+            .spawn(move || run_downstream_preconnector(config, warm_downstream, task_shutdown))?;
+        Ok(Self {
+            shutdown,
+            task: Some(task),
+        })
     }
-    let thread_name = format!("skippy-warm-downstream-{}", config.stage_index);
-    let _ = thread::Builder::new().name(thread_name).spawn(move || {
-        run_downstream_preconnector(config, warm_downstream, shutdown);
-    });
+}
+
+impl Drop for DownstreamPreconnector {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        if let Some(task) = self.task.take() {
+            let _ = task.join();
+        }
+    }
 }
 
 fn run_downstream_preconnector(
@@ -40,7 +65,11 @@ fn run_downstream_preconnector(
             thread::sleep(WARM_DOWNSTREAM_SLOT_POLL);
             continue;
         }
-        match connect_binary_downstream(&config, WARM_DOWNSTREAM_CONNECT_TIMEOUT) {
+        match connect_binary_downstream_cancellable(
+            &config,
+            WARM_DOWNSTREAM_CONNECT_TIMEOUT,
+            &shutdown,
+        ) {
             Ok(Some(stream)) => {
                 eprintln!(
                     "downstream warm preconnect ready: stage_id={} local={:?} remote={:?}",
@@ -52,13 +81,27 @@ fn run_downstream_preconnector(
             }
             Ok(None) => return,
             Err(error) => {
+                if shutdown.load(Ordering::SeqCst) {
+                    return;
+                }
                 eprintln!(
                     "downstream warm preconnect failed: stage_id={} error={error:#}",
                     config.stage_id,
                 );
-                thread::sleep(WARM_DOWNSTREAM_RETRY_SLEEP);
+                sleep_until_retry_or_shutdown(&shutdown);
             }
         }
+    }
+}
+
+fn sleep_until_retry_or_shutdown(shutdown: &AtomicBool) {
+    let deadline = std::time::Instant::now() + WARM_DOWNSTREAM_RETRY_SLEEP;
+    while !shutdown.load(Ordering::SeqCst) {
+        let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+        if remaining.is_zero() {
+            break;
+        }
+        thread::sleep(remaining.min(WARM_DOWNSTREAM_SLOT_POLL));
     }
 }
 
@@ -75,5 +118,70 @@ fn store_warm_stream(warm_downstream: &Arc<Mutex<Option<TcpStream>>>, stream: Tc
     };
     if guard.is_none() {
         *guard = Some(stream);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::DownstreamPreconnector;
+    use crate::binary_transport::stage_execution::prefix_cache_test_config;
+    use std::{
+        net::TcpListener,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, Ordering},
+            mpsc,
+        },
+        thread,
+        time::Duration,
+    };
+
+    #[test]
+    fn dropping_preconnector_signals_and_joins_its_task() {
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let task_shutdown = shutdown.clone();
+        let (finished_tx, finished_rx) = mpsc::sync_channel(1);
+        let task = thread::spawn(move || {
+            while !task_shutdown.load(Ordering::Acquire) {
+                thread::yield_now();
+            }
+            finished_tx.send(()).unwrap();
+        });
+        let preconnector = DownstreamPreconnector {
+            shutdown: shutdown.clone(),
+            task: Some(task),
+        };
+
+        drop(preconnector);
+
+        assert!(shutdown.load(Ordering::Acquire));
+        finished_rx
+            .try_recv()
+            .expect("preconnector task must be joined before the guard is dropped");
+    }
+
+    #[test]
+    fn spawned_preconnector_stops_and_joins_after_shutdown() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = listener.local_addr().unwrap().to_string();
+        drop(listener);
+        let mut config = prefix_cache_test_config();
+        config.downstream.as_mut().unwrap().endpoint = endpoint;
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let preconnector =
+            DownstreamPreconnector::spawn(config, Arc::new(Mutex::new(None)), shutdown.clone())
+                .unwrap();
+        thread::sleep(Duration::from_millis(20));
+
+        shutdown.store(true, Ordering::Release);
+        let (finished_tx, finished_rx) = mpsc::sync_channel(1);
+        thread::spawn(move || {
+            drop(preconnector);
+            finished_tx.send(()).unwrap();
+        });
+
+        finished_rx
+            .recv_timeout(Duration::from_secs(3))
+            .expect("spawned preconnector must stop and join within its connect bound");
     }
 }

--- a/crates/skippy-server/src/binary_transport/socket.rs
+++ b/crates/skippy-server/src/binary_transport/socket.rs
@@ -1,6 +1,7 @@
 use std::{
     io,
     net::{IpAddr, SocketAddr, TcpStream, ToSocketAddrs},
+    sync::atomic::{AtomicBool, Ordering},
     sync::mpsc,
     thread,
     time::Duration,
@@ -42,10 +43,34 @@ pub(crate) fn connect_downstream_socket(
     source_ip: Option<IpAddr>,
     timeout: Duration,
 ) -> io::Result<TcpStream> {
+    connect_downstream_socket_inner(downstream_addr, source_ip, timeout, None)
+}
+
+pub(crate) fn connect_downstream_socket_cancellable(
+    downstream_addr: SocketAddr,
+    source_ip: Option<IpAddr>,
+    timeout: Duration,
+    shutdown: &AtomicBool,
+) -> io::Result<TcpStream> {
+    connect_downstream_socket_inner(downstream_addr, source_ip, timeout, Some(shutdown))
+}
+
+fn connect_downstream_socket_inner(
+    downstream_addr: SocketAddr,
+    source_ip: Option<IpAddr>,
+    timeout: Duration,
+    shutdown: Option<&AtomicBool>,
+) -> io::Result<TcpStream> {
     let mut errors = Vec::new();
 
     macro_rules! try_connect {
-        ($mode:literal, $connect:expr_2021) => {
+        ($mode:literal, $connect:expr_2021) => {{
+            if shutdown.is_some_and(|shutdown| shutdown.load(Ordering::Acquire)) {
+                return Err(io::Error::new(
+                    io::ErrorKind::Interrupted,
+                    "downstream connection cancelled during shutdown",
+                ));
+            }
             match $connect {
                 Ok(stream) => return Ok(stream),
                 Err(error) => {
@@ -56,7 +81,7 @@ pub(crate) fn connect_downstream_socket(
                     errors.push(format!("{} failed: {error}", $mode));
                 }
             }
-        };
+        }};
     }
 
     try_connect!(
@@ -71,14 +96,19 @@ pub(crate) fn connect_downstream_socket(
         "source-bound",
         connect_bound_with_timeout(downstream_addr, source_ip, timeout, false)
     );
-    try_connect!(
-        "blocking-source-bound",
-        connect_blocking_with_timeout(downstream_addr, source_ip, timeout, false)
-    );
-    try_connect!(
-        "blocking-route-selected",
-        connect_route_selected_blocking_with_timeout(downstream_addr, source_ip, timeout)
-    );
+    // The blocking fallbacks spawn helper threads that cannot be interrupted.
+    // Keep them only on the legacy non-cancellable path so shutdown never
+    // returns while a downstream acquisition helper is still running.
+    if shutdown.is_none() {
+        try_connect!(
+            "blocking-source-bound",
+            connect_blocking_with_timeout(downstream_addr, source_ip, timeout, false)
+        );
+        try_connect!(
+            "blocking-route-selected",
+            connect_route_selected_blocking_with_timeout(downstream_addr, source_ip, timeout)
+        );
+    }
 
     Err(io::Error::other(errors.join("; ")))
 }
@@ -289,5 +319,29 @@ pub(super) fn sockaddr_ip(addr: *const libc::sockaddr) -> Option<IpAddr> {
             Some(IpAddr::V6(addr.sin6_addr.s6_addr.into()))
         }
         _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::connect_downstream_socket_cancellable;
+    use std::{
+        net::{Ipv4Addr, SocketAddr},
+        sync::atomic::AtomicBool,
+        time::Duration,
+    };
+
+    #[test]
+    fn cancelled_downstream_connect_does_not_start_an_attempt() {
+        let shutdown = AtomicBool::new(true);
+        let error = connect_downstream_socket_cancellable(
+            SocketAddr::from((Ipv4Addr::LOCALHOST, 9)),
+            None,
+            Duration::from_secs(30),
+            &shutdown,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.kind(), std::io::ErrorKind::Interrupted);
     }
 }

--- a/crates/skippy-server/src/binary_transport/stage_execution.rs
+++ b/crates/skippy-server/src/binary_transport/stage_execution.rs
@@ -1,9 +1,13 @@
 use std::{
     collections::BTreeMap,
     env,
-    io::{self, Write},
+    io::{self, Read, Write},
     net::TcpStream,
-    sync::{Arc, Mutex},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
     thread,
     time::{Duration, Instant},
 };
@@ -34,6 +38,7 @@ use super::socket::{connect_downstream_socket, downstream_source_ip, resolve_dow
 
 const CLIENT_READY_HELLO_ENV: &str = "SKIPPY_STAGE_CLIENT_READY_HELLO";
 const CLIENT_READY_HELLO_OPT_IN_PEEK_MS: u64 = 500;
+const DOWNSTREAM_SHUTDOWN_POLL: Duration = Duration::from_millis(100);
 
 pub(in crate::binary_transport) fn warm_downstream_preconnect_enabled() -> bool {
     warm_downstream_preconnect_enabled_from(
@@ -68,10 +73,43 @@ pub(in crate::binary_transport) fn take_warm_or_connect_downstream(
     }
 }
 
+fn take_warm_or_connect_downstream_cancellable(
+    config: &StageConfig,
+    warm_downstream: &Arc<Mutex<Option<TcpStream>>>,
+    timeout: Duration,
+    shutdown: &AtomicBool,
+) -> Result<Option<TcpStream>> {
+    ensure_downstream_acquisition_active(shutdown)?;
+    let config = config.clone();
+    let warm_downstream = warm_downstream.clone();
+    let (result_tx, result_rx) = mpsc::sync_channel(1);
+    thread::spawn(move || {
+        let result = take_warm_or_connect_downstream(&config, &warm_downstream, timeout);
+        let _ = result_tx.send(result);
+    });
+
+    let deadline = Instant::now() + timeout;
+    loop {
+        ensure_downstream_acquisition_active(shutdown)?;
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            bail!("downstream connection attempt exceeded its deadline");
+        }
+        match result_rx.recv_timeout(remaining.min(DOWNSTREAM_SHUTDOWN_POLL)) {
+            Ok(result) => return result,
+            Err(mpsc::RecvTimeoutError::Timeout) => {}
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                bail!("downstream connection attempt ended without a result");
+            }
+        }
+    }
+}
+
 pub(in crate::binary_transport) fn take_ready_downstream(
     config: &StageConfig,
     warm_downstream: &Arc<Mutex<Option<TcpStream>>>,
     timeout_secs: u64,
+    shutdown: &AtomicBool,
 ) -> Result<Option<TcpStream>> {
     if config.downstream.is_none() {
         return Ok(None);
@@ -79,21 +117,24 @@ pub(in crate::binary_transport) fn take_ready_downstream(
     let deadline = Instant::now() + Duration::from_secs(timeout_secs.max(1));
     let mut last_error = None;
     loop {
+        ensure_downstream_acquisition_active(shutdown)?;
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             break;
         }
-        match take_warm_or_connect_downstream(config, warm_downstream, remaining) {
+        match take_warm_or_connect_downstream_cancellable(
+            config,
+            warm_downstream,
+            remaining,
+            shutdown,
+        ) {
             Ok(Some(mut stream)) => {
                 let handshake_remaining = deadline.saturating_duration_since(Instant::now());
                 if handshake_remaining.is_zero() {
                     last_error = Some(anyhow!("downstream ready deadline expired after connect"));
                     continue;
                 }
-                match complete_downstream_ready(
-                    &mut stream,
-                    handshake_remaining.min(Duration::from_secs(10)),
-                ) {
+                match complete_downstream_ready(&mut stream, deadline, shutdown) {
                     Ok(()) => return Ok(Some(stream)),
                     Err(error) => last_error = Some(error),
                 }
@@ -101,9 +142,10 @@ pub(in crate::binary_transport) fn take_ready_downstream(
             Ok(None) => return Ok(None),
             Err(error) => last_error = Some(error),
         }
+        ensure_downstream_acquisition_active(shutdown)?;
         let retry_sleep = deadline
             .saturating_duration_since(Instant::now())
-            .min(Duration::from_millis(100));
+            .min(DOWNSTREAM_SHUTDOWN_POLL);
         if !retry_sleep.is_zero() {
             thread::sleep(retry_sleep);
         }
@@ -116,7 +158,25 @@ pub(in crate::binary_transport) fn take_ready_downstream(
         )))
 }
 
-fn complete_downstream_ready(stream: &mut TcpStream, timeout: Duration) -> Result<()> {
+fn ensure_downstream_acquisition_active(shutdown: &AtomicBool) -> Result<()> {
+    if shutdown.load(Ordering::Acquire) {
+        bail!("downstream acquisition cancelled during shutdown");
+    }
+    Ok(())
+}
+
+fn complete_downstream_ready(
+    stream: &mut TcpStream,
+    deadline: Instant,
+    shutdown: &AtomicBool,
+) -> Result<()> {
+    ensure_downstream_acquisition_active(shutdown)?;
+    let timeout = deadline
+        .saturating_duration_since(Instant::now())
+        .min(DOWNSTREAM_SHUTDOWN_POLL);
+    if timeout.is_zero() {
+        bail!("downstream ready deadline expired before handshake");
+    }
     stream
         .set_write_timeout(Some(timeout))
         .context("set downstream ready write timeout")?;
@@ -129,8 +189,39 @@ fn complete_downstream_ready(stream: &mut TcpStream, timeout: Duration) -> Resul
     stream
         .set_read_timeout(Some(timeout))
         .context("set downstream ready timeout")?;
-    let result = skippy_protocol::binary::recv_ready(&mut *stream)
-        .context("downstream binary stage did not become ready");
+    let result = (|| -> Result<()> {
+        let mut bytes = [0_u8; 4];
+        let mut offset = 0;
+        while offset < bytes.len() {
+            ensure_downstream_acquisition_active(shutdown)?;
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                bail!("downstream ready deadline expired during handshake");
+            }
+            stream
+                .set_read_timeout(Some(remaining.min(DOWNSTREAM_SHUTDOWN_POLL)))
+                .context("update downstream ready timeout")?;
+            match stream.read(&mut bytes[offset..]) {
+                Ok(0) => bail!("downstream binary stage closed before becoming ready"),
+                Ok(read) => offset += read,
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::Interrupted
+                            | io::ErrorKind::WouldBlock
+                            | io::ErrorKind::TimedOut
+                    ) => {}
+                Err(error) => {
+                    return Err(error).context("read downstream binary stage ready handshake");
+                }
+            }
+        }
+        if i32::from_le_bytes(bytes) != READY_MAGIC {
+            bail!("downstream binary stage ready magic mismatch");
+        }
+        Ok(())
+    })()
+    .context("downstream binary stage did not become ready");
     stream
         .set_read_timeout(None)
         .context("clear downstream ready timeout")?;
@@ -888,6 +979,11 @@ mod tests {
         io,
         net::{Shutdown, TcpListener, TcpStream},
         os::fd::AsRawFd,
+        sync::{
+            Arc, Mutex,
+            atomic::{AtomicBool, Ordering},
+            mpsc,
+        },
         thread,
         time::{Duration, Instant},
     };
@@ -988,7 +1084,8 @@ mod tests {
         config.downstream.as_mut().unwrap().endpoint = endpoint;
         let warm = std::sync::Arc::new(std::sync::Mutex::new(None));
 
-        let ready = take_ready_downstream(&config, &warm, 2)
+        let shutdown = AtomicBool::new(false);
+        let ready = take_ready_downstream(&config, &warm, 2, &shutdown)
             .unwrap()
             .expect("downstream should be present");
 
@@ -1009,13 +1106,40 @@ mod tests {
         let warm = std::sync::Arc::new(std::sync::Mutex::new(None));
 
         let started = Instant::now();
-        let error = take_ready_downstream(&config, &warm, 1).unwrap_err();
+        let shutdown = AtomicBool::new(false);
+        let error = take_ready_downstream(&config, &warm, 1, &shutdown).unwrap_err();
         let elapsed = started.elapsed();
 
         assert!(error.to_string().contains("did not become ready"));
         assert!(elapsed >= Duration::from_millis(800));
         assert!(elapsed < Duration::from_millis(1500));
         server.join().unwrap();
+    }
+
+    #[test]
+    fn downstream_acquisition_stops_when_shutdown_is_requested() {
+        let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let endpoint = listener.local_addr().unwrap().to_string();
+        let mut config = prefix_cache_test_config();
+        config.downstream.as_mut().unwrap().endpoint = endpoint;
+        let warm = Arc::new(Mutex::new(None));
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let task_shutdown = shutdown.clone();
+        let (result_tx, result_rx) = mpsc::sync_channel(1);
+        let task = thread::spawn(move || {
+            let result = take_ready_downstream(&config, &warm, 30, &task_shutdown);
+            let _ = result_tx.send(result);
+        });
+
+        let (_unready_downstream, _) = listener.accept().unwrap();
+        shutdown.store(true, Ordering::Release);
+        let error = result_rx
+            .recv_timeout(Duration::from_secs(1))
+            .expect("downstream acquisition must stop within one second")
+            .unwrap_err();
+
+        assert!(error.to_string().contains("cancelled during shutdown"));
+        task.join().unwrap();
     }
 
     #[test]

--- a/crates/skippy-server/src/binary_transport/stage_execution.rs
+++ b/crates/skippy-server/src/binary_transport/stage_execution.rs
@@ -6,7 +6,6 @@ use std::{
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
-        mpsc,
     },
     thread,
     time::{Duration, Instant},
@@ -34,7 +33,10 @@ use skippy_runtime::{
     RuntimeActivationDType, RuntimeActivationLayout, SamplingConfig,
 };
 
-use super::socket::{connect_downstream_socket, downstream_source_ip, resolve_downstream_endpoint};
+use super::socket::{
+    connect_downstream_socket, connect_downstream_socket_cancellable, downstream_source_ip,
+    resolve_downstream_endpoint,
+};
 
 const CLIENT_READY_HELLO_ENV: &str = "SKIPPY_STAGE_CLIENT_READY_HELLO";
 const CLIENT_READY_HELLO_OPT_IN_PEEK_MS: u64 = 500;
@@ -55,6 +57,7 @@ fn warm_downstream_preconnect_enabled_from(value: Option<&str>) -> bool {
     })
 }
 
+#[cfg(test)]
 pub(in crate::binary_transport) fn take_warm_or_connect_downstream(
     config: &StageConfig,
     warm_downstream: &Arc<Mutex<Option<TcpStream>>>,
@@ -80,28 +83,13 @@ fn take_warm_or_connect_downstream_cancellable(
     shutdown: &AtomicBool,
 ) -> Result<Option<TcpStream>> {
     ensure_downstream_acquisition_active(shutdown)?;
-    let config = config.clone();
-    let warm_downstream = warm_downstream.clone();
-    let (result_tx, result_rx) = mpsc::sync_channel(1);
-    thread::spawn(move || {
-        let result = take_warm_or_connect_downstream(&config, &warm_downstream, timeout);
-        let _ = result_tx.send(result);
-    });
-
-    let deadline = Instant::now() + timeout;
-    loop {
-        ensure_downstream_acquisition_active(shutdown)?;
-        let remaining = deadline.saturating_duration_since(Instant::now());
-        if remaining.is_zero() {
-            bail!("downstream connection attempt exceeded its deadline");
-        }
-        match result_rx.recv_timeout(remaining.min(DOWNSTREAM_SHUTDOWN_POLL)) {
-            Ok(result) => return result,
-            Err(mpsc::RecvTimeoutError::Timeout) => {}
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                bail!("downstream connection attempt ended without a result");
-            }
-        }
+    let warm = warm_downstream
+        .lock()
+        .map_err(|_| anyhow!("warm downstream lock poisoned"))?
+        .take();
+    match warm {
+        Some(stream) if warm_downstream_is_healthy(&stream)? => Ok(Some(stream)),
+        Some(_) | None => connect_binary_downstream_cancellable(config, timeout, shutdown),
     }
 }
 
@@ -527,6 +515,25 @@ pub(crate) fn connect_binary_downstream(
     config: &StageConfig,
     timeout: Duration,
 ) -> Result<Option<TcpStream>> {
+    connect_binary_downstream_inner(config, timeout, None)
+}
+
+pub(crate) fn connect_binary_downstream_cancellable(
+    config: &StageConfig,
+    timeout: Duration,
+    shutdown: &AtomicBool,
+) -> Result<Option<TcpStream>> {
+    connect_binary_downstream_inner(config, timeout, Some(shutdown))
+}
+
+fn connect_binary_downstream_inner(
+    config: &StageConfig,
+    timeout: Duration,
+    shutdown: Option<&AtomicBool>,
+) -> Result<Option<TcpStream>> {
+    if let Some(shutdown) = shutdown {
+        ensure_downstream_acquisition_active(shutdown)?;
+    }
     let Some(peer) = config.downstream.as_ref() else {
         return Ok(None);
     };
@@ -539,24 +546,38 @@ pub(crate) fn connect_binary_downstream(
     let deadline = Instant::now() + timeout.max(Duration::from_millis(1));
     let mut last_error = None;
     loop {
+        if let Some(shutdown) = shutdown {
+            ensure_downstream_acquisition_active(shutdown)?;
+        }
         let remaining = deadline.saturating_duration_since(Instant::now());
         if remaining.is_zero() {
             break;
         }
-        match connect_downstream_socket(
-            downstream_addr,
-            source_ip,
-            remaining.min(Duration::from_secs(2)),
-        ) {
+        let connect_timeout = remaining.min(Duration::from_secs(2));
+        let result = match shutdown {
+            Some(shutdown) => connect_downstream_socket_cancellable(
+                downstream_addr,
+                source_ip,
+                connect_timeout,
+                shutdown,
+            ),
+            None => connect_downstream_socket(downstream_addr, source_ip, connect_timeout),
+        };
+        match result {
             Ok(stream) => {
                 stream.set_nodelay(true).ok();
                 return Ok(Some(stream));
             }
             Err(error) => {
                 last_error = Some(anyhow!(error));
-                let retry_sleep = deadline
-                    .saturating_duration_since(Instant::now())
-                    .min(Duration::from_millis(500));
+                let retry_sleep =
+                    deadline
+                        .saturating_duration_since(Instant::now())
+                        .min(if shutdown.is_some() {
+                            DOWNSTREAM_SHUTDOWN_POLL
+                        } else {
+                            Duration::from_millis(500)
+                        });
                 if !retry_sleep.is_zero() {
                     thread::sleep(retry_sleep);
                 }

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4199,27 +4199,27 @@
   ],
   "crates/skippy-server/src/binary_transport/binary_messaging.rs": [
     {
-      "line": 194,
+      "line": 291,
       "macro_name": "eprintln!"
     },
     {
-      "line": 198,
+      "line": 295,
       "macro_name": "println!"
     },
     {
-      "line": 219,
+      "line": 318,
       "macro_name": "eprintln!"
     },
     {
-      "line": 234,
+      "line": 338,
       "macro_name": "eprintln!"
     },
     {
-      "line": 242,
+      "line": 346,
       "macro_name": "eprintln!"
     },
     {
-      "line": 291,
+      "line": 400,
       "macro_name": "eprintln!"
     }
   ],

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4199,27 +4199,27 @@
   ],
   "crates/skippy-server/src/binary_transport/binary_messaging.rs": [
     {
-      "line": 291,
+      "line": 288,
       "macro_name": "eprintln!"
     },
     {
-      "line": 295,
+      "line": 298,
       "macro_name": "println!"
     },
     {
-      "line": 318,
+      "line": 321,
       "macro_name": "eprintln!"
     },
     {
-      "line": 339,
+      "line": 342,
       "macro_name": "eprintln!"
     },
     {
-      "line": 347,
+      "line": 350,
       "macro_name": "eprintln!"
     },
     {
-      "line": 402,
+      "line": 405,
       "macro_name": "eprintln!"
     }
   ],
@@ -4257,31 +4257,31 @@
   ],
   "crates/skippy-server/src/binary_transport/preconnect.rs": [
     {
-      "line": 45,
+      "line": 74,
       "macro_name": "eprintln!"
     },
     {
-      "line": 55,
+      "line": 87,
       "macro_name": "eprintln!"
     }
   ],
   "crates/skippy-server/src/binary_transport/socket.rs": [
     {
-      "line": 52,
+      "line": 77,
       "macro_name": "eprintln!"
     },
     {
-      "line": 101,
+      "line": 131,
       "macro_name": "eprintln!"
     },
     {
-      "line": 139,
+      "line": 169,
       "macro_name": "eprintln!"
     }
   ],
   "crates/skippy-server/src/binary_transport/stage_execution.rs": [
     {
-      "line": 302,
+      "line": 290,
       "macro_name": "eprintln!"
     }
   ],

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4211,15 +4211,15 @@
       "macro_name": "eprintln!"
     },
     {
-      "line": 338,
+      "line": 339,
       "macro_name": "eprintln!"
     },
     {
-      "line": 346,
+      "line": 347,
       "macro_name": "eprintln!"
     },
     {
-      "line": 400,
+      "line": 402,
       "macro_name": "eprintln!"
     }
   ],
@@ -4281,7 +4281,7 @@
   ],
   "crates/skippy-server/src/binary_transport/stage_execution.rs": [
     {
-      "line": 211,
+      "line": 302,
       "macro_name": "eprintln!"
     }
   ],


### PR DESCRIPTION
## Summary

- give the split-stage control loop an explicit awaited shutdown lifecycle
- abort outstanding preparation tasks and drain every hosted stage before node shutdown completes
- track active binary-stage connection threads, close their sockets, and join them during server shutdown
- add regression coverage for the control-loop join and an active TCP worker

## Validation

- cargo fmt --all --check
- just with-lld cargo test -p skippy-server (482 passed, 3 ignored)
- just with-lld cargo test -p mesh-llm-host-runtime (2552 passed, 8 ignored; audit test passed)

A strict Clippy pass is currently blocked by pre-existing Rust 1.98 chunks_exact_to_as_chunks warnings in skippy-protocol.

Addresses the D-005 SIGTERM hang found during rc7 validation and the lifecycle mechanism described in #1103. Related: #1338.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added coordinated shutdown handling for stage control and active binary transport connections.
  - Stage servers, preparation tasks, readiness checks, connections, and worker processes now close cleanly when the runtime shuts down.
  - Downstream connection acquisition can now be interrupted during shutdown.

- **Bug Fixes**
  - Prevented lingering background tasks and connection workers after shutdown.
  - Improved shutdown error reporting while allowing remaining cleanup to continue.
  - Readiness checks and connection handshakes can now be cancelled promptly.

- **Tests**
  - Added coverage for stage control, readiness cancellation, and connection worker cleanup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->