### PR TITLE
fix(skippy-ffi): normalize native runtime library paths before LoadLibraryExW

### DIFF
--- a/crates/skippy-ffi/src/dynamic_library.rs
+++ b/crates/skippy-ffi/src/dynamic_library.rs
@@ -49,7 +49,15 @@ pub(crate) unsafe fn load(path: &Path) -> Result<Library, String> {
     // dependent DLL, even when the requested DLL has an absolute path. Native
     // runtimes are installed elsewhere, so make the loaded DLL's directory the
     // first dependency search location.
-    let result = unsafe { WindowsLibrary::load_with_flags(path, LOAD_WITH_ALTERED_SEARCH_PATH) };
+    // Native runtime manifests declare their libraries with POSIX separators
+    // and Path::join keeps them, so runtime library paths reach this point
+    // with a mixed-separator tail (`...\lib/llama.dll`). LoadLibraryExW fails
+    // those with ERROR_MOD_NOT_FOUND even though the file exists, and
+    // LOAD_WITH_ALTERED_SEARCH_PATH cannot derive the dependency directory
+    // from them. Rebuilding the path from its components normalizes every
+    // separator to a backslash.
+    let normalized: std::path::PathBuf = path.components().collect();
+    let result = unsafe { WindowsLibrary::load_with_flags(&normalized, LOAD_WITH_ALTERED_SEARCH_PATH) };
     result
         .map(Into::into)
         .map_err(|error| format_load_error(path, &error))
@@ -96,6 +104,17 @@ mod tests {
 
         assert!(message.contains("OS error unavailable"));
         assert!(!message.contains("OS error 0"));
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn component_collection_normalizes_posix_separators() {
+        // The windows load() relies on this: a manifest-derived path with a
+        // POSIX tail must come out with backslashes only, or LoadLibraryExW
+        // rejects it with ERROR_MOD_NOT_FOUND.
+        let mixed = Path::new(r"C:\runtime\lib/llama.dll");
+        let normalized: std::path::PathBuf = mixed.components().collect();
+        assert_eq!(normalized, Path::new(r"C:\runtime\lib\llama.dll"));
     }
 
     #[cfg(target_os = "windows")]


### PR DESCRIPTION
## Original problem

#1512: on native Windows, no native runtime can load — `serve` dies with `LoadLibraryExW failed (OS error 126)` for every flavor (cpu included), unless the runtime's `lib` directory happens to be on `PATH`.

## Diagnostics

Building the host from source made the failing path visible past the console redaction:

```text
[DIAG dynamic_library::load] flags=LOAD_WITH_ALTERED_SEARCH_PATH path=...\meshllm-native-runtime-windows-x86_64-cuda12\lib/cublas64_12.dll ok=false
```

Note the tail: **`lib/cublas64_12.dll`** — runtime manifests declare libraries with POSIX separators, `NativeRuntimeLoadPlan` joins them onto the runtime root with `Path::join`, and the mixed-separator path goes straight into `LoadLibraryExW`. Isolated with one `LoadLibraryExW` call per process on the same existing file:

| Path passed | `LOAD_WITH_ALTERED_SEARCH_PATH` | Result |
|---|---|---|
| `...\lib/cublas64_12.dll` (mixed) | yes | **error 126** |
| `...\lib\cublas64_12.dll` (backslashes) | yes | loads |
| `...\lib/cublas64_12.dll` (mixed) | no (flags=0) | error 126 |

So the flag introduced in #1046 is present but defeated: with a mixed-separator path the loader neither resolves the file as given nor derives the dependency directory. It also explains the `PATH` workaround — the failed absolute resolution falls back to a name search, which succeeds once the `lib` directory is on `PATH`. `std::fs` APIs accept forward slashes fine, which is why the load plan's `is_file()` validation passes and the failure only shows up at `LoadLibraryExW` time.

This corrects the stale-build-cache hypothesis I posted on the issue — a host built from today's `main` reproduces the failure identically, so it was never a build-pipeline problem.

## Fix

In `skippy-ffi`'s Windows `dynamic_library::load`, rebuild the incoming path from its components before calling `LoadLibraryExW` — `Path::components().collect::<PathBuf>()` normalizes every separator to a backslash, losslessly. One normalization point covers every load-plan caller. A unit test pins the normalization invariant the fix relies on.

## Validation

- [x] `cargo test -p skippy-ffi --features dynamic-runtime` (Windows, MSVC): passes, including the new normalization test.
- [x] End-to-end on the repro machine (RTX 4070 Ti, driver 610.74/CUDA 13.3): host built from this branch, cuda12 runtime installed via `runtime install --bundle-dir`, then `serve --local-model-only` **without any `PATH` workaround** → runtime loads, `api ready at http://127.0.0.1:9337/v1`, chat completions served on GPU.
- [x] No UI changes.

Fixes #1512.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows library loading by normalizing mixed path separators.
  * Fixed dependency resolution for library paths using POSIX-style separators on Windows.
  * Added coverage to verify path normalization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->