### PR TITLE
ci: cache SDK smoke and reuse UI artifacts

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -131,13 +131,13 @@ removable after this branch's runner contract is active on protected main.
 | `ci-{linux,macos,windows}-product-slice.yml` | Platform-pure composition-only product consumers |
 | `ci-platform-checks-slice.yml` | macOS portable/unit, Windows portable, and Windows log-store privacy ACL checks |
 | `ci-linux-product-smoke-slice.yml`, `ci-macos-product-smoke-slice.yml` | Platform-local CPU, CUDA (`gpu-nvidia` self-hosted), two-node, Metal and model-download consumers; ROCm/Vulkan products remain package-verified pending eligible inference runners |
-| `ci-linux-sdk-slice.yml`, `ci-macos-sdk-slice.yml` | Platform-local Rust/Kotlin/Swift smoke consumers; SDK producers are independent top-level calls |
+| `ci-linux-sdk-slice.yml`, `ci-macos-sdk-slice.yml` | Platform-local Rust/Kotlin/Swift smoke consumers; SDK producers are independent top-level calls and each smoke receives the lane-local immutable UI artifact |
 | `ci-runner-contract-slice.yml` | Provider/cache/plan trust and main runner-image checks |
 | `native-sdk-artifact.yml` | Typed native SDK producer |
 | `swift-sdk-artifact.yml` | Host-only/full XCFramework producer; trusted main remains `macos-15`, while eligible same-repository PRs follow the protected Depot macOS 15 gate |
 | `smoke.yml` | Artifact-based inference/OpenAI/split smoke |
 | `scripted-binary-smoke.yml` | Artifact-based scripted product smoke |
-| `sdk-smoke.yml` | Artifact-based SDK consumers |
+| `sdk-smoke.yml` | Artifact-based SDK consumers; all SDK rows consume the lane's immutable console UI artifact, while Rust smoke restores the main-seeded, target/profile/image/toolchain/recipe-bound Cargo/target cache through `Swatinem/rust-cache` |
 | `hf-download-smoke.yml` | Hugging Face download smoke |
 
 All workflow calls use typed, bounded semantic inputs. Credential-bearing smoke

--- a/.github/workflows/ci-linux-lane.yml
+++ b/.github/workflows/ci-linux-lane.yml
@@ -165,6 +165,7 @@ jobs:
       source_sha: ${{ inputs.source_sha }}
       sdk_matrix: ${{ toJson(fromJson(inputs.lane_plan_json).matrices.sdk) }}
       binary_target: target/release/mesh-llm
+      ui_artifact_name: ci-ui-dist-linux-${{ github.run_id }}
       profile: release
     secrets:
       HF_TOKEN: ${{ inputs.original_event_name == 'push' && secrets.HF_TOKEN || '' }}

--- a/.github/workflows/ci-linux-sdk-slice.yml
+++ b/.github/workflows/ci-linux-sdk-slice.yml
@@ -15,6 +15,10 @@ on:
         description: Product binary path used by SDK smoke tests.
         required: true
         type: string
+      ui_artifact_name:
+        description: Immutable console UI producer artifact.
+        required: true
+        type: string
       profile:
         description: Native SDK profile selected by the semantic CI profile.
         required: true
@@ -37,6 +41,7 @@ jobs:
       sdk_kind: rust
       artifact_name: ci-product-linux-amd64-cpu
       artifact_path: ci-artifacts/linux
+      ui_artifact_name: ${{ inputs.ui_artifact_name }}
       staged_binary_path: ${{ inputs.binary_target }}
       model_cache_scope: sdk-smoke-model
     secrets:
@@ -51,6 +56,7 @@ jobs:
       sdk_kind: kotlin
       artifact_name: ci-product-linux-amd64-cpu
       artifact_path: ci-artifacts/linux
+      ui_artifact_name: ${{ inputs.ui_artifact_name }}
       staged_binary_path: ${{ inputs.binary_target }}
       kotlin_artifact_name: ci-sdk-kotlin-native
       kotlin_artifact_target: x86_64-unknown-linux-gnu

--- a/.github/workflows/ci-macos-lane.yml
+++ b/.github/workflows/ci-macos-lane.yml
@@ -153,6 +153,7 @@ jobs:
       architecture: ${{ fromJson(inputs.lane_plan_json).matrices.runtime_products[0].architecture }}
       sdk_matrix: ${{ toJson(fromJson(inputs.lane_plan_json).matrices.sdk) }}
       binary_target: target/release/mesh-llm
+      ui_artifact_name: ci-ui-dist-macos-${{ github.run_id }}
       swift_mode: ${{ (fromJson(inputs.lane_plan_json).profile == 'main' || fromJson(inputs.lane_plan_json).profile == 'manual-full') && 'full' || 'host-only' }}
     secrets:
       HF_TOKEN: ${{ inputs.original_event_name == 'push' && secrets.HF_TOKEN || '' }}

--- a/.github/workflows/ci-macos-sdk-slice.yml
+++ b/.github/workflows/ci-macos-sdk-slice.yml
@@ -19,6 +19,10 @@ on:
         description: Product binary path used by SDK smoke tests.
         required: true
         type: string
+      ui_artifact_name:
+        description: Immutable console UI producer artifact.
+        required: true
+        type: string
       swift_mode:
         description: Swift artifact coverage selected by the semantic CI profile.
         required: true
@@ -41,6 +45,7 @@ jobs:
       sdk_kind: swift
       artifact_name: ci-product-macos-${{ inputs.architecture }}-metal
       artifact_path: ci-artifacts/macos
+      ui_artifact_name: ${{ inputs.ui_artifact_name }}
       staged_binary_path: ${{ inputs.binary_target }}
       swift_artifact_name: ci-sdk-swift
       swift_artifact_mode: ${{ inputs.swift_mode }}

--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -17,6 +17,10 @@ on:
       artifact_path:
         required: true
         type: string
+      ui_artifact_name:
+        description: Immutable console UI producer artifact.
+        required: true
+        type: string
       binary_name:
         required: false
         default: mesh-llm
@@ -80,6 +84,14 @@ on:
         required: false
 
 env:
+  CACHE_NAMESPACE: mesh-llm
+  # These values are part of the Rust SDK smoke cache ABI. Keep the target
+  # and linker/profile recipe separate from the action's own rustc/manifest
+  # suffix so a compatible cache can never cross a toolchain or image epoch.
+  SDK_RUST_TARGET: x86_64-unknown-linux-gnu
+  SDK_RUST_IMAGE_DIGEST: 8d93de6ba30173e825a16fdecf011f9c632edc6e1259df7289e491b0a05f829d
+  SDK_RUST_TOOLCHAIN_EPOCH: rust-stable-2026-07-16-4cda84d5c5c54efe2404f9d843567869ab1699d4
+  SDK_RUST_PROFILE_LINKER: debug-fuse-ld-lld
   MODEL_URL: ${{ inputs.model_url }}
   MODEL_FILE: ${{ inputs.model_file }}
 
@@ -112,6 +124,15 @@ jobs:
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
+
+      - name: Download immutable UI distribution
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        with:
+          name: ${{ inputs.ui_artifact_name }}
+          path: crates/mesh-llm-ui/dist
+
+      - name: Verify UI distribution input
+        run: test -s crates/mesh-llm-ui/dist/index.html
 
       - name: Validate bounded SDK smoke inputs
         shell: bash
@@ -231,6 +252,21 @@ jobs:
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
         if: ${{ inputs.sdk_kind == 'rust' }}
 
+      - if: ${{ inputs.sdk_kind == 'rust' }}
+        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+        continue-on-error: true
+        with:
+          workspaces: . -> target
+          cache-bin: "false"
+          # Swatinem/rust-cache appends its runner OS/arch, rustc/environment,
+          # and Cargo manifest/lock hashes to this prefix. The explicit prefix
+          # carries the boundaries that the action cannot infer: the pinned
+          # Linux image, toolchain epoch, test profile/linker recipe, and the
+          # workflow/scripts/cache-version inputs that define this smoke lane.
+          prefix-key: ${{ format('{0}-sdk-rust-cargo-v1-{1}-{2}-{3}-image-{4}-{5}-{6}-{7}', env.CACHE_NAMESPACE, runner.os, runner.arch, env.SDK_RUST_TARGET, env.SDK_RUST_IMAGE_DIGEST, env.SDK_RUST_TOOLCHAIN_EPOCH, env.SDK_RUST_PROFILE_LINKER, hashFiles('Cargo.lock', '.github/cache-version.txt', '.cargo/config.toml', '**/Cargo.toml', 'scripts/ci-rust-sdk-smoke.sh', 'scripts/ci-sdk-fixture.sh', 'scripts/ci-prepare-native-runtime.sh', 'scripts/package-sdk-console-assets.sh', 'scripts/check-sdk-contract.sh', 'scripts/verify-sdk-console-assets.sh', '.github/workflows/sdk-smoke.yml')) }}
+          shared-key: ci-sdk-smoke-rust
+          save-if: ${{ github.ref == 'refs/heads/main' && github.event.inputs.original_event_name != 'pull_request' && github.event.inputs.original_event_name != 'pull_request_target' }}
+
       - name: Verify prebuilt smoke environment
         if: ${{ inputs.sdk_kind != 'swift' }}
         run: verify-runner-image public cpu
@@ -258,7 +294,7 @@ jobs:
 
       - name: Rust SDK smoke test
         if: ${{ inputs.sdk_kind == 'rust' }}
-        run: scripts/ci-rust-sdk-smoke.sh "${{ inputs.staged_binary_path }}" "${{ inputs.artifact_path }}" "$HOME/.models/${{ inputs.model_file }}"
+        run: scripts/ci-rust-sdk-smoke.sh "${{ inputs.staged_binary_path }}" "${{ inputs.artifact_path }}" "$HOME/.models/${{ inputs.model_file }}" --skip-build
 
       - name: Kotlin SDK smoke test
         if: ${{ inputs.sdk_kind == 'kotlin' }}
@@ -270,7 +306,8 @@ jobs:
             "${{ inputs.kotlin_artifact_path }}" \
             "${{ inputs.kotlin_artifact_target }}" \
             "${{ inputs.kotlin_artifact_backend }}" \
-            "${{ inputs.kotlin_artifact_profile }}"
+            "${{ inputs.kotlin_artifact_profile }}" \
+            --skip-build
 
       - name: Swift SDK smoke test
         if: ${{ inputs.sdk_kind == 'swift' }}
@@ -286,4 +323,5 @@ jobs:
             "$HOME/.models/${{ inputs.model_file }}" \
             "$SWIFT_INPUT_ARCHIVE" \
             "$SWIFT_INPUT_MODE" \
-            "$SWIFT_INPUT_BINDING"
+            "$SWIFT_INPUT_BINDING" \
+            --skip-build

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -273,9 +273,11 @@ runtime producers are not duplicated.
   ROCm and Vulkan products remain package-verified until eligible inference
   runners are registered.
 - `ci-linux-sdk-slice.yml` and `ci-macos-sdk-slice.yml` — platform-local
-  Rust, Kotlin and Swift consumers. Swift production starts from the plan and
-  Kotlin production from the shared static ABI; only smoke consumers wait for
-  the matching product lane.
+  Rust, Kotlin and Swift consumers. Each smoke downloads the matching
+  platform lane's immutable UI artifact before packaging SDK resources;
+  Rust's smoke also uses the exact main-seeded Cargo/target cache. Swift
+  production starts from the plan and Kotlin production from the shared
+  static ABI; only smoke consumers wait for the matching product lane.
 - `ci-runner-contract-slice.yml` — plan/provider/PR cache-boundary checks and
   trusted-main runner-image contracts.
 
@@ -499,6 +501,7 @@ The implemented policy uses that isolation selectively:
 | macOS Metal unit ABI and Windows native ABI | Exact PR-scoped cache on miss | Same-PR reruns avoid the native rebuild; no restore prefixes cross an ABI boundary |
 | Console pnpm store | None -- `ui_quality`, `ui_e2e`, and `ui_artifact` all point `store-dir` at the runner image's baked pnpm store instead of an Actions cache | Every run installs warm from the image; no cache to publish, restore, or race |
 | Website npm store | None -- the `website` job runs in the prebuilt `public web` image (baked npm/node) with no bare-metal row, so its `setup-node` cache was deleted outright rather than kept | Every run does a fresh `npm ci`; no cache to invalidate or race |
+| SDK Rust Cargo registry/target | `Swatinem/rust-cache` restores the exact `mesh-llm-sdk-rust-cargo-v1` identity (OS/arch, target, pinned image and toolchain epochs, debug/LLD recipe, Cargo/manifest/script inputs, and cache-version) and only saves on `main` | PRs restore the trusted main seed without publishing; a miss still rebuilds the SDK test graph |
 | GitHub artifacts | Never used as cross-run caches | Immutable producers/consumers remain correct within one run; reruns recreate run-scoped artifacts |
 
 Outside the bounded exception, a Depot-selected run emits

--- a/crates/skippy-protocol/src/binary/codec.rs
+++ b/crates/skippy-protocol/src/binary/codec.rs
@@ -713,19 +713,23 @@ fn reply_stats_from_fields(fields: [i64; REPLY_STATS_FIELD_COUNT]) -> StageReply
     }
 }
 
+const I32_WIRE_BYTES: usize = std::mem::size_of::<i32>();
+
 fn read_i32_values(mut reader: impl Read, count: usize) -> io::Result<Vec<i32>> {
     const VALUES_PER_CHUNK: usize = 4_096;
     let mut values = Vec::with_capacity(count);
-    let mut bytes = [0_u8; VALUES_PER_CHUNK * std::mem::size_of::<i32>()];
+    let mut bytes = [0_u8; VALUES_PER_CHUNK * I32_WIRE_BYTES];
     let mut remaining = count;
     while remaining > 0 {
         let chunk_values = remaining.min(VALUES_PER_CHUNK);
-        let chunk_bytes = chunk_values * std::mem::size_of::<i32>();
+        let chunk_bytes = chunk_values * I32_WIRE_BYTES;
         reader.read_exact(&mut bytes[..chunk_bytes])?;
         values.extend(
             bytes[..chunk_bytes]
-                .chunks_exact(std::mem::size_of::<i32>())
-                .map(|chunk| i32::from_le_bytes(chunk.try_into().expect("i32 chunk size"))),
+                .as_chunks::<I32_WIRE_BYTES>()
+                .0
+                .iter()
+                .map(|chunk| i32::from_le_bytes(*chunk)),
         );
         remaining -= chunk_values;
     }
@@ -734,11 +738,13 @@ fn read_i32_values(mut reader: impl Read, count: usize) -> io::Result<Vec<i32>> 
 
 fn write_i32_slice(mut writer: impl Write, values: &[i32]) -> io::Result<()> {
     const VALUES_PER_CHUNK: usize = 4_096;
-    let mut bytes = [0_u8; VALUES_PER_CHUNK * std::mem::size_of::<i32>()];
+    let mut bytes = [0_u8; VALUES_PER_CHUNK * I32_WIRE_BYTES];
     for values in values.chunks(VALUES_PER_CHUNK) {
         let chunk_bytes = std::mem::size_of_val(values);
         for (bytes, value) in bytes[..chunk_bytes]
-            .chunks_exact_mut(std::mem::size_of::<i32>())
+            .as_chunks_mut::<I32_WIRE_BYTES>()
+            .0
+            .iter_mut()
             .zip(values)
         {
             bytes.copy_from_slice(&value.to_le_bytes());

--- a/scripts/ci-kotlin-sdk-smoke.sh
+++ b/scripts/ci-kotlin-sdk-smoke.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 7 ]; then
-    echo "Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> <native-sdk-input-dir> <target> <backend> <profile>" >&2
+SKIP_BUILD=0
+if [[ "$#" -eq 8 ]]; then
+    if [[ "$8" != "--skip-build" ]]; then
+        echo "Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> <native-sdk-input-dir> <target> <backend> <profile> [--skip-build]" >&2
+        exit 1
+    fi
+    SKIP_BUILD=1
+elif [[ "$#" -ne 7 ]]; then
+    echo "Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> <native-sdk-input-dir> <target> <backend> <profile> [--skip-build]" >&2
     exit 1
 fi
 
@@ -10,7 +17,11 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 scripts/check-sdk-contract.sh
-scripts/package-sdk-console-assets.sh --sdk kotlin
+if [[ "$SKIP_BUILD" == "1" ]]; then
+    scripts/package-sdk-console-assets.sh --sdk kotlin --skip-build
+else
+    scripts/package-sdk-console-assets.sh --sdk kotlin
+fi
 scripts/verify-sdk-console-assets.sh --sdk kotlin
 
 native_sdk_tmp="$(mktemp -d)"

--- a/scripts/ci-rust-sdk-smoke.sh
+++ b/scripts/ci-rust-sdk-smoke.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 3 ]; then
-    echo "Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>" >&2
+SKIP_BUILD=0
+if [[ "$#" -eq 4 ]]; then
+    if [[ "$4" != "--skip-build" ]]; then
+        echo "Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> [--skip-build]" >&2
+        exit 1
+    fi
+    SKIP_BUILD=1
+elif [[ "$#" -ne 3 ]]; then
+    echo "Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> [--skip-build]" >&2
     exit 1
 fi
 
@@ -10,7 +17,11 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$REPO_ROOT"
 
 scripts/check-sdk-contract.sh
-scripts/package-sdk-console-assets.sh --sdk node
+if [[ "$SKIP_BUILD" == "1" ]]; then
+    scripts/package-sdk-console-assets.sh --sdk node --skip-build
+else
+    scripts/package-sdk-console-assets.sh --sdk node
+fi
 scripts/verify-sdk-console-assets.sh --sdk node
 
 native_runtime_dir="$(

--- a/scripts/ci-swift-sdk-smoke.sh
+++ b/scripts/ci-swift-sdk-smoke.sh
@@ -1,8 +1,15 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [ "$#" -ne 6 ]; then
-    echo "Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> <xcframework-zip> <host-only|full> <generated-mesh_ffi.swift>" >&2
+SKIP_BUILD=0
+if [[ "$#" -eq 7 ]]; then
+    if [[ "$7" != "--skip-build" ]]; then
+        echo "Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> <xcframework-zip> <host-only|full> <generated-mesh_ffi.swift> [--skip-build]" >&2
+        exit 1
+    fi
+    SKIP_BUILD=1
+elif [[ "$#" -ne 6 ]]; then
+    echo "Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> <xcframework-zip> <host-only|full> <generated-mesh_ffi.swift> [--skip-build]" >&2
     exit 1
 fi
 
@@ -21,7 +28,11 @@ install -m 0644 "$SWIFT_INPUT_BINDING" "$SWIFT_TRACKED_BINDING"
 cmp "$SWIFT_INPUT_BINDING" "$SWIFT_TRACKED_BINDING"
 
 scripts/check-sdk-contract.sh
-scripts/package-sdk-console-assets.sh --sdk swift
+if [[ "$SKIP_BUILD" == "1" ]]; then
+    scripts/package-sdk-console-assets.sh --sdk swift --skip-build
+else
+    scripts/package-sdk-console-assets.sh --sdk swift
+fi
 scripts/verify-sdk-console-assets.sh --sdk swift
 
 scripts/verify-swift-release-artifact.sh \

--- a/scripts/tests/test_sccache_evidence.py
+++ b/scripts/tests/test_sccache_evidence.py
@@ -34,6 +34,7 @@ HF_WORKFLOW = ROOT / ".github" / "workflows" / "hf-download-smoke.yml"
 NATIVE_SDK_WORKFLOW = (
     ROOT / ".github" / "workflows" / "native-sdk-artifact.yml"
 )
+SDK_SMOKE_WORKFLOW = ROOT / ".github" / "workflows" / "sdk-smoke.yml"
 SEED_WARMER = ROOT / ".github" / "workflows" / "cache-warm-sccache.yml"
 SEED_KEY_PATTERN = re.compile(
     r"mesh-llm-sccache-seed-[^\n]+-\$\{\{ hashFiles\('"
@@ -447,6 +448,50 @@ class SccacheEvidenceTests(unittest.TestCase):
             "&& github.ref == 'refs/heads/main' }}",
             swift,
         )
+
+    def test_rust_sdk_cache_key_covers_smoke_compatibility_boundaries(self) -> None:
+        workflow = yaml.safe_load(SDK_SMOKE_WORKFLOW.read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["sdk_smoke"]["steps"]
+        cache_steps = [
+            step
+            for step in steps
+            if str(step.get("uses", "")).startswith("Swatinem/rust-cache@")
+        ]
+        self.assertEqual(len(cache_steps), 1)
+        cache = cache_steps[0]
+        self.assertEqual(cache["if"], "${{ inputs.sdk_kind == 'rust' }}")
+        values = cache["with"]
+
+        prefix = values["prefix-key"]
+        for boundary in (
+            "sdk-rust-cargo-v1",
+            "env.SDK_RUST_TARGET",
+            "env.SDK_RUST_IMAGE_DIGEST",
+            "env.SDK_RUST_TOOLCHAIN_EPOCH",
+            "env.SDK_RUST_PROFILE_LINKER",
+            "hashFiles(",
+            "'Cargo.lock'",
+            "'.github/cache-version.txt'",
+            "'.cargo/config.toml'",
+            "'**/Cargo.toml'",
+            "'scripts/ci-rust-sdk-smoke.sh'",
+            "'scripts/ci-sdk-fixture.sh'",
+            "'scripts/ci-prepare-native-runtime.sh'",
+            "'scripts/package-sdk-console-assets.sh'",
+            "'scripts/check-sdk-contract.sh'",
+            "'scripts/verify-sdk-console-assets.sh'",
+            "'.github/workflows/sdk-smoke.yml'",
+        ):
+            with self.subTest(boundary=boundary):
+                self.assertIn(boundary, prefix)
+
+        self.assertEqual(values["shared-key"], "ci-sdk-smoke-rust")
+        self.assertEqual(values["cache-bin"], "false")
+        self.assertIn(
+            "github.ref == 'refs/heads/main'",
+            values["save-if"],
+        )
+        self.assertNotIn("actions/cache", SDK_SMOKE_WORKFLOW.read_text(encoding="utf-8"))
 
     def test_linux_seed_producer_and_consumers_share_compatible_key(self) -> None:
         warmer_workflow = yaml.safe_load(SEED_WARMER.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- add an exact, main-seeded Rust SDK Cargo/target cache that pull requests can restore but cannot publish
- include OS, architecture, target, image, toolchain, profile/linker, and recipe inputs in the cache compatibility boundary
- reuse each lane immutable UI artifact across Rust, Kotlin, and Swift SDK smoke tests and skip redundant UI builds
- carry an isolated Rust 1.98 chunk-API compatibility fix required for current main to pass Clippy locally

## Validation

- just test-all
- just ci-validate
- just ci-shellcheck scripts/ci-rust-sdk-smoke.sh scripts/ci-kotlin-sdk-smoke.sh scripts/ci-swift-sdk-smoke.sh
- cargo test -p skippy-protocol --all-targets
- focused skippy-protocol Clippy validation

## Rollout note

The protected planner requires ci/slices.yml to match main byte-for-byte. This PR keeps the operational cache and UI-artifact changes while leaving the SDK cache_mode declaration at the protected value. A separate catalog-only maintainer merge must set it to pr-isolated; this branch can then rebase and restore that declaration.

Addresses #1381

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * SDK smoke tests now package and validate the matching platform UI assets, improving consistency across Rust, Kotlin, and Swift builds.
  * Binary data handling is more robust and avoids unnecessary failure paths.

* **Performance**
  * Rust SDK checks now reuse compatible build caches to reduce CI build times.

* **Documentation**
  * CI workflows and cache policies now document UI artifact handling and Rust cache behavior more clearly.

* **Tests**
  * Added coverage to verify cache configuration and prevent incompatible or outdated cache usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->