### PR TITLE
Keep staged llama.cpp mappings alive until every retained tensor is loaded

### DIFF
--- a/scripts/build-llama.sh
+++ b/scripts/build-llama.sh
@@ -364,13 +364,17 @@ cmake "${CMAKE_ARGS[@]}"
 
 BUILD_TARGETS=(llama llama-common mtmd)
 if [[ "${LLAMA_STAGE_BUILD_TESTS:-OFF}" == "ON" ]]; then
-  BUILD_TARGETS+=(skippy-hardware-application-probe)
+  BUILD_TARGETS+=(
+    skippy-hardware-application-probe
+    skippy-model-fixture-generator
+    skippy-model-loader-accounting
+  )
 fi
 
 cmake --build "$LLAMA_BUILD_DIR" --config "${CMAKE_BUILD_TYPE:-Release}" --parallel "$(detect_jobs)" --target "${BUILD_TARGETS[@]}"
 
 if [[ "${LLAMA_STAGE_BUILD_TESTS:-OFF}" == "ON" ]]; then
-  ctest --test-dir "$LLAMA_BUILD_DIR" --build-config "${CMAKE_BUILD_TYPE:-Release}" --output-on-failure -R '^skippy_hardware_application_probe$'
+  ctest --test-dir "$LLAMA_BUILD_DIR" --build-config "${CMAKE_BUILD_TYPE:-Release}" --output-on-failure -R '^skippy_'
 fi
 
 printf '%s\n' "$CURRENT_BUILD_STAMP" > "$BUILD_STAMP"

--- a/third_party/llama.cpp/patches/.gitattributes
+++ b/third_party/llama.cpp/patches/.gitattributes
@@ -1,0 +1,1 @@
+*.patch -whitespace

--- a/third_party/llama.cpp/patches/0035-skippy-account-retained-tensors-during-staged-loads.patch
+++ b/third_party/llama.cpp/patches/0035-skippy-account-retained-tensors-during-staged-loads.patch
@@ -1,0 +1,458 @@
+From ce95c713e0b881339653b4893458ada67c25d7dd Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Sat, 29 Aug 2026 01:31:34 -0700
+Subject: [PATCH] skippy: account retained tensors during staged loads
+
+---
+ src/CMakeLists.txt                            |  46 +++
+ src/llama-model-loader.cpp                    |  43 ++-
+ tests/CMakeLists.txt                          |  16 +
+ tests/test-skippy-model-loader-accounting.cpp | 286 ++++++++++++++++++
+ 4 files changed, 379 insertions(+), 12 deletions(-)
+ create mode 100644 tests/test-skippy-model-loader-accounting.cpp
+
+diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
+index b59528d62..981f24b1a 100644
+--- a/src/CMakeLists.txt
++++ b/src/CMakeLists.txt
+@@ -91,2 +91,48 @@ if (LLAMA_STAGE_BUILD_TESTS)
+         COMMAND skippy-hardware-application-probe)
++
++    set(SKIPPY_MODEL_FIXTURE_DIR "${CMAKE_CURRENT_BINARY_DIR}/skippy/test-models")
++    file(MAKE_DIRECTORY "${SKIPPY_MODEL_FIXTURE_DIR}")
++
++    add_executable(skippy-model-fixture-generator
++        ../tests/test-llama-archs.cpp)
++    target_compile_features(skippy-model-fixture-generator PRIVATE cxx_std_17)
++    target_link_libraries(skippy-model-fixture-generator PRIVATE llama-common)
++
++    add_executable(skippy-model-loader-accounting
++        ../tests/test-skippy-model-loader-accounting.cpp)
++    target_include_directories(skippy-model-loader-accounting PRIVATE .)
++    target_compile_features(skippy-model-loader-accounting PRIVATE cxx_std_17)
++    target_link_libraries(skippy-model-loader-accounting PRIVATE llama-common)
++
++    add_test(
++        NAME skippy_generate_gemma_fixture
++        COMMAND skippy-model-fixture-generator
++            --arch gemma
++            --seed 1
++            --out "${SKIPPY_MODEL_FIXTURE_DIR}")
++    set_tests_properties(skippy_generate_gemma_fixture PROPERTIES
++        FIXTURES_SETUP skippy-model-loader-fixtures)
++
++    add_test(
++        NAME skippy_generate_qwen2moe_fixture
++        COMMAND skippy-model-fixture-generator
++            --arch qwen2moe
++            --seed 1
++            --out "${SKIPPY_MODEL_FIXTURE_DIR}")
++    set_tests_properties(skippy_generate_qwen2moe_fixture PROPERTIES
++        FIXTURES_SETUP skippy-model-loader-fixtures)
++
++    add_test(
++        NAME skippy_model_loader_accounting_dense
++        COMMAND skippy-model-loader-accounting
++            "${SKIPPY_MODEL_FIXTURE_DIR}/gemma-dense.gguf")
++    set_tests_properties(skippy_model_loader_accounting_dense PROPERTIES
++        FIXTURES_REQUIRED skippy-model-loader-fixtures)
++
++    add_test(
++        NAME skippy_model_loader_accounting_moe
++        COMMAND skippy-model-loader-accounting
++            "${SKIPPY_MODEL_FIXTURE_DIR}/qwen2moe-moe.gguf")
++    set_tests_properties(skippy_model_loader_accounting_moe PROPERTIES
++        FIXTURES_REQUIRED skippy-model-loader-fixtures)
+ endif()
+diff --git a/src/llama-model-loader.cpp b/src/llama-model-loader.cpp
+index b831fa385..bde67cf23 100644
+--- a/src/llama-model-loader.cpp
++++ b/src/llama-model-loader.cpp
+@@ -11,2 +11,3 @@
+ #include <cinttypes>
++#include <cmath>
+ #include <cstdint>
+@@ -1313,3 +1314,2 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+                 if (requested_tensor_exists && first_filtered_request) {
+-                    size_data -= nbytes;
+                     if (!(flags & TENSOR_DUPLICATED)) {
+@@ -1364,3 +1364,2 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+ 
+-            size_data -= nbytes;
+             n_created++;
+@@ -1570,4 +1569,2 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+ 
+-    const bool duplicated = flags & TENSOR_DUPLICATED;
+-
+     struct ggml_tensor * tensor = ggml_dup_tensor(ctx, &t_meta);
+@@ -1575,5 +1572,3 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+ 
+-    if (duplicated) {
+-        size_data += ggml_nbytes(&t_meta);
+-    } else {
++    if (!(flags & TENSOR_DUPLICATED)) {
+         n_created++;
+@@ -1635,5 +1630,24 @@ void llama_model_loader::init_mappings(bool prefetch, llama_mlocks * mlock_mmaps
+ 
+-    // compute the total size of all tensors for progress reporting
+-    for (const auto & it : weights_map) {
+-        size_data += ggml_nbytes(it.second.tensor);
++    // Match load_all_data exactly once model contexts exist. A physical weight
++    // can appear in more than one context (for example, tied embeddings used as
++    // the output head), and load_all_data uploads it once per context. Counting
++    // logical create_tensor requests instead can therefore finish early and
++    // unmap weights that a later context still has to upload.
++    size_data = 0;
++    if (!ctx_map.empty()) {
++        for (const auto & [_, ctx] : ctx_map) {
++            for (ggml_tensor * tensor = ggml_get_first_tensor(ctx.get());
++                    tensor != nullptr;
++                    tensor = ggml_get_next_tensor(ctx.get(), tensor)) {
++                if (get_weight(ggml_get_name(tensor)) != nullptr) {
++                    size_data += ggml_nbytes(tensor);
++                }
++            }
++        }
++    } else {
++        // Quantization initializes mappings before constructing model contexts
++        // and reads weights through load_data_range rather than load_all_data.
++        for (const auto & [_, weight] : weights_map) {
++            size_data += ggml_nbytes(weight.tensor);
++        }
+     }
+@@ -1698,2 +1712,3 @@ bool llama_model_loader::load_all_data(
+     GGML_ASSERT(size_data != 0 && "call init_mappings() first");
++    const size_t size_done_before = size_done;
+ 
+@@ -1808,3 +1823,6 @@ bool llama_model_loader::load_all_data(
+         if (progress_callback) {
+-            if (!progress_callback((float) size_done / size_data, progress_callback_user_data)) {
++            const float progress = std::min(
++                    (float) size_done / size_data,
++                    std::nextafter(1.0f, 0.0f));
++            if (!progress_callback(progress, progress_callback_user_data)) {
+                 return false;
+@@ -1925,2 +1943,3 @@ bool llama_model_loader::load_all_data(
+         size_done += n_size;
++        GGML_ASSERT(size_done <= size_data);
+     }
+@@ -1951,3 +1970,3 @@ bool llama_model_loader::load_all_data(
+     // check if this is the last call and do final cleanup
+-    if (size_done >= size_data) {
++    if (size_done_before < size_data && size_done == size_data) {
+         // unmap offloaded tensors and metadata
+diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
+index 376e9b09f..ed156f339 100644
+--- a/tests/CMakeLists.txt
++++ b/tests/CMakeLists.txt
+@@ -219,2 +219,18 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
+ 
++    llama_build_and_test(
++        test-skippy-model-loader-accounting.cpp
++        LABEL main
++        ARGS "${MODEL_DIR}/gemma-dense.gguf"
++    )
++    target_include_directories(test-skippy-model-loader-accounting PRIVATE ${PROJECT_SOURCE_DIR}/src)
++    set_tests_properties(test-skippy-model-loader-accounting PROPERTIES FIXTURES_REQUIRED generate-models)
++
++    llama_test(
++        test-skippy-model-loader-accounting
++        NAME test-skippy-model-loader-accounting-moe
++        LABEL main
++        ARGS "${MODEL_DIR}/qwen2moe-moe.gguf"
++    )
++    set_tests_properties(test-skippy-model-loader-accounting-moe PROPERTIES FIXTURES_REQUIRED generate-models)
++
+     llama_test(
+diff --git a/tests/test-skippy-model-loader-accounting.cpp b/tests/test-skippy-model-loader-accounting.cpp
+new file mode 100644
+index 000000000..e629d555e
+--- /dev/null
++++ b/tests/test-skippy-model-loader-accounting.cpp
+@@ -0,0 +1,286 @@
++#include "llama.h"
++#include "llama-model-loader.h"
++
++#include <cmath>
++#include <cstdio>
++#include <cstdlib>
++#include <vector>
++
++struct progress_state {
++    float last = 0.0f;
++    bool bounded = true;
++    bool monotonic = true;
++    bool progressed_after_completion = false;
++    size_t completion_count = 0;
++};
++
++static bool observe_progress(float progress, void * user_data) {
++    auto * state = static_cast<progress_state *>(user_data);
++    constexpr float tolerance = 1e-6f;
++
++    state->bounded &= std::isfinite(progress) && progress >= -tolerance && progress <= 1.0f + tolerance;
++    state->monotonic &= progress + tolerance >= state->last;
++    if (progress == 1.0f) {
++        state->completion_count++;
++    } else if (state->completion_count > 0) {
++        state->progressed_after_completion = true;
++    }
++    state->last = progress;
++    return true;
++}
++
++class stage_filter_guard {
++public:
++    stage_filter_guard() {
++        llama_model_loader_stage_filter filter;
++        filter.enabled = true;
++        filter.layer_start = 0;
++        filter.layer_end = 1;
++        filter.include_embeddings = true;
++        filter.include_output = true;
++        llama_model_loader_set_stage_filter(filter);
++    }
++
++    ~stage_filter_guard() {
++        llama_model_loader_clear_stage_filter();
++    }
++};
++
++static llama_model_loader make_loader(const char * model_path, llama_load_mode load_mode = LLAMA_LOAD_MODE_NONE) {
++    std::vector<std::string> splits;
++    return llama_model_loader(
++            nullptr,
++            nullptr,
++            nullptr,
++            model_path,
++            splits,
++            false,
++            nullptr,
++            load_mode,
++            false,
++            true,
++            false,
++            nullptr,
++            nullptr);
++}
++
++static ggml_context_ptr make_accounting_context(const ggml_tensor * weight, bool include_synthetic) {
++    const size_t tensor_count = include_synthetic ? 2 : 1;
++    ggml_init_params params = {
++        /*.mem_size   =*/ tensor_count * ggml_tensor_overhead(),
++        /*.mem_buffer =*/ nullptr,
++        /*.no_alloc   =*/ true,
++    };
++    ggml_context_ptr ctx(ggml_init(params));
++    if (ctx == nullptr) {
++        return nullptr;
++    }
++
++    ggml_tensor * duplicate = ggml_dup_tensor(ctx.get(), weight);
++    ggml_set_name(duplicate, ggml_get_name(weight));
++    if (include_synthetic) {
++        ggml_tensor * synthetic = ggml_dup_tensor(ctx.get(), weight);
++        ggml_set_name(synthetic, "skippy.synthetic");
++    }
++    return ctx;
++}
++
++static ggml_context_ptr make_synthetic_context(const ggml_tensor * weight) {
++    ggml_init_params params = {
++        /*.mem_size   =*/ ggml_tensor_overhead(),
++        /*.mem_buffer =*/ nullptr,
++        /*.no_alloc   =*/ true,
++    };
++    ggml_context_ptr ctx(ggml_init(params));
++    if (ctx != nullptr) {
++        ggml_tensor * synthetic = ggml_dup_tensor(ctx.get(), weight);
++        ggml_set_name(synthetic, "skippy.synthetic.after-completion");
++    }
++    return ctx;
++}
++
++static llama_buf_map make_buffer_map(
++        const llama_model_loader & loader,
++        ggml_backend_buffer_t buffer) {
++    llama_buf_map buffers;
++    for (uint32_t idx = 0; idx < loader.files.size(); ++idx) {
++        buffers.emplace(idx, buffer);
++    }
++    return buffers;
++}
++
++static bool check_context_load_lifecycle(const char * model_path) {
++    llama_model_loader loader = make_loader(model_path, LLAMA_LOAD_MODE_MMAP);
++    if (loader.weights_map.empty()) {
++        std::fprintf(stderr, "model has no weights\n");
++        return false;
++    }
++
++    const ggml_tensor * weight = loader.weights_map.begin()->second.tensor;
++    ggml_context_ptr primary_ctx = make_accounting_context(weight, false);
++    ggml_context_ptr secondary_ctx = make_accounting_context(weight, true);
++    ggml_context_ptr synthetic_ctx = make_synthetic_context(weight);
++    if (primary_ctx == nullptr || secondary_ctx == nullptr || synthetic_ctx == nullptr) {
++        std::fprintf(stderr, "failed to allocate accounting contexts\n");
++        return false;
++    }
++
++    ggml_context * primary_ctx_raw = primary_ctx.get();
++    ggml_context * secondary_ctx_raw = secondary_ctx.get();
++    ggml_context * synthetic_ctx_raw = synthetic_ctx.get();
++    const auto cpu_buft = ggml_backend_cpu_buffer_type();
++    loader.ctx_map.emplace(llama_model_loader::ctx_key { cpu_buft, false }, std::move(primary_ctx));
++    loader.ctx_map.emplace(llama_model_loader::ctx_key { cpu_buft, true }, std::move(secondary_ctx));
++    loader.init_mappings(false);
++
++    const size_t weight_size = ggml_nbytes(weight);
++    const size_t expected = 2 * weight_size;
++    if (loader.size_data != expected) {
++        std::fprintf(
++                stderr,
++                "context accounting mismatch: expected %zu bytes, got %zu\n",
++                expected,
++                loader.size_data);
++        return false;
++    }
++
++    ggml_backend_buffer_ptr primary_buffer {
++        ggml_backend_alloc_ctx_tensors_from_buft(primary_ctx_raw, cpu_buft)
++    };
++    ggml_backend_buffer_ptr secondary_buffer {
++        ggml_backend_alloc_ctx_tensors_from_buft(secondary_ctx_raw, cpu_buft)
++    };
++    ggml_backend_buffer_ptr synthetic_buffer {
++        ggml_backend_alloc_ctx_tensors_from_buft(synthetic_ctx_raw, cpu_buft)
++    };
++    if (primary_buffer == nullptr || secondary_buffer == nullptr || synthetic_buffer == nullptr) {
++        std::fprintf(stderr, "failed to allocate CPU accounting buffers\n");
++        return false;
++    }
++
++    llama_buf_map primary_buffers = make_buffer_map(loader, primary_buffer.get());
++    llama_buf_map secondary_buffers = make_buffer_map(loader, secondary_buffer.get());
++    llama_buf_map synthetic_buffers = make_buffer_map(loader, synthetic_buffer.get());
++    progress_state progress;
++
++    if (!loader.load_all_data(primary_ctx_raw, primary_buffers, nullptr, observe_progress, &progress)) {
++        std::fprintf(stderr, "first context load was cancelled\n");
++        return false;
++    }
++    if (loader.size_done != weight_size || loader.size_done >= loader.size_data) {
++        std::fprintf(
++                stderr,
++                "first context completed early: loaded %zu of %zu bytes\n",
++                loader.size_done,
++                loader.size_data);
++        return false;
++    }
++    if (progress.completion_count != 0 || progress.last >= 1.0f) {
++        std::fprintf(stderr, "first context triggered final cleanup\n");
++        return false;
++    }
++
++    if (!loader.load_all_data(secondary_ctx_raw, secondary_buffers, nullptr, observe_progress, &progress)) {
++        std::fprintf(stderr, "second context load was cancelled\n");
++        return false;
++    }
++    if (loader.size_done != loader.size_data) {
++        std::fprintf(
++                stderr,
++                "final context did not complete accounting: loaded %zu of %zu bytes\n",
++                loader.size_done,
++                loader.size_data);
++        return false;
++    }
++    if (!loader.load_all_data(synthetic_ctx_raw, synthetic_buffers, nullptr, observe_progress, &progress)) {
++        std::fprintf(stderr, "synthetic context load was cancelled\n");
++        return false;
++    }
++    // The final 1.0 callback is emitted only after load_all_data tears down the
++    // mmap fragments. The post-completion synthetic-only context must not emit
++    // it again, so a single completion proves that cleanup ran exactly once.
++    if (!progress.bounded || !progress.monotonic || progress.completion_count != 1 ||
++            progress.progressed_after_completion) {
++        std::fprintf(stderr, "two-context progress lifecycle was invalid\n");
++        return false;
++    }
++    return true;
++}
++
++static bool check_contextless_fallback(const char * model_path) {
++    llama_model_loader loader = make_loader(model_path);
++    size_t expected = 0;
++    for (const auto & [_, weight] : loader.weights_map) {
++        expected += ggml_nbytes(weight.tensor);
++    }
++
++    loader.init_mappings(false);
++    if (loader.size_data != expected) {
++        std::fprintf(
++                stderr,
++                "contextless accounting mismatch: expected %zu bytes, got %zu\n",
++                expected,
++                loader.size_data);
++        return false;
++    }
++    return true;
++}
++
++int main(int argc, char ** argv) {
++    if (argc != 2) {
++        std::fprintf(stderr, "usage: %s MODEL\n", argv[0]);
++        return EXIT_FAILURE;
++    }
++
++    llama_backend_init();
++
++    if (!check_context_load_lifecycle(argv[1]) || !check_contextless_fallback(argv[1])) {
++        llama_backend_free();
++        return EXIT_FAILURE;
++    }
++
++    progress_state progress;
++    llama_model_params params = llama_model_default_params();
++    params.load_mode = LLAMA_LOAD_MODE_MMAP;
++    params.n_gpu_layers = 99;
++    params.progress_callback = observe_progress;
++    params.progress_callback_user_data = &progress;
++
++    llama_model * model = nullptr;
++    {
++        stage_filter_guard filter;
++        model = llama_model_load_from_file(argv[1], params);
++    }
++
++    const bool loaded = model != nullptr;
++    if (model != nullptr) {
++        llama_model_free(model);
++    }
++    llama_backend_free();
++
++    if (!loaded) {
++        std::fprintf(stderr, "filtered model load failed\n");
++        return EXIT_FAILURE;
++    }
++    if (!progress.bounded) {
++        std::fprintf(stderr, "model-load progress escaped [0, 1]\n");
++        return EXIT_FAILURE;
++    }
++    if (!progress.monotonic) {
++        std::fprintf(stderr, "model-load progress regressed\n");
++        return EXIT_FAILURE;
++    }
++    if (progress.completion_count != 1) {
++        std::fprintf(
++                stderr,
++                "model-load completion callback count mismatch: expected 1, got %zu\n",
++                progress.completion_count);
++        return EXIT_FAILURE;
++    }
++    if (progress.progressed_after_completion) {
++        std::fprintf(stderr, "model-load progress continued after completion\n");
++        return EXIT_FAILURE;
++    }
++
++    return EXIT_SUCCESS;
++}


### PR DESCRIPTION
## Summary

Staged Skippy loads now keep GGUF-backed mappings alive until every tensor retained by every backend context has actually been uploaded. Filtered and multi-context loads no longer report exact completion early or release mapped model data while a later context still needs it.

Closes #1298.

## Why

The old loader adjusted `size_data` while tensors were requested. That request-oriented total could diverge from the work later performed by `load_all_data()`:

- one physical GGUF weight can be retained by more than one backend context;
- synthetic context tensors have no GGUF weight and must not extend mapping lifetime;
- quantization initializes mappings before model contexts exist.

An undercount could make progress reach `1.0` and trigger mapping cleanup before the final retained context had loaded its data.

## Diff scope

- Add durable llama.cpp patch `0035-skippy-account-retained-tensors-during-staged-loads.patch`.
- Recompute retained byte totals from finalized backend contexts, while preserving the contextless `weights_map` fallback used by quantization.
- Reserve exact progress `1.0` for the incomplete-to-complete transition and prevent repeated completion cleanup.
- Add generated dense Gemma and Qwen2MoE fixtures plus a native accounting regression to the supported `LLAMA_STAGE_BUILD_TESTS` lane.
- Make `just skippy-native-tests` build and execute all `skippy_*` CTest cases.
- Scope Git whitespace handling to mail-format files inside `third_party/llama.cpp/patches/`; no root-level ownership entry is introduced.

No Rust API, CLI, UI, database, configuration, release, mesh-wire, plugin-protocol, or model-package contract changes.

## Architecture

`init_mappings()` now derives `size_data` from the finalized `ctx_map`, counting each retained tensor occurrence only when `get_weight()` resolves it to real GGUF storage. This mirrors the context traversal later used by `load_all_data()`. If no contexts exist, the existing `weights_map` total remains the quantization fallback.

Intermediate callbacks are clamped below `1.0`; final cleanup runs only when `size_done` crosses from incomplete to exactly complete. The existing `size_done <= size_data` invariant is asserted.

## Protocol and compatibility

Not applicable — no mesh wire format, plugin protocol, Skippy ABI surface, or ABI version changed. The patch remains additive to the existing pinned llama.cpp queue and preserves contextless quantization behavior.

## Review follow-up

All requested changes from the review on `0877468a` are implemented on the final SHA:

- Construct the current pinned `ctx_key { buft, lazy }` shape explicitly.
- Register and run the regression under `LLAMA_STAGE_BUILD_TESTS` through the normal CTest lane.
- Rebase onto current `main` and renumber the new patch from the colliding `0033` to `0035`.
- Exercise a CPU-only two-context sequential load: progress stays below completion after the first context, reaches exact completion after the second, and performs cleanup once.
- Include a synthetic context tensor for which `get_weight()` returns null, plus a post-completion context proving cleanup is not repeated.
- Cover real filtered dense and MoE loads with generated fixtures.

The later CI-planner finding is also resolved without changing the protected ownership catalog: the attributes file now lives inside the already-owned `third_party/llama.cpp/patches/**` path. The full planner test file passes.

## Branch integrity

- Base: `main@a6b16e62220a4ae98849959f5f526662906e7b47`
- Head: `9ef85e76b46d81b5cc1ad31e5edd70b8901141dd`
- Ahead/behind: `0 behind / 1 ahead`
- Merge base: `a6b16e62220a4ae98849959f5f526662906e7b47`
- `origin/main` is an ancestor of `HEAD`.

## Commit integrity

- One introduced commit: `9ef85e76b46d81b5cc1ad31e5edd70b8901141dd Fix retained staged tensor accounting`
- One logical change.
- Final diff contains only the intended native patch, its supported test-lane wiring, and patch-directory attributes.

Ledger: not applicable — not required for this change family.  
Version: not changed — `RELEASE.md` assigns release version synchronization to `scripts/release-version.sh`; no ABI or protocol version changed.

## Diff hygiene

`git diff --name-status origin/main...HEAD`:

```text
M scripts/build-llama.sh
A third_party/llama.cpp/patches/.gitattributes
A third_party/llama.cpp/patches/0035-skippy-account-retained-tensors-during-staged-loads.patch
```

- `git diff --check origin/main...HEAD`: **PASS**, no output.
- The scoped `.gitattributes` disables whitespace interpretation only for mail-format `*.patch` payloads in the patch queue; its path is covered by the existing `native-abi` ownership rule.
- No secrets, credentials, `.env` files, local configuration, caches, binaries, coverage artifacts, or unrelated generated files are present.

## Validation mode and proof

Validation mode: **Tier 4 — native verification tooling**, with **Tier 3 runtime/lifetime risk** covered by dedicated dense, MoE, sequential-context, and cleanup-transition tests.

Local proof on the final content:

- `just skippy-native-tests`: **PASS** — clean replay of all 35 patches onto llama.cpp `9723942adc518b43c4b95dc4dce6906903eb5e09`; 5/5 CTest cases passed.
- Final replayed llama.cpp SHA: `7eda86dd17e8411bb739653c1c9435137eb48b32`.
- CTest: hardware probe, Gemma fixture generation, Qwen2MoE fixture generation, dense accounting, and MoE accounting: **PASS**.
- `mise exec node@22.22.0 -- just build`: **PASS** — UI, shipped host, and Metal native runtime built.
- `bash -n scripts/build-llama.sh`: **PASS**.
- `python3 scripts/tests/test_justfile_layout.py`: **PASS** — 3 passed.
- `python3 scripts/tests/test_plan_ci.py`: **PASS** — 31 passed.
- Final PR diff through `scripts/plan-ci.py`: **PASS** — domains `tooling`, `runtime-product`, and `native-abi`; required slices include quality, static ABI, Rust tests, runtime product, and product smoke.
- `cargo fmt --all -- --check`: **PASS**.
- `cargo test -p skippy-runtime --lib`: **PASS** — 100 passed.
- `cargo test -p skippy-server --lib`: **PASS** — 553 passed, 3 ignored.
- `cargo test -p mesh-llm-host-runtime --lib inference::skippy`: **PASS** — 251 passed, 2 ignored, 2583 filtered.
- `git diff --check` and pre-commit `git diff --cached --check`: **PASS**.

The build/test logs contain pre-existing warnings in untouched Rust, Inkling, and upstream generator code; this PR introduces no known warning in changed runtime code.

Not run locally:

- CUDA/V100 reproduction — unavailable on this machine; remains a hardware-specific gate.
- Full workspace test suite — not required locally for this focused validation tier; mandatory remote CI supplied the final full-SHA proof.
- `just ci-validate` — no workflow, local action, planner, ownership catalog, slice catalog, or routing rule changed; the directly owning planner suite and final-diff plan were run instead.

## Remote CI and remaining gates

Mandatory PR CI on final SHA `9ef85e76b46d81b5cc1ad31e5edd70b8901141dd`: **PASS**.

- GitHub Actions check-runs: **33 passed, 12 expected skips, 0 failed, 0 pending**.
- Stable results `PR / Quality`, `PR / Website`, `PR / Linux`, `PR / macOS`, and `PR / Windows`: **PASS**.
- Linux host, static ABI, native runtime, four Rust-test batches, composed CPU product, core inference, two-node client, and two-node split smoke: **PASS**.
- CodeRabbit final-SHA check: **PASS**; no new inline findings were posted.

Remaining gates:

- maintainer re-review clearing the earlier `CHANGES_REQUESTED` state from `0877468a`;
- requested CUDA/V100 hardware reproduction (the CUDA smoke row was not selected by this PR plan).

GitHub reports the PR as mergeable with a clean merge state, but it is **not merge-ready** while those two required gates remain open.

CI context names are unchanged. No CI/workflow context changed.

## Runtime safety

- No new locks, queues, threads, background tasks, or unbounded allocations.
- Exact completion is tied to the final retained byte transition.
- Mapping cleanup is one-shot and cannot occur after only the first retained context.
- Synthetic non-weight tensors do not inflate lifetime accounting.
- No invariant regression introduced.

## Migration and documentation

Not applicable — no migration, data repair, operational command, runbook, or user-facing documentation changed.

## Rollback plan

Rollback: revert this PR.  
DB downgrade: not applicable.  
Data repair: not applicable.  
Operational caveat: restart any model load already in progress after rollback.

## Known residual risks

- Local native coverage is CPU/Metal; CUDA/V100 behavior still requires the requested hardware proof.
- Maintainer re-review and requested CUDA/V100 proof remain pending; mandatory remote CI is green on the final SHA.
