### PR TITLE
fix(system): apply the CPU-only runtime budget on Windows

### DIFF
--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -187,7 +187,15 @@ fn read_system_ram_bytes() -> u64 {
     .unwrap_or(0)
 }
 
-#[cfg(all(target_os = "linux", any(feature = "skippy-devices", test)))]
+#[cfg(target_os = "windows")]
+fn read_system_ram_bytes() -> u64 {
+    read_windows_total_ram_bytes().unwrap_or(0)
+}
+
+#[cfg(all(
+    any(target_os = "linux", target_os = "windows"),
+    any(feature = "skippy-devices", test)
+))]
 fn apply_cpu_only_runtime_budget(survey: &mut HardwareSurvey, metrics: &[Metric], system_ram: u64) {
     if metrics.contains(&Metric::VramBytes) && system_ram > 0 {
         survey.vram_bytes = (system_ram as f64 * 0.75) as u64;
@@ -305,13 +313,13 @@ fn apply_skippy_backend_devices_to_survey(survey: &mut HardwareSurvey, metrics: 
     let gpus = match skippy_devices::gpu_facts() {
         Ok(gpus) => gpus,
         Err(_) => {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
             apply_cpu_only_runtime_budget(survey, metrics, read_system_ram_bytes());
             return true;
         }
     };
     if gpus.is_empty() {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         apply_cpu_only_runtime_budget(survey, metrics, read_system_ram_bytes());
         return true;
     }

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -196,8 +196,16 @@ fn read_system_ram_bytes() -> u64 {
     any(target_os = "linux", target_os = "windows"),
     any(feature = "skippy-devices", test)
 ))]
-fn apply_cpu_only_runtime_budget(survey: &mut HardwareSurvey, metrics: &[Metric], system_ram: u64) {
-    if metrics.contains(&Metric::VramBytes) && system_ram > 0 {
+fn apply_cpu_only_runtime_budget(
+    survey: &mut HardwareSurvey,
+    metrics: &[Metric],
+    system_ram: impl FnOnce() -> u64,
+) {
+    if !metrics.contains(&Metric::VramBytes) {
+        return;
+    }
+    let system_ram = system_ram();
+    if system_ram > 0 {
         survey.vram_bytes = (system_ram as f64 * 0.75) as u64;
     }
 }
@@ -314,7 +322,7 @@ fn apply_skippy_backend_devices_to_survey(survey: &mut HardwareSurvey, metrics: 
         survey,
         metrics,
         skippy_devices::gpu_facts(),
-        cpu_only_budget_system_ram(),
+        cpu_only_budget_system_ram,
     )
 }
 
@@ -333,12 +341,14 @@ fn cpu_only_budget_system_ram() -> u64 {
 /// Applies a GPU probe outcome to the survey. The real probe (skippy device
 /// enumeration, /proc/meminfo, the Windows CIM query) stays in the callers so
 /// this decision can be exercised with injected values on every platform.
+/// The system RAM closure runs only on the CPU-only fallback branches, and
+/// only when VramBytes is requested, so a healthy GPU probe never pays for it.
 #[cfg(any(feature = "skippy-devices", test))]
 fn apply_gpu_probe_outcome_to_survey<E>(
     survey: &mut HardwareSurvey,
     metrics: &[Metric],
     probe: Result<Vec<GpuFacts>, E>,
-    cpu_only_system_ram: u64,
+    cpu_only_system_ram: impl FnOnce() -> u64,
 ) -> bool {
     let gpus = match probe {
         Ok(gpus) => gpus,

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -310,17 +310,47 @@ fn apply_skippy_backend_devices_to_survey(survey: &mut HardwareSurvey, metrics: 
         return false;
     }
 
-    let gpus = match skippy_devices::gpu_facts() {
+    apply_gpu_probe_outcome_to_survey(
+        survey,
+        metrics,
+        skippy_devices::gpu_facts(),
+        cpu_only_budget_system_ram(),
+    )
+}
+
+#[cfg(any(feature = "skippy-devices", test))]
+fn cpu_only_budget_system_ram() -> u64 {
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    {
+        read_system_ram_bytes()
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    {
+        0
+    }
+}
+
+/// Applies a GPU probe outcome to the survey. The real probe (skippy device
+/// enumeration, /proc/meminfo, the Windows CIM query) stays in the callers so
+/// this decision can be exercised with injected values on every platform.
+#[cfg(any(feature = "skippy-devices", test))]
+fn apply_gpu_probe_outcome_to_survey<E>(
+    survey: &mut HardwareSurvey,
+    metrics: &[Metric],
+    probe: Result<Vec<GpuFacts>, E>,
+    cpu_only_system_ram: u64,
+) -> bool {
+    let gpus = match probe {
         Ok(gpus) => gpus,
         Err(_) => {
             #[cfg(any(target_os = "linux", target_os = "windows"))]
-            apply_cpu_only_runtime_budget(survey, metrics, read_system_ram_bytes());
+            apply_cpu_only_runtime_budget(survey, metrics, cpu_only_system_ram);
             return true;
         }
     };
     if gpus.is_empty() {
         #[cfg(any(target_os = "linux", target_os = "windows"))]
-        apply_cpu_only_runtime_budget(survey, metrics, read_system_ram_bytes());
+        apply_cpu_only_runtime_budget(survey, metrics, cpu_only_system_ram);
         return true;
     }
 

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -663,6 +663,80 @@ fn test_cpu_only_runtime_budget_respects_requested_metrics() {
     assert_eq!(survey.vram_bytes, 0);
 }
 
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[test]
+fn test_probe_error_applies_cpu_only_budget_only_when_vram_requested() {
+    let mut survey = HardwareSurvey::default();
+    let handled = apply_gpu_probe_outcome_to_survey(
+        &mut survey,
+        &[Metric::VramBytes],
+        Err::<Vec<GpuFacts>, ()>(()),
+        16_000_000_000,
+    );
+    assert!(handled);
+    assert_eq!(survey.vram_bytes, 12_000_000_000);
+    assert!(survey.gpu_vram.is_empty());
+    assert!(survey.gpus.is_empty());
+
+    let mut survey = HardwareSurvey::default();
+    let handled = apply_gpu_probe_outcome_to_survey(
+        &mut survey,
+        &[Metric::GpuName],
+        Err::<Vec<GpuFacts>, ()>(()),
+        16_000_000_000,
+    );
+    assert!(handled);
+    assert_eq!(survey.vram_bytes, 0);
+}
+
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[test]
+fn test_empty_gpu_probe_applies_cpu_only_budget_only_when_vram_requested() {
+    let mut survey = HardwareSurvey::default();
+    let handled = apply_gpu_probe_outcome_to_survey(
+        &mut survey,
+        &[Metric::VramBytes],
+        Ok::<Vec<GpuFacts>, ()>(Vec::new()),
+        16_000_000_000,
+    );
+    assert!(handled);
+    assert_eq!(survey.vram_bytes, 12_000_000_000);
+    assert!(survey.gpu_vram.is_empty());
+    assert!(survey.gpus.is_empty());
+
+    let mut survey = HardwareSurvey::default();
+    let handled = apply_gpu_probe_outcome_to_survey(
+        &mut survey,
+        &[Metric::GpuName],
+        Ok::<Vec<GpuFacts>, ()>(Vec::new()),
+        16_000_000_000,
+    );
+    assert!(handled);
+    assert_eq!(survey.vram_bytes, 0);
+}
+
+#[cfg(target_os = "macos")]
+#[test]
+fn test_probe_fallback_leaves_vram_untouched_on_macos() {
+    let mut survey = HardwareSurvey::default();
+    assert!(apply_gpu_probe_outcome_to_survey(
+        &mut survey,
+        &[Metric::VramBytes],
+        Err::<Vec<GpuFacts>, ()>(()),
+        16_000_000_000,
+    ));
+    assert_eq!(survey.vram_bytes, 0);
+
+    let mut survey = HardwareSurvey::default();
+    assert!(apply_gpu_probe_outcome_to_survey(
+        &mut survey,
+        &[Metric::VramBytes],
+        Ok::<Vec<GpuFacts>, ()>(Vec::new()),
+        16_000_000_000,
+    ));
+    assert_eq!(survey.vram_bytes, 0);
+}
+
 #[cfg(all(target_os = "linux", feature = "skippy-devices"))]
 #[test]
 fn test_skippy_backend_error_uses_cpu_only_budget_without_legacy_fallback() {

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -641,7 +641,7 @@ fn test_hardware_survey_default() {
     assert!(s.gpus.is_empty());
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 #[test]
 fn test_cpu_only_runtime_budget_uses_system_ram_when_vram_requested() {
     let mut survey = HardwareSurvey::default();
@@ -653,7 +653,7 @@ fn test_cpu_only_runtime_budget_uses_system_ram_when_vram_requested() {
     assert!(survey.gpus.is_empty());
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 #[test]
 fn test_cpu_only_runtime_budget_respects_requested_metrics() {
     let mut survey = HardwareSurvey::default();

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -646,7 +646,7 @@ fn test_hardware_survey_default() {
 fn test_cpu_only_runtime_budget_uses_system_ram_when_vram_requested() {
     let mut survey = HardwareSurvey::default();
 
-    apply_cpu_only_runtime_budget(&mut survey, &[Metric::VramBytes], 16_000_000_000);
+    apply_cpu_only_runtime_budget(&mut survey, &[Metric::VramBytes], || 16_000_000_000);
 
     assert_eq!(survey.vram_bytes, 12_000_000_000);
     assert!(survey.gpu_vram.is_empty());
@@ -658,7 +658,9 @@ fn test_cpu_only_runtime_budget_uses_system_ram_when_vram_requested() {
 fn test_cpu_only_runtime_budget_respects_requested_metrics() {
     let mut survey = HardwareSurvey::default();
 
-    apply_cpu_only_runtime_budget(&mut survey, &[Metric::GpuName], 16_000_000_000);
+    apply_cpu_only_runtime_budget(&mut survey, &[Metric::GpuName], || {
+        panic!("system RAM must not be probed when VramBytes is not requested")
+    });
 
     assert_eq!(survey.vram_bytes, 0);
 }
@@ -671,7 +673,7 @@ fn test_probe_error_applies_cpu_only_budget_only_when_vram_requested() {
         &mut survey,
         &[Metric::VramBytes],
         Err::<Vec<GpuFacts>, ()>(()),
-        16_000_000_000,
+        || 16_000_000_000,
     );
     assert!(handled);
     assert_eq!(survey.vram_bytes, 12_000_000_000);
@@ -683,7 +685,7 @@ fn test_probe_error_applies_cpu_only_budget_only_when_vram_requested() {
         &mut survey,
         &[Metric::GpuName],
         Err::<Vec<GpuFacts>, ()>(()),
-        16_000_000_000,
+        || 16_000_000_000,
     );
     assert!(handled);
     assert_eq!(survey.vram_bytes, 0);
@@ -697,7 +699,7 @@ fn test_empty_gpu_probe_applies_cpu_only_budget_only_when_vram_requested() {
         &mut survey,
         &[Metric::VramBytes],
         Ok::<Vec<GpuFacts>, ()>(Vec::new()),
-        16_000_000_000,
+        || 16_000_000_000,
     );
     assert!(handled);
     assert_eq!(survey.vram_bytes, 12_000_000_000);
@@ -709,7 +711,7 @@ fn test_empty_gpu_probe_applies_cpu_only_budget_only_when_vram_requested() {
         &mut survey,
         &[Metric::GpuName],
         Ok::<Vec<GpuFacts>, ()>(Vec::new()),
-        16_000_000_000,
+        || 16_000_000_000,
     );
     assert!(handled);
     assert_eq!(survey.vram_bytes, 0);
@@ -723,7 +725,7 @@ fn test_probe_fallback_leaves_vram_untouched_on_macos() {
         &mut survey,
         &[Metric::VramBytes],
         Err::<Vec<GpuFacts>, ()>(()),
-        16_000_000_000,
+        || 16_000_000_000,
     ));
     assert_eq!(survey.vram_bytes, 0);
 
@@ -732,7 +734,7 @@ fn test_probe_fallback_leaves_vram_untouched_on_macos() {
         &mut survey,
         &[Metric::VramBytes],
         Ok::<Vec<GpuFacts>, ()>(Vec::new()),
-        16_000_000_000,
+        || 16_000_000_000,
     ));
     assert_eq!(survey.vram_bytes, 0);
 }


### PR DESCRIPTION
Fixes #1566

On Windows, a node without a usable GPU advertises `vram_bytes = 0` and the split planner excludes it forever as `missing_vram`. The 75% system RAM fallback for GPU-less nodes (`apply_cpu_only_runtime_budget`) was compiled for Linux only, and `--max-vram` cannot compensate because it is a ceiling over the detected value.

Changes, all in `mesh-llm-system`:

- add a Windows `read_system_ram_bytes()` that reuses the existing `read_windows_total_ram_bytes()` helper (same `Win32_ComputerSystem` query the video controller probe already relies on)
- widen `apply_cpu_only_runtime_budget` and its two call sites in `apply_skippy_backend_devices_to_survey` to `any(target_os = "linux", target_os = "windows")`
- widen the two budget unit tests the same way; they were compile-skipped on Windows and pass now

Deliberately out of scope: macOS (Metal makes the CPU-only branch unreachable in practice) and the RAM-offload estimate for GPU nodes (`system_ram` is still 0 off Linux in the non-SoC path; that changes advertised capacity for GPU nodes and deserves its own discussion).

Validation on real hardware:

- `cargo test --locked -p mesh-llm-system --features dynamic-native-runtime` on Windows 11: 178 passed, including the two budget tests that never ran on Windows before
- backported the patch onto v0.76.0-rc8 and ran both binaries on the same Windows desktop (33.5 GB RAM) with the GPU hidden (`CUDA_VISIBLE_DEVICES=-1`): stock rc8 fails startup with "local model requires 5.53 GB but this process has 0.00 GB", the patched build passes the gate with a 25 GB budget and opens the same model on CPU
- the real-world repro is in #1566: a GPU-less Windows laptop excluded from a two-node split with `missing_vram=1` blockers

`cargo fmt` and `repo-consistency no-console-print` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added CPU-only runtime budget support for Windows.
  - Windows now detects total physical memory when GPU information is unavailable.

- **Bug Fixes**
  - CPU-only fallback behavior now works consistently across Linux and Windows.
  - System memory is checked only when video memory is requested and GPU detection fails.
  - Avoided unnecessary synchronous memory checks when GPU information is available.
  - Improved handling of GPU probe errors, empty results, and requested memory metrics across supported platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->