### PR TITLE
feat(skippy): make resident KV admission capacity aware

### DIFF
--- a/crates/skippy-cache/src/lib.rs
+++ b/crates/skippy-cache/src/lib.rs
@@ -14,7 +14,9 @@ pub use payload::{
     CacheBlobStore, CacheBytes, CacheBytesReconstructStats, CacheDedupeStats, ExactStatePayload,
     ExactStatePayloadKind,
 };
-pub use radix::{RadixEviction, RadixMatch, UnifiedRadixCache, UnifiedRadixCacheStats};
+pub use radix::{
+    RadixEviction, RadixEvictionCandidate, RadixMatch, UnifiedRadixCache, UnifiedRadixCacheStats,
+};
 pub use resident::{
     ResidentActivationCache, ResidentActivationLookup, ResidentActivationRecordOutcome,
     ResidentActivationStats,

--- a/crates/skippy-cache/src/radix.rs
+++ b/crates/skippy-cache/src/radix.rs
@@ -81,6 +81,17 @@ pub struct RadixEviction<T> {
     pub value: T,
 }
 
+/// One unreferenced component that may be released by an external capacity
+/// planner. Selecting a candidate does not mutate recency or the tree.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RadixEvictionCandidate<T> {
+    pub namespace: String,
+    pub tokens: Vec<i32>,
+    pub logical_bytes: u64,
+    pub last_used: u64,
+    pub value: T,
+}
+
 /// Aggregate metadata for the logical radix topology and its payloads.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub struct UnifiedRadixCacheStats {
@@ -92,6 +103,7 @@ pub struct UnifiedRadixCacheStats {
     pub resident_tokens: u64,
     pub resident_logical_bytes: u64,
     pub resident_active_refs: u64,
+    pub resident_pinned_tokens: u64,
     pub recurrent_entries: usize,
     pub recurrent_logical_bytes: u64,
     pub recurrent_active_refs: u64,
@@ -279,12 +291,30 @@ impl<R, E> UnifiedRadixCache<R, E> {
 
     pub fn evict_lru_resident(&mut self) -> Option<RadixEviction<R>> {
         let victim = self.lru_victim(ComponentKind::ResidentKv)?;
-        let value = self.remove_resident(&victim.namespace, &victim.tokens)?;
+        self.evict_resident_candidate(&victim.namespace, &victim.tokens)
+    }
+
+    /// Remove one exact unreferenced resident candidate selected by an
+    /// external policy. Active references fail closed and remain resident.
+    pub fn evict_resident_candidate(
+        &mut self,
+        namespace: &str,
+        tokens: &[i32],
+    ) -> Option<RadixEviction<R>> {
+        let entry = node_at(self.roots.get(namespace)?, tokens)?
+            .components
+            .resident
+            .as_ref()?;
+        if entry.active_refs > 0 {
+            return None;
+        }
+        let logical_bytes = entry.logical_bytes;
+        let value = self.remove_resident(namespace, tokens)?;
         self.resident_evictions = self.resident_evictions.saturating_add(1);
         Some(RadixEviction {
-            namespace: victim.namespace,
-            tokens: victim.tokens,
-            logical_bytes: victim.logical_bytes,
+            namespace: namespace.to_string(),
+            tokens: tokens.to_vec(),
+            logical_bytes,
             value,
         })
     }
@@ -336,6 +366,15 @@ impl<R, E> UnifiedRadixCache<R, E> {
 }
 
 impl<R: Clone, E> UnifiedRadixCache<R, E> {
+    /// Snapshot all unreferenced resident entries for capacity planning.
+    pub fn resident_eviction_candidates(&self) -> Vec<RadixEvictionCandidate<R>> {
+        let mut candidates = Vec::new();
+        for (namespace, root) in &self.roots {
+            collect_resident_eviction_candidates(namespace, root, &mut Vec::new(), &mut candidates);
+        }
+        candidates
+    }
+
     /// Find the resident prefix without changing recency or active references.
     /// Scheduler scans must not make merely considered entries look hot.
     pub fn peek_resident(&self, namespace: &str, tokens: &[i32]) -> Option<RadixMatch<R>> {
@@ -889,6 +928,34 @@ fn collect_lru_victim<R, E>(
     path.truncate(original_len);
 }
 
+fn collect_resident_eviction_candidates<R: Clone, E>(
+    namespace: &str,
+    node: &RadixNode<R, E>,
+    path: &mut Vec<i32>,
+    candidates: &mut Vec<RadixEvictionCandidate<R>>,
+) {
+    let original_len = path.len();
+    path.extend_from_slice(&node.edge);
+    if let Some(entry) = node
+        .components
+        .resident
+        .as_ref()
+        .filter(|entry| entry.active_refs == 0)
+    {
+        candidates.push(RadixEvictionCandidate {
+            namespace: namespace.to_string(),
+            tokens: path.clone(),
+            logical_bytes: entry.logical_bytes,
+            last_used: entry.last_used,
+            value: entry.value.clone(),
+        });
+    }
+    for child in node.children.values() {
+        collect_resident_eviction_candidates(namespace, child, path, candidates);
+    }
+    path.truncate(original_len);
+}
+
 fn normalize_root<R, E>(root: &mut RadixNode<R, E>) {
     normalize_children(root);
 }
@@ -947,6 +1014,10 @@ fn accumulate_stats<R, E>(
         stats.resident_active_refs = stats
             .resident_active_refs
             .saturating_add(u64::from(entry.active_refs));
+        if entry.active_refs > 0 {
+            stats.resident_pinned_tokens =
+                stats.resident_pinned_tokens.saturating_add(depth as u64);
+        }
     }
     if let Some(entry) = &node.components.recurrent {
         stats.recurrent_entries = stats.recurrent_entries.saturating_add(1);
@@ -1222,6 +1293,37 @@ mod tests {
         assert_eq!(cache.evict_lru_resident().unwrap().value, "old");
         assert_eq!(cache.stats().resident_evictions, 2);
         assert_eq!(cache.stats().namespaces, 0);
+    }
+
+    #[test]
+    fn capacity_candidates_exclude_pinned_entries_and_support_exact_eviction() {
+        let mut cache = UnifiedRadixCache::<&str, &str>::new();
+        cache
+            .insert_resident("stage", &[1, 2, 3], 30, "pinned")
+            .unwrap();
+        cache
+            .insert_resident("stage", &[4, 5], 20, "evictable")
+            .unwrap();
+        cache.acquire_resident("stage", &[1, 2, 3]).unwrap();
+
+        let candidates = cache.resident_eviction_candidates();
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].tokens, vec![4, 5]);
+        assert_eq!(candidates[0].value, "evictable");
+        assert_eq!(cache.stats().resident_pinned_tokens, 3);
+        assert!(
+            cache
+                .evict_resident_candidate("stage", &[1, 2, 3])
+                .is_none()
+        );
+        assert_eq!(
+            cache
+                .evict_resident_candidate("stage", &[4, 5])
+                .unwrap()
+                .value,
+            "evictable"
+        );
+        assert_eq!(cache.stats().resident_evictions, 1);
     }
 
     #[test]

--- a/crates/skippy-metrics/src/lib.rs
+++ b/crates/skippy-metrics/src/lib.rs
@@ -23,6 +23,22 @@ pub mod attr {
         "skippy.kv.proactive_eviction_target_tokens";
     pub const KV_PROACTIVE_EVICTED_ENTRIES: &str = "skippy.kv.proactive_evicted_entries";
     pub const KV_PROACTIVE_EVICTED_TOKENS: &str = "skippy.kv.proactive_evicted_tokens";
+    pub const KV_CAPACITY_STATUS: &str = "skippy.kv.capacity_status";
+    pub const KV_CAPACITY_TOKENS: &str = "skippy.kv.capacity_tokens";
+    pub const KV_CAPACITY_ACTIVE_TOKENS: &str = "skippy.kv.capacity_active_tokens";
+    pub const KV_CAPACITY_PINNED_TOKENS: &str = "skippy.kv.capacity_pinned_tokens";
+    pub const KV_CAPACITY_REQUEST_TOKENS: &str = "skippy.kv.capacity_request_tokens";
+    pub const KV_CAPACITY_MINIMUM_FREE_TOKENS: &str = "skippy.kv.capacity_minimum_free_tokens";
+    pub const KV_CAPACITY_TARGET_FREE_TOKENS: &str = "skippy.kv.capacity_target_free_tokens";
+    pub const KV_CAPACITY_PROJECTED_FREE_TOKENS: &str = "skippy.kv.capacity_projected_free_tokens";
+    pub const KV_CAPACITY_ADMISSION_DEFICIT_TOKENS: &str =
+        "skippy.kv.capacity_admission_deficit_tokens";
+    pub const KV_CAPACITY_REQUIRED_EVICTION_TOKENS: &str =
+        "skippy.kv.capacity_required_eviction_tokens";
+    pub const KV_CAPACITY_EVICTED_ENTRIES: &str = "skippy.kv.capacity_evicted_entries";
+    pub const KV_CAPACITY_EVICTED_TOKENS: &str = "skippy.kv.capacity_evicted_tokens";
+    pub const KV_CAPACITY_PREDICTED_RECOMPUTE_COST: &str =
+        "skippy.kv.capacity_predicted_recompute_cost";
     pub const VERIFY_WINDOW_DIRECT_RETURN_UPSTREAM_OPENED: &str =
         "llama_stage.verify_window.direct_return_upstream_opened";
     pub const VERIFY_WINDOW_DIRECT_RETURN_REVERSE_FALLBACK: &str =

--- a/crates/skippy-scheduler/src/capacity.rs
+++ b/crates/skippy-scheduler/src/capacity.rs
@@ -47,8 +47,11 @@ pub struct CapacityPlan {
 /// cache entries to recompute until the target free-space watermark is met.
 ///
 /// Pinned cache units are never candidates. Entries are ordered by
-/// recomputation cost per released unit, then total cost, recency, and stable
-/// identity. The plan rejects only when active + pinned + request + minimum
+/// recomputation cost per released unit, then recency, total cost, and stable
+/// identity. Recency precedes total cost when density ties because uniform
+/// per-token stage costs would otherwise prefer small, recently used prefixes
+/// over cold entries that are less likely to be restored again. The plan
+/// rejects only when active + pinned + request + minimum
 /// headroom cannot fit even after every evictable entry is released.
 pub fn plan_component_capacity(
     snapshot: &ComponentCapacitySnapshot,
@@ -122,8 +125,8 @@ fn compare_eviction_value(left: &EvictableCacheEntry, right: &EvictableCacheEntr
     u128::from(left.recompute_cost)
         .saturating_mul(u128::from(right_units))
         .cmp(&u128::from(right.recompute_cost).saturating_mul(u128::from(left_units)))
-        .then_with(|| left.recompute_cost.cmp(&right.recompute_cost))
         .then_with(|| left.last_used.cmp(&right.last_used))
+        .then_with(|| left.recompute_cost.cmp(&right.recompute_cost))
         .then_with(|| left.id.cmp(&right.id))
 }
 
@@ -187,6 +190,32 @@ mod tests {
         assert_eq!(plan.evicted_units, 30);
         assert_eq!(plan.predicted_recompute_cost, 30);
         assert_eq!(plan.projected_free_units, 20);
+    }
+
+    #[test]
+    fn equal_cost_density_prefers_cold_entries_before_smaller_hot_entries() {
+        let plan = plan_component_capacity(
+            &ComponentCapacitySnapshot {
+                component: "kv-cells".into(),
+                capacity_units: 100,
+                active_units: 30,
+                pinned_cache_units: 0,
+                evictable_entries: vec![
+                    entry("cold-large", 30, 300, 1),
+                    entry("hot-small", 10, 100, 2),
+                ],
+            },
+            CapacityDemand {
+                request_units: 20,
+                minimum_free_units: 10,
+                target_free_units: 20,
+            },
+        );
+
+        assert!(plan.admitted);
+        assert_eq!(plan.victim_ids, ["cold-large"]);
+        assert_eq!(plan.evicted_units, 30);
+        assert_eq!(plan.predicted_recompute_cost, 300);
     }
 
     #[test]

--- a/crates/skippy-scheduler/src/capacity.rs
+++ b/crates/skippy-scheduler/src/capacity.rs
@@ -1,0 +1,235 @@
+use std::cmp::Ordering;
+
+/// One releasable cache entry considered by capacity-aware admission.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct EvictableCacheEntry {
+    pub id: String,
+    pub units: u64,
+    pub recompute_cost: u64,
+    pub last_used: u64,
+}
+
+/// Current occupancy for one independently constrained memory component.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ComponentCapacitySnapshot {
+    pub component: String,
+    pub capacity_units: u64,
+    pub active_units: u64,
+    pub pinned_cache_units: u64,
+    pub evictable_entries: Vec<EvictableCacheEntry>,
+}
+
+/// Capacity required before a request may enter execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CapacityDemand {
+    pub request_units: u64,
+    /// Admission must leave at least this much free space after eviction.
+    pub minimum_free_units: u64,
+    /// Healthy operation prefers this much free space when entries are
+    /// releasable. This must be greater than or equal to the minimum.
+    pub target_free_units: u64,
+}
+
+/// Deterministic admission and eviction decision for one component.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CapacityPlan {
+    pub component: String,
+    pub admitted: bool,
+    pub victim_ids: Vec<String>,
+    pub required_eviction_units: u64,
+    pub evicted_units: u64,
+    pub predicted_recompute_cost: u64,
+    pub projected_free_units: u64,
+    pub admission_deficit_units: u64,
+}
+
+/// Admit against pinned-versus-evictable capacity and select the cheapest
+/// cache entries to recompute until the target free-space watermark is met.
+///
+/// Pinned cache units are never candidates. Entries are ordered by
+/// recomputation cost per released unit, then total cost, recency, and stable
+/// identity. The plan rejects only when active + pinned + request + minimum
+/// headroom cannot fit even after every evictable entry is released.
+pub fn plan_component_capacity(
+    snapshot: &ComponentCapacitySnapshot,
+    demand: CapacityDemand,
+) -> CapacityPlan {
+    let minimum_free = demand.minimum_free_units.min(snapshot.capacity_units);
+    let target_free = demand
+        .target_free_units
+        .max(minimum_free)
+        .min(snapshot.capacity_units);
+    let protected_units = snapshot
+        .active_units
+        .saturating_add(snapshot.pinned_cache_units)
+        .saturating_add(demand.request_units);
+    let protected_with_minimum = protected_units.saturating_add(minimum_free);
+    if protected_with_minimum > snapshot.capacity_units {
+        return CapacityPlan {
+            component: snapshot.component.clone(),
+            admitted: false,
+            victim_ids: Vec::new(),
+            required_eviction_units: 0,
+            evicted_units: 0,
+            predicted_recompute_cost: 0,
+            projected_free_units: snapshot.capacity_units.saturating_sub(protected_units),
+            admission_deficit_units: protected_with_minimum.saturating_sub(snapshot.capacity_units),
+        };
+    }
+
+    let evictable_units = snapshot
+        .evictable_entries
+        .iter()
+        .map(|entry| entry.units)
+        .fold(0u64, u64::saturating_add);
+    let projected_occupancy = protected_units.saturating_add(evictable_units);
+    let eviction_target = projected_occupancy
+        .saturating_add(target_free)
+        .saturating_sub(snapshot.capacity_units);
+    let mut candidates = snapshot.evictable_entries.clone();
+    candidates.sort_by(compare_eviction_value);
+    let mut victim_ids = Vec::new();
+    let mut evicted_units = 0u64;
+    let mut predicted_recompute_cost = 0u64;
+    for entry in candidates {
+        if evicted_units >= eviction_target {
+            break;
+        }
+        if entry.units == 0 {
+            continue;
+        }
+        victim_ids.push(entry.id);
+        evicted_units = evicted_units.saturating_add(entry.units);
+        predicted_recompute_cost = predicted_recompute_cost.saturating_add(entry.recompute_cost);
+    }
+    CapacityPlan {
+        component: snapshot.component.clone(),
+        admitted: true,
+        victim_ids,
+        required_eviction_units: eviction_target,
+        evicted_units,
+        predicted_recompute_cost,
+        projected_free_units: snapshot
+            .capacity_units
+            .saturating_sub(projected_occupancy.saturating_sub(evicted_units)),
+        admission_deficit_units: 0,
+    }
+}
+
+fn compare_eviction_value(left: &EvictableCacheEntry, right: &EvictableCacheEntry) -> Ordering {
+    let left_units = left.units.max(1);
+    let right_units = right.units.max(1);
+    u128::from(left.recompute_cost)
+        .saturating_mul(u128::from(right_units))
+        .cmp(&u128::from(right.recompute_cost).saturating_mul(u128::from(left_units)))
+        .then_with(|| left.recompute_cost.cmp(&right.recompute_cost))
+        .then_with(|| left.last_used.cmp(&right.last_used))
+        .then_with(|| left.id.cmp(&right.id))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn entry(id: &str, units: u64, recompute_cost: u64, last_used: u64) -> EvictableCacheEntry {
+        EvictableCacheEntry {
+            id: id.to_string(),
+            units,
+            recompute_cost,
+            last_used,
+        }
+    }
+
+    #[test]
+    fn rejects_when_pinned_capacity_cannot_leave_the_minimum_watermark() {
+        let plan = plan_component_capacity(
+            &ComponentCapacitySnapshot {
+                component: "kv-cells".into(),
+                capacity_units: 100,
+                active_units: 50,
+                pinned_cache_units: 40,
+                evictable_entries: vec![entry("evictable", 10, 10, 0)],
+            },
+            CapacityDemand {
+                request_units: 5,
+                minimum_free_units: 10,
+                target_free_units: 20,
+            },
+        );
+
+        assert!(!plan.admitted);
+        assert_eq!(plan.admission_deficit_units, 5);
+        assert!(plan.victim_ids.is_empty());
+    }
+
+    #[test]
+    fn evicts_low_recompute_cost_before_older_expensive_entries() {
+        let plan = plan_component_capacity(
+            &ComponentCapacitySnapshot {
+                component: "kv-cells".into(),
+                capacity_units: 100,
+                active_units: 30,
+                pinned_cache_units: 0,
+                evictable_entries: vec![
+                    entry("old-expensive", 30, 300, 1),
+                    entry("new-cheap", 30, 30, 2),
+                ],
+            },
+            CapacityDemand {
+                request_units: 20,
+                minimum_free_units: 10,
+                target_free_units: 20,
+            },
+        );
+
+        assert!(plan.admitted);
+        assert_eq!(plan.victim_ids, ["new-cheap"]);
+        assert_eq!(plan.evicted_units, 30);
+        assert_eq!(plan.predicted_recompute_cost, 30);
+        assert_eq!(plan.projected_free_units, 20);
+    }
+
+    #[test]
+    fn target_watermark_evicts_when_the_hard_minimum_was_already_met() {
+        let plan = plan_component_capacity(
+            &ComponentCapacitySnapshot {
+                component: "kv-cells".into(),
+                capacity_units: 100,
+                active_units: 30,
+                pinned_cache_units: 0,
+                evictable_entries: vec![entry("cheap", 20, 20, 0)],
+            },
+            CapacityDemand {
+                request_units: 20,
+                minimum_free_units: 10,
+                target_free_units: 40,
+            },
+        );
+
+        assert!(plan.admitted);
+        assert_eq!(plan.victim_ids, ["cheap"]);
+        assert_eq!(plan.projected_free_units, 50);
+    }
+
+    #[test]
+    fn keeps_every_entry_when_the_target_watermark_is_already_met() {
+        let plan = plan_component_capacity(
+            &ComponentCapacitySnapshot {
+                component: "kv-cells".into(),
+                capacity_units: 100,
+                active_units: 20,
+                pinned_cache_units: 0,
+                evictable_entries: vec![entry("keep", 20, 20, 0)],
+            },
+            CapacityDemand {
+                request_units: 10,
+                minimum_free_units: 10,
+                target_free_units: 30,
+            },
+        );
+
+        assert!(plan.admitted);
+        assert!(plan.victim_ids.is_empty());
+        assert_eq!(plan.projected_free_units, 50);
+    }
+}

--- a/crates/skippy-scheduler/src/lib.rs
+++ b/crates/skippy-scheduler/src/lib.rs
@@ -5,6 +5,7 @@
 //! native ABI requests.
 
 mod cache_policy;
+mod capacity;
 mod config;
 mod engine;
 mod sequence;
@@ -13,6 +14,10 @@ mod telemetry;
 pub use cache_policy::{
     CacheAffinity, CacheAwareCandidate, StageCacheAffinity, order_cache_aware_candidates,
     select_cache_aware_candidate,
+};
+pub use capacity::{
+    CapacityDemand, CapacityPlan, ComponentCapacitySnapshot, EvictableCacheEntry,
+    plan_component_capacity,
 };
 pub use config::{MemoryComponent, SchedulerConfig};
 pub use engine::{AdmissionError, Scheduler, SchedulerSnapshot};

--- a/crates/skippy-server/src/frontend/local_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation.rs
@@ -4,6 +4,8 @@ mod native_mtp_decode;
 #[cfg(test)]
 mod tests;
 mod token_generation;
+#[cfg(test)]
+pub(in crate::frontend) use token_generation::resident_capacity_admission_error;
 
 #[cfg(test)]
 pub(super) use token_generation::{

--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -23,9 +23,11 @@ use openai_frontend::ChatCompletionRequest;
 use openai_frontend::OpenAiError;
 use openai_frontend::OpenAiResult;
 use serde_json::json;
+use skippy_metrics::attr as attr_key;
 use skippy_runtime::NativeMtpDraft as RuntimeNativeMtpDraft;
 use skippy_runtime::SamplingConfig;
 use std::cell::RefCell;
+use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
 
@@ -65,11 +67,92 @@ struct KvRecordResult {
     proactive_eviction_error: Option<anyhow::Error>,
 }
 
+impl Default for KvRecordResult {
+    fn default() -> Self {
+        Self {
+            resident_recorded_pages: 0,
+            proactive_eviction_status: "disabled",
+            proactive_eviction_error_kind: None,
+            proactive_eviction_target_tokens: 0,
+            proactive_evicted_entries: 0,
+            proactive_evicted_tokens: 0,
+            proactive_eviction_error: None,
+        }
+    }
+}
+
+fn insert_resident_capacity_attrs(
+    attrs: &mut BTreeMap<String, serde_json::Value>,
+    decision: &crate::kv_integration::ResidentCapacityDecision,
+) {
+    let status = if !decision.enabled {
+        "disabled"
+    } else if !decision.capacity_known {
+        "unknown_capacity"
+    } else if !decision.admitted {
+        "rejected"
+    } else if decision.evicted_entries > 0 {
+        "evicted"
+    } else {
+        "admitted"
+    };
+    attrs.insert(attr_key::KV_CAPACITY_STATUS.to_string(), json!(status));
+    attrs.insert(
+        attr_key::KV_CAPACITY_TOKENS.to_string(),
+        json!(decision.capacity_tokens),
+    );
+    attrs.insert(
+        attr_key::KV_CAPACITY_ACTIVE_TOKENS.to_string(),
+        json!(decision.active_tokens),
+    );
+    attrs.insert(
+        attr_key::KV_CAPACITY_PINNED_TOKENS.to_string(),
+        json!(decision.pinned_tokens),
+    );
+    attrs.insert(
+        attr_key::KV_CAPACITY_REQUEST_TOKENS.to_string(),
+        json!(decision.request_tokens),
+    );
+    attrs.insert(
+        attr_key::KV_CAPACITY_MINIMUM_FREE_TOKENS.to_string(),
+        json!(decision.minimum_free_tokens),
+    );
+    attrs.insert(
+        attr_key::KV_CAPACITY_TARGET_FREE_TOKENS.to_string(),
+        json!(decision.target_free_tokens),
+    );
+    attrs.insert(
+        attr_key::KV_CAPACITY_PROJECTED_FREE_TOKENS.to_string(),
+        json!(decision.projected_free_tokens),
+    );
+    attrs.insert(
+        attr_key::KV_CAPACITY_ADMISSION_DEFICIT_TOKENS.to_string(),
+        json!(decision.admission_deficit_tokens),
+    );
+    attrs.insert(
+        attr_key::KV_CAPACITY_REQUIRED_EVICTION_TOKENS.to_string(),
+        json!(decision.required_eviction_tokens),
+    );
+    attrs.insert(
+        attr_key::KV_CAPACITY_EVICTED_ENTRIES.to_string(),
+        json!(decision.evicted_entries),
+    );
+    attrs.insert(
+        attr_key::KV_CAPACITY_EVICTED_TOKENS.to_string(),
+        json!(decision.evicted_tokens),
+    );
+    attrs.insert(
+        attr_key::KV_CAPACITY_PREDICTED_RECOMPUTE_COST.to_string(),
+        json!(decision.predicted_recompute_cost),
+    );
+}
+
 struct KvRestoreOutcome {
     runtime_sessions_before: RuntimeSessionStats,
     runtime_sessions_after: RuntimeSessionStats,
     restored_prefill: bool,
     restored_prefill_tokens: usize,
+    capacity: crate::kv_integration::ResidentCapacityDecision,
     record: KvRecordResult,
 }
 
@@ -515,6 +598,7 @@ impl StageOpenAiBackend {
         let recurrent_cache_prefix_token_ids = request
             .recurrent_cache_prefix_token_ids
             .map(<[i32]>::to_vec);
+        let max_tokens = request.max_tokens;
         let (cache_affinity, refresh_cache_affinity) = match self.kv.as_ref() {
             Some(kv) => {
                 let base = self.local_kv_message_base(session_id, request.ids);
@@ -546,6 +630,7 @@ impl StageOpenAiBackend {
                     &scheduler_session_id,
                     prefill_tokens.as_ref(),
                     recurrent_cache_prefix_token_ids.as_deref(),
+                    max_tokens,
                     &mut scheduler_cache_stats,
                 )?;
                 Ok((outcome, scheduler_cache_stats))
@@ -560,6 +645,7 @@ impl StageOpenAiBackend {
             runtime_sessions_after,
             restored_prefill,
             restored_prefill_tokens,
+            capacity,
             record,
         } = outcome;
         let mut attrs = self.openai_attrs(request.ids);
@@ -590,6 +676,7 @@ impl StageOpenAiBackend {
             "skippy.kv.recorded_pages".to_string(),
             json!(record.resident_recorded_pages),
         );
+        insert_resident_capacity_attrs(&mut attrs, &capacity);
         attrs.insert(
             "llama_stage.runtime_lock_wait_ms".to_string(),
             json!(runtime_lock_wait_ms),
@@ -621,6 +708,21 @@ impl StageOpenAiBackend {
                 record.proactive_evicted_tokens,
             ),
         );
+        let mut capacity_attrs = self.openai_attrs(request.ids);
+        insert_resident_capacity_attrs(&mut capacity_attrs, &capacity);
+        self.telemetry
+            .emit("stage.openai_kv_capacity_decision", capacity_attrs);
+        if !capacity.admitted {
+            return Err(OpenAiError::backend(format!(
+                "resident KV capacity admission rejected request: {} token deficit (capacity={}, active={}, pinned={}, request={}, minimum_free={})",
+                capacity.admission_deficit_tokens,
+                capacity.capacity_tokens,
+                capacity.active_tokens,
+                capacity.pinned_tokens,
+                capacity.request_tokens,
+                capacity.minimum_free_tokens,
+            )));
+        }
         if let Some(error) = record.proactive_eviction_error {
             return Err(openai_backend_error(error));
         }
@@ -635,6 +737,7 @@ impl StageOpenAiBackend {
         session_id: &str,
         prefill_tokens: &[i32],
         recurrent_cache_prefix_token_ids: Option<&[i32]>,
+        max_tokens: u32,
         cache_stats: &mut GenerationCacheStats,
     ) -> OpenAiResult<KvRestoreOutcome> {
         let runtime_sessions_before = runtime.session_stats();
@@ -644,6 +747,37 @@ impl StageOpenAiBackend {
         } else {
             (false, 0)
         };
+        let suffix_tokens = prefill_tokens.len().saturating_sub(restored_prefill_tokens) as u64;
+        let capacity = if let Some(kv) = self.kv.as_ref() {
+            let decode_batch_tokens = runtime
+                .admit_session_batch_size(session_id)
+                .map_err(openai_backend_error)? as u64;
+            let target_free_tokens =
+                decode_batch_tokens.saturating_add(u64::from(max_tokens).min(decode_batch_tokens));
+            kv.admit_resident_capacity(
+                runtime,
+                session_id,
+                suffix_tokens,
+                decode_batch_tokens,
+                target_free_tokens,
+            )
+            .map_err(openai_backend_error)?
+        } else {
+            crate::kv_integration::ResidentCapacityDecision {
+                admitted: true,
+                ..crate::kv_integration::ResidentCapacityDecision::default()
+            }
+        };
+        if !capacity.admitted {
+            return Ok(KvRestoreOutcome {
+                runtime_sessions_before,
+                runtime_sessions_after: runtime.session_stats(),
+                restored_prefill,
+                restored_prefill_tokens,
+                capacity,
+                record: KvRecordResult::default(),
+            });
+        }
         let mut decoded_prefill_suffix = false;
         if restored_prefill_tokens < prefill_tokens.len() {
             decoded_prefill_suffix = true;
@@ -721,6 +855,7 @@ impl StageOpenAiBackend {
             runtime_sessions_after,
             restored_prefill,
             restored_prefill_tokens,
+            capacity,
             record,
         })
     }
@@ -1445,6 +1580,40 @@ pub(super) fn decode_native_mtp(
             proposal_compute_us: draft.proposal_compute_us,
         }),
     ))
+}
+
+#[cfg(test)]
+#[test]
+fn resident_capacity_attrs_report_bounded_rejection_evidence() {
+    let mut attrs = BTreeMap::new();
+    insert_resident_capacity_attrs(
+        &mut attrs,
+        &crate::kv_integration::ResidentCapacityDecision {
+            enabled: true,
+            capacity_known: true,
+            admitted: false,
+            capacity_tokens: 100,
+            active_tokens: 60,
+            pinned_tokens: 30,
+            request_tokens: 8,
+            minimum_free_tokens: 5,
+            target_free_tokens: 10,
+            projected_free_tokens: 2,
+            admission_deficit_tokens: 3,
+            ..crate::kv_integration::ResidentCapacityDecision::default()
+        },
+    );
+
+    assert_eq!(
+        attrs.get(attr_key::KV_CAPACITY_STATUS),
+        Some(&json!("rejected"))
+    );
+    assert_eq!(
+        attrs.get(attr_key::KV_CAPACITY_ADMISSION_DEFICIT_TOKENS),
+        Some(&json!(3))
+    );
+    assert!(!attrs.contains_key(attr_key::REQUEST_ID));
+    assert!(!attrs.contains_key(attr_key::SESSION_ID));
 }
 
 #[cfg(test)]

--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -2,6 +2,7 @@ use super::native_mtp_decode::NativeMtpSpanProgress;
 use crate::frontend::NativeMtpDecodeOptions;
 use crate::frontend::NativeMtpDraft;
 use crate::frontend::NativeMtpVerifier;
+use crate::frontend::generation::GENERATION_RETRY_AFTER_SECS;
 use crate::frontend::generation::GenerationCacheStats;
 use crate::frontend::generation::LocalGeneration;
 use crate::frontend::generation::OpenAiGenerationIds;
@@ -19,8 +20,10 @@ use crate::kv_integration::proactive_eviction_attrs;
 use crate::kv_integration::proactive_eviction_error_kind;
 use crate::kv_integration::{KvStageIntegration, StagePrefixCachePayload};
 use crate::runtime_state::{RuntimeSessionStats, RuntimeState};
+use axum::http::StatusCode;
 use openai_frontend::ChatCompletionRequest;
 use openai_frontend::OpenAiError;
+use openai_frontend::OpenAiErrorKind;
 use openai_frontend::OpenAiResult;
 use serde_json::json;
 use skippy_metrics::attr as attr_key;
@@ -32,6 +35,25 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use super::{LocalGenerationReceiptFinalization, prompt_fits_single_prefill_sample};
+
+pub(in crate::frontend) fn resident_capacity_admission_error(
+    capacity: &crate::kv_integration::ResidentCapacityDecision,
+) -> OpenAiError {
+    OpenAiError::from_kind(
+        StatusCode::TOO_MANY_REQUESTS,
+        OpenAiErrorKind::RateLimit,
+        format!(
+            "resident KV capacity admission rejected request: {} token deficit (capacity={}, active={}, pinned={}, request={}, minimum_free={})",
+            capacity.admission_deficit_tokens,
+            capacity.capacity_tokens,
+            capacity.active_tokens,
+            capacity.pinned_tokens,
+            capacity.request_tokens,
+            capacity.minimum_free_tokens,
+        ),
+    )
+    .with_retry_after_secs(GENERATION_RETRY_AFTER_SECS)
+}
 
 pub(super) fn commit_local_generation_token(
     config: Option<&crate::frontend::GenerationReceiptConfig>,
@@ -713,15 +735,7 @@ impl StageOpenAiBackend {
         self.telemetry
             .emit("stage.openai_kv_capacity_decision", capacity_attrs);
         if !capacity.admitted {
-            return Err(OpenAiError::backend(format!(
-                "resident KV capacity admission rejected request: {} token deficit (capacity={}, active={}, pinned={}, request={}, minimum_free={})",
-                capacity.admission_deficit_tokens,
-                capacity.capacity_tokens,
-                capacity.active_tokens,
-                capacity.pinned_tokens,
-                capacity.request_tokens,
-                capacity.minimum_free_tokens,
-            )));
+            return Err(resident_capacity_admission_error(&capacity));
         }
         if let Some(error) = record.proactive_eviction_error {
             return Err(openai_backend_error(error));
@@ -741,23 +755,14 @@ impl StageOpenAiBackend {
         cache_stats: &mut GenerationCacheStats,
     ) -> OpenAiResult<KvRestoreOutcome> {
         let runtime_sessions_before = runtime.session_stats();
-        let (restored_prefill, restored_prefill_tokens) = if let Some(kv) = self.kv.as_ref() {
-            cache_stats.status = "miss";
-            self.lookup_and_restore_kv(kv, runtime, session_id, ids, prefill_tokens, cache_stats)
-        } else {
-            (false, 0)
-        };
-        let suffix_tokens = prefill_tokens.len().saturating_sub(restored_prefill_tokens) as u64;
         let capacity = if let Some(kv) = self.kv.as_ref() {
-            let decode_batch_tokens = runtime
-                .admit_session_batch_size(session_id)
-                .map_err(openai_backend_error)? as u64;
+            let decode_batch_tokens = u64::from(self.config.n_batch.unwrap_or(2048));
             let target_free_tokens =
                 decode_batch_tokens.saturating_add(u64::from(max_tokens).min(decode_batch_tokens));
             kv.admit_resident_capacity(
                 runtime,
                 session_id,
-                suffix_tokens,
+                prefill_tokens.len() as u64,
                 decode_batch_tokens,
                 target_free_tokens,
             )
@@ -772,12 +777,18 @@ impl StageOpenAiBackend {
             return Ok(KvRestoreOutcome {
                 runtime_sessions_before,
                 runtime_sessions_after: runtime.session_stats(),
-                restored_prefill,
-                restored_prefill_tokens,
+                restored_prefill: false,
+                restored_prefill_tokens: 0,
                 capacity,
                 record: KvRecordResult::default(),
             });
         }
+        let (restored_prefill, restored_prefill_tokens) = if let Some(kv) = self.kv.as_ref() {
+            cache_stats.status = "miss";
+            self.lookup_and_restore_kv(kv, runtime, session_id, ids, prefill_tokens, cache_stats)
+        } else {
+            (false, 0)
+        };
         let mut decoded_prefill_suffix = false;
         if restored_prefill_tokens < prefill_tokens.len() {
             decoded_prefill_suffix = true;

--- a/crates/skippy-server/src/frontend/tests/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/tests/prefix_cache.rs
@@ -36,6 +36,43 @@ fn proactive_eviction_attrs_are_bounded_and_request_free() {
 }
 
 #[test]
+fn resident_capacity_rejection_is_side_effect_free_and_retryable() {
+    let config = prefix_cache_test_config();
+    let kv = KvStageIntegration::from_config(&config)
+        .unwrap()
+        .expect("resident prefix cache enabled");
+    let mut runtime = crate::runtime_state::RuntimeState::new_modelless_with_capacity_for_test(
+        config.lane_count,
+        8,
+    );
+    let before = runtime.session_stats();
+
+    let first = kv
+        .admit_resident_capacity(&mut runtime, "request", 9, 1, 1)
+        .unwrap();
+    let second = kv
+        .admit_resident_capacity(&mut runtime, "request", 9, 1, 1)
+        .unwrap();
+    let recovered = kv
+        .admit_resident_capacity(&mut runtime, "request", 4, 1, 1)
+        .unwrap();
+
+    assert!(!first.admitted);
+    assert!(recovered.admitted);
+    assert_eq!(second.active_tokens, first.active_tokens);
+    assert_eq!(
+        second.admission_deficit_tokens,
+        first.admission_deficit_tokens
+    );
+    assert_eq!(runtime.session_stats(), before);
+
+    let response = crate::frontend::local_generation::resident_capacity_admission_error(&first)
+        .into_response();
+    assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+    assert_eq!(response.headers().get("retry-after").unwrap(), "1");
+}
+
+#[test]
 fn openai_cache_stats_default_to_disabled() {
     let stats = GenerationCacheStats::default();
 

--- a/crates/skippy-server/src/frontend/tests/support.rs
+++ b/crates/skippy-server/src/frontend/tests/support.rs
@@ -94,6 +94,7 @@ pub(super) fn seed_resident_prefix(kv: &KvStageIntegration, identity: &PrefillKv
                 page_id: identity.page_id.clone(),
                 seq_id,
                 token_count,
+                recompute_cost: token_count,
             },
         )
         .expect("synthetic radix prefix should record");

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -34,6 +34,7 @@ pub use records::{
     RecordPageOutcome, ResidentActivationRecord, ResidentActivationRestore, ResidentPrefixRecord,
     ResidentPrefixRestore,
 };
+pub use resident_prefix::{ResidentCapacityDecision, ResidentPrefixEviction};
 
 /// Return a bounded, stable telemetry class without exporting error text.
 ///
@@ -175,6 +176,9 @@ pub(crate) struct RadixResidentEntry {
     pub(crate) page_id: String,
     pub(crate) seq_id: i32,
     pub(crate) token_count: u64,
+    /// Deterministic first-order estimate of work needed to recreate this
+    /// entry: cached tokens multiplied by stage-local layer count.
+    pub(crate) recompute_cost: u64,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/skippy-server/src/kv_integration/resident_prefix.rs
+++ b/crates/skippy-server/src/kv_integration/resident_prefix.rs
@@ -1,4 +1,7 @@
 use anyhow::{Context, Result};
+use skippy_scheduler::{
+    CapacityDemand, ComponentCapacitySnapshot, EvictableCacheEntry, plan_component_capacity,
+};
 
 use crate::runtime_state::RuntimeState;
 
@@ -35,7 +38,132 @@ impl Drop for ResidentRadixLease {
     }
 }
 
+#[derive(Debug, Clone, Default)]
+pub struct ResidentCapacityDecision {
+    pub enabled: bool,
+    pub capacity_known: bool,
+    pub admitted: bool,
+    pub capacity_tokens: u64,
+    pub active_tokens: u64,
+    pub pinned_tokens: u64,
+    pub request_tokens: u64,
+    pub minimum_free_tokens: u64,
+    pub target_free_tokens: u64,
+    pub projected_free_tokens: u64,
+    pub admission_deficit_tokens: u64,
+    pub required_eviction_tokens: u64,
+    pub evicted_entries: usize,
+    pub evicted_tokens: u64,
+    pub predicted_recompute_cost: u64,
+}
+
 impl KvStageIntegration {
+    /// Admit one resident-KV operation against the native unified KV pool and
+    /// release the cheapest unreferenced prefixes needed to reach the healthy
+    /// free-space watermark. Native sequence deletion always precedes radix
+    /// mutation, so a runtime failure leaves the selected cache entry intact.
+    pub fn admit_resident_capacity(
+        &self,
+        runtime: &mut RuntimeState,
+        session_id: &str,
+        request_tokens: u64,
+        minimum_free_tokens: u64,
+        target_free_tokens: u64,
+    ) -> Result<ResidentCapacityDecision> {
+        if self.payload != StagePrefixCachePayload::ResidentKv {
+            return Ok(ResidentCapacityDecision {
+                admitted: true,
+                ..ResidentCapacityDecision::default()
+            });
+        }
+        let capacity_tokens = u64::from(runtime.kv_pool_tokens());
+        let active_tokens = runtime.session_stats().total_session_tokens;
+        if capacity_tokens == 0 {
+            return Ok(ResidentCapacityDecision {
+                enabled: true,
+                admitted: true,
+                active_tokens,
+                request_tokens,
+                minimum_free_tokens,
+                target_free_tokens,
+                ..ResidentCapacityDecision::default()
+            });
+        }
+
+        let mut radix = self.radix.lock().expect("radix cache lock poisoned");
+        let stats = radix.stats();
+        let candidates = radix.resident_eviction_candidates();
+        let plan = plan_component_capacity(
+            &ComponentCapacitySnapshot {
+                component: "resident-kv-tokens".to_string(),
+                capacity_units: capacity_tokens,
+                active_units: active_tokens,
+                pinned_cache_units: stats.resident_pinned_tokens,
+                evictable_entries: candidates
+                    .iter()
+                    .map(|candidate| EvictableCacheEntry {
+                        id: candidate.value.seq_id.to_string(),
+                        units: candidate.value.token_count,
+                        recompute_cost: candidate.value.recompute_cost,
+                        last_used: candidate.last_used,
+                    })
+                    .collect(),
+            },
+            CapacityDemand {
+                request_units: request_tokens,
+                minimum_free_units: minimum_free_tokens,
+                target_free_units: target_free_tokens,
+            },
+        );
+        let mut decision = ResidentCapacityDecision {
+            enabled: true,
+            capacity_known: true,
+            admitted: plan.admitted,
+            capacity_tokens,
+            active_tokens,
+            pinned_tokens: stats.resident_pinned_tokens,
+            request_tokens,
+            minimum_free_tokens,
+            target_free_tokens,
+            projected_free_tokens: plan.projected_free_units,
+            admission_deficit_tokens: plan.admission_deficit_units,
+            required_eviction_tokens: plan.required_eviction_units,
+            predicted_recompute_cost: plan.predicted_recompute_cost,
+            ..ResidentCapacityDecision::default()
+        };
+        if !plan.admitted {
+            return Ok(decision);
+        }
+
+        let mut sequences = self
+            .resident_sequences
+            .lock()
+            .expect("resident sequence pool lock poisoned");
+        for victim_id in &plan.victim_ids {
+            let Some(victim) = candidates
+                .iter()
+                .find(|candidate| candidate.value.seq_id.to_string() == *victim_id)
+            else {
+                anyhow::bail!("capacity planner selected missing resident victim {victim_id}");
+            };
+            runtime.drop_resident_prefix_sequence(session_id, victim.value.seq_id)?;
+            let removed = radix
+                .evict_resident_candidate(&victim.namespace, &victim.tokens)
+                .with_context(|| {
+                    format!(
+                        "resident victim {} became unavailable after native deletion",
+                        victim.value.seq_id
+                    )
+                })?;
+            sequences.release(removed.value.seq_id);
+            decision.evicted_entries = decision.evicted_entries.saturating_add(1);
+            decision.evicted_tokens = decision
+                .evicted_tokens
+                .saturating_add(removed.value.token_count);
+        }
+        Ok(decision)
+    }
+
     pub fn probe_resident_prefix(
         &self,
         identity: &PrefillKvIdentity,
@@ -161,20 +289,21 @@ impl KvStageIntegration {
         session_id: &str,
     ) -> Result<ResidentPrefixEviction> {
         let decode_batch_tokens = runtime.active_session_batch_size(session_id)? as u64;
-        let active_session_tokens = runtime.session_stats().total_session_tokens;
-        let resident_tokens = self
-            .radix
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .stats()
-            .resident_tokens;
-        let target_tokens = proactive_resident_eviction_target(
-            u64::from(runtime.kv_pool_tokens()),
-            active_session_tokens,
-            resident_tokens,
+        if runtime.kv_pool_tokens() == 0 {
+            return self.evict_resident_prefix_for_tokens(runtime, session_id, decode_batch_tokens);
+        }
+        let decision = self.admit_resident_capacity(
+            runtime,
+            session_id,
+            0,
             decode_batch_tokens,
-        );
-        self.evict_resident_prefix_for_tokens(runtime, session_id, target_tokens)
+            decode_batch_tokens,
+        )?;
+        Ok(ResidentPrefixEviction {
+            target_tokens: decision.required_eviction_tokens,
+            evicted_entries: decision.evicted_entries,
+            evicted_tokens: decision.evicted_tokens,
+        })
     }
 
     pub fn record_resident_prefix(
@@ -285,6 +414,7 @@ impl KvStageIntegration {
                 page_id: identity.page_id.clone(),
                 seq_id,
                 token_count: token_count as u64,
+                recompute_cost: (token_count as u64).saturating_mul(u64::from(layer_count)),
             },
             |seq_id| runtime.drop_resident_prefix_sequence(session_id, seq_id),
         )?;
@@ -323,12 +453,44 @@ fn evict_one_resident(
     sequences: &mut ResidentSequencePool,
     mut drop_native: impl FnMut(i32) -> Result<()>,
 ) -> Result<Option<skippy_cache::RadixEviction<RadixResidentEntry>>> {
-    let Some(victim) = radix.lru_resident_candidate() else {
+    let stats = radix.stats();
+    let candidates = radix.resident_eviction_candidates();
+    if candidates.is_empty() {
         return Ok(None);
-    };
+    }
+    let plan = plan_component_capacity(
+        &ComponentCapacitySnapshot {
+            component: "resident-kv-tokens".to_string(),
+            capacity_units: stats.resident_tokens,
+            active_units: 0,
+            pinned_cache_units: stats.resident_pinned_tokens,
+            evictable_entries: candidates
+                .iter()
+                .map(|candidate| EvictableCacheEntry {
+                    id: candidate.value.seq_id.to_string(),
+                    units: candidate.value.token_count,
+                    recompute_cost: candidate.value.recompute_cost,
+                    last_used: candidate.last_used,
+                })
+                .collect(),
+        },
+        CapacityDemand {
+            request_units: 0,
+            minimum_free_units: 0,
+            target_free_units: 1,
+        },
+    );
+    let victim_id = plan
+        .victim_ids
+        .first()
+        .context("resident capacity planner returned no victim")?;
+    let victim = candidates
+        .iter()
+        .find(|candidate| candidate.value.seq_id.to_string() == *victim_id)
+        .context("resident capacity planner selected missing victim")?;
     drop_native(victim.value.seq_id)?;
     let removed = radix
-        .evict_lru_resident()
+        .evict_resident_candidate(&victim.namespace, &victim.tokens)
         .expect("selected radix resident victim should exist");
     debug_assert_eq!(removed.value.page_id, victim.value.page_id);
     sequences.release(removed.value.seq_id);
@@ -366,21 +528,6 @@ fn insert_saved_resident(
     }
 }
 
-fn proactive_resident_eviction_target(
-    kv_pool_tokens: u64,
-    active_session_tokens: u64,
-    resident_tokens: u64,
-    decode_batch_tokens: u64,
-) -> u64 {
-    if kv_pool_tokens == 0 {
-        return decode_batch_tokens;
-    }
-    active_session_tokens
-        .saturating_add(resident_tokens)
-        .saturating_add(decode_batch_tokens)
-        .saturating_sub(kv_pool_tokens)
-}
-
 fn resident_estimated_bytes(token_count: u64, layer_count: u32) -> u64 {
     token_count
         .saturating_mul(u64::from(layer_count))
@@ -390,30 +537,6 @@ fn resident_estimated_bytes(token_count: u64, layer_count: u32) -> u64 {
 #[cfg(test)]
 mod proactive_eviction_tests {
     use super::*;
-
-    #[test]
-    fn keeps_resident_prefixes_when_unified_pool_already_has_batch_headroom() {
-        assert_eq!(
-            proactive_resident_eviction_target(32_768, 776, 1_992, 2_048),
-            0
-        );
-    }
-
-    #[test]
-    fn evicts_only_the_unified_pool_deficit() {
-        assert_eq!(
-            proactive_resident_eviction_target(8_192, 6_500, 1_500, 2_048),
-            1_856
-        );
-    }
-
-    #[test]
-    fn unknown_pool_preserves_fixed_batch_fallback() {
-        assert_eq!(
-            proactive_resident_eviction_target(0, 776, 1_992, 2_048),
-            2_048
-        );
-    }
 
     #[test]
     fn native_drop_failure_preserves_the_radix_entry_and_sequence_id() {
@@ -429,6 +552,7 @@ mod proactive_eviction_tests {
                     page_id: "page".to_string(),
                     seq_id,
                     token_count: 3,
+                    recompute_cost: 3,
                 },
             )
             .unwrap();
@@ -457,6 +581,7 @@ mod proactive_eviction_tests {
                     page_id: "page".to_string(),
                     seq_id,
                     token_count: 3,
+                    recompute_cost: 3,
                 },
             )
             .unwrap();
@@ -489,6 +614,7 @@ mod proactive_eviction_tests {
                     page_id: "page".to_string(),
                     seq_id: 1,
                     token_count: 3,
+                    recompute_cost: 3,
                 },
             )
             .unwrap();
@@ -515,6 +641,52 @@ mod proactive_eviction_tests {
     }
 
     #[test]
+    fn eviction_prefers_low_recompute_cost_over_lru_age() {
+        let mut radix = skippy_cache::UnifiedRadixCache::new();
+        let mut sequences = ResidentSequencePool::new(1);
+        let expensive_seq_id = sequences.allocate().unwrap();
+        radix
+            .insert_resident(
+                "stage",
+                &[1, 2, 3],
+                3,
+                RadixResidentEntry {
+                    page_id: "old-expensive".to_string(),
+                    seq_id: expensive_seq_id,
+                    token_count: 3,
+                    recompute_cost: 300,
+                },
+            )
+            .unwrap();
+        let cheap_seq_id = sequences.allocate().unwrap();
+        radix
+            .insert_resident(
+                "stage",
+                &[4, 5, 6],
+                3,
+                RadixResidentEntry {
+                    page_id: "new-cheap".to_string(),
+                    seq_id: cheap_seq_id,
+                    token_count: 3,
+                    recompute_cost: 3,
+                },
+            )
+            .unwrap();
+        let mut dropped = None;
+
+        let removed = evict_one_resident(&mut radix, &mut sequences, |seq_id| {
+            dropped = Some(seq_id);
+            Ok(())
+        })
+        .unwrap()
+        .unwrap();
+
+        assert_eq!(dropped, Some(cheap_seq_id));
+        assert_eq!(removed.value.page_id, "new-cheap");
+        assert!(radix.resident_exact("stage", &[1, 2, 3]).is_some());
+    }
+
+    #[test]
     fn radix_insert_failure_rolls_back_native_state_and_recycles_sequence_id() {
         let mut radix = skippy_cache::UnifiedRadixCache::new();
         let mut sequences = ResidentSequencePool::new(4);
@@ -531,6 +703,7 @@ mod proactive_eviction_tests {
                 page_id: "page".to_string(),
                 seq_id,
                 token_count: 0,
+                recompute_cost: 0,
             },
             |seq_id| {
                 dropped = Some(seq_id);
@@ -562,6 +735,7 @@ mod proactive_eviction_tests {
                     page_id: "existing".to_string(),
                     seq_id: existing_seq_id,
                     token_count: 3,
+                    recompute_cost: 3,
                 },
             )
             .unwrap();
@@ -578,6 +752,7 @@ mod proactive_eviction_tests {
                 page_id: "duplicate".to_string(),
                 seq_id: duplicate_seq_id,
                 token_count: 3,
+                recompute_cost: 3,
             },
             |seq_id| {
                 dropped = Some(seq_id);

--- a/crates/skippy-server/src/kv_integration/resident_prefix.rs
+++ b/crates/skippy-server/src/kv_integration/resident_prefix.rs
@@ -59,7 +59,7 @@ pub struct ResidentCapacityDecision {
 
 impl KvStageIntegration {
     /// Admit one resident-KV operation against the native unified KV pool and
-    /// release the cheapest unreferenced prefixes needed to reach the healthy
+    /// release deterministic unreferenced prefixes needed to reach the healthy
     /// free-space watermark. Native sequence deletion always precedes radix
     /// mutation, so a runtime failure leaves the selected cache entry intact.
     pub fn admit_resident_capacity(
@@ -90,7 +90,10 @@ impl KvStageIntegration {
             });
         }
 
-        let mut radix = self.radix.lock().expect("radix cache lock poisoned");
+        let mut radix = self
+            .radix
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let stats = radix.stats();
         let candidates = radix.resident_eviction_candidates();
         let plan = plan_component_capacity(
@@ -103,7 +106,7 @@ impl KvStageIntegration {
                     .iter()
                     .map(|candidate| EvictableCacheEntry {
                         id: candidate.value.seq_id.to_string(),
-                        units: candidate.value.token_count,
+                        units: resident_candidate_units(candidate),
                         recompute_cost: candidate.value.recompute_cost,
                         last_used: candidate.last_used,
                     })
@@ -135,10 +138,14 @@ impl KvStageIntegration {
             return Ok(decision);
         }
 
+        if !plan.victim_ids.is_empty() {
+            runtime.ensure_session_active(session_id)?;
+        }
+
         let mut sequences = self
             .resident_sequences
             .lock()
-            .expect("resident sequence pool lock poisoned");
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         for victim_id in &plan.victim_ids {
             let Some(victim) = candidates
                 .iter()
@@ -299,6 +306,9 @@ impl KvStageIntegration {
             decode_batch_tokens,
             decode_batch_tokens,
         )?;
+        if !decision.admitted {
+            return self.evict_resident_prefix_for_tokens(runtime, session_id, decode_batch_tokens);
+        }
         Ok(ResidentPrefixEviction {
             target_tokens: decision.required_eviction_tokens,
             evicted_entries: decision.evicted_entries,
@@ -453,7 +463,6 @@ fn evict_one_resident(
     sequences: &mut ResidentSequencePool,
     mut drop_native: impl FnMut(i32) -> Result<()>,
 ) -> Result<Option<skippy_cache::RadixEviction<RadixResidentEntry>>> {
-    let stats = radix.stats();
     let candidates = radix.resident_eviction_candidates();
     if candidates.is_empty() {
         return Ok(None);
@@ -461,14 +470,17 @@ fn evict_one_resident(
     let plan = plan_component_capacity(
         &ComponentCapacitySnapshot {
             component: "resident-kv-tokens".to_string(),
-            capacity_units: stats.resident_tokens,
+            capacity_units: candidates
+                .iter()
+                .map(resident_candidate_units)
+                .fold(0u64, u64::saturating_add),
             active_units: 0,
-            pinned_cache_units: stats.resident_pinned_tokens,
+            pinned_cache_units: 0,
             evictable_entries: candidates
                 .iter()
                 .map(|candidate| EvictableCacheEntry {
                     id: candidate.value.seq_id.to_string(),
-                    units: candidate.value.token_count,
+                    units: resident_candidate_units(candidate),
                     recompute_cost: candidate.value.recompute_cost,
                     last_used: candidate.last_used,
                 })
@@ -495,6 +507,15 @@ fn evict_one_resident(
     debug_assert_eq!(removed.value.page_id, victim.value.page_id);
     sequences.release(removed.value.seq_id);
     Ok(Some(removed))
+}
+
+fn resident_candidate_units(
+    candidate: &skippy_cache::RadixEvictionCandidate<RadixResidentEntry>,
+) -> u64 {
+    candidate
+        .value
+        .token_count
+        .max(candidate.tokens.len() as u64)
 }
 
 fn insert_saved_resident(
@@ -597,6 +618,38 @@ mod proactive_eviction_tests {
         assert!(removed.is_none());
         assert!(!dropped);
         assert_eq!(radix.stats().resident_entries, 1);
+    }
+
+    #[test]
+    fn zero_metadata_token_count_falls_back_to_radix_path_length() {
+        let mut radix = skippy_cache::UnifiedRadixCache::new();
+        let mut sequences = ResidentSequencePool::new(1);
+        let seq_id = sequences.allocate().unwrap();
+        radix
+            .insert_resident(
+                "stage",
+                &[1, 2, 3],
+                3,
+                RadixResidentEntry {
+                    page_id: "legacy-zero".to_string(),
+                    seq_id,
+                    token_count: 0,
+                    recompute_cost: 0,
+                },
+            )
+            .unwrap();
+        let mut dropped = None;
+
+        let removed = evict_one_resident(&mut radix, &mut sequences, |seq_id| {
+            dropped = Some(seq_id);
+            Ok(())
+        })
+        .unwrap()
+        .expect("zero-metadata resident entry should remain evictable");
+
+        assert_eq!(dropped, Some(seq_id));
+        assert_eq!(removed.value.page_id, "legacy-zero");
+        assert_eq!(radix.stats().resident_entries, 0);
     }
 
     #[test]

--- a/crates/skippy-server/src/runtime_state.rs
+++ b/crates/skippy-server/src/runtime_state.rs
@@ -142,12 +142,17 @@ impl RuntimeState {
     /// this must not be used to drive inference.
     #[cfg(test)]
     pub(crate) fn new_modelless_for_test(lane_count: u32) -> Self {
+        Self::new_modelless_with_capacity_for_test(lane_count, 0)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn new_modelless_with_capacity_for_test(lane_count: u32, ctx_size: u32) -> Self {
         Self {
             model: StageModel::new_dummy(),
             layer_start: 0,
             layer_end: 1,
             lane_count,
-            ctx_size: 0,
+            ctx_size,
             next_lane_index: 0,
             free_lane_indices: Vec::new(),
             sessions: BTreeMap::new(),

--- a/docs/SKIPPY.md
+++ b/docs/SKIPPY.md
@@ -459,6 +459,14 @@ agentic eviction-pressure profiles in
 is inference-free; periodic hardware runs fetch and verify the pinned Hugging
 Face corpus in the shared cache and never vendor trajectory data.
 
+Resident-KV admission is capacity-aware: active sessions and referenced cache
+entries are non-evictable, while releasable prefixes are ranked by estimated
+recomputation cost per KV token. Admission preserves a hard decode watermark,
+evicts through a larger healthy watermark to avoid churn, and rejects with an
+explicit deficit when pinned pressure makes the request impossible. The first
+cost proxy is prefix tokens multiplied by local stage layers; calibrated stage
+duration is the planned replacement.
+
 Example shape:
 
 ```toml

--- a/docs/SKIPPY.md
+++ b/docs/SKIPPY.md
@@ -460,12 +460,14 @@ is inference-free; periodic hardware runs fetch and verify the pinned Hugging
 Face corpus in the shared cache and never vendor trajectory data.
 
 Resident-KV admission is capacity-aware: active sessions and referenced cache
-entries are non-evictable, while releasable prefixes are ranked by estimated
-recomputation cost per KV token. Admission preserves a hard decode watermark,
-evicts through a larger healthy watermark to avoid churn, and rejects with an
-explicit deficit when pinned pressure makes the request impossible. The first
-cost proxy is prefix tokens multiplied by local stage layers; calibrated stage
-duration is the planned replacement.
+entries are non-evictable. Admission preserves a hard decode watermark, evicts
+through a larger healthy watermark to avoid churn, and returns a retriable 429
+with an explicit deficit when pinned pressure makes the request impossible.
+The current resident backend has a uniform per-token recomputation proxy
+(prefix tokens multiplied by the same stage-local layer count), so its density
+comparison intentionally collapses to cold-first LRU ordering. A future
+calibrated stage-duration signal can make the generic planner's cost dimension
+meaningful without changing its contract.
 
 Example shape:
 

--- a/docs/design/SKIPPY_UNIFIED_RADIX_CACHE.md
+++ b/docs/design/SKIPPY_UNIFIED_RADIX_CACHE.md
@@ -58,6 +58,23 @@ the radix path and are never replaced by a short hash.
   only to the request sequence.
 - Capacity is charged in native KV cells/tokens and estimated bytes.
 
+Resident-KV admission uses the runtime's unified KV-cell ceiling rather than
+the cache's entry limit alone. The planner accounts separately for active
+session tokens, referenced (pinned) resident prefixes, and unreferenced
+prefixes. It rejects only when active + pinned + request + the minimum decode
+watermark cannot fit after every releasable prefix is removed. Otherwise it
+evicts until a larger healthy watermark is reached, ranking candidates by
+predicted recomputation work per released token, total recomputation work,
+recency, and stable identity. The current cost estimate is cached tokens times
+the stage-local layer count; stage timing calibration can replace that proxy
+without changing the planner contract.
+
+Native sequence deletion precedes exact radix removal for every selected
+victim. A failed native drop therefore leaves the logical cache owner and its
+sequence-id allocation intact. Capacity decisions report active, pinned,
+requested, minimum/target/projected-free, deficit, victim, and predicted-cost
+fields through `stage.openai_kv_capacity_decision` telemetry.
+
 ### KvRecurrent
 
 - The tree can share prefix identity and policy with ResidentKv, but recurrent

--- a/docs/design/SKIPPY_UNIFIED_RADIX_CACHE.md
+++ b/docs/design/SKIPPY_UNIFIED_RADIX_CACHE.md
@@ -64,16 +64,24 @@ session tokens, referenced (pinned) resident prefixes, and unreferenced
 prefixes. It rejects only when active + pinned + request + the minimum decode
 watermark cannot fit after every releasable prefix is removed. Otherwise it
 evicts until a larger healthy watermark is reached, ranking candidates by
-predicted recomputation work per released token, total recomputation work,
-recency, and stable identity. The current cost estimate is cached tokens times
-the stage-local layer count; stage timing calibration can replace that proxy
-without changing the planner contract.
+predicted recomputation work per released token, recency, total work, and
+stable identity. The current resident estimate is cached tokens times a
+stage-local layer count that is constant for every entry, so density ties and
+recency is the effective production policy. This is cold-first LRU, not a
+measured cost-aware policy. Stage timing calibration can replace that uniform
+proxy without changing the generic planner contract.
 
 Native sequence deletion precedes exact radix removal for every selected
 victim. A failed native drop therefore leaves the logical cache owner and its
 sequence-id allocation intact. Capacity decisions report active, pinned,
 requested, minimum/target/projected-free, deficit, victim, and predicted-cost
 fields through `stage.openai_kv_capacity_decision` telemetry.
+
+Hard admission runs before request-session creation or prefix restoration.
+Rejected requests therefore do not change active-token accounting and can be
+retried after pressure clears. Decode-batch maintenance falls back to the
+legacy best-effort eviction pass when the hard planner cannot satisfy its
+watermark, so the most pressured state does not silently skip cleanup.
 
 ### KvRecurrent
 

--- a/docs/skippy/SCHEDULER_FIXTURES.md
+++ b/docs/skippy/SCHEDULER_FIXTURES.md
@@ -76,6 +76,7 @@ run the A/B harness with the named profile:
 ```bash
 python3 evals/skippy-waiting-prefix-ab.py \
   --fixture-profile agentic-eviction-pressure \
+  --acceptance-contract evals/skippy-capacity-acceptance.json \
   --prompt-manifest /tmp/skippy-agentic-eviction-pressure.json \
   --case-file /path/to/one-model-case.json \
   --old-bin /path/to/old/skippy-server \
@@ -93,14 +94,18 @@ HF profiles require their exact generated prompt manifest, while synthetic
 profiles reject external manifests. The result records the profile name and
 catalog SHA alongside binary, model, and prompt-manifest hashes.
 
-The same replay is also the capacity-policy certificate. The runner combines
+The same replay is also the capacity-policy certificate. Pass the checked-in
+`skippy-capacity-acceptance.json` contract when comparing the capacity layer;
+the workload remains identical, but the gate changes from proving the DFS gain
+a second time to requiring zero fail-closed rejections and no regression over
+10% in recomputation, p95 TTFT, makespan, or throughput. The runner combines
 pre-admission and post-record resident eviction telemetry into per-round token
 and entry totals, reports fail-closed capacity rejections, and retains the new
 planner's predicted recomputation cost. This lets a stacked capacity change be
 compared against the preceding scheduler binary without changing the pinned
 requests or silently treating legacy proactive eviction as zero.
 
-The eviction-pressure certificate requires every request to succeed and, at
+The waiting-prefix eviction-pressure certificate requires every request to succeed and, at
 minimum, a 50,000-token suffix-prefill baseline and eight family switches so a
 drifted non-pressure workload cannot pass. It then requires 10% improvements
 in suffix prefill, family switches, p95 TTFT, and makespan plus 10% higher

--- a/docs/skippy/SCHEDULER_FIXTURES.md
+++ b/docs/skippy/SCHEDULER_FIXTURES.md
@@ -97,17 +97,20 @@ catalog SHA alongside binary, model, and prompt-manifest hashes.
 The same replay is also the capacity-policy certificate. Pass the checked-in
 `skippy-capacity-acceptance.json` contract when comparing the capacity layer;
 the measured agentic requests remain identical, but the gate changes from
-proving the DFS gain a second time to requiring an exercised cost prediction,
-actual eviction, zero fail-closed rejections, and no regression over 10% in
-recomputation, p95 TTFT, makespan, or throughput. The contract first
+proving the DFS gain a second time to requiring actual eviction, zero
+fail-closed rejections, and no regression over 2% in recomputation, p95 TTFT,
+makespan, or throughput. The contract first
 seeds eight deterministic synthetic resident prefixes and raises the entry cap
 to sixteen, so the measured agentic requests encounter evictable cold state
 without reducing the validated per-lane context budget. The runner combines
 pre-admission and post-record resident eviction telemetry into per-round token
-and entry totals, reports fail-closed capacity rejections, and retains the new
-planner's predicted recomputation cost. This lets a stacked capacity change be
-compared against the preceding scheduler binary without changing the pinned
-requests or silently treating legacy proactive eviction as zero.
+and entry totals, reports fail-closed capacity rejections, and retains the
+planner's deterministic work estimate. Because the current per-token estimate
+is uniform within a stage, the certificate describes the effective victim
+policy as cold-first LRU rather than attributing results to cost density. This
+lets a stacked capacity change be compared against the preceding scheduler
+binary without changing the pinned requests or silently treating legacy
+proactive eviction as zero.
 
 The waiting-prefix eviction-pressure certificate requires every request to succeed and, at
 minimum, a 50,000-token suffix-prefill baseline and eight family switches so a

--- a/docs/skippy/SCHEDULER_FIXTURES.md
+++ b/docs/skippy/SCHEDULER_FIXTURES.md
@@ -93,6 +93,13 @@ HF profiles require their exact generated prompt manifest, while synthetic
 profiles reject external manifests. The result records the profile name and
 catalog SHA alongside binary, model, and prompt-manifest hashes.
 
+The same replay is also the capacity-policy certificate. The runner combines
+pre-admission and post-record resident eviction telemetry into per-round token
+and entry totals, reports fail-closed capacity rejections, and retains the new
+planner's predicted recomputation cost. This lets a stacked capacity change be
+compared against the preceding scheduler binary without changing the pinned
+requests or silently treating legacy proactive eviction as zero.
+
 The eviction-pressure certificate requires every request to succeed and, at
 minimum, a 50,000-token suffix-prefill baseline and eight family switches so a
 drifted non-pressure workload cannot pass. It then requires 10% improvements

--- a/docs/skippy/SCHEDULER_FIXTURES.md
+++ b/docs/skippy/SCHEDULER_FIXTURES.md
@@ -96,9 +96,13 @@ catalog SHA alongside binary, model, and prompt-manifest hashes.
 
 The same replay is also the capacity-policy certificate. Pass the checked-in
 `skippy-capacity-acceptance.json` contract when comparing the capacity layer;
-the workload remains identical, but the gate changes from proving the DFS gain
-a second time to requiring zero fail-closed rejections and no regression over
-10% in recomputation, p95 TTFT, makespan, or throughput. The runner combines
+the measured agentic requests remain identical, but the gate changes from
+proving the DFS gain a second time to requiring an exercised cost prediction,
+actual eviction, zero fail-closed rejections, and no regression over 10% in
+recomputation, p95 TTFT, makespan, or throughput. The contract first
+seeds eight deterministic synthetic resident prefixes and raises the entry cap
+to sixteen, so the measured agentic requests encounter evictable cold state
+without reducing the validated per-lane context budget. The runner combines
 pre-admission and post-record resident eviction telemetry into per-round token
 and entry totals, reports fail-closed capacity rejections, and retains the new
 planner's predicted recomputation cost. This lets a stacked capacity change be

--- a/evals/skippy-capacity-acceptance.json
+++ b/evals/skippy-capacity-acceptance.json
@@ -1,7 +1,7 @@
 {
   "schema_version": 1,
   "name": "capacity-eviction-pressure",
-  "description": "Capacity-aware admission must preserve the pinned agentic workload without fail-closed rejection or a material user-facing regression.",
+  "description": "Capacity-aware admission must preserve the pinned agentic workload without rejection or more than a 2% user-facing regression.",
   "workload_profile": "agentic-eviction-pressure",
   "workload_overrides": {
     "cache_entries": 16
@@ -17,9 +17,9 @@
     "capacity_rejections_after_max": 0,
     "resident_evicted_tokens_after_min": 1,
     "predicted_recompute_cost_after_min": 1,
-    "suffix_prefill_delta_percent_max": 10.0,
-    "ttft_p95_delta_percent_max": 10.0,
-    "makespan_delta_percent_max": 10.0,
-    "output_throughput_delta_percent_min": -10.0
+    "suffix_prefill_delta_percent_max": 2.0,
+    "ttft_p95_delta_percent_max": 2.0,
+    "makespan_delta_percent_max": 2.0,
+    "output_throughput_delta_percent_min": -2.0
   }
 }

--- a/evals/skippy-capacity-acceptance.json
+++ b/evals/skippy-capacity-acceptance.json
@@ -3,9 +3,20 @@
   "name": "capacity-eviction-pressure",
   "description": "Capacity-aware admission must preserve the pinned agentic workload without fail-closed rejection or a material user-facing regression.",
   "workload_profile": "agentic-eviction-pressure",
+  "workload_overrides": {
+    "cache_entries": 16
+  },
+  "cache_seed": {
+    "families": 8,
+    "prefix_blocks": 192,
+    "output_tokens": 16,
+    "stagger_ms": 2.0
+  },
   "hardware_acceptance": {
     "successful_requests_per_binary": 64,
     "capacity_rejections_after_max": 0,
+    "resident_evicted_tokens_after_min": 1,
+    "predicted_recompute_cost_after_min": 1,
     "suffix_prefill_delta_percent_max": 10.0,
     "ttft_p95_delta_percent_max": 10.0,
     "makespan_delta_percent_max": 10.0,

--- a/evals/skippy-capacity-acceptance.json
+++ b/evals/skippy-capacity-acceptance.json
@@ -1,0 +1,14 @@
+{
+  "schema_version": 1,
+  "name": "capacity-eviction-pressure",
+  "description": "Capacity-aware admission must preserve the pinned agentic workload without fail-closed rejection or a material user-facing regression.",
+  "workload_profile": "agentic-eviction-pressure",
+  "hardware_acceptance": {
+    "successful_requests_per_binary": 64,
+    "capacity_rejections_after_max": 0,
+    "suffix_prefill_delta_percent_max": 10.0,
+    "ttft_p95_delta_percent_max": 10.0,
+    "makespan_delta_percent_max": 10.0,
+    "output_throughput_delta_percent_min": -10.0
+  }
+}

--- a/evals/skippy-waiting-prefix-ab.py
+++ b/evals/skippy-waiting-prefix-ab.py
@@ -150,6 +150,20 @@ def load_acceptance_contract(path: Path) -> dict[str, Any]:
     contract = document.get("hardware_acceptance")
     if not isinstance(contract, dict) or "successful_requests_per_binary" not in contract:
         raise ValueError("acceptance contract needs hardware_acceptance success bounds")
+    overrides = document.get("workload_overrides", {})
+    if not isinstance(overrides, dict) or set(overrides) - {"cache_entries"}:
+        raise ValueError("acceptance workload_overrides may only set cache_entries")
+    if overrides and int(overrides["cache_entries"]) <= 0:
+        raise ValueError("acceptance cache_entries override must be positive")
+    seed = document.get("cache_seed")
+    if seed is not None:
+        if not isinstance(seed, dict):
+            raise ValueError("acceptance cache_seed must be an object")
+        required_seed_keys = {"families", "prefix_blocks", "output_tokens", "stagger_ms"}
+        if set(seed) != required_seed_keys:
+            raise ValueError("acceptance cache_seed keys do not match the schema")
+        if any(float(seed[key]) <= 0 for key in required_seed_keys):
+            raise ValueError("acceptance cache_seed values must be positive")
     return document
 
 
@@ -419,6 +433,35 @@ def run_cell(
         )
         try:
             harness.wait_ready(port, process, 900, path="/v1/models", server_name=version)
+            seed_result = None
+            if args.cache_seed is not None:
+                seed = args.cache_seed
+                seed_prompts = interleaved_prompts(
+                    int(seed["families"]), 1, int(seed["prefix_blocks"])
+                )
+                seed_event_start = len(radix.json_events(log_path, SUMMARY_EVENT))
+                seed_requests, seed_makespan_ms = run_requests(
+                    seed_prompts,
+                    case.model_id,
+                    int(seed["output_tokens"]),
+                    port,
+                    args.request_timeout_secs,
+                    float(seed["stagger_ms"]),
+                )
+                seed_successful = sum("error" not in row for row in seed_requests)
+                if seed_successful != len(seed_requests):
+                    errors = [row for row in seed_requests if "error" in row]
+                    raise RuntimeError(f"cache seed failed: {errors}")
+                radix.wait_for_json_events(
+                    log_path,
+                    SUMMARY_EVENT,
+                    seed_event_start + seed_successful,
+                    process,
+                )
+                seed_result = {
+                    "requests": seed_requests,
+                    "makespan_ms": seed_makespan_ms,
+                }
             event_start = len(radix.json_events(log_path, SUMMARY_EVENT))
             capacity_event_start = len(radix.json_events(log_path, KV_CAPACITY_EVENT))
             record_event_start = len(radix.json_events(log_path, KV_RECORD_EVENT))
@@ -454,6 +497,7 @@ def run_cell(
         "binary": str(binary),
         "config": str(config_path),
         "log": str(log_path),
+        "cache_seed": seed_result,
         "requests": requests,
         "summary": summarize(requests, events, capacity_events, record_events, makespan_ms),
     }
@@ -597,6 +641,20 @@ def evaluate_acceptance(
             "max",
             contract["capacity_rejections_after_max"],
         )
+    for contract_key, label, row_key in (
+        (
+            "resident_evicted_tokens_after_min",
+            "after resident KV evicted tokens per round",
+            "resident_evicted_tokens_median",
+        ),
+        (
+            "predicted_recompute_cost_after_min",
+            "after predicted recompute cost per round",
+            "predicted_recompute_cost_median",
+        ),
+    ):
+        if contract_key in contract:
+            record(label, new[row_key], "min", contract[contract_key])
     delta_keys = {
         "suffix_prefill": "suffix_prefill_tokens_median",
         "family_switch": "family_switches_median",
@@ -782,6 +840,13 @@ def main() -> int:
             parser.error(
                 "acceptance contract workload_profile does not match --fixture-profile"
             )
+        for key, value in acceptance_contract.get("workload_overrides", {}).items():
+            setattr(args, key, value)
+    args.cache_seed = (
+        acceptance_contract.get("cache_seed")
+        if acceptance_contract is not None
+        else None
+    )
     if min(args.rounds, args.families, args.requests_per_family, args.lanes, args.cache_entries) <= 0:
         parser.error("rounds, families, requests, lanes, and cache entries must be positive")
     if args.admission_concurrency < 0:
@@ -898,6 +963,7 @@ def main() -> int:
             "admission_concurrency": args.admission_concurrency,
             "cache_entries": args.cache_entries,
             "stagger_ms": args.stagger_ms,
+            "cache_seed": args.cache_seed,
         },
         "cells": cells,
         "aggregate": rows,

--- a/evals/skippy-waiting-prefix-ab.py
+++ b/evals/skippy-waiting-prefix-ab.py
@@ -139,6 +139,20 @@ def validate_fixture_inputs(
         raise ValueError("synthetic fixture profiles do not accept a prompt manifest")
 
 
+def load_acceptance_contract(path: Path) -> dict[str, Any]:
+    document = json.loads(path.read_text())
+    if not isinstance(document, dict) or document.get("schema_version") != 1:
+        raise ValueError("acceptance contract schema_version must be 1")
+    if not isinstance(document.get("name"), str) or not document["name"]:
+        raise ValueError("acceptance contract needs a nonempty name")
+    if not isinstance(document.get("workload_profile"), str):
+        raise ValueError("acceptance contract needs a workload_profile")
+    contract = document.get("hardware_acceptance")
+    if not isinstance(contract, dict) or "successful_requests_per_binary" not in contract:
+        raise ValueError("acceptance contract needs hardware_acceptance success bounds")
+    return document
+
+
 def percentile(values: list[float], quantile: float) -> float | None:
     if not values:
         return None
@@ -496,19 +510,26 @@ def format_delta(old: float | None, new: float | None) -> str:
 
 
 def evaluate_acceptance(
-    rows: list[dict[str, Any]], profile: dict[str, Any] | None
+    rows: list[dict[str, Any]],
+    profile: dict[str, Any] | None,
+    contract_override: dict[str, Any] | None = None,
 ) -> dict[str, Any] | None:
     if profile is None:
         return None
     indexed = {row["version"]: row for row in rows}
     old, new = indexed["old"], indexed["new"]
-    contract = profile["hardware_acceptance"]
+    contract = (
+        contract_override["hardware_acceptance"]
+        if contract_override is not None
+        else profile["hardware_acceptance"]
+    )
     checks: list[dict[str, Any]] = []
     known_contract_keys = {
         "successful_requests_per_binary",
         "absolute_user_metric_delta_percent_max",
         "suffix_prefill_before_min",
         "family_switch_before_min",
+        "capacity_rejections_after_max",
     }
     for prefix in (
         "suffix_prefill",
@@ -568,6 +589,13 @@ def evaluate_acceptance(
             old["family_switches_median"],
             "min",
             contract["family_switch_before_min"],
+        )
+    if "capacity_rejections_after_max" in contract:
+        record(
+            "after capacity rejections",
+            new["capacity_rejections"],
+            "max",
+            contract["capacity_rejections_after_max"],
         )
     delta_keys = {
         "suffix_prefill": "suffix_prefill_tokens_median",
@@ -707,6 +735,11 @@ def main() -> int:
         type=Path,
         default=DEFAULT_FIXTURE_CATALOG,
     )
+    parser.add_argument(
+        "--acceptance-contract",
+        type=Path,
+        help="checked-in acceptance bounds for this layer over the selected workload",
+    )
     parser.add_argument("--rounds", type=int, default=4)
     parser.add_argument("--families", type=int, default=2)
     parser.add_argument("--requests-per-family", type=int, default=6)
@@ -734,6 +767,21 @@ def main() -> int:
         fixture_profile, fixture_catalog_sha256 = apply_fixture_profile(args)
     except (json.JSONDecodeError, OSError, ValueError) as error:
         parser.error(f"invalid fixture profile: {error}")
+    acceptance_contract = None
+    acceptance_contract_sha256 = None
+    if args.acceptance_contract is not None:
+        try:
+            acceptance_contract_path = args.acceptance_contract.resolve()
+            acceptance_contract = load_acceptance_contract(acceptance_contract_path)
+            acceptance_contract_sha256 = sha256(acceptance_contract_path)
+        except (json.JSONDecodeError, OSError, ValueError) as error:
+            parser.error(f"invalid acceptance contract: {error}")
+        if args.fixture_profile is None:
+            parser.error("--acceptance-contract requires --fixture-profile")
+        if acceptance_contract["workload_profile"] != args.fixture_profile:
+            parser.error(
+                "acceptance contract workload_profile does not match --fixture-profile"
+            )
     if min(args.rounds, args.families, args.requests_per_family, args.lanes, args.cache_entries) <= 0:
         parser.error("rounds, families, requests, lanes, and cache entries must be positive")
     if args.admission_concurrency < 0:
@@ -811,7 +859,7 @@ def main() -> int:
                 )
             )
     rows = aggregate(cells)
-    acceptance = evaluate_acceptance(rows, fixture_profile)
+    acceptance = evaluate_acceptance(rows, fixture_profile, acceptance_contract)
     result = {
         "metadata": {
             "old": {"commit": args.old_commit, "binary": str(binaries["old"]), "sha256": sha256(binaries["old"])},
@@ -836,6 +884,15 @@ def main() -> int:
                 str(args.fixture_catalog.resolve()) if fixture_profile is not None else None
             ),
             "fixture_catalog_sha256": fixture_catalog_sha256,
+            "acceptance_contract": (
+                str(args.acceptance_contract.resolve())
+                if acceptance_contract is not None
+                else None
+            ),
+            "acceptance_contract_name": (
+                acceptance_contract["name"] if acceptance_contract is not None else None
+            ),
+            "acceptance_contract_sha256": acceptance_contract_sha256,
             "output_tokens": args.output_tokens,
             "lanes": args.lanes,
             "admission_concurrency": args.admission_concurrency,

--- a/evals/skippy-waiting-prefix-ab.py
+++ b/evals/skippy-waiting-prefix-ab.py
@@ -574,6 +574,8 @@ def evaluate_acceptance(
         "suffix_prefill_before_min",
         "family_switch_before_min",
         "capacity_rejections_after_max",
+        "resident_evicted_tokens_after_min",
+        "predicted_recompute_cost_after_min",
     }
     for prefix in (
         "suffix_prefill",

--- a/evals/skippy-waiting-prefix-ab.py
+++ b/evals/skippy-waiting-prefix-ab.py
@@ -28,6 +28,8 @@ from typing import Any
 
 REPO = Path(__file__).resolve().parents[1]
 SUMMARY_EVENT = "stage.openai_generation_summary"
+KV_CAPACITY_EVENT = "stage.openai_kv_capacity_decision"
+KV_RECORD_EVENT = "stage.openai_kv_record_decision"
 DEFAULT_FIXTURE_CATALOG = REPO / "evals/skippy-scheduler-fixtures.json"
 
 
@@ -272,17 +274,52 @@ def attributes(event: dict[str, Any]) -> dict[str, Any]:
     return value if isinstance(value, dict) else {}
 
 
-def summarize(requests: list[dict[str, Any]], events: list[dict[str, Any]], makespan_ms: float) -> dict[str, Any]:
+def summarize(
+    requests: list[dict[str, Any]],
+    events: list[dict[str, Any]],
+    capacity_events: list[dict[str, Any]],
+    record_events: list[dict[str, Any]],
+    makespan_ms: float,
+) -> dict[str, Any]:
     successful = [row for row in requests if "error" not in row]
     attrs = [attributes(event) for event in events]
+    capacity_attrs = [attributes(event) for event in capacity_events]
+    record_attrs = [attributes(event) for event in record_events]
     statuses = [str(row.get("skippy.kv.status", "unknown")) for row in attrs]
+    capacity_observed = any("skippy.kv.capacity_status" in row for row in capacity_attrs)
+    capacity_statuses = [
+        str(row.get("skippy.kv.capacity_status", "legacy")) for row in capacity_attrs
+    ]
 
     def numeric(key: str) -> list[float]:
         return [float(row[key]) for row in attrs if isinstance(row.get(key), (int, float))]
 
+    def capacity_numeric(key: str) -> list[float]:
+        return [
+            float(row[key])
+            for row in capacity_attrs
+            if isinstance(row.get(key), (int, float))
+        ]
+
     ttft = [float(row["ttft_ms"]) for row in successful]
     matched = numeric("skippy.kv.matched_prefix_tokens")
     suffix = numeric("skippy.kv.suffix_prefill_tokens")
+    capacity_evicted_tokens = capacity_numeric("skippy.kv.capacity_evicted_tokens")
+    capacity_evicted_entries = capacity_numeric("skippy.kv.capacity_evicted_entries")
+    predicted_recompute_cost = capacity_numeric("skippy.kv.capacity_predicted_recompute_cost")
+    proactive = [
+        row for row in record_attrs if row.get("skippy.kv.decision") == "proactive_eviction"
+    ]
+    proactive_evicted_tokens = [
+        float(row["skippy.kv.proactive_evicted_tokens"])
+        for row in proactive
+        if isinstance(row.get("skippy.kv.proactive_evicted_tokens"), (int, float))
+    ]
+    proactive_evicted_entries = [
+        float(row["skippy.kv.proactive_evicted_entries"])
+        for row in proactive
+        if isinstance(row.get("skippy.kv.proactive_evicted_entries"), (int, float))
+    ]
     service_order = sorted(successful, key=lambda row: row["first_token_ms"])
     family_order = [str(row["family"]) for row in service_order]
     switches = sum(left != right for left, right in zip(family_order, family_order[1:]))
@@ -296,6 +333,14 @@ def summarize(requests: list[dict[str, Any]], events: list[dict[str, Any]], make
         "usage_cached_requests": sum(int(row.get("cached_tokens", 0)) > 0 for row in successful),
         "matched_prefix_tokens_total": sum(matched),
         "suffix_prefill_tokens_total": sum(suffix),
+        "capacity_rejections": capacity_statuses.count("rejected"),
+        "resident_evicted_tokens_total": sum(capacity_evicted_tokens)
+        + sum(proactive_evicted_tokens),
+        "resident_evicted_entries_total": sum(capacity_evicted_entries)
+        + sum(proactive_evicted_entries),
+        "predicted_recompute_cost_total": (
+            sum(predicted_recompute_cost) if capacity_observed else None
+        ),
         "ttft_ms_p50": percentile(ttft, 0.50),
         "ttft_ms_p95": percentile(ttft, 0.95),
         "makespan_ms": makespan_ms,
@@ -361,6 +406,8 @@ def run_cell(
         try:
             harness.wait_ready(port, process, 900, path="/v1/models", server_name=version)
             event_start = len(radix.json_events(log_path, SUMMARY_EVENT))
+            capacity_event_start = len(radix.json_events(log_path, KV_CAPACITY_EVENT))
+            record_event_start = len(radix.json_events(log_path, KV_RECORD_EVENT))
             requests, makespan_ms = run_requests(
                 prompts,
                 case.model_id,
@@ -376,6 +423,10 @@ def run_cell(
                 event_start + expected,
                 process,
             )[event_start:]
+            capacity_events = radix.json_events(log_path, KV_CAPACITY_EVENT)[
+                capacity_event_start:
+            ]
+            record_events = radix.json_events(log_path, KV_RECORD_EVENT)[record_event_start:]
         finally:
             process.terminate()
             try:
@@ -390,7 +441,7 @@ def run_cell(
         "config": str(config_path),
         "log": str(log_path),
         "requests": requests,
-        "summary": summarize(requests, events, makespan_ms),
+        "summary": summarize(requests, events, capacity_events, record_events, makespan_ms),
     }
 
 
@@ -411,6 +462,12 @@ def aggregate(cells: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "successful": sum(int(row["successful"]) for row in summaries),
                 "cache_hits_median": median("cache_hits"),
                 "suffix_prefill_tokens_median": median("suffix_prefill_tokens_total"),
+                "capacity_rejections": sum(
+                    int(row["capacity_rejections"]) for row in summaries
+                ),
+                "resident_evicted_tokens_median": median("resident_evicted_tokens_total"),
+                "resident_evicted_entries_median": median("resident_evicted_entries_total"),
+                "predicted_recompute_cost_median": median("predicted_recompute_cost_total"),
                 "ttft_ms_p50_median": median("ttft_ms_p50"),
                 "ttft_ms_p95_median": median("ttft_ms_p95"),
                 "makespan_ms_median": median("makespan_ms"),
@@ -568,6 +625,22 @@ def report(rows: list[dict[str, Any]], acceptance: dict[str, Any] | None = None)
                 "",
             ]
         )
+    old_evicted = old["resident_evicted_tokens_median"]
+    new_evicted = new["resident_evicted_tokens_median"]
+    if old_evicted is not None and new_evicted is not None:
+        eviction_ceiling = max(old_evicted, new_evicted, 1)
+        lines.extend(
+            [
+                "```mermaid",
+                "xychart-beta",
+                '    title "Resident KV tokens evicted (lower is better)"',
+                '    x-axis ["Before", "After"]',
+                f'    y-axis "tokens" 0 --> {int(eviction_ceiling * 1.1)}',
+                f"    bar [{old_evicted:.0f}, {new_evicted:.0f}]",
+                "```",
+                "",
+            ]
+        )
     lines.extend(
         [
         "| Metric | Before | After | Delta |",
@@ -577,6 +650,10 @@ def report(rows: list[dict[str, Any]], acceptance: dict[str, Any] | None = None)
     metrics = (
         ("Cache hits / round", "cache_hits_median", False),
         ("Suffix prefill tokens / round", "suffix_prefill_tokens_median", True),
+        ("Capacity rejections", "capacity_rejections", True),
+        ("Resident KV evicted tokens / round", "resident_evicted_tokens_median", True),
+        ("Resident KV evicted entries / round", "resident_evicted_entries_median", True),
+        ("Predicted recompute cost / round", "predicted_recompute_cost_median", True),
         ("Family switches / round", "family_switches_median", True),
         ("TTFT p50 ms", "ttft_ms_p50_median", True),
         ("TTFT p95 ms", "ttft_ms_p95_median", True),

--- a/scripts/tests/test_skippy_waiting_prefix_ab.py
+++ b/scripts/tests/test_skippy_waiting_prefix_ab.py
@@ -196,11 +196,15 @@ class WaitingPrefixAbTest(unittest.TestCase):
         contract = BENCH.load_acceptance_contract(
             REPO / "evals/skippy-capacity-acceptance.json"
         )
+        self.assertEqual(contract["workload_overrides"], {"cache_entries": 16})
+        self.assertEqual(contract["cache_seed"]["families"], 8)
         rows = [
             {
                 "version": "old",
                 "successful": 64,
                 "capacity_rejections": 0,
+                "resident_evicted_tokens_median": 2000.0,
+                "predicted_recompute_cost_median": None,
                 "suffix_prefill_tokens_median": 66735.5,
                 "family_switches_median": 10.0,
                 "ttft_ms_p95_median": 27901.1,
@@ -211,6 +215,8 @@ class WaitingPrefixAbTest(unittest.TestCase):
                 "version": "new",
                 "successful": 64,
                 "capacity_rejections": 0,
+                "resident_evicted_tokens_median": 1500.0,
+                "predicted_recompute_cost_median": 42000.0,
                 "suffix_prefill_tokens_median": 65000.0,
                 "family_switches_median": 10.0,
                 "ttft_ms_p95_median": 27500.0,

--- a/scripts/tests/test_skippy_waiting_prefix_ab.py
+++ b/scripts/tests/test_skippy_waiting_prefix_ab.py
@@ -34,6 +34,10 @@ def cell(version: str, ttft_ms: float | None) -> dict:
             "successful": int(ttft_ms is not None),
             "cache_hits": 0,
             "suffix_prefill_tokens_total": 0,
+            "capacity_rejections": 0,
+            "resident_evicted_tokens_total": 0,
+            "resident_evicted_entries_total": 0,
+            "predicted_recompute_cost_total": 0,
             "ttft_ms_p50": ttft_ms,
             "ttft_ms_p95": ttft_ms,
             "makespan_ms": 10,
@@ -44,6 +48,54 @@ def cell(version: str, ttft_ms: float | None) -> dict:
 
 
 class WaitingPrefixAbTest(unittest.TestCase):
+    def test_summary_combines_capacity_and_legacy_proactive_evictions(self) -> None:
+        requests = [
+            {
+                "request_id": 0,
+                "family": "one",
+                "first_token_ms": 5.0,
+                "ttft_ms": 5.0,
+                "tokens_predicted": 2,
+                "cached_tokens": 0,
+            }
+        ]
+        summary_events = [
+            {
+                "attributes": {
+                    "skippy.kv.status": "miss",
+                    "skippy.kv.suffix_prefill_tokens": 10,
+                }
+            }
+        ]
+        capacity_events = [
+            {
+                "attributes": {
+                    "skippy.kv.capacity_status": "evicted",
+                    "skippy.kv.capacity_evicted_tokens": 6,
+                    "skippy.kv.capacity_evicted_entries": 1,
+                    "skippy.kv.capacity_predicted_recompute_cost": 24,
+                }
+            }
+        ]
+        record_events = [
+            {
+                "attributes": {
+                    "skippy.kv.decision": "proactive_eviction",
+                    "skippy.kv.proactive_evicted_tokens": 4,
+                    "skippy.kv.proactive_evicted_entries": 1,
+                }
+            }
+        ]
+
+        summary = BENCH.summarize(
+            requests, summary_events, capacity_events, record_events, 10.0
+        )
+
+        self.assertEqual(summary["resident_evicted_tokens_total"], 10)
+        self.assertEqual(summary["resident_evicted_entries_total"], 2)
+        self.assertEqual(summary["predicted_recompute_cost_total"], 24)
+        self.assertEqual(summary["capacity_rejections"], 0)
+
     def test_warm_profile_accepts_the_measured_neutral_boundary(self) -> None:
         catalog = json.loads((REPO / "evals/skippy-scheduler-fixtures.json").read_text())
         profile = catalog["profiles"]["warm-affinity"]

--- a/scripts/tests/test_skippy_waiting_prefix_ab.py
+++ b/scripts/tests/test_skippy_waiting_prefix_ab.py
@@ -190,6 +190,39 @@ class WaitingPrefixAbTest(unittest.TestCase):
         ]
         self.assertFalse(BENCH.evaluate_acceptance(rows, profile)["passed"])
 
+    def test_capacity_contract_reuses_workload_with_layer_specific_bounds(self) -> None:
+        catalog = json.loads((REPO / "evals/skippy-scheduler-fixtures.json").read_text())
+        profile = catalog["profiles"]["agentic-eviction-pressure"]
+        contract = BENCH.load_acceptance_contract(
+            REPO / "evals/skippy-capacity-acceptance.json"
+        )
+        rows = [
+            {
+                "version": "old",
+                "successful": 64,
+                "capacity_rejections": 0,
+                "suffix_prefill_tokens_median": 66735.5,
+                "family_switches_median": 10.0,
+                "ttft_ms_p95_median": 27901.1,
+                "makespan_ms_median": 30328.4,
+                "output_tokens_per_second_median": 16.26,
+            },
+            {
+                "version": "new",
+                "successful": 64,
+                "capacity_rejections": 0,
+                "suffix_prefill_tokens_median": 65000.0,
+                "family_switches_median": 10.0,
+                "ttft_ms_p95_median": 27500.0,
+                "makespan_ms_median": 30000.0,
+                "output_tokens_per_second_median": 16.5,
+            },
+        ]
+
+        self.assertTrue(BENCH.evaluate_acceptance(rows, profile, contract)["passed"])
+        rows[1]["capacity_rejections"] = 1
+        self.assertFalse(BENCH.evaluate_acceptance(rows, profile, contract)["passed"])
+
     def test_checked_in_fixture_profile_owns_the_workload_shape(self) -> None:
         args = Namespace(
             fixture_profile="agentic-eviction-pressure",

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4359,27 +4359,27 @@
   ],
   "crates/skippy-server/src/runtime_state.rs": [
     {
-      "line": 528,
+      "line": 533,
       "macro_name": "eprintln!"
     },
     {
-      "line": 608,
+      "line": 613,
       "macro_name": "eprintln!"
     },
     {
-      "line": 650,
+      "line": 655,
       "macro_name": "eprintln!"
     },
     {
-      "line": 687,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 691,
+      "line": 692,
       "macro_name": "eprintln!"
     },
     {
       "line": 696,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 701,
       "macro_name": "eprintln!"
     }
   ],


### PR DESCRIPTION
## Summary

Adds capacity-aware resident-KV admission and eviction, with rejection handled as retriable load pressure.

- Capacity is preflighted before prefix restore or session admission, so rejection has no lane, runtime, or token-accounting side effect.
- Hard capacity rejection returns OpenAI-compatible HTTP 429 with `Retry-After: 1`.
- Decode-batch pressure falls back to the previous best-effort eviction path when the hard planner cannot admit.
- Entries with zero caller metadata use radix path depth as their effective capacity units and remain evictable.
- The rejection regression test performs two identical rejected attempts, proves stable accounting/runtime statistics, then proves a reduced request can be admitted.

## Policy scope

The generic planner orders candidates by recomputation-cost density, coldness, recency, size, and stable identity. Production currently computes recomputation cost as `token_count * constant_stage_layer_count`, so density is uniform within a stage. The effective shipped production policy is therefore cold-first LRU. The benchmark below is evidence for that policy under the pinned pressure trace; it is not evidence for non-uniform cost-density optimization.

## Acceptance contract

The hardware certificate must observe nonzero resident eviction and predicted cost. Regression bounds are tightened to 2% for suffix recomputation, p95 TTFT, makespan, and throughput. These gates reject a broadly worse candidate but do not erase the uncertainty of four paired rounds.

The historical exact-head run compared fixture head `80f7ea98` with pre-review capacity head `8d8fa201`. It completed 64/64 measured requests per binary and observed median suffix prefill -6.5%, p95 TTFT -6.2%, makespan -5.6%, and throughput +6.2%; paired ranges were wide and one of four rounds moved the other way. This is a pressure-workload result, not a universal speedup claim. Because review fixes changed both the base and candidate heads, those numbers are retained as historical evidence and are not attributed to current head `ac265261`; an exact-head rerun is required before landing.

## Current validation

Exact reviewed head: `ac2652617d5f33ae0cc7164c93021ecc05c91972`

- `skippy-scheduler`: 27 unit + 7 simulation tests passed
- `skippy-server`: 525 passed, 3 ignored
- fixture and harness Python suites: 17 passed
- strict all-target/all-feature Clippy passed
- formatting and diff checks passed
- console-print occurrence ratchet regenerated and passing after the test-only constructor shifted pre-existing lines

## Stack

This PR targets #1450. #1453 is rebased on this exact head.
