### PR TITLE
fix(proxy): cancel upstream before response headers

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/response/probe.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/probe.rs
@@ -225,7 +225,8 @@ pub(in crate::network::openai::response) async fn probe_http_response_with_timeo
         let first_read = buffered.is_empty();
         if first_read {
             let mut chunk = [0u8; 8192];
-            let read_result = tokio::time::timeout(timeout, reader.read(&mut chunk))
+            let read_timeout = timeout.saturating_sub(started.elapsed());
+            let read_result = tokio::time::timeout(read_timeout, reader.read(&mut chunk))
                 .await
                 .map_err(|_| {
                     anyhow!(
@@ -238,7 +239,8 @@ pub(in crate::network::openai::response) async fn probe_http_response_with_timeo
             }
             buffered.extend_from_slice(&chunk[..read_result]);
         } else {
-            read_response_chunk_with_timeout(reader, &mut buffered, timeout).await?;
+            let read_timeout = timeout.saturating_sub(started.elapsed());
+            read_response_chunk_with_timeout(reader, &mut buffered, read_timeout).await?;
         }
         if buffered.len() > MAX_HEADER_BYTES {
             bail!("HTTP response headers exceed {MAX_HEADER_BYTES} bytes");
@@ -254,7 +256,8 @@ pub(in crate::network::openai::response) async fn probe_http_response_with_timeo
         0
     };
     while buffered.len() < parsed.header_end + preview_len {
-        read_response_chunk_with_timeout(reader, &mut buffered, timeout).await?;
+        let read_timeout = timeout.saturating_sub(started.elapsed());
+        read_response_chunk_with_timeout(reader, &mut buffered, read_timeout).await?;
     }
 
     let retryable_context_overflow = parsed.status_code == 400
@@ -369,6 +372,42 @@ mod tests {
 
         assert!(is_timeout_error(&error), "unexpected error: {error:#}");
         assert!(error.to_string().contains("continuation read timeout"));
+    }
+
+    #[tokio::test]
+    async fn probe_partial_headers_share_one_timeout_budget() {
+        let timeout_budget = Duration::from_millis(100);
+        let (mut writer, mut reader) = tokio::io::duplex(4096);
+        let writer_task = tokio::spawn(async move {
+            writer.write_all(b"H").await.unwrap();
+            for byte in b"TTP/1.1 200 OK\r\n" {
+                tokio::time::sleep(Duration::from_millis(20)).await;
+                if writer.write_all(&[*byte]).await.is_err() {
+                    return;
+                }
+            }
+            std::future::pending::<()>().await;
+        });
+
+        let started = Instant::now();
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            probe_http_response_with_timeout(&mut reader, timeout_budget),
+        )
+        .await
+        .expect("partial headers must time out before the outer guard");
+        let elapsed = started.elapsed();
+        writer_task.abort();
+
+        let error = match result {
+            Ok(_) => panic!("a partial header stream must time out"),
+            Err(error) => error,
+        };
+        assert!(is_timeout_error(&error), "unexpected error: {error:#}");
+        assert!(
+            elapsed < Duration::from_millis(300),
+            "partial bytes extended the overall header budget: {elapsed:?}"
+        );
     }
 
     #[tokio::test(start_paused = true)]

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/probe.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/probe.rs
@@ -94,7 +94,7 @@ pub(in crate::network::openai::response) fn try_parse_response_headers(
 }
 
 /// Read the next chunk of HTTP response data without any timeout.
-/// Used for continuation reads after the first byte has already arrived.
+/// Used by relay paths whose own body limits provide the lifetime bound.
 pub(in crate::network::openai::response) async fn read_response_chunk<R: AsyncRead + Unpin>(
     reader: &mut R,
     buf: &mut Vec<u8>,
@@ -106,6 +106,16 @@ pub(in crate::network::openai::response) async fn read_response_chunk<R: AsyncRe
     }
     buf.extend_from_slice(&chunk[..read_result]);
     Ok(read_result)
+}
+
+async fn read_response_chunk_with_timeout<R: AsyncRead + Unpin>(
+    reader: &mut R,
+    buf: &mut Vec<u8>,
+    timeout: Duration,
+) -> Result<usize> {
+    tokio::time::timeout(timeout, read_response_chunk(reader, buf))
+        .await
+        .context("upstream response continuation read timeout")?
 }
 
 pub(in crate::network::openai::response) async fn read_transformed_response_body<
@@ -228,7 +238,7 @@ pub(in crate::network::openai::response) async fn probe_http_response_with_timeo
             }
             buffered.extend_from_slice(&chunk[..read_result]);
         } else {
-            read_response_chunk(reader, &mut buffered).await?;
+            read_response_chunk_with_timeout(reader, &mut buffered, timeout).await?;
         }
         if buffered.len() > MAX_HEADER_BYTES {
             bail!("HTTP response headers exceed {MAX_HEADER_BYTES} bytes");
@@ -244,7 +254,7 @@ pub(in crate::network::openai::response) async fn probe_http_response_with_timeo
         0
     };
     while buffered.len() < parsed.header_end + preview_len {
-        read_response_chunk(reader, &mut buffered).await?;
+        read_response_chunk_with_timeout(reader, &mut buffered, timeout).await?;
     }
 
     let retryable_context_overflow = parsed.status_code == 400
@@ -340,6 +350,27 @@ mod tests {
 
         assert!(is_timeout_error(&error), "unexpected error: {error:#}");
     }
+
+    #[tokio::test]
+    async fn probe_continuation_read_has_timeout_after_partial_headers() {
+        let (mut writer, mut reader) = tokio::io::duplex(4096);
+        writer.write_all(b"HTTP/1.1 200 OK\r\n").await.unwrap();
+
+        let result = tokio::time::timeout(
+            Duration::from_secs(1),
+            probe_http_response_with_timeout(&mut reader, Duration::from_millis(10)),
+        )
+        .await
+        .expect("partial response headers must honor the configured timeout");
+        let error = match result {
+            Ok(_) => panic!("a stalled partial header must time out"),
+            Err(error) => error,
+        };
+
+        assert!(is_timeout_error(&error), "unexpected error: {error:#}");
+        assert!(error.to_string().contains("continuation read timeout"));
+    }
+
     #[tokio::test(start_paused = true)]
     async fn test_probe_http_response_local_tolerates_slow_first_byte() {
         use tokio::io::AsyncWriteExt;

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/routing.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/routing.rs
@@ -4,12 +4,14 @@ use super::common::{
     retryable_route_result_from_error,
 };
 use super::dispatch::{RelayAttemptContext, relay_attempted_response};
-use super::probe::{probe_http_response, probe_http_response_local};
+use super::probe::{ResponseProbe, probe_http_response, probe_http_response_local};
 use crate::logging::OpenAiRouteObserver;
 use crate::mesh;
 use crate::network::openai::forwarded_request::prepare_peer_forwarded_request;
 use crate::network::openai::request_normalize::ResponseAdapter;
+use anyhow::Result;
 use mesh_llm_events::logging::identifiers::RequestId;
+use std::future::Future;
 use tokio::io::{AsyncRead, AsyncWrite, AsyncWriteExt};
 use tokio::net::TcpStream;
 
@@ -68,17 +70,21 @@ async fn acquire_local_attempt_upstream(
     Ok((instance_request, upstream))
 }
 
-async fn route_local_attempt_after_forward(
+async fn route_local_attempt_after_forward<U: AsyncRead + Unpin + CancelUpstream>(
     tcp_stream: &mut TcpStream,
-    upstream: &mut TcpStream,
+    upstream: &mut U,
     port: u16,
     request_id: RequestId,
     retry_policy: ResponseRetryPolicy,
     response_adapter: ResponseAdapter,
     route_observer: OpenAiRouteObserver<'_>,
 ) -> RouteAttemptResult {
-    match probe_http_response_local(upstream).await {
-        Ok(probe) => {
+    match probe_with_downstream_disconnect(tcp_stream, probe_http_response_local(upstream)).await {
+        ProbeOutcome::ClientDisconnected => {
+            cancel_upstream_if_client_disconnected(RouteAttemptResult::ClientDisconnected, upstream)
+                .await
+        }
+        ProbeOutcome::Response(Ok(probe)) => {
             let result = relay_attempted_response(
                 tcp_stream,
                 upstream,
@@ -95,9 +101,102 @@ async fn route_local_attempt_after_forward(
             .await;
             cancel_upstream_if_client_disconnected(result, upstream).await
         }
-        Err(err) => {
+        ProbeOutcome::Response(Err(err)) => {
             tracing::warn!(
                 "API proxy: failed to read local response from OpenAI surface on {port}: {err}"
+            );
+            retryable_route_result_from_error(&err)
+        }
+    }
+}
+
+/// A read-ready downstream socket can be checked without consuming request
+/// bytes. A peek error is an unambiguous disconnect (including a reset), while
+/// EOF leaves this watcher pending. Keeping the watcher pending avoids a
+/// readiness spin and lets the upstream response probe win for clients that
+/// legally half-close their write side after sending a request.
+async fn wait_for_downstream_disconnect(tcp_stream: &TcpStream) -> DownstreamWatchResult {
+    if tcp_stream.readable().await.is_err() {
+        return DownstreamWatchResult::Disconnected;
+    }
+
+    let mut peeked = [0u8; 1];
+    match tcp_stream.peek(&mut peeked).await {
+        Ok(0) => std::future::pending::<DownstreamWatchResult>().await,
+        Err(_) => DownstreamWatchResult::Disconnected,
+        Ok(_) => DownstreamWatchResult::PipelinedBytes,
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DownstreamWatchResult {
+    Disconnected,
+    PipelinedBytes,
+}
+
+enum ProbeOutcome {
+    ClientDisconnected,
+    Response(Result<ResponseProbe>),
+}
+
+/// Race the complete upstream response probe against a non-consuming
+/// downstream close check. If pipelined bytes are already available, stop
+/// watching and leave them for the normal request/response handling path.
+async fn probe_with_downstream_disconnect<F>(tcp_stream: &TcpStream, probe: F) -> ProbeOutcome
+where
+    F: Future<Output = Result<ResponseProbe>>,
+{
+    tokio::pin!(probe);
+    tokio::select! {
+        biased;
+        downstream = wait_for_downstream_disconnect(tcp_stream) => {
+            match downstream {
+                DownstreamWatchResult::Disconnected => ProbeOutcome::ClientDisconnected,
+                DownstreamWatchResult::PipelinedBytes => ProbeOutcome::Response(probe.await),
+            }
+        }
+        response = &mut probe => ProbeOutcome::Response(response),
+    }
+}
+
+async fn route_remote_attempt_after_forward<R: AsyncRead + Unpin + CancelUpstream>(
+    tcp_stream: &mut TcpStream,
+    quic_recv: &mut R,
+    host_id: iroh::EndpointId,
+    request_id: RequestId,
+    retry_policy: ResponseRetryPolicy,
+    response_adapter: ResponseAdapter,
+    route_observer: OpenAiRouteObserver<'_>,
+) -> RouteAttemptResult {
+    match probe_with_downstream_disconnect(tcp_stream, probe_http_response(quic_recv)).await {
+        ProbeOutcome::ClientDisconnected => {
+            cancel_upstream_if_client_disconnected(
+                RouteAttemptResult::ClientDisconnected,
+                quic_recv,
+            )
+            .await
+        }
+        ProbeOutcome::Response(Ok(probe)) => {
+            let result = relay_attempted_response(
+                tcp_stream,
+                quic_recv,
+                probe,
+                RelayAttemptContext {
+                    request_id,
+                    disconnect_message: "API proxy (remote): downstream client disconnected during relay",
+                    commit_message: "API proxy (remote) ended after commit",
+                    route_observer,
+                },
+                retry_policy,
+                response_adapter,
+            )
+            .await;
+            cancel_upstream_if_client_disconnected(result, quic_recv).await
+        }
+        ProbeOutcome::Response(Err(err)) => {
+            tracing::warn!(
+                "API proxy: failed to read response from host {}: {err}",
+                host_id.fmt_short()
             );
             retryable_route_result_from_error(&err)
         }
@@ -182,43 +281,6 @@ async fn forward_buffered_request<W: AsyncWrite + Unpin>(
     upstream.write_all(prefetched).await
 }
 
-async fn route_remote_attempt_after_forward<R: AsyncRead + Unpin + CancelUpstream>(
-    tcp_stream: &mut TcpStream,
-    quic_recv: &mut R,
-    host_id: iroh::EndpointId,
-    request_id: RequestId,
-    retry_policy: ResponseRetryPolicy,
-    response_adapter: ResponseAdapter,
-    route_observer: OpenAiRouteObserver<'_>,
-) -> RouteAttemptResult {
-    match probe_http_response(quic_recv).await {
-        Ok(probe) => {
-            let result = relay_attempted_response(
-                tcp_stream,
-                quic_recv,
-                probe,
-                RelayAttemptContext {
-                    request_id,
-                    disconnect_message: "API proxy (remote): downstream client disconnected during relay",
-                    commit_message: "API proxy (remote) ended after commit",
-                    route_observer,
-                },
-                retry_policy,
-                response_adapter,
-            )
-            .await;
-            cancel_upstream_if_client_disconnected(result, quic_recv).await
-        }
-        Err(err) => {
-            tracing::warn!(
-                "API proxy: failed to read response from host {}: {err}",
-                host_id.fmt_short()
-            );
-            retryable_route_result_from_error(&err)
-        }
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -230,21 +292,13 @@ mod tests {
     use tokio::io::AsyncReadExt;
     use tokio::io::ReadBuf;
     use tokio::net::TcpListener;
-    use tokio::sync::Notify;
     use tokio::sync::oneshot;
     use tokio::time::{Duration, timeout};
 
-    /// A real duplex pipe as the upstream half of `CancelUpstream`, wrapped to
-    /// signal a `Notify` the moment a read finds nothing buffered yet.
-    ///
-    /// Unlike `ScriptedUpstream` below, this can genuinely block waiting for
-    /// more bytes, which is what lets a test prove the route arm is actively
-    /// relaying (header consumed, now waiting on the body) at a specific
-    /// moment, rather than assuming it from timing.
+    /// A real silent duplex pipe as the upstream half of `CancelUpstream`.
     struct DuplexUpstream {
         inner: tokio::io::DuplexStream,
         cancels: Arc<AtomicUsize>,
-        waiting_for_more: Arc<Notify>,
     }
 
     impl AsyncRead for DuplexUpstream {
@@ -253,11 +307,7 @@ mod tests {
             cx: &mut Context<'_>,
             buf: &mut ReadBuf<'_>,
         ) -> Poll<io::Result<()>> {
-            let result = Pin::new(&mut self.inner).poll_read(cx, buf);
-            if result.is_pending() {
-                self.waiting_for_more.notify_one();
-            }
-            result
+            Pin::new(&mut self.inner).poll_read(cx, buf)
         }
     }
 
@@ -306,48 +356,72 @@ mod tests {
         }
     }
 
-    /// A remote attempt that loses its client must tell the worker peer to stop.
-    ///
-    /// The local arm has always shut its upstream down here. The remote arm did
-    /// not, so a worker on another node kept generating a response for a client
-    /// that had already hung up — observed in rc6 validation as the worker
-    /// logging `request_stream_completed` after the gateway had already logged
-    /// `request_dropped`.
+    /// Both route arms must cancel their silent upstream as soon as the real
+    /// downstream socket is reset, without waiting for the response probe.
+    #[tokio::test]
+    async fn a_local_attempt_cancels_the_upstream_when_the_client_disconnects() {
+        let upstream_listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let upstream_address = upstream_listener.local_addr().unwrap();
+        let (upstream_ready_tx, upstream_ready_rx) = oneshot::channel();
+        let upstream_task = tokio::spawn(async move {
+            let (mut upstream_peer, _) = upstream_listener.accept().await.unwrap();
+            upstream_ready_tx.send(()).unwrap();
+            let mut bytes = [0u8; 1];
+            timeout(Duration::from_secs(2), upstream_peer.read(&mut bytes))
+                .await
+                .expect("local cancellation must reach the upstream socket")
+                .expect("reading the cancelled upstream socket must succeed")
+        });
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut client, _) = listener.accept().await.unwrap();
+            let mut upstream = TcpStream::connect(upstream_address).await.unwrap();
+            route_local_attempt_after_forward(
+                &mut client,
+                &mut upstream,
+                0,
+                RequestId::new(),
+                ResponseRetryPolicy::next_target_available(false),
+                ResponseAdapter::None,
+                OpenAiRouteObserver::default(),
+            )
+            .await
+        });
+        let client_socket = TcpStream::connect(address).await.unwrap();
+        upstream_ready_rx.await.unwrap();
+        client_socket.set_zero_linger().unwrap();
+        drop(client_socket);
+
+        let result = timeout(Duration::from_secs(2), task)
+            .await
+            .expect("local route must notice a reset promptly")
+            .unwrap();
+
+        assert_eq!(result, RouteAttemptResult::ClientDisconnected);
+        assert_eq!(
+            upstream_task.await.unwrap(),
+            0,
+            "local cancellation must shut down the concrete TCP upstream"
+        );
+    }
+
     #[tokio::test]
     async fn a_remote_attempt_cancels_the_peer_tunnel_when_the_client_disconnects() {
-        let (mut upstream_writer, upstream_reader) = tokio::io::duplex(64 * 1024);
+        let (_upstream_writer, upstream_reader) = tokio::io::duplex(64 * 1024);
         let cancels = Arc::new(AtomicUsize::new(0));
-        let waiting_for_more = Arc::new(Notify::new());
         let mut upstream = DuplexUpstream {
             inner: upstream_reader,
             cancels: Arc::clone(&cancels),
-            waiting_for_more: Arc::clone(&waiting_for_more),
         };
         let host_id = iroh::SecretKey::generate().public();
 
         let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
         let address = listener.local_addr().unwrap();
-        let (disconnected_tx, disconnected_rx) = oneshot::channel();
         let task = tokio::spawn(async move {
-            let (client, _) = listener.accept().await.unwrap();
-            let client_std = client.into_std().unwrap();
-            let observer_std = client_std.try_clone().unwrap();
-            let mut client = TcpStream::from_std(client_std).unwrap();
-            let observer = TcpStream::from_std(observer_std).unwrap();
-            let observer_task = tokio::spawn(async move {
-                let mut peeked = [0; 1];
-                loop {
-                    if observer.readable().await.is_err() {
-                        break;
-                    }
-                    match observer.peek(&mut peeked).await {
-                        Ok(0) | Err(_) => break,
-                        Ok(_) => {}
-                    }
-                }
-                let _ = disconnected_tx.send(());
-            });
-            let result = route_remote_attempt_after_forward(
+            let (mut client, _) = listener.accept().await.unwrap();
+            route_remote_attempt_after_forward(
                 &mut client,
                 &mut upstream,
                 host_id,
@@ -356,47 +430,45 @@ mod tests {
                 ResponseAdapter::None,
                 OpenAiRouteObserver::default(),
             )
-            .await;
-            observer_task.await.unwrap();
-            result
+            .await
         });
         let client_socket = TcpStream::connect(address).await.unwrap();
-
-        let body = "x".repeat(64);
-        let header = format!(
-            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n",
-            body.len()
-        );
-        // Send only the header. The route arm buffers it, then blocks asking
-        // upstream for body bytes that have not arrived yet.
-        upstream_writer.write_all(header.as_bytes()).await.unwrap();
-        waiting_for_more.notified().await;
-
-        // The route arm is now genuinely waiting on upstream body bytes, not
-        // still parsing the header -- closing the client here means the write
-        // it makes once the body arrives lands on an actually disconnected
-        // socket, rather than an upstream read failure standing in for one.
-        //
-        // A graceful close (a plain `drop`) sends only a FIN; wait until the
-        // accepted socket observes EOF/reset before releasing the body. This
-        // closes the propagation window without consuming route data.
         client_socket.set_zero_linger().unwrap();
         drop(client_socket);
-        timeout(Duration::from_secs(5), disconnected_rx)
+
+        let result = timeout(Duration::from_secs(2), task)
             .await
-            .unwrap()
+            .expect("remote route must notice a reset promptly")
             .unwrap();
 
-        upstream_writer.write_all(body.as_bytes()).await.unwrap();
-
-        let result = task.await.unwrap();
-
         assert_eq!(result, RouteAttemptResult::ClientDisconnected);
-        assert_eq!(
-            cancels.load(Ordering::SeqCst),
-            1,
-            "the peer tunnel was left running after the client disconnected"
-        );
+        assert_eq!(cancels.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn pipelined_downstream_bytes_are_not_consumed_by_disconnect_watch() {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut downstream, _) = listener.accept().await.unwrap();
+            let outcome = wait_for_downstream_disconnect(&downstream).await;
+            let mut pipelined = [0u8; 1];
+            timeout(
+                Duration::from_secs(1),
+                downstream.read_exact(&mut pipelined),
+            )
+            .await
+            .expect("pipelined byte must remain available after probing")
+            .unwrap();
+            (outcome, pipelined)
+        });
+
+        let mut client = TcpStream::connect(address).await.unwrap();
+        client.write_all(b"x").await.unwrap();
+
+        let (outcome, pipelined) = task.await.unwrap();
+        assert_eq!(outcome, DownstreamWatchResult::PipelinedBytes);
+        assert_eq!(pipelined, [b'x']);
     }
 
     /// The counterpart: a normal delivery must not cancel anything.
@@ -434,6 +506,48 @@ mod tests {
 
         assert!(matches!(result, RouteAttemptResult::Delivered { .. }));
         assert_eq!(cancels.load(Ordering::SeqCst), 0);
+    }
+
+    #[tokio::test]
+    async fn a_write_half_closed_downstream_still_receives_the_upstream_response() {
+        let body = "half-close response";
+        let response = format!(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\n\r\n{body}",
+            body.len()
+        );
+        let mut upstream = ScriptedUpstream::new(vec![Ok(response.into_bytes())]);
+        let host_id = iroh::SecretKey::generate().public();
+
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let task = tokio::spawn(async move {
+            let (mut client, _) = listener.accept().await.unwrap();
+            route_remote_attempt_after_forward(
+                &mut client,
+                &mut upstream,
+                host_id,
+                RequestId::new(),
+                ResponseRetryPolicy::next_target_available(false),
+                ResponseAdapter::None,
+                OpenAiRouteObserver::default(),
+            )
+            .await
+        });
+
+        let mut socket = TcpStream::connect(address).await.unwrap();
+        socket.shutdown().await.unwrap();
+        let mut relayed = Vec::new();
+        timeout(Duration::from_secs(1), socket.read_to_end(&mut relayed))
+            .await
+            .expect("write-half-closed client should still receive a response")
+            .unwrap();
+        let result = timeout(Duration::from_secs(1), task)
+            .await
+            .expect("route should finish after relaying the response")
+            .unwrap();
+
+        assert!(matches!(result, RouteAttemptResult::Delivered { .. }));
+        assert!(String::from_utf8_lossy(&relayed).contains(body));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #1406.

## What changed

- Race local and remote upstream response probes against a non-consuming downstream socket watcher.
- Treat socket errors and resets as terminal client disconnects, canceling the active local TCP or remote QUIC upstream through the existing cancellation path.
- Preserve legal HTTP write-half-close behavior by leaving clean EOF pending, and preserve pipelined request bytes with peek.
- Bound the complete response-header and overflow-preview probe to one configured deadline, including continuation reads after partial data.

## Disconnect semantics

A downstream reset or socket error counts as a disconnect and cancels upstream work immediately. A clean FIN does not: HTTP clients may legally half-close their write side after sending a request, so clean EOF remains pending while the response probe runs. If the upstream also stalls, that case is bounded by the probe deadline (5 minutes for remote routes and 10 minutes for local routes).

## Validation

- `cargo test -p mesh-llm-host-runtime --lib`: 2666 passed, 8 ignored (initial change)
- Response probe tests: 6 passed
- Routing tests: 6 passed
- Concrete API proxy regression tests: 28 passed
- `cargo test -p mesh-llm-host-runtime probe_partial_headers_share_one_timeout_budget --lib`
- `cargo clippy -p mesh-llm-host-runtime --lib --no-deps -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

The broader all-targets Clippy run is currently blocked by pre-existing Rust 1.98 `chunks_exact_to_as_chunks` warnings in `skippy-protocol` and `network/openai/transport_tests/lifecycle.rs`; neither is changed here.

The regression suite exercises real local sockets and the remote cancellation arm, including reset, pipelined-byte, half-close, partial-header timeout, and slow-drip deadline behavior. The original rc6 report has not been reproduced on a separate two-node deployment in this worktree.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Upstream response probing now respects the remaining configured timeout, preventing stalled responses from extending request wait times.
  - Disconnected client connections now cancel upstream processing promptly, improving responsiveness and reducing unnecessary work.
  - Pipelined downstream data is preserved while checking connection status.
  - Improved handling of partially received responses, stalled continuation reads, and write-half-closed connections.
  - Requests now respond more reliably when clients disconnect or upstream services stop sending data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->