### PR TITLE
Keep operator-enforced guardrails enabled

### DIFF
--- a/crates/openai-frontend/src/guardrails/engine.rs
+++ b/crates/openai-frontend/src/guardrails/engine.rs
@@ -48,10 +48,12 @@ impl GuardrailEngine {
             GuardrailRequestOutcome::PassThrough {
                 reason: GuardrailTelemetryBypassReason::Streaming,
             }
-        } else if matches!(
-            state.mesh_guardrails_override,
-            MeshGuardrailsOverride::Disabled
-        ) {
+        } else if !matches!(state.mode, super::policy::GuardrailMode::Enforce)
+            && matches!(
+                state.mesh_guardrails_override,
+                MeshGuardrailsOverride::Disabled
+            )
+        {
             GuardrailRequestOutcome::PassThrough {
                 reason: GuardrailTelemetryBypassReason::Disabled,
             }

--- a/crates/openai-frontend/src/guardrails/tests.rs
+++ b/crates/openai-frontend/src/guardrails/tests.rs
@@ -1156,7 +1156,7 @@ async fn all_model_policy_guards_large_models_too() {
 }
 
 #[tokio::test]
-async fn mesh_guardrails_false_bypasses_request() {
+async fn mesh_guardrails_false_cannot_bypass_enforced_request() {
     let backend = Arc::new(RecordingBackend::default());
     let telemetry = Arc::new(RecordingTelemetrySink::default());
     let guarded = GuardedOpenAiBackend::new(
@@ -1175,13 +1175,13 @@ async fn mesh_guardrails_false_bypasses_request() {
         "tools": [{"type": "function", "function": {"name": "lookup"}}]
     }))
     .unwrap();
-    let original = request.clone();
 
     let _ = guarded.chat_completion(request).await.unwrap();
 
-    assert_eq!(backend.seen_chat.lock().unwrap().clone(), Some(original));
+    let seen = backend.seen_chat.lock().unwrap().clone().unwrap();
+    assert_eq!(seen.tools.unwrap().as_array().unwrap().len(), 2);
     let decisions = telemetry.decisions.lock().unwrap().clone();
-    assert!(decisions.iter().any(|record| {
+    assert!(!decisions.iter().any(|record| {
         record.decision == GuardrailTelemetryDecision::Bypassed.as_str()
             && record.bypass_reason == Some(GuardrailTelemetryBypassReason::Disabled.as_str())
     }));


### PR DESCRIPTION
Operator-enforced OpenAI guardrails can no longer be disabled by a request-level `mesh_guardrails: false` override. Requests retain opt-out behavior in non-enforcing modes, while `enforce` remains an operator-controlled policy boundary.

Addresses [Project Loupe audit-mesh-llm #1664 — Prevent requests from disabling enforced guardrails](https://github.com/project-loupe/audit-mesh-llm/issues/1664).

## What changed

- honor the request disable override only when guardrails are not in enforcement mode
- keep operator-selected enforcement active for all otherwise eligible contracts
- update the regression to verify the backend receives the guarded tool contract and no disabled-bypass decision is emitted

## Validation

- `cargo fmt --all --check`
- `cargo test -p openai-frontend --lib` — 185 passed
- `cargo check -p openai-frontend`
- `cargo clippy -p openai-frontend --all-targets -- -D warnings`
- `cargo check -p mesh-llm` — passed with 28 pre-existing unfulfilled-lint-expectation warnings
- `cargo test -p skippy-server --lib` — 529 passed, 3 ignored

`cargo clippy -p mesh-llm --all-targets -- -D warnings` remains blocked on the base commit by those same 28 pre-existing unfulfilled lint expectations in `mesh-llm-host-runtime`; this patch does not touch them.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced guardrail policies can no longer be bypassed by disabling guardrails in a request.
  * Requests under enforced policies continue through normal guardrail processing, including required tool injection.
  * Bypass telemetry is no longer recorded for requests that remain subject to enforcement.

* **Tests**
  * Updated coverage to verify that enforced requests cannot bypass guardrails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->