### PR TITLE
ci(llama): auto-approve agent tool permissions in the repair sandbox

### DIFF
--- a/scripts/llama-canary-agent-repair.sh
+++ b/scripts/llama-canary-agent-repair.sh
@@ -135,8 +135,10 @@ check_repair_token_permissions() {
     echo "preflight: identity '${login}' cannot write refs on ${GITHUB_REPOSITORY}: the fine-grained PAT must include this repository with Contents: Read and write (account-level write is not enough). Edit the PAT's permissions or mint one with Contents: RW, then re-save CANARY_REPAIR_TOKEN." >&2
     return 1
   fi
+  # The delete URL uses the branch name only (slashes percent-encoded); the
+  # refs/ prefix is part of the path, not the ref identifier.
   if ! gh_repair gh api --method DELETE \
-      "repos/${GITHUB_REPOSITORY:?}/git/refs/${probe_ref//\//%2F}" >/dev/null 2>&1; then
+      "repos/${GITHUB_REPOSITORY:?}/git/refs/heads%2Fcanary-repair-token-preflight" >/dev/null 2>&1; then
     echo "preflight: WARNING: write probe succeeded but the temporary ref ${probe_ref} could not be deleted; delete it manually" >&2
   fi
   echo "preflight: repair token identity '${login}' verified read+write on ${GITHUB_REPOSITORY}"
@@ -158,6 +160,17 @@ if [[ "$MODE" == "patch-queue" ]]; then
   rm -f "$BATTERY_LOG"
 fi
 rm -f "$ROOT/.deps/llama-canary-pr-body.md"
+
+# Repair turns routinely build scratch worktrees under /tmp (e.g.
+# /tmp/llama-old-pin, /tmp/llama-repair). On this persistent runner those
+# directories and their registrations in .deps/llama.cpp/.git/worktrees
+# survive across runs, and a later `git worktree add` for the same path
+# fails ("missing but already registered" / stale admin files) — the agent
+# treats that as fatal and ends its turn early (live: run 33158798988
+# aborted at `rm -rf /tmp/llama-old-pin && git worktree add ...`). Prune
+# stale registrations and clear the known scratch paths up front.
+git -C "$ROOT/.deps/llama.cpp" worktree prune >/dev/null 2>&1 || true
+rm -rf /tmp/llama-old-pin /tmp/llama-repair /tmp/llama-repair-* 2>/dev/null || true
 
 # The agent reuses the open repair PR on $BRANCH if one exists, so repeated
 # canary failures amend a single PR instead of stacking duplicates. Surface

--- a/scripts/llama-canary-agent-repair.sh
+++ b/scripts/llama-canary-agent-repair.sh
@@ -211,8 +211,15 @@ agent_turn() {
   ' heartbeat "$ROOT" "$started" &
   heartbeat_pid=$!
   set +m
+  # --auto: auto-approve opencode's permission prompts. The sandbox auto-
+  # REJECTS out-of-workspace writes (e.g. scratch dirs under /tmp) in non-
+  # interactive mode, and a rejection terminates the whole turn — every
+  # short-turn failure so far traces to this (live: run 33160131810 aborted
+  # on "external_directory (/tmp/opencode/*); auto-rejecting"). The agent
+  # runs with all GitHub tokens stripped and only the wrapper holds write
+  # credentials, so auto-approval inside this sandbox is safe.
   env -u GH_TOKEN -u GITHUB_TOKEN -u CANARY_REPAIR_TOKEN \
-    opencode run --model "$AGENT_MODEL" "$prompt" \
+    opencode run --auto --model "$AGENT_MODEL" "$prompt" \
     || echo "warning: opencode turn exited non-zero" >&2
   kill -- "-$heartbeat_pid" 2>/dev/null || kill "$heartbeat_pid" 2>/dev/null || true
   wait "$heartbeat_pid" 2>/dev/null || true

--- a/scripts/tests/test_llama_canary_agent_repair_contract.py
+++ b/scripts/tests/test_llama_canary_agent_repair_contract.py
@@ -28,6 +28,11 @@ class LlamaCanaryAgentRepairContractTests(unittest.TestCase):
         self.assertNotIn("export GH_TOKEN", wrapper)
         # Agent turns explicitly strip every GitHub credential.
         self.assertIn("env -u GH_TOKEN -u GITHUB_TOKEN -u CANARY_REPAIR_TOKEN", wrapper)
+        # Turns run with --auto: opencode's sandbox otherwise auto-rejects
+        # out-of-workspace scratch writes (/tmp) in non-interactive mode and
+        # the rejection kills the whole turn (live: run 33160131810). Safe
+        # because no GitHub credential is present in the agent environment.
+        self.assertIn('opencode run --auto --model "$AGENT_MODEL"', wrapper)
         # GitHub mutations go through the token-scoped helper.
         self.assertIn("gh_repair() {", wrapper)
         self.assertNotIn("\n  gh pr create", wrapper)

--- a/scripts/tests/test_llama_canary_agent_repair_contract.py
+++ b/scripts/tests/test_llama_canary_agent_repair_contract.py
@@ -119,6 +119,12 @@ class LlamaCanaryAgentRepairContractTests(unittest.TestCase):
             'rm -f "$ROOT/.deps/llama-canary-pr-body.md"', wrapper
         )
         self.assertIn('if [[ "$MODE" == "patch-queue" ]]; then\n  rm -f "$BATTERY_LOG"', wrapper)
+        # Scratch worktrees under /tmp and their registrations survive across
+        # runs on the persistent runner and make the agent's own
+        # `git worktree add` fail; the wrapper prunes them up front (live:
+        # run 33158798988 aborted its turn on a stale /tmp/llama-old-pin).
+        self.assertIn('git -C "$ROOT/.deps/llama.cpp" worktree prune', wrapper)
+        self.assertIn("rm -rf /tmp/llama-old-pin /tmp/llama-repair /tmp/llama-repair-*", wrapper)
         # The repair push URL embeds the token; its stderr is redacted.
         self.assertIn("redact_token", wrapper)
 
@@ -137,6 +143,10 @@ class LlamaCanaryAgentRepairContractTests(unittest.TestCase):
         self.assertIn('gh_repair gh api user --jq .login', wrapper)
         self.assertIn('gh_repair gh api --method POST "repos/${GITHUB_REPOSITORY:?}/git/refs"', wrapper)
         self.assertIn('gh_repair gh api --method DELETE', wrapper)
+        # The probe ref must actually be cleaned up: the delete URL uses the
+        # percent-encoded branch name under /git/refs/ (a refs/-prefixed path
+        # 404s and leaves the probe branch behind; live: run 33158798988).
+        self.assertIn('git/refs/heads%2Fcanary-repair-token-preflight', wrapper)
         # It runs unconditionally before the repair loop starts.
         preflight_call = wrapper.index("check_repair_token_permissions\n\n# Run-scope")
         self.assertGreater(preflight_call, wrapper.index("gh_repair()"))


### PR DESCRIPTION
## Why

Run 33160131810 finally produced the smoking gun for every short agent turn so far. The log shows the agent ~11 minutes into healthy repair work (heartbeat active, real conflict resolution in progress), then:

```
permission requested: external_directory (/tmp/opencode/*); auto-rejecting
✗ mkdir -p /tmp/opencode/p0012 && … failed
Error: The user rejected permission to use this specific tool call.
agent repair turn finished
```

opencode's permission system auto-**rejects** out-of-workspace writes (scratch dirs under `/tmp`) in non-interactive runs, and a rejection **terminates the entire turn**. The agent's own repair playbook — scratch worktrees under `/tmp/llama-repair`, splitting conflicted patches into `/tmp/opencode/` parts — requests exactly the permission class the sandbox always refuses. Three of the last four runs died to this or its close cousin (stale worktree registrations from earlier `/tmp` scratch attempts, fixed in #1499).

## What

`opencode run` now passes `--auto` (auto-approve permissions not explicitly denied).

Why this is safe here — the loop's existing fail-closed design does the containment:
- the agent runs with `GH_TOKEN`/`GITHUB_TOKEN`/`CANARY_REPAIR_TOKEN` stripped from its environment,
- the job's own token is read-only (`contents: read`),
- every GitHub mutation is wrapper-only via the token-scoped `gh_repair()`,

so the worst the agent can touch is the runner's own checkout and scratch space — which is precisely what it needs to do the repair.

## Validation

11/11 contract tests (new pin: `--auto` on the turn invocation), ShellCheck + `bash -n` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repair preparation by removing stale Git worktree registrations and known temporary directories.
  * Strengthened cleanup of temporary branch references, including branch names requiring URL encoding.
  * Enabled automatic approval handling during agent repair runs while continuing to protect GitHub credentials.

* **Tests**
  * Added coverage validating workspace cleanup, secure environment handling, and encoded reference cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->