### PR TITLE
ci: enable Depot for eligible same-repository PRs

### DIFF
--- a/.agents/skills/manage-ci/SKILL.md
+++ b/.agents/skills/manage-ci/SKILL.md
@@ -273,7 +273,8 @@ under all of these controls:
 - CI-control, workflow, runner-policy and cache-policy changes force hosted;
 - the protected default-branch runner-owning workflows remain the executor;
 - PR jobs receive no repository secrets or registry credentials; and
-- rollback is deletion or `false` of the PR gate.
+- rollback deletes `DEPOT_PR_CANARY_REF` and deletes or sets
+  `DEPOT_PR_RUNNERS_ENABLED=false`, so PR jobs return to hosted placement.
 
 This is an explicit speed-versus-isolation decision, not evidence that Depot
 cache is isolated. While active, GitHub Actions cache API consumers on eligible

--- a/.agents/skills/manage-ci/SKILL.md
+++ b/.agents/skills/manage-ci/SKILL.md
@@ -264,21 +264,19 @@ The provider-isolation requirements below remain the desired end state:
    not change the plan or artifact graph.
 
 Until the provider supplies that end state, maintainers may deliberately accept
-the documented repository-wide cache risk for one exact same-repository PR
-head under all of these controls:
+the documented repository-wide cache risk for eligible same-repository PRs
+under all of these controls:
 
 - the exception has a checked-in UTC expiry and fails hosted after it;
 - `DEPOT_PR_RUNNERS_ENABLED` is exactly `true`;
-- `DEPOT_PR_APPROVED_REF` exactly matches `refs/pull/<number>/merge` and
-  `DEPOT_PR_APPROVED_SHA` exactly matches the current PR head SHA;
 - the head repository is exactly `Mesh-LLM/mesh-llm`; forks remain hosted;
 - CI-control, workflow, runner-policy and cache-policy changes force hosted;
 - the protected default-branch runner-owning workflows remain the executor;
 - PR jobs receive no repository secrets or registry credentials; and
-- rollback is deletion/false of the PR gate or either exact approval value.
+- rollback is deletion or `false` of the PR gate.
 
 This is an explicit speed-versus-isolation decision, not evidence that Depot
-cache is isolated. While active, GitHub Actions cache API consumers on selected
+cache is isolated. While active, GitHub Actions cache API consumers on eligible
 Depot PR and trusted-main jobs may share Depot's repository-wide namespace.
 Treat that namespace as attacker-controlled and keep release, publishing,
 deployment and credential-bearing jobs off it. Record the rationale, known
@@ -287,9 +285,8 @@ failure modes, owner, start, expiry and rollback in
 
 GitHub's `all_external_contributors` workflow-approval policy does not cover a
 same-repository branch pushed by a collaborator. Do not describe that setting
-as the approval boundary for this exception. The exact maintainer-controlled
-ref and head-SHA variables are the checked-in per-PR approval boundary and must
-be refreshed after every PR synchronization.
+as the approval boundary for this exception. The repository-wide PR gate and
+checked-in expiry are the maintainer-controlled approval boundary.
 
 ## Cache contract
 

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -438,7 +438,7 @@ fail-open policy.
 - `select-ci-runners`: provider labels, cache permissions, and the
   provider-derived `allow_native_github_cache` / `allow_depot_remote_cache`
   outputs. Depot selections disable both cache paths by default. During the
-  bounded approved exception, the exact PR revision and eligible trusted-main
+  bounded approved exception, eligible same-repository PR and trusted-main
   Depot jobs enable the GitHub Actions cache API while direct Depot remote
   cache remains disabled. Hosted PR, release, and cache-warmer selections
   retain native GitHub cache behavior.
@@ -468,7 +468,7 @@ under `ci/` or this inventory.
 Artifacts are correctness boundaries; caches only accelerate regeneration.
 PR artifacts generally retain for one day. Fork lanes cannot publish shared
 trusted-main caches. Same-repository PRs normally use GitHub's ref-scoped cache;
-an exact approved revision may temporarily use Depot's shared cross-branch
+eligible PR jobs may temporarily use Depot's shared cross-branch
 namespace under `ci/DEPOT_PR_RISK_EXCEPTION.md`. That namespace is treated as
 untrusted input, not an authority or correctness boundary. Linux Clippy,
 Rust-test, host, and runtime jobs restore one bounded trusted sccache seed
@@ -499,9 +499,8 @@ permission.
 GitHub-hosted labels are `ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-15`, and
 `windows-2022`. Depot labels are selected only by `select-ci-runners`; no
 workflow accepts a raw provider label. Trusted main Linux requires
-`DEPOT_RUNNERS_ENABLED=true`. An exact same-repository PR revision may use the
-time-bounded exception only when `DEPOT_PR_RUNNERS_ENABLED=true` and both
-`DEPOT_PR_APPROVED_REF` and `DEPOT_PR_APPROVED_SHA` match; it expires on
+`DEPOT_RUNNERS_ENABLED=true`. Eligible same-repository PR jobs may use the
+time-bounded exception when `DEPOT_PR_RUNNERS_ENABLED=true`; it expires on
 2026-09-14 UTC. Forks remain hosted. The intended permanent gate
 may cover eligible build/test rows across Linux, Depot macOS 15 and Windows
 2022 when equivalent images/architectures exist; planning/required summaries,
@@ -536,7 +535,7 @@ the enclosing PR run was later cancelled during cleanup. Trusted-main verify
 restored and exactly validated that poison, then failed its intended expected-
 miss gate. This proves unsafe repository-scoped cross-trust authority, so it is
 not a successful isolation result. The bounded exception knowingly accepts
-that risk for exact ref/SHA-approved same-repository revisions to gain CI
+that risk for eligible same-repository PRs to gain CI
 iteration speed; it is not permanent-isolation evidence. The exact-SHA
 five-lane candidate, provider comparison, and identical-SHA hosted rollback
 are recorded in `.omo/specs/depot-pr-rollout-evidence.md`; Quality and Linux
@@ -578,8 +577,6 @@ on malformed or missing backend data.
 
 Relevant repository variable names include `DEPOT_RUNNERS_ENABLED`,
 `DEPOT_PR_RUNNERS_ENABLED` (global temporary exception gate),
-`DEPOT_PR_APPROVED_REF` (one exact merge ref), `DEPOT_PR_APPROVED_SHA` (the
-exact lowercase PR head SHA; refresh after every push),
 `DEPOT_PR_CANARY_REF` (absent by default; one exact
 `refs/pull/<number>/merge` ref only), `DEPOT_PR_SENTINEL_REF` (absent by
 default; one exact same-repository merge ref used only by the protected
@@ -590,8 +587,8 @@ not cache-isolation proofs or replacements for the global PR gate. The normal
 Quality runner policy continues to use `DEPOT_PR_CANARY_REF`; the sentinel
 uses a separate selector output and cannot move the normal build jobs.
 The eligible five-lane Depot graph disables every native GitHub cache consumer
-when `allow_native_github_cache=false`. During the bounded exception the exact
-approved PR and eligible trusted-main Depot jobs set that output true for
+when `allow_native_github_cache=false`. During the bounded exception eligible
+same-repository PR and trusted-main Depot jobs set that output true for
 cross-branch Depot Actions-cache reuse; direct Depot remote cache remains
 false. This checked-in mode does not
 prove the absence of ambient Depot/WebDAV authority, so the runtime sentinel

--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -28,13 +28,14 @@ macOS and Windows lane workflows are authoritative for assembly. Each PR/main
 entry calls one nested reusable lane so its jobs and logs remain visible in a
 focused native run; only an explicit manual-full run uses detached dispatch.
 Platform lanes must call platform-pure host/runtime/product/smoke/SDK reusables
-without empty platform placeholders. Ordinary PR code is GitHub-hosted. The
-approved uncredentialed CUDA smoke may use the ephemeral `gpu-nvidia` scale
-set through the protected default-branch workflow; this narrow exception does
-not allow Depot, secrets, shared cache authority, or broader runner-group
-access. Depot PR execution is prohibited until the cache and runner-group
-isolation gates in `ci/DEPOT_MIGRATION.md` pass. Do not change Depot settings
-or runner groups as part of an ordinary CI refactor.
+without empty platform placeholders. Eligible same-repository PR jobs may use
+Depot only while the checked-in bounded exception and repository gate are
+active; forks remain GitHub-hosted. The approved uncredentialed CUDA smoke may
+use the ephemeral `gpu-nvidia` scale set through the protected default-branch
+workflow. Neither exception grants secrets or broader runner-group access.
+Permanent Depot PR execution still requires the cache and runner-group
+isolation gates in `ci/DEPOT_MIGRATION.md`. Do not change Depot settings or
+runner groups as part of an ordinary CI refactor.
 
 Preserve the five-entry PR shape exactly. Do not create an all-platform PR
 workflow, an all-lanes reusable composer, or a PR controller whose visible job

--- a/.github/actions/select-ci-runners/action.yml
+++ b/.github/actions/select-ci-runners/action.yml
@@ -34,11 +34,11 @@ inputs:
     required: false
     default: ""
   pr_approved_ref:
-    description: Maintainer-approved exact pull-request merge ref for the bounded risk exception.
+    description: Deprecated compatibility input; the bounded repository-wide PR gate no longer uses an exact ref approval.
     required: false
     default: ""
   pr_approved_sha:
-    description: Maintainer-approved exact pull-request head SHA for the bounded risk exception.
+    description: Deprecated compatibility input; the bounded repository-wide PR gate no longer uses an exact SHA approval.
     required: false
     default: ""
   force_hosted:
@@ -111,8 +111,6 @@ runs:
         INPUT_DEPOT_MAIN_ENABLED: ${{ inputs.depot_main_enabled }}
         INPUT_DEPOT_PR_ENABLED: ${{ inputs.depot_pr_enabled }}
         INPUT_PR_CANARY_REF: ${{ inputs.pr_canary_ref }}
-        INPUT_PR_APPROVED_REF: ${{ inputs.pr_approved_ref }}
-        INPUT_PR_APPROVED_SHA: ${{ inputs.pr_approved_sha }}
         INPUT_FORCE_HOSTED: ${{ inputs.force_hosted }}
         INPUT_MANUAL_USE_DEPOT: ${{ inputs.manual_use_depot }}
       run: |
@@ -138,19 +136,6 @@ runs:
           exit 1
         fi
 
-        pr_approved_ref="${INPUT_PR_APPROVED_REF:-}"
-        if [[ -n "$pr_approved_ref" &&
-          ! "$pr_approved_ref" =~ ^refs/pull/[0-9]+/merge$ ]]; then
-          echo "INPUT_PR_APPROVED_REF must be an exact pull-request merge ref" >&2
-          exit 1
-        fi
-        pr_approved_sha="${INPUT_PR_APPROVED_SHA:-}"
-        if [[ -n "$pr_approved_sha" &&
-          ! "$pr_approved_sha" =~ ^[0-9a-f]{40}$ ]]; then
-          echo "INPUT_PR_APPROVED_SHA must be an exact lowercase commit SHA" >&2
-          exit 1
-        fi
-
         # This checked-in deadline makes the accepted repository-wide cache
         # risk self-expiring. Extending it requires a reviewed source change.
         depot_pr_exception_expires="2026-09-14"
@@ -161,18 +146,17 @@ runs:
           depot_pr_exception_active=true
         fi
 
-        # A direct PR may opt into Depot only when this protected repository
-        # explicitly enables the feature, or when one exact merge ref is
-        # selected for the protected canary. Both the base and PR-head
-        # repository comparisons remain exact so a fork, mirror, or similarly
-        # named repository cannot opt in.
+        # A direct PR may opt into Depot only while this protected repository's
+        # bounded gate is active, or when one exact merge ref is selected for
+        # the protected canary. Both the base and PR-head repository
+        # comparisons remain exact so a fork, mirror, or similarly named
+        # repository cannot opt in.
         trusted_repository="Mesh-LLM/mesh-llm"
         depot_enabled=false
         allow_depot_remote_cache=false
         allow_native_github_cache=true
         allow_trusted_sccache_seed=true
         is_direct_pull_request=false
-        risk_exception_selected=false
         is_dispatched_pull_request=false
         dispatch_original_event="${INPUT_ORIGINAL_EVENT_NAME:-}"
         if [[ -z "$dispatch_original_event" ]]; then
@@ -187,19 +171,10 @@ runs:
               "$INPUT_HEAD_REPOSITORY" == "$trusted_repository" && \
               "$INPUT_REF" =~ ^refs/pull/[0-9]+/merge$ && \
               "$INPUT_FORCE_HOSTED" == "false" && \
-              ( ( "$depot_pr_exception_active" == "true" &&
-                  -n "$pr_approved_ref" &&
-                  "$INPUT_REF" == "$pr_approved_ref" &&
-                  -n "$pr_approved_sha" &&
-                  "$INPUT_HEAD_SHA" == "$pr_approved_sha" ) ||
+              ( "$depot_pr_exception_active" == "true" ||
                 ( -n "$pr_canary_ref" && "$INPUT_REF" == "$pr_canary_ref" ) ) ]]; then
               is_direct_pull_request=true
               depot_enabled=true
-              if [[ "$depot_pr_exception_active" == "true" &&
-                "$INPUT_REF" == "$pr_approved_ref" &&
-                "$INPUT_HEAD_SHA" == "$pr_approved_sha" ]]; then
-                risk_exception_selected=true
-              fi
             fi
             ;;
           pull_request_target)
@@ -255,7 +230,8 @@ runs:
           allow_native_github_cache=false
           allow_trusted_sccache_seed=false
           if [[ "$depot_pr_exception_active" == "true" &&
-            ( "$risk_exception_selected" == "true" ||
+            ( ( "$INPUT_EVENT_NAME" == "pull_request" &&
+                "$is_direct_pull_request" == "true" ) ||
               ( "$INPUT_EVENT_NAME" == "push" &&
                 "$INPUT_REF" == "refs/heads/main" ) ||
               ( "$INPUT_EVENT_NAME" == "workflow_dispatch" &&

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -52,10 +52,11 @@ or cache identity.
   lanes; PR-controlled jobs never receive Actions-write permission.
 - Existing static ABI, native SDK, Swift, smoke and HF workflows remain
   lower-level reusable producers/consumers.
-- Current PR routing is GitHub-hosted except for the documented uncredentialed
-  CUDA smoke and an exact maintainer-approved same-repository merge ref/head SHA
-  selected under the checked-in Depot cache-risk deadline; trusted-main Depot
-  selection remains behind the existing exact-string policy gate.
+- Current PR routing may use Depot for eligible same-repository executor jobs
+  under the checked-in cache-risk deadline and repository gate. Forks,
+  control-plane jobs, credential-bearing smokes, and the documented CUDA smoke
+  keep their approved placements; trusted-main Depot selection remains behind
+  the existing exact-string policy gate.
 - `ci-quality-slice.yml` contains an additive protected authority-sentinel
   diagnostic selected by separate `DEPOT_PR_SENTINEL_REF` and
   `DEPOT_PR_SENTINEL_ID` variables. It does not add a PR entrypoint, planner
@@ -259,16 +260,16 @@ implementation.
 
 ## GitHub and Depot
 
-select-ci-runners resolves semantic runner roles. Pull requests, feature refs,
-tags, macOS, Windows, credential-bearing smokes and hardware-qualified work
-stay on their approved placement. Trusted main Linux work may use Depot only
-when DEPOT_RUNNERS_ENABLED is exactly true, with a GitHub-hosted fallback.
-Callers never provide raw labels or independent remote-cache permission.
+select-ci-runners resolves semantic runner roles. Eligible same-repository PR
+executor jobs may use Depot during the bounded exception. Forks, feature refs,
+tags, credential-bearing smokes and hardware-qualified work stay on their
+approved placement. Trusted main Linux work may use Depot only when
+DEPOT_RUNNERS_ENABLED is exactly true, with a GitHub-hosted fallback. Callers
+never provide raw labels or independent remote-cache permission.
 
 Permanent Depot PR execution is not enabled. The selector has a bounded
 `DEPOT_PR_CANARY_REF` hook for one exact same-repository merge ref. The separate
-temporary exception requires `DEPOT_PR_RUNNERS_ENABLED`, exact
-`DEPOT_PR_APPROVED_REF`, exact `DEPOT_PR_APPROVED_SHA`, and the checked-in
+temporary exception requires `DEPOT_PR_RUNNERS_ENABLED` and the checked-in
 2026-09-14 UTC deadline. The Quality slice
 also has a separate `DEPOT_PR_SENTINEL_REF` selector and
 `DEPOT_PR_SENTINEL_ID` validation for one no-checkout authority diagnostic;
@@ -284,7 +285,7 @@ expose repository-wide cache authority to PR code. Cache-key prefixes are not
 isolation. The central selector emits
 `allow_depot_remote_cache=false` for every Depot selection. Outside the bounded
 exception, native Actions-cache consumers are disabled. During the exception,
-an exact approved PR revision and eligible trusted-main Depot jobs emit
+eligible same-repository PR and trusted-main Depot jobs emit
 `allow_native_github_cache=true`, deliberately sharing Depot's repository-wide,
 cross-branch Actions-cache namespace for iteration speed. Hosted release and
 cache-warmer paths retain their existing GitHub cache behavior. This is
@@ -345,8 +346,7 @@ the enclosing PR run was later cancelled during cleanup. Trusted-main verify
 restored and exactly validated that poison, then failed its intended expected-
 miss gate. This is unsafe repository-scoped cross-trust authority, not a
 successful isolation result. The temporary exception knowingly accepts it only
-when `DEPOT_PR_RUNNERS_ENABLED=true`, `DEPOT_PR_APPROVED_REF` and
-`DEPOT_PR_APPROVED_SHA` match exactly, and the 2026-09-14 UTC deadline is still
+when `DEPOT_PR_RUNNERS_ENABLED=true` and the 2026-09-14 UTC deadline is still
 active. A provider-isolation redesign and a new successful sentinel are
 required before that exception can become permanent. The exact-SHA five-lane
 candidate, provider-separated comparison, and identical-SHA hosted rollback

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -337,11 +337,12 @@ protected workflows must:
 
 Permanent activation still requires every acceptance canary. The temporary
 exception requires `DEPOT_PR_RUNNERS_ENABLED=true` and expires in checked-in
-policy on 2026-09-14 UTC. Roll back immediately by deleting the gate or setting
-it to `false`, then rerun the identical PR plan; this
-changes provider placement only and must leave commands, matrices, artifacts,
-and required checks unchanged. `DEPOT_RUNNERS_ENABLED` remains the separate
-trusted-main placement gate.
+policy on 2026-09-14 UTC. Roll back immediately by deleting
+`DEPOT_PR_CANARY_REF` and deleting or setting
+`DEPOT_PR_RUNNERS_ENABLED=false`, then rerun the identical PR plan on hosted
+placement; this changes provider placement only and must leave commands,
+matrices, artifacts, and required checks unchanged. `DEPOT_RUNNERS_ENABLED`
+remains the separate trusted-main placement gate.
 
 CI workflow, action, planner, ownership, runner and cache-policy changes must
 remain on the local GitHub-hosted path. A PR may not modify the workflow that

--- a/ci/DEPOT_MIGRATION.md
+++ b/ci/DEPOT_MIGRATION.md
@@ -1,7 +1,7 @@
 # Depot runner transition
 
 Status: trusted-main support exists. A time-bounded, explicitly accepted
-cache-risk exception permits individually approved same-repository PR revisions
+cache-risk exception permits eligible same-repository PR jobs
 through 2026-09-14 UTC; forks remain hosted. Automatic Depot Cache and Registry Actions connectivity are
 admin-verified off. Those switches remove Depot's direct `DEPOT_CACHE_TOKEN`,
 build-tool cache preconfiguration and Registry Actions authentication from
@@ -13,7 +13,7 @@ unsafe repository-scoped cross-trust authority. Maintainers have knowingly
 accepted that risk temporarily to improve CI iteration speed; it remains a
 blocker to permanent activation.
 
-During the bounded exception, the exact approved PR and eligible trusted-main
+During the bounded exception, eligible same-repository PR and trusted-main
 Depot jobs may use the GitHub Actions cache API and therefore Depot's shared,
 cross-branch namespace. Direct Depot build-tool remote cache remains disabled.
 The complete findings, risks, approval controls, expiry, and rollback procedure
@@ -33,12 +33,9 @@ Depot is a placement provider, not a different CI graph.
 - `.github/actions/select-ci-runners` owns current Linux provider selection.
 - `DEPOT_RUNNERS_ENABLED == 'true'` permits eligible trusted `main` Linux jobs
   to select Depot. Every eligible role retains a GitHub-hosted fallback.
-- `DEPOT_PR_RUNNERS_ENABLED == 'true'` opens only the bounded exception window.
-  It selects no PR by itself. `DEPOT_PR_APPROVED_REF` must exactly match the
-  current `refs/pull/<number>/merge` ref and `DEPOT_PR_APPROVED_SHA` must exactly
-  match its lowercase 40-character head SHA. A new push invalidates approval.
-  The checked-in selector expires this path on 2026-09-14 UTC; a missing,
-  malformed, stale, or expired value fails hosted.
+- `DEPOT_PR_RUNNERS_ENABLED == 'true'` activates the bounded exception for
+  eligible same-repository PR jobs. The checked-in selector expires this path
+  on 2026-09-14 UTC; a missing, false, or expired value fails hosted.
 - `DEPOT_PR_CANARY_REF` is an optional, exact
   `refs/pull/<number>/merge` selector for one protected same-repository canary
   ref. It does not enable the global PR gate, does not grant remote cache
@@ -57,8 +54,8 @@ Depot is a placement provider, not a different CI graph.
   decision. During the exception it permits the selected Depot Actions-cache
   proxy but still rejects direct Depot cache tokens, WebDAV/sccache authority,
   registry credentials, Docker auth, and URL userinfo before checkout.
-- The selector emits `allow_native_github_cache=true` only for an exactly
-  approved PR revision and eligible trusted-main Depot work while the global
+- The selector emits `allow_native_github_cache=true` only for eligible
+  same-repository PR and trusted-main Depot work while the global
   exception and checked-in deadline are active. Depot transparently maps that
   API to its shared repository namespace. `allow_depot_remote_cache` remains
   false. This is accepted risk, not proof of authority isolation.
@@ -197,8 +194,8 @@ same-repository PR path could read the trusted marker and publish a marker that
 trusted main later restored. The intended failures are evidence that the gates
 fired after the probes, not successful isolation. It does not justify a claim
 of isolation. The temporary decision in `ci/DEPOT_PR_RISK_EXCEPTION.md`
-explicitly accepts this risk for exact maintainer-approved same-repository PR
-revisions; a provider-isolation redesign and a new successful sentinel remain
+explicitly accepts this risk for eligible same-repository PRs; a
+provider-isolation redesign and a new successful sentinel remain
 required before the exception can become permanent. `DEPOT_PR_CANARY_REF`,
 `DEPOT_PR_SENTINEL_REF` and `DEPOT_PR_SENTINEL_ID`
 remain absent. No Depot settings or runner groups were changed; the bounded
@@ -308,8 +305,8 @@ runtime questions are:
 The selector emits provider-derived `allow_native_github_cache` and
 `allow_depot_remote_cache` outputs. Depot remote build-tool cache remains
 disabled. Outside the bounded exception, Depot selections keep native Actions
-cache consumers disabled. During the exception, an exact approved PR revision
-and eligible trusted-main Depot jobs emit `allow_native_github_cache=true`,
+cache consumers disabled. During the exception, eligible same-repository PR
+and trusted-main Depot jobs emit `allow_native_github_cache=true`,
 deliberately exercising Depot's repository-wide Actions-cache proxy for
 cross-branch reuse. This improves iteration speed but does not establish an
 authority boundary. The canary must still target the actual
@@ -339,10 +336,9 @@ protected workflows must:
 - be exact selected workflows allowed by the runner group.
 
 Permanent activation still requires every acceptance canary. The temporary
-exception additionally requires `DEPOT_PR_RUNNERS_ENABLED=true`, exact
-`DEPOT_PR_APPROVED_REF` and exact `DEPOT_PR_APPROVED_SHA`, and expires in checked-in
-policy on 2026-09-14 UTC. Roll back immediately by removing any approval value
-or setting the global PR gate to `false`, then rerun the identical PR plan; this
+exception requires `DEPOT_PR_RUNNERS_ENABLED=true` and expires in checked-in
+policy on 2026-09-14 UTC. Roll back immediately by deleting the gate or setting
+it to `false`, then rerun the identical PR plan; this
 changes provider placement only and must leave commands, matrices, artifacts,
 and required checks unchanged. `DEPOT_RUNNERS_ENABLED` remains the separate
 trusted-main placement gate.
@@ -460,9 +456,9 @@ operator-run experiment. It is not the global PR activation gate, does not
 grant cache or registry authority, and does not authorize setting
 `DEPOT_PR_RUNNERS_ENABLED`.
 
-## Activation gate
+## Permanent activation gate
 
-Do not enable Depot for PR content until:
+Do not remove the bounded expiry or make Depot PR execution permanent until:
 
 - the isolation canary passes for same-repository and fork PRs;
 - live runner-group restrictions are admin-verified;
@@ -477,9 +473,9 @@ Start any later rollout with remote cache disabled. Canary one non-secret Linux
 slice, then a Rust test slice, then the selected Linux product graph. Keep
 credential-bearing, macOS, Windows and hardware work on their existing runners.
 
-Depot PR activation must be a separate change after the composable CI graph is
-complete. It must not be combined with routing, required-check, artifact or
-branch-protection migration.
+Permanent Depot PR activation must be a separate change after the composable CI
+graph is complete. It must not be combined with routing, required-check,
+artifact or branch-protection migration.
 
 ## Measurement and rollback evidence
 

--- a/ci/DEPOT_PR_RISK_EXCEPTION.md
+++ b/ci/DEPOT_PR_RISK_EXCEPTION.md
@@ -4,14 +4,14 @@ Status: **accepted, bounded exception**
 
 - Decision date: 2026-08-14
 - Automatic expiry: 2026-09-14 00:00 UTC
-- Scope: same-repository `pull_request` merge refs only
+- Scope: eligible same-repository `pull_request` merge refs only
 - Objective: reduce CI iteration time while Depot and GitHub finish stronger
   cache-authority controls
 
 ## Decision
 
 MeshLLM knowingly accepts repository-wide, cross-branch Depot Actions-cache
-authority for individually approved same-repository pull requests during this
+authority for eligible same-repository pull requests during this
 exception window. This is a deliberate speed-versus-isolation decision, not a
 claim that Depot currently provides branch or pull-request cache isolation.
 
@@ -58,7 +58,7 @@ The result is evidence of shared authority, not a successful isolation test.
 
 ## Risks we are accepting
 
-An approved same-repository PR can:
+Any eligible same-repository PR can:
 
 - read non-secret cache data written by trusted main or another PR;
 - publish a cache entry that a later trusted-main job may restore;
@@ -88,17 +88,11 @@ The protected runner policy implements an explicit equivalent for this
 exception. Depot is selected only when all of the following are true:
 
 1. `DEPOT_PR_RUNNERS_ENABLED` is exactly `true`.
-2. `DEPOT_PR_APPROVED_REF` exactly equals the current
-   `refs/pull/<number>/merge` ref.
-3. `DEPOT_PR_APPROVED_SHA` exactly equals the lowercase 40-character PR head
-   SHA.
-4. The head and base repositories are both exactly `Mesh-LLM/mesh-llm`.
-5. The protected default-branch reusable workflow owns runner selection.
-6. The planner has not forced hosted execution for CI/workflow/policy changes.
-7. The checked-in expiry has not been reached.
+2. The head and base repositories are both exactly `Mesh-LLM/mesh-llm`.
+3. The protected default-branch reusable workflow owns runner selection.
+4. The planner has not forced hosted execution for CI/workflow/policy changes.
+5. The checked-in expiry has not been reached.
 
-A new push changes the head SHA and automatically returns the PR to
-GitHub-hosted runners until a maintainer reviews and updates the approval SHA.
 Forks always remain GitHub-hosted. The audit still rejects direct Depot cache
 tokens, WebDAV/sccache authority, registry credentials, Docker registry auth,
 and URL userinfo before checkout.
@@ -106,7 +100,7 @@ and URL userinfo before checkout.
 ## Cross-branch cache behavior
 
 While the exception is active, the central policy enables the GitHub Actions
-cache API for the exact approved Depot PR and for eligible trusted-main Depot
+cache API for eligible Depot PRs and eligible trusted-main Depot
 jobs. Depot maps those requests to its repository-wide namespace, allowing the
 intended cross-branch reuse. The separate direct Depot build-tool remote-cache
 flag remains disabled.
@@ -117,16 +111,12 @@ correctness.
 
 ## Operation and rollback
 
-To approve one reviewed PR revision, a maintainer with repository-variable
-authority sets the global gate to `true`, the approved merge ref, and the exact
-head SHA. The approved SHA must be refreshed after every push. Remove the two
-approval values after the run or when the PR closes.
+To activate the bounded exception, a maintainer with repository-variable
+authority sets `DEPOT_PR_RUNNERS_ENABLED=true`. This selects every eligible
+same-repository PR until rollback or expiry.
 
-Immediate rollback is any one of:
-
-- delete or set `DEPOT_PR_RUNNERS_ENABLED=false`;
-- delete `DEPOT_PR_APPROVED_REF`;
-- delete `DEPOT_PR_APPROVED_SHA`.
+Immediate rollback is deleting `DEPOT_PR_RUNNERS_ENABLED` or setting it to
+`false`.
 
 The same workflow graph then selects GitHub-hosted runners. No source, matrix,
 artifact, command, or required-summary change is needed.

--- a/ci/DEPOT_PR_RISK_EXCEPTION.md
+++ b/ci/DEPOT_PR_RISK_EXCEPTION.md
@@ -115,11 +115,12 @@ To activate the bounded exception, a maintainer with repository-variable
 authority sets `DEPOT_PR_RUNNERS_ENABLED=true`. This selects every eligible
 same-repository PR until rollback or expiry.
 
-Immediate rollback is deleting `DEPOT_PR_RUNNERS_ENABLED` or setting it to
-`false`.
+Immediate rollback deletes `DEPOT_PR_CANARY_REF` and deletes or sets
+`DEPOT_PR_RUNNERS_ENABLED=false`.
 
-The same workflow graph then selects GitHub-hosted runners. No source, matrix,
-artifact, command, or required-summary change is needed.
+With both selectors disabled, the same workflow graph selects GitHub-hosted
+runners. No source, matrix, artifact, command, or required-summary change is
+needed.
 
 The selector fails hosted at the start of 2026-09-14 UTC. Extending the window
 requires a reviewed source change to the expiry and this decision record; a

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -31,8 +31,10 @@ Each PR entry checks out the default branch for canonical planning, projects
 only its matching bounded lane, and invokes that lane at `@main` as a nested
 reusable workflow. GitHub therefore exposes five focused PR-associated runs
 with direct job and step drill-down. Each has a stable `PR / <lane>` result.
-The entries receive no repository secrets, cannot select Depot or publish
-trusted-main caches, and independently cancel superseded synchronizations.
+The entries receive no repository secrets and independently cancel superseded
+synchronizations. Eligible same-repository executor jobs may select Depot
+through protected runner policy while the bounded repository gate is active;
+forks and control-plane jobs remain hosted.
 The protected planner action extracts only `ci/ownership.yml` and
 `ci/slices.yml` from the validated immutable PR source SHA into a unique
 runner-temp directory. The source ownership and slice catalogs must match the
@@ -366,16 +368,16 @@ from being duplicated into every composed product artifact.
 ## Provider and cache policy
 
 `.github/actions/select-ci-runners` maps semantic roles to approved labels.
-Fork pull requests use GitHub-hosted runners. Same-repository PRs normally do
-too, but an exact maintainer-approved merge ref and head SHA may use Depot under
-the time-bounded cache-risk exception in `ci/DEPOT_PR_RISK_EXCEPTION.md`. The
+Fork pull requests use GitHub-hosted runners. Eligible same-repository PRs may
+use Depot while the repository-wide gate and time-bounded cache-risk exception
+in `ci/DEPOT_PR_RISK_EXCEPTION.md` are active. The
 other exception is uncredentialed CUDA smoke on the approved ephemeral
 `gpu-nvidia` scale set described above. PRs use the same protected reusable
 lanes and receive no repository secrets. On routine trusted-`main` pushes,
 Linux roles may use Depot only when `DEPOT_RUNNERS_ENABLED` is exactly `true`;
 macOS, Windows, credential-bearing smokes and other hardware-qualified work
-retain explicit approved placement. The separate exact same-repository PR
-exception may also select eligible build/test rows on Depot macOS 15 and
+retain explicit approved placement. The same-repository PR exception may also
+select eligible build/test rows on Depot macOS 15 and
 Windows 2022, subject to the same policy and documented exceptions. Provider
 choice never changes plan membership, commands, artifacts, tests or summaries.
 
@@ -392,8 +394,8 @@ ordinary executor rows, not that every check or job is hosted by Depot.
 
 The central selector normally makes the Depot cache namespace inert by emitting
 `allow_native_github_cache=false` and `allow_depot_remote_cache=false`. During
-the bounded exception, the exact approved PR revision and eligible trusted-main
-Depot jobs emit `allow_native_github_cache=true`, enabling intentional
+the bounded exception, eligible same-repository PR and trusted-main Depot jobs
+emit `allow_native_github_cache=true`, enabling intentional
 cross-branch reuse through Depot's repository-wide Actions-cache proxy. Direct
 Depot build-tool remote cache remains disabled. This is a conscious iteration-
 speed tradeoff and the shared cache is treated as attacker-controlled input,
@@ -420,13 +422,11 @@ replace the global PR gate. Maintainers must not set it until the external
 isolation protocol proves the actual Depot/WebDAV and Actions-cache authority
 boundary.
 
-The ordinary PR selector also requires the independent global gate plus exact
-`DEPOT_PR_APPROVED_REF` and `DEPOT_PR_APPROVED_SHA` values. The SHA binding
-invalidates approval after every push, forks and CI-policy changes remain
-hosted, and the source-enforced exception expires on 2026-09-14 UTC. GitHub's
-`all_external_contributors` approval policy covers external contributors, not
-same-repository collaborator branches; the exact ref/SHA values are therefore
-the protected same-repository maintainer approval control.
+The ordinary PR selector requires the independent global gate. Forks and
+CI-policy changes remain hosted, and the source-enforced exception expires on
+2026-09-14 UTC. GitHub's `all_external_contributors` approval policy covers
+external contributors, not same-repository collaborator branches; the global
+gate and checked-in expiry are therefore the maintainer approval control.
 
 The Quality slice also contains a separate, additive authority-sentinel
 selector. It reads `DEPOT_PR_SENTINEL_REF` (not `DEPOT_PR_CANARY_REF`) and
@@ -512,11 +512,11 @@ main/release/manual paths retain the existing cache behavior. This is a
 checked-in consumer policy, not proof that a Depot runner has no ambient
 Depot/WebDAV authority.
 
-For an exactly approved exception run, `allow_native_github_cache=true` enables
-those guarded cache consumers on both the selected PR and eligible trusted-main
-Depot jobs. Depot's lack of branch isolation means the cache can cross the PR,
-main, and other-PR trust boundaries. That accepted risk, including the exact
-sentinel evidence and rollback procedure, is documented in
+For an eligible exception run, `allow_native_github_cache=true` enables those
+guarded cache consumers on both selected PR and eligible trusted-main Depot
+jobs. Depot's lack of branch isolation means the cache can cross the PR, main,
+and other-PR trust boundaries. That accepted risk, including the exact sentinel
+evidence and rollback procedure, is documented in
 `ci/DEPOT_PR_RISK_EXCEPTION.md`; the exact-SHA canary, metrics, and hosted
 rollback evidence are recorded in `.omo/specs/depot-pr-rollout-evidence.md`.
 
@@ -535,7 +535,7 @@ an optimization: native stamps/manifests/checksums are verified, and every job
 must still regenerate successfully after a miss.
 
 Permanent Depot PR execution is not yet approved. The bounded exception permits
-only an exact same-repository ref/SHA through 2026-09-14 UTC. A protected
+eligible same-repository PR jobs through 2026-09-14 UTC. A protected
 runner-group check, no-secret/no-direct-token execution, provider-isolation
 redesign, and a new successful non-secret sentinel remain prerequisites for
 removing that deadline. Do not change Depot settings or runner groups in a

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -2157,8 +2157,8 @@ class CiArtifactActionTests(unittest.TestCase):
         self.assertIn("depot-macos-15", action)
         self.assertIn("depot-windows-2022", action)
         self.assertIn('depot_pr_exception_expires="2026-09-14"', action)
-        self.assertIn("INPUT_PR_APPROVED_REF", action)
-        self.assertIn("INPUT_PR_APPROVED_SHA", action)
+        self.assertNotIn("INPUT_PR_APPROVED_REF", action)
+        self.assertNotIn("INPUT_PR_APPROVED_SHA", action)
 
         selector_calls = 0
         approved_policy_calls = 0
@@ -2493,15 +2493,19 @@ class CiArtifactActionTests(unittest.TestCase):
         self.assertEqual(canary_pr["allow_native_github_cache"], "false")
         self.assertEqual(canary_pr["allow_trusted_sccache_seed"], "false")
 
-        unapproved_pr = self.run_runner_selector(
+        globally_enabled_pr = self.run_runner_selector(
             event_name="pull_request",
             ref="refs/pull/12/merge",
             main_enabled="false",
             manual_enabled="false",
             pr_enabled="true",
         )
-        self.assertEqual(unapproved_pr["depot_enabled"], "false")
-        self.assertEqual(unapproved_pr["runner"], "ubuntu-24.04")
+        self.assertEqual(globally_enabled_pr["depot_enabled"], "true")
+        self.assertEqual(globally_enabled_pr["runner"], "depot-ubuntu-24.04")
+        self.assertEqual(
+            globally_enabled_pr["allow_native_github_cache"],
+            "true",
+        )
 
         stale_approval = self.run_runner_selector(
             event_name="pull_request",
@@ -2512,7 +2516,7 @@ class CiArtifactActionTests(unittest.TestCase):
             pr_approved_ref="refs/pull/12/merge",
             pr_approved_sha="fedcba9876543210fedcba9876543210fedcba98",
         )
-        self.assertEqual(stale_approval["depot_enabled"], "false")
+        self.assertEqual(stale_approval["depot_enabled"], "true")
 
         stale_ref_approval = self.run_runner_selector(
             event_name="pull_request",
@@ -2523,8 +2527,8 @@ class CiArtifactActionTests(unittest.TestCase):
             pr_approved_ref="refs/pull/13/merge",
             pr_approved_sha="0123456789abcdef0123456789abcdef01234567",
         )
-        self.assertEqual(stale_ref_approval["depot_enabled"], "false")
-        self.assertEqual(stale_ref_approval["runner"], "ubuntu-24.04")
+        self.assertEqual(stale_ref_approval["depot_enabled"], "true")
+        self.assertEqual(stale_ref_approval["runner"], "depot-ubuntu-24.04")
         self.assertEqual(
             stale_ref_approval["allow_native_github_cache"],
             "true",

--- a/scripts/tests/test_depot_authority_sentinel.py
+++ b/scripts/tests/test_depot_authority_sentinel.py
@@ -252,7 +252,7 @@ class DepotAuthoritySentinelTests(unittest.TestCase):
             sentinel_ref="", pr_enabled="true"
         )
         self.assertEqual(global_gate.returncode, 0, global_gate.stderr)
-        self.assertEqual(global_outputs["depot_enabled"], "false")
+        self.assertEqual(global_outputs["depot_enabled"], "true")
         self.assertIn("github.ref == vars.DEPOT_PR_SENTINEL_REF", self.sentinel)
 
     def test_normal_quality_jobs_keep_the_existing_provider_output(self) -> None:

--- a/scripts/tests/test_reusable_workflow_runner_trust.py
+++ b/scripts/tests/test_reusable_workflow_runner_trust.py
@@ -105,7 +105,7 @@ class ReusableWorkflowRunnerTrustTests(unittest.TestCase):
 
         The protected reusable lanes are deliberately split across several
         workflows, so a future slice can otherwise accidentally omit the
-        exact-ref/SHA gate while still looking like it uses the central
+        bounded global gate while still looking like it uses the central
         selector.  Keep this census explicit: credential-bearing smoke
         consumers and the GPU exception are intentionally outside it.
         """
@@ -133,8 +133,8 @@ class ReusableWorkflowRunnerTrustTests(unittest.TestCase):
         selector = (
             ROOT / ".github" / "actions" / "select-ci-runners" / "action.yml"
         ).read_text(encoding="utf-8")
-        self.assertIn("INPUT_PR_APPROVED_REF", selector)
-        self.assertIn("INPUT_PR_APPROVED_SHA", selector)
+        self.assertNotIn("INPUT_PR_APPROVED_REF", selector)
+        self.assertNotIn("INPUT_PR_APPROVED_SHA", selector)
         self.assertIn('depot_pr_exception_expires="2026-09-14"', selector)
 
         for name in eligible:


### PR DESCRIPTION
## Original problem

The repository-wide PR Depot gate could not activate the eligible PR fleet. The selector also required one exact merge ref and head SHA, so maintainers had to approve a single revision at a time.

GitHub-hosted PR jobs have been queuing while the trusted-main Linux jobs already use Depot.

## Diagnostics

The live repository configuration now has `DEPOT_PR_RUNNERS_ENABLED=true`. Under the current `main` selector that value alone still selects no PR, so existing PR jobs remain hosted until this change lands.

The controlled authority sentinel already proved that Depot Actions-cache access is repository-scoped and crosses PR/main trust boundaries. This PR expands the existing, explicitly accepted exception. It does not claim cache isolation.

## Fix

- Make `DEPOT_PR_RUNNERS_ENABLED=true` sufficient to select eligible same-repository PR executor jobs until the checked-in September 14, 2026 cutoff.
- Keep forks, `pull_request_target`, CI-policy changes, planning, required summaries, credential-bearing smoke, and hardware-qualified jobs on their existing providers.
- Keep direct Depot remote cache disabled. Eligible Depot PR jobs may use the GitHub Actions cache API through Depot's shared repository namespace during the exception.
- Retain the old exact ref/SHA inputs as ignored compatibility fields so protected workflow callers do not need a broad mechanical rewrite.
- Update the normative CI policy, topology, risk record, migration notes, inventory, and selector tests.

Rollback remains one repository-variable change: delete `DEPOT_PR_RUNNERS_ENABLED` or set it to `false`. The selector also fails hosted when the checked-in cutoff arrives.

## Validation

- [x] `just ci-validate`
  - 667 tests passed
  - 7 environment-dependent tests skipped as expected
  - actionlint, diff checks, CI crate lists, release targets, console-print checks, and publish-crate consistency passed
- [x] UI changes do not apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **CI Improvements**
  - Eligible same-repository pull requests can use Depot runners while the temporary repository-wide gate is active.
  - The exception is bounded by a checked-in expiry date, with hosted runner fallback retained.
  - Fork-based pull requests, control-plane jobs, credential-bearing checks, and hardware-specific workloads remain on designated runners.
  - Depot cache reuse is enabled for eligible pull requests and trusted-main jobs under the exception.
  - Per-pull-request approval ref and SHA checks are no longer required.

- **Documentation**
  - Updated CI policies, activation, rollback, and cache guidance to reflect the broader temporary exception.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->