### PR TITLE
ci(llama): ensure the repair PR exists before applying the agent's body

### DIFF
--- a/scripts/llama-canary-agent-repair.sh
+++ b/scripts/llama-canary-agent-repair.sh
@@ -342,6 +342,13 @@ report_success() {
   # publishes the certified tree, writes the status comment, and verifies the
   # PR head binding before declaring success.
   publish_repair_branch
+  # Ensure the PR exists BEFORE applying the body: on a first run no PR
+  # exists yet, ensure_pr creates it (with the generic body), and the agent's
+  # pre-certification draft is then applied on top (live: run 33163990453
+  # pushed a certified branch and opened the PR via pr_comment's ensure_pr
+  # AFTER apply_pr_body had already no-op'd, so the PR kept the generic body
+  # and the agent's 103-line analysis was never shown).
+  ensure_pr >/dev/null
   apply_pr_body
   # The literal backticks around the certified SHA are Markdown, not command
   # substitution.

--- a/scripts/tests/test_llama_canary_agent_repair_contract.py
+++ b/scripts/tests/test_llama_canary_agent_repair_contract.py
@@ -48,6 +48,11 @@ class LlamaCanaryAgentRepairContractTests(unittest.TestCase):
         self.assertIn('CERTIFIED_SHA="$(git rev-parse HEAD)"', wrapper)
         # Success requires the remote PR head to equal the certified commit.
         self.assertIn("verify_pr_head_is_certified", wrapper)
+        # The PR must exist before apply_pr_body runs: on a first run the PR
+        # is created lazily, and applying the agent's draft body before
+        # ensure_pr silently no-ops, leaving the generic body on the PR
+        # (live: run 33163990453 — the agent's full analysis never showed).
+        self.assertIn("ensure_pr >/dev/null\n  apply_pr_body", wrapper)
         self.assertIn("report_success", wrapper)
         # The PR-body agent turn runs only before certification; after a green
         # battery only the deterministic apply_pr_body may run.


### PR DESCRIPTION
## Why

Run 33163990453 was the first complete end-to-end repair — and its PR (#1505) showed only the one-sentence fallback body, even though the agent wrote a full 103-line upstream/queue/risk analysis (visible in the run log). James flagged the thin body.

Root cause is an ordering bug in `report_success`: `apply_pr_body` runs first and silently no-ops when no PR exists yet (first run: the PR hasn't been created); the PR is only created later inside `pr_comment` → `ensure_pr` with the generic body. The agent's draft, written before certification exactly as designed, never gets applied.

## What

`report_success` now calls `ensure_pr` (creating the PR if needed) **before** `apply_pr_body`, so the agent-drafted description always lands on the PR. Deterministic, wrapper-only — no agent turn runs after the green battery.

(The body of PR #1505 itself was hand-repaired from the run-log evidence.)

## Validation

11/11 contract tests (new pin: `ensure_pr` precedes `apply_pr_body` in `report_success`), ShellCheck + `bash -n` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed repair pull requests so the agent’s pre-certification draft description is preserved, including on the first run.

* **Tests**
  * Added coverage to verify the repair request is created before its draft description is applied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->