### PR TITLE
Clarify end-to-end encryption for mesh traffic

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,9 @@ mesh-llm serve --auto --headless
   the model locally without stage traffic.
 - **Mesh routing.** Every node exposes the same `/v1` API. Requests are routed
   by the `model` field to the peer that can serve that model.
+- **Encrypted peer transport.** QUIC end-to-end encrypts traffic between Mesh
+  nodes, including inference requests, responses, and split-model activations.
+  Iroh relays forward encrypted packets without reading their payload.
 - **Owner-control plane.** Operator config and inventory actions use an
   additive `mesh-llm-control/1` lane with explicit endpoint bootstrap, while
   public mesh join, gossip, routing, and inference stay on the public mesh

--- a/docs/MESHES.md
+++ b/docs/MESHES.md
@@ -96,7 +96,10 @@ mesh-llm serve --model Qwen3-8B-Q4_K_M
 ```
 
 This starts a private mesh, loads the requested model, opens the local API and
-console, and prints an invite token. Only nodes with the token can join.
+console, and prints an invite token. Only nodes with the token can join. Traffic
+between Mesh nodes—including prompts, responses, and split-model activations—is
+end-to-end encrypted by QUIC. If iroh falls back to a relay, the relay forwards
+encrypted packets and cannot read the inference payload.
 
 Join from another GPU node:
 

--- a/website/src/docs/pages/architecture.md
+++ b/website/src/docs/pages/architecture.md
@@ -100,7 +100,17 @@ Discovery finds a candidate mesh. Admission decides whether the node is allowed 
 
 ### Transport and compatibility
 
-Mesh transport uses QUIC through iroh. A connection is multiplexed into control, gossip, route, tunnel, and lifecycle streams. The current protobuf lane uses ALPN `mesh-llm/1`; legacy JSON peers can still negotiate `mesh-llm/0` for mixed-version operation.
+Mesh transport uses QUIC through iroh. QUIC provides end-to-end encryption and
+authenticates the remote node's endpoint identity for all peer traffic,
+including inference requests, responses, control messages, gossip, and
+split-model activations. This remains end-to-end encrypted when iroh uses a
+relay: the relay forwards encrypted packets but does not terminate the QUIC
+connection or read its payload. This transport guarantee covers traffic between
+Mesh nodes; the local `http://localhost` API is a separate loopback hop.
+
+A connection is multiplexed into control, gossip, route, tunnel, and lifecycle
+streams. The current protobuf lane uses ALPN `mesh-llm/1`; legacy JSON peers can
+still negotiate `mesh-llm/0` for mixed-version operation.
 
 Protocol changes should be additive: older nodes must be able to ignore new optional fields, and newer nodes must continue to understand the legacy lane where compatibility is required. See the [protocol deep dive](https://github.com/Mesh-LLM/mesh-llm/blob/main/docs/design/message_protocol.md) for the wire-level contract.
 

--- a/website/src/docs/pages/private-meshes.md
+++ b/website/src/docs/pages/private-meshes.md
@@ -1,6 +1,9 @@
 # Private Meshes
 
-A private mesh is a named group of your own machines. Use the same name on each machine you want to connect.
+A private mesh is a named group of your own machines. Use the same name on each
+machine you want to connect. Traffic between those Mesh nodes is end-to-end
+encrypted by QUIC. If iroh uses a relay, the relay forwards encrypted packets
+and cannot read prompts, responses, or split-model activations.
 
 ## Start the first serving node
 

--- a/website/src/docs/pages/quickstart.md
+++ b/website/src/docs/pages/quickstart.md
@@ -153,7 +153,9 @@ For tools without a Mesh launcher, configure an OpenAI-compatible provider with 
 
 ## 7. Add another machine
 
-Install Mesh on another machine and run the same command with the same mesh name:
+Install Mesh on another machine and run the same command with the same mesh name.
+Traffic between the two Mesh nodes is end-to-end encrypted by QUIC, whether iroh
+connects them directly or forwards the encrypted packets through a relay:
 
 ```sh
 mesh-llm serve --discover my-private-mesh --model unsloth/gemma-4-E4B-it-GGUF:UD-Q4_K_XL


### PR DESCRIPTION
## Summary

Mesh users can now see clearly that traffic between nodes is end-to-end encrypted by QUIC, including prompts, responses, control traffic, gossip, and split-model activations.

The docs also explain that iroh relays only forward encrypted packets: they do not terminate the peer QUIC connection or read inference payloads. The architecture page scopes this guarantee to node-to-node traffic and keeps the local `http://localhost` API identified as a separate loopback hop.

Updated surfaces:
- repository README
- mesh workflow guide
- website Quickstart
- website Private Meshes guide
- website Architecture reference

## Validation

- `npm run build` from `website/` — passed at base `a6e0fd2ca0bc2c60c205aae45956538ebf2be9a7` with these docs changes in the working tree
- `git diff --check` — passed before commit

The full `just website-build` reached and passed Tailwind, Eleventy, and Pagefind, then hit the existing macOS shell portability issue in `scripts/build-crate-docs.sh` (`mapfile: command not found`). The website-only build above completed successfully.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that traffic between mesh nodes—including prompts, responses, and split-model activations—is end-to-end encrypted.
  * Documented that relay services forward encrypted packets without accessing inference payloads.
  * Updated architecture and quickstart guides with details on endpoint authentication, direct connections, and relayed connections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->