### PR TITLE
fix(skippy): address Qwen4 split framing review findings

### DIFF
--- a/crates/skippy-ffi/README.md
+++ b/crates/skippy-ffi/README.md
@@ -243,6 +243,6 @@ hook currently bound by this crate.
 | `skippy_model_info_tensor_at` | Returns tensor metadata for one index. |
 | `skippy_slice_plan_create` | Creates a GGUF slicing plan from model metadata. |
 | `skippy_slice_plan_free` | Releases a slicing plan. |
-| `skippy_slice_plan_add_layer_range` | Adds one stage layer range and embedding/output ownership flags to a plan. |
+| `skippy_slice_plan_add_layer_range` | Adds one stage layer range and shared-tensor ownership flags to a plan. |
 | `skippy_write_slice_gguf` | Writes one planned stage slice as a GGUF artifact. |
 | `skippy_write_gguf_from_parts` | Composes multiple GGUF parts into one materialized package. |

--- a/crates/skippy-ffi/src/dynamic.rs
+++ b/crates/skippy-ffi/src/dynamic.rs
@@ -227,7 +227,7 @@ dynamic_symbols! {
     skippy_model_info_tensor_at(info: *mut ModelInfo, index: usize, out_tensor: *mut TensorInfo, out_error: *mut *mut Error) -> Status;
     skippy_slice_plan_create(info: *mut ModelInfo, out_plan: *mut *mut SlicePlan, out_error: *mut *mut Error) -> Status;
     skippy_slice_plan_free(plan: *mut SlicePlan, out_error: *mut *mut Error) -> Status;
-    skippy_slice_plan_add_layer_range(plan: *mut SlicePlan, stage_index: i32, layer_start: i32, layer_end: i32, include_embeddings: bool, include_output: bool, out_error: *mut *mut Error) -> Status;
+    skippy_slice_plan_add_layer_range(plan: *mut SlicePlan, stage_index: i32, layer_start: i32, layer_end: i32, include_embeddings: bool, include_output: bool, include_per_layer_token_embd: bool, out_error: *mut *mut Error) -> Status;
     skippy_write_slice_gguf(info: *mut ModelInfo, plan: *const SlicePlan, stage_index: i32, output_path: *const c_char, out_error: *mut *mut Error) -> Status;
     skippy_write_gguf_from_parts(input_paths: *const *const c_char, input_count: usize, output_path: *const c_char, out_error: *mut *mut Error) -> Status;
     mtmd_default_marker() -> *const c_char;

--- a/crates/skippy-ffi/src/lib.rs
+++ b/crates/skippy-ffi/src/lib.rs
@@ -5,7 +5,7 @@ mod dynamic_library;
 // without compiling the crate to determine native-runtime compatibility.
 pub const ABI_VERSION_MAJOR: u32 = 0;
 pub const ABI_VERSION_MINOR: u32 = 1;
-pub const ABI_VERSION_PATCH: u32 = 41;
+pub const ABI_VERSION_PATCH: u32 = 42;
 
 mod abi;
 mod activation;

--- a/crates/skippy-ffi/src/static_bindings.rs
+++ b/crates/skippy-ffi/src/static_bindings.rs
@@ -566,6 +566,7 @@ unsafe extern "C" {
         layer_end: i32,
         include_embeddings: bool,
         include_output: bool,
+        include_per_layer_token_embd: bool,
         out_error: *mut *mut Error,
     ) -> Status;
 

--- a/crates/skippy-model-package/src/plan.rs
+++ b/crates/skippy-model-package/src/plan.rs
@@ -23,6 +23,8 @@ pub(crate) struct StagePlan {
     pub(crate) layer_end: u32,
     pub(crate) includes_embeddings: bool,
     pub(crate) includes_output: bool,
+    #[serde(skip_serializing)]
+    pub(crate) includes_per_layer_token_embd: bool,
     pub(crate) tensor_count: usize,
     pub(crate) tensor_bytes: u64,
 }
@@ -67,6 +69,9 @@ pub(crate) fn build_plan_from_tensors(stages: usize, tensors: &[TensorInfo]) -> 
                     layer_end,
                     includes_embeddings: stage_index == 0,
                     includes_output: stage_index + 1 == stages,
+                    includes_per_layer_token_embd: tensors
+                        .iter()
+                        .any(|tensor| is_per_layer_token_embd(&tensor.name)),
                     tensor_count: tensors.len(),
                     tensor_bytes: tensors.iter().map(|tensor| tensor.byte_size).sum(),
                 }
@@ -111,6 +116,9 @@ pub(crate) fn stage_plan_from_tensors(
         layer_end,
         includes_embeddings,
         includes_output,
+        includes_per_layer_token_embd: selected
+            .iter()
+            .any(|tensor| is_per_layer_token_embd(&tensor.name)),
         tensor_count: selected.len(),
         tensor_bytes: selected.iter().map(|tensor| tensor.byte_size).sum(),
     }
@@ -142,11 +150,8 @@ fn tensor_in_explicit_stage(
     includes_embeddings: bool,
     includes_output: bool,
 ) -> bool {
-    if is_per_layer_token_embd(&tensor.name)
-        && let Some(retained) =
-            sparse_per_layer_embedding_retention(all_tensors, layer_start, layer_end)
-    {
-        return retained;
+    if is_per_layer_token_embd(&tensor.name) {
+        return per_layer_embedding_retained(all_tensors, layer_start, layer_end);
     }
     matches!(
         tensor.layer_index,
@@ -174,19 +179,19 @@ fn is_per_layer_token_embd(name: &str) -> bool {
 ///
 /// Only qwen4exp is known to consume it from a *sparse* subset of layers
 /// (`blk.N.ple_*`; `qwen4exp.ple.layers = [1]` on Qwen3.8-Flash-Next), so only
-/// one stage of a split can ever read it. Return `Some(retain)` for that shape.
+/// one stage of a split can ever read it. Retain it only with those consumers.
 ///
-/// Return `None` for every other artifact so the caller falls back to the
-/// ordinary embedding-ownership rule. This matters: Gemma3n/Gemma4 gather the
-/// same table through per-block tensors named `blk.N.inp_gate`, `blk.N.proj`
+/// Retain the table on every stage for every other artifact. This matters:
+/// Gemma3n/Gemma4 gather the same table through per-block tensors named
+/// `blk.N.inp_gate`, `blk.N.proj`
 /// and `blk.N.post_norm` (`llama-arch.cpp:568-570`) — *not* `per_layer_*` — so
 /// a name-based consumer scan finds nothing for them. Failing closed here would
 /// silently drop their table from every stage.
-fn sparse_per_layer_embedding_retention(
+fn per_layer_embedding_retained(
     all_tensors: &[TensorInfo],
     layer_start: u32,
     layer_end: u32,
-) -> Option<bool> {
+) -> bool {
     let mut saw_sparse_consumer = false;
     let mut retained = false;
     for tensor in all_tensors {
@@ -199,7 +204,7 @@ fn sparse_per_layer_embedding_retention(
             break;
         }
     }
-    saw_sparse_consumer.then_some(retained)
+    !saw_sparse_consumer || retained
 }
 
 fn is_sparse_per_layer_embedding_consumer(name: &str) -> bool {

--- a/crates/skippy-model-package/src/tests.rs
+++ b/crates/skippy-model-package/src/tests.rs
@@ -485,8 +485,7 @@ fn per_layer_token_embd_is_kept_by_every_stage_for_a_gemma_shaped_artifact() {
     // `blk.N.inp_gate` / `blk.N.proj` / `blk.N.post_norm` (llama-arch.cpp:568-570)
     // -- none of which carry a `ple_` or `per_layer_` prefix. A name-based
     // consumer scan therefore finds nothing for them, and the qwen4exp rule must
-    // NOT fail closed: it must defer to ordinary embedding ownership, which keeps
-    // the table wherever these artifacts already put it.
+    // NOT fail closed: every stage must retain the shared table.
     let mut tensors = vec![
         sized_tensor("token_embd.weight", None, TensorRole::Embedding, 100),
         sized_tensor(
@@ -512,18 +511,68 @@ fn per_layer_token_embd_is_kept_by_every_stage_for_a_gemma_shaped_artifact() {
     }
 
     let plan = crate::plan::build_plan_from_tensors(4, &tensors).unwrap();
-    let stage0 = &plan.stages[0];
-    assert!(
-        stage_selects(
-            &tensors,
-            stage0.layer_start,
-            stage0.layer_end,
-            stage0.includes_embeddings,
-            stage0.includes_output
+    for stage in &plan.stages {
+        assert!(
+            stage.includes_per_layer_token_embd
+                && stage_selects(
+                    &tensors,
+                    stage.layer_start,
+                    stage.layer_end,
+                    stage.includes_embeddings,
+                    stage.includes_output
+                ),
+            "gemma-shaped stage {} must retain per_layer_token_embd.weight",
+            stage.stage_index
+        );
+    }
+}
+
+#[test]
+fn cross_shard_ple_ownership_uses_complete_source_tensor_counts_and_bytes() {
+    // The shared table is in shard 0 while the only sparse PLE consumer is in
+    // shard 1. Planning joins both inventories before it decides which stage
+    // owns the table, and the resulting ownership bit is passed to every
+    // shard-local native slice plan.
+    let table_bytes = 28_800_138_240;
+    let table_shard = vec![
+        sized_tensor("token_embd.weight", None, TensorRole::Embedding, 100),
+        sized_tensor(
+            "per_layer_token_embd.weight",
+            None,
+            TensorRole::Embedding,
+            table_bytes,
         ),
-        "a gemma-shaped artifact must fall back to embedding ownership, not be \
-         silently stripped of its per-layer table by the qwen4exp rule"
-    );
+    ];
+    let mut consumer_shard = Vec::new();
+    for layer in 0..4u32 {
+        consumer_shard.push(sized_tensor(
+            &format!("blk.{layer}.attn_norm.weight"),
+            Some(layer),
+            TensorRole::Layer,
+            10,
+        ));
+    }
+    consumer_shard.push(sized_tensor(
+        "blk.1.ple_mlp.weight",
+        Some(1),
+        TensorRole::Layer,
+        7,
+    ));
+
+    let tensors = table_shard
+        .into_iter()
+        .chain(consumer_shard)
+        .collect::<Vec<_>>();
+    let plan = crate::plan::build_plan_from_tensors(2, &tensors).unwrap();
+    let stage0 = &plan.stages[0];
+    let stage1 = &plan.stages[1];
+
+    assert!(stage0.includes_per_layer_token_embd);
+    assert!(!stage1.includes_per_layer_token_embd);
+    assert_eq!(stage0.tensor_count, 5);
+    assert_eq!(stage0.tensor_bytes, table_bytes + 127);
+    assert_eq!(stage1.tensor_count, 2);
+    assert_eq!(stage1.tensor_bytes, 20);
 }
 
 fn stage_selects(

--- a/crates/skippy-model-package/src/write.rs
+++ b/crates/skippy-model-package/src/write.rs
@@ -319,6 +319,7 @@ fn write_single_source_stage_artifact(
         stage.layer_end,
         stage.includes_embeddings,
         stage.includes_output,
+        stage.includes_per_layer_token_embd,
     )?;
     info.write_slice_gguf(&plan, stage.stage_index as u32, out)
         .with_context(|| format!("write GGUF slice {}", out.display()))

--- a/crates/skippy-runtime/src/gguf_writer.rs
+++ b/crates/skippy-runtime/src/gguf_writer.rs
@@ -134,6 +134,7 @@ impl SlicePlan {
         layer_end: u32,
         include_embeddings: bool,
         include_output: bool,
+        include_per_layer_token_embd: bool,
     ) -> Result<()> {
         let mut error = ptr::null_mut();
         let status = unsafe {
@@ -144,6 +145,7 @@ impl SlicePlan {
                 i32::try_from(layer_end).context("layer_end exceeds i32")?,
                 include_embeddings,
                 include_output,
+                include_per_layer_token_embd,
                 &mut error,
             )
         };

--- a/scripts/prepare-llama.sh
+++ b/scripts/prepare-llama.sh
@@ -8,7 +8,7 @@ LLAMA_UPSTREAM_URL="${LLAMA_UPSTREAM_URL:-https://github.com/ggml-org/llama.cpp.
 LLAMA_WORKDIR="${LLAMA_WORKDIR:-$ROOT/.deps/llama.cpp}"
 PIN_FILE="${LLAMA_PIN_FILE:-$ROOT/third_party/llama.cpp/upstream.txt}"
 PATCH_DIR="${LLAMA_PATCH_DIR:-$ROOT/third_party/llama.cpp/patches}"
-PREPARE_SCHEMA=2
+PREPARE_SCHEMA=3
 
 if [[ ! -f "$PIN_FILE" ]]; then
   echo "missing llama upstream pin: $PIN_FILE" >&2

--- a/scripts/tests/test_prepare_llama.py
+++ b/scripts/tests/test_prepare_llama.py
@@ -200,7 +200,7 @@ class PrepareLlamaTests(unittest.TestCase):
                     (workdir / ".mesh-llm-prepare-schema")
                     .read_text(encoding="utf-8")
                     .strip(),
-                    "2",
+                    "3",
                 )
                 self.assertFalse(hook_marker.exists())
 

--- a/third_party/llama.cpp/patches/0031-skippy-fix-Qwen4Exp-activation-frame-staging.patch
+++ b/third_party/llama.cpp/patches/0031-skippy-fix-Qwen4Exp-activation-frame-staging.patch
@@ -1,0 +1,95 @@
+From 17067fe5c8d5cbee04f7974e1d93b98d4d7c4034 Mon Sep 17 00:00:00 2001
+From: Scam
+ <44c96d97d4bda5bbcbd62565b0b19bb2e895e1fad5d9e9116f267909f1dae78e@meshllm.communities.buzz.xyz>
+Date: Sat, 29 Aug 2026 08:35:38 +1000
+Subject: [PATCH 31/32] skippy: fix Qwen4Exp activation frame staging
+
+---
+ src/skippy/activation.cpp      |  5 ++++-
+ src/skippy/execution-batch.cpp | 27 ++++++++++++++++++++++-----
+ 2 files changed, 26 insertions(+), 6 deletions(-)
+
+diff --git a/src/skippy/activation.cpp b/src/skippy/activation.cpp
+index 43cba21f3..82d22ebf8 100644
+--- a/src/skippy/activation.cpp
++++ b/src/skippy/activation.cpp
+@@ -646,9 +646,12 @@ enum skippy_status skippy_decode_activation_frame(
+         }
+     } else {
+         const float * input = static_cast<const float *>(input_payload);
++        const size_t input_row_width = qwen4exp_activation_input
++            ? static_cast<size_t>(llama_model_n_embd_out(session->stage_model->model))
++            : static_cast<size_t>(n_embd);
+         for (int32_t i = 0; i < n_tokens; ++i) {
+             float * dst = embd_storage.data() + static_cast<size_t>(i)*n_embd_inp;
+-            std::memcpy(dst, input + static_cast<size_t>(i)*n_embd, static_cast<size_t>(n_embd)*sizeof(float));
++            std::memcpy(dst, input + static_cast<size_t>(i)*input_row_width, static_cast<size_t>(n_embd)*sizeof(float));
+             std::memset(dst + n_embd, 0, static_cast<size_t>(n_embd_inp - n_embd)*sizeof(float));
+         }
+     }
+diff --git a/src/skippy/execution-batch.cpp b/src/skippy/execution-batch.cpp
+index eaab6d31f..0124f2f6d 100644
+--- a/src/skippy/execution-batch.cpp
++++ b/src/skippy/execution-batch.cpp
+@@ -410,6 +410,14 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+     const int32_t n_embd_inp = llama_model_n_embd_inp(first->stage_model->model);
+     const int32_t n_pos_per_embd = first->stage_model->model->hparams.n_pos_per_embd();
+     const bool activation_input = skippy_is_filtered(first) && first->stage_model->config.layer_start > 0;
++    const bool qwen4exp_activation_input =
++            activation_input && first->stage_model->model->arch == LLM_ARCH_QWEN4EXP;
++    const int32_t qwen4exp_hc = qwen4exp_activation_input
++        ? static_cast<int32_t>(first->stage_model->model->hparams.dsv4_hc_mult)
++        : 0;
++    const size_t activation_width = qwen4exp_activation_input
++        ? static_cast<size_t>(n_embd) * static_cast<size_t>(qwen4exp_hc)
++        : static_cast<size_t>(n_embd);
+     const bool request_logits = first->stage_model->config.include_output;
+     const bool request_embeddings = skippy_emits_activation_frame(first);
+ 
+@@ -473,10 +481,14 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+     }
+ 
+     std::vector<float> embd_storage;
++    std::vector<float> qwen4exp_hc_storage;
+     std::vector<int32_t> glm_dsa_input_top_k_storage;
+     std::vector<llama_token> token_storage;
+     if (activation_input) {
+         embd_storage.resize(static_cast<size_t>(n_tokens)*n_embd_inp);
++        if (qwen4exp_activation_input) {
++            qwen4exp_hc_storage.resize(request_count*activation_width);
++        }
+         if ((batch_input_flags & SKIPPY_ACTIVATION_FLAG_GLM_DSA_TOP_K) != 0) {
+             glm_dsa_input_top_k_storage.resize(request_count*batch_input_top_k);
+         }
+@@ -487,6 +499,15 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+             if ((input_desc->flags & SKIPPY_ACTIVATION_FLAG_GEMMA3N_ALTUP) != 0) {
+                 skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, "batched activation decode does not support Gemma3n AltUp sidebands yet");
+                 return SKIPPY_STATUS_UNSUPPORTED;
++            } else if (qwen4exp_activation_input) {
++                std::memcpy(dst, input_payload, static_cast<size_t>(n_embd)*sizeof(float));
++                if (n_embd_inp > n_embd) {
++                    std::memset(dst + n_embd, 0, static_cast<size_t>(n_embd_inp - n_embd)*sizeof(float));
++                }
++                std::memcpy(
++                        qwen4exp_hc_storage.data() + static_cast<size_t>(i)*activation_width,
++                        input_payload,
++                        hidden_bytes_per_request);
+             } else if (n_embd_inp == n_embd) {
+                 std::memcpy(dst, input_payload, hidden_bytes_per_request);
+             } else {
+@@ -538,12 +559,8 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+     };
+ 
+     skippy_activation_tokens_scope activation_tokens_scope(token_ids, request_count);
+-    const bool qwen4exp_activation_input = activation_input && first->stage_model->model->arch == LLM_ARCH_QWEN4EXP;
+-    const int32_t qwen4exp_hc = qwen4exp_activation_input
+-        ? static_cast<int32_t>(first->stage_model->model->hparams.dsv4_hc_mult)
+-        : 0;
+     skippy_qwen4exp_hc_scope qwen4exp_hc_scope(
+-            qwen4exp_activation_input ? embd_storage.data() : nullptr,
++            qwen4exp_hc_storage.empty() ? nullptr : qwen4exp_hc_storage.data(),
+             static_cast<uint32_t>(request_count),
+             n_embd,
+             qwen4exp_hc);
+-- 
+2.54.0 (Apple Git-157)

--- a/third_party/llama.cpp/patches/0032-skippy-carry-full-source-shared-table-ownership.patch
+++ b/third_party/llama.cpp/patches/0032-skippy-carry-full-source-shared-table-ownership.patch
@@ -1,0 +1,128 @@
+From cb6738898187f1f351f21b6cbeb9597feb32e9df Mon Sep 17 00:00:00 2001
+From: Scam
+ <44c96d97d4bda5bbcbd62565b0b19bb2e895e1fad5d9e9116f267909f1dae78e@meshllm.communities.buzz.xyz>
+Date: Sat, 29 Aug 2026 08:36:03 +1000
+Subject: [PATCH 32/32] skippy: carry full-source shared-table ownership
+
+---
+ include/skippy/common.h        |  2 +-
+ include/skippy/model_package.h |  3 ++-
+ src/skippy/model_package.cpp   | 36 ++++++++--------------------------
+ 3 files changed, 11 insertions(+), 30 deletions(-)
+
+diff --git a/include/skippy/common.h b/include/skippy/common.h
+index e7f322abf..af927f835 100644
+--- a/include/skippy/common.h
++++ b/include/skippy/common.h
+@@ -34,7 +34,7 @@ extern "C" {
+ 
+ #define SKIPPY_ABI_VERSION_MAJOR 0
+ #define SKIPPY_ABI_VERSION_MINOR 1
+-#define SKIPPY_ABI_VERSION_PATCH 41
++#define SKIPPY_ABI_VERSION_PATCH 42
+ 
+ #if defined(_MSC_VER)
+ #define SKIPPY_DEPRECATED(message) __declspec(deprecated(message))
+diff --git a/include/skippy/model_package.h b/include/skippy/model_package.h
+index e2e566a29..22639b8f5 100644
+--- a/include/skippy/model_package.h
++++ b/include/skippy/model_package.h
+@@ -70,7 +70,7 @@ LLAMA_API enum skippy_status skippy_slice_plan_free(
+         struct skippy_slice_plan * plan,
+         struct skippy_error ** out_error);
+ 
+-/** @brief Adds a stage layer range and its embedding/output ownership to a plan. */
++/** @brief Adds a stage layer range and its shared-tensor ownership to a plan. */
+ LLAMA_API enum skippy_status skippy_slice_plan_add_layer_range(
+         struct skippy_slice_plan * plan,
+         int32_t stage_index,
+@@ -78,6 +78,7 @@ LLAMA_API enum skippy_status skippy_slice_plan_add_layer_range(
+         int32_t layer_end,
+         bool include_embeddings,
+         bool include_output,
++        bool include_per_layer_token_embd,
+         struct skippy_error ** out_error);
+ 
+ /** @brief Writes one planned stage slice as a GGUF file. */
+diff --git a/src/skippy/model_package.cpp b/src/skippy/model_package.cpp
+index 36f32119a..ffd84c132 100644
+--- a/src/skippy/model_package.cpp
++++ b/src/skippy/model_package.cpp
+@@ -41,6 +41,7 @@ struct skippy_slice_range {
+     int32_t layer_end = 0;
+     bool include_embeddings = false;
+     bool include_output = false;
++    bool include_per_layer_token_embd = false;
+ };
+ 
+ struct skippy_slice_plan {
+@@ -250,37 +251,14 @@ static bool skippy_parse_tensor_metadata(skippy_model_info * info) {
+     return ok && info->tensors.size() == static_cast<size_t>(n_tensors);
+ }
+ 
+-static bool skippy_stage_contains_ple(
+-        const skippy_model_info & info,
+-        const skippy_slice_range & range) {
+-    return std::any_of(info.tensors.begin(), info.tensors.end(), [&](const skippy_tensor_meta & tensor) {
+-        if (tensor.layer_index < range.layer_start || tensor.layer_index >= range.layer_end) {
+-            return false;
+-        }
+-        static const std::regex ple_pattern("^blk\\.[0-9]+\\.ple_");
+-        return std::regex_search(tensor.name, ple_pattern);
+-    });
+-}
+-
+ static bool skippy_tensor_selected(
+-        const skippy_model_info & info,
+         const skippy_tensor_meta & tensor,
+         const skippy_slice_range & range) {
+     if (tensor.name == "per_layer_token_embd.weight") {
+-        const bool qwen4exp_shape = std::any_of(
+-                info.tensors.begin(), info.tensors.end(), [](const skippy_tensor_meta & candidate) {
+-                    static const std::regex ple_pattern("^blk\\.[0-9]+\\.ple_");
+-                    return std::regex_search(candidate.name, ple_pattern);
+-                });
+-        if (qwen4exp_shape) {
+-            // Qwen4Exp has sparse PLE consumers. Infer them from the PLE block
+-            // tensors because a split-shard GGUF context exposes only shard-local
+-            // metadata and may omit qwen4exp.ple.layers entirely.
+-            return skippy_stage_contains_ple(info, range);
+-        }
+-        // Other families using this shared table consume it throughout their
+-        // blocks; preserve retention on every stage for those architectures.
+-        return true;
++        // The caller plans from the complete tensor inventory. A single shard
++        // cannot infer ownership when this table and its PLE consumers live in
++        // different GGUF parts.
++        return range.include_per_layer_token_embd;
+     }
+     if (tensor.layer_index >= 0) {
+         return tensor.layer_index >= range.layer_start && tensor.layer_index < range.layer_end;
+@@ -564,6 +542,7 @@ enum skippy_status skippy_slice_plan_add_layer_range(
+         int32_t layer_end,
+         bool include_embeddings,
+         bool include_output,
++        bool include_per_layer_token_embd,
+         struct skippy_error ** out_error) {
+     if (plan == nullptr) {
+         skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "plan is required");
+@@ -580,6 +559,7 @@ enum skippy_status skippy_slice_plan_add_layer_range(
+     range.layer_end = layer_end;
+     range.include_embeddings = include_embeddings;
+     range.include_output = include_output;
++    range.include_per_layer_token_embd = include_per_layer_token_embd;
+     plan->ranges.push_back(range);
+     return skippy_success(out_error);
+ }
+@@ -609,7 +589,7 @@ enum skippy_status skippy_write_slice_gguf(
+ 
+     std::vector<skippy_source_tensor> selected;
+     for (const skippy_tensor_meta & tensor : info->tensors) {
+-        if (skippy_tensor_selected(*info, tensor, *range)) {
++        if (skippy_tensor_selected(tensor, *range)) {
+             selected.push_back({ info, &tensor });
+         }
+     }
+-- 
+2.54.0 (Apple Git-157)
+

--- a/website/src/docs/pages/skippy-api.md
+++ b/website/src/docs/pages/skippy-api.md
@@ -624,7 +624,7 @@ LLAMA_API enum skippy_status skippy_slice_plan_free(
 <a id="skippy-fn-skippy-slice-plan-add-layer-range"></a>
 #### `skippy_slice_plan_add_layer_range`
 
-Adds a stage layer range and its embedding/output ownership to a plan.
+Adds a stage layer range and its shared-tensor ownership to a plan.
 
 ```cpp
 LLAMA_API enum skippy_status skippy_slice_plan_add_layer_range(
@@ -634,6 +634,7 @@ LLAMA_API enum skippy_status skippy_slice_plan_add_layer_range(
         int32_t layer_end,
         bool include_embeddings,
         bool include_output,
+        bool include_per_layer_token_embd,
         struct skippy_error ** out_error);
 ```
 
@@ -1301,7 +1302,7 @@ LLAMA_API enum skippy_status skippy_parse_chat_response_json(
 The headers also define the following enums, structs, opaque handles, and ABI constants:
 
 - `activation.h`: `skippy_activation_dtype`, `skippy_activation_layout`, `skippy_activation_desc`, `SKIPPY_ACTIVATION_FLAG_RWKV7_V_FIRST = (UINT64_C(1) << 0)`, `SKIPPY_ACTIVATION_FLAG_GEMMA3N_ALTUP = (UINT64_C(1) << 1)`, `SKIPPY_ACTIVATION_FLAG_INKLING_MTP_EMBD = (UINT64_C(1) << 2)`, `SKIPPY_ACTIVATION_FLAG_GLM_DSA_TOP_K = (UINT64_C(1) << 3)`
-- `common.h`: `skippy_feature`, `skippy_status`, `skippy_error`, `skippy_abi_version`, `SKIPPY_ABI_VERSION_MAJOR = 0`, `SKIPPY_ABI_VERSION_MINOR = 1`, `SKIPPY_ABI_VERSION_PATCH = 41`
+- `common.h`: `skippy_feature`, `skippy_status`, `skippy_error`, `skippy_abi_version`, `SKIPPY_ABI_VERSION_MAJOR = 0`, `SKIPPY_ABI_VERSION_MINOR = 1`, `SKIPPY_ABI_VERSION_PATCH = 42`
 - `devices.h`: `skippy_backend_device_type`, `skippy_backend_device_cap`, `skippy_backend_device`
 - `events.h`: `skippy_runtime_event_v1`, `skippy_runtime_event_reporter_v1`, `SKIPPY_RUNTIME_EVENT_V1_ABI_VERSION = 1`
 - `execution.h`: `skippy_iteration_request`


### PR DESCRIPTION
## Summary

Follow-up to the four unresolved CodeRabbit threads on #1509, which merged before those findings were addressed.

- copy Qwen4Exp multi-token activation rows with the wide source stride
- keep sampled-batch Qwen4Exp hyper-connected activations in a dedicated wide buffer
- retain `per_layer_token_embd.weight` on every stage for non-sparse/Gemma-shaped consumers
- decide sparse PLE shared-table ownership from the complete multi-shard inventory, then pass that decision into each shard-local native writer

## ABI inventory

Native ABI version: `0.1.41` -> `0.1.42`.

| Changed | Declaration | Implementation and mirrors | Reason | Compatibility |
| --- | --- | --- | --- | --- |
| `skippy_slice_plan_add_layer_range(struct skippy_slice_plan *, int32_t, int32_t, int32_t, bool, bool, bool, struct skippy_error **)` | `include/skippy/model_package.h` | `src/skippy/model_package.cpp`; `crates/skippy-ffi/src/{dynamic.rs,static_bindings.rs}`; `crates/skippy-runtime/src/gguf_writer.rs` | Carry full-source shared-table ownership across shard-local writes | Rust mirror and caller updated in lockstep; older native runtimes are intentionally rejected by the ABI-version gate |

No public declaration was removed. `PREPARE_SCHEMA` advances from 2 to 3 so existing prepared llama trees cannot silently reuse the prior ABI.

## Validation

- llama patch queue applies cleanly at pinned upstream `f5e85d43a048f3d5adefb4c5e29867d8077fba62`, producing patched head `d4e194b4c6ac55a38dd74cef8531c705404f13c2`
- `cargo test -p skippy-model-package`: 64 passed
- `cargo test -p skippy-runtime --lib`: 84 passed
- `cargo test -p skippy-server --lib`: 529 passed, 3 ignored
- focused prepare-llama contracts: 2 passed
- static and dynamic model-package lanes: 64 passed each
- Clippy is clean for `skippy-model-package`, `skippy-runtime`, and static `skippy-ffi`
- `cargo fmt --all --check`, generated API-doc check, C11 public-header compile, and C++17 public-header compile pass

The root `cargo check -p mesh-llm` reached the final dependency layer but could not finish because the local volume ran out of space while Cargo created an rmeta temp directory. No compiler diagnostic was emitted before that environment failure; CI remains the authoritative root-package gate.

## Original review threads

- https://github.com/Mesh-LLM/mesh-llm/pull/1509#discussion_r3882772891
- https://github.com/Mesh-LLM/mesh-llm/pull/1509#discussion_r3882772898
- https://github.com/Mesh-LLM/mesh-llm/pull/1509#discussion_r3882772917
- https://github.com/Mesh-LLM/mesh-llm/pull/1509#discussion_r3882772929


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved model slicing for shared per-layer token embeddings, including correct cross-shard ownership and retention.
  * Added support for explicitly selecting per-layer token embeddings in slice plans.
  * Improved Qwen4Exp activation staging during decoding.

* **Bug Fixes**
  * Corrected tensor counts, sizes, and ownership when shared embedding tables span shards.
  * Updated preparation checks to rebuild outdated llama.cpp worktrees.

* **Documentation**
  * Updated API documentation and ABI version information for the revised slice-planning interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->