### PR TITLE
fix: bound downstream endpoint resolution

### DIFF
--- a/crates/skippy-server/src/binary_transport/direct_return.rs
+++ b/crates/skippy-server/src/binary_transport/direct_return.rs
@@ -400,8 +400,8 @@ pub(crate) fn open_prediction_return_stream(
     _timeout_secs: u64,
 ) -> Result<TcpStream> {
     let endpoint = driver_stage_endpoint(config, topology)?;
-    let return_addr = resolve_downstream_endpoint(endpoint)?;
     let source_ip = downstream_source_ip(config)?;
+    let return_addr = resolve_downstream_endpoint(endpoint, source_ip)?;
     open_return_sink_once(
         return_addr,
         source_ip,
@@ -424,8 +424,8 @@ pub(crate) fn open_downstream_prediction_return_stream(
         .as_ref()
         .ok_or_else(|| anyhow!("direct prediction return requires downstream stage"))?;
     let endpoint = strip_tcp_prefix(&downstream.endpoint);
-    let return_addr = resolve_downstream_endpoint(endpoint)?;
     let source_ip = downstream_source_ip(config)?;
+    let return_addr = resolve_downstream_endpoint(endpoint, source_ip)?;
     open_return_sink_once(
         return_addr,
         source_ip,

--- a/crates/skippy-server/src/binary_transport/socket.rs
+++ b/crates/skippy-server/src/binary_transport/socket.rs
@@ -4,10 +4,10 @@ use std::{
     sync::atomic::{AtomicBool, Ordering},
     sync::mpsc,
     thread,
-    time::Duration,
+    time::{Duration, Instant},
 };
 
-use anyhow::{Context, Result};
+use anyhow::{Context, Result, anyhow, bail};
 use skippy_protocol::StageConfig;
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 
@@ -28,14 +28,72 @@ pub(crate) fn downstream_source_ip(config: &StageConfig) -> Result<Option<IpAddr
 }
 
 pub(crate) fn resolve_downstream_endpoint(endpoint: &str) -> Result<SocketAddr> {
-    endpoint
+    if let Ok(addr) = endpoint.parse::<SocketAddr>() {
+        return Ok(addr);
+    }
+    let mut addrs = endpoint
         .to_socket_addrs()
-        .with_context(|| format!("resolve downstream binary stage endpoint {endpoint}"))?
-        .find(SocketAddr::is_ipv4)
-        .or_else(|| endpoint.to_socket_addrs().ok()?.next())
+        .with_context(|| format!("resolve downstream binary stage endpoint {endpoint}"))?;
+    let first = addrs.next();
+    first
+        .filter(SocketAddr::is_ipv4)
+        .or_else(|| addrs.find(SocketAddr::is_ipv4))
+        .or(first)
         .with_context(|| {
             format!("downstream binary stage endpoint resolved no addresses: {endpoint}")
         })
+}
+
+pub(crate) fn resolve_downstream_endpoint_cancellable(
+    endpoint: &str,
+    deadline: Instant,
+    shutdown: &AtomicBool,
+) -> Result<SocketAddr> {
+    if shutdown.load(Ordering::Acquire) {
+        bail!("downstream endpoint resolution cancelled during shutdown");
+    }
+    if let Ok(addr) = endpoint.parse::<SocketAddr>() {
+        return Ok(addr);
+    }
+    let endpoint = endpoint.to_string();
+    let (tx, rx) = mpsc::sync_channel(1);
+    // The system resolver has no cancellation API. Detach only that call so the
+    // join-owned connection worker can still honor its deadline and shutdown;
+    // the resolver exits when libc returns and drops its result if we moved on.
+    thread::Builder::new()
+        .name("skippy-downstream-resolver".to_string())
+        .spawn(move || {
+            let result = resolve_downstream_endpoint(&endpoint);
+            let _ = tx.send(result);
+        })
+        .context("spawn downstream endpoint resolver")?;
+    wait_for_downstream_resolution(rx, deadline, shutdown)
+}
+
+fn wait_for_downstream_resolution(
+    rx: mpsc::Receiver<Result<SocketAddr>>,
+    deadline: Instant,
+    shutdown: &AtomicBool,
+) -> Result<SocketAddr> {
+    const POLL: Duration = Duration::from_millis(50);
+    loop {
+        if shutdown.load(Ordering::Acquire) {
+            bail!("downstream endpoint resolution cancelled during shutdown");
+        }
+        let remaining = deadline.saturating_duration_since(Instant::now());
+        if remaining.is_zero() {
+            bail!("downstream endpoint resolution timed out");
+        }
+        match rx.recv_timeout(remaining.min(POLL)) {
+            Ok(result) => return result,
+            Err(mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(anyhow!(
+                    "downstream endpoint resolver stopped without a result"
+                ));
+            }
+        }
+    }
 }
 
 pub(crate) fn connect_downstream_socket(
@@ -324,11 +382,11 @@ pub(super) fn sockaddr_ip(addr: *const libc::sockaddr) -> Option<IpAddr> {
 
 #[cfg(test)]
 mod tests {
-    use super::connect_downstream_socket_cancellable;
+    use super::{connect_downstream_socket_cancellable, wait_for_downstream_resolution};
     use std::{
         net::{Ipv4Addr, SocketAddr},
-        sync::atomic::AtomicBool,
-        time::Duration,
+        sync::{atomic::AtomicBool, mpsc},
+        time::{Duration, Instant},
     };
 
     #[test]
@@ -343,5 +401,19 @@ mod tests {
         .unwrap_err();
 
         assert_eq!(error.kind(), std::io::ErrorKind::Interrupted);
+    }
+
+    #[test]
+    fn downstream_resolution_observes_its_deadline() {
+        let (_tx, rx) = mpsc::sync_channel(1);
+        let shutdown = AtomicBool::new(false);
+        let error = wait_for_downstream_resolution(
+            rx,
+            Instant::now() + Duration::from_millis(10),
+            &shutdown,
+        )
+        .unwrap_err();
+
+        assert!(error.to_string().contains("timed out"));
     }
 }

--- a/crates/skippy-server/src/binary_transport/socket.rs
+++ b/crates/skippy-server/src/binary_transport/socket.rs
@@ -27,25 +27,40 @@ pub(crate) fn downstream_source_ip(config: &StageConfig) -> Result<Option<IpAddr
     }
 }
 
-pub(crate) fn resolve_downstream_endpoint(endpoint: &str) -> Result<SocketAddr> {
+pub(crate) fn resolve_downstream_endpoint(
+    endpoint: &str,
+    source_ip: Option<IpAddr>,
+) -> Result<SocketAddr> {
     if let Ok(addr) = endpoint.parse::<SocketAddr>() {
         return Ok(addr);
     }
-    let mut addrs = endpoint
+    let addrs = endpoint
         .to_socket_addrs()
-        .with_context(|| format!("resolve downstream binary stage endpoint {endpoint}"))?;
-    let first = addrs.next();
-    first
-        .filter(SocketAddr::is_ipv4)
-        .or_else(|| addrs.find(SocketAddr::is_ipv4))
-        .or(first)
-        .with_context(|| {
-            format!("downstream binary stage endpoint resolved no addresses: {endpoint}")
+        .with_context(|| format!("resolve downstream binary stage endpoint {endpoint}"))?
+        .collect::<Vec<_>>();
+    select_downstream_address(&addrs, source_ip).with_context(|| {
+        format!("downstream binary stage endpoint resolved no addresses: {endpoint}")
+    })
+}
+
+fn select_downstream_address(
+    addrs: &[SocketAddr],
+    source_ip: Option<IpAddr>,
+) -> Option<SocketAddr> {
+    source_ip
+        .and_then(|source_ip| {
+            addrs
+                .iter()
+                .find(|addr| addr.is_ipv4() == source_ip.is_ipv4())
         })
+        .or_else(|| addrs.iter().find(|addr| addr.is_ipv4()))
+        .or_else(|| addrs.first())
+        .copied()
 }
 
 pub(crate) fn resolve_downstream_endpoint_cancellable(
     endpoint: &str,
+    source_ip: Option<IpAddr>,
     deadline: Instant,
     shutdown: &AtomicBool,
 ) -> Result<SocketAddr> {
@@ -63,7 +78,7 @@ pub(crate) fn resolve_downstream_endpoint_cancellable(
     thread::Builder::new()
         .name("skippy-downstream-resolver".to_string())
         .spawn(move || {
-            let result = resolve_downstream_endpoint(&endpoint);
+            let result = resolve_downstream_endpoint(&endpoint, source_ip);
             let _ = tx.send(result);
         })
         .context("spawn downstream endpoint resolver")?;
@@ -382,9 +397,12 @@ pub(super) fn sockaddr_ip(addr: *const libc::sockaddr) -> Option<IpAddr> {
 
 #[cfg(test)]
 mod tests {
-    use super::{connect_downstream_socket_cancellable, wait_for_downstream_resolution};
+    use super::{
+        connect_downstream_socket_cancellable, select_downstream_address,
+        wait_for_downstream_resolution,
+    };
     use std::{
-        net::{Ipv4Addr, SocketAddr},
+        net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
         sync::{atomic::AtomicBool, mpsc},
         time::{Duration, Instant},
     };
@@ -415,5 +433,32 @@ mod tests {
         .unwrap_err();
 
         assert!(error.to_string().contains("timed out"));
+    }
+
+    #[test]
+    fn downstream_resolution_prefers_source_address_family() {
+        let ipv4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9337);
+        let ipv6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 9337);
+
+        assert_eq!(
+            select_downstream_address(&[ipv4, ipv6], Some(IpAddr::V6(Ipv6Addr::LOCALHOST))),
+            Some(ipv6)
+        );
+        assert_eq!(
+            select_downstream_address(&[ipv6, ipv4], Some(IpAddr::V4(Ipv4Addr::LOCALHOST))),
+            Some(ipv4)
+        );
+    }
+
+    #[test]
+    fn downstream_resolution_preserves_generic_ipv4_preference() {
+        let ipv4 = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 9337);
+        let ipv6 = SocketAddr::new(IpAddr::V6(Ipv6Addr::LOCALHOST), 9337);
+
+        assert_eq!(select_downstream_address(&[ipv6, ipv4], None), Some(ipv4));
+        assert_eq!(
+            select_downstream_address(&[ipv4], Some(IpAddr::V6(Ipv6Addr::LOCALHOST))),
+            Some(ipv4)
+        );
     }
 }

--- a/crates/skippy-server/src/binary_transport/stage_execution.rs
+++ b/crates/skippy-server/src/binary_transport/stage_execution.rs
@@ -544,8 +544,10 @@ fn connect_binary_downstream_inner(
     let source_ip = downstream_source_ip(config)?;
     let deadline = Instant::now() + timeout.max(Duration::from_millis(1));
     let downstream_addr = match shutdown {
-        Some(shutdown) => resolve_downstream_endpoint_cancellable(endpoint, deadline, shutdown)?,
-        None => resolve_downstream_endpoint(endpoint)?,
+        Some(shutdown) => {
+            resolve_downstream_endpoint_cancellable(endpoint, source_ip, deadline, shutdown)?
+        }
+        None => resolve_downstream_endpoint(endpoint, source_ip)?,
     };
     let mut last_error = None;
     loop {

--- a/crates/skippy-server/src/binary_transport/stage_execution.rs
+++ b/crates/skippy-server/src/binary_transport/stage_execution.rs
@@ -35,7 +35,7 @@ use skippy_runtime::{
 
 use super::socket::{
     connect_downstream_socket, connect_downstream_socket_cancellable, downstream_source_ip,
-    resolve_downstream_endpoint,
+    resolve_downstream_endpoint, resolve_downstream_endpoint_cancellable,
 };
 
 const CLIENT_READY_HELLO_ENV: &str = "SKIPPY_STAGE_CLIENT_READY_HELLO";
@@ -541,9 +541,12 @@ fn connect_binary_downstream_inner(
         .endpoint
         .strip_prefix("tcp://")
         .unwrap_or(&peer.endpoint);
-    let downstream_addr = resolve_downstream_endpoint(endpoint)?;
     let source_ip = downstream_source_ip(config)?;
     let deadline = Instant::now() + timeout.max(Duration::from_millis(1));
+    let downstream_addr = match shutdown {
+        Some(shutdown) => resolve_downstream_endpoint_cancellable(endpoint, deadline, shutdown)?,
+        None => resolve_downstream_endpoint(endpoint)?,
+    };
     let mut last_error = None;
     loop {
         if let Some(shutdown) = shutdown {

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4267,15 +4267,15 @@
   ],
   "crates/skippy-server/src/binary_transport/socket.rs": [
     {
-      "line": 77,
+      "line": 135,
       "macro_name": "eprintln!"
     },
     {
-      "line": 131,
+      "line": 189,
       "macro_name": "eprintln!"
     },
     {
-      "line": 169,
+      "line": 227,
       "macro_name": "eprintln!"
     }
   ],

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4267,15 +4267,15 @@
   ],
   "crates/skippy-server/src/binary_transport/socket.rs": [
     {
-      "line": 135,
+      "line": 150,
       "macro_name": "eprintln!"
     },
     {
-      "line": 189,
+      "line": 204,
       "macro_name": "eprintln!"
     },
     {
-      "line": 227,
+      "line": 242,
       "macro_name": "eprintln!"
     }
   ],


### PR DESCRIPTION
Follow-up to #1433 for a valid exact-head CodeRabbit finding that arrived as the PR was being merged.

## What changed

- include hostname resolution in the existing downstream acquisition deadline
- poll shutdown while waiting for the system resolver
- keep the legacy non-cancellable persistent-lane path unchanged
- avoid a second DNS lookup when the first result set has no IPv4 address
- add deterministic deadline regression coverage

The system resolver itself has no cancellation API, so only that libc call is detached; the join-owned connection worker exits on shutdown or deadline and cannot hold stage shutdown open.

## Validation

- `cargo test -p skippy-server`: 488 passed, 3 ignored
- `just no-console-print`
- `cargo fmt --all --check`
- `git diff --check origin/main...HEAD`
- console-print ratchet remains 1,040 legacy hits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved downstream connection handling for literal socket addresses and IPv4 endpoints.
  - Endpoint selection now prefers addresses matching the connection’s source address family, with IPv4 fallback when appropriate.
  - Added cancellation and deadline support during endpoint resolution.
  - Connections now report clearer errors for shutdowns, timeouts, DNS failures, and interrupted resolution.
  - Prevented downstream resolution from continuing after a connection deadline or shutdown signal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->