### PR TITLE
fix(skippy): restore small-context admission and state handoff

### DIFF
--- a/crates/skippy-scheduler/src/capacity.rs
+++ b/crates/skippy-scheduler/src/capacity.rs
@@ -57,15 +57,29 @@ pub fn plan_component_capacity(
     snapshot: &ComponentCapacitySnapshot,
     demand: CapacityDemand,
 ) -> CapacityPlan {
-    let minimum_free = demand.minimum_free_units.min(snapshot.capacity_units);
-    let target_free = demand
-        .target_free_units
-        .max(minimum_free)
-        .min(snapshot.capacity_units);
     let protected_units = snapshot
         .active_units
         .saturating_add(snapshot.pinned_cache_units)
         .saturating_add(demand.request_units);
+    // A decode-batch watermark is a hint derived from the serving
+    // configuration. It may be larger than a small runtime's entire KV pool;
+    // when it fills or exceeds the pool, cap it at the space that can actually
+    // remain after the non-evictable work and this request. Otherwise a request
+    // that fits in the pool is rejected before any evictable cache can be
+    // considered. A smaller configured watermark remains a hard minimum.
+    let available_free = snapshot.capacity_units.saturating_sub(protected_units);
+    let minimum_free = if demand.minimum_free_units >= snapshot.capacity_units {
+        available_free
+    } else {
+        demand.minimum_free_units
+    };
+    let target_free = if demand.target_free_units >= snapshot.capacity_units {
+        available_free
+    } else {
+        demand.target_free_units
+    }
+    .max(minimum_free)
+    .min(snapshot.capacity_units);
     let protected_with_minimum = protected_units.saturating_add(minimum_free);
     if protected_with_minimum > snapshot.capacity_units {
         return CapacityPlan {
@@ -162,6 +176,74 @@ mod tests {
 
         assert!(!plan.admitted);
         assert_eq!(plan.admission_deficit_units, 5);
+        assert!(plan.victim_ids.is_empty());
+    }
+
+    #[test]
+    fn admits_a_request_that_fits_when_watermarks_exceed_the_pool() {
+        let plan = plan_component_capacity(
+            &ComponentCapacitySnapshot {
+                component: "kv-cells".into(),
+                capacity_units: 256,
+                active_units: 0,
+                pinned_cache_units: 0,
+                evictable_entries: Vec::new(),
+            },
+            CapacityDemand {
+                request_units: 39,
+                minimum_free_units: 512,
+                target_free_units: 1024,
+            },
+        );
+
+        assert!(plan.admitted);
+        assert_eq!(plan.projected_free_units, 217);
+        assert_eq!(plan.admission_deficit_units, 0);
+        assert!(plan.victim_ids.is_empty());
+    }
+
+    #[test]
+    fn admits_a_request_when_minimum_watermark_matches_pool_capacity() {
+        let plan = plan_component_capacity(
+            &ComponentCapacitySnapshot {
+                component: "kv-cells".into(),
+                capacity_units: 256,
+                active_units: 0,
+                pinned_cache_units: 0,
+                evictable_entries: Vec::new(),
+            },
+            CapacityDemand {
+                request_units: 39,
+                minimum_free_units: 256,
+                target_free_units: 256,
+            },
+        );
+
+        assert!(plan.admitted);
+        assert_eq!(plan.projected_free_units, 217);
+        assert_eq!(plan.required_eviction_units, 0);
+        assert_eq!(plan.admission_deficit_units, 0);
+    }
+
+    #[test]
+    fn still_rejects_when_non_evictable_work_exceeds_the_pool() {
+        let plan = plan_component_capacity(
+            &ComponentCapacitySnapshot {
+                component: "kv-cells".into(),
+                capacity_units: 256,
+                active_units: 200,
+                pinned_cache_units: 0,
+                evictable_entries: vec![entry("evictable", 100, 100, 0)],
+            },
+            CapacityDemand {
+                request_units: 57,
+                minimum_free_units: 512,
+                target_free_units: 1024,
+            },
+        );
+
+        assert!(!plan.admitted);
+        assert_eq!(plan.admission_deficit_units, 1);
         assert!(plan.victim_ids.is_empty());
     }
 

--- a/third_party/llama.cpp/patches/0023-skippy-derive-restored-position-from-native-memory.patch
+++ b/third_party/llama.cpp/patches/0023-skippy-derive-restored-position-from-native-memory.patch
@@ -1,0 +1,146 @@
+From 7ed84952652a35dfbf1bbccd51423395b82161a2 Mon Sep 17 00:00:00 2001
+From: Scam
+ <a1860575018c4680d5669dd7bc3bd356b478bccb8d42e194df46304a5e25f49a@meshllm.communities.buzz.xyz>
+Date: Thu, 27 Aug 2026 04:53:05 +1000
+Subject: [PATCH] skippy: derive restored position from native memory
+
+---
+ src/skippy/state.cpp | 72 ++++++++++++++++++++++++++------------------
+ 1 file changed, 42 insertions(+), 30 deletions(-)
+
+diff --git a/src/skippy/state.cpp b/src/skippy/state.cpp
+index 375cc7196..7270d2ea2 100644
+--- a/src/skippy/state.cpp
++++ b/src/skippy/state.cpp
+@@ -13,7 +13,6 @@
+ 
+ #include <algorithm>
+ #include <cstdint>
+-#include <cstring>
+ #include <limits>
+ #include <vector>
+ 
+@@ -41,11 +40,11 @@ static enum skippy_status skippy_validate_state_range(
+ 
+ static void skippy_update_session_state_after_import(
+         skippy_session * session,
+-        uint32_t imported_cells) {
++        uint32_t imported_position) {
+     session->n_past = std::max<int32_t>(
+             session->n_past,
+             static_cast<int32_t>(std::min<uint32_t>(
+-                    imported_cells,
++                    imported_position,
+                     static_cast<uint32_t>(std::numeric_limits<int32_t>::max()))));
+     if (session->token_history.size() > static_cast<size_t>(session->n_past)) {
+         session->token_history.resize(static_cast<size_t>(session->n_past));
+@@ -57,14 +56,37 @@ static void skippy_update_session_state_after_import(
+     session->verify_checkpoints.clear();
+ }
+ 
+-static enum skippy_status skippy_validate_imported_cell_count(
++static enum skippy_status skippy_imported_session_position(
+         skippy_session * session,
+-        uint32_t imported_cells,
++        bool partial_only,
++        uint32_t * out_position,
+         skippy_error ** out_error) {
+-    if (imported_cells > llama_n_ctx(session->ctx)) {
+-        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "imported state cell count exceeds context size");
+-        return SKIPPY_STATUS_INVALID_ARGUMENT;
++    llama_memory_t memory = session->ctx->get_memory();
++    if (memory == nullptr) {
++        skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "runtime memory is unavailable after state import");
++        return SKIPPY_STATUS_RUNTIME_ERROR;
+     }
++
++    llama_memory_t restored_memory = memory;
++    if (partial_only) {
++        if (auto * hybrid = dynamic_cast<llama_memory_hybrid *>(memory)) {
++            restored_memory = hybrid->get_mem_recr();
++        } else if (auto * hybrid_iswa = dynamic_cast<llama_memory_hybrid_iswa *>(memory)) {
++            restored_memory = hybrid_iswa->get_mem_recr();
++        }
++    }
++
++    const llama_pos max_pos = llama_memory_seq_pos_max(restored_memory, session->seq_id);
++    if (max_pos < 0) {
++        *out_position = 0;
++        return SKIPPY_STATUS_OK;
++    }
++    if (max_pos >= std::numeric_limits<int32_t>::max()) {
++        skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "imported state position exceeds the supported range");
++        return SKIPPY_STATUS_RUNTIME_ERROR;
++    }
++
++    *out_position = static_cast<uint32_t>(max_pos) + 1;
+     return SKIPPY_STATUS_OK;
+ }
+ 
+@@ -133,16 +155,6 @@ enum skippy_status skippy_import_state(
+         return SKIPPY_STATUS_INVALID_ARGUMENT;
+     }
+ 
+-    uint32_t imported_cells = 0;
+-    if (input_bytes >= sizeof(imported_cells)) {
+-        // The partial sequence-state wire header stores its cell count first.
+-        std::memcpy(&imported_cells, input, sizeof(imported_cells));
+-    }
+-    status = skippy_validate_imported_cell_count(session, imported_cells, out_error);
+-    if (status != SKIPPY_STATUS_OK) {
+-        return status;
+-    }
+-
+     session->ctx->synchronize();
+     const size_t read = llama_state_seq_set_data_ext(
+             session->ctx,
+@@ -154,8 +166,13 @@ enum skippy_status skippy_import_state(
+         skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "failed to import sequence state");
+         return SKIPPY_STATUS_RUNTIME_ERROR;
+     }
+-    skippy_update_session_state_after_import(session, imported_cells);
+     session->ctx->synchronize();
++    uint32_t imported_position = 0;
++    status = skippy_imported_session_position(session, true, &imported_position, out_error);
++    if (status != SKIPPY_STATUS_OK) {
++        return status;
++    }
++    skippy_update_session_state_after_import(session, imported_position);
+ 
+     return skippy_success(out_error);
+ }
+@@ -221,16 +238,6 @@ enum skippy_status skippy_import_full_state(
+         return SKIPPY_STATUS_INVALID_ARGUMENT;
+     }
+ 
+-    uint32_t imported_cells = 0;
+-    if (input_bytes >= 2 * sizeof(uint32_t)) {
+-        // The full sequence-state wire header stores its cell count after the sequence id.
+-        std::memcpy(&imported_cells, static_cast<const uint8_t *>(input) + sizeof(uint32_t), sizeof(imported_cells));
+-    }
+-    status = skippy_validate_imported_cell_count(session, imported_cells, out_error);
+-    if (status != SKIPPY_STATUS_OK) {
+-        return status;
+-    }
+-
+     session->ctx->synchronize();
+     const size_t read = llama_state_seq_set_data(
+             session->ctx,
+@@ -241,8 +248,13 @@ enum skippy_status skippy_import_full_state(
+         skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "failed to import full sequence state");
+         return SKIPPY_STATUS_RUNTIME_ERROR;
+     }
+-    skippy_update_session_state_after_import(session, imported_cells);
+     session->ctx->synchronize();
++    uint32_t imported_position = 0;
++    status = skippy_imported_session_position(session, false, &imported_position, out_error);
++    if (status != SKIPPY_STATUS_OK) {
++        return status;
++    }
++    skippy_update_session_state_after_import(session, imported_position);
+ 
+     return skippy_success(out_error);
+ }
+-- 
+2.54.0 (Apple Git-157)
+


### PR DESCRIPTION
## Summary

- normalize impossible resident-KV watermarks so requests that fit a small KV pool are admitted while non-evictable overcommit still fails closed
- derive Skippy's restored session cursor from llama.cpp's native memory position instead of parsing its private sequence-state wire header
- add scheduler regressions for watermarks larger than, and equal to, KV capacity

## Root cause

The main-branch smoke failures exposed by `836aeb0f` were introduced by the earlier capacity-aware admission change. A 256-cell smoke runtime received a 39-token request with `minimum_free=512`; treating that configuration-derived watermark as a hard reserve made the first request mathematically impossible and returned HTTP 429.

The [latest-upstream canary](https://github.com/Mesh-LLM/mesh-llm/actions/runs/32964721554/job/98164615089) was a separate compatibility regression. Skippy inferred the imported cursor by reading fixed offsets in llama.cpp's private state payload. Current upstream prepends a magic value and sequence id, so the full-state path read sequence id `0` as the cell count and reported restored position 0 after native state had correctly restored one token.

## Validation

- `just ci-validate` — 606 passed, 7 skipped
- `cargo fmt --all --check`
- `cargo check -p mesh-llm`
- `cargo test -p skippy-scheduler --lib --features scheduler-lab` — 30 passed
- `cargo test -p skippy-runtime --lib` — 79 passed
- `cargo test -p skippy-server --lib` — 532 passed, 3 ignored
- `cargo test -p mesh-llm --lib` — 48 passed
- complete patch queue applies at pinned llama.cpp `d222767c7a6516559a3f49e7721b6c6b1acc87b4` and current upstream `539f24529bdf99e0baefd54fefff1660034bfe7b`
- static CPU llama.cpp builds pass at both revisions
- model-backed Llama 3.2 1B `state-handoff` passes exact roundtrip, restored output, suffix-prefill, and repeated cache-hit checks on current upstream
- local OpenAI smoke with a 256-cell KV pool and configured 512-token watermark returns HTTP 200

## ABI inventory

No public C ABI declarations, Rust FFI mirrors, or ABI version constants changed. Patch 0023 changes only the internal implementation of existing state-import functions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Capacity planning now accepts requests that fit within available pool space, even when configured free-space thresholds are larger than the pool.
  - Requests are still rejected when non-evictable usage leaves insufficient capacity.
  - Restored sessions now calculate their position from active runtime state, improving accuracy for partial and complete state imports.
  - State restoration now reports clear errors for unavailable memory, empty sequences, or unsupported positions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->