### PR TITLE
fix(skippy-server): make connection worker reads interruptible by shutdown

### DIFF
--- a/crates/skippy-server/src/binary_transport/binary_messaging.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging.rs
@@ -2,7 +2,7 @@ use std::{
     collections::BTreeMap,
     future::Future,
     io::{self, Write},
-    net::TcpListener,
+    net::{TcpListener, TcpStream},
     sync::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
@@ -45,6 +45,10 @@ mod telemetry;
 
 use self::connection::handle_binary_connection;
 
+/// How often a waiting connection worker rechecks the shutdown flag, matching
+/// the downstream DOWNSTREAM_SHUTDOWN_POLL cadence in stage_execution.
+const WORKER_SHUTDOWN_POLL: Duration = Duration::from_millis(100);
+
 #[derive(Default)]
 struct ConnectionWorkerControl {
     shutting_down: AtomicBool,
@@ -81,6 +85,41 @@ impl ConnectionWorkerControl {
             .lock()
             .expect("connection sockets lock poisoned")
             .clear();
+    }
+
+    fn is_shutting_down(&self) -> bool {
+        self.shutting_down.load(Ordering::Acquire)
+    }
+
+    /// Block until `stream` has readable data (or EOF), returning false when
+    /// shutdown is requested instead. Peeks under a short read timeout so no
+    /// message bytes are consumed and the worker never sits in an
+    /// uninterruptible blocking read: `TcpStream::shutdown` on a tracked
+    /// clone does not unblock an in-flight `read` on Windows (#1538).
+    fn wait_for_readable(&self, stream: &TcpStream) -> io::Result<bool> {
+        stream.set_read_timeout(Some(WORKER_SHUTDOWN_POLL))?;
+        let mut probe = [0u8; 1];
+        let ready = loop {
+            if self.is_shutting_down() {
+                break false;
+            }
+            match stream.peek(&mut probe) {
+                Ok(_) => break true,
+                Err(error)
+                    if matches!(
+                        error.kind(),
+                        io::ErrorKind::Interrupted
+                            | io::ErrorKind::WouldBlock
+                            | io::ErrorKind::TimedOut
+                    ) => {}
+                Err(error) => {
+                    let _ = stream.set_read_timeout(None);
+                    return Err(error);
+                }
+            }
+        };
+        stream.set_read_timeout(None)?;
+        Ok(ready)
     }
 }
 
@@ -374,6 +413,12 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
                         "binary sent ready: stage_id={} peer={peer_addr:?}",
                         config.stage_id
                     );
+                    if !task_control
+                        .wait_for_readable(&upstream)
+                        .context("wait for the first binary stage message")?
+                    {
+                        return Ok(());
+                    }
                     let first_message = match read_stage_message(&mut upstream, activation_width) {
                         Ok(message) => message,
                         Err(error) if error.kind() == io::ErrorKind::UnexpectedEof => return Ok(()),
@@ -413,6 +458,7 @@ fn run_binary_stage(options: BinaryStageOptions, shutdown: Arc<AtomicBool>) -> R
                         downstream_connect_timeout_secs,
                         native_mtp_enabled,
                         &prediction_return_sinks,
+                        &task_control,
                         first_message,
                     )
                 })()
@@ -466,8 +512,10 @@ mod shutdown_tests {
         control.track(&server).unwrap();
         let task_control = control.clone();
         let task = thread::spawn(move || {
-            let mut byte = [0u8; 1];
-            let _ = server.read(&mut byte);
+            if let Ok(true) = task_control.wait_for_readable(&server) {
+                let mut byte = [0u8; 1];
+                let _ = server.read(&mut byte);
+            }
             task_control.clear();
         });
         let mut workers = ConnectionWorkers::default();
@@ -495,8 +543,10 @@ mod shutdown_tests {
         let finished = Arc::new(AtomicBool::new(false));
         let task_finished = finished.clone();
         let task = thread::spawn(move || {
-            let mut byte = [0u8; 1];
-            let _ = server.read(&mut byte);
+            if let Ok(true) = task_control.wait_for_readable(&server) {
+                let mut byte = [0u8; 1];
+                let _ = server.read(&mut byte);
+            }
             task_control.clear();
             task_finished.store(true, Ordering::Release);
         });

--- a/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
@@ -1,3 +1,4 @@
+use super::ConnectionWorkerControl;
 use super::async_forwarder::AsyncForwarder;
 use super::control_messages::{
     handle_generation_control, handle_prefix_cache_control, handle_session_control, handle_stop,
@@ -86,6 +87,7 @@ pub(super) fn handle_binary_connection(
     downstream_connect_timeout_secs: u64,
     native_mtp_enabled: bool,
     prediction_return_sinks: &PredictionReturnSinks,
+    worker_control: &ConnectionWorkerControl,
     first_message: StageWireMessage,
 ) -> Result<()> {
     let mut session_tracker = ConnectionSessionTracker::default();
@@ -105,6 +107,7 @@ pub(super) fn handle_binary_connection(
         downstream_connect_timeout_secs,
         native_mtp_enabled,
         prediction_return_sinks,
+        worker_control,
         first_message,
         &mut session_tracker,
     );
@@ -134,6 +137,7 @@ fn handle_binary_connection_messages(
     downstream_connect_timeout_secs: u64,
     native_mtp_enabled: bool,
     prediction_return_sinks: &PredictionReturnSinks,
+    worker_control: &ConnectionWorkerControl,
     first_message: StageWireMessage,
     session_tracker: &mut ConnectionSessionTracker,
 ) -> Result<()> {
@@ -162,6 +166,7 @@ fn handle_binary_connection_messages(
         let recv_started = Instant::now();
         let Some(mut message) = receive_next_message(
             upstream,
+            worker_control,
             activation_width,
             next_message.take(),
             pending_prefill_replies,

--- a/crates/skippy-server/src/binary_transport/binary_messaging/message_receive.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/message_receive.rs
@@ -1,3 +1,4 @@
+use super::ConnectionWorkerControl;
 use anyhow::{Context, Result};
 use skippy_protocol::binary::{StageWireMessage, read_stage_message};
 use std::io;
@@ -12,6 +13,7 @@ pub(super) fn next_connection_session_id() -> u64 {
 
 pub(super) fn receive_next_message(
     upstream: &mut TcpStream,
+    worker_control: &ConnectionWorkerControl,
     activation_width: i32,
     first_message: Option<StageWireMessage>,
     pending_prefill_replies: usize,
@@ -19,6 +21,15 @@ pub(super) fn receive_next_message(
 ) -> Result<Option<StageWireMessage>> {
     if first_message.is_some() {
         return Ok(first_message);
+    }
+    if !worker_control
+        .wait_for_readable(upstream)
+        .context("wait for the next binary stage message")?
+    {
+        // Shutdown was requested while the connection was idle: end the
+        // worker cleanly instead of blocking in a read that a socket
+        // shutdown cannot interrupt on Windows (#1538).
+        return Ok(None);
     }
     match read_stage_message(upstream, activation_width) {
         Ok(message) => Ok(Some(message)),

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4205,27 +4205,27 @@
   ],
   "crates/skippy-server/src/binary_transport/binary_messaging.rs": [
     {
-      "line": 305,
+      "line": 344,
       "macro_name": "eprintln!"
     },
     {
-      "line": 315,
+      "line": 354,
       "macro_name": "println!"
     },
     {
-      "line": 345,
+      "line": 384,
       "macro_name": "eprintln!"
     },
     {
-      "line": 365,
+      "line": 404,
       "macro_name": "eprintln!"
     },
     {
-      "line": 373,
+      "line": 412,
       "macro_name": "eprintln!"
     },
     {
-      "line": 426,
+      "line": 472,
       "macro_name": "eprintln!"
     }
   ],


### PR DESCRIPTION
## Original problem

#1538: `ConnectionWorkerControl::shutdown` unblocks connection workers by calling `TcpStream::shutdown(Both)` on a tracked clone while the worker blocks in `read()`. On Windows that does not interrupt an in-flight blocking read, so binary-stage server shutdown can hang until every connected peer happens to send data or disconnect. It is also why `shutdown_tests::accept_error_still_closes_and_joins_active_connection_worker` failed deterministically on Windows once the lib tests could run there (flagged in the #1536 review as a follow-up worth tracking).

## Diagnostics

Isolated in the issue with a 40-line standalone program: on Windows, `shutdown(Both)` on a clone does not unblock a read that is already in flight (3 s timeout), while a read that starts after the shutdown returns `Ok(0)` immediately. So the only losing state is a worker parked inside a blocking read when shutdown fires, which is exactly where idle connection workers spend their lives.

## Fix

Connection workers no longer park inside an uninterruptible read. `ConnectionWorkerControl` gains `wait_for_readable`: it peeks under a short read timeout (`WORKER_SHUTDOWN_POLL`, 100 ms, matching `DOWNSTREAM_SHUTDOWN_POLL`) and rechecks the shutdown flag between attempts. The gate runs before the first-message read and before every subsequent `receive_next_message`; when shutdown is requested it returns cleanly, and the connection path already releases tracked sessions on that exit.

Design notes:

- `peek` consumes nothing, so message framing is never at risk, and the read timeout is cleared before the real `read_stage_message` call. The accepted-connection-remains-blocking invariant from `prepare_binary_stage_connection` is preserved.
- The pattern mirrors two mechanisms already in the tree: the downstream ready handshake polling in `stage_execution.rs`, and the peek-based optional client hello.
- `ConnectionWorkerControl::shutdown` itself is unchanged: socket shutdown still covers the non-Windows platforms immediately and remains correct everywhere else.
- Residual limitation, stated for honesty: a peer that stalls mid-frame during shutdown can still delay a worker inside `read_stage_message` on Windows. The gate covers the idle wait between messages, which is the state the failing test exercises and where workers actually park. Frame-level read deadlines would be the follow-up if that ever bites in practice.

The two shutdown tests now model the worker contract (wait through the gate, then read) instead of a raw blocked `read()`, and pass on Windows where one of them previously failed deterministically.

## Validation

- [x] `cargo test -p skippy-server --features dynamic-native-runtime --lib -- binary_transport` on Windows 11 (MSVC): 75 tests green, 0 failed, including the two shutdown tests (one previously failing deterministically there) and the `reap_finished` tests.
- [x] `cargo fmt` applied and the console-print ratchet regenerated (line shifts only).
- [x] No protocol or ABI surface is touched.

Fixes #1538.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection shutdown handling, especially on Windows.
  * Idle connections now respond promptly to shutdown requests instead of remaining blocked while waiting for incoming data.
  * Enhanced connection readiness checks for more reliable binary communication and testing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->