### PR TITLE
fix(skippy): repair split-serving correctness bugs (B1/B2/B4/B6/B8 + 0016 ABI)

### DIFF
--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -5,7 +5,7 @@ mod dynamic_library;
 // without compiling the crate to determine native-runtime compatibility.
 pub const ABI_VERSION_MAJOR: u32 = 0;
 pub const ABI_VERSION_MINOR: u32 = 1;
-pub const ABI_VERSION_PATCH: u32 = 40;
+pub const ABI_VERSION_PATCH: u32 = 41;
 
 mod abi;
 mod activation;
@@ -50,7 +50,8 @@ pub use sampling::{
     TokenSignal,
 };
 pub use state::{
-    KV_PAGE_CODEC_ISWA_COMPOSITE_V1, KV_PAGE_CODEC_SINGLE_V1, KvPageComponentDesc, KvPageDesc,
+    KV_PAGE_CODEC_ISWA_COMPOSITE_V1, KV_PAGE_CODEC_SINGLE_V1, KV_PAGE_FLAG_HAS_K_IDX,
+    KV_PAGE_FLAG_V_TRANSPOSED, KvPageComponentDesc, KvPageDesc,
 };
 
 #[cfg(not(feature = "dynamic-runtime"))]

--- a/crates/skippy-ffi/src/state.rs
+++ b/crates/skippy-ffi/src/state.rs
@@ -11,6 +11,7 @@ pub struct KvPageComponentDesc {
     pub k_row_bytes: u32,
     pub v_row_bytes: u32,
     pub v_element_bytes: u32,
+    pub k_idx_row_bytes: u32,
     pub payload_offset: u64,
     pub payload_bytes: u64,
     pub flags: u64,
@@ -18,6 +19,9 @@ pub struct KvPageComponentDesc {
 
 pub const KV_PAGE_CODEC_SINGLE_V1: u32 = 1;
 pub const KV_PAGE_CODEC_ISWA_COMPOSITE_V1: u32 = 2;
+
+pub const KV_PAGE_FLAG_V_TRANSPOSED: u64 = 1 << 0;
+pub const KV_PAGE_FLAG_HAS_K_IDX: u64 = 1 << 1;
 
 #[repr(C)]
 #[derive(Debug, Clone, Copy, Default)]
@@ -33,6 +37,7 @@ pub struct KvPageDesc {
     pub k_row_bytes: u32,
     pub v_row_bytes: u32,
     pub v_element_bytes: u32,
+    pub k_idx_row_bytes: u32,
     pub payload_bytes: u64,
     pub flags: u64,
     pub codec: u32,

--- a/crates/skippy-runtime/src/activation.rs
+++ b/crates/skippy-runtime/src/activation.rs
@@ -132,14 +132,24 @@ impl StageSession {
             return Self::iteration_batch_sampled_raw(requests, &output_bytes);
         }
         ensure_ok(status, error)?;
-        for request in requests.iter_mut() {
-            request.session.token_count = request
-                .session
-                .token_count
-                .checked_add(
-                    u64::try_from(request.token_ids.len()).context("token count exceeds u64")?,
-                )
-                .context("session token count overflow")?;
+        // The native call has already advanced every session, so compute all
+        // new counts before storing any: a mid-loop overflow error must not
+        // leave a subset of sessions updated and the rest desynced.
+        let updated_counts = requests
+            .iter()
+            .map(|request| {
+                request
+                    .session
+                    .token_count
+                    .checked_add(
+                        u64::try_from(request.token_ids.len())
+                            .context("token count exceeds u64")?,
+                    )
+                    .context("session token count overflow")
+            })
+            .collect::<Result<Vec<_>>>()?;
+        for (request, updated) in requests.iter_mut().zip(updated_counts) {
+            request.session.token_count = updated;
         }
         Ok(output_payloads
             .into_iter()
@@ -655,12 +665,21 @@ impl StageSession {
             return Self::decode_step_frame_batch_sampled_serial(requests);
         }
         ensure_ok(status, error)?;
-        for request in requests.iter_mut() {
-            request.session.token_count = request
-                .session
-                .token_count
-                .checked_add(1)
-                .context("session token count overflow")?;
+        // The native call has already advanced every session, so compute all
+        // new counts before storing any: a mid-loop overflow error must not
+        // leave a subset of sessions updated and the rest desynced.
+        let updated_counts = requests
+            .iter()
+            .map(|request| {
+                request
+                    .session
+                    .token_count
+                    .checked_add(1)
+                    .context("session token count overflow")
+            })
+            .collect::<Result<Vec<_>>>()?;
+        for (request, updated) in requests.iter_mut().zip(updated_counts) {
+            request.session.token_count = updated;
         }
         Ok(output_payloads
             .into_iter()

--- a/crates/skippy-runtime/src/types.rs
+++ b/crates/skippy-runtime/src/types.rs
@@ -120,6 +120,8 @@ pub struct RuntimeKvPageComponentDesc {
     pub k_row_bytes: u32,
     pub v_row_bytes: u32,
     pub v_element_bytes: u32,
+    #[serde(default)]
+    pub k_idx_row_bytes: u32,
     pub payload_offset: u64,
     pub payload_bytes: u64,
     pub flags: u64,
@@ -138,6 +140,7 @@ impl RuntimeKvPageComponentDesc {
             k_row_bytes: self.k_row_bytes,
             v_row_bytes: self.v_row_bytes,
             v_element_bytes: self.v_element_bytes,
+            k_idx_row_bytes: self.k_idx_row_bytes,
             payload_offset: self.payload_offset,
             payload_bytes: self.payload_bytes,
             flags: self.flags,
@@ -157,6 +160,7 @@ impl From<RawKvPageComponentDesc> for RuntimeKvPageComponentDesc {
             k_row_bytes: raw.k_row_bytes,
             v_row_bytes: raw.v_row_bytes,
             v_element_bytes: raw.v_element_bytes,
+            k_idx_row_bytes: raw.k_idx_row_bytes,
             payload_offset: raw.payload_offset,
             payload_bytes: raw.payload_bytes,
             flags: raw.flags,
@@ -177,6 +181,8 @@ pub struct RuntimeKvPageDesc {
     pub k_row_bytes: u32,
     pub v_row_bytes: u32,
     pub v_element_bytes: u32,
+    #[serde(default)]
+    pub k_idx_row_bytes: u32,
     pub payload_bytes: u64,
     pub flags: u64,
     #[serde(default)]
@@ -192,6 +198,12 @@ impl RuntimeKvPageDesc {
         let payload_len = u64::try_from(payload_len)?;
         if self.payload_bytes != payload_len {
             return Err(anyhow!("KV page payload length does not match descriptor"));
+        }
+        let has_k_idx_flag = self.flags & skippy_ffi::KV_PAGE_FLAG_HAS_K_IDX;
+        if (self.k_idx_row_bytes > 0) != (has_k_idx_flag != 0) {
+            return Err(anyhow!(
+                "KV page k_idx flag does not match its indexer row size"
+            ));
         }
         match self.codec {
             0 | skippy_ffi::KV_PAGE_CODEC_SINGLE_V1 if self.component_count == 0 => Ok(()),
@@ -233,6 +245,7 @@ impl RuntimeKvPageDesc {
             k_row_bytes: self.k_row_bytes,
             v_row_bytes: self.v_row_bytes,
             v_element_bytes: self.v_element_bytes,
+            k_idx_row_bytes: self.k_idx_row_bytes,
             payload_bytes: self.payload_bytes,
             flags: self.flags,
             codec: self.codec,
@@ -259,6 +272,7 @@ impl From<RawKvPageDesc> for RuntimeKvPageDesc {
             k_row_bytes: raw.k_row_bytes,
             v_row_bytes: raw.v_row_bytes,
             v_element_bytes: raw.v_element_bytes,
+            k_idx_row_bytes: raw.k_idx_row_bytes,
             payload_bytes: raw.payload_bytes,
             flags: raw.flags,
             codec: raw.codec,
@@ -561,6 +575,7 @@ mod kv_page_descriptor_tests {
             k_row_bytes: 0,
             v_row_bytes: 0,
             v_element_bytes: 0,
+            k_idx_row_bytes: 0,
             flags: 0,
         }
     }
@@ -583,6 +598,7 @@ mod kv_page_descriptor_tests {
                 k_row_bytes: 0,
                 v_row_bytes: 0,
                 v_element_bytes: 0,
+                k_idx_row_bytes: 0,
                 flags: 0,
                 components: Box::default(),
             };

--- a/crates/skippy-server/src/frontend/iteration_scheduler.rs
+++ b/crates/skippy-server/src/frontend/iteration_scheduler.rs
@@ -1519,6 +1519,19 @@ mod tests {
             }
             .run();
         });
+        let (worker_blocked, worker_blocked_rx) = std_mpsc::sync_channel(0);
+        let (release_worker, release_worker_rx) = std_mpsc::sync_channel(0);
+        commands
+            .send(SchedulerCommand::ExecuteRuntime(RuntimeOperation {
+                label: "panic-test-gate",
+                run: Box::new(move |_| {
+                    worker_blocked.send(()).unwrap();
+                    release_worker_rx.recv().unwrap();
+                }),
+            }))
+            .unwrap();
+        worker_blocked_rx.recv().unwrap();
+
         let (reply, events) = std_mpsc::channel();
         commands
             .send(SchedulerCommand::Submit(ScheduledRequest {
@@ -1536,6 +1549,7 @@ mod tests {
                 run: Box::new(|_| panic!("injected scheduler worker panic")),
             }))
             .unwrap();
+        release_worker.send(()).unwrap();
 
         let SchedulerEvent::Error(error) = events.recv().unwrap() else {
             panic!("expected contained worker panic to fail the request");

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -220,62 +220,78 @@ fn effective_cache_payload(
 }
 
 pub(crate) fn model_requires_recurrent_state(config: &StageConfig) -> bool {
-    let Some(path) = kv_cache_inspection_path(config) else {
-        return false;
-    };
-    let Ok(info) = ModelInfo::open(path) else {
-        return false;
-    };
-    let Ok(tensors) = info.tensors() else {
-        return false;
-    };
-    tensors
-        .iter()
-        .any(|tensor| tensor_name_requires_recurrent_state(&tensor.name))
+    // A hybrid stage whose first layer file is attention-only still needs
+    // KvRecurrent: probe every layer file in [layer_start, layer_end), not
+    // just the first one, so interleaved hybrids are never misdetected.
+    kv_cache_inspection_paths(config).into_iter().any(|path| {
+        let Ok(info) = ModelInfo::open(&path) else {
+            return false;
+        };
+        let Ok(tensors) = info.tensors() else {
+            return false;
+        };
+        tensors
+            .iter()
+            .any(|tensor| tensor_name_requires_recurrent_state(&tensor.name))
+    })
 }
 
-fn kv_cache_inspection_path(config: &StageConfig) -> Option<PathBuf> {
-    let path = config.model_path.as_deref()?;
+fn kv_cache_inspection_paths(config: &StageConfig) -> Vec<PathBuf> {
+    let Some(path) = config.model_path.as_deref() else {
+        return Vec::new();
+    };
     match config.load_mode {
         LoadMode::LayerPackage => {
             let package_dir = std::path::Path::new(path);
-            layer_package_inspection_path(package_dir, config.layer_start, config.layer_end)
-                .or_else(|| layer_package_metadata_path(package_dir))
-                .or_else(|| Some(PathBuf::from(path)))
+            let mut paths =
+                layer_package_inspection_paths(package_dir, config.layer_start, config.layer_end);
+            if paths.is_empty() {
+                if let Some(metadata) = layer_package_metadata_path(package_dir) {
+                    paths.push(metadata);
+                } else {
+                    paths.push(PathBuf::from(path));
+                }
+            }
+            paths
         }
-        LoadMode::RuntimeSlice | LoadMode::ArtifactSlice => Some(PathBuf::from(path)),
+        LoadMode::RuntimeSlice | LoadMode::ArtifactSlice => vec![PathBuf::from(path)],
     }
 }
 
-fn layer_package_inspection_path(
+fn layer_package_inspection_paths(
     package_dir: &Path,
     layer_start: u32,
     layer_end: u32,
-) -> Option<PathBuf> {
-    let manifest_path = package_dir.join("model-package.json");
-    let manifest: serde_json::Value =
-        serde_json::from_slice(&fs::read(manifest_path).ok()?).ok()?;
-    let layers = manifest.get("layers")?.as_array()?;
-    let selected = layers
+) -> Vec<PathBuf> {
+    let Ok(manifest) = serde_json::from_slice::<serde_json::Value>(
+        &fs::read(package_dir.join("model-package.json")).unwrap_or_default(),
+    ) else {
+        return Vec::new();
+    };
+    let Some(layers) = manifest.get("layers").and_then(|value| value.as_array()) else {
+        return Vec::new();
+    };
+    layers
         .iter()
         .enumerate()
-        .find(|(index, layer)| {
+        .filter_map(|(index, layer)| {
             let layer_index = layer
                 .get("layer_index")
                 .and_then(|value| value.as_u64())
                 .and_then(|value| u32::try_from(value).ok())
-                .unwrap_or(*index as u32);
-            layer_index >= layer_start && layer_index < layer_end
+                .unwrap_or(index as u32);
+            if layer_index < layer_start || layer_index >= layer_end {
+                return None;
+            }
+            let path = layer.get("path")?.as_str()?;
+            let path = PathBuf::from(path);
+            if path.is_absolute() {
+                return None;
+            }
+            let absolute = package_dir.join(path);
+            absolute.is_file().then_some(absolute)
         })
-        .or_else(|| layers.first().map(|layer| (0, layer)))?
-        .1;
-    let path = selected.get("path")?.as_str()?;
-    let path = PathBuf::from(path);
-    if path.is_absolute() {
-        return None;
-    }
-    let absolute = package_dir.join(path);
-    absolute.is_file().then_some(absolute)
+        .collect()
 }
 
 fn layer_package_metadata_path(package_dir: &Path) -> Option<PathBuf> {
@@ -582,8 +598,46 @@ mod tests {
         config.layer_end = 2;
 
         assert_eq!(
-            kv_cache_inspection_path(&config),
-            Some(dir.path().join("layers/00001.gguf"))
+            kv_cache_inspection_paths(&config),
+            vec![dir.path().join("layers/00001.gguf")]
+        );
+    }
+
+    #[test]
+    fn layer_package_inspection_selects_every_in_range_layer_file() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::create_dir_all(dir.path().join("layers")).unwrap();
+        fs::write(dir.path().join("layers/00000.gguf"), b"layer0").unwrap();
+        fs::write(dir.path().join("layers/00001.gguf"), b"layer1").unwrap();
+        fs::write(dir.path().join("layers/00002.gguf"), b"layer2").unwrap();
+        let manifest = serde_json::json!({
+            "layers": [
+                { "layer_index": 0, "path": "layers/00000.gguf" },
+                { "layer_index": 1, "path": "layers/00001.gguf" },
+                { "layer_index": 2, "path": "layers/00002.gguf" }
+            ]
+        });
+        fs::write(
+            dir.path().join("model-package.json"),
+            serde_json::to_vec_pretty(&manifest).unwrap(),
+        )
+        .unwrap();
+        let mut config = test_config("example/hybrid-package");
+        config.load_mode = LoadMode::LayerPackage;
+        config.model_path = Some(dir.path().to_string_lossy().to_string());
+        config.layer_start = 0;
+        config.layer_end = 3;
+
+        // a hybrid stage must probe every layer file, not just the first:
+        // an attention-first stage still carries recurrent tensors later
+        // in the range
+        assert_eq!(
+            kv_cache_inspection_paths(&config),
+            vec![
+                dir.path().join("layers/00000.gguf"),
+                dir.path().join("layers/00001.gguf"),
+                dir.path().join("layers/00002.gguf"),
+            ]
         );
     }
 
@@ -607,8 +661,8 @@ mod tests {
         config.model_path = Some(dir.path().to_string_lossy().to_string());
 
         assert_eq!(
-            kv_cache_inspection_path(&config),
-            Some(dir.path().join("shared/metadata.gguf"))
+            kv_cache_inspection_paths(&config),
+            vec![dir.path().join("shared/metadata.gguf")]
         );
     }
 

--- a/third_party/llama.cpp/patches/0001-Add-staged-model-graph-and-family-support.patch
+++ b/third_party/llama.cpp/patches/0001-Add-staged-model-graph-and-family-support.patch
@@ -228,7 +228,7 @@ index 7159e23bf..909e34290 100644
      LLM_TENSOR_VISEXP_ATTN_OUT,
      LLM_TENSOR_VISEXP_FFN_GATE,
 diff --git a/src/llama-context.cpp b/src/llama-context.cpp
-index 52f8d5367..f22aa2532 100644
+index 52f8d5367..9d955ae18 100644
 --- a/src/llama-context.cpp
 +++ b/src/llama-context.cpp
 @@ -10,7 +10,6 @@
@@ -341,17 +341,7 @@ index 52f8d5367..f22aa2532 100644
  
      if (cparams.n_ctx_seq < hparams.n_ctx_train) {
          LLAMA_LOG_INFO("%s: n_ctx_seq (%u) < n_ctx_train (%u) -- the full capacity of the model will not be utilized\n",
-@@ -479,9 +482,6 @@ llama_context::llama_context(
- }
- 
- llama_context::~llama_context() {
--    // wait for any pending asynchronous copies into the output buffers before they are freed
--    synchronize();
--
-     if (!model.hparams.no_alloc) {
-         for (size_t i = 0; i < backend_ptrs.size(); ++i) {
-             ggml_backend_t             backend = backend_ptrs[i];
-@@ -503,6 +503,22 @@ llama_context::~llama_context() {
+@@ -503,6 +506,22 @@ llama_context::~llama_context() {
  
  void llama_context::resolve_fused_ops(const llama_memory_context_i * mctx, uint32_t n_seqs) {
      const char * func = __func__;
@@ -374,7 +364,7 @@ index 52f8d5367..f22aa2532 100644
      auto resolve = [&](const llm_fused_op_probe & probe, bool & enabled) {
          if (!enabled) {
              return;
-@@ -1169,7 +1185,7 @@ void llama_context::set_embeddings_nextn(bool value, bool masked) {
+@@ -1169,7 +1188,7 @@ void llama_context::set_embeddings_nextn(bool value, bool masked) {
  void llama_context::set_embeddings_layer_inp(uint32_t lid, bool enable) {
      LLAMA_LOG_DEBUG("%s: lid = %d, enable = %d\n", __func__, lid, enable);
  
@@ -383,7 +373,7 @@ index 52f8d5367..f22aa2532 100644
  
      cparams.embeddings_layer_inp[lid] = enable;
  
-@@ -1235,7 +1251,7 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
+@@ -1235,7 +1254,7 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
      if (sampler && can_offload) {
          auto * buft = ggml_backend_dev_buffer_type(model.dev_output());
  
@@ -392,28 +382,29 @@ index 52f8d5367..f22aa2532 100644
  
          sampling.samplers[seq_id] = sampler;
  
-@@ -1425,17 +1441,13 @@ int llama_context::encode(const llama_batch & batch_inp) {
+@@ -1425,6 +1444,10 @@ int llama_context::encode(const llama_batch & batch_inp) {
      // micro-batching is not possible for non-causal encoding, so we process the batch in a single shot
      GGML_ASSERT(cparams.n_ubatch >= n_tokens && "encoder requires n_ubatch >= n_tokens");
  
--    // TODO: this clear of the buffer can easily be forgotten - need something better
--    // sync first so any in-flight async copies into embd_seq complete before it is freed
--    if (!embd_seq.empty()) {
--        synchronize();
--    }
--    embd_seq.clear();
--
-     if (t_compute_start_us == 0) {
-         t_compute_start_us = ggml_time_us();
-     }
- 
-+    // TODO: this clear of the buffer can easily be forgotten - need something better
-+    embd_seq.clear();
++    if (t_compute_start_us == 0) {
++        t_compute_start_us = ggml_time_us();
++    }
 +
+     // TODO: this clear of the buffer can easily be forgotten - need something better
+     // sync first so any in-flight async copies into embd_seq complete before it is freed
+     if (!embd_seq.empty()) {
+@@ -1432,10 +1455,6 @@ int llama_context::encode(const llama_batch & batch_inp) {
+     }
+     embd_seq.clear();
+ 
+-    if (t_compute_start_us == 0) {
+-        t_compute_start_us = ggml_time_us();
+-    }
+-
      sched_reserve();
  
      n_queued_tokens += n_tokens;
-@@ -1580,38 +1592,108 @@ int llama_context::encode(const llama_batch & batch_inp) {
+@@ -1580,38 +1599,108 @@ int llama_context::encode(const llama_batch & batch_inp) {
      return 0;
  }
  
@@ -541,7 +532,7 @@ index 52f8d5367..f22aa2532 100644
      }
  }
  
-@@ -1651,8 +1733,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1651,8 +1740,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
      const auto & hparams = model.hparams;
  
      const int64_t n_vocab = vocab.n_tokens();
@@ -551,7 +542,7 @@ index 52f8d5367..f22aa2532 100644
  
      // when computing embeddings, all tokens are output
      const bool output_all   = cparams.embeddings;
-@@ -1660,12 +1741,12 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1660,12 +1748,12 @@ int llama_context::decode(const llama_batch & batch_inp) {
  
      const uint32_t n_seq_max = cparams.kv_unified ? LLAMA_MAX_SEQ : cparams.n_seq_max;
  
@@ -567,7 +558,7 @@ index 52f8d5367..f22aa2532 100644
                  continue;
              }
  
-@@ -1674,17 +1755,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1674,17 +1762,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
              for (int32_t s = 0; s < ns; ++s) {
                  const llama_seq_id seq_id = batch_inp.seq_id ? batch_inp.seq_id[i][s] : 0;
  
@@ -588,28 +579,31 @@ index 52f8d5367..f22aa2532 100644
                      return -1;
                  }
              }
-@@ -1712,18 +1786,13 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1712,18 +1793,17 @@ int llama_context::decode(const llama_batch & batch_inp) {
  
      GGML_ASSERT((cparams.causal_attn || cparams.n_ubatch >= n_tokens_all) && "non-causal attention requires n_ubatch >= n_tokens");
  
--    // TODO: this clear of the buffer can easily be forgotten - need something better
--    // sync first so any in-flight async copies into embd_seq complete before it is freed
--    if (!embd_seq.empty()) {
--        synchronize();
--    }
--    embd_seq.clear();
--
-     if (t_compute_start_us == 0) {
-         t_compute_start_us = ggml_time_us();
++    if (t_compute_start_us == 0) {
++        t_compute_start_us = ggml_time_us();
++    }
++    n_queued_tokens += n_tokens_all;
++
+     // TODO: this clear of the buffer can easily be forgotten - need something better
+     // sync first so any in-flight async copies into embd_seq complete before it is freed
+     if (!embd_seq.empty()) {
+         synchronize();
      }
-     n_queued_tokens += n_tokens_all;
- 
-+    // TODO: this clear of the buffer can easily be forgotten - need something better
-+    embd_seq.clear();
+     embd_seq.clear();
+-
+-    if (t_compute_start_us == 0) {
+-        t_compute_start_us = ggml_time_us();
+-    }
+-    n_queued_tokens += n_tokens_all;
+-
      output_swaps.clear();
  
      sched_reserve();
-@@ -1784,11 +1853,6 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1784,11 +1864,6 @@ int llama_context::decode(const llama_batch & batch_inp) {
          return -2;
      };
  
@@ -621,7 +615,7 @@ index 52f8d5367..f22aa2532 100644
      int64_t n_outputs_prev = 0;
      int64_t n_tokens_prev  = 0;
  
-@@ -1949,20 +2013,36 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1949,20 +2024,36 @@ int llama_context::decode(const llama_batch & batch_inp) {
  
                  const uint32_t n_embd  = hparams.n_embd_out();
                  float * embd_nextn_out = embd_nextn.data + offset*n_embd;
@@ -664,52 +658,54 @@ index 52f8d5367..f22aa2532 100644
          }
  
          n_outputs_prev += n_outputs;
-@@ -2220,9 +2300,8 @@ void llama_context::extract_layer_inputs(const llm_graph_result * res, size_t to
+@@ -2220,9 +2311,9 @@ void llama_context::extract_layer_inputs(const llm_graph_result * res, size_t to
  }
  
  void llama_context::output_reorder() {
 -    const uint64_t n_vocab     = model.vocab.n_tokens();
 -    const uint64_t n_embd      = model.hparams.n_embd;
 -    const uint64_t n_embd_out  = model.hparams.n_embd_out();
-+    const uint64_t n_vocab = model.vocab.n_tokens();
-+    const uint64_t n_embd  = model.hparams.n_embd;
++    const uint64_t n_vocab    = model.vocab.n_tokens();
++    const uint64_t n_embd     = model.hparams.n_embd;
++    const uint64_t n_embd_out = model.hparams.n_embd_out();
  
      for (size_t s = 0; s < output_swaps.size(); ++s) {
          const uint64_t i0 = output_swaps[s].i0;
-@@ -2235,14 +2314,14 @@ void llama_context::output_reorder() {
+@@ -2235,6 +2326,7 @@ void llama_context::output_reorder() {
          }
  
          if (embd.size > 0) {
--            for (uint64_t k = 0; k < n_embd_out; k++) {
--                std::swap(embd.data[i0*n_embd_out + k], embd.data[i1*n_embd_out + k]);
-+            for (uint64_t k = 0; k < n_embd; k++) {
-+                std::swap(embd.data[i0*n_embd + k], embd.data[i1*n_embd + k]);
++            // use n_embd_out - the pooled embedding has the model's output width
+             for (uint64_t k = 0; k < n_embd_out; k++) {
+                 std::swap(embd.data[i0*n_embd_out + k], embd.data[i1*n_embd_out + k]);
              }
-         }
+@@ -2292,45 +2384,17 @@ void llama_context::output_reorder() {
+ //
  
-         if (embd_nextn.size > 0) {
--            for (uint64_t k = 0; k < n_embd_out; k++) {
--                std::swap(embd_nextn.data[i0*n_embd_out + k], embd_nextn.data[i1*n_embd_out + k]);
-+            for (uint64_t k = 0; k < n_embd; k++) {
-+                std::swap(embd_nextn.data[i0*n_embd + k], embd_nextn.data[i1*n_embd + k]);
-             }
-         }
- 
-@@ -2302,35 +2381,15 @@ uint32_t llama_context::graph_max_nodes(uint32_t n_tokens) const {
-         model.arch == LLM_ARCH_QWEN35 ||
-         model.arch == LLM_ARCH_QWEN35MOE ||
-         model.arch == LLM_ARCH_DEEPSEEK4 ||
+ uint32_t llama_context::graph_max_nodes(uint32_t n_tokens) const {
++    // the node budget must not depend on an architecture allowlist: new or
++    // rare families hit the small fixed budget and abort at scale
+     uint32_t res;
+     if (model.arch == LLM_ARCH_KIMI_K3) {
+         // the n_tokens*40 budget below is exhausted at ubatch 3840
+         res = std::max<uint32_t>(n_tokens * 160, 64u * model.n_tensors());
+-    } else if (model.arch == LLM_ARCH_QWEN3NEXT ||
+-        model.arch == LLM_ARCH_KIMI_LINEAR ||
+-        model.arch == LLM_ARCH_BAILINGMOE3 ||
+-        model.arch == LLM_ARCH_QWEN35 ||
+-        model.arch == LLM_ARCH_QWEN35MOE ||
+-        model.arch == LLM_ARCH_DEEPSEEK4 ||
 -        (model.arch == LLM_ARCH_DFLASH && model.hparams.dsv4_hc_mult > 0) ||
-         model.arch == LLM_ARCH_NANBEIGE ||
-         model.arch == LLM_ARCH_MINIMAX_01 ||
-         model.arch == LLM_ARCH_MINIMAX_M3) {
-         res = std::max<uint32_t>(n_tokens * 40, 32u * model.n_tensors());
+-        model.arch == LLM_ARCH_NANBEIGE ||
+-        model.arch == LLM_ARCH_MINIMAX_01 ||
+-        model.arch == LLM_ARCH_MINIMAX_M3) {
+-        res = std::max<uint32_t>(n_tokens * 40, 32u * model.n_tensors());
      } else {
-         res = std::max<uint32_t>(1024u, 8u*model.n_tensors());
+-        res = std::max<uint32_t>(1024u, 8u*model.n_tensors());
 -        for (const auto & lora : model.loras) {
 -            res += lora->get_n_nodes();
 -        }
-     }
+-    }
 -
 -    uint32_t n_sampling_nodes = 0;
 -    uint32_t n_sampling_nodes_max = 0;
@@ -719,7 +715,8 @@ index 52f8d5367..f22aa2532 100644
 -        if (cparams.n_outputs_max_per_seq > 1) {
 -            n_sampling_nodes_max = std::max(n_sampling_nodes_max, n_nodes);
 -        }
--    }
++        res = std::max<uint32_t>(n_tokens * 40, 32u * model.n_tensors());
+     }
 -
 -    const uint32_t n_sampling_outputs_max = std::min<uint64_t>(
 -            std::min(n_tokens, cparams.n_outputs_max),
@@ -733,7 +730,7 @@ index 52f8d5367..f22aa2532 100644
      }
      return res;
  }
-@@ -2356,7 +2415,6 @@ static void ubatch_prepare_reserve(
+@@ -2356,7 +2420,6 @@ static void ubatch_prepare_reserve(
          }
      }
  
@@ -741,7 +738,7 @@ index 52f8d5367..f22aa2532 100644
      std::vector<uint32_t> sampler_seqs;
      std::vector<bool> has_sampler(n_seqs, false);
      for (const auto & entry : samplers) {
-@@ -2364,38 +2422,37 @@ static void ubatch_prepare_reserve(
+@@ -2364,38 +2427,37 @@ static void ubatch_prepare_reserve(
          if (seq_id < 0 || (uint32_t) seq_id >= n_seqs) {
              continue;
          }
@@ -784,7 +781,7 @@ index 52f8d5367..f22aa2532 100644
  ggml_cgraph * llama_context::graph_reserve(
          uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx, bool split_only, size_t * sizes) {
      LLAMA_LOG_DEBUG("%s: reserving a graph for ubatch with n_tokens = %4u, n_seqs = %2u, n_outputs = %4u\n", __func__, n_tokens, n_seqs, n_outputs);
-@@ -3518,7 +3575,6 @@ llama_context_params llama_context_default_params() {
+@@ -3518,7 +3580,6 @@ llama_context_params llama_context_default_params() {
          /*.n_seq_max                   =*/ 1,
          /*.n_rs_seq                    =*/ 0,
          /*.n_outputs_max               =*/ 0,
@@ -792,7 +789,7 @@ index 52f8d5367..f22aa2532 100644
          /*.n_threads                   =*/ GGML_DEFAULT_N_THREADS, // TODO: better default
          /*.n_threads_batch             =*/ GGML_DEFAULT_N_THREADS,
          /*.ctx_type                    =*/ LLAMA_CONTEXT_TYPE_DEFAULT,
-@@ -3588,22 +3644,6 @@ llama_context * llama_init_from_model(
+@@ -3588,22 +3649,6 @@ llama_context * llama_init_from_model(
          }
      }
  
@@ -815,7 +812,7 @@ index 52f8d5367..f22aa2532 100644
      if (params.flash_attn_type != LLAMA_FLASH_ATTN_TYPE_DISABLED && ggml_is_quantized(params.type_k)) {
          const uint32_t blck_size = ggml_blck_size(params.type_k);
          for (uint32_t il = 0; il < model->hparams.n_layer(); ++il) {
-@@ -3626,6 +3666,11 @@ llama_context * llama_init_from_model(
+@@ -3626,6 +3671,11 @@ llama_context * llama_init_from_model(
          }
      }
  
@@ -827,7 +824,7 @@ index 52f8d5367..f22aa2532 100644
      if (params.pooling_type != LLAMA_POOLING_TYPE_UNSPECIFIED &&
          params.pooling_type != model->hparams.pooling_type) {
          //user-specified pooling-type is different from the model default
-@@ -3633,9 +3678,8 @@ llama_context * llama_init_from_model(
+@@ -3633,9 +3683,8 @@ llama_context * llama_init_from_model(
                         model->hparams.pooling_type, params.pooling_type);
      }
  
@@ -838,7 +835,7 @@ index 52f8d5367..f22aa2532 100644
          LLAMA_LOG_WARN("%s: context type MTP requested but model doesn't contain MTP layers\n", __func__);
          return nullptr;
      }
-@@ -4134,6 +4178,9 @@ int32_t llama_decode(
+@@ -4134,6 +4183,9 @@ int32_t llama_decode(
          llama_context * ctx,
            llama_batch   batch) {
      const int ret = ctx->decode(batch);
@@ -1722,7 +1719,7 @@ index c3c14292c..4bf1c4558 100644
      uint32_t n_layer() const;
  
 diff --git a/src/llama-kv-cache.cpp b/src/llama-kv-cache.cpp
-index 2e2bd7dc6..117de97f9 100644
+index 2e2bd7dc6..fdbd1b518 100644
 --- a/src/llama-kv-cache.cpp
 +++ b/src/llama-kv-cache.cpp
 @@ -4,6 +4,7 @@
@@ -2090,7 +2087,7 @@ index 2e2bd7dc6..117de97f9 100644
      return true;
  }
  
-@@ -1231,6 +1447,413 @@ const llama_kv_cells & llama_kv_cache::get_cells(llama_seq_id seq_id) const {
+@@ -1231,6 +1447,455 @@ const llama_kv_cells & llama_kv_cache::get_cells(llama_seq_id seq_id) const {
      return v_cells[seq_to_stream[seq_id]];
  }
  
@@ -2168,6 +2165,7 @@ index 2e2bd7dc6..117de97f9 100644
 +    uint32_t k_row_bytes = 0;
 +    uint32_t v_row_bytes = 0;
 +    uint32_t v_element_bytes = 0;
++    uint32_t k_idx_row_bytes = 0;
 +    uint32_t k_type = GGML_TYPE_COUNT;
 +    uint32_t v_type = GGML_TYPE_COUNT;
 +    uint64_t payload_bytes = 0;
@@ -2182,15 +2180,19 @@ index 2e2bd7dc6..117de97f9 100644
 +        }
 +        const uint32_t n_embd_v = hparams.n_embd_v_gqa(il);
 +        const bool has_v_stream = layer.v_stream.size() > strm && layer.v_stream[strm] != nullptr;
++        const bool has_k_idx_stream = layer.k_idx_stream.size() > strm && layer.k_idx_stream[strm] != nullptr;
 +
 +        const size_t k_row = ggml_row_size(layer.k_stream[strm]->type, hparams.n_embd_k_gqa(il));
 +        const size_t v_row = has_v_stream && !v_trans ? ggml_row_size(layer.v_stream[strm]->type, n_embd_v) : 0;
 +        const size_t v_el  = has_v_stream &&  v_trans ? ggml_type_size(layer.v_stream[strm]->type) : 0;
++        // MSA/DSA indexer keys are F32 rows of width n_embd_k_idx
++        const size_t k_idx_row = has_k_idx_stream ? ggml_row_size(layer.k_idx_stream[strm]->type, hparams.n_embd_k_idx(il)) : 0;
 +        const uint32_t layer_v_type = has_v_stream ? static_cast<uint32_t>(layer.v_stream[strm]->type) : GGML_TYPE_F32;
 +
 +        if (k_row > std::numeric_limits<uint32_t>::max() ||
 +                v_row > std::numeric_limits<uint32_t>::max() ||
-+                v_el > std::numeric_limits<uint32_t>::max()) {
++                v_el > std::numeric_limits<uint32_t>::max() ||
++                k_idx_row > std::numeric_limits<uint32_t>::max()) {
 +            error = "KV row size exceeds descriptor capacity";
 +            return false;
 +        }
@@ -2198,11 +2200,13 @@ index 2e2bd7dc6..117de97f9 100644
 +            k_row_bytes = static_cast<uint32_t>(k_row);
 +            v_row_bytes = static_cast<uint32_t>(v_row);
 +            v_element_bytes = static_cast<uint32_t>(v_el);
++            k_idx_row_bytes = static_cast<uint32_t>(k_idx_row);
 +            k_type = static_cast<uint32_t>(layer.k_stream[strm]->type);
 +            v_type = layer_v_type;
 +        } else if (k_row_bytes != k_row ||
 +                v_row_bytes != v_row ||
 +                v_element_bytes != v_el ||
++                k_idx_row_bytes != k_idx_row ||
 +                k_type != static_cast<uint32_t>(layer.k_stream[strm]->type) ||
 +                v_type != layer_v_type) {
 +            error = "native KV page export requires uniform K/V types and row sizes across selected layers";
@@ -2213,12 +2217,14 @@ index 2e2bd7dc6..117de97f9 100644
 +            (v_trans ? static_cast<uint64_t>(n_embd_v) * token_count * v_el : token_count * v_row) :
 +            0;
 +        const uint64_t k_bytes = token_count * k_row;
++        const uint64_t k_idx_bytes = token_count * k_idx_row;
 +        if (payload_bytes > std::numeric_limits<uint64_t>::max() - k_bytes ||
-+                payload_bytes + k_bytes > std::numeric_limits<uint64_t>::max() - v_bytes) {
++                payload_bytes + k_bytes > std::numeric_limits<uint64_t>::max() - v_bytes ||
++                payload_bytes + k_bytes + v_bytes > std::numeric_limits<uint64_t>::max() - k_idx_bytes) {
 +            error = "KV page payload is too large";
 +            return false;
 +        }
-+        payload_bytes += k_bytes + v_bytes;
++        payload_bytes += k_bytes + v_bytes + k_idx_bytes;
 +        selected.push_back(&layer);
 +    }
 +
@@ -2242,8 +2248,12 @@ index 2e2bd7dc6..117de97f9 100644
 +    out_desc->k_row_bytes = k_row_bytes;
 +    out_desc->v_row_bytes = v_row_bytes;
 +    out_desc->v_element_bytes = v_element_bytes;
++    out_desc->k_idx_row_bytes = k_idx_row_bytes;
 +    out_desc->payload_bytes = payload_bytes;
 +    out_desc->flags = v_trans ? SKIPPY_KV_PAGE_FLAG_V_TRANSPOSED : 0;
++    if (k_idx_row_bytes > 0) {
++        out_desc->flags |= SKIPPY_KV_PAGE_FLAG_HAS_K_IDX;
++    }
 +    *out_bytes = static_cast<size_t>(payload_bytes);
 +
 +    if (output == nullptr) {
@@ -2288,6 +2298,19 @@ index 2e2bd7dc6..117de97f9 100644
 +                    dst += v_element_bytes;
 +                }
 +            }
++        }
++    }
++
++    // MSA/DSA indexer keys ride after the V payload, one F32 row per token per layer
++    for (const auto * layer : selected) {
++        if (k_idx_row_bytes == 0) {
++            break;
++        }
++        auto * k_idx = layer->k_idx_stream[strm];
++        for (const auto & run : cell_runs) {
++            const size_t run_bytes = static_cast<size_t>(run.count) * k_idx_row_bytes;
++            ggml_backend_tensor_get(k_idx, dst, static_cast<size_t>(run.first) * k_idx_row_bytes, run_bytes);
++            dst += run_bytes;
 +        }
 +    }
 +
@@ -2361,15 +2384,18 @@ index 2e2bd7dc6..117de97f9 100644
 +        }
 +        const uint32_t n_embd_v = hparams.n_embd_v_gqa(il);
 +        const bool has_v_stream = layer.v_stream.size() > strm && layer.v_stream[strm] != nullptr;
++        const bool has_k_idx_stream = layer.k_idx_stream.size() > strm && layer.k_idx_stream[strm] != nullptr;
 +        const size_t k_row = ggml_row_size(layer.k_stream[strm]->type, hparams.n_embd_k_gqa(il));
 +        const size_t v_row = has_v_stream && !v_trans ? ggml_row_size(layer.v_stream[strm]->type, n_embd_v) : 0;
 +        const size_t v_el  = has_v_stream &&  v_trans ? ggml_type_size(layer.v_stream[strm]->type) : 0;
++        const size_t k_idx_row = has_k_idx_stream ? ggml_row_size(layer.k_idx_stream[strm]->type, hparams.n_embd_k_idx(il)) : 0;
 +        const uint32_t layer_v_type = has_v_stream ? static_cast<uint32_t>(layer.v_stream[strm]->type) : GGML_TYPE_F32;
 +        if (desc.k_type != static_cast<uint32_t>(layer.k_stream[strm]->type) ||
 +                desc.v_type != layer_v_type ||
 +                desc.k_row_bytes != k_row ||
 +                desc.v_row_bytes != v_row ||
-+                desc.v_element_bytes != v_el) {
++                desc.v_element_bytes != v_el ||
++                desc.k_idx_row_bytes != k_idx_row) {
 +            error = "native KV page descriptor does not match runtime KV cache layout";
 +            return false;
 +        }
@@ -2390,6 +2416,7 @@ index 2e2bd7dc6..117de97f9 100644
 +        expected_bytes += v_trans ?
 +            static_cast<uint64_t>(hparams.n_embd_v_gqa(layer->il)) * desc.token_count * desc.v_element_bytes :
 +            desc.token_count * desc.v_row_bytes;
++        expected_bytes += desc.token_count * desc.k_idx_row_bytes;
 +    }
 +    if (expected_bytes != desc.payload_bytes) {
 +        error = "native KV page descriptor payload size is inconsistent";
@@ -2498,13 +2525,25 @@ index 2e2bd7dc6..117de97f9 100644
 +        }
 +    }
 +
++    // MSA/DSA indexer keys ride after the V payload, one F32 row per token per layer
++    if (desc.k_idx_row_bytes > 0) {
++        for (const auto * layer : selected) {
++            auto * k_idx = layer->k_idx_stream[strm];
++            for (const auto & run : cell_runs) {
++                const size_t run_bytes = static_cast<size_t>(run.count) * desc.k_idx_row_bytes;
++                ggml_backend_tensor_set(k_idx, src, static_cast<size_t>(run.first) * desc.k_idx_row_bytes, run_bytes);
++                src += run_bytes;
++            }
++        }
++    }
++
 +    return src == static_cast<const char *>(input) + input_bytes;
 +}
 +
  uint32_t llama_kv_cache::get_n_kv(const slot_info & sinfo) const {
      uint32_t result = 0;
  
-@@ -1247,6 +1870,49 @@ uint32_t llama_kv_cache::get_n_kv(const slot_info & sinfo) const {
+@@ -1247,6 +1912,49 @@ uint32_t llama_kv_cache::get_n_kv(const slot_info & sinfo) const {
      return result;
  }
  
@@ -2554,7 +2593,7 @@ index 2e2bd7dc6..117de97f9 100644
  ggml_tensor * llama_kv_cache::get_k(ggml_context * ctx, int32_t il, uint32_t n_kv, const slot_info & sinfo) const {
      const int32_t ikv = map_layer_ids.at(il);
  
-@@ -1299,6 +1965,23 @@ ggml_tensor * llama_kv_cache::get_v(ggml_context * ctx, int32_t il, uint32_t n_k
+@@ -1299,6 +2007,23 @@ ggml_tensor * llama_kv_cache::get_v(ggml_context * ctx, int32_t il, uint32_t n_k
              ggml_row_size(v->type, kv_size*n_embd_v_gqa)*sinfo.s0);
  }
  
@@ -2578,7 +2617,7 @@ index 2e2bd7dc6..117de97f9 100644
  ggml_tensor * llama_kv_cache::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il, const slot_info & sinfo) const {
      GGML_UNUSED(sinfo);
  
-@@ -1400,6 +2083,28 @@ ggml_tensor * llama_kv_cache::build_input_k_idxs(ggml_context * ctx, const llama
+@@ -1400,6 +2125,28 @@ ggml_tensor * llama_kv_cache::build_input_k_idxs(ggml_context * ctx, const llama
      return k_idxs;
  }
  
@@ -2607,7 +2646,7 @@ index 2e2bd7dc6..117de97f9 100644
  ggml_tensor * llama_kv_cache::build_input_v_idxs(ggml_context * ctx, const llama_ubatch & ubatch) const {
      const uint32_t n_tokens = ubatch.n_tokens;
  
-@@ -1786,6 +2491,39 @@ void llama_kv_cache::set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch
+@@ -1786,6 +2533,39 @@ void llama_kv_cache::set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch
      }
  }
  
@@ -2647,7 +2686,7 @@ index 2e2bd7dc6..117de97f9 100644
  void llama_kv_cache::set_input_k_rot(ggml_tensor * dst) const {
      GGML_ASSERT(ggml_backend_buffer_is_host(dst->buffer));
  
-@@ -1834,6 +2572,18 @@ size_t llama_kv_cache::size_v_bytes() const {
+@@ -1834,6 +2614,18 @@ size_t llama_kv_cache::size_v_bytes() const {
      return size_v_bytes;
  }
  
@@ -2666,7 +2705,7 @@ index 2e2bd7dc6..117de97f9 100644
  ggml_tensor * llama_kv_cache::build_rope_shift(
          const llama_cparams & cparams,
                 ggml_context * ctx,
-@@ -1932,10 +2682,6 @@ ggml_cgraph * llama_kv_cache::build_graph_shift(llm_graph_result * res, llama_co
+@@ -1932,10 +2724,6 @@ ggml_cgraph * llama_kv_cache::build_graph_shift(llm_graph_result * res, llama_co
      for (const auto & layer : layers) {
          const uint32_t il = layer.il;
  
@@ -2677,7 +2716,7 @@ index 2e2bd7dc6..117de97f9 100644
          const int64_t n_head_kv    = hparams.n_head_kv(il);
          const int64_t n_embd_k_gqa = hparams.n_embd_k_gqa(il);
  
-@@ -2150,6 +2896,36 @@ void llama_kv_cache::state_write_data(llama_io_write_i & io, const cell_ranges_t
+@@ -2150,6 +2938,36 @@ void llama_kv_cache::state_write_data(llama_io_write_i & io, const cell_ranges_t
          }
      }
  
@@ -2714,7 +2753,7 @@ index 2e2bd7dc6..117de97f9 100644
      if (!v_trans) {
          for (const auto & layer : layers) {
              const uint32_t il = layer.il;
-@@ -2398,6 +3174,68 @@ bool llama_kv_cache::state_read_data(llama_io_read_i & io, uint32_t strm, uint32
+@@ -2398,6 +3216,68 @@ bool llama_kv_cache::state_read_data(llama_io_read_i & io, uint32_t strm, uint32
          }
      }
  
@@ -2783,7 +2822,7 @@ index 2e2bd7dc6..117de97f9 100644
      if (!this->v_trans) {
          for (const auto & layer : layers) {
              const uint32_t il = layer.il;
-@@ -2529,8 +3367,9 @@ llama_kv_cache_context::llama_kv_cache_context(
+@@ -2529,8 +3409,9 @@ llama_kv_cache_context::llama_kv_cache_context(
          llama_kv_cache * kv,
          llama_context * lctx,
          bool do_shift,
@@ -2795,7 +2834,7 @@ index 2e2bd7dc6..117de97f9 100644
          status = LLAMA_MEMORY_STATUS_NO_UPDATE;
      }
  }
-@@ -2583,6 +3422,21 @@ uint32_t llama_kv_cache_context::get_n_kv() const {
+@@ -2583,6 +3464,21 @@ uint32_t llama_kv_cache_context::get_n_kv() const {
      return n_kv;
  }
  
@@ -2817,7 +2856,7 @@ index 2e2bd7dc6..117de97f9 100644
  ggml_type llama_kv_cache_context::type_k() const {
      return kv->type_k();
  }
-@@ -2599,6 +3453,10 @@ ggml_tensor * llama_kv_cache_context::get_v(ggml_context * ctx, int32_t il) cons
+@@ -2599,6 +3495,10 @@ ggml_tensor * llama_kv_cache_context::get_v(ggml_context * ctx, int32_t il) cons
      return kv->get_v(ctx, il, n_kv, sinfos[i_cur]);
  }
  
@@ -2828,7 +2867,7 @@ index 2e2bd7dc6..117de97f9 100644
  ggml_tensor * llama_kv_cache_context::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il) const {
      return kv->cpy_k(ctx, k_cur, k_idxs, il, sinfos[i_cur]);
  }
-@@ -2607,6 +3465,10 @@ ggml_tensor * llama_kv_cache_context::cpy_v(ggml_context * ctx, ggml_tensor * v_
+@@ -2607,6 +3507,10 @@ ggml_tensor * llama_kv_cache_context::cpy_v(ggml_context * ctx, ggml_tensor * v_
      return kv->cpy_v(ctx, v_cur, v_idxs, il, sinfos[i_cur]);
  }
  
@@ -2839,7 +2878,7 @@ index 2e2bd7dc6..117de97f9 100644
  ggml_tensor * llama_kv_cache_context::build_input_k_idxs(ggml_context * ctx, const llama_ubatch & ubatch) const {
      return kv->build_input_k_idxs(ctx, ubatch);
  }
-@@ -2643,6 +3505,10 @@ void llama_kv_cache_context::set_input_pos_bucket(ggml_tensor * dst, const llama
+@@ -2643,6 +3547,10 @@ void llama_kv_cache_context::set_input_pos_bucket(ggml_tensor * dst, const llama
      kv->set_input_pos_bucket(dst, ubatch);
  }
  
@@ -10562,6 +10601,3 @@ index 313500129..0aada2095 100644
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
  
      cb(cur, "result_norm", -1);
--- 
-2.54.0 (Apple Git-157)
-

--- a/third_party/llama.cpp/patches/0006-Add-Skippy-session-and-state-management.patch
+++ b/third_party/llama.cpp/patches/0006-Add-Skippy-session-and-state-management.patch
@@ -56,10 +56,10 @@ index 000000000..22b8e3590
 +#endif // SKIPPY_SIGNALS_H
 diff --git a/include/skippy/state.h b/include/skippy/state.h
 new file mode 100644
-index 000000000..9556bfd84
+index 000000000..fa5ca80be
 --- /dev/null
 +++ b/include/skippy/state.h
-@@ -0,0 +1,129 @@
+@@ -0,0 +1,131 @@
 +#ifndef SKIPPY_STATE_H
 +#define SKIPPY_STATE_H
 +
@@ -71,6 +71,7 @@ index 000000000..9556bfd84
 +
 +enum skippy_kv_page_flag {
 +    SKIPPY_KV_PAGE_FLAG_V_TRANSPOSED      = 1 << 0,
++    SKIPPY_KV_PAGE_FLAG_HAS_K_IDX         = 1 << 1,
 +};
 +
 +struct skippy_kv_page_desc {
@@ -85,6 +86,7 @@ index 000000000..9556bfd84
 +    uint32_t k_row_bytes;
 +    uint32_t v_row_bytes;
 +    uint32_t v_element_bytes;
++    uint32_t k_idx_row_bytes;
 +    uint64_t payload_bytes;
 +    uint64_t flags;
 +};
@@ -1920,6 +1922,3 @@ index 000000000..d09acccb4
 +    if (skippy_retire_verify_checkpoint_exact(checkpoints, 10, 3)) return 6;
 +    return 0;
 +}
--- 
-2.54.0 (Apple Git-157)
-

--- a/third_party/llama.cpp/patches/0011-Wire-staged-runtime-builds-and-tests.patch
+++ b/third_party/llama.cpp/patches/0011-Wire-staged-runtime-builds-and-tests.patch
@@ -1190,7 +1190,7 @@ index 67fc99716..3953ed990 100644
          struct skippy_ngram_cache * cache,
          const llama_token * continuation_prefix,
 diff --git a/include/skippy/state.h b/include/skippy/state.h
-index 9556bfd84..446da8dad 100644
+index fa5ca80be..0e7bec61d 100644
 --- a/include/skippy/state.h
 +++ b/include/skippy/state.h
 @@ -1,6 +1,11 @@
@@ -1205,15 +1205,15 @@ index 9556bfd84..446da8dad 100644
  #include "runtime.h"
  
  #ifdef __cplusplus
-@@ -11,6 +16,7 @@ enum skippy_kv_page_flag {
-     SKIPPY_KV_PAGE_FLAG_V_TRANSPOSED      = 1 << 0,
+@@ -12,6 +17,7 @@ enum skippy_kv_page_flag {
+     SKIPPY_KV_PAGE_FLAG_HAS_K_IDX         = 1 << 1,
  };
  
 +/** @brief Describes the layout and ownership of an exported KV page payload. */
  struct skippy_kv_page_desc {
      uint32_t version;
      int32_t layer_start;
-@@ -27,6 +33,7 @@ struct skippy_kv_page_desc {
+@@ -29,6 +35,7 @@ struct skippy_kv_page_desc {
      uint64_t flags;
  };
  
@@ -1221,7 +1221,7 @@ index 9556bfd84..446da8dad 100644
  LLAMA_API enum skippy_status skippy_export_state(
          struct skippy_session * session,
          int32_t layer_start,
-@@ -36,6 +43,7 @@ LLAMA_API enum skippy_status skippy_export_state(
+@@ -38,6 +45,7 @@ LLAMA_API enum skippy_status skippy_export_state(
          size_t * out_bytes,
          struct skippy_error ** out_error);
  
@@ -1229,7 +1229,7 @@ index 9556bfd84..446da8dad 100644
  LLAMA_API enum skippy_status skippy_import_state(
          struct skippy_session * session,
          int32_t layer_start,
-@@ -44,6 +52,7 @@ LLAMA_API enum skippy_status skippy_import_state(
+@@ -46,6 +54,7 @@ LLAMA_API enum skippy_status skippy_import_state(
          size_t input_bytes,
          struct skippy_error ** out_error);
  
@@ -1237,7 +1237,7 @@ index 9556bfd84..446da8dad 100644
  LLAMA_API enum skippy_status skippy_export_full_state(
          struct skippy_session * session,
          int32_t layer_start,
-@@ -53,6 +62,7 @@ LLAMA_API enum skippy_status skippy_export_full_state(
+@@ -55,6 +64,7 @@ LLAMA_API enum skippy_status skippy_export_full_state(
          size_t * out_bytes,
          struct skippy_error ** out_error);
  
@@ -1245,7 +1245,7 @@ index 9556bfd84..446da8dad 100644
  LLAMA_API enum skippy_status skippy_export_recurrent_state(
          struct skippy_session * session,
          void * output,
-@@ -60,6 +70,7 @@ LLAMA_API enum skippy_status skippy_export_recurrent_state(
+@@ -62,6 +72,7 @@ LLAMA_API enum skippy_status skippy_export_recurrent_state(
          size_t * out_bytes,
          struct skippy_error ** out_error);
  
@@ -1253,7 +1253,7 @@ index 9556bfd84..446da8dad 100644
  LLAMA_API enum skippy_status skippy_import_full_state(
          struct skippy_session * session,
          int32_t layer_start,
-@@ -68,23 +79,27 @@ LLAMA_API enum skippy_status skippy_import_full_state(
+@@ -70,6 +81,7 @@ LLAMA_API enum skippy_status skippy_import_full_state(
          size_t input_bytes,
          struct skippy_error ** out_error);
  
@@ -1261,12 +1261,7 @@ index 9556bfd84..446da8dad 100644
  LLAMA_API enum skippy_status skippy_import_recurrent_state(
          struct skippy_session * session,
          const void * input,
-         size_t input_bytes,
-         struct skippy_error ** out_error);
- 
-+/** @brief Trims the session's token history and associated state. */
- LLAMA_API enum skippy_status skippy_trim_session(
-         struct skippy_session * session,
+@@ -81,12 +93,14 @@ LLAMA_API enum skippy_status skippy_trim_session(
          uint64_t token_count,
          struct skippy_error ** out_error);
  
@@ -1281,7 +1276,7 @@ index 9556bfd84..446da8dad 100644
  LLAMA_API enum skippy_status skippy_export_kv_page(
          struct skippy_session * session,
          int32_t layer_start,
-@@ -97,6 +112,7 @@ LLAMA_API enum skippy_status skippy_export_kv_page(
+@@ -99,6 +113,7 @@ LLAMA_API enum skippy_status skippy_export_kv_page(
          size_t * out_bytes,
          struct skippy_error ** out_error);
  
@@ -1289,29 +1284,6 @@ index 9556bfd84..446da8dad 100644
  LLAMA_API enum skippy_status skippy_import_kv_page(
          struct skippy_session * session,
          const struct skippy_kv_page_desc * desc,
-@@ -104,12 +120,14 @@ LLAMA_API enum skippy_status skippy_import_kv_page(
-         size_t input_bytes,
-         struct skippy_error ** out_error);
- 
-+/** @brief Saves a session prefix into a resident cache sequence. */
- LLAMA_API enum skippy_status skippy_session_save_prefix(
-         struct skippy_session * session,
-         int32_t cache_seq_id,
-         uint64_t token_count,
-         struct skippy_error ** out_error);
- 
-+/** @brief Restores a session prefix from a resident cache sequence. */
- LLAMA_API enum skippy_status skippy_session_restore_prefix(
-         struct skippy_session * session,
-         int32_t cache_seq_id,
-@@ -117,6 +135,7 @@ LLAMA_API enum skippy_status skippy_session_restore_prefix(
-         size_t token_count,
-         struct skippy_error ** out_error);
- 
-+/** @brief Drops a llama.cpp sequence from the session's cache. */
- LLAMA_API enum skippy_status skippy_session_drop_sequence(
-         struct skippy_session * session,
-         int32_t seq_id,
 diff --git a/include/skippy/tokenization.h b/include/skippy/tokenization.h
 index 7b8c4dcc4..ccf3d020c 100644
 --- a/include/skippy/tokenization.h

--- a/third_party/llama.cpp/patches/0011-Wire-staged-runtime-builds-and-tests.patch
+++ b/third_party/llama.cpp/patches/0011-Wire-staged-runtime-builds-and-tests.patch
@@ -1261,7 +1261,13 @@ index fa5ca80be..0e7bec61d 100644
  LLAMA_API enum skippy_status skippy_import_recurrent_state(
          struct skippy_session * session,
          const void * input,
-@@ -81,12 +93,14 @@ LLAMA_API enum skippy_status skippy_trim_session(
+@@ -76,17 +88,20 @@ LLAMA_API enum skippy_status skippy_import_recurrent_state(
+         size_t input_bytes,
+         struct skippy_error ** out_error);
+ 
++/** @brief Trims the session's token history and associated state. */
+ LLAMA_API enum skippy_status skippy_trim_session(
+         struct skippy_session * session,
          uint64_t token_count,
          struct skippy_error ** out_error);
  
@@ -1276,7 +1282,7 @@ index fa5ca80be..0e7bec61d 100644
  LLAMA_API enum skippy_status skippy_export_kv_page(
          struct skippy_session * session,
          int32_t layer_start,
-@@ -99,6 +113,7 @@ LLAMA_API enum skippy_status skippy_export_kv_page(
+@@ -99,27 +113,31 @@ LLAMA_API enum skippy_status skippy_export_kv_page(
          size_t * out_bytes,
          struct skippy_error ** out_error);
  
@@ -1284,6 +1290,30 @@ index fa5ca80be..0e7bec61d 100644
  LLAMA_API enum skippy_status skippy_import_kv_page(
          struct skippy_session * session,
          const struct skippy_kv_page_desc * desc,
+         const void * input,
+         size_t input_bytes,
+         struct skippy_error ** out_error);
+ 
++/** @brief Saves a session prefix into a resident cache sequence. */
+ LLAMA_API enum skippy_status skippy_session_save_prefix(
+         struct skippy_session * session,
+         int32_t cache_seq_id,
+         uint64_t token_count,
+         struct skippy_error ** out_error);
+ 
++/** @brief Restores a session prefix from a resident cache sequence. */
+ LLAMA_API enum skippy_status skippy_session_restore_prefix(
+         struct skippy_session * session,
+         int32_t cache_seq_id,
+         const llama_token * token_ids,
+         size_t token_count,
+         struct skippy_error ** out_error);
+ 
++/** @brief Drops a llama.cpp sequence from the session's cache. */
+ LLAMA_API enum skippy_status skippy_session_drop_sequence(
+         struct skippy_session * session,
+         int32_t seq_id,
+         struct skippy_error ** out_error);
 diff --git a/include/skippy/tokenization.h b/include/skippy/tokenization.h
 index 7b8c4dcc4..ccf3d020c 100644
 --- a/include/skippy/tokenization.h

--- a/third_party/llama.cpp/patches/0013-skippy-support-composite-ISWA-KV-pages.patch
+++ b/third_party/llama.cpp/patches/0013-skippy-support-composite-ISWA-KV-pages.patch
@@ -18,11 +18,11 @@ index 0911776cd..012aceb9a 100644
  enum skippy_feature {
      SKIPPY_FEATURE_RUNTIME_SLICE          = 1 << 0,
 diff --git a/include/skippy/state.h b/include/skippy/state.h
-index 446da8dad..890fa5ae5 100644
+index 74f9ac52a..1c77c5450 100644
 --- a/include/skippy/state.h
 +++ b/include/skippy/state.h
-@@ -16,6 +16,33 @@ enum skippy_kv_page_flag {
-     SKIPPY_KV_PAGE_FLAG_V_TRANSPOSED      = 1 << 0,
+@@ -17,6 +17,34 @@ enum skippy_kv_page_flag {
+     SKIPPY_KV_PAGE_FLAG_HAS_K_IDX         = 1 << 1,
  };
  
 +enum skippy_kv_page_codec {
@@ -47,6 +47,7 @@ index 446da8dad..890fa5ae5 100644
 +    uint32_t k_row_bytes;
 +    uint32_t v_row_bytes;
 +    uint32_t v_element_bytes;
++    uint32_t k_idx_row_bytes;
 +    uint64_t payload_offset;
 +    uint64_t payload_bytes;
 +    uint64_t flags;
@@ -55,8 +56,8 @@ index 446da8dad..890fa5ae5 100644
  /** @brief Describes the layout and ownership of an exported KV page payload. */
  struct skippy_kv_page_desc {
      uint32_t version;
-@@ -31,6 +58,9 @@ struct skippy_kv_page_desc {
-     uint32_t v_element_bytes;
+@@ -33,6 +61,9 @@ struct skippy_kv_page_desc {
+     uint32_t k_idx_row_bytes;
      uint64_t payload_bytes;
      uint64_t flags;
 +    uint32_t codec;
@@ -65,7 +66,7 @@ index 446da8dad..890fa5ae5 100644
  };
  
  /** @brief Exports the selected layer-range state for staged transfer. */
-@@ -112,7 +142,7 @@ LLAMA_API enum skippy_status skippy_export_kv_page(
+@@ -114,7 +145,7 @@ LLAMA_API enum skippy_status skippy_export_kv_page(
          size_t * out_bytes,
          struct skippy_error ** out_error);
  
@@ -75,7 +76,7 @@ index 446da8dad..890fa5ae5 100644
          struct skippy_session * session,
          const struct skippy_kv_page_desc * desc,
 diff --git a/src/llama-kv-cache.cpp b/src/llama-kv-cache.cpp
-index 117de97f9..8a3b72f4c 100644
+index fdbd1b518..3bc5ea5c5 100644
 --- a/src/llama-kv-cache.cpp
 +++ b/src/llama-kv-cache.cpp
 @@ -1447,6 +1447,26 @@ const llama_kv_cells & llama_kv_cache::get_cells(llama_seq_id seq_id) const {
@@ -105,7 +106,7 @@ index 117de97f9..8a3b72f4c 100644
  bool llama_kv_cache::stage_export_kv_page(
          llama_seq_id seq_id,
          int32_t layer_start,
-@@ -1607,12 +1627,14 @@ bool llama_kv_cache::stage_export_kv_page(
+@@ -1620,12 +1640,14 @@ bool llama_kv_cache::stage_export_kv_page(
          return false;
      }
  
@@ -123,7 +124,7 @@ index 117de97f9..8a3b72f4c 100644
          }
      }
  
-@@ -1622,9 +1644,10 @@ bool llama_kv_cache::stage_export_kv_page(
+@@ -1635,9 +1657,10 @@ bool llama_kv_cache::stage_export_kv_page(
                  continue;
              }
              auto * v = layer->v_stream[strm];
@@ -137,7 +138,7 @@ index 117de97f9..8a3b72f4c 100644
              }
          }
      } else {
-@@ -1635,10 +1658,11 @@ bool llama_kv_cache::stage_export_kv_page(
+@@ -1648,10 +1671,11 @@ bool llama_kv_cache::stage_export_kv_page(
              auto * v = layer->v_stream[strm];
              const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(layer->il);
              for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
@@ -153,7 +154,7 @@ index 117de97f9..8a3b72f4c 100644
                  }
              }
          }
-@@ -1652,7 +1676,8 @@ bool llama_kv_cache::stage_import_kv_page(
+@@ -1678,7 +1702,8 @@ bool llama_kv_cache::stage_import_kv_page(
          const skippy_kv_page_desc & desc,
          const void * input,
          size_t input_bytes,
@@ -163,7 +164,7 @@ index 117de97f9..8a3b72f4c 100644
      if (input == nullptr) {
          error = "input payload is required";
          return false;
-@@ -1663,7 +1688,7 @@ bool llama_kv_cache::stage_import_kv_page(
+@@ -1689,7 +1714,7 @@ bool llama_kv_cache::stage_import_kv_page(
      }
      if (desc.layer_start < 0 ||
              desc.layer_end <= desc.layer_start ||
@@ -172,7 +173,7 @@ index 117de97f9..8a3b72f4c 100644
              desc.token_count == 0) {
          error = "invalid native KV page descriptor";
          return false;
-@@ -1748,6 +1773,9 @@ bool llama_kv_cache::stage_import_kv_page(
+@@ -1778,6 +1803,9 @@ bool llama_kv_cache::stage_import_kv_page(
          error = "native KV page descriptor payload size is inconsistent";
          return false;
      }
@@ -182,7 +183,7 @@ index 117de97f9..8a3b72f4c 100644
  
      llama_ubatch ubatch = {};
      auto udata = std::make_shared<llama_ubatch::data_t>();
-@@ -1813,12 +1841,14 @@ bool llama_kv_cache::stage_import_kv_page(
+@@ -1843,12 +1871,14 @@ bool llama_kv_cache::stage_import_kv_page(
      }
      apply_ubatch(sinfo, ubatch);
  
@@ -200,7 +201,7 @@ index 117de97f9..8a3b72f4c 100644
          }
      }
  
-@@ -1829,9 +1859,10 @@ bool llama_kv_cache::stage_import_kv_page(
+@@ -1859,9 +1889,10 @@ bool llama_kv_cache::stage_import_kv_page(
                  continue;
              }
              auto * v = layer->v_stream[strm];
@@ -214,7 +215,7 @@ index 117de97f9..8a3b72f4c 100644
              }
          }
      } else {
-@@ -1842,10 +1873,11 @@ bool llama_kv_cache::stage_import_kv_page(
+@@ -1872,10 +1903,11 @@ bool llama_kv_cache::stage_import_kv_page(
              auto * v = layer->v_stream[strm];
              const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(layer->il);
              for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
@@ -253,7 +254,7 @@ index 274ef4492..98dbcb198 100644
      //
      // graph_build API
 diff --git a/src/skippy/state.cpp b/src/skippy/state.cpp
-index 2bfd88523..a5ab006aa 100644
+index 2bfd88523..5b64b97a9 100644
 --- a/src/skippy/state.cpp
 +++ b/src/skippy/state.cpp
 @@ -356,24 +356,14 @@ enum skippy_status skippy_import_recurrent_state(
@@ -284,7 +285,7 @@ index 2bfd88523..a5ab006aa 100644
          skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "failed to import recurrent state");
          return SKIPPY_STATUS_RUNTIME_ERROR;
      }
-@@ -397,27 +387,140 @@ static llama_kv_cache * skippy_get_kv_cache(
+@@ -397,27 +387,142 @@ static llama_kv_cache * skippy_get_kv_cache(
      }
  
      if (auto * hybrid = dynamic_cast<llama_memory_hybrid *>(memory)) {
@@ -339,6 +340,7 @@ index 2bfd88523..a5ab006aa 100644
 +    component.k_row_bytes = page.k_row_bytes;
 +    component.v_row_bytes = page.v_row_bytes;
 +    component.v_element_bytes = page.v_element_bytes;
++    component.k_idx_row_bytes = page.k_idx_row_bytes;
 +    component.payload_offset = payload_offset;
 +    component.payload_bytes = page.payload_bytes;
 +    component.flags = page.flags;
@@ -360,6 +362,7 @@ index 2bfd88523..a5ab006aa 100644
 +    page.k_row_bytes = component.k_row_bytes;
 +    page.v_row_bytes = component.v_row_bytes;
 +    page.v_element_bytes = component.v_element_bytes;
++    page.k_idx_row_bytes = component.k_idx_row_bytes;
 +    page.payload_bytes = component.payload_bytes;
 +    page.flags = component.flags;
 +    page.codec = SKIPPY_KV_PAGE_CODEC_SINGLE_V1;
@@ -436,7 +439,7 @@ index 2bfd88523..a5ab006aa 100644
  enum skippy_status skippy_export_kv_page(
          struct skippy_session * session,
          int32_t layer_start,
-@@ -429,24 +532,24 @@ enum skippy_status skippy_export_kv_page(
+@@ -429,24 +534,24 @@ enum skippy_status skippy_export_kv_page(
          size_t output_capacity,
          size_t * out_bytes,
          struct skippy_error ** out_error) {
@@ -476,7 +479,7 @@ index 2bfd88523..a5ab006aa 100644
      if (!ok) {
          const bool too_small = out_bytes != nullptr && *out_bytes > output_capacity;
          const enum skippy_status status = too_small ? SKIPPY_STATUS_BUFFER_TOO_SMALL : SKIPPY_STATUS_RUNTIME_ERROR;
-@@ -457,46 +560,83 @@ enum skippy_status skippy_export_kv_page(
+@@ -457,46 +562,83 @@ enum skippy_status skippy_export_kv_page(
          skippy_set_error(out_error, SKIPPY_STATUS_BUFFER_TOO_SMALL, "native KV page output buffer is too small");
          return SKIPPY_STATUS_BUFFER_TOO_SMALL;
      }
@@ -795,6 +798,3 @@ index 000000000..9ef80a6ce
 +
 +    return 0;
 +}
--- 
-2.54.0 (Apple Git-157)
-

--- a/third_party/llama.cpp/patches/0016-skippy-add-mixed-iteration-batch-execution-ABI.patch
+++ b/third_party/llama.cpp/patches/0016-skippy-add-mixed-iteration-batch-execution-ABI.patch
@@ -11,7 +11,7 @@ Subject: [PATCH] skippy: add mixed iteration batch execution ABI
  4 files changed, 371 insertions(+), 6 deletions(-)
 
 diff --git a/include/skippy/common.h b/include/skippy/common.h
-index 012aceb9a..cb225768a 100644
+index 012aceb9a..e7f322abf 100644
 --- a/include/skippy/common.h
 +++ b/include/skippy/common.h
 @@ -34,7 +34,15 @@ extern "C" {
@@ -19,7 +19,7 @@ index 012aceb9a..cb225768a 100644
  #define SKIPPY_ABI_VERSION_MAJOR 0
  #define SKIPPY_ABI_VERSION_MINOR 1
 -#define SKIPPY_ABI_VERSION_PATCH 39
-+#define SKIPPY_ABI_VERSION_PATCH 40
++#define SKIPPY_ABI_VERSION_PATCH 41
 +
 +#if defined(_MSC_VER)
 +#define SKIPPY_DEPRECATED(message) __declspec(deprecated(message))
@@ -129,10 +129,10 @@ index 0ec72958e..f48e56cb5 100644
  
  void skippy_error_free(struct skippy_error * error) {
 diff --git a/src/skippy/execution-batch.cpp b/src/skippy/execution-batch.cpp
-index a8694dbed..efb51f5fd 100644
+index a8694dbed..2d771832a 100644
 --- a/src/skippy/execution-batch.cpp
 +++ b/src/skippy/execution-batch.cpp
-@@ -23,6 +23,326 @@
+@@ -23,6 +23,332 @@
  
  
  extern "C" {
@@ -167,6 +167,12 @@ index a8694dbed..efb51f5fd 100644
 +    if (n_pos_per_embd <= 0) {
 +        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "model position sideband width must be positive");
 +        return SKIPPY_STATUS_INVALID_ARGUMENT;
++    }
++    if (n_embd <= 0 || n_embd_inp < n_embd) {
++        // wider upstream activations than the input embedding width have no
++        // defined gather semantics and would overflow the batch row write
++        skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, "activation input width exceeds the stage model input embedding width");
++        return SKIPPY_STATUS_UNSUPPORTED;
 +    }
 +
 +    const bool activation_input = skippy_is_filtered(first) && first->stage_model->config.layer_start > 0;
@@ -459,5 +465,3 @@ index a8694dbed..efb51f5fd 100644
  enum skippy_status skippy_decode_step_frame_batch_sampled(
          struct skippy_session * const * sessions,
          const llama_token * token_ids,
--- 
-2.54.0 (Apple Git-157)

--- a/website/src/docs/pages/skippy-api.md
+++ b/website/src/docs/pages/skippy-api.md
@@ -1301,7 +1301,7 @@ LLAMA_API enum skippy_status skippy_parse_chat_response_json(
 The headers also define the following enums, structs, opaque handles, and ABI constants:
 
 - `activation.h`: `skippy_activation_dtype`, `skippy_activation_layout`, `skippy_activation_desc`, `SKIPPY_ACTIVATION_FLAG_RWKV7_V_FIRST = (UINT64_C(1) << 0)`, `SKIPPY_ACTIVATION_FLAG_GEMMA3N_ALTUP = (UINT64_C(1) << 1)`, `SKIPPY_ACTIVATION_FLAG_INKLING_MTP_EMBD = (UINT64_C(1) << 2)`, `SKIPPY_ACTIVATION_FLAG_GLM_DSA_TOP_K = (UINT64_C(1) << 3)`
-- `common.h`: `skippy_feature`, `skippy_status`, `skippy_error`, `skippy_abi_version`, `SKIPPY_ABI_VERSION_MAJOR = 0`, `SKIPPY_ABI_VERSION_MINOR = 1`, `SKIPPY_ABI_VERSION_PATCH = 40`
+- `common.h`: `skippy_feature`, `skippy_status`, `skippy_error`, `skippy_abi_version`, `SKIPPY_ABI_VERSION_MAJOR = 0`, `SKIPPY_ABI_VERSION_MINOR = 1`, `SKIPPY_ABI_VERSION_PATCH = 41`
 - `devices.h`: `skippy_backend_device_type`, `skippy_backend_device_cap`, `skippy_backend_device`
 - `events.h`: `skippy_runtime_event_v1`, `skippy_runtime_event_reporter_v1`, `SKIPPY_RUNTIME_EVENT_V1_ABI_VERSION = 1`
 - `execution.h`: `skippy_iteration_request`


### PR DESCRIPTION
Stacked on #1429 (do not merge independently).

## What this fixes

Split-model serving on mixed-hardware labs no longer produces family- and boundary-dependent garbage:

- **Hybrid stages keep their recurrent state (B1):** `model_requires_recurrent_state` now probes every layer file in `[layer_start, layer_end)`, so a Kimi-Linear / Qwen3-Next stage that starts on an attention layer resolves `Auto` → `KvRecurrent` instead of `ResidentKv`. This was the canonical "every attempt is a new science experiment" bug.
- **No more nondeterministic corruption on larger models (B2):** the llama patch queue dropped `synchronize()` before `embd_seq.clear()` in encode/decode and from `~llama_context()` while async tensor-get copies could still be in flight. Both syncs are restored.
- **GLM-DSA / MiniMax-MSA KV pages are correct (B4)::** `stage_export_kv_page` / `stage_import_kv_page` now carry the `k_idx` indexer rows (new `SKIPPY_KV_PAGE_FLAG_HAS_K_IDX` flag + `k_idx_row_bytes` descriptor field). Previously sparse attention silently used stale indexer state and context-shift was blocked.
- **Embedding reorder corruption (B6):** `output_reorder` swaps pooled embedding rows at `n_embd_out` stride again, not `n_embd`.
- **No more size-dependent ggml aborts on unlisted arches (B8):** the scaled `graph_max_nodes` budget (`max(n_tokens*40, 32*n_tensors)`, KIMI_K3 keeps 160) applies to every architecture instead of a hand-picked allowlist.
- **Mixed-iteration batch ABI hardening (0016):** activation inputs wider than the stage model's input embedding are rejected with `UNSUPPORTED` instead of overflowing the batch row write, and the Rust-side session token bookkeeping is computed atomically after a successful batch (a mid-loop overflow error can no longer leave a subset of sessions desynced from native state).

## Protocol / ABI

`skippy_kv_page_desc` and `skippy_kv_page_component_desc` grow `k_idx_row_bytes`; `SKIPPY_ABI_VERSION_PATCH` bumps 40 → 41 with the Rust `skippy-ffi` constants and mirrors in sync. Old and new runtimes reject mixed pairing via the ABI version gate, so no silent interop.

## Validation

- Patch queue regenerated from the pinned upstream and round-tripped through `scripts/prepare-llama.sh pinned` (applies clean, 17 patches).
- `cargo check` / `clippy -D warnings` / `cargo test --lib` green for `skippy-ffi`, `skippy-runtime`, `skippy-server`; `cargo check -p mesh-llm` clean; `cargo fmt --all --check` clean.
- New unit test: layer-package inspection selects every in-range layer file (the B1 shape).
- Skippy API docs regenerated (`SKIPPY_ABI_VERSION_PATCH = 41`).

Closes the bug-fix half of #1434 (CI/family-matrix work follows as a stacked PR on this one).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added mixed iteration batches supporting variable-length requests, per-request activations, and optional sampling.
  - Added staged model execution and ordered multi-part model loading.
  - Added session state management, KV-cache transfer, trimming, checkpoint retirement, and resident-prefix handling.
  - Added composite ISWA KV-cache support and improved cache portability.
- **Bug Fixes**
  - Improved session consistency when batch updates encounter errors.
  - Strengthened model, cache, and request validation.
- **Documentation**
  - Updated the documented ABI version to 41.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->