### PR TITLE
ci(llama): preflight repair-token push permission before any repair work

### DIFF
--- a/scripts/llama-canary-agent-repair.sh
+++ b/scripts/llama-canary-agent-repair.sh
@@ -103,7 +103,31 @@ gh_repair() {
   GH_TOKEN="$CANARY_REPAIR_TOKEN" "$@"
 }
 
+check_repair_token_permissions() {
+  # Preflight (issue #1434 follow-up): fail in seconds when the identity behind
+  # CANARY_REPAIR_TOKEN cannot actually write to this repository, instead of
+  # discovering it via a git 403 after hours of repair work (seen live: a
+  # token minted by an account without repo write). The token is used only
+  # in scoped single commands, never exported, and never echoed.
+  local login perms
+  if ! login="$(gh_repair gh api user --jq .login 2>/dev/null)"; then
+    echo "preflight: CANARY_REPAIR_TOKEN does not authenticate (gh api user failed); check the secret value" >&2
+    return 1
+  fi
+  perms="$(gh_repair gh api "repos/${GITHUB_REPOSITORY:?}" --jq '.permissions.push' 2>/dev/null)"
+  if [[ "$perms" != "true" ]]; then
+    echo "preflight: identity '${login}' behind CANARY_REPAIR_TOKEN lacks push permission on ${GITHUB_REPOSITORY}; grant it Contents write (fine-grained PAT: repository access + Contents: Read and write) and re-save the secret, or mint the PAT from an account with write" >&2
+    return 1
+  fi
+  echo "preflight: repair token identity '${login}' has push access to ${GITHUB_REPOSITORY}"
+}
+
 cd "$ROOT"
+
+# Preflight the repair token before any repair work: a permission gap here
+# fails the run in seconds with the exact fix, instead of surfacing as a git
+# 403 after a potentially hours-long certified repair (seen live, run 33151501701).
+check_repair_token_permissions
 
 # Run-scope the persistent-runner artifacts before anything else can fail and
 # leave a previous run's state behind. The PR-body file is always cleared. The

--- a/scripts/tests/test_llama_canary_agent_repair_contract.py
+++ b/scripts/tests/test_llama_canary_agent_repair_contract.py
@@ -122,6 +122,22 @@ class LlamaCanaryAgentRepairContractTests(unittest.TestCase):
         # The repair push URL embeds the token; its stderr is redacted.
         self.assertIn("redact_token", wrapper)
 
+    def test_token_permissions_are_preflighted_before_repair_work(self) -> None:
+        wrapper = REPAIR.read_text(encoding="utf-8")
+        # A permission gap on CANARY_REPAIR_TOKEN must fail the run in
+        # seconds, before any repair work — not as a git 403 after a
+        # potentially hours-long certified repair (live: run 33151501701,
+        # "denied to i386").
+        self.assertIn("check_repair_token_permissions", wrapper)
+        # The preflight authenticates the token and asserts push permission
+        # on the target repo via scoped gh calls (never exporting the token).
+        self.assertIn('gh_repair gh api user --jq .login', wrapper)
+        self.assertIn("gh api \"repos/${GITHUB_REPOSITORY:?}\" --jq '.permissions.push'", wrapper)
+        # It runs unconditionally before the repair loop starts.
+        preflight_call = wrapper.index("check_repair_token_permissions\n\n# Run-scope")
+        self.assertGreater(preflight_call, wrapper.index("gh_repair()"))
+        self.assertLess(preflight_call, wrapper.index("agent_turn"))
+
     def test_battery_build_mirrors_the_workflow_arch_guard(self) -> None:
         wrapper = REPAIR.read_text(encoding="utf-8")
         # The family-certify job runs under Rosetta; the wrapper's build must


### PR DESCRIPTION
placeholder


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added an early permission check for the repair token.
  * Runs now fail quickly with a diagnostic message when authentication or repository push access is unavailable, instead of encountering a later access error.

* **Tests**
  * Added coverage to verify permission checks occur before repair work begins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->