### PR TITLE
Keep PR tests portable across socket timer granularities

### DIFF
--- a/crates/skippy-server/src/frontend/embedded_execution.rs
+++ b/crates/skippy-server/src/frontend/embedded_execution.rs
@@ -588,18 +588,24 @@ mod tests {
     #[test]
     fn direct_return_fallback_timeout_restores_on_drop_after_early_exit() {
         let (stream, _peer) = connected_stream_pair();
-        let original = Some(Duration::from_millis(123));
-        stream.set_read_timeout(original).unwrap();
+        // Socket timeout readback may be rounded to the OS timer granularity.
+        // Capture the effective values so the test verifies install and restore
+        // without assuming the kernel preserves the requested duration exactly.
+        stream
+            .set_read_timeout(Some(DIRECT_RETURN_FALLBACK_POLL))
+            .unwrap();
+        let effective_poll = stream.read_timeout().unwrap();
+        stream
+            .set_read_timeout(Some(Duration::from_millis(123)))
+            .unwrap();
+        let effective_original = stream.read_timeout().unwrap();
 
         {
             let _restore = DirectReturnFallbackTimeout::install(&stream).unwrap();
-            assert_eq!(
-                stream.read_timeout().unwrap(),
-                Some(DIRECT_RETURN_FALLBACK_POLL)
-            );
+            assert_eq!(stream.read_timeout().unwrap(), effective_poll);
         }
 
-        assert_eq!(stream.read_timeout().unwrap(), original);
+        assert_eq!(stream.read_timeout().unwrap(), effective_original);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR CI no longer fails when a runner kernel rounds a requested 10 ms TCP read timeout to its effective timer granularity (12 ms on the affected Depot Linux runners).

The regression test now captures the kernel's effective timeout values, then still verifies both lifecycle properties exactly:

- installing `DirectReturnFallbackTimeout` applies the effective poll timeout;
- dropping it after an early exit restores the effective original timeout.

No product runtime behavior changes.

## Validation

At commit `b0d20746f75862a7ef1d8a6d5dfc172f2bb7cdb1`:

- `cargo fmt --all --check`
- `cargo check -p skippy-server`
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo test -p skippy-server --lib` — 553 passed, 0 failed, 3 ignored
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`

The macOS test link emitted an existing deployment-target warning from embedded Metal objects (`26.0.0` vs target `11.0.0`); the suite completed successfully.

## Credits

Thinker diagnosed and implemented the runner-granularity-safe assertion.

Co-authored-by: Thinker <75d8a808fa21bb8d1812e080cf471db601c6e8e6a62dcd516d37531e83a7bb77@meshllm.communities.buzz.xyz>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved timeout-restoration test reliability by accounting for operating system timer granularity and reported socket timeout values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->