### PR TITLE
ci(llama): probe actual token write capability in the repair preflight

### DIFF
--- a/scripts/llama-canary-agent-repair.sh
+++ b/scripts/llama-canary-agent-repair.sh
@@ -107,19 +107,39 @@ check_repair_token_permissions() {
   # Preflight (issue #1434 follow-up): fail in seconds when the identity behind
   # CANARY_REPAIR_TOKEN cannot actually write to this repository, instead of
   # discovering it via a git 403 after hours of repair work (seen live: a
-  # token minted by an account without repo write). The token is used only
-  # in scoped single commands, never exported, and never echoed.
-  local login perms
+  # fine-grained PAT whose account HAD repo write, but whose token lacked the
+  # Contents: write permission). The REST permissions object reflects the
+  # ACCOUNT's access, not the token's fine-grained scope, so reading
+  # .permissions is not sufficient — the check probes the actual capability by
+  # creating and deleting a temporary ref, which requires exactly the
+  # Contents: write permission a push needs. The token is used only in scoped
+  # single commands, never exported, and never echoed.
+  local login default_branch head_sha probe_ref
   if ! login="$(gh_repair gh api user --jq .login 2>/dev/null)"; then
     echo "preflight: CANARY_REPAIR_TOKEN does not authenticate (gh api user failed); check the secret value" >&2
     return 1
   fi
-  perms="$(gh_repair gh api "repos/${GITHUB_REPOSITORY:?}" --jq '.permissions.push' 2>/dev/null)"
-  if [[ "$perms" != "true" ]]; then
-    echo "preflight: identity '${login}' behind CANARY_REPAIR_TOKEN lacks push permission on ${GITHUB_REPOSITORY}; grant it Contents write (fine-grained PAT: repository access + Contents: Read and write) and re-save the secret, or mint the PAT from an account with write" >&2
+  default_branch="$(gh_repair gh api "repos/${GITHUB_REPOSITORY:?}" --jq .default_branch 2>/dev/null)"
+  if [[ -z "$default_branch" ]]; then
+    echo "preflight: could not read ${GITHUB_REPOSITORY} with the repair token; grant the PAT access to this repository" >&2
     return 1
   fi
-  echo "preflight: repair token identity '${login}' has push access to ${GITHUB_REPOSITORY}"
+  head_sha="$(gh_repair gh api "repos/${GITHUB_REPOSITORY:?}/branches/${default_branch}" --jq .commit.sha 2>/dev/null)"
+  if [[ -z "$head_sha" ]]; then
+    echo "preflight: could not resolve ${default_branch} on ${GITHUB_REPOSITORY} with the repair token" >&2
+    return 1
+  fi
+  probe_ref="refs/heads/canary-repair-token-preflight"
+  if ! gh_repair gh api --method POST "repos/${GITHUB_REPOSITORY:?}/git/refs" \
+      -f ref="$probe_ref" -f sha="$head_sha" >/dev/null 2>&1; then
+    echo "preflight: identity '${login}' cannot write refs on ${GITHUB_REPOSITORY}: the fine-grained PAT must include this repository with Contents: Read and write (account-level write is not enough). Edit the PAT's permissions or mint one with Contents: RW, then re-save CANARY_REPAIR_TOKEN." >&2
+    return 1
+  fi
+  if ! gh_repair gh api --method DELETE \
+      "repos/${GITHUB_REPOSITORY:?}/git/refs/${probe_ref//\//%2F}" >/dev/null 2>&1; then
+    echo "preflight: WARNING: write probe succeeded but the temporary ref ${probe_ref} could not be deleted; delete it manually" >&2
+  fi
+  echo "preflight: repair token identity '${login}' verified read+write on ${GITHUB_REPOSITORY}"
 }
 
 cd "$ROOT"

--- a/scripts/tests/test_llama_canary_agent_repair_contract.py
+++ b/scripts/tests/test_llama_canary_agent_repair_contract.py
@@ -126,13 +126,17 @@ class LlamaCanaryAgentRepairContractTests(unittest.TestCase):
         wrapper = REPAIR.read_text(encoding="utf-8")
         # A permission gap on CANARY_REPAIR_TOKEN must fail the run in
         # seconds, before any repair work — not as a git 403 after a
-        # potentially hours-long certified repair (live: run 33151501701,
-        # "denied to i386").
+        # potentially hours-long certified repair (live: run 33153507371,
+        # where the account HAD push but the fine-grained PAT lacked
+        # Contents: write, so REST permissions passed while git push 403'd).
         self.assertIn("check_repair_token_permissions", wrapper)
-        # The preflight authenticates the token and asserts push permission
-        # on the target repo via scoped gh calls (never exporting the token).
+        # The preflight authenticates the token and PROBES the actual write
+        # capability (create+delete a temp ref) via scoped gh calls — reading
+        # the REST permissions object is not sufficient, because it reflects
+        # the account's access, not the token's fine-grained scope.
         self.assertIn('gh_repair gh api user --jq .login', wrapper)
-        self.assertIn("gh api \"repos/${GITHUB_REPOSITORY:?}\" --jq '.permissions.push'", wrapper)
+        self.assertIn('gh_repair gh api --method POST "repos/${GITHUB_REPOSITORY:?}/git/refs"', wrapper)
+        self.assertIn('gh_repair gh api --method DELETE', wrapper)
         # It runs unconditionally before the repair loop starts.
         preflight_call = wrapper.index("check_repair_token_permissions\n\n# Run-scope")
         self.assertGreater(preflight_call, wrapper.index("gh_repair()"))


### PR DESCRIPTION
## Why

Live run 33153507371 falsified the preflight merged in #1493: it reported `repair token identity 'i386' has push access` — and the git push eleven minutes later still failed `403 denied to i386`.

Root cause: the REST `.permissions` object reports the **account's** access (i386 had been granted repo write), not the **fine-grained PAT's** scope (the token itself never had `Contents: write`). Reading permissions cannot distinguish those — only exercising the capability can.

## What

`check_repair_token_permissions()` now:

1. authenticates the token (`gh api user`),
2. reads the default branch head,
3. **creates a temporary ref** `refs/heads/canary-repair-token-preflight` pointing at it — this requires exactly the Contents: write permission a push needs — then
4. deletes the probe ref.

A failure at step 3 fails the run in seconds with the precise remediation ("the fine-grained PAT must include this repository with Contents: Read and write — account-level write is not enough; edit the PAT or mint one with Contents: RW, then re-save CANARY_REPAIR_TOKEN"). If the delete fails, a warning names the leftover ref for manual cleanup. All calls stay token-scoped through `gh_repair()`; the token is never exported or echoed.

## Validation

- 11/11 contract tests (test updated to pin the write-probe contract and record the live falsifier).
- ShellCheck, `bash -n` clean.
- The probe itself verified live: create+delete of the ref against this repository.

## Note

The current `CANARY_REPAIR_TOKEN` still lacks Contents: write — this preflight will fail fast (correctly) until the PAT itself is edited to add it or a new PAT with Contents: RW is minted and the secret re-saved. That token-side fix is admin-side.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Added an early access check before repair operations begin.
  - Repair runs now detect insufficient permissions within seconds instead of failing later.
  - Added clearer, actionable error messages when authentication or write access is unavailable.

- **Tests**
  - Added coverage to verify that access checks run consistently before repair work starts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->