### PR TITLE
ci: assign imported Just files to Rust ownership

### DIFF
--- a/ci/ownership.yml
+++ b/ci/ownership.yml
@@ -114,6 +114,7 @@
         "Cargo.toml",
         "Cargo.lock",
         "Justfile",
+        "just/**",
         "rust-toolchain",
         "rust-toolchain.toml",
         "crates/**",


### PR DESCRIPTION
## Summary

- classify `just/**` files as Rust-owned planner inputs
- land the protected catalog entry separately so PR #1458 can rebase onto it after merge

## Validation

- `python3 -m unittest scripts.tests.test_plan_ci -v`
- `just ci-validate`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project file classification for content under the `just/` directory.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->