### PR TITLE
ci(llama): prune stale /tmp worktrees and fix the preflight probe delete

### DIFF
--- a/scripts/llama-canary-agent-repair.sh
+++ b/scripts/llama-canary-agent-repair.sh
@@ -135,8 +135,10 @@ check_repair_token_permissions() {
     echo "preflight: identity '${login}' cannot write refs on ${GITHUB_REPOSITORY}: the fine-grained PAT must include this repository with Contents: Read and write (account-level write is not enough). Edit the PAT's permissions or mint one with Contents: RW, then re-save CANARY_REPAIR_TOKEN." >&2
     return 1
   fi
+  # The delete URL uses the branch name only (slashes percent-encoded); the
+  # refs/ prefix is part of the path, not the ref identifier.
   if ! gh_repair gh api --method DELETE \
-      "repos/${GITHUB_REPOSITORY:?}/git/refs/${probe_ref//\//%2F}" >/dev/null 2>&1; then
+      "repos/${GITHUB_REPOSITORY:?}/git/refs/heads%2Fcanary-repair-token-preflight" >/dev/null 2>&1; then
     echo "preflight: WARNING: write probe succeeded but the temporary ref ${probe_ref} could not be deleted; delete it manually" >&2
   fi
   echo "preflight: repair token identity '${login}' verified read+write on ${GITHUB_REPOSITORY}"
@@ -158,6 +160,17 @@ if [[ "$MODE" == "patch-queue" ]]; then
   rm -f "$BATTERY_LOG"
 fi
 rm -f "$ROOT/.deps/llama-canary-pr-body.md"
+
+# Repair turns routinely build scratch worktrees under /tmp (e.g.
+# /tmp/llama-old-pin, /tmp/llama-repair). On this persistent runner those
+# directories and their registrations in .deps/llama.cpp/.git/worktrees
+# survive across runs, and a later `git worktree add` for the same path
+# fails ("missing but already registered" / stale admin files) — the agent
+# treats that as fatal and ends its turn early (live: run 33158798988
+# aborted at `rm -rf /tmp/llama-old-pin && git worktree add ...`). Prune
+# stale registrations and clear the known scratch paths up front.
+git -C "$ROOT/.deps/llama.cpp" worktree prune >/dev/null 2>&1 || true
+rm -rf /tmp/llama-old-pin /tmp/llama-repair /tmp/llama-repair-* 2>/dev/null || true
 
 # The agent reuses the open repair PR on $BRANCH if one exists, so repeated
 # canary failures amend a single PR instead of stacking duplicates. Surface

--- a/scripts/tests/test_llama_canary_agent_repair_contract.py
+++ b/scripts/tests/test_llama_canary_agent_repair_contract.py
@@ -119,6 +119,12 @@ class LlamaCanaryAgentRepairContractTests(unittest.TestCase):
             'rm -f "$ROOT/.deps/llama-canary-pr-body.md"', wrapper
         )
         self.assertIn('if [[ "$MODE" == "patch-queue" ]]; then\n  rm -f "$BATTERY_LOG"', wrapper)
+        # Scratch worktrees under /tmp and their registrations survive across
+        # runs on the persistent runner and make the agent's own
+        # `git worktree add` fail; the wrapper prunes them up front (live:
+        # run 33158798988 aborted its turn on a stale /tmp/llama-old-pin).
+        self.assertIn('git -C "$ROOT/.deps/llama.cpp" worktree prune', wrapper)
+        self.assertIn("rm -rf /tmp/llama-old-pin /tmp/llama-repair /tmp/llama-repair-*", wrapper)
         # The repair push URL embeds the token; its stderr is redacted.
         self.assertIn("redact_token", wrapper)
 
@@ -137,6 +143,10 @@ class LlamaCanaryAgentRepairContractTests(unittest.TestCase):
         self.assertIn('gh_repair gh api user --jq .login', wrapper)
         self.assertIn('gh_repair gh api --method POST "repos/${GITHUB_REPOSITORY:?}/git/refs"', wrapper)
         self.assertIn('gh_repair gh api --method DELETE', wrapper)
+        # The probe ref must actually be cleaned up: the delete URL uses the
+        # percent-encoded branch name under /git/refs/ (a refs/-prefixed path
+        # 404s and leaves the probe branch behind; live: run 33158798988).
+        self.assertIn('git/refs/heads%2Fcanary-repair-token-preflight', wrapper)
         # It runs unconditionally before the repair loop starts.
         preflight_call = wrapper.index("check_repair_token_permissions\n\n# Run-scope")
         self.assertGreater(preflight_call, wrapper.index("gh_repair()"))


### PR DESCRIPTION
## Why

Run 33158798988 was the first where the token preflight passed and the repair branch actually pushed — and it exposed two small follow-ups:

1. **The agent's turn aborted early** (5 min, no rebase completed): its own `rm -rf /tmp/llama-old-pin && git worktree add ...` failed because scratch worktrees and their registrations in `.deps/llama.cpp/.git/worktrees` survive across runs on the persistent family-certify runner. This is the second short-turn failure in three runs, both environmental.

2. **The write-probe delete 404'd** — it used a `refs/`-prefixed URL; the delete endpoint takes the percent-encoded branch name. Left `refs/heads/canary-repair-token-preflight` behind (manually deleted this time).

## What

- The wrapper now runs `git worktree prune` on the llama.cpp checkout and clears the known scratch paths (`/tmp/llama-old-pin`, `/tmp/llama-repair*`) before any repair turn starts — run-scoping extends to the worktrees the turns themselves create.
- The probe delete uses `git/refs/heads%2Fcanary-repair-token-preflight`.

## Validation

11/11 contract tests (both behaviors pinned), ShellCheck + `bash -n` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repair cleanup by removing stale Git worktree registrations and known temporary repair directories.
  * Fixed temporary branch cleanup to reliably target encoded branch paths.

* **Tests**
  * Added coverage confirming stale worktrees and temporary directories are cleaned up.
  * Added validation for encoded branch cleanup requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->