### PR TITLE
ci: regenerate console-print ratchet after #1516

### DIFF
--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -3701,11 +3701,11 @@
   ],
   "crates/skippy-model-package/src/tests.rs": [
     {
-      "line": 703,
+      "line": 752,
       "macro_name": "eprintln!"
     },
     {
-      "line": 710,
+      "line": 759,
       "macro_name": "eprintln!"
     }
   ],


### PR DESCRIPTION
## Why

#1516 moved two `eprintln!` calls in `crates/skippy-model-package/src/tests.rs` from lines 703/710 to 752/759 without regenerating the console-print allowlist, so `just no-console-print` ("CI contracts and consistency") fails on `main` at `38840cb9d` and on every PR based on it — including #1518, the rc8 release blocker.

Reproduced locally on clean `origin/main`:

```
error: forbidden console print macros found in product code:
crates/skippy-model-package/src/tests.rs:752 eprintln!
crates/skippy-model-package/src/tests.rs:759 eprintln!

console print ratchet is out of sync with the tree:
crates/skippy-model-package/src/tests.rs:703 eprintln!: approved occurrence is missing or was replaced
crates/skippy-model-package/src/tests.rs:710 eprintln!: approved occurrence is missing or was replaced
```

## What

Regenerated `tools/xtask/data/console_print_allowlist.json` with the documented command:

```
cargo run -p xtask -- repo-consistency no-console-print --regen
```

The diff is exactly the two line-number moves — no new hits approved, nothing else touched.

Verified `just no-console-print` passes locally on this branch, and also passes with #1518 cherry-picked on top — these two PRs are additive and either merge order works.

Follow-up worth noting: the check's guidance says to route these prints through `mesh_llm_events::emit_event` eventually; that debt retirement is separate and not this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal console output tracking to reflect shifted test output locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->