### PR TITLE
fix(release): use dotted workspace version form in skippy-scheduler

### DIFF
--- a/crates/skippy-scheduler/Cargo.toml
+++ b/crates/skippy-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "skippy-scheduler"
-version = { workspace = true }
+version.workspace = true
 edition = { workspace = true }
 license = { workspace = true }
 description = "Iteration-level scheduler for concurrent staged serving with unified KV"

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -3701,11 +3701,11 @@
   ],
   "crates/skippy-model-package/src/tests.rs": [
     {
-      "line": 703,
+      "line": 752,
       "macro_name": "eprintln!"
     },
     {
-      "line": 710,
+      "line": 759,
       "macro_name": "eprintln!"
     }
   ],


### PR DESCRIPTION
## Problem

The `v0.76.0-rc8` dispatch failed in **Resolve release metadata**, before any build:

```
failed to update [package].version in crates/skippy-scheduler/Cargo.toml
```

Run: https://github.com/Mesh-LLM/mesh-llm/actions/runs/33230096911

`scripts/release-version.sh` recognises workspace version inheritance only as `version.workspace = true`. `crates/skippy-scheduler/Cargo.toml` used the equivalent inline-table form `version = { workspace = true }`, so the script tried to rewrite a literal `[package].version` that is not there and exited 1.

## Fix

One line. `skippy-scheduler` was the only manifest of 61 in the inline-table form; align it with the rest.

```diff
-version = { workspace = true }
+version.workspace = true
```

Hardening the script to accept both valid TOML spellings is defensible but is separate tooling work, not a release blocker — dropped from this PR at Jimmy's and Mic's request.

## Verification

`scripts/release-version.sh v0.76.0-rc8` on the full tree: exit 0, 52 files bumped, `Cargo.lock` regenerated. Reverted afterwards; this PR contains no version bump.

No tag or release was created by the failed run, so `v0.76.0-rc8` is still free. Once merged I re-dispatch rc8.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated package version metadata to use the workspace-managed configuration.
  * Refreshed internal console-print validation references to match current source locations.
  * No user-facing functionality, behavior, or interface changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->