### PR TITLE
fix(deps): bump OpenTelemetry stack to 0.32 and rpassword to 7.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5336,9 +5336,9 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b84bcd6ae87133e903af7ef497404dda70c60d0ea14895fc8a5e6722754fc2a0"
+checksum = "b0142c63252a9e054e68a4c61a5778f7b14f576274d593f8ce883d191a099682"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -5350,22 +5350,22 @@ dependencies = [
 
 [[package]]
 name = "opentelemetry-http"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a6d09a73194e6b66df7c8f1b680f156d916a1a942abf2de06823dd02b7855d"
+checksum = "5683015d09e2df236ef005b17f6f196f0d5f6313c4fa43a7b6a53b52776e4331"
 dependencies = [
  "async-trait",
  "bytes",
  "http",
  "opentelemetry",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
 ]
 
 [[package]]
 name = "opentelemetry-otlp"
-version = "0.31.1"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f69cd6acbb9af919df949cd1ec9e5e7fdc2ef15d234b6b795aaa525cc02f71f"
+checksum = "9966929966d17620d7c316c643ba62631826e10021409357772d5eea84f62c35"
 dependencies = [
  "http",
  "opentelemetry",
@@ -5373,15 +5373,15 @@ dependencies = [
  "opentelemetry-proto",
  "opentelemetry_sdk",
  "prost",
- "reqwest 0.12.28",
+ "reqwest 0.13.4",
  "thiserror 2.0.18",
 ]
 
 [[package]]
 name = "opentelemetry-proto"
-version = "0.31.0"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7175df06de5eaee9909d4805a3d07e28bb752c34cab57fa9cff549da596b30f"
+checksum = "56d658ba1faf63f7b9c492cfbe6e0ec365440a16132d3270c1065f7b33f1b638"
 dependencies = [
  "base64",
  "const-hex",
@@ -5389,26 +5389,25 @@ dependencies = [
  "opentelemetry_sdk",
  "prost",
  "serde",
- "serde_json",
  "tonic",
  "tonic-prost",
 ]
 
 [[package]]
 name = "opentelemetry_sdk"
-version = "0.31.0"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e14ae4f5991976fd48df6d843de219ca6d31b01daaab2dad5af2badeded372bd"
+checksum = "9b59f80e1ac4d5ff7a2db8fb6c80badb7f0f3f858211fba08dd9aaec750894f9"
 dependencies = [
  "futures-channel",
  "futures-executor",
  "futures-util",
  "opentelemetry",
  "percent-encoding",
+ "portable-atomic",
  "rand 0.9.4",
  "thiserror 2.0.18",
  "tokio",
- "tokio-stream",
 ]
 
 [[package]]
@@ -6544,6 +6543,7 @@ dependencies = [
  "base64",
  "bytes",
  "encoding_rs",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "h2",
@@ -6662,12 +6662,23 @@ dependencies = [
 
 [[package]]
 name = "rpassword"
-version = "5.0.1"
+version = "7.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffc936cf8a7ea60c58f030fd36a612a48f440610214dc54bc36431f9ea0c3efb"
+checksum = "2da316a15f47e3d053de9cb2c439650bd8fa4aaeb9365f2e5f27f492ff73c196"
 dependencies = [
  "libc",
- "winapi",
+ "rtoolbox",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rtoolbox"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a1efe12a1469752d0e6ff5ebec0b6ef4924cc5c4c71046b0ec730040535819d"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/mesh-llm-commands/Cargo.toml
+++ b/crates/mesh-llm-commands/Cargo.toml
@@ -37,7 +37,7 @@ model-artifact = { path = "../model-artifact", version = "0.76.0-rc8" }
 model-hf = { path = "../model-hf", version = "0.76.0-rc8" }
 model-package = { path = "../model-package", version = "0.76.0-rc8" }
 model-ref = { path = "../model-ref", version = "0.76.0-rc8" }
-rpassword = "5"
+rpassword = "7.5"
 reqwest = { version = "0.12", features = ["blocking", "json"] }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/mesh-llm-commands/src/auth.rs
+++ b/crates/mesh-llm-commands/src/auth.rs
@@ -180,14 +180,14 @@ fn prompt_new_passphrase(no_passphrase: bool) -> Result<Option<Zeroizing<String>
         return Ok(None);
     }
 
-    let passphrase = Zeroizing::new(rpassword::prompt_password_stderr(
+    let passphrase = Zeroizing::new(rpassword::prompt_password(
         "Enter passphrase (empty for none): ",
     )?);
     if passphrase.is_empty() {
         return Ok(None);
     }
 
-    let confirm = Zeroizing::new(rpassword::prompt_password_stderr("Confirm passphrase: ")?);
+    let confirm = Zeroizing::new(rpassword::prompt_password("Confirm passphrase: ")?);
     if passphrase.as_str() != confirm.as_str() {
         bail!("Passphrases do not match.");
     }
@@ -207,7 +207,7 @@ fn resolve_keystore_passphrase(path: &Path) -> Result<Option<Zeroizing<String>>>
 
     if std::io::stdin().is_terminal() && std::io::stderr().is_terminal() {
         let prompt = format!("Enter owner keystore passphrase for {}: ", path.display());
-        let passphrase = rpassword::prompt_password_stderr(&prompt)?;
+        let passphrase = rpassword::prompt_password(&prompt)?;
         return Ok(Some(Zeroizing::new(passphrase)));
     }
 

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -72,9 +72,9 @@ base64 = "0.22"
 dirs = "6.0.0"
 hex = "0.4.3"
 nostr-sdk = { version = "0.45.1", default-features = false }
-opentelemetry = { version = "0.31.0", default-features = false, features = ["metrics"] }
-opentelemetry_sdk = { version = "0.31.0", default-features = false, features = ["metrics"] }
-opentelemetry-otlp = { version = "0.31.0", default-features = false, features = ["metrics", "http-proto", "reqwest-blocking-client"] }
+opentelemetry = { version = "0.32.0", default-features = false, features = ["metrics"] }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["metrics"] }
+opentelemetry-otlp = { version = "0.32.0", default-features = false, features = ["metrics", "http-proto", "reqwest-blocking-client"] }
 rustls = "0.23.36"
 reqwest = { version = "0.12", features = ["stream", "json"] }
 flate2 = "1"
@@ -88,7 +88,7 @@ chacha20poly1305 = "0.10"
 argon2 = "0.5"
 thiserror = "2"
 zeroize = { version = "1", features = ["derive"] }
-rpassword = "5"
+rpassword = "7.5"
 keyring = { version = "3", features = ["apple-native", "windows-native", "sync-secret-service", "crypto-rust", "vendored"] }
 chrono = { version = "0.4", features = ["serde"] }
 httparse = "1"
@@ -122,7 +122,7 @@ windows-sys = { version = "0.61", features = [
 
 [dev-dependencies]
 serial_test = "3"
-opentelemetry_sdk = { version = "0.31.0", default-features = false, features = ["metrics", "testing"] }
+opentelemetry_sdk = { version = "0.32.1", default-features = false, features = ["metrics", "testing"] }
 mesh-client = { package = "mesh-llm-client", path = "../mesh-client", version = "0.76.0-rc8"  }
 # Used by the gated-relay regression test to spawn an in-process iroh-relay
 # with AccessConfig::Restricted, then build a real iroh::Endpoint from our

--- a/crates/mesh-llm-host-runtime/src/runtime/startup_models.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/startup_models.rs
@@ -108,7 +108,7 @@ pub(super) fn resolve_owner_passphrase(path: &Path) -> Result<Option<Zeroizing<S
 
     if std::io::stdin().is_terminal() && std::io::stderr().is_terminal() {
         let prompt = format!("Enter owner keystore passphrase for {}: ", path.display());
-        let passphrase = rpassword::prompt_password_stderr(&prompt)?;
+        let passphrase = rpassword::prompt_password(&prompt)?;
         return Ok(Some(Zeroizing::new(passphrase)));
     }
 

--- a/crates/metrics-server/Cargo.toml
+++ b/crates/metrics-server/Cargo.toml
@@ -10,7 +10,7 @@ axum = "0.8"
 clap.workspace = true
 rusqlite = { version = "0.37", features = ["bundled"] }
 skippy-metrics = { path = "../skippy-metrics" }
-opentelemetry-proto = "0.31.0"
+opentelemetry-proto = "0.32.0"
 prost = "0.14"
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/metrics-server/src/otlp_value.rs
+++ b/crates/metrics-server/src/otlp_value.rs
@@ -31,6 +31,8 @@ pub(crate) fn any_value_to_json(value: &AnyValue) -> Value {
         }
         Some(any_value::Value::KvlistValue(value)) => attributes_to_json(&value.values),
         Some(any_value::Value::BytesValue(value)) => Value::String(bytes_to_hex(value)),
+        // Strindex values reference a string table we don't carry at this level.
+        Some(any_value::Value::StringValueStrindex(_)) => Value::Null,
         None => Value::Null,
     }
 }
@@ -59,7 +61,9 @@ pub(crate) fn any_value_to_string(value: &AnyValue) -> Option<String> {
         any_value::Value::IntValue(value) => Some(value.to_string()),
         any_value::Value::DoubleValue(value) => Some(value.to_string()),
         any_value::Value::BytesValue(value) => Some(bytes_to_hex(value)),
-        any_value::Value::ArrayValue(_) | any_value::Value::KvlistValue(_) => None,
+        any_value::Value::ArrayValue(_)
+        | any_value::Value::KvlistValue(_)
+        | any_value::Value::StringValueStrindex(_) => None,
     }
 }
 
@@ -69,6 +73,7 @@ pub(crate) fn kv_string(key: &str, value: &str) -> KeyValue {
         value: Some(AnyValue {
             value: Some(any_value::Value::StringValue(value.to_string())),
         }),
+        ..Default::default()
     }
 }
 
@@ -78,6 +83,7 @@ pub(crate) fn kv_i64(key: &str, value: i64) -> KeyValue {
         value: Some(AnyValue {
             value: Some(any_value::Value::IntValue(value)),
         }),
+        ..Default::default()
     }
 }
 

--- a/crates/skippy-server/Cargo.toml
+++ b/crates/skippy-server/Cargo.toml
@@ -36,7 +36,7 @@ skippy-cache = { path = "../skippy-cache", version = "0.76.0-rc8"  }
 skippy-metrics = { path = "../skippy-metrics", version = "0.76.0-rc8"  }
 skippy-topology = { path = "../skippy-topology", version = "0.76.0-rc8" }
 openai-frontend = { path = "../openai-frontend", version = "0.76.0-rc8"  }
-opentelemetry-proto = "0.31.0"
+opentelemetry-proto = "0.32.0"
 serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true

--- a/crates/skippy-server/src/telemetry.rs
+++ b/crates/skippy-server/src/telemetry.rs
@@ -430,6 +430,7 @@ fn event_to_span(event: &TelemetryEvent, stats: &TelemetryCounters) -> Span {
             .map(|(key, value)| KeyValue {
                 key,
                 value: Some(json_to_any_value(value)),
+                ..Default::default()
             })
             .collect(),
         dropped_attributes_count: 0,
@@ -447,6 +448,7 @@ fn resource_attributes(config: &StageConfig) -> Vec<KeyValue> {
         .map(|(key, value)| KeyValue {
             key,
             value: Some(json_to_any_value(value)),
+            ..Default::default()
         })
         .collect()
 }
@@ -474,6 +476,7 @@ fn json_to_any_value(value: Value) -> AnyValue {
                     .map(|(key, value)| KeyValue {
                         key,
                         value: Some(json_to_any_value(value)),
+                        ..Default::default()
                     })
                     .collect(),
             })


### PR DESCRIPTION
## Summary

Closes #1484.

`mesh-llm-host-runtime` currently resolves two dependencies with open security advisories, and downstream consumers pinning by release tag can't remediate through their own lockfiles:

- **`opentelemetry_sdk` 0.31.0** → bumped to **0.32.1** (with `opentelemetry`, `opentelemetry-otlp`, and `opentelemetry-proto` moved to the 0.32 series in lockstep, across `mesh-llm-host-runtime`, `skippy-server`, and `metrics-server`)
- **`rpassword` 5.0.1** → bumped to **7.5** (in `mesh-llm-host-runtime` and also `mesh-llm-commands`, which carried the same pin)

## Code changes required by the bumps

- rpassword 7 removed `prompt_password_stderr`; call sites now use `prompt_password`, which prompts on the TTY — the prompt still stays out of piped stdout, matching the old behavior's intent.
- `opentelemetry-proto` 0.32 tracks a newer OTLP schema: `KeyValue` gained a `key_strindex` field and `AnyValue` a `StringValueStrindex` variant. Struct initializers now fill the new field via `..Default::default()`, and the value-conversion matches in `metrics-server` map strindex values (which reference a string table not carried at that level) to null/`None`.

## Testing

- `cargo check --workspace --tests` passes.
- `cargo test -p metrics-server -p mesh-llm-commands --lib` — 235 passed.
- `cargo test -p skippy-server --lib telemetry` — 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Passphrase prompts now appear consistently in standard command-line output.
  - Improved handling of OpenTelemetry string-table values in metrics conversion.
  - Telemetry attributes now initialize reliably with default values.

- **Maintenance**
  - Updated OpenTelemetry and password-input components for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->