### PR TITLE
Disable ggml compiler-cache autodetection when we decline sccache

### DIFF
--- a/scripts/build-llama.sh
+++ b/scripts/build-llama.sh
@@ -286,13 +286,20 @@ if [[ "$USE_SCCACHE" != "0" && -n "$SCCACHE_BIN" ]]; then
       ;;
   esac
   echo "using sccache for llama.cpp C/C++ compilation: $SCCACHE_BIN"
-elif [[ "$USE_SCCACHE" != "0" ]]; then
-  if [[ "${MESH_LLM_REQUIRE_SCCACHE:-0}" == "1" ]]; then
-    echo "sccache is required but was not found" >&2
-    exit 1
-  fi
-  echo "sccache not found; llama.cpp build will run without compiler caching" >&2
 else
+  if [[ "$USE_SCCACHE" != "0" ]]; then
+    if [[ "${MESH_LLM_REQUIRE_SCCACHE:-0}" == "1" ]]; then
+      echo "sccache is required but was not found" >&2
+      exit 1
+    fi
+    echo "sccache not found; llama.cpp build will run without compiler caching" >&2
+  fi
+  # This script owns the compiler-caching decision, so ggml must not make its
+  # own. With GGML_CCACHE left ON, ggml runs find_program(sccache/ccache), which
+  # searches CMAKE_SYSTEM_PREFIX_PATH rather than just PATH and registers a bare
+  # `sccache` launcher. A sanitized build environment that has such a binary
+  # installed but not on PATH then fails every compile with
+  # "/bin/sh: sccache: command not found".
   CMAKE_ARGS+=(-DGGML_CCACHE=OFF)
 fi
 


### PR DESCRIPTION
## The bug

`scripts/build-llama.sh` owns the compiler-caching decision, but it only passed `-DGGML_CCACHE=OFF` when caching was disabled *explicitly*. When no sccache was found it printed

```
sccache not found; llama.cpp build will run without compiler caching
```

and left `GGML_CCACHE` ON, so ggml ran its own `find_program(sccache/ccache)`. That search covers `CMAKE_SYSTEM_PREFIX_PATH`, not just `PATH`, so a build environment with a sanitized `PATH` but an sccache installed elsewhere on the system gets a bare `sccache` compiler launcher it cannot execute:

```
/bin/sh: sccache: command not found
ninja: build stopped: subcommand failed.
```

So the message says caching is off while the build is in fact configured to use a cache binary that isn't reachable.

I hit this building the Metal runtime inside Homebrew's build sandbox, which strips `/opt/homebrew/bin` from `PATH` but leaves `/opt/homebrew` on CMake's system prefix path. Any sanitized or containerized build with a host-installed sccache can trip it.

## The fix

Fold the two non-injecting branches together so `GGML_CCACHE=OFF` is passed whenever this script does not install a launcher itself. Note the sccache-*unavailable* path (binary found but not startable) already fell through to the correct branch — only the sccache-*not-found* path was affected.

## Verification

Ran the script against a stub `cmake` that captures the configure arguments, with a fake prepared workdir, across all three decision paths:

| scenario | `-DGGML_CCACHE=OFF` | compiler launchers |
| --- | --- | --- |
| sccache absent from PATH — **before this change** | ✗ not passed | none |
| sccache absent from PATH — **after** | ✓ passed | none |
| sccache present and working | not passed | ✓ C and CXX |
| `LLAMA_STAGE_USE_SCCACHE=0` | ✓ passed | none |

`bash -n scripts/build-llama.sh` is clean. The two unchanged rows confirm the normal cached build and the explicit opt-out are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build behavior when the compiler cache is unavailable.
  * Preserved expected failures when compiler caching is explicitly required.
  * Prevented unintended compiler-cache detection during builds without a usable cache launcher.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->