### PR TITLE
style: apply rustfmt to dynamic_library.rs

### DIFF
--- a/crates/skippy-ffi/src/dynamic_library.rs
+++ b/crates/skippy-ffi/src/dynamic_library.rs
@@ -57,7 +57,8 @@ pub(crate) unsafe fn load(path: &Path) -> Result<Library, String> {
     // from them. Rebuilding the path from its components normalizes every
     // separator to a backslash.
     let normalized: std::path::PathBuf = path.components().collect();
-    let result = unsafe { WindowsLibrary::load_with_flags(&normalized, LOAD_WITH_ALTERED_SEARCH_PATH) };
+    let result =
+        unsafe { WindowsLibrary::load_with_flags(&normalized, LOAD_WITH_ALTERED_SEARCH_PATH) };
     result
         .map(Into::into)
         .map_err(|error| format_load_error(path, &error))


### PR DESCRIPTION
## Original problem

Main's Quality lane (Rust format) has been red since #1537 merged: the path normalization change carried one line rustfmt wants wrapped. My apologies for the noise.

## Fix

`cargo fmt -p skippy-ffi`, no code change.

## Validation

- [x] `cargo fmt --check -p skippy-ffi` passes locally.

:robot: Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Reformatted Windows library loading code for improved readability.
  * No user-visible behavior or functionality changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->