### PR TITLE
Keep embedded startup on one validated config image

### DIFF
--- a/crates/mesh-llm-host-runtime/src/sdk.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk.rs
@@ -61,7 +61,7 @@ pub struct EmbeddedServeHandle {
     invite_token: Option<String>,
     control_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::api::RuntimeControlRequest>>,
     task: Option<std::thread::JoinHandle<Result<()>>>,
-    _isolated_config: Option<NamedTempFile>,
+    _config_snapshot: NamedTempFile,
 }
 
 pub type EmbeddedMeshNodeHandle = EmbeddedServeHandle;
@@ -142,7 +142,10 @@ pub async fn start_embedded_node(
 ) -> Result<EmbeddedServeHandle> {
     embedded_startup::prepare_embedded_native_runtime(&config.mode)?;
     let isolated_config = prepare_isolated_config(&mut config)?;
-    embedded_logging::validate_embedded_config(config.storage.config_path.as_deref())?;
+    let config_snapshot =
+        embedded_logging::snapshot_validated_config(config.storage.config_path.as_deref())?;
+    config.storage.config_path = Some(embedded_logging::snapshot_path(&config_snapshot));
+    drop(isolated_config);
     let (control_tx, control_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime_options = embedded_runtime_options(&config, Some(control_rx));
     let api_base_url = format!("http://127.0.0.1:{}/v1", config.http.api_port);
@@ -181,7 +184,7 @@ pub async fn start_embedded_node(
         invite_token: token_from_status(&status),
         control_tx: Some(control_tx),
         task: Some(task),
-        _isolated_config: isolated_config,
+        _config_snapshot: config_snapshot,
     })
 }
 

--- a/crates/mesh-llm-host-runtime/src/sdk/embedded_logging.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk/embedded_logging.rs
@@ -1,14 +1,39 @@
 //! Logging initialization shared by the embedded SDK startup boundary.
 
-use anyhow::Result;
-use std::path::Path;
+use anyhow::{Context, Result};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
 
-/// Validate an embedded configuration before starting its worker thread.
+/// Validate an embedded configuration and retain the exact validated image.
 ///
-/// This keeps configuration errors attributable to the SDK caller rather than
-/// reducing them to an early worker-thread exit during readiness polling.
-pub(crate) fn validate_embedded_config(config_path: Option<&Path>) -> Result<()> {
-    crate::plugin::load_config(config_path).map(|_| ())
+/// Embedded startup crosses a worker-thread boundary and several subsystems
+/// load configuration independently. Snapshotting the bytes after validation
+/// ensures every startup load observes the image accepted by the SDK caller,
+/// even if the original pathname changes while the worker starts.
+pub(crate) fn snapshot_validated_config(config_path: Option<&Path>) -> Result<NamedTempFile> {
+    let resolved_path = crate::plugin::config_path(config_path)?;
+    let raw = if resolved_path.exists() {
+        std::fs::read(&resolved_path)
+            .with_context(|| format!("Failed to read config {}", resolved_path.display()))?
+    } else {
+        Vec::new()
+    };
+    let raw_text = std::str::from_utf8(&raw)
+        .with_context(|| format!("Invalid config {}", resolved_path.display()))?;
+    crate::plugin::parse_config_toml(raw_text)
+        .with_context(|| format!("Invalid config {}", resolved_path.display()))?;
+
+    let mut snapshot = NamedTempFile::new().context("create embedded config snapshot")?;
+    snapshot
+        .write_all(&raw)
+        .context("write embedded config snapshot")?;
+    snapshot.flush().context("flush embedded config snapshot")?;
+    Ok(snapshot)
+}
+
+pub(crate) fn snapshot_path(snapshot: &NamedTempFile) -> PathBuf {
+    snapshot.path().to_path_buf()
 }
 
 /// Install the host-owned logging foundation for an embedded runtime.
@@ -39,6 +64,31 @@ mod tests {
             format!("[logging]\nenabled = {enabled}\napplication_state_root = \"{root}\"\n"),
         )
         .expect("write embedded logging config");
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn validated_config_snapshot_is_stable_when_source_changes() {
+        let temporary_directory = tempfile::tempdir().expect("temporary config directory");
+        let config_path = temporary_directory.path().join("mesh-llm.toml");
+        let validated_root = temporary_directory.path().join("validated-logging");
+        let swapped_root = temporary_directory.path().join("swapped-logging");
+        write_logging_config(&config_path, true, &validated_root);
+
+        let snapshot = snapshot_validated_config(Some(&config_path))
+            .expect("snapshot validated embedded config");
+        write_logging_config(&config_path, true, &swapped_root);
+        initialize_embedded_logging(Some(snapshot.path()))
+            .await
+            .expect("initialize logging from validated snapshot");
+
+        assert_eq!(
+            crate::logging_foundation()
+                .expect("installed foundation")
+                .app_state_root(),
+            validated_root
+        );
+        assert!(!swapped_root.exists());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Embedded SDK callers now get consistent startup behavior even if the source config file changes while the worker thread starts.

The SDK validates the source bytes once, stores them in a process-owned temporary snapshot, and routes every embedded startup config load through that snapshot. The snapshot stays alive for the embedded handle's lifetime. This prevents logging, plugins, and runtime options from observing different config images during one startup.

This is startup consistency hardening rather than a high-severity security fix: deployments should still keep executable config policy in appropriately owned locations.

Closes project-loupe/audit-mesh-llm#752.

## Validation

- `cargo test -p mesh-llm-host-runtime --lib` — 2679 passed, 8 ignored
- `cargo check -p mesh-llm-host-runtime`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings -A unfulfilled-lint-expectations`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings -A unfulfilled-lint-expectations`
- `cargo fmt --all --check`

The lint-expectation allowance is for pre-existing unfulfilled `#[expect(dead_code)]` attributes on current `main`; unmodified Clippy fails on those unrelated existing warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Embedded nodes now use a stable snapshot of the validated configuration, preventing changes to the original configuration file from affecting an active runtime.
  * Configuration files are validated for readability, UTF-8 encoding, and valid TOML before startup.
* **Tests**
  * Added coverage confirming runtime behavior remains stable when the source configuration changes after initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->