### PR TITLE
canary: certify GLM-4.5-Air pipeline splits

### DIFF
--- a/ci/llama-canary/family-certified.json
+++ b/ci/llama-canary/family-certified.json
@@ -62,8 +62,8 @@
       "profile": "full",
       "cadences": ["llama-bump", "manual-full"],
       "artifact": {"repo": "unsloth/GLM-4.5-Air-GGUF", "revision": "506d64aa8c5cfe9dbbf00bc7a15739438f83204d", "files": ["Q4_K_M/GLM-4.5-Air-Q4_K_M-00001-of-00002.gguf", "Q4_K_M/GLM-4.5-Air-Q4_K_M-00002-of-00002.gguf"], "file_integrity": {"Q4_K_M/GLM-4.5-Air-Q4_K_M-00001-of-00002.gguf": {"size_bytes": 50000746752, "blob_id": "3e7e5d25a6db33b7c90f8c5203d6f490d6c0a4f04a46f228af0e33727db5df5e"}, "Q4_K_M/GLM-4.5-Air-Q4_K_M-00002-of-00002.gguf": {"size_bytes": 22975001632, "blob_id": "ac6e50523d45c53faf3bf72d8fe109f3dd54bc6abe98a7773a3636112ead82a6"}}, "selector": "Q4_K_M"},
-      "execution": {"trunk_layers": 46, "mtp_layers": 1, "activation_width": 4096, "boundary_sweep_period": 0, "speculative_policy": "mtp-if-present"},
-      "resources": {"runner_role": "family-certify", "cache_policy": "immutable-local", "estimated_model_bytes": 72966388736},
+      "execution": {"trunk_layers": 46, "mtp_layers": 1, "activation_width": 4096, "boundary_sweep_period": 0, "speculative_policy": "mtp-if-present", "boundary_report": true},
+      "resources": {"runner_role": "family-certify", "cache_policy": "immutable-local", "estimated_model_bytes": 72966388736, "n_gpu_layers_cap": 40},
       "notes": "GLM4.5 MoE lineage; 46 trunk layers plus one MTP runtime layer; two shards"
     },
     {

--- a/ci/llama-canary/family-certified.json
+++ b/ci/llama-canary/family-certified.json
@@ -1,6 +1,13 @@
 {
   "schema_version": 1,
   "policy": {
+    "runner_budgets": {
+      "metal-128gb": {
+        "wired_budget_bytes": 100700000000,
+        "expected_hw_mem_bytes": 137438953472,
+        "note": "measured on studio54 (M1 Ultra 128GB) with iogpu.wired_limit_mb=0 (default); see RESEARCH/GLM45_AIR_METAL_OOM_ROOT_CAUSE_2026_08_29.md"
+      }
+    },
     "profiles": {
       "full": {
         "status": "certified",
@@ -63,7 +70,7 @@
       "cadences": ["llama-bump", "manual-full"],
       "artifact": {"repo": "unsloth/GLM-4.5-Air-GGUF", "revision": "506d64aa8c5cfe9dbbf00bc7a15739438f83204d", "files": ["Q4_K_M/GLM-4.5-Air-Q4_K_M-00001-of-00002.gguf", "Q4_K_M/GLM-4.5-Air-Q4_K_M-00002-of-00002.gguf"], "file_integrity": {"Q4_K_M/GLM-4.5-Air-Q4_K_M-00001-of-00002.gguf": {"size_bytes": 50000746752, "blob_id": "3e7e5d25a6db33b7c90f8c5203d6f490d6c0a4f04a46f228af0e33727db5df5e"}, "Q4_K_M/GLM-4.5-Air-Q4_K_M-00002-of-00002.gguf": {"size_bytes": 22975001632, "blob_id": "ac6e50523d45c53faf3bf72d8fe109f3dd54bc6abe98a7773a3636112ead82a6"}}, "selector": "Q4_K_M"},
       "execution": {"trunk_layers": 46, "mtp_layers": 1, "activation_width": 4096, "boundary_sweep_period": 0, "speculative_policy": "mtp-if-present", "boundary_report": true},
-      "resources": {"runner_role": "family-certify", "cache_policy": "immutable-local", "estimated_model_bytes": 72966388736, "n_gpu_layers_cap": 40},
+      "resources": {"runner_role": "family-certify", "cache_policy": "immutable-local", "estimated_model_bytes": 72966388736, "n_gpu_layers_cap": 40, "runner_budget_class": "metal-128gb"},
       "notes": "GLM4.5 MoE lineage; 46 trunk layers plus one MTP runtime layer; two shards"
     },
     {

--- a/ci/llama-canary/family-certified.json
+++ b/ci/llama-canary/family-certified.json
@@ -69,7 +69,7 @@
       "profile": "full",
       "cadences": ["llama-bump", "manual-full"],
       "artifact": {"repo": "unsloth/GLM-4.5-Air-GGUF", "revision": "506d64aa8c5cfe9dbbf00bc7a15739438f83204d", "files": ["Q4_K_M/GLM-4.5-Air-Q4_K_M-00001-of-00002.gguf", "Q4_K_M/GLM-4.5-Air-Q4_K_M-00002-of-00002.gguf"], "file_integrity": {"Q4_K_M/GLM-4.5-Air-Q4_K_M-00001-of-00002.gguf": {"size_bytes": 50000746752, "blob_id": "3e7e5d25a6db33b7c90f8c5203d6f490d6c0a4f04a46f228af0e33727db5df5e"}, "Q4_K_M/GLM-4.5-Air-Q4_K_M-00002-of-00002.gguf": {"size_bytes": 22975001632, "blob_id": "ac6e50523d45c53faf3bf72d8fe109f3dd54bc6abe98a7773a3636112ead82a6"}}, "selector": "Q4_K_M"},
-      "execution": {"trunk_layers": 46, "mtp_layers": 1, "activation_width": 4096, "boundary_sweep_period": 0, "speculative_policy": "mtp-if-present", "boundary_report": true},
+      "execution": {"trunk_layers": 46, "mtp_layers": 1, "activation_width": 4096, "boundary_sweep_period": 0, "speculative_policy": "mtp-if-present", "boundary_report": true, "boundary_prefill": true},
       "resources": {"runner_role": "family-certify", "cache_policy": "immutable-local", "estimated_model_bytes": 72966388736, "n_gpu_layers_cap": 40, "runner_budget_class": "metal-128gb"},
       "notes": "GLM4.5 MoE lineage; 46 trunk layers plus one MTP runtime layer; two shards"
     },

--- a/ci/llama-canary/family-certified.schema.json
+++ b/ci/llama-canary/family-certified.schema.json
@@ -130,7 +130,8 @@
             "activation_width": {"type": "integer", "minimum": 1},
             "boundary_sweep_period": {"type": "integer", "minimum": 0},
             "speculative_policy": {"enum": ["mtp-if-present", "disabled"]},
-            "boundary_report": {"type": "boolean"}
+            "boundary_report": {"type": "boolean"},
+            "boundary_prefill": {"type": "boolean"}
           }
         },
         "resources": {

--- a/ci/llama-canary/family-certified.schema.json
+++ b/ci/llama-canary/family-certified.schema.json
@@ -13,6 +13,19 @@
       "additionalProperties": false,
       "required": ["profiles", "cadences"],
       "properties": {
+        "runner_budgets": {
+          "type": "object",
+          "additionalProperties": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["wired_budget_bytes", "expected_hw_mem_bytes"],
+            "properties": {
+              "wired_budget_bytes": {"type": "integer", "minimum": 1},
+              "expected_hw_mem_bytes": {"type": "integer", "minimum": 1},
+              "note": {"type": "string"}
+            }
+          }
+        },
         "profiles": {
           "type": "object",
           "additionalProperties": false,
@@ -143,7 +156,8 @@
             "cache_policy": {"const": "immutable-local"},
             "estimated_model_bytes": {"type": "integer", "minimum": 1},
             "startup_timeout_secs": {"type": "integer", "minimum": 180, "maximum": 900},
-            "n_gpu_layers_cap": {"type": "integer", "minimum": 0}
+            "n_gpu_layers_cap": {"type": "integer", "minimum": 0},
+            "runner_budget_class": {"type": "string", "minLength": 1}
           }
         },
         "notes": {"$ref": "#/$defs/singleLine"}

--- a/ci/llama-canary/family-certified.schema.json
+++ b/ci/llama-canary/family-certified.schema.json
@@ -129,8 +129,8 @@
             "mtp_layers": {"type": "integer", "minimum": 0},
             "activation_width": {"type": "integer", "minimum": 1},
             "boundary_sweep_period": {"type": "integer", "minimum": 0},
-            "speculative_policy": {"enum": ["mtp-if-present", "disabled"]}
-          , "boundary_report": {"type": "boolean"}
+            "speculative_policy": {"enum": ["mtp-if-present", "disabled"]},
+            "boundary_report": {"type": "boolean"}
           }
         },
         "resources": {
@@ -141,8 +141,8 @@
             "runner_role": {"const": "family-certify"},
             "cache_policy": {"const": "immutable-local"},
             "estimated_model_bytes": {"type": "integer", "minimum": 1},
-            "startup_timeout_secs": {"type": "integer", "minimum": 180, "maximum": 900}
-          , "n_gpu_layers_cap": {"type": "integer", "minimum": 0}
+            "startup_timeout_secs": {"type": "integer", "minimum": 180, "maximum": 900},
+            "n_gpu_layers_cap": {"type": "integer", "minimum": 0}
           }
         },
         "notes": {"$ref": "#/$defs/singleLine"}

--- a/ci/llama-canary/family-certified.schema.json
+++ b/ci/llama-canary/family-certified.schema.json
@@ -130,6 +130,7 @@
             "activation_width": {"type": "integer", "minimum": 1},
             "boundary_sweep_period": {"type": "integer", "minimum": 0},
             "speculative_policy": {"enum": ["mtp-if-present", "disabled"]}
+          , "boundary_report": {"type": "boolean"}
           }
         },
         "resources": {
@@ -141,6 +142,7 @@
             "cache_policy": {"const": "immutable-local"},
             "estimated_model_bytes": {"type": "integer", "minimum": 1},
             "startup_timeout_secs": {"type": "integer", "minimum": 180, "maximum": 900}
+          , "n_gpu_layers_cap": {"type": "integer", "minimum": 0}
           }
         },
         "notes": {"$ref": "#/$defs/singleLine"}

--- a/scripts/plan-family-battery.py
+++ b/scripts/plan-family-battery.py
@@ -368,6 +368,7 @@ def _normalize_models(value: object, policy: dict[str, Any]) -> list[dict[str, A
                 "boundary_sweep_period",
                 "speculative_policy",
                 "boundary_report",
+                "boundary_prefill",
             },
             f"{field}.execution",
         )
@@ -389,6 +390,10 @@ def _normalize_models(value: object, policy: dict[str, Any]) -> list[dict[str, A
         boundary_report = _boolean(
             execution.get("boundary_report", False),
             f"{field}.execution.boundary_report",
+        )
+        boundary_prefill = _boolean(
+            execution.get("boundary_prefill", False),
+            f"{field}.execution.boundary_prefill",
         )
         layer_end = trunk_layers + mtp_layers
         if sweep_period > layer_end:
@@ -461,6 +466,7 @@ def _normalize_models(value: object, policy: dict[str, Any]) -> list[dict[str, A
                     "boundary_sweep_period": sweep_period,
                     "speculative_policy": speculative_policy,
                     "boundary_report": boundary_report,
+                    "boundary_prefill": boundary_prefill,
                 },
                 "resources": {
                     "runner_role": runner_role,

--- a/scripts/plan-family-battery.py
+++ b/scripts/plan-family-battery.py
@@ -278,10 +278,39 @@ def _load_manifest(path: Path) -> tuple[dict[str, Any], str]:
 
 def _validate_policy(value: object) -> dict[str, Any]:
     policy = _object(value, "policy")
-    _exact_keys(policy, {"profiles", "cadences"}, "policy")
+    _exact_keys(policy, {"profiles", "cadences", "runner_budgets"}, "policy")
     cadences = _string_list(policy.get("cadences"), "policy.cadences")
     if tuple(cadences) != CADENCES:
         raise PlanError("policy.cadences must list the complete supported cadence order")
+
+    runner_budgets: dict[str, Any] = {}
+    if "runner_budgets" in policy:
+        budgets = _object(policy["runner_budgets"], "policy.runner_budgets")
+        for name, budget in budgets.items():
+            entry = _object(budget, f"policy.runner_budgets.{name}")
+            _exact_keys(
+                entry,
+                {"wired_budget_bytes", "expected_hw_mem_bytes", "note"},
+                f"policy.runner_budgets.{name}",
+            )
+            wired = _integer(
+                entry.get("wired_budget_bytes"),
+                f"policy.runner_budgets.{name}.wired_budget_bytes",
+                1,
+            )
+            hw_mem = _integer(
+                entry.get("expected_hw_mem_bytes"),
+                f"policy.runner_budgets.{name}.expected_hw_mem_bytes",
+                1,
+            )
+            if wired >= hw_mem:
+                raise PlanError(
+                    f"policy.runner_budgets.{name}.wired_budget_bytes must be below the expected hardware memory"
+                )
+            runner_budgets[name] = {
+                "wired_budget_bytes": wired,
+                "expected_hw_mem_bytes": hw_mem,
+            }
 
     profiles = _object(policy.get("profiles"), "policy.profiles")
     if set(profiles) != set(PROFILE_NAMES):
@@ -318,7 +347,9 @@ def _validate_policy(value: object) -> dict[str, Any]:
         raise PlanError("full profile must use the local-monolithic oracle")
     if normalized["package-oracle"]["oracle"] != "independent-trace":
         raise PlanError("package-oracle must use an independent trace")
-    return {"profiles": normalized, "cadences": cadences}
+    if "runner_budgets" not in policy:
+        return {"profiles": normalized, "cadences": cadences}
+    return {"profiles": normalized, "cadences": cadences, "runner_budgets": runner_budgets}
 
 
 def _normalize_models(value: object, policy: dict[str, Any]) -> list[dict[str, Any]]:
@@ -413,6 +444,7 @@ def _normalize_models(value: object, policy: dict[str, Any]) -> list[dict[str, A
                 "estimated_model_bytes",
                 "startup_timeout_secs",
                 "n_gpu_layers_cap",
+                "runner_budget_class",
             },
             f"{field}.resources",
         )
@@ -446,6 +478,21 @@ def _normalize_models(value: object, policy: dict[str, Any]) -> list[dict[str, A
                 f"{field}.resources.n_gpu_layers_cap",
                 0,
             )
+        runner_budget_class = None
+        if "runner_budget_class" in resources:
+            runner_budget_class = _string(
+                resources["runner_budget_class"],
+                f"{field}.resources.runner_budget_class",
+            )
+            if runner_budget_class not in policy.get("runner_budgets", {}):
+                raise PlanError(
+                    f"{field}.resources.runner_budget_class {runner_budget_class!r} is not defined in policy.runner_budgets"
+                )
+        if n_gpu_layers_cap is not None and runner_budget_class is None:
+            raise PlanError(
+                f"{field}.resources.n_gpu_layers_cap requires runner_budget_class "
+                "(the cap is a runner-budget claim; name the class it was derived against)"
+            )
         notes = _string(model.get("notes"), f"{field}.notes")
         profile_policy = policy["profiles"][profile]
         models.append(
@@ -474,6 +521,7 @@ def _normalize_models(value: object, policy: dict[str, Any]) -> list[dict[str, A
                     "estimated_model_bytes": estimated_model_bytes,
                     "startup_timeout_secs": startup_timeout_secs,
                     "n_gpu_layers_cap": n_gpu_layers_cap,
+                    "runner_budget_class": runner_budget_class,
                 },
                 "notes": notes,
                 "manifest_index": index,
@@ -632,6 +680,7 @@ def build_plan(
         "manifest": manifest_source,
         "manifest_sha256": manifest_sha256,
         "required_certification_lanes": list(CORE_LANES),
+        "runner_budgets": policy.get("runner_budgets", {}),
         "selected_family_count": len(models),
         "selected_models": models,
         "shards": shards,

--- a/scripts/plan-family-battery.py
+++ b/scripts/plan-family-battery.py
@@ -162,6 +162,12 @@ def _exact_keys(value: dict[str, Any], allowed: set[str], field: str) -> None:
         raise PlanError(f"{field} contains unknown fields: {', '.join(unknown)}")
 
 
+def _boolean(value: object, field: str) -> bool:
+    if type(value) is not bool:
+        raise PlanError(f"{field} must be a boolean")
+    return value
+
+
 def _string(value: object, field: str) -> str:
     if not isinstance(value, str) or not value or any(char in value for char in "\r\n\t|"):
         raise PlanError(f"{field} must be a non-empty single-line string")
@@ -361,6 +367,7 @@ def _normalize_models(value: object, policy: dict[str, Any]) -> list[dict[str, A
                 "activation_width",
                 "boundary_sweep_period",
                 "speculative_policy",
+                "boundary_report",
             },
             f"{field}.execution",
         )
@@ -379,6 +386,10 @@ def _normalize_models(value: object, policy: dict[str, Any]) -> list[dict[str, A
             execution.get("boundary_sweep_period"),
             f"{field}.execution.boundary_sweep_period",
         )
+        boundary_report = _boolean(
+            execution.get("boundary_report", False),
+            f"{field}.execution.boundary_report",
+        )
         layer_end = trunk_layers + mtp_layers
         if sweep_period > layer_end:
             raise PlanError(f"{field}.execution.boundary_sweep_period exceeds layer range")
@@ -396,6 +407,7 @@ def _normalize_models(value: object, policy: dict[str, Any]) -> list[dict[str, A
                 "cache_policy",
                 "estimated_model_bytes",
                 "startup_timeout_secs",
+                "n_gpu_layers_cap",
             },
             f"{field}.resources",
         )
@@ -422,6 +434,13 @@ def _normalize_models(value: object, policy: dict[str, Any]) -> list[dict[str, A
                 180,
                 900,
             )
+        n_gpu_layers_cap = None
+        if "n_gpu_layers_cap" in resources:
+            n_gpu_layers_cap = _integer(
+                resources["n_gpu_layers_cap"],
+                f"{field}.resources.n_gpu_layers_cap",
+                0,
+            )
         notes = _string(model.get("notes"), f"{field}.notes")
         profile_policy = policy["profiles"][profile]
         models.append(
@@ -441,12 +460,14 @@ def _normalize_models(value: object, policy: dict[str, Any]) -> list[dict[str, A
                     "layer_end": layer_end,
                     "boundary_sweep_period": sweep_period,
                     "speculative_policy": speculative_policy,
+                    "boundary_report": boundary_report,
                 },
                 "resources": {
                     "runner_role": runner_role,
                     "cache_policy": cache_policy,
                     "estimated_model_bytes": estimated_model_bytes,
                     "startup_timeout_secs": startup_timeout_secs,
+                    "n_gpu_layers_cap": n_gpu_layers_cap,
                 },
                 "notes": notes,
                 "manifest_index": index,

--- a/scripts/skippy-family-battery.sh
+++ b/scripts/skippy-family-battery.sh
@@ -158,7 +158,7 @@ fi
 mkdir -p "$MODEL_SCAN_DIR" "$PREFLIGHT_DIR" "$CERT_DIR"
 : > "$RESULTS_JSONL"
 printf 'family\tmodel_id\tsource_revision\tmodel_path\tmtp_layers\n' > "$MTP_CORPUS_TSV"
-printf 'family|repo|source_revision|file|selector|sweep_period|layer_end|notes|target_path|draft_repo|draft_revision|draft_file|draft_path|native_mtp|model_size_bytes|mtp_layers|activation_width|startup_timeout_secs\n' > "$RESOLVED_MANIFEST"
+printf 'family|repo|source_revision|file|selector|sweep_period|layer_end|notes|target_path|draft_repo|draft_revision|draft_file|draft_path|native_mtp|model_size_bytes|mtp_layers|activation_width|startup_timeout_secs|boundary_report|boundary_prefill|ngl_cap\n' > "$RESOLVED_MANIFEST"
 
 prepare_policy_plan() {
   local plan_args=(
@@ -223,9 +223,11 @@ fi
 
 FAILURES=()
 TOTAL=0
+BOUNDARY_TOTAL=0
 EXPECTED_TOTAL=0
 EXPECTED_FAMILY_COUNT=0
 CERT_FAILURE_COUNT=0
+BOUNDARY_FAILURE_COUNT=0
 PREFLIGHT_FAILURE_COUNT=0
 PREFLIGHT_SPEC_FAMILY=""
 PREFLIGHT_SPEC_TARGET=""
@@ -597,7 +599,7 @@ preflight_manifest() {
     return 1
   fi
 
-  while IFS='|' read -r family profile repo source_revision file selector sweep_period layer_end activation_width notes draft_repo draft_revision draft_file expected_model_bytes startup_timeout_override expected_mtp_layers lane_csv speculative_policy; do
+  while IFS='|' read -r family profile repo source_revision file selector sweep_period layer_end activation_width notes draft_repo draft_revision draft_file expected_model_bytes startup_timeout_override expected_mtp_layers lane_csv speculative_policy boundary_report boundary_prefill ngl_cap; do
     if [[ "$profile" != "full" ]]; then
       echo "the local monolithic battery cannot execute profile $profile for $family" >&2
       exit 1
@@ -692,9 +694,10 @@ preflight_manifest() {
 
     local startup_timeout
     startup_timeout="${startup_timeout_override:-$(startup_timeout_for_bytes "$MODEL_SIZE_BYTES")}"
-    printf '%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
+    printf '%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
       "$family" "$repo" "$source_revision" "$file" "$selector" "$sweep_period" "$layer_end" "$notes" "$target" \
-      "$draft_repo" "$draft_revision" "$draft_file" "$draft" "$MODEL_HAS_MTP" "$MODEL_SIZE_BYTES" "$MODEL_MTP_LAYERS" "$activation_width" "$startup_timeout" \
+      "$draft_repo" "$draft_revision" "$draft_file" "$draft" "$MODEL_HAS_MTP" "$MODEL_SIZE_BYTES" "${MODEL_MTP_LAYERS:-$expected_mtp_layers}" "$activation_width" "$startup_timeout" \
+      "$boundary_report" "$boundary_prefill" "$ngl_cap" \
       >> "$RESOLVED_MANIFEST"
     if (( DRY_RUN == 0 )); then
       record_preflight_outcome "model-preflight" "$family" "$model_id" "pass" "pass" "resolved immutable snapshot $source_revision; tensor scan complete"
@@ -728,7 +731,10 @@ preflight_manifest() {
           (.resources.startup_timeout_secs // ""),
           .execution.mtp_layers,
           (.certification_lanes | join(",")),
-          .execution.speculative_policy
+          .execution.speculative_policy,
+          (.execution.boundary_report // false | if . then 1 else 0 end),
+          (.execution.boundary_prefill // false | if . then 1 else 0 end),
+          (.resources.n_gpu_layers_cap // "")
         ]
       | join("|")
     ' "$plan"
@@ -804,9 +810,87 @@ planned_certification_count() {
   printf '%s\n' "$planned"
 }
 
+run_boundary_report() {
+  # One boundary-report lane invocation per family. Passes when every probed
+  # cut matches the full-model baseline (exit code 0 and report status pass).
+  local family="$1" target="$2" model_id="$3" layer_end="$4" mtp_layers="$5" ngl_cap="$6" startup_timeout="$7" prefill_flag="$8"
+  local trunk_layers=$(( layer_end - mtp_layers ))
+  if (( trunk_layers < 1 )); then
+    echo "boundary lane requires at least one trunk layer for $family" >&2
+    FAILURES+=("$family(boundary-extent)")
+    BOUNDARY_FAILURE_COUNT=$((BOUNDARY_FAILURE_COUNT + 1))
+    return 1
+  fi
+  BOUNDARY_TOTAL=$((BOUNDARY_TOTAL + 1))
+  local run_id boundary_dir boundary_json mode_label timeout_secs ngl exit_code
+  run_id="$(printf '%03d-%s-boundary-report' "$BOUNDARY_TOTAL" "$(slugify "$family")")"
+  boundary_dir="$CERT_DIR/$run_id"
+  boundary_json="$boundary_dir/boundary-report.json"
+  mode_label="boundary-report"
+  if [[ -n "$prefill_flag" ]]; then
+    mode_label="boundary-report-prefill"
+  fi
+  timeout_secs="$(cert_timeout_for_startup "$startup_timeout")"
+  ngl="999"
+  if [[ -n "$ngl_cap" ]]; then
+    ngl="$ngl_cap"
+  fi
+  echo "==> $mode_label: family=$family splits=1..$trunk_layers layer_end=$layer_end ngl=$ngl model=$(basename "$target")"
+  local command=(
+    "$BIN_DIR/skippy-correctness" boundary-report
+    --model "$target"
+    --model-id "$model_id"
+    --layer-end "$layer_end"
+    --splits "1..$trunk_layers"
+    --n-gpu-layers "$ngl"
+    --report-out "$boundary_json"
+  )
+  if [[ -n "$prefill_flag" ]]; then
+    command+=("$prefill_flag")
+  fi
+  if (( DRY_RUN == 1 )); then
+    printf '%q ' "${command[@]}"
+    printf '\n'
+    return 0
+  fi
+  exit_code=0
+  "$ROOT/scripts/run-command-with-timeout.py" \
+    --seconds "$timeout_secs" \
+    --label "$mode_label $family" \
+    -- "${command[@]}" || exit_code=$?
+  local status="fail" outcome="harness" note=""
+  if [[ -f "$boundary_json" ]]; then
+    status="$(jq -r '.status // "fail"' "$boundary_json")"
+    outcome="report"
+    note="$(jq -r '"splits=\(.split_count // 0) mismatches=\(.mismatch_count // 0) errors=\(.error_count // 0)"' "$boundary_json")"
+  elif (( exit_code == 124 )); then
+    outcome="timeout"
+    note="boundary-report exceeded its wall-clock budget before writing a report"
+  else
+    note="boundary-report produced no report"
+  fi
+  if [[ "$status" != "pass" ]]; then
+    exit_code="${exit_code:-1}"
+  fi
+  jq -n \
+    --arg family "$family" \
+    --arg model_id "$model_id" \
+    --arg mode "$mode_label" \
+    --arg status "$status" \
+    --arg outcome "$outcome" \
+    --arg note "$note" \
+    --argjson exit_code "${exit_code:-1}" \
+    '{family:$family,model_id:$model_id,split_layer:null,outcomes:[{name:$mode,status:$status,outcome:$outcome,exit_code:$exit_code,note:$note}]}' \
+    >> "$RESULTS_JSONL"
+  if [[ "$status" != "pass" ]]; then
+    FAILURES+=("$family@boundary-report")
+    BOUNDARY_FAILURE_COUNT=$((BOUNDARY_FAILURE_COUNT + 1))
+  fi
+}
+
 run_resolved_manifest() {
   local resolved_manifest="$1"
-  while IFS='|' read -r family repo source_revision file selector sweep_period layer_end _notes target draft_repo draft_revision draft_file draft native_mtp model_size_bytes _mtp_layers activation_width startup_timeout; do
+  while IFS='|' read -r family repo source_revision file selector sweep_period layer_end _notes target draft_repo draft_revision draft_file draft native_mtp model_size_bytes mtp_layers activation_width startup_timeout boundary_report boundary_prefill ngl_cap; do
     [[ "$family" == "family" ]] && continue
     local model_id="$repo:$selector"
 
@@ -827,6 +911,24 @@ run_resolved_manifest() {
           cuts=$((cuts + 1))
         done
       done
+    fi
+
+    if [[ "$boundary_report" == "1" ]]; then
+      # Boundary-report lane (opt-in per family): one in-process invocation
+      # sweeps every certified cut. The extent is derived, not per-family
+      # data: cuts 1..trunk_layers are exactly the cuts where stage 1 keeps
+      # at least one trunk layer (the --splits range is end-exclusive). The
+      # MTP-only cut (trunk_layers+1..layer_end) stays out of the lane until
+      # a runner-validated probe certifies it. The n_gpu_layers_cap from the
+      # manifest applies to this lane only: the concurrent stage pair can
+      # exceed the runner's wired-memory budget at full offload, while the
+      # sequential core lanes stay at the production ngl default (999).
+      run_boundary_report "$family" "$target" "$model_id" "$layer_end" "$mtp_layers" "$ngl_cap" "$startup_timeout" ""
+    fi
+    if [[ "$boundary_prefill" == "1" ]]; then
+      # Prefill rider (opt-in, off until a multi-token ngl-capped run is
+      # certified): same sweep in multi-token prefill mode, second report.
+      run_boundary_report "$family" "$target" "$model_id" "$layer_end" "$mtp_layers" "$ngl_cap" "$startup_timeout" "--prefill"
     fi
   done < "$resolved_manifest"
 }
@@ -894,7 +996,7 @@ fi
 if (( PREFLIGHT_ONLY == 1 )); then
   echo "family battery preflight complete: $PREFLIGHT_FAILURE_COUNT failures"
 else
-  echo "family battery complete: $((TOTAL - CERT_FAILURE_COUNT))/$TOTAL certifications passed"
+  echo "family battery complete: $((TOTAL - CERT_FAILURE_COUNT))/$TOTAL certifications passed, $((BOUNDARY_TOTAL - BOUNDARY_FAILURE_COUNT))/$BOUNDARY_TOTAL boundary-report lanes passed"
 fi
 echo "artifacts: $ARTIFACT_DIR"
 if (( ${#FAILURES[@]} > 0 )); then

--- a/scripts/skippy-family-battery.sh
+++ b/scripts/skippy-family-battery.sh
@@ -158,7 +158,7 @@ fi
 mkdir -p "$MODEL_SCAN_DIR" "$PREFLIGHT_DIR" "$CERT_DIR"
 : > "$RESULTS_JSONL"
 printf 'family\tmodel_id\tsource_revision\tmodel_path\tmtp_layers\n' > "$MTP_CORPUS_TSV"
-printf 'family|repo|source_revision|file|selector|sweep_period|layer_end|notes|target_path|draft_repo|draft_revision|draft_file|draft_path|native_mtp|model_size_bytes|mtp_layers|activation_width|startup_timeout_secs|boundary_report|boundary_prefill|ngl_cap\n' > "$RESOLVED_MANIFEST"
+printf 'family|repo|source_revision|file|selector|sweep_period|layer_end|notes|target_path|draft_repo|draft_revision|draft_file|draft_path|native_mtp|model_size_bytes|mtp_layers|activation_width|startup_timeout_secs|boundary_report|boundary_prefill|ngl_cap|runner_budget_class\n' > "$RESOLVED_MANIFEST"
 
 prepare_policy_plan() {
   local plan_args=(
@@ -599,7 +599,7 @@ preflight_manifest() {
     return 1
   fi
 
-  while IFS='|' read -r family profile repo source_revision file selector sweep_period layer_end activation_width notes draft_repo draft_revision draft_file expected_model_bytes startup_timeout_override expected_mtp_layers lane_csv speculative_policy boundary_report boundary_prefill ngl_cap; do
+  while IFS='|' read -r family profile repo source_revision file selector sweep_period layer_end activation_width notes draft_repo draft_revision draft_file expected_model_bytes startup_timeout_override expected_mtp_layers lane_csv speculative_policy boundary_report boundary_prefill ngl_cap runner_budget_class; do
     if [[ "$profile" != "full" ]]; then
       echo "the local monolithic battery cannot execute profile $profile for $family" >&2
       exit 1
@@ -692,12 +692,35 @@ preflight_manifest() {
       fi
     fi
 
+    if [[ -n "$runner_budget_class" && -n "$ngl_cap" ]] && (( DRY_RUN == 0 )); then
+      # The ngl cap is a claim derived against a named runner budget class;
+      # verify this machine matches the class before certifying against the cap.
+      local expected_mem
+      expected_mem="$(jq -r --arg class "$runner_budget_class" '.runner_budgets[$class].expected_hw_mem_bytes // empty' "$POLICY_PLAN_COPY")"
+      if [[ -z "$expected_mem" ]]; then
+        echo "policy plan does not define runner budget class $runner_budget_class required by $family" >&2
+        FAILURES+=("$family(runner-budget-class)")
+        PREFLIGHT_FAILURE_COUNT=$((PREFLIGHT_FAILURE_COUNT + 1))
+        record_preflight_outcome "model-preflight" "$family" "$model_id" "fail" "harness" "plan is missing runner budget class $runner_budget_class"
+        continue
+      fi
+      local actual_mem
+      actual_mem="$(sysctl -n hw.memsize 2>/dev/null || true)"
+      if [[ "$actual_mem" != "$expected_mem" ]]; then
+        echo "runner memory mismatch for $family: class $runner_budget_class expects ${expected_mem} bytes, this machine has ${actual_mem:-unknown}" >&2
+        FAILURES+=("$family(runner-budget-class)")
+        PREFLIGHT_FAILURE_COUNT=$((PREFLIGHT_FAILURE_COUNT + 1))
+        record_preflight_outcome "model-preflight" "$family" "$model_id" "fail" "harness" "runner does not match budget class $runner_budget_class (expected ${expected_mem} bytes hw mem, found ${actual_mem:-unknown})"
+        continue
+      fi
+    fi
+
     local startup_timeout
     startup_timeout="${startup_timeout_override:-$(startup_timeout_for_bytes "$MODEL_SIZE_BYTES")}"
-    printf '%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
+    printf '%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s\n' \
       "$family" "$repo" "$source_revision" "$file" "$selector" "$sweep_period" "$layer_end" "$notes" "$target" \
       "$draft_repo" "$draft_revision" "$draft_file" "$draft" "$MODEL_HAS_MTP" "$MODEL_SIZE_BYTES" "${MODEL_MTP_LAYERS:-$expected_mtp_layers}" "$activation_width" "$startup_timeout" \
-      "$boundary_report" "$boundary_prefill" "$ngl_cap" \
+      "$boundary_report" "$boundary_prefill" "$ngl_cap" "$runner_budget_class" \
       >> "$RESOLVED_MANIFEST"
     if (( DRY_RUN == 0 )); then
       record_preflight_outcome "model-preflight" "$family" "$model_id" "pass" "pass" "resolved immutable snapshot $source_revision; tensor scan complete"
@@ -734,7 +757,8 @@ preflight_manifest() {
           .execution.speculative_policy,
           (.execution.boundary_report // false | if . then 1 else 0 end),
           (.execution.boundary_prefill // false | if . then 1 else 0 end),
-          (.resources.n_gpu_layers_cap // "")
+          (.resources.n_gpu_layers_cap // ""),
+          (.resources.runner_budget_class // "")
         ]
       | join("|")
     ' "$plan"
@@ -890,7 +914,7 @@ run_boundary_report() {
 
 run_resolved_manifest() {
   local resolved_manifest="$1"
-  while IFS='|' read -r family repo source_revision file selector sweep_period layer_end _notes target draft_repo draft_revision draft_file draft native_mtp model_size_bytes mtp_layers activation_width startup_timeout boundary_report boundary_prefill ngl_cap; do
+  while IFS='|' read -r family repo source_revision file selector sweep_period layer_end _notes target draft_repo draft_revision draft_file draft native_mtp model_size_bytes mtp_layers activation_width startup_timeout boundary_report boundary_prefill ngl_cap runner_budget_class; do
     [[ "$family" == "family" ]] && continue
     local model_id="$repo:$selector"
 


### PR DESCRIPTION
## Purpose

PR #1524 adds a test that validates every pipeline split at the tensor boundary. This PR turns that test into an automated certification check for GLM-4.5-Air.

It contains only canary configuration and test-runner wiring; the native runtime changes are in #1524.

## What this PR changes

- Enables boundary validation for the certified GLM-4.5-Air Q4_K_M configuration.
- Runs both the normal boundary check and a second check that prefills the complete prompt before evaluating the split.
- Tests cuts 1 through 45 with `n_gpu_layers=40`.
- Defines the GPU-layer cap through a named runner memory class instead of a hard-coded machine assumption.
- Verifies the runner's physical memory before starting, so a job fails with a configuration error instead of producing misleading results on the wrong machine.
- Leaves other model families unchanged until they explicitly opt in.

## Why `n_gpu_layers=40`

Full offload (`n_gpu_layers=99`) is not a safe certification setting for deep GLM-4.5-Air cuts on this runner class: opening both stages can exceed Metal's wired-memory budget. The native changes in #1524 turn that condition into a hard error, but certification still needs a configuration that can exercise every valid cut.

`n_gpu_layers=40` passed the complete cut range with memory headroom. Cut 46 is intentionally excluded because it would leave the second stage with only the model's MTP layer and no normal transformer layer; that is not a valid pipeline split.

## Evidence

- Planner tests: 16 passed, including validation of every checked-in certified model.
- Battery dry-run emits two GLM-4.5-Air boundary jobs, with and without full-prompt prefill, using cuts 1 through 45 and `n_gpu_layers=40`.
- A family that has not opted in emits no boundary jobs.
- On the certification runner, all GLM-4.5-Air cuts passed at `n_gpu_layers=40`.
- Cut 45 matched all 45 reference tokens with a 16-token prompt.
- Full-stack tests: `skippy-correctness` 81 passed; `skippy-ffi` 6 passed.

## Stack order

Review and merge #1524 first, then this PR.
