### PR TITLE
fix(api): preserve split capability when model size is unknown

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/model_target_capacity.rs
+++ b/crates/mesh-llm-host-runtime/src/api/model_target_capacity.rs
@@ -55,6 +55,15 @@ impl ModelTargetSizeLookup {
                     .packages
                     .iter()
                     .any(|package| package.package_type == "layer-package");
+                if split_capable {
+                    lookup.insert_split_capability_aliases(
+                        variant_name,
+                        &variant.curated.name,
+                        &variant.source.repo,
+                        variant.source.revision.as_deref(),
+                        source_file,
+                    );
+                }
                 if let Some(model_bytes) = variant
                     .curated
                     .size
@@ -164,6 +173,40 @@ impl ModelTargetSizeLookup {
     fn insert_split_capability(&mut self, alias: &str, split_capable: bool) {
         self.split_capable_by_key
             .insert(normalize_match_key(alias), split_capable);
+    }
+
+    fn insert_split_capability_aliases(
+        &mut self,
+        variant_name: &str,
+        curated_name: &str,
+        repo: &str,
+        revision: Option<&str>,
+        source_file: &str,
+    ) {
+        let basename = source_file.rsplit('/').next().unwrap_or(source_file);
+        let selector = model_ref::quant_selector_from_gguf_file(source_file);
+        let model_ref_with_revision =
+            model_ref::format_model_ref(repo, revision, selector.as_deref());
+        let model_ref_without_revision =
+            model_ref::format_model_ref(repo, None, selector.as_deref());
+        let canonical_ref =
+            revision.map(|revision| model_ref::format_canonical_ref(repo, revision, source_file));
+
+        for alias in [
+            variant_name,
+            curated_name,
+            repo,
+            source_file,
+            basename,
+            basename.trim_end_matches(".gguf"),
+            model_ref_with_revision.as_str(),
+            model_ref_without_revision.as_str(),
+        ] {
+            self.insert_split_capability(alias, true);
+        }
+        if let Some(canonical_ref) = canonical_ref {
+            self.insert_split_capability(&canonical_ref, true);
+        }
     }
 }
 
@@ -460,6 +503,11 @@ mod tests {
             lookup.split_capable("meshllm/model-q4_k_m-layers@rev-a"),
             Some(true)
         );
+        assert_eq!(
+            lookup.split_capable("hf://example/source@rev-a:Q4_K_M"),
+            Some(true)
+        );
+        assert_eq!(lookup.split_capable("Model-Q4_K_M"), Some(true));
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/api/model_target_capacity.rs
+++ b/crates/mesh-llm-host-runtime/src/api/model_target_capacity.rs
@@ -30,6 +30,7 @@ struct ModelSizeHint {
 #[derive(Clone, Debug, Default)]
 pub(crate) struct ModelTargetSizeLookup {
     hints_by_key: HashMap<String, ModelSizeHint>,
+    split_capable_by_key: HashMap<String, bool>,
 }
 
 impl ModelTargetSizeLookup {
@@ -78,6 +79,7 @@ impl ModelTargetSizeLookup {
                     .iter()
                     .filter(|package| package.package_type == "layer-package")
                 {
+                    lookup.insert_split_capability(&package.repo, true);
                     if let Some(model_bytes) = package.total_bytes {
                         lookup.insert_package_alias(
                             &package.repo,
@@ -95,6 +97,23 @@ impl ModelTargetSizeLookup {
 
     fn find(&self, query: &str) -> Option<ModelSizeHint> {
         self.hints_by_key.get(&normalize_match_key(query)).copied()
+    }
+
+    fn split_capable(&self, query: &str) -> Option<bool> {
+        self.find(query)
+            .map(|hint| hint.split_capable)
+            .or_else(|| {
+                self.split_capable_by_key
+                    .get(&normalize_match_key(query))
+                    .copied()
+            })
+            .or_else(|| {
+                model_ref::ModelRef::parse(query).ok().and_then(|parsed| {
+                    self.split_capable_by_key
+                        .get(&normalize_match_key(&parsed.repo))
+                        .copied()
+                })
+            })
     }
 
     fn insert_model_aliases(
@@ -141,6 +160,11 @@ impl ModelTargetSizeLookup {
     fn insert_package_alias(&mut self, alias: &str, hint: ModelSizeHint) {
         self.hints_by_key.insert(normalize_match_key(alias), hint);
     }
+
+    fn insert_split_capability(&mut self, alias: &str, split_capable: bool) {
+        self.split_capable_by_key
+            .insert(normalize_match_key(alias), split_capable);
+    }
 }
 
 pub(crate) fn evaluate_model_target_capacity(
@@ -155,7 +179,15 @@ pub(crate) fn evaluate_model_target_capacity(
     let required_bytes = size_hint
         .map(|hint| runtime::runtime_model_required_bytes(hint.model_bytes))
         .filter(|required| *required > 0);
-    let split_capable = size_hint.map(|hint| hint.split_capable).unwrap_or(false);
+    let split_capable = input
+        .size_lookup
+        .split_capable(input.model_ref)
+        .or_else(|| {
+            input
+                .model_name
+                .and_then(|name| input.size_lookup.split_capable(name))
+        });
+    let split_capable_for_capacity = split_capable == Some(true);
 
     if input.serving_node_count > 0 {
         return advice(
@@ -225,7 +257,7 @@ pub(crate) fn evaluate_model_target_capacity(
         );
     }
 
-    if split_capable
+    if split_capable_for_capacity
         && capacity.eligible_node_count >= 2
         && capacity.aggregate_capacity_bytes >= required_bytes
     {
@@ -241,7 +273,7 @@ pub(crate) fn evaluate_model_target_capacity(
         );
     }
 
-    let comparable_capacity = if split_capable && capacity.eligible_node_count >= 2 {
+    let comparable_capacity = if split_capable_for_capacity && capacity.eligible_node_count >= 2 {
         capacity.aggregate_capacity_bytes
     } else {
         capacity.best_single_node_capacity_bytes.unwrap_or_default()
@@ -306,7 +338,7 @@ fn record_node_capacity(summary: &mut CapacitySummary, role: &NodeRole, vram_byt
 struct AdviceDetails {
     required_bytes: Option<u64>,
     shortfall_bytes: Option<u64>,
-    split_capable: bool,
+    split_capable: Option<bool>,
 }
 
 fn advice(
@@ -410,6 +442,71 @@ mod tests {
                 model_bytes: 24_000_000_000,
                 split_capable: true,
             })
+        );
+    }
+
+    #[test]
+    fn split_capability_is_known_when_layer_package_size_is_missing() {
+        let mut entry = catalog_entry();
+        entry.variants.get_mut("Model-Q4_K_M").unwrap().packages[0].total_bytes = None;
+        let lookup = ModelTargetSizeLookup::from_entries(vec![entry]);
+
+        assert_eq!(lookup.find("meshllm/model-q4_k_m-layers"), None);
+        assert_eq!(
+            lookup.split_capable("meshllm/model-q4_k_m-layers"),
+            Some(true)
+        );
+        assert_eq!(
+            lookup.split_capable("meshllm/model-q4_k_m-layers@rev-a"),
+            Some(true)
+        );
+    }
+
+    #[test]
+    fn capacity_advice_preserves_layer_package_capability_without_size() {
+        let mut entry = catalog_entry();
+        entry.variants.get_mut("Model-Q4_K_M").unwrap().packages[0].total_bytes = None;
+        let lookup = ModelTargetSizeLookup::from_entries(vec![entry]);
+        let local_role = NodeRole::Host { http_port: 9337 };
+
+        let payload = evaluate_model_target_capacity(ModelTargetCapacityInput {
+            model_ref: "meshllm/model-q4_k_m-layers",
+            model_name: None,
+            serving_node_count: 0,
+            local_role: &local_role,
+            local_vram_bytes: 8_000_000_000,
+            peers: &[],
+            size_lookup: &lookup,
+        });
+
+        assert_eq!(
+            payload.state,
+            ModelTargetCapacityAdviceState::UnknownModelSize
+        );
+        assert_eq!(payload.split_capable, Some(true));
+    }
+
+    #[test]
+    fn capacity_advice_omits_unknown_split_capability() {
+        let lookup = ModelTargetSizeLookup::default();
+        let local_role = NodeRole::Host { http_port: 9337 };
+
+        let payload = evaluate_model_target_capacity(ModelTargetCapacityInput {
+            model_ref: "unknown/model",
+            model_name: None,
+            serving_node_count: 0,
+            local_role: &local_role,
+            local_vram_bytes: 8_000_000_000,
+            peers: &[],
+            size_lookup: &lookup,
+        });
+
+        assert_eq!(payload.split_capable, None);
+        assert!(
+            serde_json::to_value(payload)
+                .unwrap()
+                .get("split_capable")
+                .is_none()
         );
     }
 

--- a/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
+++ b/crates/mesh-llm-host-runtime/src/api/split_readiness.rs
@@ -332,10 +332,11 @@ fn participant_capacity_advice(
         return Some(advice);
     };
 
-    advice.state = participant_capacity_state(required_bytes, advice.split_capable, summary);
+    advice.state =
+        participant_capacity_state(required_bytes, advice.split_capable == Some(true), summary);
     advice.reason = participant_capacity_reason(advice.state);
     advice.shortfall_bytes =
-        participant_capacity_shortfall(required_bytes, advice.split_capable, summary);
+        participant_capacity_shortfall(required_bytes, advice.split_capable == Some(true), summary);
     Some(advice)
 }
 
@@ -783,7 +784,7 @@ mod tests {
             eligible_node_count: 2,
             missing_capacity_node_count: 0,
             excluded_client_node_count: 0,
-            split_capable: true,
+            split_capable: Some(true),
         }
     }
 

--- a/crates/mesh-llm-host-runtime/src/api/status.rs
+++ b/crates/mesh-llm-host-runtime/src/api/status.rs
@@ -702,7 +702,8 @@ pub(crate) struct ModelTargetCapacityAdvicePayload {
     pub(crate) eligible_node_count: usize,
     pub(crate) missing_capacity_node_count: usize,
     pub(crate) excluded_client_node_count: usize,
-    pub(crate) split_capable: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) split_capable: Option<bool>,
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize)]

--- a/crates/mesh-llm-host-runtime/src/runtime/tests/model_lifecycle.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/tests/model_lifecycle.rs
@@ -29,7 +29,7 @@ fn reconciliation_target_with_required_bytes(
             eligible_node_count: 1,
             missing_capacity_node_count: 0,
             excluded_client_node_count: 0,
-            split_capable: false,
+            split_capable: Some(false),
         },
     }
 }


### PR DESCRIPTION
## Summary

`doctor split` reported `split_capable: false` when a layer package had no catalog `total_bytes`, even though the package type itself proves that it can participate in a split. This conflated unknown model size with a known non-splittable model.

This change tracks split capability independently from size hints, registers layer-package aliases even when their size is absent, and resolves revision-qualified references back to their package repository. Capacity classification remains `unknown_model_size` until bytes are known, while known `true` and `false` values are preserved. An actually unknown capability is omitted from the JSON payload instead of being reported as `false`.

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p mesh-llm-host-runtime model_target_capacity::tests --lib` (5 passed)
- `cargo check -p mesh-llm-host-runtime` (passed)
- `cargo clippy -p mesh-llm-host-runtime --lib` (passed with existing warnings)
- `cargo test -p mesh-llm-host-runtime --lib` (2782 passed, 21 unrelated Windows/environment failures, 8 ignored)
- `cargo test --workspace --all-targets` (blocked by missing patched `llama.cpp` quant archives on Windows; automatic native preparation is unsupported by the repository build script)

The full-test failures are in untouched config, resolver, logging, mesh-admission, process-scan, and Windows-path fixtures; the changed capacity tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Split-capability detection now works consistently across model variants and aliases.
  * Models can be recognized using direct repository references or variant names.
  * Capacity evaluations distinguish between confirmed split support and unknown capability states.
  * Models without known package sizes can still be evaluated accurately.

* **Bug Fixes**
  * Status responses omit split-capability information when it is unavailable, avoiding misleading default values.
  * Improved handling of model aliases and repository identifiers when determining split support.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->