### PR TITLE
bench(skippy): close the direct prediction return ring in the distributed driver

### DIFF
--- a/crates/skippy-bench/src/direct_return_listener.rs
+++ b/crates/skippy-bench/src/direct_return_listener.rs
@@ -10,10 +10,10 @@
 use std::{
     collections::HashMap,
     io::ErrorKind,
-    net::{SocketAddr, TcpListener, TcpStream},
+    net::{IpAddr, SocketAddr, TcpListener, TcpStream},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicBool, Ordering},
+        atomic::{AtomicBool, AtomicUsize, Ordering},
         mpsc,
     },
     thread::{self, JoinHandle},
@@ -26,6 +26,20 @@ use skippy_protocol::binary::{
     send_ready,
 };
 
+/// Upper bound on concurrently served return connections. Each distributed
+/// run drives one prompt at a time, so legitimate traffic is a handful of
+/// connections; the cap only exists so idle or hostile peers cannot pile up
+/// blocking handler threads.
+const MAX_RETURN_CONNECTIONS: usize = 16;
+
+/// A peer must finish the ready/open handshake within this deadline.
+const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Framed replies must keep arriving within this deadline once the stream is
+/// open. Matches the driver-side reply wait so a wedged stage releases the
+/// handler thread instead of pinning it forever.
+const REPLY_READ_TIMEOUT: Duration = Duration::from_secs(180);
+
 type ReplyResult = std::result::Result<StageReply, String>;
 
 #[derive(Default)]
@@ -37,6 +51,8 @@ pub(crate) struct DriverReturnListener {
     shutdown: Arc<AtomicBool>,
     thread: Option<JoinHandle<()>>,
     waiters: Arc<Waiters>,
+    #[cfg_attr(not(test), allow(dead_code))]
+    local_addr: SocketAddr,
 }
 
 pub(crate) struct DriverReturnReceiver {
@@ -45,21 +61,73 @@ pub(crate) struct DriverReturnReceiver {
     receiver: mpsc::Receiver<ReplyResult>,
 }
 
+struct ConnectionSlot {
+    active: Arc<AtomicUsize>,
+}
+
+impl ConnectionSlot {
+    fn acquire(active: &Arc<AtomicUsize>) -> Option<Self> {
+        let mut current = active.load(Ordering::SeqCst);
+        loop {
+            if current >= MAX_RETURN_CONNECTIONS {
+                return None;
+            }
+            match active.compare_exchange(current, current + 1, Ordering::SeqCst, Ordering::SeqCst)
+            {
+                Ok(_) => {
+                    return Some(Self {
+                        active: active.clone(),
+                    });
+                }
+                Err(observed) => current = observed,
+            }
+        }
+    }
+}
+
+impl Drop for ConnectionSlot {
+    fn drop(&mut self) {
+        self.active.fetch_sub(1, Ordering::SeqCst);
+    }
+}
+
 impl DriverReturnListener {
-    pub(crate) fn start(bind_addr: SocketAddr) -> Result<Self> {
+    /// Bind the return listener. `allowed_sources` is the set of peer
+    /// addresses permitted to deliver replies (loopback is always allowed so
+    /// same-host stages keep working); connections from any other source are
+    /// dropped before the handshake.
+    pub(crate) fn start(bind_addr: SocketAddr, allowed_sources: Vec<IpAddr>) -> Result<Self> {
         let listener = TcpListener::bind(bind_addr)
             .with_context(|| format!("bind driver prediction return listener {bind_addr}"))?;
+        let local_addr = listener
+            .local_addr()
+            .context("read driver prediction return listener local addr")?;
         listener
             .set_nonblocking(true)
             .context("set driver prediction return listener nonblocking")?;
         let shutdown = Arc::new(AtomicBool::new(false));
         let waiters = Arc::new(Waiters::default());
+        let active_connections = Arc::new(AtomicUsize::new(0));
         let thread_shutdown = shutdown.clone();
         let thread_waiters = waiters.clone();
         let thread = thread::spawn(move || {
             while !thread_shutdown.load(Ordering::SeqCst) {
                 match listener.accept() {
-                    Ok((stream, _)) => {
+                    Ok((stream, peer)) => {
+                        if !source_allowed(peer.ip(), &allowed_sources) {
+                            eprintln!(
+                                "driver prediction return refused connection from unexpected \
+                                 source {peer}"
+                            );
+                            continue;
+                        }
+                        let Some(slot) = ConnectionSlot::acquire(&active_connections) else {
+                            eprintln!(
+                                "driver prediction return refused connection from {peer}: \
+                                 connection limit ({MAX_RETURN_CONNECTIONS}) reached"
+                            );
+                            continue;
+                        };
                         // Accepted sockets inherit O_NONBLOCK from the listener
                         // on BSD/macOS (Linux clears it); restore blocking mode
                         // so the framed reads below don't fail with EAGAIN.
@@ -71,6 +139,7 @@ impl DriverReturnListener {
                         }
                         let waiters = thread_waiters.clone();
                         thread::spawn(move || {
+                            let _slot = slot;
                             if let Err(error) = handle_return_connection(&waiters, stream) {
                                 eprintln!("driver prediction return connection failed: {error:#}");
                             }
@@ -91,7 +160,13 @@ impl DriverReturnListener {
             shutdown,
             thread: Some(thread),
             waiters,
+            local_addr,
         })
+    }
+
+    #[cfg(test)]
+    pub(crate) fn local_addr(&self) -> SocketAddr {
+        self.local_addr
     }
 
     pub(crate) fn register(
@@ -112,6 +187,10 @@ impl DriverReturnListener {
             receiver,
         })
     }
+}
+
+fn source_allowed(source: IpAddr, allowed_sources: &[IpAddr]) -> bool {
+    source.is_loopback() || allowed_sources.contains(&source)
 }
 
 impl Drop for DriverReturnListener {
@@ -148,6 +227,9 @@ impl DriverReturnReceiver {
 }
 
 fn handle_return_connection(waiters: &Waiters, mut stream: TcpStream) -> Result<()> {
+    stream
+        .set_read_timeout(Some(HANDSHAKE_TIMEOUT))
+        .context("set driver prediction return handshake deadline")?;
     consume_optional_ready_hello(&mut stream)?;
     send_ready(&mut stream).context("send driver prediction return ready")?;
     let open = read_stage_message(&mut stream, 0).context("read driver prediction return open")?;
@@ -170,6 +252,9 @@ fn handle_return_connection(waiters: &Waiters, mut stream: TcpStream) -> Result<
                 open.session_id
             )
         })?;
+    stream
+        .set_read_timeout(Some(REPLY_READ_TIMEOUT))
+        .context("set driver prediction return reply deadline")?;
     loop {
         match recv_reply(&mut stream) {
             Ok(reply) => {
@@ -214,4 +299,94 @@ fn consume_optional_ready_hello(stream: &mut TcpStream) -> Result<()> {
         Err(error) => return Err(error).context("peek driver prediction return hello"),
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use skippy_protocol::binary::{
+        StageStateHeader, StageWireMessage, send_reply_predicted_with_stats, write_stage_message,
+    };
+
+    fn open_message(request_id: u64, session_id: u64) -> StageWireMessage {
+        StageWireMessage {
+            kind: WireMessageKind::PredictionReturnOpen,
+            pos_start: 0,
+            token_count: 0,
+            state: StageStateHeader::new(WireMessageKind::PredictionReturnOpen),
+            request_id,
+            session_id,
+            sampling: None,
+            chat_sampling_metadata: None,
+            tokens: Vec::new(),
+            positions: Vec::new(),
+            activation: Vec::new(),
+            raw_bytes: Vec::new(),
+        }
+    }
+
+    fn loopback_listener() -> DriverReturnListener {
+        DriverReturnListener::start(SocketAddr::from(([127, 0, 0, 1], 0)), Vec::new()).unwrap()
+    }
+
+    #[test]
+    fn delivers_framed_reply_to_registered_waiter_after_handshake() {
+        let listener = loopback_listener();
+        let receiver = listener.register(17, 23).unwrap();
+
+        let mut client = TcpStream::connect(listener.local_addr()).unwrap();
+        send_ready(&mut client).unwrap();
+        recv_ready(&mut client).unwrap();
+        write_stage_message(&mut client, &open_message(17, 23)).unwrap();
+        send_reply_predicted_with_stats(&mut client, 42, Default::default()).unwrap();
+
+        let reply = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap()
+            .expect("direct return reply");
+        assert_eq!(reply.predicted, 42);
+    }
+
+    #[test]
+    fn closed_connection_wakes_registered_waiter_with_error() {
+        let listener = loopback_listener();
+        let receiver = listener.register(29, 31).unwrap();
+
+        let mut client = TcpStream::connect(listener.local_addr()).unwrap();
+        recv_ready(&mut client).unwrap();
+        write_stage_message(&mut client, &open_message(29, 31)).unwrap();
+        drop(client);
+
+        let error = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .expect_err("closed direct return must wake the waiter");
+        assert!(error.to_string().contains("closed before the next reply"));
+    }
+
+    #[test]
+    fn unregistered_ids_never_reach_a_waiter() {
+        let listener = loopback_listener();
+        let receiver = listener.register(37, 41).unwrap();
+
+        let mut client = TcpStream::connect(listener.local_addr()).unwrap();
+        recv_ready(&mut client).unwrap();
+        write_stage_message(&mut client, &open_message(999, 999)).unwrap();
+        send_reply_predicted_with_stats(&mut client, 7, Default::default()).unwrap();
+
+        assert!(
+            receiver
+                .recv_timeout(Duration::from_millis(300))
+                .unwrap()
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn source_allowlist_always_admits_loopback() {
+        assert!(source_allowed("127.0.0.1".parse().unwrap(), &[]));
+        assert!(source_allowed("::1".parse().unwrap(), &[]));
+        let lan: IpAddr = "192.168.0.54".parse().unwrap();
+        assert!(source_allowed(lan, &[lan]));
+        assert!(!source_allowed("192.168.0.99".parse().unwrap(), &[lan]));
+    }
 }

--- a/crates/skippy-bench/src/direct_return_listener.rs
+++ b/crates/skippy-bench/src/direct_return_listener.rs
@@ -1,0 +1,208 @@
+//! Closes the direct prediction return ring for the distributed bench driver.
+//!
+//! The deployment plan rewrites stage 0's topology endpoint to the driver
+//! return endpoint, so the final stage forwards each prediction "downstream"
+//! straight back to the driver. Nothing listened on that endpoint before this
+//! module existed: the final stage's connect was refused, its upstream
+//! fallback never reached the driver, and every distributed run deadlocked on
+//! decode step 0 waiting for a reply.
+
+use std::{
+    collections::HashMap,
+    io::ErrorKind,
+    net::{SocketAddr, TcpListener, TcpStream},
+    sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+        mpsc,
+    },
+    thread::{self, JoinHandle},
+    time::Duration,
+};
+
+use anyhow::{Context, Result, anyhow, bail};
+use skippy_protocol::binary::{
+    READY_MAGIC, StageReply, WireMessageKind, read_stage_message, recv_ready, recv_reply,
+    send_ready,
+};
+
+type ReplyResult = std::result::Result<StageReply, String>;
+
+#[derive(Default)]
+struct Waiters {
+    map: Mutex<HashMap<(u64, u64), mpsc::Sender<ReplyResult>>>,
+}
+
+pub(crate) struct DriverReturnListener {
+    shutdown: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+    waiters: Arc<Waiters>,
+}
+
+pub(crate) struct DriverReturnReceiver {
+    key: (u64, u64),
+    waiters: Arc<Waiters>,
+    receiver: mpsc::Receiver<ReplyResult>,
+}
+
+impl DriverReturnListener {
+    pub(crate) fn start(bind_addr: SocketAddr) -> Result<Self> {
+        let listener = TcpListener::bind(bind_addr)
+            .with_context(|| format!("bind driver prediction return listener {bind_addr}"))?;
+        listener
+            .set_nonblocking(true)
+            .context("set driver prediction return listener nonblocking")?;
+        let shutdown = Arc::new(AtomicBool::new(false));
+        let waiters = Arc::new(Waiters::default());
+        let thread_shutdown = shutdown.clone();
+        let thread_waiters = waiters.clone();
+        let thread = thread::spawn(move || {
+            while !thread_shutdown.load(Ordering::SeqCst) {
+                match listener.accept() {
+                    Ok((stream, _)) => {
+                        let waiters = thread_waiters.clone();
+                        thread::spawn(move || {
+                            if let Err(error) = handle_return_connection(&waiters, stream) {
+                                eprintln!("driver prediction return connection failed: {error:#}");
+                            }
+                        });
+                    }
+                    Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                        thread::sleep(Duration::from_millis(50));
+                    }
+                    Err(error) if error.kind() == ErrorKind::Interrupted => {}
+                    Err(error) => {
+                        eprintln!("driver prediction return listener failed: {error}");
+                        break;
+                    }
+                }
+            }
+        });
+        Ok(Self {
+            shutdown,
+            thread: Some(thread),
+            waiters,
+        })
+    }
+
+    pub(crate) fn register(
+        &self,
+        request_id: u64,
+        session_id: u64,
+    ) -> Result<DriverReturnReceiver> {
+        let key = (request_id, session_id);
+        let (sender, receiver) = mpsc::channel();
+        self.waiters
+            .map
+            .lock()
+            .map_err(|_| anyhow!("driver prediction return waiters lock poisoned"))?
+            .insert(key, sender);
+        Ok(DriverReturnReceiver {
+            key,
+            waiters: self.waiters.clone(),
+            receiver,
+        })
+    }
+}
+
+impl Drop for DriverReturnListener {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::SeqCst);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+impl Drop for DriverReturnReceiver {
+    fn drop(&mut self) {
+        if let Ok(mut map) = self.waiters.map.lock() {
+            map.remove(&self.key);
+        }
+    }
+}
+
+impl DriverReturnReceiver {
+    /// Wait for the next direct-return reply. `Ok(None)` means nothing arrived
+    /// within the timeout; the caller decides whether to fall back to the
+    /// upstream reply path.
+    pub(crate) fn recv_timeout(&self, timeout: Duration) -> Result<Option<StageReply>> {
+        match self.receiver.recv_timeout(timeout) {
+            Ok(Ok(reply)) => Ok(Some(reply)),
+            Ok(Err(error)) => bail!("direct prediction return failed: {error}"),
+            Err(mpsc::RecvTimeoutError::Timeout) => Ok(None),
+            Err(mpsc::RecvTimeoutError::Disconnected) => {
+                bail!("direct prediction return listener stopped")
+            }
+        }
+    }
+}
+
+fn handle_return_connection(waiters: &Waiters, mut stream: TcpStream) -> Result<()> {
+    consume_optional_ready_hello(&mut stream)?;
+    send_ready(&mut stream).context("send driver prediction return ready")?;
+    let open = read_stage_message(&mut stream, 0).context("read driver prediction return open")?;
+    if open.kind != WireMessageKind::PredictionReturnOpen {
+        bail!(
+            "expected prediction return open message, got {:?}",
+            open.kind
+        );
+    }
+    let sender = waiters
+        .map
+        .lock()
+        .map_err(|_| anyhow!("driver prediction return waiters lock poisoned"))?
+        .get(&(open.request_id, open.session_id))
+        .cloned()
+        .ok_or_else(|| {
+            anyhow!(
+                "no driver prediction return waiter for request {} session {}",
+                open.request_id,
+                open.session_id
+            )
+        })?;
+    loop {
+        match recv_reply(&mut stream) {
+            Ok(reply) => {
+                if sender.send(Ok(reply)).is_err() {
+                    return Ok(());
+                }
+            }
+            Err(error) if error.kind() == ErrorKind::UnexpectedEof => {
+                let _ = sender.send(Err(format!(
+                    "direct prediction return closed before the next reply: {error}"
+                )));
+                return Ok(());
+            }
+            Err(error) => {
+                let _ = sender.send(Err(error.to_string()));
+                return Err(error).context("read driver prediction return reply");
+            }
+        }
+    }
+}
+
+/// The connecting stage may open with a client ready hello before it waits for
+/// our ready. Mirror the stage server's optional peek so both dialects work.
+fn consume_optional_ready_hello(stream: &mut TcpStream) -> Result<()> {
+    let previous = stream
+        .read_timeout()
+        .context("read driver prediction return stream timeout")?;
+    stream
+        .set_read_timeout(Some(Duration::from_millis(250)))
+        .context("set driver prediction return hello peek timeout")?;
+    let mut bytes = [0_u8; 4];
+    let peeked = stream.peek(&mut bytes);
+    stream
+        .set_read_timeout(previous)
+        .context("restore driver prediction return stream timeout")?;
+    match peeked {
+        Ok(4) if i32::from_le_bytes(bytes) == READY_MAGIC => {
+            recv_ready(&mut *stream).context("consume driver prediction return client hello")?;
+        }
+        Ok(_) => {}
+        Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {}
+        Err(error) => return Err(error).context("peek driver prediction return hello"),
+    }
+    Ok(())
+}

--- a/crates/skippy-bench/src/direct_return_listener.rs
+++ b/crates/skippy-bench/src/direct_return_listener.rs
@@ -60,6 +60,15 @@ impl DriverReturnListener {
             while !thread_shutdown.load(Ordering::SeqCst) {
                 match listener.accept() {
                     Ok((stream, _)) => {
+                        // Accepted sockets inherit O_NONBLOCK from the listener
+                        // on BSD/macOS (Linux clears it); restore blocking mode
+                        // so the framed reads below don't fail with EAGAIN.
+                        if let Err(error) = stream.set_nonblocking(false) {
+                            eprintln!(
+                                "driver prediction return accept failed to restore blocking mode: {error}"
+                            );
+                            continue;
+                        }
                         let waiters = thread_waiters.clone();
                         thread::spawn(move || {
                             if let Err(error) = handle_return_connection(&waiters, stream) {

--- a/crates/skippy-bench/src/direct_return_listener.rs
+++ b/crates/skippy-bench/src/direct_return_listener.rs
@@ -17,7 +17,7 @@ use std::{
         mpsc,
     },
     thread::{self, JoinHandle},
-    time::Duration,
+    time::{Duration, Instant},
 };
 
 use anyhow::{Context, Result, anyhow, bail};
@@ -34,6 +34,14 @@ const MAX_RETURN_CONNECTIONS: usize = 16;
 
 /// A peer must finish the ready/open handshake within this deadline.
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// How long the optional client ready hello has to appear, and to arrive in
+/// full once its first bytes have. Bounded so the other dialect — the stage
+/// waits for our ready before sending anything — still moves on promptly.
+const HELLO_PEEK_BUDGET: Duration = Duration::from_millis(250);
+
+/// Pause between peeks while a partial hello completes.
+const HELLO_PEEK_POLL: Duration = Duration::from_millis(1);
 
 /// Framed replies must keep arriving within this deadline once the stream is
 /// open. Matches the driver-side reply wait so a wedged stage releases the
@@ -283,26 +291,53 @@ fn consume_optional_ready_hello(stream: &mut TcpStream) -> Result<()> {
         .read_timeout()
         .context("read driver prediction return stream timeout")?;
     stream
-        .set_read_timeout(Some(Duration::from_millis(250)))
+        .set_read_timeout(Some(HELLO_PEEK_BUDGET))
         .context("set driver prediction return hello peek timeout")?;
-    let mut bytes = [0_u8; 4];
-    let peeked = stream.peek(&mut bytes);
+    let peeked = peek_ready_hello(stream);
     stream
         .set_read_timeout(previous)
         .context("restore driver prediction return stream timeout")?;
-    match peeked {
-        Ok(4) if i32::from_le_bytes(bytes) == READY_MAGIC => {
-            recv_ready(&mut *stream).context("consume driver prediction return client hello")?;
-        }
-        Ok(_) => {}
-        Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {}
-        Err(error) => return Err(error).context("peek driver prediction return hello"),
+    if peeked.context("peek driver prediction return hello")? {
+        recv_ready(&mut *stream).context("consume driver prediction return client hello")?;
     }
     Ok(())
 }
 
+/// Reports whether the peer opened with a client ready hello, leaving the
+/// stream unread either way. A short peek is not proof there is no hello: TCP
+/// may split the four magic bytes, so keep peeking while what has arrived is
+/// still a `READY_MAGIC` prefix. Anything else — a full non-matching word, a
+/// byte that diverges from the magic, EOF, or the budget running out — means
+/// no hello, and the caller reads the bytes as a stage message instead.
+fn peek_ready_hello(stream: &mut TcpStream) -> std::io::Result<bool> {
+    let magic = READY_MAGIC.to_le_bytes();
+    let deadline = Instant::now() + HELLO_PEEK_BUDGET;
+    loop {
+        let mut bytes = [0_u8; 4];
+        match stream.peek(&mut bytes) {
+            Ok(4) => return Ok(bytes == magic),
+            // Only a prefix so far; the rest may still be in flight.
+            Ok(peeked) if peeked > 0 && bytes[..peeked] == magic[..peeked] => {}
+            Ok(_) => return Ok(false),
+            Err(error) if error.kind() == ErrorKind::Interrupted => {}
+            Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+                return Ok(false);
+            }
+            Err(error) => return Err(error),
+        }
+        // The buffered prefix makes the next peek return immediately, so pause
+        // rather than spin while the remaining bytes arrive.
+        if Instant::now() >= deadline {
+            return Ok(false);
+        }
+        thread::sleep(HELLO_PEEK_POLL);
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use std::io::Write;
+
     use super::*;
     use skippy_protocol::binary::{
         StageStateHeader, StageWireMessage, send_reply_predicted_with_stats, write_stage_message,
@@ -345,6 +380,31 @@ mod tests {
             .unwrap()
             .expect("direct return reply");
         assert_eq!(reply.predicted, 42);
+    }
+
+    #[test]
+    fn delivers_reply_when_the_client_hello_arrives_split() {
+        let listener = loopback_listener();
+        let receiver = listener.register(19, 27).unwrap();
+
+        let mut client = TcpStream::connect(listener.local_addr()).unwrap();
+        // TCP may split the four-byte hello; the peek must wait for the rest
+        // instead of reading the tail as the start of a stage message.
+        let magic = READY_MAGIC.to_le_bytes();
+        client.set_nodelay(true).unwrap();
+        client.write_all(&magic[..1]).unwrap();
+        thread::sleep(Duration::from_millis(25));
+        client.write_all(&magic[1..]).unwrap();
+
+        recv_ready(&mut client).unwrap();
+        write_stage_message(&mut client, &open_message(19, 27)).unwrap();
+        send_reply_predicted_with_stats(&mut client, 55, Default::default()).unwrap();
+
+        let reply = receiver
+            .recv_timeout(Duration::from_secs(5))
+            .unwrap()
+            .expect("direct return reply");
+        assert_eq!(reply.predicted, 55);
     }
 
     #[test]

--- a/crates/skippy-bench/src/distributed.rs
+++ b/crates/skippy-bench/src/distributed.rs
@@ -23,6 +23,7 @@ use skippy_runtime::{
 
 use crate::{
     cli::{DEFAULT_RUN_MAX_NEW_TOKENS, FocusedRuntimeArgs, RunArgs},
+    direct_return_listener::{DriverReturnListener, DriverReturnReceiver},
     model_identity::model_identity_for_path,
     support::{ChildGuard, ensure_release_skippy_server_bin, retry},
 };
@@ -366,6 +367,21 @@ fn run_remote_prompt_driver(args: &RunArgs, plan: &DeploymentPlan) -> Result<Pro
         .stages
         .first()
         .context("deployment plan has no stages")?;
+    // The topology hands the final stage the driver return endpoint as its
+    // downstream, so the driver must listen there to close the prediction ring.
+    let return_port = plan
+        .driver_return_endpoint
+        .rsplit_once(':')
+        .and_then(|(_, port)| port.parse::<u16>().ok())
+        .with_context(|| {
+            format!(
+                "parse driver return endpoint port from {}",
+                plan.driver_return_endpoint
+            )
+        })?;
+    let return_listener =
+        DriverReturnListener::start(std::net::SocketAddr::from(([0, 0, 0, 0], return_port)))
+            .context("start driver prediction return listener")?;
     let prompt_cases = prompt_cases(args)?;
     if prompt_cases.is_empty() {
         bail!("prompt corpus is empty");
@@ -389,7 +405,8 @@ fn run_remote_prompt_driver(args: &RunArgs, plan: &DeploymentPlan) -> Result<Pro
                 .expect("tokenizer is present without explicit prompt tokens")
                 .tokenize(&prompt_case.prompt)?
         };
-        let mut result = run_remote_prompt_case(args, first, prompt_case, token_ids, index)?;
+        let mut result =
+            run_remote_prompt_case(args, first, prompt_case, token_ids, index, &return_listener)?;
         result.elapsed_ms = started.elapsed().as_millis();
         results.push(result);
     }
@@ -491,12 +508,55 @@ fn ensure_reply_kind(
     Ok(())
 }
 
+/// The final stage prefers delivering predictions over the direct return
+/// connection; if it could not connect there it falls back to the upstream
+/// reply chain. Decide once per prompt which path is live: wait on the direct
+/// channel first, and only fall back to a blocking upstream read when the
+/// direct path stayed silent through the first decode step.
+const DIRECT_RETURN_REPLY_TIMEOUT: Duration = Duration::from_secs(180);
+
+fn receive_decode_reply(
+    stream: &mut TcpStream,
+    direct_return: &DriverReturnReceiver,
+    direct_mode: &mut Option<bool>,
+    decode_step: usize,
+    prompt_index: usize,
+) -> Result<skippy_protocol::binary::StageReply> {
+    let upstream = |stream: &mut TcpStream| {
+        recv_reply(stream).with_context(|| {
+            format!("receive decode step {decode_step} reply for prompt {prompt_index}")
+        })
+    };
+    match *direct_mode {
+        Some(true) => direct_return
+            .recv_timeout(DIRECT_RETURN_REPLY_TIMEOUT)?
+            .with_context(|| {
+                format!(
+                    "timed out waiting for direct prediction return reply at decode step \
+                     {decode_step} for prompt {prompt_index}"
+                )
+            }),
+        Some(false) => upstream(stream),
+        None => match direct_return.recv_timeout(DIRECT_RETURN_REPLY_TIMEOUT)? {
+            Some(reply) => {
+                *direct_mode = Some(true);
+                Ok(reply)
+            }
+            None => {
+                *direct_mode = Some(false);
+                upstream(stream)
+            }
+        },
+    }
+}
+
 fn run_remote_prompt_case(
     args: &RunArgs,
     first: &StageAssignment,
     prompt_case: &PromptCase,
     token_ids: Vec<i32>,
     prompt_index: usize,
+    return_listener: &DriverReturnListener,
 ) -> Result<PromptDriverResult> {
     if token_ids.is_empty() {
         bail!("prompt produced no tokens");
@@ -513,6 +573,9 @@ fn run_remote_prompt_case(
     let wire_started = Instant::now();
     let request_id = 10_000_u64 + prompt_index as u64;
     let session_id = 20_000_u64 + prompt_index as u64;
+    let direct_return = return_listener
+        .register(request_id, session_id)
+        .with_context(|| format!("register direct prediction return for prompt {prompt_index}"))?;
     send_generation_config(&mut stream, request_id, session_id, token_ids.len())
         .with_context(|| format!("send generation config for prompt {prompt_index}"))?;
     let prefill_token_count = token_ids.len().saturating_sub(1);
@@ -546,6 +609,7 @@ fn run_remote_prompt_case(
     let max_new_tokens = effective_run_max_new_tokens(args);
     let mut predicted_tokens = Vec::with_capacity(max_new_tokens);
     let mut current = *token_ids.last().expect("checked non-empty tokens");
+    let mut direct_mode: Option<bool> = None;
     let decode_started = Instant::now();
     let mut ttft_ms = 0;
     for decode_step in 0..max_new_tokens {
@@ -575,9 +639,13 @@ fn run_remote_prompt_case(
         write_stage_message(&mut stream, &message).with_context(|| {
             format!("send remote decode step {decode_step} for prompt {prompt_index}")
         })?;
-        let reply = recv_reply(&mut stream).with_context(|| {
-            format!("receive decode step {decode_step} reply for prompt {prompt_index}")
-        })?;
+        let reply = receive_decode_reply(
+            &mut stream,
+            &direct_return,
+            &mut direct_mode,
+            decode_step,
+            prompt_index,
+        )?;
         ensure_reply_kind(&reply, WireReplyKind::PredictedToken)?;
         if decode_step == 0 {
             ttft_ms = wire_started.elapsed().as_millis();

--- a/crates/skippy-bench/src/distributed.rs
+++ b/crates/skippy-bench/src/distributed.rs
@@ -1,6 +1,9 @@
 use std::{
+    collections::hash_map::RandomState,
     fs,
-    net::TcpStream,
+    hash::{BuildHasher, Hasher},
+    io::ErrorKind,
+    net::{IpAddr, SocketAddr, TcpStream, ToSocketAddrs},
     path::{Path, PathBuf},
     process::Command,
     thread,
@@ -369,19 +372,7 @@ fn run_remote_prompt_driver(args: &RunArgs, plan: &DeploymentPlan) -> Result<Pro
         .context("deployment plan has no stages")?;
     // The topology hands the final stage the driver return endpoint as its
     // downstream, so the driver must listen there to close the prediction ring.
-    let return_port = plan
-        .driver_return_endpoint
-        .rsplit_once(':')
-        .and_then(|(_, port)| port.parse::<u16>().ok())
-        .with_context(|| {
-            format!(
-                "parse driver return endpoint port from {}",
-                plan.driver_return_endpoint
-            )
-        })?;
-    let return_listener =
-        DriverReturnListener::start(std::net::SocketAddr::from(([0, 0, 0, 0], return_port)))
-            .context("start driver prediction return listener")?;
+    let return_listener = start_driver_return_listener(plan)?;
     let prompt_cases = prompt_cases(args)?;
     if prompt_cases.is_empty() {
         bail!("prompt corpus is empty");
@@ -510,10 +501,14 @@ fn ensure_reply_kind(
 
 /// The final stage prefers delivering predictions over the direct return
 /// connection; if it could not connect there it falls back to the upstream
-/// reply chain. Decide once per prompt which path is live: wait on the direct
-/// channel first, and only fall back to a blocking upstream read when the
-/// direct path stayed silent through the first decode step.
+/// reply chain. Decide once per prompt which path is live: poll both reply
+/// paths until one produces data, so a failed direct connection costs
+/// milliseconds — not a full direct-return timeout — before the upstream
+/// reply is consumed.
 const DIRECT_RETURN_REPLY_TIMEOUT: Duration = Duration::from_secs(180);
+
+/// Alternating poll interval while neither reply path has produced data yet.
+const REPLY_PATH_POLL_INTERVAL: Duration = Duration::from_millis(20);
 
 fn receive_decode_reply(
     stream: &mut TcpStream,
@@ -537,17 +532,109 @@ fn receive_decode_reply(
                 )
             }),
         Some(false) => upstream(stream),
-        None => match direct_return.recv_timeout(DIRECT_RETURN_REPLY_TIMEOUT)? {
-            Some(reply) => {
-                *direct_mode = Some(true);
-                Ok(reply)
+        None => {
+            let deadline = Instant::now() + DIRECT_RETURN_REPLY_TIMEOUT;
+            loop {
+                if let Some(reply) = direct_return.recv_timeout(REPLY_PATH_POLL_INTERVAL)? {
+                    *direct_mode = Some(true);
+                    return Ok(reply);
+                }
+                if upstream_reply_ready(stream)? {
+                    *direct_mode = Some(false);
+                    return upstream(stream);
+                }
+                if Instant::now() >= deadline {
+                    bail!(
+                        "timed out waiting for a reply on either return path at decode step \
+                         {decode_step} for prompt {prompt_index}"
+                    );
+                }
             }
-            None => {
-                *direct_mode = Some(false);
-                upstream(stream)
-            }
-        },
+        }
     }
+}
+
+/// Peek the upstream stream without consuming bytes so the undecided reply
+/// wait can notice a fallback reply immediately. EOF also counts as "ready":
+/// the follow-up blocking read surfaces the disconnect error promptly instead
+/// of spinning until the deadline.
+fn upstream_reply_ready(stream: &mut TcpStream) -> Result<bool> {
+    let previous = stream
+        .read_timeout()
+        .context("read upstream reply stream timeout")?;
+    stream
+        .set_read_timeout(Some(REPLY_PATH_POLL_INTERVAL))
+        .context("set upstream reply peek timeout")?;
+    let peeked = stream.peek(&mut [0_u8; 1]);
+    stream
+        .set_read_timeout(previous)
+        .context("restore upstream reply stream timeout")?;
+    match peeked {
+        Ok(_) => Ok(true),
+        Err(error) if matches!(error.kind(), ErrorKind::WouldBlock | ErrorKind::TimedOut) => {
+            Ok(false)
+        }
+        Err(error) => Err(error).context("peek upstream reply stream"),
+    }
+}
+
+/// Bind the driver return listener on the interface named by the deployment
+/// plan rather than every interface; fall back to the wildcard only when that
+/// address is not local (e.g. the plan names a NAT-visible address), keeping
+/// the peer allowlist as the guard in that case.
+fn start_driver_return_listener(plan: &DeploymentPlan) -> Result<DriverReturnListener> {
+    let endpoint = plan.driver_return_endpoint.as_str();
+    let planned_addr = endpoint
+        .to_socket_addrs()
+        .with_context(|| format!("resolve driver return endpoint {endpoint}"))?
+        .next()
+        .with_context(|| format!("driver return endpoint resolved to no address: {endpoint}"))?;
+    let allowed_sources = stage_host_ips(plan);
+    match DriverReturnListener::start(planned_addr, allowed_sources.clone()) {
+        Ok(listener) => Ok(listener),
+        Err(bind_error) => {
+            eprintln!(
+                "driver prediction return listener could not bind {planned_addr} ({bind_error:#}); \
+                 falling back to a wildcard bind guarded by the stage-host allowlist"
+            );
+            DriverReturnListener::start(
+                SocketAddr::from(([0, 0, 0, 0], planned_addr.port())),
+                allowed_sources,
+            )
+            .context("start driver prediction return listener")
+        }
+    }
+}
+
+/// Resolve every stage host in the plan; these are the only non-loopback
+/// sources allowed to deliver direct prediction returns.
+fn stage_host_ips(plan: &DeploymentPlan) -> Vec<IpAddr> {
+    let mut ips = Vec::new();
+    for stage in &plan.stages {
+        let endpoint = stage
+            .endpoint
+            .strip_prefix("tcp://")
+            .unwrap_or(&stage.endpoint);
+        let Ok(resolved) = endpoint.to_socket_addrs() else {
+            eprintln!(
+                "driver prediction return allowlist skipping unresolvable stage endpoint \
+                 {endpoint}"
+            );
+            continue;
+        };
+        for addr in resolved {
+            if !ips.contains(&addr.ip()) {
+                ips.push(addr.ip());
+            }
+        }
+    }
+    ips
+}
+
+/// Random request/session identifiers so a peer on the benchmark network
+/// cannot guess a live ID and inject a forged prediction reply.
+fn random_wire_id() -> u64 {
+    RandomState::new().build_hasher().finish()
 }
 
 fn run_remote_prompt_case(
@@ -571,8 +658,8 @@ fn run_remote_prompt_case(
         })?;
 
     let wire_started = Instant::now();
-    let request_id = 10_000_u64 + prompt_index as u64;
-    let session_id = 20_000_u64 + prompt_index as u64;
+    let request_id = random_wire_id();
+    let session_id = random_wire_id();
     let direct_return = return_listener
         .register(request_id, session_id)
         .with_context(|| format!("register direct prediction return for prompt {prompt_index}"))?;
@@ -1009,6 +1096,87 @@ pub(super) fn generate_bench_run_id() -> String {
 mod tests {
     use super::*;
     use serde_json::json;
+    use skippy_protocol::binary::send_reply_predicted_with_stats;
+    use std::net::TcpListener;
+
+    #[test]
+    fn undecided_reply_wait_consumes_upstream_reply_promptly() {
+        let return_listener =
+            DriverReturnListener::start(SocketAddr::from(([127, 0, 0, 1], 0)), Vec::new()).unwrap();
+        let direct_return = return_listener.register(1, 2).unwrap();
+
+        let upstream_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut stream = TcpStream::connect(upstream_listener.local_addr().unwrap()).unwrap();
+        let (mut upstream_side, _) = upstream_listener.accept().unwrap();
+        thread::spawn(move || {
+            send_reply_predicted_with_stats(&mut upstream_side, 7, Default::default()).unwrap();
+            // Keep the write side open so the driver's read is not racing EOF.
+            thread::sleep(Duration::from_secs(2));
+        });
+
+        let started = Instant::now();
+        let mut direct_mode = None;
+        let reply = receive_decode_reply(&mut stream, &direct_return, &mut direct_mode, 0, 0)
+            .expect("upstream fallback reply");
+        assert_eq!(reply.predicted, 7);
+        assert_eq!(direct_mode, Some(false));
+        // The whole point of the dual wait: nowhere near DIRECT_RETURN_REPLY_TIMEOUT.
+        assert!(started.elapsed() < Duration::from_secs(5));
+    }
+
+    #[test]
+    fn undecided_reply_wait_prefers_direct_reply_and_locks_direct_mode() {
+        let return_listener =
+            DriverReturnListener::start(SocketAddr::from(([127, 0, 0, 1], 0)), Vec::new()).unwrap();
+        let direct_return = return_listener.register(3, 4).unwrap();
+
+        // Silent upstream: connect a peer that never writes.
+        let upstream_listener = TcpListener::bind("127.0.0.1:0").unwrap();
+        let mut stream = TcpStream::connect(upstream_listener.local_addr().unwrap()).unwrap();
+        let (_upstream_side, _) = upstream_listener.accept().unwrap();
+
+        let return_addr = return_listener.local_addr();
+        thread::spawn(move || {
+            use skippy_protocol::binary::{
+                StageStateHeader, StageWireMessage, recv_ready, write_stage_message,
+            };
+            let mut client = TcpStream::connect(return_addr).unwrap();
+            recv_ready(&mut client).unwrap();
+            write_stage_message(
+                &mut client,
+                &StageWireMessage {
+                    kind: WireMessageKind::PredictionReturnOpen,
+                    pos_start: 0,
+                    token_count: 0,
+                    state: StageStateHeader::new(WireMessageKind::PredictionReturnOpen),
+                    request_id: 3,
+                    session_id: 4,
+                    sampling: None,
+                    chat_sampling_metadata: None,
+                    tokens: Vec::new(),
+                    positions: Vec::new(),
+                    activation: Vec::new(),
+                    raw_bytes: Vec::new(),
+                },
+            )
+            .unwrap();
+            send_reply_predicted_with_stats(&mut client, 11, Default::default()).unwrap();
+            thread::sleep(Duration::from_secs(2));
+        });
+
+        let mut direct_mode = None;
+        let reply = receive_decode_reply(&mut stream, &direct_return, &mut direct_mode, 0, 0)
+            .expect("direct return reply");
+        assert_eq!(reply.predicted, 11);
+        assert_eq!(direct_mode, Some(true));
+    }
+
+    #[test]
+    fn random_wire_ids_are_not_predictable_constants() {
+        let first = random_wire_id();
+        let second = random_wire_id();
+        assert_ne!(first, second);
+    }
 
     #[test]
     fn parses_prompt_token_ids() {

--- a/crates/skippy-bench/src/main.rs
+++ b/crates/skippy-bench/src/main.rs
@@ -1,5 +1,6 @@
 mod chat_corpus;
 mod cli;
+mod direct_return_listener;
 mod distributed;
 mod evals;
 mod local_single;

--- a/scripts/materialize-competitive-inputs.sh
+++ b/scripts/materialize-competitive-inputs.sh
@@ -91,6 +91,13 @@ file_sha256() { # portable sha256 of a file (Linux sha256sum / macOS shasum)
   fi
 }
 
+resolve_path() { # portable `readlink -f` (BSD/macOS readlink has no -f)
+  "$PYTHON_BIN" - "$1" <<'PY'
+import pathlib, sys
+print(pathlib.Path(sys.argv[1]).resolve())
+PY
+}
+
 fail_count=0
 
 echo "=== Materialize competitive inputs ==="
@@ -131,8 +138,8 @@ PY
     continue
   fi
   mkdir -p "$ROOT/models/$key"
-  ln -sfn "$(readlink -f "$cached")" "$ROOT/models/$key/$filename"
-  echo "    ok: $filename ($(du -h "$(readlink -f "$cached")" | cut -f1), sha256 verified)"
+  ln -sfn "$(resolve_path "$cached")" "$ROOT/models/$key/$filename"
+  echo "    ok: $filename ($(du -h "$(resolve_path "$cached")" | cut -f1), sha256 verified)"
 done
 
 # ---------------------------------------------------------------------------
@@ -245,7 +252,7 @@ if [[ "$SKIP_VLLM_CONFIGS" -eq 0 ]]; then
       continue
     fi
     mkdir -p "$ROOT/vllm-configs/$key"
-    ln -sfn "$(readlink -f "$cached")" "$ROOT/vllm-configs/$key/config.json"
+    ln -sfn "$(resolve_path "$cached")" "$ROOT/vllm-configs/$key/config.json"
     echo "    ok: config.json (sha256 verified)"
   done
 fi
@@ -266,7 +273,7 @@ if [[ "$SKIP_DATASET" -eq 0 ]]; then
     fail_count=$((fail_count+1))
   else
     mkdir -p "$ROOT/thoughtworks"
-    ln -sfn "$(readlink -f "$cached")" "$ROOT/thoughtworks/$ds_file"
+    ln -sfn "$(resolve_path "$cached")" "$ROOT/thoughtworks/$ds_file"
     echo "    ok: $ds_file (sha256 verified)"
     sources=()
     while IFS= read -r source; do

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -3433,10 +3433,40 @@
       "macro_name": "println!"
     }
   ],
+  "crates/skippy-bench/src/direct_return_listener.rs": [
+    {
+      "line": 117,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 124,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 134,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 143,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 152,
+      "macro_name": "eprintln!"
+    }
+  ],
   "crates/skippy-bench/src/distributed.rs": [
     {
-      "line": 337,
+      "line": 341,
       "macro_name": "println!"
+    },
+    {
+      "line": 596,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 619,
+      "macro_name": "eprintln!"
     }
   ],
   "crates/skippy-bench/src/evals.rs": [
@@ -3589,11 +3619,11 @@
   ],
   "crates/skippy-bench/src/main.rs": [
     {
-      "line": 33,
+      "line": 34,
       "macro_name": "eprintln!"
     },
     {
-      "line": 41,
+      "line": 42,
       "macro_name": "eprintln!"
     }
   ],

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -3435,15 +3435,11 @@
   ],
   "crates/skippy-bench/src/direct_return_listener.rs": [
     {
-      "line": 117,
+      "line": 126,
       "macro_name": "eprintln!"
     },
     {
-      "line": 124,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 134,
+      "line": 133,
       "macro_name": "eprintln!"
     },
     {
@@ -3452,6 +3448,10 @@
     },
     {
       "line": 152,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 161,
       "macro_name": "eprintln!"
     }
   ],


### PR DESCRIPTION
## Problem

Every multi-stage `skippy-bench run --execute-remote` deadlocks at decode step 0. Reproduced on 4x L4 (CUDA sm_89) at `162256ded` across GLM-4.5-Air (artifact-slice), Qwen3-30B-A3B (published layer package), and the documented 3-stage topology — deterministic, model- and load-mode-independent.

Root cause: `deployment.rs` rewrites stage 0's topology endpoint to the driver return endpoint (`first_stage_port + 1000`), so the final stage forwards each prediction "downstream" straight back to the driver — but nothing in skippy-bench ever listens there. Every run logs, at the final stage:

```
downstream connect retry: remote=127.0.0.1:20031 ... Connection refused (all 5 modes)
direct prediction return unavailable; falling back to upstream reply
```

...after which the driver blocks forever in `recv_reply` on the stage-0 connection. The advertised-but-refused upstream fallback never delivers to the driver either — that fallback path may deserve its own look (possibly related to the reply-ownership rework in #1118), but with the ring closed it is no longer on the critical path.

## Fix

Add a small prediction-return listener to skippy-bench (a protocol-level twin of skippy-server's `PredictionReturnListener`, self-contained so the bench keeps depending only on skippy-protocol): bind the driver return port before driving prompts, register per request, and prefer the direct channel for `PredictedToken` replies with a one-shot fallback to the upstream path if the direct channel stays silent through the first decode step.

## Evidence — previously-impossible benchmark now runs

Qwen3-30B-A3B Q4_K_M (published `meshllm/Qwen3-30B-A3B-Q4_K_M-layers` package), 4x NVIDIA L4, CUDA, 3 corpus prompts x 192 tokens, greedy, `--stage-downstream-wire-delay-ms` swept:

| configuration | decode tok/s (mean) |
|---|---|
| co-located reference (llama-bench, same patched llama.cpp, `-sm layer`, 4 GPU) | 105.1 |
| 3-stage split (documented `16,32`), 0ms | 84.3 |
| 4-stage split (`12,24,36`), 0ms | 79.6 |
| 4-stage split, 0.2ms/hop | 72.8 |
| 4-stage split, 5ms/hop | 34.8 |

TTFT ~650–820ms across all arms. Before this fix, all split arms hang indefinitely at decode step 0.

## Related finding (not addressed here)

Qwen3.6-35B-A3B stages fail with `InvalidArgument: position sideband count must equal token_count * n_pos_per_embd` — the driver/upstream sends one position per token where the native side (patch 0006) expects `n_pos_per_embd` (4 for M-RoPE-family models). Separate fix needed if Qwen3.6-class models should run on the binary stage path; happy to file details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Distributed benchmark runs can receive prediction results through a direct return path, with automatic fallback to the upstream response path.
  * Direct connections are restricted to approved sources and use bounded timeouts for improved reliability.

* **Bug Fixes**
  * Improved handling of disconnected, delayed, or partially delivered result connections.
  * Improved request tracking for reliable result delivery.

* **Compatibility**
  * Input materialization scripts now work on platforms where `readlink -f` is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->