### PR TITLE
fix(skippy): enforce resident prefix minimum

### DIFF
--- a/crates/skippy-server/src/frontend/tests/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/tests/prefix_cache.rs
@@ -199,6 +199,37 @@ fn resident_prefix_cache_hits_radix_common_prefix_without_a_record_ladder() {
 }
 
 #[test]
+fn resident_prefix_cache_rejects_common_prefix_below_configured_minimum() {
+    let config = StageConfig {
+        kv_cache: Some(StageKvCacheConfig {
+            min_tokens: 64,
+            ..prefix_cache_test_config()
+                .kv_cache
+                .expect("test cache config")
+        }),
+        ..prefix_cache_test_config()
+    };
+    let kv = KvStageIntegration::from_config(&config)
+        .unwrap()
+        .expect("resident prefix cache enabled");
+    let donor = prefix_cache_base_with_request("donor-request", "donor-session");
+    let receiver = prefix_cache_base_with_request("receiver-request", "receiver-session");
+    let recorded_tokens = (0..20_751).collect::<Vec<_>>();
+    let mut lookup_tokens = recorded_tokens[..27].to_vec();
+    lookup_tokens.extend(100_000..128_065);
+    let recorded = kv.prefill_identity(&config, &donor, 0, &recorded_tokens);
+    let lookup = kv.prefill_identity(&config, &receiver, 0, &lookup_tokens);
+
+    seed_resident_prefix(&kv, &recorded);
+
+    assert!(kv.probe_resident_prefix(&lookup).is_none());
+    assert_eq!(
+        kv.peek_cache_affinity(&config, &[lookup]),
+        skippy_scheduler::CacheAffinity::default()
+    );
+}
+
+#[test]
 fn stage0_full_prefill_uses_one_radix_path_per_request() {
     let config = prefix_cache_test_config();
     let kv = KvStageIntegration::from_config(&config)

--- a/crates/skippy-server/src/kv_integration/cache_affinity.rs
+++ b/crates/skippy-server/src/kv_integration/cache_affinity.rs
@@ -30,6 +30,7 @@ impl KvStageIntegration {
                     .map(|hit| hit.matched_tokens),
                 StagePrefixCachePayload::Disabled => None,
             })
+            .filter(|matched_tokens| self.meets_shared_prefix_min_tokens(*matched_tokens))
             .max()
             .unwrap_or(0);
         if matched_tokens == 0 {

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -301,6 +301,10 @@ impl KvStageIntegration {
         )
     }
 
+    pub(crate) fn meets_shared_prefix_min_tokens(&self, matched_tokens: usize) -> bool {
+        u64::try_from(matched_tokens).unwrap_or(u64::MAX) >= self.checkpoint_policy.min_tokens
+    }
+
     pub fn try_begin_record(&self, page_id: &str) -> bool {
         self.inflight_records
             .lock()

--- a/crates/skippy-server/src/kv_integration/resident_prefix.rs
+++ b/crates/skippy-server/src/kv_integration/resident_prefix.rs
@@ -183,6 +183,9 @@ impl KvStageIntegration {
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         let radix_hit = radix.peek_resident(&identity.namespace, &identity.token_ids)?;
+        if !self.meets_shared_prefix_min_tokens(radix_hit.matched_tokens) {
+            return None;
+        }
         let entries = radix.stats().resident_entries;
         Some(ResidentPrefixRestore {
             page_id: radix_hit.value.page_id,
@@ -203,11 +206,20 @@ impl KvStageIntegration {
             return Ok(None);
         }
         for identity in identities {
-            let radix_hit = self
-                .radix
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .acquire_resident(&identity.namespace, &identity.token_ids);
+            let radix_hit = {
+                let mut radix = self
+                    .radix
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner);
+                let eligible = radix
+                    .peek_resident(&identity.namespace, &identity.token_ids)
+                    .is_some_and(|hit| self.meets_shared_prefix_min_tokens(hit.matched_tokens));
+                if eligible {
+                    radix.acquire_resident(&identity.namespace, &identity.token_ids)
+                } else {
+                    None
+                }
+            };
             let Some(radix_hit) = radix_hit else {
                 continue;
             };


### PR DESCRIPTION
## Outcome

Reject resident-prefix restores whose actual common prefix is shorter than the
configured shared-prefix minimum.

The Llama 3.3 70B qualification exposed this with a 20,751-token donor and a
28,092-token receiver. Their exact common prefix was only 27 tokens, but the
stage configured `min_tokens = 64`; Mesh still advertised and restored the
27-token hit. Recording already enforced the floor, while the resident radix
probe/affinity/restore paths did not.

This change applies the admission floor consistently to:

- scheduler cache affinity;
- non-mutating resident-prefix probes; and
- resident-prefix acquisition/restore.

Rejected matches do not update recency or active-reference state. Valid
resident common-prefix reuse at or above the configured minimum remains
enabled.

## Regression

The new test reproduces the deployed request shape: a 20,751-token donor, a
27-token common prefix, and a 28,065-token receiver suffix. It verifies that
both cache probing and scheduler affinity treat the below-floor match as cold.

## Validation

- `cargo fmt --all --check`
- `cargo check -p skippy-server`
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo test -p skippy-server --lib` — 554 passed, 0 failed, 3 ignored
- `cargo check -p mesh-llm` — passed; emitted 28 pre-existing unfulfilled
  lint-expectation warnings in `mesh-llm-host-runtime`
- patch applies cleanly to deployed Mesh commit
  `2a3e268c52d461370bcbfddc6372959737c2e6bf`

`cargo clippy -p mesh-llm --all-targets -- -D warnings` remains blocked by the
same 28 pre-existing `mesh-llm-host-runtime` warnings; none is in a touched
file.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enforced the configured minimum shared-prefix length for resident cache lookups.
  * Prevented short prefix matches from being treated as usable cache hits or influencing cache affinity.
  * Ensured identities with insufficient prefix matches continue through normal fallback handling.

* **Tests**
  * Added coverage confirming short radix prefixes are rejected and report default cache affinity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->