### PR TITLE
fix(ffi): sync mtmd struct layouts with the pinned llama.cpp headers

### DIFF
--- a/crates/skippy-ffi/src/multimodal.rs
+++ b/crates/skippy-ffi/src/multimodal.rs
@@ -38,6 +38,11 @@ pub struct MtmdDecoderPos {
 #[derive(Debug, Clone, Copy)]
 pub struct MtmdInputText {
     pub text: *const c_char,
+    /// Length of `text` in bytes, excluding the trailing NUL. Added upstream by
+    /// llama.cpp `4114ba18b` (`mtmd: fix silent prompt truncation on embedded
+    /// NUL`); `mtmd_tokenize` reads it directly, so leaving it out makes the
+    /// native side size the prompt from uninitialised padding.
+    pub text_len: usize,
     pub add_special: bool,
     pub parse_special: bool,
 }
@@ -46,6 +51,10 @@ pub struct MtmdInputText {
 #[derive(Debug, Clone, Copy)]
 pub struct MtmdContextParams {
     pub use_gpu: bool,
+    /// `ggml_backend_dev_t`, an opaque device handle. Added upstream by
+    /// llama.cpp `681c29d36` (`mtmd: add --mmproj-device argument`); omitting
+    /// it shifts every following field and truncates the struct.
+    pub device: *mut c_void,
     pub print_timings: bool,
     pub n_threads: c_int,
     pub image_marker: *const c_char,

--- a/crates/skippy-ffi/src/tests.rs
+++ b/crates/skippy-ffi/src/tests.rs
@@ -5,7 +5,7 @@ use crate::{
 };
 
 #[cfg(target_pointer_width = "64")]
-use crate::MtmdContextParams;
+use crate::{MtmdContextParams, MtmdInputText};
 
 #[cfg(not(feature = "dynamic-runtime"))]
 use crate::mtmd_context_params_default;
@@ -60,13 +60,30 @@ fn rejects_major_and_minor_mismatches() {
 #[test]
 #[cfg(target_pointer_width = "64")]
 fn mtmd_context_params_matches_native_layout() {
-    assert_eq!(size_of::<MtmdContextParams>(), 80);
-    assert_eq!(offset_of!(MtmdContextParams, batch_max_tokens), 56);
-    assert_eq!(offset_of!(MtmdContextParams, progress_callback), 64);
+    // Mirrors `struct mtmd_context_params` in tools/mtmd/mtmd.h. `device` sits
+    // second, right after `use_gpu`; leaving it out shifts everything below it
+    // by 8 bytes and makes the struct 16 bytes short, so the C side reads
+    // `progress_callback` from past the end of what Rust allocated.
+    assert_eq!(size_of::<MtmdContextParams>(), 96);
+    assert_eq!(offset_of!(MtmdContextParams, device), 8);
+    assert_eq!(offset_of!(MtmdContextParams, batch_max_tokens), 72);
+    assert_eq!(offset_of!(MtmdContextParams, progress_callback), 80);
     assert_eq!(
         offset_of!(MtmdContextParams, progress_callback_user_data),
-        72
+        88
     );
+}
+
+#[test]
+#[cfg(target_pointer_width = "64")]
+fn mtmd_input_text_matches_native_layout() {
+    // Mirrors `struct mtmd_input_text` in tools/mtmd/mtmd.h. `mtmd_tokenize`
+    // reads `text_len` to size the prompt, so a missing field here hands the
+    // native side a length built from uninitialised padding.
+    assert_eq!(size_of::<MtmdInputText>(), 24);
+    assert_eq!(offset_of!(MtmdInputText, text_len), 8);
+    assert_eq!(offset_of!(MtmdInputText, add_special), 16);
+    assert_eq!(offset_of!(MtmdInputText, parse_special), 17);
 }
 
 #[test]

--- a/crates/skippy-runtime/src/media.rs
+++ b/crates/skippy-runtime/src/media.rs
@@ -180,6 +180,7 @@ impl StageModel {
             .context("multimodal prompt contains an interior NUL byte")?;
         let input_text = skippy_ffi::MtmdInputText {
             text: prompt.as_ptr(),
+            text_len: prompt.as_bytes().len(),
             add_special: true,
             parse_special: true,
         };
@@ -349,6 +350,7 @@ impl StageModel {
             .context("multimodal prompt contains an interior NUL byte")?;
         let input_text = skippy_ffi::MtmdInputText {
             text: prompt.as_ptr(),
+            text_len: prompt.as_bytes().len(),
             add_special: true,
             parse_special: true,
         };


### PR DESCRIPTION
Fixes #1548.

## Problem

Two by-value structs in `skippy-ffi` have drifted from the `tools/mtmd` headers at the current
pin, so the native side reads fields the Rust side never wrote.

**`mtmd_context_params` is missing `device`** (upstream `681c29d36`, *mtmd: add --mmproj-device
argument*). It is the second field, so everything below it shifts 8 bytes and the struct ends
up 16 bytes short:

| field | Rust before | C |
|---|---|---|
| `batch_max_tokens` | 56 | 72 |
| `progress_callback` | 64 | 80 |
| `progress_callback_user_data` | 72 | 88 |
| **size** | **80** | **96** |

`mtmd_context_params_default()` returns by value, so the native side writes 96 bytes into an
80-byte Rust value, and `mtmd_init_from_file` then reads `progress_callback` from past the end.
The resulting pointer is non-null garbage, so the guard at `clip.cpp:3587` passes and
`clip_model_loader::load_tensors` calls it:

```
#0  0x000055555a570098 in std::panicking::panic_count::GLOBAL_PANIC_COUNT ()
#1  clip_model_loader::load_tensors (...) at tools/mtmd/clip.cpp:3587
#2  clip_init (...) at tools/mtmd/clip.cpp:3974
#3  mtmd_context::mtmd_context (...) at tools/mtmd/mtmd.cpp:580
#4  mtmd_init_from_file (...) at tools/mtmd/mtmd.cpp:1095
#5  <skippy_runtime::native::StageModel>::from_opened_raw ()
```

Frame #0 is a data symbol, not code. Any model with an `mmproj` dies at load on `main`.

**`mtmd_input_text` is missing `text_len`** (upstream `4114ba18b`). `mtmd_tokenize` does
`input_text.assign(text->text, text->text_len)`, so the prompt is sized from uninitialised
padding and tokenization fails with `std::bad_alloc`.

`mtmd_context_params_matches_native_layout` asserted the stale offsets (80/56/64/72), so it
stayed green through both upstream changes.

## The change

- add `device` to `MtmdContextParams` and `text_len` to `MtmdInputText`
- set `text_len` at both `mtmd_tokenize` call sites in `skippy-runtime/src/media.rs`
- correct the layout test to the real offsets and add the matching one for `MtmdInputText`

## Evidence

3x Tesla P40 (sm_61), driver 580.173.02, CUDA 12 runtime. `Qwen3.8-27B-ABLITERATED-Q4_K_M.gguf`
+ `mmproj-Qwen3.8-27B-ABLITERATED-Q8_0.gguf`, `split_mode = "layer"`,
`tensor_split = "33,33,34"`, `parallel = 2`.

| build | model load | vision request |
|---|---|---|
| `main` (`c8f55b4`) | SIGSEGV, exit 139 | never reached |
| `+ device` | loads, `loaded 334 tensors`, serves, advertises `vision_status: supported` | `std::bad_alloc` in `mtmd_tokenize` |
| `+ device + text_len` | same | tokenizes; fails at `mtmd_encode_chunk_impl: image tokens batch is placeholder` |

`cargo fmt --all --check` clean, `cargo test -p skippy-ffi` 7 passed, `cargo clippy -p
skippy-ffi -p skippy-runtime --all-targets -- -D warnings` clean (the one remaining warning is
the pre-existing `sha2-asm` profile spec).

## What this does not do

This does not make vision work end to end. The failure it lands on is the one already
diagnosed in #1313 — closed deliberately as "necessary but not sufficient", with the reviewed
FFI fix parked on `fix/mtmd-bitmap-helper-ffi` for #1314. I have left that layer alone rather
than duplicate reviewed work against a stated plan.

What changes is the starting point: today the process dies before it can serve anything with a
projector attached, so neither #1313 nor #1314 is reachable on `main`.

Worth noting for whoever picks up #1508: nothing in CI currently opens an `mmproj`, which is
how both of these shipped. #1402's validation was a Metal load-and-completion smoke with Smol,
a text-only model. The layout tests added here fail loudly on the next such drift, but only for
these two structs.

---

🤖 Investigated and written with AI assistance (Claude), on real hardware. The diagnosis is
backed by the gdb backtrace, the struct offsets, and an A/B against upstream llama.cpp
`d7bd3bfca` (one day older than the pin, no `tools/mtmd` commits in between), which loads the
same model and projector on the same three GPUs without incident.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multimodal prompt tokenization by correctly passing text byte lengths.
  * Added support for backend device handles in multimodal processing.
  * Ensured native and application data layouts remain compatible across multimodal operations.

* **Tests**
  * Added and updated validation for multimodal structure layouts and field offsets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->