### PR TITLE
test(skippy): pin scheduler workload fixtures

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7514,6 +7514,8 @@ dependencies = [
 name = "skippy-scheduler"
 version = "0.76.0-rc7"
 dependencies = [
+ "serde",
+ "serde_json",
  "skippy-cache",
  "skippy-runtime",
  "thiserror 2.0.18",

--- a/ci/requirements-ci-python.txt
+++ b/ci/requirements-ci-python.txt
@@ -1,4 +1,4 @@
-huggingface_hub[cli]
+huggingface_hub[cli]>=1.1.0
 langchain-openai
 litellm
 openai

--- a/crates/skippy-scheduler/Cargo.toml
+++ b/crates/skippy-scheduler/Cargo.toml
@@ -16,6 +16,8 @@ skippy-runtime = { path = "../skippy-runtime", version = "0.76.0-rc7" }
 thiserror = "2"
 
 [dev-dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
 skippy-cache = { path = "../skippy-cache", version = "0.76.0-rc7" }
 
 [[bench]]

--- a/crates/skippy-scheduler/tests/simulation.rs
+++ b/crates/skippy-scheduler/tests/simulation.rs
@@ -1,7 +1,78 @@
 mod support;
 
+use std::collections::BTreeMap;
+
+use serde::Deserialize;
 use skippy_scheduler::SchedulerConfig;
 use support::{RuntimeCostModel, burst_requests, simulate, staggered_prefill_requests};
+
+#[derive(Deserialize)]
+struct FixtureCatalog {
+    profiles: BTreeMap<String, FixtureProfile>,
+}
+
+#[derive(Deserialize)]
+struct FixtureProfile {
+    ci_trace: FixtureTrace,
+}
+
+#[derive(Deserialize)]
+struct FixtureTrace {
+    family_order: Vec<i32>,
+    prompt_tokens: usize,
+    expected_fcfs_switches: usize,
+    expected_dfs_switches: usize,
+}
+
+fn scheduler_fixture_catalog() -> FixtureCatalog {
+    serde_json::from_str(include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../../evals/skippy-scheduler-fixtures.json"
+    )))
+    .expect("valid checked-in scheduler fixture catalog")
+}
+
+fn replay_family_switches(trace: &FixtureTrace, group_waiting_prefixes: bool) -> usize {
+    let mut request_families = BTreeMap::new();
+    let requests = trace
+        .family_order
+        .iter()
+        .enumerate()
+        .map(|(index, family)| {
+            let id = format!("request-{index:03}-family-{family:02}");
+            request_families.insert(id.clone(), *family);
+            support::SimRequest::new(id, 0, trace.prompt_tokens, 1)
+                .with_token_offset(family.saturating_add(1).saturating_mul(10_000))
+        })
+        .collect();
+    let report = simulate(
+        SchedulerConfig {
+            max_active_sequences: 1,
+            group_waiting_prefixes,
+            ..SchedulerConfig::default()
+        },
+        RuntimeCostModel::default(),
+        requests,
+    )
+    .expect("fixture replay completes");
+    let mut service_order = report
+        .requests
+        .iter()
+        .map(|(id, metrics)| {
+            (
+                metrics
+                    .first_scheduled_us
+                    .expect("fixture request was scheduled"),
+                request_families[id],
+            )
+        })
+        .collect::<Vec<_>>();
+    service_order.sort_unstable();
+    service_order
+        .windows(2)
+        .filter(|pair| pair[0].1 != pair[1].1)
+        .count()
+}
 
 #[test]
 fn scheduler_simulation_is_deterministic() {
@@ -13,6 +84,23 @@ fn scheduler_simulation_is_deterministic() {
     let second = simulate(config, cost, requests).unwrap();
 
     assert_eq!(first, second);
+}
+
+#[test]
+fn named_scheduler_profiles_replay_the_measured_locality_boundary() {
+    for (name, profile) in scheduler_fixture_catalog().profiles {
+        let fcfs_switches = replay_family_switches(&profile.ci_trace, false);
+        let dfs_switches = replay_family_switches(&profile.ci_trace, true);
+
+        assert_eq!(
+            fcfs_switches, profile.ci_trace.expected_fcfs_switches,
+            "{name} FCFS trace drifted"
+        );
+        assert_eq!(
+            dfs_switches, profile.ci_trace.expected_dfs_switches,
+            "{name} waiting-prefix trace drifted"
+        );
+    }
 }
 
 #[test]

--- a/docs/SKIPPY.md
+++ b/docs/SKIPPY.md
@@ -453,6 +453,12 @@ Operational requirements:
   deletion/prune can discard it safely;
 - keep a global emergency off switch for burn-in and incident response.
 
+Scheduler changes that use this cache are gated by the named warm-affinity and
+agentic eviction-pressure profiles in
+[Scheduler workload fixtures](skippy/SCHEDULER_FIXTURES.md). The fast PR replay
+is inference-free; periodic hardware runs fetch and verify the pinned Hugging
+Face corpus in the shared cache and never vendor trajectory data.
+
 Example shape:
 
 ```toml

--- a/docs/skippy/SCHEDULER_FIXTURES.md
+++ b/docs/skippy/SCHEDULER_FIXTURES.md
@@ -7,15 +7,18 @@ waiting-prefix policy boundary:
   affinity supplies the same order before waiting-prefix DFS, so the replay
   must stay neutral.
 - `agentic-eviction-pressure` is an interleaved eight-family trace with only
-  two resident prefix-cache entries and the measured 131,072-token aggregate
-  context budget. Waiting-prefix DFS must reduce family switches and the
-  periodic model-backed run must reduce recomputation and tail latency.
+  two resident prefix-cache entries. Its 131,072-token aggregate context is
+  the smallest power-of-two capacity covering the pinned row totals, request
+  multiplicity, and output allowance. Waiting-prefix DFS must reduce family
+  switches and the periodic model-backed run must reduce recomputation and
+  tail latency.
 
 The source of truth is
 [`evals/skippy-scheduler-fixtures.json`](../../evals/skippy-scheduler-fixtures.json).
 It pins the Hugging Face commit, selected source, eight session IDs, selection
-rules, runtime shape, generated prompt-manifest hash, and acceptance bounds.
-It contains no trajectory text or dataset files.
+rules, runtime shape, generated prompt-manifest hash, exact GGUF repository
+revision and content hash (including its embedded tokenizer), and acceptance
+bounds. It contains no trajectory text or dataset files.
 
 ## Fast PR gate
 
@@ -24,7 +27,7 @@ traces:
 
 ```bash
 python3 evals/skippy-scheduler-fixtures.py validate
-cargo test -p skippy-scheduler
+just with-lld cargo test -p skippy-scheduler
 ```
 
 The Rust replay reads the checked-in catalog directly. With
@@ -34,9 +37,10 @@ trace remains at one switch while the eviction-pressure trace collapses to
 seven. This gate is deterministic and performs no model inference or network
 access.
 
-The normal Python script-test lane also validates the catalog, the strict HF
-command shape, row-provenance rejection, and profile application in the A/B
-runner.
+The normal Python script-test lane also validates the catalog, derives the
+minimum context from the checked-in rows, exercises the real prompt generator
+with canned rows, verifies the strict HF command shape and row-provenance
+rejection, and covers profile application in the A/B runner.
 
 ## Pinned corpus cache
 
@@ -84,12 +88,18 @@ python3 evals/skippy-waiting-prefix-ab.py \
 
 The named profile owns rounds, lanes, admission concurrency, cache entries,
 output length, and arrival stagger; ad hoc workload flags do not override it.
-The result records the profile name and catalog SHA alongside binary, model,
-and prompt-manifest hashes.
+The case file must also match the profile's pinned model ID and GGUF SHA-256.
+HF profiles require their exact generated prompt manifest, while synthetic
+profiles reject external manifests. The result records the profile name and
+catalog SHA alongside binary, model, and prompt-manifest hashes.
 
 The eviction-pressure certificate requires every request to succeed and, at
-minimum, 10% improvements in suffix prefill, family switches, p95 TTFT, and
-makespan plus 10% higher output throughput. The warm certificate requires
+minimum, a 50,000-token suffix-prefill baseline and eight family switches so a
+drifted non-pressure workload cannot pass. It then requires 10% improvements
+in suffix prefill, family switches, p95 TTFT, and makespan plus 10% higher
+output throughput. The warm certificate requires
 identical suffix prefill and switch counts, with user-facing timing/throughput
-movement inside ±5%. Alternate binary order across all four rounds and retain
-raw requests, telemetry, configs, logs, `comparison.json`, and `report.md`.
+movement inside ±5%. A zero baseline is neutral only when both binaries remain
+at zero; any nonzero candidate value fails closed. Alternate binary order
+across all four rounds and retain raw requests, telemetry, configs, logs,
+`comparison.json`, and `report.md`.

--- a/docs/skippy/SCHEDULER_FIXTURES.md
+++ b/docs/skippy/SCHEDULER_FIXTURES.md
@@ -7,9 +7,9 @@ waiting-prefix policy boundary:
   affinity supplies the same order before waiting-prefix DFS, so the replay
   must stay neutral.
 - `agentic-eviction-pressure` is an interleaved eight-family trace with only
-  two resident prefix-cache entries. Waiting-prefix DFS must reduce family
-  switches and the periodic model-backed run must reduce recomputation and
-  tail latency.
+  two resident prefix-cache entries and the measured 131,072-token aggregate
+  context budget. Waiting-prefix DFS must reduce family switches and the
+  periodic model-backed run must reduce recomputation and tail latency.
 
 The source of truth is
 [`evals/skippy-scheduler-fixtures.json`](../../evals/skippy-scheduler-fixtures.json).

--- a/docs/skippy/SCHEDULER_FIXTURES.md
+++ b/docs/skippy/SCHEDULER_FIXTURES.md
@@ -1,0 +1,95 @@
+# Scheduler workload fixtures
+
+The scheduler fixture catalog preserves the two workload shapes that define the
+waiting-prefix policy boundary:
+
+- `warm-affinity` is an already-grouped two-family trace. Materialized cache
+  affinity supplies the same order before waiting-prefix DFS, so the replay
+  must stay neutral.
+- `agentic-eviction-pressure` is an interleaved eight-family trace with only
+  two resident prefix-cache entries. Waiting-prefix DFS must reduce family
+  switches and the periodic model-backed run must reduce recomputation and
+  tail latency.
+
+The source of truth is
+[`evals/skippy-scheduler-fixtures.json`](../../evals/skippy-scheduler-fixtures.json).
+It pins the Hugging Face commit, selected source, eight session IDs, selection
+rules, runtime shape, generated prompt-manifest hash, and acceptance bounds.
+It contains no trajectory text or dataset files.
+
+## Fast PR gate
+
+Validate the catalog and run the actual Rust scheduler against both compact
+traces:
+
+```bash
+python3 evals/skippy-scheduler-fixtures.py validate
+cargo test -p skippy-scheduler
+```
+
+The Rust replay reads the checked-in catalog directly. With
+`group_waiting_prefixes=false`, the warm trace retains one family switch and
+the eviction-pressure trace retains fifteen. With grouping enabled, the warm
+trace remains at one switch while the eviction-pressure trace collapses to
+seven. This gate is deterministic and performs no model inference or network
+access.
+
+The normal Python script-test lane also validates the catalog, the strict HF
+command shape, row-provenance rejection, and profile application in the A/B
+runner.
+
+## Pinned corpus cache
+
+Prepare the model-backed eviction-pressure prompts with:
+
+```bash
+python3 evals/skippy-scheduler-fixtures.py prepare \
+  --profile agentic-eviction-pressure \
+  --output /tmp/skippy-agentic-eviction-pressure.json
+```
+
+`prepare` performs both operations required by the fixture contract:
+
+1. `hf download thoughtworks/agentic-coding-trajectories ... --repo-type dataset --revision cef72d1f4d0caabf85937adf8337a14b7522c782`
+2. `hf cache verify ... --fail-on-missing-files` at the same revision
+
+It then selects the pinned rows from `sessions.parquet`, rebuilds the prompt
+manifest, and rejects either row drift or a SHA-256 other than
+`f1ddbe3d5974f3f4bd06f5d70fa45d0e10305bbafa4eb7399a0f972458d1beef`.
+Use `--cache-dir` when a benchmark host owns a dedicated shared cache.
+
+Never copy `sessions.parquet` or the generated prompt manifest into the
+repository. The corpus is a derivative multi-source dataset; this fixture uses
+only the `swe-smith-claude-3-7-sonnet` rows, whose upstream is
+`SWE-bench/SWE-smith-trajectories` (MIT). The checked-in catalog retains row
+provenance without redistributing the text.
+
+## Periodic hardware replay
+
+Use exact OLD and NEW release binaries built against the same native ABI, then
+run the A/B harness with the named profile:
+
+```bash
+python3 evals/skippy-waiting-prefix-ab.py \
+  --fixture-profile agentic-eviction-pressure \
+  --prompt-manifest /tmp/skippy-agentic-eviction-pressure.json \
+  --case-file /path/to/one-model-case.json \
+  --old-bin /path/to/old/skippy-server \
+  --new-bin /path/to/new/skippy-server \
+  --old-commit <old-commit> \
+  --new-commit <new-commit> \
+  --native-build /path/to/matched/native-build \
+  --output-dir /path/to/artifacts
+```
+
+The named profile owns rounds, lanes, admission concurrency, cache entries,
+output length, and arrival stagger; ad hoc workload flags do not override it.
+The result records the profile name and catalog SHA alongside binary, model,
+and prompt-manifest hashes.
+
+The eviction-pressure certificate requires every request to succeed and, at
+minimum, 10% improvements in suffix prefill, family switches, p95 TTFT, and
+makespan plus 10% higher output throughput. The warm certificate requires
+identical suffix prefill and switch counts, with user-facing timing/throughput
+movement inside ±5%. Alternate binary order across all four rounds and retain
+raw requests, telemetry, configs, logs, `comparison.json`, and `report.md`.

--- a/evals/skippy-agentic-prompt-manifest.py
+++ b/evals/skippy-agentic-prompt-manifest.py
@@ -33,7 +33,7 @@ def select_trajectories(
                 total_tokens,
                 row_number() OVER (
                     PARTITION BY session_id
-                    ORDER BY max_isl DESC, total_tokens DESC
+                    ORDER BY max_isl DESC, total_tokens DESC, md5(messages_json)
                 ) AS occurrence
             FROM read_parquet(?)
             WHERE max_isl >= ?

--- a/evals/skippy-scheduler-fixtures.json
+++ b/evals/skippy-scheduler-fixtures.json
@@ -23,6 +23,13 @@
   "profiles": {
     "warm-affinity": {
       "description": "Two already-warm prompt families; materialized affinity supplies the same grouped order with or without waiting-prefix DFS.",
+      "model": {
+        "id": "bartowski/DeepSeek-Coder-V2-Lite-Instruct-GGUF:Q4_K_M",
+        "repo": "bartowski/DeepSeek-Coder-V2-Lite-Instruct-GGUF",
+        "revision": "8f248fa2072348f77a8bc37754e470de1f61866e",
+        "filename": "DeepSeek-Coder-V2-Lite-Instruct-Q4_K_M.gguf",
+        "sha256": "603bd3f8a0281d16571da7c08bd661ee17ff0d1be6fcbd1b42242da257ef0bb8"
+      },
       "corpus": {
         "kind": "synthetic",
         "generator": "stable-prefix-v1"
@@ -60,6 +67,13 @@
     },
     "agentic-eviction-pressure": {
       "description": "Eight interleaved 4K-6K coding-agent families competing for two resident prefix-cache entries.",
+      "model": {
+        "id": "bartowski/DeepSeek-Coder-V2-Lite-Instruct-GGUF:Q4_K_M",
+        "repo": "bartowski/DeepSeek-Coder-V2-Lite-Instruct-GGUF",
+        "revision": "8f248fa2072348f77a8bc37754e470de1f61866e",
+        "filename": "DeepSeek-Coder-V2-Lite-Instruct-Q4_K_M.gguf",
+        "sha256": "603bd3f8a0281d16571da7c08bd661ee17ff0d1be6fcbd1b42242da257ef0bb8"
+      },
       "corpus": {
         "kind": "hf",
         "dataset": "agentic-coding-trajectories",
@@ -153,6 +167,8 @@
       },
       "hardware_acceptance": {
         "successful_requests_per_binary": 64,
+        "suffix_prefill_before_min": 50000,
+        "family_switch_before_min": 8,
         "suffix_prefill_delta_percent_max": -10.0,
         "family_switch_delta_percent_max": -10.0,
         "ttft_p95_delta_percent_max": -10.0,

--- a/evals/skippy-scheduler-fixtures.json
+++ b/evals/skippy-scheduler-fixtures.json
@@ -139,7 +139,7 @@
         "requests_per_family": 2,
         "prefix_blocks": 192,
         "output_tokens": 32,
-        "ctx_size": 65536,
+        "ctx_size": 131072,
         "lanes": 16,
         "admission_concurrency": 16,
         "cache_entries": 2,

--- a/evals/skippy-scheduler-fixtures.json
+++ b/evals/skippy-scheduler-fixtures.json
@@ -1,0 +1,164 @@
+{
+  "schema_version": 1,
+  "datasets": {
+    "agentic-coding-trajectories": {
+      "repo_id": "thoughtworks/agentic-coding-trajectories",
+      "repo_type": "dataset",
+      "revision": "cef72d1f4d0caabf85937adf8337a14b7522c782",
+      "files": [
+        ".gitattributes",
+        "README.md",
+        "manifest.json",
+        "sessions.parquet"
+      ],
+      "parquet_file": "sessions.parquet",
+      "license": "derivative-multi-source",
+      "provenance": {
+        "selected_source": "swe-smith-claude-3-7-sonnet",
+        "upstream": "SWE-bench/SWE-smith-trajectories",
+        "upstream_license": "MIT"
+      }
+    }
+  },
+  "profiles": {
+    "warm-affinity": {
+      "description": "Two already-warm prompt families; materialized affinity supplies the same grouped order with or without waiting-prefix DFS.",
+      "corpus": {
+        "kind": "synthetic",
+        "generator": "stable-prefix-v1"
+      },
+      "workload": {
+        "rounds": 4,
+        "families": 2,
+        "requests_per_family": 3,
+        "prefix_blocks": 120,
+        "output_tokens": 64,
+        "ctx_size": 65536,
+        "lanes": 6,
+        "admission_concurrency": 6,
+        "cache_entries": 1,
+        "stagger_ms": 5.0
+      },
+      "ci_trace": {
+        "family_order": [0, 0, 0, 1, 1, 1],
+        "prompt_tokens": 128,
+        "expected_fcfs_switches": 1,
+        "expected_dfs_switches": 1
+      },
+      "hardware_acceptance": {
+        "successful_requests_per_binary": 24,
+        "suffix_prefill_delta_percent": {
+          "min": 0.0,
+          "max": 0.0
+        },
+        "family_switch_delta_percent": {
+          "min": 0.0,
+          "max": 0.0
+        },
+        "absolute_user_metric_delta_percent_max": 5.0
+      }
+    },
+    "agentic-eviction-pressure": {
+      "description": "Eight interleaved 4K-6K coding-agent families competing for two resident prefix-cache entries.",
+      "corpus": {
+        "kind": "hf",
+        "dataset": "agentic-coding-trajectories",
+        "selection": {
+          "sources": [
+            "swe-smith-claude-3-7-sonnet"
+          ],
+          "families": 8,
+          "min_isl": 4096,
+          "max_isl_exclusive": 6144,
+          "min_turns": 10,
+          "order": "md5(session_id)"
+        },
+        "rows": [
+          {
+            "session_id": "swe-smith-claude-3-7-sonnet::un33k__python-slugify.872b3750.lm_rewrite__kidne8vn.3qdud4nz",
+            "source_dataset": "swe-smith-claude-3-7-sonnet",
+            "n_turns": 11,
+            "max_isl": 4534,
+            "total_tokens": 4545
+          },
+          {
+            "session_id": "swe-smith-claude-3-7-sonnet::Project-MONAI__MONAI.a09c1f08.pr_4583.kv86f030",
+            "source_dataset": "swe-smith-claude-3-7-sonnet",
+            "n_turns": 12,
+            "max_isl": 4780,
+            "total_tokens": 4815
+          },
+          {
+            "session_id": "swe-smith-claude-3-7-sonnet::sqlfluff__sqlfluff.50a1c4b6.func_pm_ctrl_shuffle__urk3we51.91hmylr4",
+            "source_dataset": "swe-smith-claude-3-7-sonnet",
+            "n_turns": 15,
+            "max_isl": 5643,
+            "total_tokens": 5649
+          },
+          {
+            "session_id": "swe-smith-claude-3-7-sonnet::cookiecutter__cookiecutter.b4451231.func_pm_remove_assign__u2kljodk.3qdud4nz",
+            "source_dataset": "swe-smith-claude-3-7-sonnet",
+            "n_turns": 14,
+            "max_isl": 5220,
+            "total_tokens": 5226
+          },
+          {
+            "session_id": "swe-smith-claude-3-7-sonnet::jawah__charset_normalizer.1fdd6463.func_pm_remove_cond__67254dru.3qdud4nz",
+            "source_dataset": "swe-smith-claude-3-7-sonnet",
+            "n_turns": 18,
+            "max_isl": 5480,
+            "total_tokens": 5486
+          },
+          {
+            "session_id": "swe-smith-claude-3-7-sonnet::Project-MONAI__MONAI.a09c1f08.pr_6895.oosvj10h",
+            "source_dataset": "swe-smith-claude-3-7-sonnet",
+            "n_turns": 11,
+            "max_isl": 5816,
+            "total_tokens": 5970
+          },
+          {
+            "session_id": "swe-smith-claude-3-7-sonnet::pytest-dev__iniconfig.16793ead.combine_module__sxsvwi72.3qdud4nz",
+            "source_dataset": "swe-smith-claude-3-7-sonnet",
+            "n_turns": 13,
+            "max_isl": 6071,
+            "total_tokens": 6077
+          },
+          {
+            "session_id": "swe-smith-claude-3-7-sonnet::dask__dask.5f61e423.pr_6749.oosvj10h",
+            "source_dataset": "swe-smith-claude-3-7-sonnet",
+            "n_turns": 10,
+            "max_isl": 4669,
+            "total_tokens": 4691
+          }
+        ],
+        "prompt_manifest_sha256": "f1ddbe3d5974f3f4bd06f5d70fa45d0e10305bbafa4eb7399a0f972458d1beef"
+      },
+      "workload": {
+        "rounds": 4,
+        "families": 8,
+        "requests_per_family": 2,
+        "prefix_blocks": 192,
+        "output_tokens": 32,
+        "ctx_size": 65536,
+        "lanes": 16,
+        "admission_concurrency": 16,
+        "cache_entries": 2,
+        "stagger_ms": 2.0
+      },
+      "ci_trace": {
+        "family_order": [0, 1, 2, 3, 4, 5, 6, 7, 0, 1, 2, 3, 4, 5, 6, 7],
+        "prompt_tokens": 128,
+        "expected_fcfs_switches": 15,
+        "expected_dfs_switches": 7
+      },
+      "hardware_acceptance": {
+        "successful_requests_per_binary": 64,
+        "suffix_prefill_delta_percent_max": -10.0,
+        "family_switch_delta_percent_max": -10.0,
+        "ttft_p95_delta_percent_max": -10.0,
+        "makespan_delta_percent_max": -10.0,
+        "output_throughput_delta_percent_min": 10.0
+      }
+    }
+  }
+}

--- a/evals/skippy-scheduler-fixtures.py
+++ b/evals/skippy-scheduler-fixtures.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Validate and materialize the pinned Skippy scheduler workload fixtures."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Sequence
+
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_CATALOG = REPO / "evals/skippy-scheduler-fixtures.json"
+GENERATOR = REPO / "evals/skippy-agentic-prompt-manifest.py"
+WORKLOAD_KEYS = (
+    "rounds",
+    "families",
+    "requests_per_family",
+    "prefix_blocks",
+    "output_tokens",
+    "ctx_size",
+    "lanes",
+    "admission_concurrency",
+    "cache_entries",
+    "stagger_ms",
+)
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def load_catalog(path: Path) -> dict[str, Any]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    validate_catalog(document)
+    return document
+
+
+def require_keys(document: dict[str, Any], keys: Sequence[str], context: str) -> None:
+    missing = [key for key in keys if key not in document]
+    if missing:
+        raise ValueError(f"{context} is missing: {', '.join(missing)}")
+
+
+def validate_catalog(catalog: dict[str, Any]) -> None:
+    if catalog.get("schema_version") != 1:
+        raise ValueError("scheduler fixture schema_version must be 1")
+    datasets = catalog.get("datasets")
+    profiles = catalog.get("profiles")
+    if not isinstance(datasets, dict) or not isinstance(profiles, dict) or not profiles:
+        raise ValueError("scheduler fixture catalog needs datasets and profiles objects")
+    for dataset_name, dataset in datasets.items():
+        if not isinstance(dataset, dict):
+            raise ValueError(f"dataset {dataset_name} must be an object")
+        require_keys(
+            dataset,
+            ("repo_id", "repo_type", "revision", "files", "parquet_file", "provenance"),
+            f"dataset {dataset_name}",
+        )
+        revision = dataset["revision"]
+        if not isinstance(revision, str) or len(revision) != 40:
+            raise ValueError(f"dataset {dataset_name} revision must be a 40-character commit")
+        if dataset["repo_type"] != "dataset":
+            raise ValueError(f"dataset {dataset_name} repo_type must be dataset")
+        files = dataset["files"]
+        if not isinstance(files, list) or dataset["parquet_file"] not in files:
+            raise ValueError(f"dataset {dataset_name} files must include parquet_file")
+    for profile_name, profile in profiles.items():
+        if not isinstance(profile, dict):
+            raise ValueError(f"profile {profile_name} must be an object")
+        require_keys(
+            profile,
+            ("description", "corpus", "workload", "ci_trace", "hardware_acceptance"),
+            f"profile {profile_name}",
+        )
+        workload = profile["workload"]
+        require_keys(workload, WORKLOAD_KEYS, f"profile {profile_name} workload")
+        if any(float(workload[key]) <= 0 for key in WORKLOAD_KEYS):
+            raise ValueError(f"profile {profile_name} workload values must be positive")
+        expected_requests = int(workload["families"]) * int(workload["requests_per_family"])
+        if int(workload["admission_concurrency"]) != expected_requests:
+            raise ValueError(f"profile {profile_name} must admit its complete workload")
+        if int(workload["lanes"]) < expected_requests:
+            raise ValueError(f"profile {profile_name} needs at least one lane per request")
+        trace = profile["ci_trace"]
+        require_keys(
+            trace,
+            (
+                "family_order",
+                "prompt_tokens",
+                "expected_fcfs_switches",
+                "expected_dfs_switches",
+            ),
+            f"profile {profile_name} ci_trace",
+        )
+        family_order = trace["family_order"]
+        if not isinstance(family_order, list) or len(family_order) != expected_requests:
+            raise ValueError(f"profile {profile_name} ci_trace must cover every request")
+        if set(family_order) != set(range(int(workload["families"]))):
+            raise ValueError(f"profile {profile_name} ci_trace families do not match workload")
+        corpus = profile["corpus"]
+        if corpus.get("kind") == "hf":
+            dataset_name = corpus.get("dataset")
+            if dataset_name not in datasets:
+                raise ValueError(f"profile {profile_name} references an unknown dataset")
+            selection = corpus.get("selection")
+            rows = corpus.get("rows")
+            if not isinstance(selection, dict) or not isinstance(rows, list):
+                raise ValueError(f"profile {profile_name} needs selection and rows")
+            if len(rows) != int(workload["families"]):
+                raise ValueError(f"profile {profile_name} must pin one row per family")
+            if selection.get("families") != int(workload["families"]):
+                raise ValueError(f"profile {profile_name} selection family count drifted")
+            if selection.get("order") != "md5(session_id)":
+                raise ValueError(f"profile {profile_name} selection order must be deterministic")
+            manifest_hash = corpus.get("prompt_manifest_sha256")
+            if not isinstance(manifest_hash, str) or len(manifest_hash) != 64:
+                raise ValueError(f"profile {profile_name} needs a prompt manifest SHA-256")
+        elif corpus.get("kind") != "synthetic":
+            raise ValueError(f"profile {profile_name} has an unsupported corpus kind")
+
+
+def profile(catalog: dict[str, Any], name: str) -> dict[str, Any]:
+    try:
+        return catalog["profiles"][name]
+    except KeyError as error:
+        choices = ", ".join(sorted(catalog["profiles"]))
+        raise ValueError(f"unknown profile {name!r}; choose one of: {choices}") from error
+
+
+def dataset_for_profile(catalog: dict[str, Any], selected: dict[str, Any]) -> dict[str, Any]:
+    corpus = selected["corpus"]
+    if corpus["kind"] != "hf":
+        raise ValueError("the selected profile does not use a Hugging Face corpus")
+    return catalog["datasets"][corpus["dataset"]]
+
+
+def run_checked(
+    command: list[str],
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        return runner(command, check=True, text=True, capture_output=True)
+    except subprocess.CalledProcessError as error:
+        detail = (error.stderr or error.stdout or "").strip()
+        suffix = f": {detail}" if detail else ""
+        message = f"command failed ({error.returncode}): {' '.join(command)}{suffix}"
+        raise RuntimeError(message) from error
+
+
+def fetch_dataset(
+    dataset: dict[str, Any],
+    cache_dir: Path | None = None,
+    runner: Callable[..., subprocess.CompletedProcess[str]] = subprocess.run,
+) -> Path:
+    download = [
+        "hf",
+        "download",
+        dataset["repo_id"],
+        *dataset["files"],
+        "--repo-type",
+        dataset["repo_type"],
+        "--revision",
+        dataset["revision"],
+        "--format",
+        "json",
+    ]
+    verify = [
+        "hf",
+        "cache",
+        "verify",
+        dataset["repo_id"],
+        "--repo-type",
+        dataset["repo_type"],
+        "--revision",
+        dataset["revision"],
+        "--fail-on-missing-files",
+        "--format",
+        "json",
+    ]
+    if cache_dir is not None:
+        download.extend(("--cache-dir", str(cache_dir)))
+        verify.extend(("--cache-dir", str(cache_dir)))
+    downloaded = json.loads(run_checked(download, runner).stdout)
+    snapshot = Path(downloaded["path"])
+    run_checked(verify, runner)
+    parquet = snapshot / dataset["parquet_file"]
+    if not parquet.is_file():
+        raise RuntimeError(f"verified snapshot is missing {dataset['parquet_file']}: {snapshot}")
+    return parquet
+
+
+def load_generator() -> Any:
+    spec = importlib.util.spec_from_file_location("skippy_agentic_prompt_manifest", GENERATOR)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import {GENERATOR}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def materialize_prompt_manifest(
+    catalog: dict[str, Any],
+    selected: dict[str, Any],
+    dataset_file: Path,
+    output: Path,
+) -> str:
+    dataset = dataset_for_profile(catalog, selected)
+    corpus = selected["corpus"]
+    selection = corpus["selection"]
+    generator = load_generator()
+    rows = generator.select_trajectories(
+        dataset_file,
+        selection["sources"],
+        selection["families"],
+        selection["min_isl"],
+        selection["max_isl_exclusive"],
+        selection["min_turns"],
+    )
+    pinned_rows = [
+        {
+            key: row[key]
+            for key in ("session_id", "source_dataset", "n_turns", "max_isl", "total_tokens")
+        }
+        for row in rows
+    ]
+    if pinned_rows != corpus["rows"]:
+        raise RuntimeError("selected HF rows do not match the pinned fixture provenance")
+    document = generator.build_manifest(
+        rows,
+        selected["workload"]["requests_per_family"],
+        {
+            "dataset": dataset["repo_id"],
+            "dataset_revision": dataset["revision"],
+            "selection": selection,
+        },
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=output.parent,
+        prefix=f".{output.name}.",
+        suffix=".tmp",
+        delete=False,
+    ) as handle:
+        handle.write(json.dumps(document, indent=2, ensure_ascii=False) + "\n")
+        temporary = Path(handle.name)
+    actual = sha256(temporary)
+    expected = corpus["prompt_manifest_sha256"]
+    if actual != expected:
+        temporary.unlink(missing_ok=True)
+        raise RuntimeError(f"prompt manifest SHA-256 mismatch: expected {expected}, got {actual}")
+    temporary.replace(output)
+    return actual
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--catalog", type=Path, default=DEFAULT_CATALOG)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    subparsers.add_parser("validate", help="validate the checked-in catalog without inference")
+    show = subparsers.add_parser("show", help="print one resolved profile")
+    show.add_argument("--profile", required=True)
+    fetch = subparsers.add_parser("fetch", help="download and verify one pinned HF corpus")
+    fetch.add_argument("--profile", required=True)
+    fetch.add_argument("--cache-dir", type=Path)
+    materialize = subparsers.add_parser(
+        "materialize", help="build and hash-check a prompt manifest from a verified parquet"
+    )
+    materialize.add_argument("--profile", required=True)
+    materialize.add_argument("--dataset-file", type=Path, required=True)
+    materialize.add_argument("--output", type=Path, required=True)
+    prepare = subparsers.add_parser("prepare", help="fetch, verify, and materialize in one step")
+    prepare.add_argument("--profile", required=True)
+    prepare.add_argument("--cache-dir", type=Path)
+    prepare.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+    try:
+        catalog = load_catalog(args.catalog)
+        if args.command == "validate":
+            print(json.dumps({"profiles": sorted(catalog["profiles"]), "status": "valid"}))
+            return 0
+        selected = profile(catalog, args.profile)
+        if args.command == "show":
+            print(json.dumps(selected, indent=2))
+            return 0
+        dataset = dataset_for_profile(catalog, selected)
+        if args.command == "fetch":
+            print(fetch_dataset(dataset, args.cache_dir))
+            return 0
+        dataset_file = (
+            args.dataset_file
+            if args.command == "materialize"
+            else fetch_dataset(dataset, args.cache_dir)
+        )
+        if not dataset_file.is_file():
+            raise ValueError(f"dataset parquet not found: {dataset_file}")
+        actual = materialize_prompt_manifest(catalog, selected, dataset_file, args.output)
+        print(json.dumps({"output": str(args.output), "sha256": actual}))
+        return 0
+    except (
+        json.JSONDecodeError,
+        OSError,
+        RuntimeError,
+        ValueError,
+        subprocess.CalledProcessError,
+    ) as error:
+        parser.error(str(error))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/skippy-scheduler-fixtures.py
+++ b/evals/skippy-scheduler-fixtures.py
@@ -51,6 +51,21 @@ def require_keys(document: dict[str, Any], keys: Sequence[str], context: str) ->
         raise ValueError(f"{context} is missing: {', '.join(missing)}")
 
 
+def derived_context_size(profile: dict[str, Any]) -> int | None:
+    """Return the smallest power-of-two context that covers the pinned workload."""
+    corpus = profile["corpus"]
+    if corpus.get("kind") != "hf":
+        return None
+    workload = profile["workload"]
+    prompt_tokens = sum(int(row["total_tokens"]) for row in corpus["rows"])
+    prompt_tokens *= int(workload["requests_per_family"])
+    output_tokens = int(workload["output_tokens"]) * (
+        int(workload["families"]) * int(workload["requests_per_family"])
+    )
+    required_tokens = prompt_tokens + output_tokens
+    return 1 << max(required_tokens - 1, 0).bit_length()
+
+
 def validate_catalog(catalog: dict[str, Any]) -> None:
     if catalog.get("schema_version") != 1:
         raise ValueError("scheduler fixture schema_version must be 1")
@@ -79,9 +94,28 @@ def validate_catalog(catalog: dict[str, Any]) -> None:
             raise ValueError(f"profile {profile_name} must be an object")
         require_keys(
             profile,
-            ("description", "corpus", "workload", "ci_trace", "hardware_acceptance"),
+            (
+                "description",
+                "model",
+                "corpus",
+                "workload",
+                "ci_trace",
+                "hardware_acceptance",
+            ),
             f"profile {profile_name}",
         )
+        model = profile["model"]
+        require_keys(
+            model,
+            ("id", "repo", "revision", "filename", "sha256"),
+            f"profile {profile_name} model",
+        )
+        if not isinstance(model["id"], str) or not model["id"]:
+            raise ValueError(f"profile {profile_name} model id must be nonempty")
+        if not isinstance(model["revision"], str) or len(model["revision"]) != 40:
+            raise ValueError(f"profile {profile_name} model revision must be a commit")
+        if not isinstance(model["sha256"], str) or len(model["sha256"]) != 64:
+            raise ValueError(f"profile {profile_name} model needs a SHA-256")
         workload = profile["workload"]
         require_keys(workload, WORKLOAD_KEYS, f"profile {profile_name} workload")
         if any(float(workload[key]) <= 0 for key in WORKLOAD_KEYS):
@@ -118,6 +152,18 @@ def validate_catalog(catalog: dict[str, Any]) -> None:
                 raise ValueError(f"profile {profile_name} needs selection and rows")
             if len(rows) != int(workload["families"]):
                 raise ValueError(f"profile {profile_name} must pin one row per family")
+            for row_index, row in enumerate(rows):
+                if not isinstance(row, dict):
+                    raise ValueError(f"profile {profile_name} row {row_index} must be an object")
+                require_keys(
+                    row,
+                    ("session_id", "source_dataset", "n_turns", "max_isl", "total_tokens"),
+                    f"profile {profile_name} row {row_index}",
+                )
+                if int(row["total_tokens"]) <= 0:
+                    raise ValueError(
+                        f"profile {profile_name} row {row_index} total_tokens must be positive"
+                    )
             if selection.get("families") != int(workload["families"]):
                 raise ValueError(f"profile {profile_name} selection family count drifted")
             if selection.get("order") != "md5(session_id)":
@@ -125,6 +171,12 @@ def validate_catalog(catalog: dict[str, Any]) -> None:
             manifest_hash = corpus.get("prompt_manifest_sha256")
             if not isinstance(manifest_hash, str) or len(manifest_hash) != 64:
                 raise ValueError(f"profile {profile_name} needs a prompt manifest SHA-256")
+            required_ctx_size = derived_context_size(profile)
+            if required_ctx_size is None or int(workload["ctx_size"]) < required_ctx_size:
+                raise ValueError(
+                    f"profile {profile_name} ctx_size must cover its pinned row totals; "
+                    f"need at least {required_ctx_size}"
+                )
         elif corpus.get("kind") != "synthetic":
             raise ValueError(f"profile {profile_name} has an unsupported corpus kind")
 

--- a/evals/skippy-scheduler-fixtures.py
+++ b/evals/skippy-scheduler-fixtures.py
@@ -171,8 +171,6 @@ def fetch_dataset(
         dataset["repo_type"],
         "--revision",
         dataset["revision"],
-        "--format",
-        "json",
     ]
     verify = [
         "hf",
@@ -184,14 +182,11 @@ def fetch_dataset(
         "--revision",
         dataset["revision"],
         "--fail-on-missing-files",
-        "--format",
-        "json",
     ]
     if cache_dir is not None:
         download.extend(("--cache-dir", str(cache_dir)))
         verify.extend(("--cache-dir", str(cache_dir)))
-    downloaded = json.loads(run_checked(download, runner).stdout)
-    snapshot = Path(downloaded["path"])
+    snapshot = Path(run_checked(download, runner).stdout.strip())
     run_checked(verify, runner)
     parquet = snapshot / dataset["parquet_file"]
     if not parquet.is_file():

--- a/evals/skippy-waiting-prefix-ab.py
+++ b/evals/skippy-waiting-prefix-ab.py
@@ -28,6 +28,7 @@ from typing import Any
 
 REPO = Path(__file__).resolve().parents[1]
 SUMMARY_EVENT = "stage.openai_generation_summary"
+DEFAULT_FIXTURE_CATALOG = REPO / "evals/skippy-scheduler-fixtures.json"
 
 
 def load_module(name: str, path: Path) -> Any:
@@ -97,6 +98,20 @@ def read_prompt_manifest(path: Path) -> tuple[list[dict[str, str]], dict[str, An
     if not isinstance(metadata, dict):
         raise ValueError("prompt manifest metadata must be an object")
     return prompts, metadata
+
+
+def apply_fixture_profile(args: argparse.Namespace) -> tuple[dict[str, Any] | None, str | None]:
+    if args.fixture_profile is None:
+        return None, None
+    fixtures = load_module(
+        "skippy_scheduler_fixtures", REPO / "evals/skippy-scheduler-fixtures.py"
+    )
+    catalog_path = args.fixture_catalog.resolve()
+    catalog = fixtures.load_catalog(catalog_path)
+    selected = fixtures.profile(catalog, args.fixture_profile)
+    for key, value in selected["workload"].items():
+        setattr(args, key, value)
+    return selected, sha256(catalog_path)
 
 
 def percentile(values: list[float], quantile: float) -> float | None:
@@ -398,7 +413,79 @@ def format_delta(old: float | None, new: float | None) -> str:
     return "n/a" if value is None else f"{value:+.1f}%"
 
 
-def report(rows: list[dict[str, Any]]) -> str:
+def evaluate_acceptance(
+    rows: list[dict[str, Any]], profile: dict[str, Any] | None
+) -> dict[str, Any] | None:
+    if profile is None:
+        return None
+    indexed = {row["version"]: row for row in rows}
+    old, new = indexed["old"], indexed["new"]
+    contract = profile["hardware_acceptance"]
+    checks: list[dict[str, Any]] = []
+
+    def record(label: str, actual: float | None, relation: str, threshold: Any) -> None:
+        if actual is None:
+            passed = False
+        elif relation == "eq":
+            passed = actual == threshold
+        elif relation == "max":
+            passed = actual <= threshold
+        elif relation == "min":
+            passed = actual >= threshold
+        elif relation == "range":
+            passed = threshold["min"] <= actual <= threshold["max"]
+        else:
+            raise ValueError(f"unsupported acceptance relation: {relation}")
+        checks.append(
+            {
+                "label": label,
+                "actual": actual,
+                "relation": relation,
+                "threshold": threshold,
+                "passed": passed,
+            }
+        )
+
+    expected_successes = contract["successful_requests_per_binary"]
+    record("before successful requests", old["successful"], "eq", expected_successes)
+    record("after successful requests", new["successful"], "eq", expected_successes)
+    delta_keys = {
+        "suffix_prefill": "suffix_prefill_tokens_median",
+        "family_switch": "family_switches_median",
+        "ttft_p95": "ttft_ms_p95_median",
+        "makespan": "makespan_ms_median",
+        "output_throughput": "output_tokens_per_second_median",
+    }
+    for prefix, row_key in delta_keys.items():
+        actual = delta(old[row_key], new[row_key])
+        range_key = f"{prefix}_delta_percent"
+        max_key = f"{prefix}_delta_percent_max"
+        min_key = f"{prefix}_delta_percent_min"
+        if range_key in contract:
+            record(f"{prefix} delta percent", actual, "range", contract[range_key])
+        if max_key in contract:
+            record(f"{prefix} delta percent", actual, "max", contract[max_key])
+        if min_key in contract:
+            record(f"{prefix} delta percent", actual, "min", contract[min_key])
+    if "absolute_user_metric_delta_percent_max" in contract:
+        threshold = contract["absolute_user_metric_delta_percent_max"]
+        for label, row_key in (
+            ("TTFT p50", "ttft_ms_p50_median"),
+            ("TTFT p95", "ttft_ms_p95_median"),
+            ("makespan", "makespan_ms_median"),
+            ("output throughput", "output_tokens_per_second_median"),
+        ):
+            value = delta(old[row_key], new[row_key])
+            record(
+                f"absolute {label} delta percent",
+                abs(value) if value is not None else None,
+                "max",
+                threshold,
+            )
+    return {"passed": all(check["passed"] for check in checks), "checks": checks}
+
+
+def report(rows: list[dict[str, Any]], acceptance: dict[str, Any] | None = None) -> str:
     indexed = {row["version"]: row for row in rows}
     old, new = indexed["old"], indexed["new"]
     old_suffix = old["suffix_prefill_tokens_median"]
@@ -439,6 +526,26 @@ def report(rows: list[dict[str, Any]]) -> str:
             f"| {label} | {format_metric(before)} | {format_metric(after)} | "
             f"{format_delta(before, after)} |"
         )
+    if acceptance is not None:
+        lines.extend(
+            [
+                "",
+                f"Fixture acceptance: **{'PASS' if acceptance['passed'] else 'FAIL'}**",
+                "",
+                "| Check | Actual | Required | Result |",
+                "| --- | ---: | ---: | ---: |",
+            ]
+        )
+        for check in acceptance["checks"]:
+            threshold = check["threshold"]
+            if isinstance(threshold, dict):
+                required = f"{threshold['min']} to {threshold['max']}"
+            else:
+                operators = {"eq": "=", "max": "≤", "min": "≥"}
+                required = f"{operators[check['relation']]} {threshold}"
+            actual = format_metric(check["actual"])
+            result = "PASS" if check["passed"] else "FAIL"
+            lines.append(f"| {check['label']} | {actual} | {required} | {result} |")
     return "\n".join(lines) + "\n"
 
 
@@ -451,6 +558,15 @@ def main() -> int:
     parser.add_argument("--new-commit", required=True)
     parser.add_argument("--native-build", type=Path, required=True)
     parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument(
+        "--fixture-profile",
+        help="checked-in workload profile; its shape overrides workload flags",
+    )
+    parser.add_argument(
+        "--fixture-catalog",
+        type=Path,
+        default=DEFAULT_FIXTURE_CATALOG,
+    )
     parser.add_argument("--rounds", type=int, default=4)
     parser.add_argument("--families", type=int, default=2)
     parser.add_argument("--requests-per-family", type=int, default=6)
@@ -474,6 +590,10 @@ def main() -> int:
     parser.add_argument("--request-timeout-secs", type=float, default=900.0)
     parser.add_argument("--n-gpu-layers", type=int, default=999)
     args = parser.parse_args()
+    try:
+        fixture_profile, fixture_catalog_sha256 = apply_fixture_profile(args)
+    except (json.JSONDecodeError, OSError, ValueError) as error:
+        parser.error(f"invalid fixture profile: {error}")
     if min(args.rounds, args.families, args.requests_per_family, args.lanes, args.cache_entries) <= 0:
         parser.error("rounds, families, requests, lanes, and cache entries must be positive")
     if args.admission_concurrency < 0:
@@ -491,6 +611,12 @@ def main() -> int:
         parser.error("case file must contain exactly one model")
     case = cases[0]
     prompt_manifest_metadata: dict[str, Any] = {}
+    if (
+        fixture_profile is not None
+        and fixture_profile["corpus"]["kind"] == "hf"
+        and args.prompt_manifest is None
+    ):
+        parser.error("HF fixture profiles require --prompt-manifest from the prepare command")
     if args.prompt_manifest is not None:
         prompt_manifest = args.prompt_manifest.resolve()
         if not prompt_manifest.is_file():
@@ -499,6 +625,14 @@ def main() -> int:
             prompts, prompt_manifest_metadata = read_prompt_manifest(prompt_manifest)
         except (json.JSONDecodeError, OSError, ValueError) as error:
             parser.error(f"invalid prompt manifest: {error}")
+        if fixture_profile is not None and fixture_profile["corpus"]["kind"] == "hf":
+            expected_manifest_sha = fixture_profile["corpus"]["prompt_manifest_sha256"]
+            actual_manifest_sha = sha256(prompt_manifest)
+            if actual_manifest_sha != expected_manifest_sha:
+                parser.error(
+                    "prompt manifest does not match fixture profile: "
+                    f"expected {expected_manifest_sha}, got {actual_manifest_sha}"
+                )
     else:
         prompt_manifest = None
         prompts = interleaved_prompts(args.families, args.requests_per_family, args.prefix_blocks)
@@ -532,6 +666,7 @@ def main() -> int:
                 )
             )
     rows = aggregate(cells)
+    acceptance = evaluate_acceptance(rows, fixture_profile)
     result = {
         "metadata": {
             "old": {"commit": args.old_commit, "binary": str(binaries["old"]), "sha256": sha256(binaries["old"])},
@@ -551,6 +686,11 @@ def main() -> int:
                 sha256(prompt_manifest) if prompt_manifest is not None else None
             ),
             "prompt_manifest_metadata": prompt_manifest_metadata,
+            "fixture_profile": args.fixture_profile,
+            "fixture_catalog": (
+                str(args.fixture_catalog.resolve()) if fixture_profile is not None else None
+            ),
+            "fixture_catalog_sha256": fixture_catalog_sha256,
             "output_tokens": args.output_tokens,
             "lanes": args.lanes,
             "admission_concurrency": args.admission_concurrency,
@@ -559,11 +699,16 @@ def main() -> int:
         },
         "cells": cells,
         "aggregate": rows,
+        "acceptance": acceptance,
     }
     (args.output_dir / "comparison.json").write_text(json.dumps(result, indent=2) + "\n")
-    (args.output_dir / "report.md").write_text(report(rows))
+    (args.output_dir / "report.md").write_text(report(rows, acceptance))
     print(args.output_dir / "comparison.json")
-    return 0 if all(cell["summary"]["successful"] == cell["summary"]["requests"] for cell in cells) else 1
+    successful = all(
+        cell["summary"]["successful"] == cell["summary"]["requests"] for cell in cells
+    )
+    accepted = acceptance is None or acceptance["passed"]
+    return 0 if successful and accepted else 1
 
 
 if __name__ == "__main__":

--- a/evals/skippy-waiting-prefix-ab.py
+++ b/evals/skippy-waiting-prefix-ab.py
@@ -114,6 +114,29 @@ def apply_fixture_profile(args: argparse.Namespace) -> tuple[dict[str, Any] | No
     return selected, sha256(catalog_path)
 
 
+def validate_fixture_inputs(
+    selected: dict[str, Any],
+    model_id: str,
+    model_sha256: str,
+    prompt_manifest: Path | None,
+) -> None:
+    expected_model = selected["model"]
+    if model_id != expected_model["id"]:
+        raise ValueError(
+            f"model id must be {expected_model['id']}, got {model_id}"
+        )
+    if model_sha256 != expected_model["sha256"]:
+        raise ValueError(
+            "model SHA-256 must be "
+            f"{expected_model['sha256']}, got {model_sha256}"
+        )
+    corpus_kind = selected["corpus"]["kind"]
+    if corpus_kind == "hf" and prompt_manifest is None:
+        raise ValueError("HF fixture profiles require a prepared prompt manifest")
+    if corpus_kind == "synthetic" and prompt_manifest is not None:
+        raise ValueError("synthetic fixture profiles do not accept a prompt manifest")
+
+
 def percentile(values: list[float], quantile: float) -> float | None:
     if not values:
         return None
@@ -401,7 +424,9 @@ def aggregate(cells: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def delta(old: float | None, new: float | None) -> float | None:
     if old is None or new is None:
         return None
-    return (new - old) / old * 100.0 if old else 0.0
+    if old == 0:
+        return 0.0 if new == 0 else None
+    return (new - old) / old * 100.0
 
 
 def format_metric(value: float | None) -> str:
@@ -422,6 +447,30 @@ def evaluate_acceptance(
     old, new = indexed["old"], indexed["new"]
     contract = profile["hardware_acceptance"]
     checks: list[dict[str, Any]] = []
+    known_contract_keys = {
+        "successful_requests_per_binary",
+        "absolute_user_metric_delta_percent_max",
+        "suffix_prefill_before_min",
+        "family_switch_before_min",
+    }
+    for prefix in (
+        "suffix_prefill",
+        "family_switch",
+        "ttft_p95",
+        "makespan",
+        "output_throughput",
+    ):
+        known_contract_keys.update(
+            {
+                f"{prefix}_delta_percent",
+                f"{prefix}_delta_percent_max",
+                f"{prefix}_delta_percent_min",
+            }
+        )
+    unknown_contract_keys = set(contract) - known_contract_keys
+    if unknown_contract_keys:
+        unknown = ", ".join(sorted(unknown_contract_keys))
+        raise ValueError(f"unsupported hardware acceptance keys: {unknown}")
 
     def record(label: str, actual: float | None, relation: str, threshold: Any) -> None:
         if actual is None:
@@ -449,6 +498,20 @@ def evaluate_acceptance(
     expected_successes = contract["successful_requests_per_binary"]
     record("before successful requests", old["successful"], "eq", expected_successes)
     record("after successful requests", new["successful"], "eq", expected_successes)
+    if "suffix_prefill_before_min" in contract:
+        record(
+            "before suffix prefill pressure",
+            old["suffix_prefill_tokens_median"],
+            "min",
+            contract["suffix_prefill_before_min"],
+        )
+    if "family_switch_before_min" in contract:
+        record(
+            "before family-switch pressure",
+            old["family_switches_median"],
+            "min",
+            contract["family_switch_before_min"],
+        )
     delta_keys = {
         "suffix_prefill": "suffix_prefill_tokens_median",
         "family_switch": "family_switches_median",
@@ -610,13 +673,18 @@ def main() -> int:
     if len(cases) != 1:
         parser.error("case file must contain exactly one model")
     case = cases[0]
+    model_sha256 = harness.model_sha256(case.model_path)
+    if fixture_profile is not None:
+        try:
+            validate_fixture_inputs(
+                fixture_profile,
+                case.model_id,
+                model_sha256,
+                args.prompt_manifest,
+            )
+        except ValueError as error:
+            parser.error(f"fixture input mismatch: {error}")
     prompt_manifest_metadata: dict[str, Any] = {}
-    if (
-        fixture_profile is not None
-        and fixture_profile["corpus"]["kind"] == "hf"
-        and args.prompt_manifest is None
-    ):
-        parser.error("HF fixture profiles require --prompt-manifest from the prepare command")
     if args.prompt_manifest is not None:
         prompt_manifest = args.prompt_manifest.resolve()
         if not prompt_manifest.is_file():
@@ -673,7 +741,7 @@ def main() -> int:
             "new": {"commit": args.new_commit, "binary": str(binaries["new"]), "sha256": sha256(binaries["new"])},
             "model_id": case.model_id,
             "model_path": str(case.model_path),
-            "model_sha256": harness.model_sha256(case.model_path),
+            "model_sha256": model_sha256,
             "rounds": args.rounds,
             "families": len(family_request_counts),
             "requests_per_family": (

--- a/scripts/tests/test_skippy_scheduler_fixtures.py
+++ b/scripts/tests/test_skippy_scheduler_fixtures.py
@@ -35,6 +35,7 @@ class SchedulerFixturesTest(unittest.TestCase):
         profile = catalog["profiles"]["agentic-eviction-pressure"]
 
         self.assertEqual(profile["workload"]["families"], 8)
+        self.assertEqual(profile["workload"]["ctx_size"], 131072)
         self.assertEqual(len(profile["corpus"]["rows"]), 8)
         self.assertEqual(
             profile["corpus"]["prompt_manifest_sha256"],

--- a/scripts/tests/test_skippy_scheduler_fixtures.py
+++ b/scripts/tests/test_skippy_scheduler_fixtures.py
@@ -1,0 +1,105 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def load_module():
+    path = REPO / "evals/skippy-scheduler-fixtures.py"
+    spec = importlib.util.spec_from_file_location("skippy_scheduler_fixtures", path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+FIXTURES = load_module()
+CATALOG_PATH = REPO / "evals/skippy-scheduler-fixtures.json"
+
+
+class SchedulerFixturesTest(unittest.TestCase):
+    def test_checked_in_catalog_is_valid_and_pins_measured_rows(self) -> None:
+        catalog = FIXTURES.load_catalog(CATALOG_PATH)
+        profile = catalog["profiles"]["agentic-eviction-pressure"]
+
+        self.assertEqual(profile["workload"]["families"], 8)
+        self.assertEqual(len(profile["corpus"]["rows"]), 8)
+        self.assertEqual(
+            profile["corpus"]["prompt_manifest_sha256"],
+            "f1ddbe3d5974f3f4bd06f5d70fa45d0e10305bbafa4eb7399a0f972458d1beef",
+        )
+
+    def test_fetch_uses_pinned_hf_cache_and_strict_verification(self) -> None:
+        catalog = FIXTURES.load_catalog(CATALOG_PATH)
+        dataset = catalog["datasets"]["agentic-coding-trajectories"]
+        commands: list[list[str]] = []
+        with tempfile.TemporaryDirectory() as directory:
+            snapshot = Path(directory) / "snapshot"
+            snapshot.mkdir()
+            (snapshot / "sessions.parquet").touch()
+
+            def runner(command, **kwargs):
+                commands.append(command)
+                stdout = json.dumps({"path": str(snapshot)}) if command[1] == "download" else "{}"
+                return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
+
+            parquet = FIXTURES.fetch_dataset(dataset, Path(directory) / "cache", runner)
+
+        self.assertEqual(parquet.name, "sessions.parquet")
+        self.assertEqual(commands[0][:3], ["hf", "download", dataset["repo_id"]])
+        self.assertIn(dataset["revision"], commands[0])
+        self.assertEqual(commands[1][:3], ["hf", "cache", "verify"])
+        self.assertIn("--fail-on-missing-files", commands[1])
+
+    def test_materialization_rejects_row_provenance_drift(self) -> None:
+        catalog = FIXTURES.load_catalog(CATALOG_PATH)
+        selected = catalog["profiles"]["agentic-eviction-pressure"]
+        row = {**selected["corpus"]["rows"][0], "messages_json": "[]"}
+        row["session_id"] = "unexpected"
+        generator = SimpleNamespace(select_trajectories=lambda *_args: [row] * 8)
+        with tempfile.TemporaryDirectory() as directory:
+            parquet = Path(directory) / "sessions.parquet"
+            parquet.touch()
+            output = Path(directory) / "prompts.json"
+            with mock.patch.object(FIXTURES, "load_generator", return_value=generator):
+                with self.assertRaisesRegex(RuntimeError, "pinned fixture provenance"):
+                    FIXTURES.materialize_prompt_manifest(catalog, selected, parquet, output)
+
+    def test_manifest_hash_failure_preserves_an_existing_output(self) -> None:
+        catalog = FIXTURES.load_catalog(CATALOG_PATH)
+        selected = catalog["profiles"]["agentic-eviction-pressure"]
+        rows = [
+            {**row, "messages_json": '[{"role": "user", "content": "fixture"}]'}
+            for row in selected["corpus"]["rows"]
+        ]
+        generator = SimpleNamespace(
+            select_trajectories=lambda *_args: rows,
+            build_manifest=lambda *_args: {"unexpected": True},
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            parquet = Path(directory) / "sessions.parquet"
+            parquet.touch()
+            output = Path(directory) / "prompts.json"
+            output.write_text("keep-me")
+            with mock.patch.object(FIXTURES, "load_generator", return_value=generator):
+                with self.assertRaisesRegex(RuntimeError, "SHA-256 mismatch"):
+                    FIXTURES.materialize_prompt_manifest(catalog, selected, parquet, output)
+
+            self.assertEqual(output.read_text(), "keep-me")
+            self.assertEqual(list(Path(directory).glob("*.tmp")), [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_skippy_scheduler_fixtures.py
+++ b/scripts/tests/test_skippy_scheduler_fixtures.py
@@ -36,7 +36,12 @@ class SchedulerFixturesTest(unittest.TestCase):
 
         self.assertEqual(profile["workload"]["families"], 8)
         self.assertEqual(profile["workload"]["ctx_size"], 131072)
+        self.assertEqual(FIXTURES.derived_context_size(profile), 131072)
         self.assertEqual(len(profile["corpus"]["rows"]), 8)
+        self.assertEqual(
+            profile["model"]["sha256"],
+            "603bd3f8a0281d16571da7c08bd661ee17ff0d1be6fcbd1b42242da257ef0bb8",
+        )
         self.assertEqual(
             profile["corpus"]["prompt_manifest_sha256"],
             "f1ddbe3d5974f3f4bd06f5d70fa45d0e10305bbafa4eb7399a0f972458d1beef",
@@ -53,7 +58,7 @@ class SchedulerFixturesTest(unittest.TestCase):
 
             def runner(command, **kwargs):
                 commands.append(command)
-                stdout = json.dumps({"path": str(snapshot)}) if command[1] == "download" else "{}"
+                stdout = str(snapshot) if command[1] == "download" else ""
                 return subprocess.CompletedProcess(command, 0, stdout=stdout, stderr="")
 
             parquet = FIXTURES.fetch_dataset(dataset, Path(directory) / "cache", runner)
@@ -63,6 +68,60 @@ class SchedulerFixturesTest(unittest.TestCase):
         self.assertIn(dataset["revision"], commands[0])
         self.assertEqual(commands[1][:3], ["hf", "cache", "verify"])
         self.assertIn("--fail-on-missing-files", commands[1])
+
+    def test_catalog_rejects_context_below_derived_pinned_requirement(self) -> None:
+        catalog = json.loads(CATALOG_PATH.read_text())
+        catalog["profiles"]["agentic-eviction-pressure"]["workload"]["ctx_size"] = 65536
+
+        with self.assertRaisesRegex(ValueError, "pinned row totals"):
+            FIXTURES.validate_catalog(catalog)
+
+    def test_catalog_rejects_unpinned_model_identity(self) -> None:
+        catalog = json.loads(CATALOG_PATH.read_text())
+        del catalog["profiles"]["warm-affinity"]["model"]["sha256"]
+
+        with self.assertRaisesRegex(ValueError, "model.*missing"):
+            FIXTURES.validate_catalog(catalog)
+
+    def test_real_generator_builds_deterministic_canned_manifest(self) -> None:
+        generator = FIXTURES.load_generator()
+        trajectories = [
+            {
+                "session_id": "session-b",
+                "source_dataset": "fixture",
+                "n_turns": 2,
+                "max_isl": 128,
+                "total_tokens": 144,
+                "messages_json": json.dumps(
+                    [
+                        {"role": "user", "content": "inspect"},
+                        {
+                            "role": "assistant",
+                            "content": "calling tool",
+                            "tool_calls_json": '[{"name":"read"}]',
+                        },
+                    ]
+                ),
+            },
+            {
+                "session_id": "session-a",
+                "source_dataset": "fixture",
+                "n_turns": 1,
+                "max_isl": 64,
+                "total_tokens": 72,
+                "messages_json": '[{"role":"user","content":{"path":"src/lib.rs"}}]',
+            },
+        ]
+
+        manifest = generator.build_manifest(trajectories, 2, {"fixture": True})
+
+        self.assertEqual(
+            [prompt["family"] for prompt in manifest["prompts"]],
+            ["trajectory-0", "trajectory-1", "trajectory-0", "trajectory-1"],
+        )
+        self.assertIn("<tool_calls>", manifest["prompts"][0]["prompt"])
+        self.assertIn('{"path": "src/lib.rs"}', manifest["prompts"][1]["prompt"])
+        self.assertEqual(manifest["metadata"]["rows"][0]["session_id"], "session-b")
 
     def test_materialization_rejects_row_provenance_drift(self) -> None:
         catalog = FIXTURES.load_catalog(CATALOG_PATH)

--- a/scripts/tests/test_skippy_waiting_prefix_ab.py
+++ b/scripts/tests/test_skippy_waiting_prefix_ab.py
@@ -5,6 +5,7 @@ import json
 import sys
 import tempfile
 import unittest
+from argparse import Namespace
 from pathlib import Path
 
 
@@ -43,6 +44,85 @@ def cell(version: str, ttft_ms: float | None) -> dict:
 
 
 class WaitingPrefixAbTest(unittest.TestCase):
+    def test_warm_profile_accepts_the_measured_neutral_boundary(self) -> None:
+        catalog = json.loads((REPO / "evals/skippy-scheduler-fixtures.json").read_text())
+        profile = catalog["profiles"]["warm-affinity"]
+        rows = [
+            {
+                "version": "old",
+                "successful": 24,
+                "suffix_prefill_tokens_median": 8237.0,
+                "family_switches_median": 1.0,
+                "ttft_ms_p50_median": 3161.1,
+                "ttft_ms_p95_median": 3313.7,
+                "makespan_ms_median": 5326.8,
+                "output_tokens_per_second_median": 71.34,
+            },
+            {
+                "version": "new",
+                "successful": 24,
+                "suffix_prefill_tokens_median": 8237.0,
+                "family_switches_median": 1.0,
+                "ttft_ms_p50_median": 3190.0,
+                "ttft_ms_p95_median": 3305.4,
+                "makespan_ms_median": 5331.8,
+                "output_tokens_per_second_median": 71.27,
+            },
+        ]
+
+        acceptance = BENCH.evaluate_acceptance(rows, profile)
+
+        self.assertTrue(acceptance["passed"])
+
+    def test_eviction_profile_enforces_hardware_acceptance(self) -> None:
+        catalog = json.loads((REPO / "evals/skippy-scheduler-fixtures.json").read_text())
+        profile = catalog["profiles"]["agentic-eviction-pressure"]
+        rows = [
+            {
+                "version": "old",
+                "successful": 64,
+                "suffix_prefill_tokens_median": 92061.5,
+                "family_switches_median": 14.0,
+                "ttft_ms_p95_median": 38646.5,
+                "makespan_ms_median": 41132.9,
+                "output_tokens_per_second_median": 12.02,
+            },
+            {
+                "version": "new",
+                "successful": 64,
+                "suffix_prefill_tokens_median": 66735.5,
+                "family_switches_median": 10.0,
+                "ttft_ms_p95_median": 27901.1,
+                "makespan_ms_median": 30328.4,
+                "output_tokens_per_second_median": 16.26,
+            },
+        ]
+
+        acceptance = BENCH.evaluate_acceptance(rows, profile)
+
+        self.assertTrue(acceptance["passed"])
+        self.assertTrue(all(check["passed"] for check in acceptance["checks"]))
+        rows[1]["output_tokens_per_second_median"] = rows[0][
+            "output_tokens_per_second_median"
+        ]
+        self.assertFalse(BENCH.evaluate_acceptance(rows, profile)["passed"])
+
+    def test_checked_in_fixture_profile_owns_the_workload_shape(self) -> None:
+        args = Namespace(
+            fixture_profile="agentic-eviction-pressure",
+            fixture_catalog=REPO / "evals/skippy-scheduler-fixtures.json",
+            rounds=1,
+            families=1,
+        )
+
+        selected, catalog_hash = BENCH.apply_fixture_profile(args)
+
+        self.assertEqual(args.rounds, 4)
+        self.assertEqual(args.families, 8)
+        self.assertEqual(args.admission_concurrency, 16)
+        self.assertEqual(selected["corpus"]["kind"], "hf")
+        self.assertEqual(len(catalog_hash), 64)
+
     def test_reads_a_deterministic_prompt_manifest(self) -> None:
         document = {
             "metadata": {"dataset_revision": "abc123"},

--- a/scripts/tests/test_skippy_waiting_prefix_ab.py
+++ b/scripts/tests/test_skippy_waiting_prefix_ab.py
@@ -74,6 +74,37 @@ class WaitingPrefixAbTest(unittest.TestCase):
 
         self.assertTrue(acceptance["passed"])
 
+    def test_zero_baseline_regression_fails_closed(self) -> None:
+        catalog = json.loads((REPO / "evals/skippy-scheduler-fixtures.json").read_text())
+        profile = catalog["profiles"]["warm-affinity"]
+        rows = [
+            {
+                "version": "old",
+                "successful": 24,
+                "suffix_prefill_tokens_median": 0.0,
+                "family_switches_median": 0.0,
+                "ttft_ms_p50_median": 10.0,
+                "ttft_ms_p95_median": 10.0,
+                "makespan_ms_median": 10.0,
+                "output_tokens_per_second_median": 10.0,
+            },
+            {
+                "version": "new",
+                "successful": 24,
+                "suffix_prefill_tokens_median": 1.0,
+                "family_switches_median": 1.0,
+                "ttft_ms_p50_median": 10.0,
+                "ttft_ms_p95_median": 10.0,
+                "makespan_ms_median": 10.0,
+                "output_tokens_per_second_median": 10.0,
+            },
+        ]
+
+        acceptance = BENCH.evaluate_acceptance(rows, profile)
+
+        self.assertFalse(acceptance["passed"])
+        self.assertIsNone(BENCH.delta(0.0, 1.0))
+
     def test_eviction_profile_enforces_hardware_acceptance(self) -> None:
         catalog = json.loads((REPO / "evals/skippy-scheduler-fixtures.json").read_text())
         profile = catalog["profiles"]["agentic-eviction-pressure"]
@@ -122,6 +153,20 @@ class WaitingPrefixAbTest(unittest.TestCase):
         self.assertEqual(args.admission_concurrency, 16)
         self.assertEqual(selected["corpus"]["kind"], "hf")
         self.assertEqual(len(catalog_hash), 64)
+
+    def test_fixture_input_validation_pins_model_and_manifest_mode(self) -> None:
+        catalog = json.loads((REPO / "evals/skippy-scheduler-fixtures.json").read_text())
+        warm = catalog["profiles"]["warm-affinity"]
+        agentic = catalog["profiles"]["agentic-eviction-pressure"]
+        model = warm["model"]
+
+        BENCH.validate_fixture_inputs(warm, model["id"], model["sha256"], None)
+        with self.assertRaisesRegex(ValueError, "model id"):
+            BENCH.validate_fixture_inputs(warm, "different", model["sha256"], None)
+        with self.assertRaisesRegex(ValueError, "do not accept"):
+            BENCH.validate_fixture_inputs(warm, model["id"], model["sha256"], Path("x"))
+        with self.assertRaisesRegex(ValueError, "require a prepared"):
+            BENCH.validate_fixture_inputs(agentic, model["id"], model["sha256"], None)
 
     def test_reads_a_deterministic_prompt_manifest(self) -> None:
         document = {


### PR DESCRIPTION
## Summary

Pins and fail-closes the scheduler performance certificates used by the stacked capacity work.

- The exact model repository, revision, GGUF filename, file SHA-256, dataset revision, prompt manifest, and embedded tokenizer are fixed.
- Context capacity is derived from checked-in row token totals, request multiplicity, and output allowance, then rounded to the smallest covering power of two. The current derived value is 131,072; it is not duplicated as an unexplained literal.
- Synthetic fixtures reject arbitrary prompt manifests. Hugging Face materialization accepts only the pinned manifest.
- The warm-neutral delta gate treats `old == 0, new > 0` as a regression instead of returning false neutrality.
- The pressure certificate requires an absolute suffix-prefill floor and a family-switch floor, so a workload that never creates pressure fails closed.
- Generator coverage exercises real canned rows, and deterministic DuckDB selection has an explicit tie-break.

## Contracts

The warm certificate proves that an already-materialized profile remains neutral. The pressure certificate proves that the selected trace actually creates recomputation and family switching before comparing policies. These are fixture-validity gates; they do not convert a small four-round performance sample into a universal speedup claim.

## Current validation

Exact reviewed head: `570ac3e23168fd9d1201eff879816baa31755715`

- fixture and harness Python suites: 15 passed at this layer
- fixture catalog validation passed
- `skippy-scheduler`: 22 unit + 7 simulation tests passed
- formatting and diff checks passed

## Stack

This PR targets #1447. #1452 and #1453 remain stacked above it.
