### PR TITLE
fix(skippy): harden KV cache ownership and runtime bounds

### DIFF
--- a/crates/skippy-cache/src/payload/blob_store.rs
+++ b/crates/skippy-cache/src/payload/blob_store.rs
@@ -1,5 +1,7 @@
 use std::{collections::HashMap, sync::Arc, time::Instant};
 
+use anyhow::{Result, bail};
+
 use super::CacheBytes;
 use super::bytes::{CacheBlockRef, CacheBytesRepr};
 
@@ -37,8 +39,31 @@ impl CacheBlobStore {
         let len = bytes.len;
         let bytes = match bytes.repr {
             CacheBytesRepr::Inline(bytes) => bytes,
-            repr @ CacheBytesRepr::Blocks(_) => {
-                return (CacheBytes { len, repr }, CacheDedupeStats::default());
+            CacheBytesRepr::Blocks(blocks) => {
+                let mut stats = CacheDedupeStats::default();
+                for block in blocks.iter() {
+                    stats.block_count = stats.block_count.saturating_add(1);
+                    let entry = self.blocks.entry(block.hash.clone()).or_insert_with(|| {
+                        self.physical_bytes =
+                            self.physical_bytes.saturating_add(block.bytes.len() as u64);
+                        stats.new_block_count = stats.new_block_count.saturating_add(1);
+                        CacheBlob {
+                            bytes: block.bytes.clone(),
+                            ref_count: 0,
+                        }
+                    });
+                    if entry.ref_count > 0 {
+                        stats.reused_block_count = stats.reused_block_count.saturating_add(1);
+                    }
+                    entry.ref_count = entry.ref_count.saturating_add(1);
+                }
+                return (
+                    CacheBytes {
+                        len,
+                        repr: CacheBytesRepr::Blocks(blocks),
+                    },
+                    stats,
+                );
             }
         };
         let mut blocks = Vec::new();
@@ -68,22 +93,55 @@ impl CacheBlobStore {
         (CacheBytes::blocks(bytes.len() as u64, blocks), stats)
     }
 
-    pub fn release_bytes(&mut self, bytes: &CacheBytes) {
-        let hashes = bytes.block_hashes().map(str::to_string).collect::<Vec<_>>();
-        for hash in hashes {
-            let mut remove = false;
-            if let Some(entry) = self.blocks.get_mut(&hash) {
-                entry.ref_count = entry.ref_count.saturating_sub(1);
-                if entry.ref_count == 0 {
-                    self.physical_bytes =
-                        self.physical_bytes.saturating_sub(entry.bytes.len() as u64);
-                    remove = true;
-                }
+    pub fn release_bytes(&mut self, bytes: &CacheBytes) -> Result<()> {
+        self.release_bytes_batch(&[bytes])
+    }
+
+    pub(crate) fn release_bytes_batch(&mut self, payloads: &[&CacheBytes]) -> Result<()> {
+        let mut releases = HashMap::<String, u64>::new();
+        for bytes in payloads {
+            for hash in bytes.block_hashes() {
+                let count = releases.entry(hash.to_string()).or_default();
+                *count = count
+                    .checked_add(1)
+                    .ok_or_else(|| anyhow::anyhow!("cache blob release count overflow"))?;
             }
-            if remove {
+        }
+        let mut physical_bytes_to_remove = 0u64;
+        for (hash, count) in &releases {
+            let Some(entry) = self.blocks.get(hash) else {
+                bail!("cache blob release references missing block {hash}");
+            };
+            if entry.ref_count < *count {
+                bail!(
+                    "cache blob release underflow for block {hash}: refs={} releases={count}",
+                    entry.ref_count
+                );
+            }
+            if entry.ref_count == *count {
+                physical_bytes_to_remove = physical_bytes_to_remove
+                    .checked_add(entry.bytes.len() as u64)
+                    .ok_or_else(|| anyhow::anyhow!("cache blob physical byte count overflow"))?;
+            }
+        }
+        if physical_bytes_to_remove > self.physical_bytes {
+            bail!(
+                "cache blob physical byte accounting underflow: bytes={} releases={physical_bytes_to_remove}",
+                self.physical_bytes
+            );
+        }
+        for (hash, count) in releases {
+            let entry = self
+                .blocks
+                .get_mut(&hash)
+                .expect("release prevalidation guarantees block presence");
+            entry.ref_count -= count;
+            if entry.ref_count == 0 {
                 self.blocks.remove(&hash);
             }
         }
+        self.physical_bytes -= physical_bytes_to_remove;
+        Ok(())
     }
 
     pub fn physical_bytes(&self) -> u64 {
@@ -92,6 +150,13 @@ impl CacheBlobStore {
 
     pub fn block_count(&self) -> usize {
         self.blocks.len()
+    }
+
+    pub fn logical_ref_count(&self) -> u64 {
+        self.blocks
+            .values()
+            .map(|block| block.ref_count)
+            .fold(0, u64::saturating_add)
     }
 }
 
@@ -136,5 +201,79 @@ mod tests {
         assert_eq!(second_stats.reused_block_count, 1);
         assert_eq!(blobs.physical_bytes(), 12);
         assert_eq!(second.byte_len(), 8);
+    }
+
+    #[test]
+    fn rededuping_block_payload_retains_a_logical_owner() {
+        let mut blobs = CacheBlobStore::new(4);
+        let original = ExactStatePayload::full_state(b"aaaabbbb".to_vec());
+        let (first_owner, _) = original.dedupe_into(&mut blobs);
+        let (second_owner, stats) = first_owner.clone().dedupe_into(&mut blobs);
+
+        assert_eq!(stats.reused_block_count, 2);
+        assert_eq!(blobs.physical_bytes(), 8);
+        first_owner.release_from(&mut blobs).unwrap();
+        assert_eq!(blobs.physical_bytes(), 8);
+        assert_eq!(
+            second_owner.full_state_bytes_timed().unwrap().0.as_ref(),
+            b"aaaabbbb"
+        );
+        second_owner.release_from(&mut blobs).unwrap();
+        assert_eq!(blobs.physical_bytes(), 0);
+    }
+
+    #[test]
+    fn duplicate_release_is_reported_without_accounting_drift() {
+        let mut blobs = CacheBlobStore::new(4);
+        let (payload, _) =
+            ExactStatePayload::full_state(b"aaaabbbb".to_vec()).dedupe_into(&mut blobs);
+
+        payload.release_from(&mut blobs).unwrap();
+        let error = payload.release_from(&mut blobs).unwrap_err();
+
+        assert!(error.to_string().contains("missing block"));
+        assert_eq!(blobs.physical_bytes(), 0);
+        assert_eq!(blobs.block_count(), 0);
+    }
+
+    #[test]
+    fn composite_release_prevalidates_every_component() {
+        let mut blobs = CacheBlobStore::new(4);
+        let (payload, _) =
+            ExactStatePayload::kv_recurrent(b"aaaabbbb".to_vec(), b"ccccdddd".to_vec())
+                .dedupe_into(&mut blobs);
+        let ExactStatePayload::KvRecurrent { recurrent, .. } = &payload else {
+            panic!("expected composite payload");
+        };
+
+        blobs.release_bytes(recurrent).unwrap();
+        let physical_before = blobs.physical_bytes();
+        let refs_before = blobs.logical_ref_count();
+
+        let error = payload.release_from(&mut blobs).unwrap_err();
+
+        assert!(error.to_string().contains("missing block"));
+        assert_eq!(blobs.physical_bytes(), physical_before);
+        assert_eq!(blobs.logical_ref_count(), refs_before);
+        assert_eq!(blobs.block_count(), 2);
+    }
+
+    #[test]
+    fn physical_accounting_underflow_does_not_mutate_references() {
+        let mut blobs = CacheBlobStore::new(4);
+        let (payload, _) =
+            ExactStatePayload::full_state(b"aaaabbbb".to_vec()).dedupe_into(&mut blobs);
+        let refs_before = blobs.logical_ref_count();
+        blobs.physical_bytes = 0;
+
+        let error = payload.release_from(&mut blobs).unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("physical byte accounting underflow")
+        );
+        assert_eq!(blobs.logical_ref_count(), refs_before);
+        assert_eq!(blobs.block_count(), 2);
     }
 }

--- a/crates/skippy-cache/src/payload/mod.rs
+++ b/crates/skippy-cache/src/payload/mod.rs
@@ -127,14 +127,11 @@ impl ExactStatePayload {
         }
     }
 
-    pub fn release_from(&self, blobs: &mut CacheBlobStore) {
+    pub fn release_from(&self, blobs: &mut CacheBlobStore) -> Result<()> {
         match self {
             Self::FullState { bytes } => blobs.release_bytes(bytes),
             Self::RecurrentOnly { recurrent } => blobs.release_bytes(recurrent),
-            Self::KvRecurrent { kv, recurrent } => {
-                blobs.release_bytes(kv);
-                blobs.release_bytes(recurrent);
-            }
+            Self::KvRecurrent { kv, recurrent } => blobs.release_bytes_batch(&[kv, recurrent]),
         }
     }
 }

--- a/crates/skippy-cache/src/radix.rs
+++ b/crates/skippy-cache/src/radix.rs
@@ -218,9 +218,19 @@ impl<R, E> UnifiedRadixCache<R, E> {
         value: E,
     ) -> Result<Option<E>> {
         validate_tokens(tokens)?;
+        let namespace = namespace.into();
+        if self
+            .roots
+            .get(&namespace)
+            .and_then(|root| node_at(root, tokens))
+            .and_then(|node| node.components.recurrent.as_ref())
+            .is_some_and(|entry| entry.active_refs > 0)
+        {
+            bail!("cannot replace an active recurrent radix entry");
+        }
         self.clock = self.clock.saturating_add(1);
         let last_used = self.clock;
-        let node = self.ensure_node(namespace.into(), tokens);
+        let node = self.ensure_node(namespace, tokens);
         Ok(node
             .components
             .recurrent
@@ -1440,6 +1450,28 @@ mod tests {
             cache.remove_recurrent_if("stage", &[1, 2], |value| *value == "payload-b"),
             Some("payload-b")
         );
+    }
+
+    #[test]
+    fn recurrent_insert_cannot_replace_an_active_restore_source() {
+        let mut cache = UnifiedRadixCache::<(), &str>::new();
+        cache
+            .insert_recurrent("stage", &[1, 2], 2, "original")
+            .unwrap();
+        cache.acquire_recurrent("stage", &[1, 2]).unwrap();
+
+        assert_eq!(
+            cache
+                .insert_recurrent("stage", &[1, 2], 2, "replacement")
+                .unwrap_err()
+                .to_string(),
+            "cannot replace an active recurrent radix entry"
+        );
+        assert_eq!(
+            cache.lookup_recurrent("stage", &[1, 2]).unwrap().value,
+            "original"
+        );
+        assert!(cache.release_recurrent("stage", &[1, 2]));
     }
 
     #[test]

--- a/crates/skippy-server/src/frontend/iteration_scheduler.rs
+++ b/crates/skippy-server/src/frontend/iteration_scheduler.rs
@@ -132,8 +132,33 @@ struct DirectIteration {
     input: Option<ActivationFrame>,
     sample_last: bool,
     phase: IterationBatchPhase,
+    deadline: Option<Instant>,
+    cancellation: Option<openai_frontend::CancellationToken>,
     enqueued_at: Instant,
     reply: std_mpsc::SyncSender<OpenAiResult<SchedulerIterationOutcome>>,
+}
+
+impl DirectIteration {
+    fn ensure_active(&self) -> OpenAiResult<()> {
+        ensure_direct_iteration_active(self.deadline, self.cancellation.as_ref())
+    }
+}
+
+fn ensure_direct_iteration_active(
+    deadline: Option<Instant>,
+    cancellation: Option<&openai_frontend::CancellationToken>,
+) -> OpenAiResult<()> {
+    if cancellation.is_some_and(openai_frontend::CancellationToken::is_cancelled) {
+        return Err(OpenAiError::cancelled(
+            "request cancelled during scheduler iteration",
+        ));
+    }
+    if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+        return Err(OpenAiError::backend(
+            "cache operation deadline exceeded during scheduler iteration",
+        ));
+    }
+    Ok(())
 }
 
 type RuntimeOperationFn = Box<dyn FnOnce(&Arc<Mutex<RuntimeState>>) + Send>;
@@ -592,6 +617,8 @@ impl IterationScheduler {
             sampling,
             sample_last,
             phase,
+            None,
+            None,
         )
     }
 
@@ -605,6 +632,8 @@ impl IterationScheduler {
         sampling: Option<&SamplingConfig>,
         sample_last: bool,
         phase: IterationBatchPhase,
+        deadline: Option<Instant>,
+        cancellation: Option<&openai_frontend::CancellationToken>,
     ) -> OpenAiResult<SchedulerIterationOutcome> {
         self.execute_direct_iteration(
             channel,
@@ -616,6 +645,8 @@ impl IterationScheduler {
             None,
             sample_last,
             phase,
+            deadline,
+            cancellation,
         )
     }
 
@@ -641,6 +672,8 @@ impl IterationScheduler {
             input,
             sample_last,
             IterationBatchPhase::Decode,
+            None,
+            None,
         )
     }
 
@@ -656,8 +689,11 @@ impl IterationScheduler {
         input: Option<ActivationFrame>,
         sample_last: bool,
         phase: IterationBatchPhase,
+        deadline: Option<Instant>,
+        cancellation: Option<&openai_frontend::CancellationToken>,
     ) -> OpenAiResult<SchedulerIterationOutcome> {
         validate_direct_iteration(token_ids, positions)?;
+        ensure_direct_iteration_active(deadline, cancellation)?;
         self.enqueue_command(SchedulerCommand::ExecuteIteration(DirectIteration {
             session_id: session_id.to_string(),
             target_token_count,
@@ -667,12 +703,16 @@ impl IterationScheduler {
             input,
             sample_last,
             phase,
+            deadline,
+            cancellation: cancellation.cloned(),
             enqueued_at: Instant::now(),
             reply: channel.reply.clone(),
         }))?;
-        channel.result.recv().map_err(|error| {
+        let result = channel.result.recv().map_err(|error| {
             OpenAiError::backend(format!("iteration scheduler stopped: {error}"))
-        })?
+        })?;
+        ensure_direct_iteration_active(deadline, cancellation)?;
+        result
     }
 
     /// Runs an operation on the scheduler worker so speculative verification,
@@ -1263,11 +1303,24 @@ impl SchedulerWorker {
         );
         debug_assert!(!batch.is_empty(), "validated direct queue must yield work");
 
+        let mut active = Vec::with_capacity(batch.len());
+        for request in batch {
+            match request.ensure_active() {
+                Ok(()) => active.push(request),
+                Err(error) => {
+                    let _ = request.reply.send(Err(error));
+                }
+            }
+        }
+        if active.is_empty() {
+            return;
+        }
+
         let lock_started = Instant::now();
         let mut runtime = match self.runtime.lock() {
             Ok(runtime) => runtime,
             Err(_) => {
-                for request in batch {
+                for request in active {
                     let _ = request
                         .reply
                         .send(Err(OpenAiError::backend("runtime lock poisoned")));
@@ -1277,8 +1330,12 @@ impl SchedulerWorker {
         };
         let runtime_lock_wait_ms = lock_started.elapsed().as_secs_f64() * 1_000.0;
         let hold_started = Instant::now();
-        let mut runnable = Vec::with_capacity(batch.len());
-        for request in batch {
+        let mut runnable = Vec::with_capacity(active.len());
+        for request in active {
+            if let Err(error) = request.ensure_active() {
+                let _ = request.reply.send(Err(error));
+                continue;
+            }
             let alignment = match request.target_token_count {
                 Some(target_token_count) => runtime
                     .align_session_to_token_count_if_ahead(&request.session_id, target_token_count),
@@ -1846,9 +1903,128 @@ mod tests {
             input: None,
             sample_last: true,
             phase: IterationBatchPhase::Prefill,
+            deadline: None,
+            cancellation: None,
             enqueued_at: Instant::now(),
             reply,
         }
+    }
+
+    #[test]
+    fn expired_direct_iteration_behind_blocked_worker_never_reaches_native_runtime() {
+        let runtime = Arc::new(Mutex::new(RuntimeState::new_modelless_for_test(1)));
+        let (commands, receiver) = std_mpsc::sync_channel(8);
+        let worker = thread::spawn(move || {
+            SchedulerWorker {
+                runtime,
+                scheduler: Scheduler::new(build_scheduler_config(1, 64, 0, Some(8), Some(8), 8)),
+                requests: BTreeMap::new(),
+                direct_iterations: VecDeque::new(),
+                cache_runtime_queue: CacheRuntimeQueue::new(CACHE_AGING_COST_PER_TURN, true),
+                commands: receiver,
+                kv_capacity_tokens: 64,
+                max_direct_batch_size: 1,
+                max_commands_per_turn: 8,
+                iteration_interval: Duration::ZERO,
+                active_runtime_sessions: 0,
+                direct_wave_full: false,
+                telemetry: None,
+                last_served_direct: false,
+                last_served_cache_runtime: false,
+                last_emitted_lifecycle_counters: (0, 0, 0, 0),
+            }
+            .run();
+        });
+        let (worker_blocked, worker_blocked_rx) = std_mpsc::sync_channel(0);
+        let (release_worker, release_worker_rx) = std_mpsc::sync_channel(0);
+        commands
+            .send(SchedulerCommand::ExecuteRuntime(RuntimeOperation {
+                label: "deadline-test-gate",
+                control: None,
+                run: Box::new(move |_| {
+                    worker_blocked.send(()).unwrap();
+                    release_worker_rx.recv().unwrap();
+                }),
+            }))
+            .unwrap();
+        worker_blocked_rx.recv().unwrap();
+
+        let deadline = Instant::now() + Duration::from_millis(10);
+        let (reply, result) = std_mpsc::sync_channel(1);
+        let mut request = direct_iteration("expired-deferred-suffix", 1);
+        request.deadline = Some(deadline);
+        request.reply = reply;
+        commands
+            .send(SchedulerCommand::ExecuteIteration(request))
+            .unwrap();
+        thread::sleep(
+            deadline
+                .saturating_duration_since(Instant::now())
+                .saturating_add(Duration::from_millis(1)),
+        );
+        release_worker.send(()).unwrap();
+
+        let error = result
+            .recv_timeout(Duration::from_secs(1))
+            .expect("blocked direct iteration returned")
+            .unwrap_err();
+        assert!(error.to_string().contains("deadline exceeded"));
+        commands.send(SchedulerCommand::Shutdown).unwrap();
+        worker.join().unwrap();
+    }
+
+    #[test]
+    fn direct_iteration_rechecks_deadline_after_worker_reply() {
+        let (commands, receiver) = std_mpsc::sync_channel(1);
+        let scheduler = IterationScheduler {
+            shared: Arc::new(IterationSchedulerShared {
+                commands,
+                owner_count: AtomicUsize::new(1),
+                worker: Mutex::new(None),
+            }),
+        };
+        let deadline = Instant::now() + Duration::from_millis(10);
+        let caller = thread::spawn(move || {
+            let channel = scheduler.direct_iteration_channel();
+            scheduler.execute_iteration_on(
+                &channel,
+                "late-worker-reply",
+                &[1],
+                &[],
+                None,
+                false,
+                IterationBatchPhase::Prefill,
+                Some(deadline),
+                None,
+            )
+        });
+
+        let SchedulerCommand::ExecuteIteration(request) = receiver.recv().unwrap() else {
+            panic!("expected direct iteration command");
+        };
+        thread::sleep(
+            deadline
+                .saturating_duration_since(Instant::now())
+                .saturating_add(Duration::from_millis(1)),
+        );
+        request
+            .reply
+            .send(Err(OpenAiError::backend("late worker result")))
+            .unwrap();
+
+        let error = caller.join().unwrap().unwrap_err();
+        assert!(error.to_string().contains("deadline exceeded"));
+    }
+
+    #[test]
+    fn queued_direct_iteration_carries_cancellation_state() {
+        let cancellation = openai_frontend::CancellationToken::new();
+        let mut request = direct_iteration("cancelled-deferred-suffix", 1);
+        request.cancellation = Some(cancellation.clone());
+        cancellation.cancel();
+
+        let error = request.ensure_active().unwrap_err();
+        assert!(error.to_string().contains("request cancelled"));
     }
 
     #[test]

--- a/crates/skippy-server/src/frontend/iteration_scheduler.rs
+++ b/crates/skippy-server/src/frontend/iteration_scheduler.rs
@@ -29,7 +29,7 @@ use std::collections::{BTreeMap, BTreeSet, VecDeque};
 use std::env;
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU8, AtomicUsize, Ordering};
 use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread::{self, JoinHandle};
@@ -95,6 +95,16 @@ pub(crate) struct DirectIterationChannel {
     result: std_mpsc::Receiver<OpenAiResult<SchedulerIterationOutcome>>,
 }
 
+pub(crate) struct CacheAwareRuntimeRequest<'a> {
+    pub(crate) operation_id: String,
+    pub(crate) deadline: Instant,
+    pub(crate) cancellation: Option<&'a openai_frontend::CancellationToken>,
+    pub(crate) prompt_tokens: Arc<[i32]>,
+    pub(crate) priority: u64,
+    pub(crate) payload: StagePrefixCachePayload,
+    pub(crate) refresh_affinity: CacheAffinityRefresh,
+}
+
 struct IterationSchedulerShared {
     commands: std_mpsc::SyncSender<SchedulerCommand>,
     owner_count: AtomicUsize,
@@ -131,7 +141,71 @@ type RuntimeSetupOutcome = (Vec<String>, Vec<(String, OpenAiError)>);
 
 struct RuntimeOperation {
     label: &'static str,
+    control: Option<CacheRuntimeContext>,
     run: RuntimeOperationFn,
+}
+
+const CACHE_OPERATION_ACTIVE: u8 = 0;
+const CACHE_OPERATION_CANCELLED: u8 = 1;
+const CACHE_OPERATION_DEADLINE_EXCEEDED: u8 = 2;
+
+#[derive(Clone)]
+pub(crate) struct CacheRuntimeContext {
+    operation_id: String,
+    deadline: Instant,
+    cancellation: Option<openai_frontend::CancellationToken>,
+    state: Arc<AtomicU8>,
+}
+
+impl CacheRuntimeContext {
+    fn new(
+        operation_id: String,
+        deadline: Instant,
+        cancellation: Option<&openai_frontend::CancellationToken>,
+    ) -> Self {
+        Self {
+            operation_id,
+            deadline,
+            cancellation: cancellation.cloned(),
+            state: Arc::new(AtomicU8::new(CACHE_OPERATION_ACTIVE)),
+        }
+    }
+
+    pub(crate) fn ensure_active(&self) -> OpenAiResult<()> {
+        if self
+            .cancellation
+            .as_ref()
+            .is_some_and(openai_frontend::CancellationToken::is_cancelled)
+        {
+            self.cancel(CACHE_OPERATION_CANCELLED);
+        } else if Instant::now() >= self.deadline {
+            self.cancel(CACHE_OPERATION_DEADLINE_EXCEEDED);
+        }
+        match self.state.load(Ordering::Acquire) {
+            CACHE_OPERATION_ACTIVE => Ok(()),
+            CACHE_OPERATION_CANCELLED => Err(OpenAiError::cancelled(format!(
+                "cache runtime operation {} was cancelled",
+                self.operation_id
+            ))),
+            CACHE_OPERATION_DEADLINE_EXCEEDED => Err(OpenAiError::backend(format!(
+                "cache runtime operation {} exceeded its deadline",
+                self.operation_id
+            ))),
+            _ => Err(OpenAiError::backend(format!(
+                "cache runtime operation {} entered an invalid state",
+                self.operation_id
+            ))),
+        }
+    }
+
+    fn cancel(&self, reason: u8) {
+        let _ = self.state.compare_exchange(
+            CACHE_OPERATION_ACTIVE,
+            reason,
+            Ordering::AcqRel,
+            Ordering::Acquire,
+        );
+    }
 }
 
 fn runtime_operation<T>(
@@ -148,6 +222,7 @@ where
     let enqueued_at = Instant::now();
     let operation = RuntimeOperation {
         label,
+        control: None,
         run: Box::new(move |runtime: &Arc<Mutex<RuntimeState>>| {
             let queue_wait_ms = enqueued_at.elapsed().as_secs_f64() * 1_000.0;
             let lock_started = Instant::now();
@@ -168,6 +243,52 @@ where
         }),
     };
     (operation, result)
+}
+
+fn cache_runtime_operation<T>(
+    label: &'static str,
+    operation_id: String,
+    deadline: Instant,
+    cancellation: Option<&openai_frontend::CancellationToken>,
+    operation: impl FnOnce(&mut RuntimeState, &CacheRuntimeContext) -> OpenAiResult<T> + Send + 'static,
+) -> (
+    RuntimeOperation,
+    std_mpsc::Receiver<OpenAiResult<SchedulerRuntimeOutcome<T>>>,
+    CacheRuntimeContext,
+)
+where
+    T: Send + 'static,
+{
+    let (reply, result) = std_mpsc::sync_channel(1);
+    let enqueued_at = Instant::now();
+    let control = CacheRuntimeContext::new(operation_id, deadline, cancellation);
+    let worker_control = control.clone();
+    let runtime_operation = RuntimeOperation {
+        label,
+        control: Some(control.clone()),
+        run: Box::new(move |runtime: &Arc<Mutex<RuntimeState>>| {
+            let queue_wait_ms = enqueued_at.elapsed().as_secs_f64() * 1_000.0;
+            let lock_started = Instant::now();
+            let outcome = worker_control.ensure_active().and_then(|()| {
+                runtime
+                    .lock()
+                    .map_err(|_| OpenAiError::backend("runtime lock poisoned"))
+            });
+            let outcome = outcome.and_then(|mut runtime| {
+                worker_control.ensure_active()?;
+                let runtime_lock_wait_ms = lock_started.elapsed().as_secs_f64() * 1_000.0;
+                let hold_started = Instant::now();
+                operation(&mut runtime, &worker_control).map(|value| SchedulerRuntimeOutcome {
+                    value,
+                    queue_wait_ms,
+                    runtime_lock_wait_ms,
+                    runtime_lock_hold_ms: hold_started.elapsed().as_secs_f64() * 1_000.0,
+                })
+            });
+            let _ = reply.send(outcome);
+        }),
+    };
+    (runtime_operation, result, control)
 }
 
 enum SchedulerCommand {
@@ -589,26 +710,29 @@ impl IterationScheduler {
     pub(crate) fn execute_cache_aware_runtime_timed<T>(
         &self,
         label: &'static str,
-        prompt_tokens: Arc<[i32]>,
-        priority: u64,
-        payload: StagePrefixCachePayload,
-        refresh_affinity: CacheAffinityRefresh,
-        operation: impl FnOnce(&mut RuntimeState) -> OpenAiResult<T> + Send + 'static,
+        request: CacheAwareRuntimeRequest<'_>,
+        operation: impl FnOnce(&mut RuntimeState, &CacheRuntimeContext) -> OpenAiResult<T>
+        + Send
+        + 'static,
     ) -> OpenAiResult<SchedulerRuntimeOutcome<T>>
     where
         T: Send + 'static,
     {
-        let (runtime_operation, result) = runtime_operation(label, operation);
+        let (runtime_operation, result, control) = cache_runtime_operation(
+            label,
+            request.operation_id,
+            request.deadline,
+            request.cancellation,
+            operation,
+        );
         self.enqueue_command(SchedulerCommand::ExecuteCacheAwareRuntime(
             runtime_operation,
-            prompt_tokens,
-            priority,
-            payload,
-            refresh_affinity,
+            request.prompt_tokens,
+            request.priority,
+            request.payload,
+            request.refresh_affinity,
         ))?;
-        result.recv().map_err(|error| {
-            OpenAiError::backend(format!("iteration scheduler stopped: {error}"))
-        })?
+        wait_for_cache_runtime(result, &control)
     }
 
     fn enqueue_command(&self, command: SchedulerCommand) -> OpenAiResult<()> {
@@ -621,6 +745,26 @@ impl IterationScheduler {
                     OpenAiError::backend("iteration scheduler stopped")
                 }
             })
+    }
+}
+
+fn wait_for_cache_runtime<T>(
+    result: std_mpsc::Receiver<OpenAiResult<SchedulerRuntimeOutcome<T>>>,
+    control: &CacheRuntimeContext,
+) -> OpenAiResult<SchedulerRuntimeOutcome<T>> {
+    loop {
+        control.ensure_active()?;
+        let remaining = control
+            .deadline
+            .saturating_duration_since(Instant::now())
+            .min(CANCELLATION_POLL_INTERVAL);
+        match result.recv_timeout(remaining) {
+            Ok(outcome) => return outcome,
+            Err(std_mpsc::RecvTimeoutError::Timeout) => continue,
+            Err(std_mpsc::RecvTimeoutError::Disconnected) => {
+                return Err(OpenAiError::backend("iteration scheduler stopped"));
+            }
+        }
     }
 }
 
@@ -838,6 +982,7 @@ impl SchedulerWorker {
     ) {
         let started = Instant::now();
         let label = operation.label;
+        let cache_operation = operation.control.clone();
         (operation.run)(&self.runtime);
         if let Ok(runtime) = self.runtime.lock() {
             self.active_runtime_sessions = runtime.active_session_count();
@@ -858,6 +1003,21 @@ impl SchedulerWorker {
                     json!(started.elapsed().as_secs_f64() * 1_000.0),
                 ),
             ]);
+            if let Some(cache_operation) = cache_operation {
+                attrs.insert(
+                    "skippy.scheduler.cache_operation_id".to_string(),
+                    json!(cache_operation.operation_id),
+                );
+                attrs.insert(
+                    "skippy.scheduler.cache_operation_state".to_string(),
+                    json!(match cache_operation.state.load(Ordering::Acquire) {
+                        CACHE_OPERATION_ACTIVE => "active",
+                        CACHE_OPERATION_CANCELLED => "cancelled",
+                        CACHE_OPERATION_DEADLINE_EXCEEDED => "deadline_exceeded",
+                        _ => "invalid",
+                    }),
+                );
+            }
             if let Some(cache) = cache {
                 attrs.insert(
                     "skippy.scheduler.cache_matched_tokens".to_string(),
@@ -2017,6 +2177,96 @@ mod tests {
     }
 
     #[test]
+    fn cancelled_cache_runtime_is_rejected_before_runtime_or_user_work() {
+        let runtime = Arc::new(Mutex::new(RuntimeState::new_modelless_for_test(1)));
+        let cancellation = openai_frontend::CancellationToken::new();
+        let executions = Arc::new(AtomicUsize::new(0));
+        let worker_executions = executions.clone();
+        let (operation, result, _) = cache_runtime_operation(
+            "cancelled-cache",
+            "request-7".to_string(),
+            Instant::now() + Duration::from_secs(1),
+            Some(&cancellation),
+            move |_, _| {
+                worker_executions.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            },
+        );
+
+        cancellation.cancel();
+        (operation.run)(&runtime);
+
+        let error = result.recv().unwrap().unwrap_err();
+        assert!(error.to_string().contains("request-7 was cancelled"));
+        assert_eq!(executions.load(Ordering::Relaxed), 0);
+        assert_eq!(runtime.lock().unwrap().active_session_count(), 0);
+    }
+
+    #[test]
+    fn expired_cache_runtime_is_rejected_before_runtime_or_user_work() {
+        let runtime = Arc::new(Mutex::new(RuntimeState::new_modelless_for_test(1)));
+        let executions = Arc::new(AtomicUsize::new(0));
+        let worker_executions = executions.clone();
+        let (operation, result, _) = cache_runtime_operation(
+            "expired-cache",
+            "request-8".to_string(),
+            Instant::now(),
+            None,
+            move |_, _| {
+                worker_executions.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            },
+        );
+
+        (operation.run)(&runtime);
+
+        let error = result.recv().unwrap().unwrap_err();
+        assert!(
+            error
+                .to_string()
+                .contains("request-8 exceeded its deadline")
+        );
+        assert_eq!(executions.load(Ordering::Relaxed), 0);
+        assert_eq!(runtime.lock().unwrap().active_session_count(), 0);
+    }
+
+    #[test]
+    fn in_flight_cache_runtime_observes_cancellation_at_checkpoint() {
+        let runtime = Arc::new(Mutex::new(RuntimeState::new_modelless_for_test(1)));
+        let cancellation = openai_frontend::CancellationToken::new();
+        let executions = Arc::new(AtomicUsize::new(0));
+        let worker_executions = executions.clone();
+        let (started, started_rx) = std_mpsc::sync_channel(0);
+        let (cancelled, cancelled_rx) = std_mpsc::sync_channel(0);
+        let (operation, result, _) = cache_runtime_operation(
+            "in-flight-cancelled-cache",
+            "request-9".to_string(),
+            Instant::now() + Duration::from_secs(1),
+            Some(&cancellation),
+            move |_, control| {
+                worker_executions.fetch_add(1, Ordering::Relaxed);
+                started.send(()).unwrap();
+                cancelled_rx.recv().unwrap();
+                control.ensure_active()?;
+                worker_executions.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            },
+        );
+        let canceller = thread::spawn(move || {
+            started_rx.recv().unwrap();
+            cancellation.cancel();
+            cancelled.send(()).unwrap();
+        });
+
+        (operation.run)(&runtime);
+        canceller.join().unwrap();
+
+        let error = result.recv().unwrap().unwrap_err();
+        assert!(error.to_string().contains("request-9 was cancelled"));
+        assert_eq!(executions.load(Ordering::Relaxed), 1);
+    }
+
+    #[test]
     fn full_direct_wave_suppresses_cache_runtime_while_direct_queue_is_temporarily_empty() {
         let runtime = Arc::new(Mutex::new(RuntimeState::new_modelless_for_test(1)));
         let (_commands, receiver) = std_mpsc::channel();
@@ -2042,6 +2292,7 @@ mod tests {
         worker.cache_runtime_queue.enqueue_with_payload(
             RuntimeOperation {
                 label: "full-wave-cache",
+                control: None,
                 run: Box::new(move |_| {
                     selected.send(()).unwrap();
                 }),
@@ -2085,6 +2336,7 @@ mod tests {
         worker.cache_runtime_queue.enqueue(
             RuntimeOperation {
                 label: "resident-cache",
+                control: None,
                 run: Box::new(move |_| {
                     selected.send(()).unwrap();
                 }),
@@ -2178,6 +2430,7 @@ mod tests {
         commands
             .send(SchedulerCommand::ExecuteRuntime(RuntimeOperation {
                 label: "panic-test-gate",
+                control: None,
                 run: Box::new(move |_| {
                     worker_blocked.send(()).unwrap();
                     release_worker_rx.recv().unwrap();
@@ -2203,6 +2456,7 @@ mod tests {
         commands
             .send(SchedulerCommand::ExecuteRuntime(RuntimeOperation {
                 label: "panic-test",
+                control: None,
                 run: Box::new(|_| panic!("injected scheduler worker panic")),
             }))
             .unwrap();

--- a/crates/skippy-server/src/frontend/iteration_scheduler/cache_runtime.rs
+++ b/crates/skippy-server/src/frontend/iteration_scheduler/cache_runtime.rs
@@ -314,6 +314,7 @@ mod tests {
         let selected = selected.clone();
         RuntimeOperation {
             label,
+            control: None,
             run: Box::new(move |_| {
                 selected.send(label).unwrap();
             }),

--- a/crates/skippy-server/src/frontend/local_generation/decode_step.rs
+++ b/crates/skippy-server/src/frontend/local_generation/decode_step.rs
@@ -83,6 +83,8 @@ impl StageOpenAiBackend {
                 request.sampling.enabled.then_some(request.sampling),
                 true,
                 skippy_runtime::IterationBatchPhase::Decode,
+                None,
+                request.cancellation,
             )?;
             (
                 outcome.predicted,

--- a/crates/skippy-server/src/frontend/local_generation/resident_prefill.rs
+++ b/crates/skippy-server/src/frontend/local_generation/resident_prefill.rs
@@ -63,6 +63,8 @@ impl StageOpenAiBackend {
                 sampling,
                 should_sample,
                 IterationBatchPhase::Prefill,
+                Some(deadline),
+                cancellation,
             )?;
             chunk_count = chunk_count.saturating_add(1);
             max_batch_size = max_batch_size.max(outcome.batch_size);

--- a/crates/skippy-server/src/frontend/local_generation/resident_prefill.rs
+++ b/crates/skippy-server/src/frontend/local_generation/resident_prefill.rs
@@ -1,6 +1,7 @@
 use crate::frontend::generation::StageOpenAiBackend;
 use openai_frontend::{OpenAiError, OpenAiResult};
 use skippy_runtime::{IterationBatchPhase, SamplingConfig};
+use std::time::Instant;
 
 const MAX_NATIVE_ITERATION_TOKENS: usize = 2_048;
 
@@ -34,6 +35,8 @@ impl StageOpenAiBackend {
         suffix: &[i32],
         sampling: Option<&SamplingConfig>,
         sample_last: bool,
+        deadline: Instant,
+        cancellation: Option<&openai_frontend::CancellationToken>,
     ) -> OpenAiResult<SuffixPrefillOutcome> {
         if suffix.is_empty() {
             return Err(OpenAiError::backend(
@@ -51,6 +54,7 @@ impl StageOpenAiBackend {
         let mut runtime_lock_wait_ms = 0.0;
         let mut runtime_lock_hold_ms = 0.0;
         for (chunk, should_sample) in suffix.chunks(chunk_tokens).zip(sample_flags) {
+            ensure_suffix_prefill_active(deadline, cancellation)?;
             let outcome = self.iteration_scheduler.execute_iteration_on(
                 &channel,
                 session_id,
@@ -76,6 +80,23 @@ impl StageOpenAiBackend {
             runtime_lock_hold_ms,
         })
     }
+}
+
+fn ensure_suffix_prefill_active(
+    deadline: Instant,
+    cancellation: Option<&openai_frontend::CancellationToken>,
+) -> OpenAiResult<()> {
+    if cancellation.is_some_and(openai_frontend::CancellationToken::is_cancelled) {
+        return Err(OpenAiError::cancelled(
+            "request cancelled during deferred suffix prefill",
+        ));
+    }
+    if Instant::now() >= deadline {
+        return Err(OpenAiError::backend(
+            "cache operation deadline exceeded during deferred suffix prefill",
+        ));
+    }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -12,6 +12,7 @@ use crate::frontend::generation::TokenControl;
 use crate::frontend::generation_receipt::{
     GenerationCommit, GenerationStart, complete_generation_before_cleanup,
 };
+use crate::frontend::iteration_scheduler::CacheRuntimeContext;
 use crate::frontend::iteration_scheduler::DirectIterationChannel;
 use crate::frontend::iteration_scheduler::ScheduledGenerationRequest;
 use crate::frontend::iteration_scheduler::ScheduledResumeRequest;
@@ -34,7 +35,7 @@ use skippy_runtime::SamplingConfig;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use super::{LocalGenerationReceiptFinalization, prompt_fits_single_prefill_sample};
 
@@ -89,6 +90,34 @@ struct KvRecordResult {
     proactive_evicted_entries: usize,
     proactive_evicted_tokens: u64,
     proactive_eviction_error: Option<anyhow::Error>,
+}
+
+fn ensure_cache_operation_active(
+    runtime: &mut RuntimeState,
+    session_id: &str,
+    cache_operation: &CacheRuntimeContext,
+) -> OpenAiResult<()> {
+    if let Err(error) = cache_operation.ensure_active() {
+        let _ = runtime.drop_session_timed(session_id);
+        return Err(error);
+    }
+    Ok(())
+}
+
+fn prefill_cache_chunks(
+    runtime: &mut RuntimeState,
+    session_id: &str,
+    tokens: &[i32],
+    chunk_tokens: usize,
+    cache_operation: &CacheRuntimeContext,
+) -> OpenAiResult<()> {
+    for chunk in tokens.chunks(chunk_tokens.max(1)) {
+        ensure_cache_operation_active(runtime, session_id, cache_operation)?;
+        runtime
+            .prefill(session_id, chunk)
+            .map_err(openai_backend_error)?;
+    }
+    ensure_cache_operation_active(runtime, session_id, cache_operation)
 }
 
 impl Default for KvRecordResult {
@@ -748,15 +777,24 @@ impl StageOpenAiBackend {
         let scheduler_prefill_tokens = Arc::clone(&prefill_tokens);
         let record_prefill_tokens = Arc::clone(&prefill_tokens);
         let mut scheduler_cache_stats = std::mem::take(cache_stats);
+        let cache_operation_deadline = Instant::now()
+            .checked_add(self.generation_admission_timeout)
+            .ok_or_else(|| OpenAiError::backend("cache operation deadline overflow"))?;
         let outcome = self.iteration_scheduler.execute_cache_aware_runtime_timed(
             "feature-kv-restore-prefill-record",
-            Arc::clone(&prefill_tokens),
-            0,
-            cache_payload,
-            refresh_cache_affinity,
-            move |runtime| {
+            super::super::iteration_scheduler::CacheAwareRuntimeRequest {
+                operation_id: request.ids.request_id_string(),
+                deadline: cache_operation_deadline,
+                cancellation: request.cancellation,
+                prompt_tokens: Arc::clone(&prefill_tokens),
+                priority: 0,
+                payload: cache_payload,
+                refresh_affinity: refresh_cache_affinity,
+            },
+            move |runtime, cache_operation| {
                 let outcome = scheduler_backend.restore_or_record_kv_on_runtime(
                     runtime,
+                    cache_operation,
                     &scheduler_ids,
                     &scheduler_session_id,
                     scheduler_prefill_tokens.as_ref(),
@@ -815,6 +853,8 @@ impl StageOpenAiBackend {
                     &request.prompt_token_ids[suffix_start..boundary],
                     None,
                     false,
+                    cache_operation_deadline,
+                    request.cancellation,
                 )?;
                 prefill_chunk_count = prefill_chunk_count
                     .saturating_add(checkpoint_prefill.chunk_count)
@@ -867,6 +907,8 @@ impl StageOpenAiBackend {
                 &request.prompt_token_ids[suffix_start..],
                 request.sampling.enabled.then_some(request.sampling),
                 true,
+                cache_operation_deadline,
+                request.cancellation,
             )?;
             prompt_prefill_sample =
                 Some(suffix_outcome.predicted.ok_or_else(|| {
@@ -1095,6 +1137,7 @@ impl StageOpenAiBackend {
     fn restore_or_record_kv_on_runtime(
         &self,
         runtime: &mut RuntimeState,
+        cache_operation: &CacheRuntimeContext,
         ids: &OpenAiGenerationIds,
         session_id: &str,
         prefill_tokens: &[i32],
@@ -1104,6 +1147,7 @@ impl StageOpenAiBackend {
         max_tokens: u32,
         cache_stats: &mut GenerationCacheStats,
     ) -> OpenAiResult<KvRestoreOutcome> {
+        ensure_cache_operation_active(runtime, session_id, cache_operation)?;
         let emit_debug = self.telemetry.is_debug_enabled();
         let runtime_sessions_before = emit_debug.then(|| runtime.session_stats());
         let (restored_prefill, restored_prefill_tokens, protected_resident_seq_id) =
@@ -1122,6 +1166,7 @@ impl StageOpenAiBackend {
             } else {
                 (false, 0, None)
             };
+        ensure_cache_operation_active(runtime, session_id, cache_operation)?;
         let capacity = if let Some(kv) = self.kv.as_ref() {
             let decode_batch_tokens = u64::from(self.config.n_batch.unwrap_or(2048));
             let target_free_tokens =
@@ -1149,6 +1194,7 @@ impl StageOpenAiBackend {
                 ..crate::kv_integration::ResidentCapacityDecision::default()
             }
         };
+        ensure_cache_operation_active(runtime, session_id, cache_operation)?;
         if !capacity.admitted {
             return Ok(KvRestoreOutcome {
                 runtime_sessions_before,
@@ -1181,6 +1227,9 @@ impl StageOpenAiBackend {
         }
         let prompt_prefill_sample = None;
         let mut decoded_prefill_suffix = false;
+        let cache_prefill_chunk_tokens = usize::try_from(self.config.n_ubatch.unwrap_or(256))
+            .unwrap_or(2_048)
+            .clamp(1, 2_048);
         if restored_prefill_tokens < prefill_tokens.len() {
             decoded_prefill_suffix = true;
             if let Some(checkpoint_tokens) =
@@ -1191,9 +1240,14 @@ impl StageOpenAiBackend {
                         && restored_prefill_tokens < checkpoint_tokens.len()
                 })
             {
-                runtime
-                    .prefill(session_id, &checkpoint_tokens[restored_prefill_tokens..])
-                    .map_err(openai_backend_error)?;
+                prefill_cache_chunks(
+                    runtime,
+                    session_id,
+                    &checkpoint_tokens[restored_prefill_tokens..],
+                    cache_prefill_chunk_tokens,
+                    cache_operation,
+                )?;
+                ensure_cache_operation_active(runtime, session_id, cache_operation)?;
                 let _ = self.record_exact_state_at_tokens(
                     runtime,
                     session_id,
@@ -1201,9 +1255,13 @@ impl StageOpenAiBackend {
                     checkpoint_tokens,
                     "chat_prefix_checkpoint",
                 );
-                runtime
-                    .prefill(session_id, &prefill_tokens[checkpoint_tokens.len()..])
-                    .map_err(openai_backend_error)?;
+                prefill_cache_chunks(
+                    runtime,
+                    session_id,
+                    &prefill_tokens[checkpoint_tokens.len()..],
+                    cache_prefill_chunk_tokens,
+                    cache_operation,
+                )?;
             } else if let Some(kv) = self.kv.as_ref().filter(|kv| kv.payload_is_exact_state()) {
                 // Recurrent and full-state payloads cannot reconstruct a shorter
                 // shared prefix from the state at the end of the request. Stop
@@ -1218,28 +1276,43 @@ impl StageOpenAiBackend {
                     identity.identity.token_count as usize > restored_prefill_tokens
                 }) {
                     let boundary = identity.identity.token_count as usize;
-                    runtime
-                        .prefill(
-                            session_id,
-                            &prefill_tokens[restored_prefill_tokens..boundary],
-                        )
-                        .map_err(openai_backend_error)?;
+                    prefill_cache_chunks(
+                        runtime,
+                        session_id,
+                        &prefill_tokens[restored_prefill_tokens..boundary],
+                        cache_prefill_chunk_tokens,
+                        cache_operation,
+                    )?;
+                    ensure_cache_operation_active(runtime, session_id, cache_operation)?;
                     kv.record_exact_state(runtime, session_id, &identity)
                         .map_err(openai_backend_error)?;
-                    runtime
-                        .prefill(session_id, &prefill_tokens[boundary..])
-                        .map_err(openai_backend_error)?;
+                    prefill_cache_chunks(
+                        runtime,
+                        session_id,
+                        &prefill_tokens[boundary..],
+                        cache_prefill_chunk_tokens,
+                        cache_operation,
+                    )?;
                 } else {
-                    runtime
-                        .prefill(session_id, &prefill_tokens[restored_prefill_tokens..])
-                        .map_err(openai_backend_error)?;
+                    prefill_cache_chunks(
+                        runtime,
+                        session_id,
+                        &prefill_tokens[restored_prefill_tokens..],
+                        cache_prefill_chunk_tokens,
+                        cache_operation,
+                    )?;
                 }
             } else {
-                runtime
-                    .prefill(session_id, &prefill_tokens[restored_prefill_tokens..])
-                    .map_err(openai_backend_error)?;
+                prefill_cache_chunks(
+                    runtime,
+                    session_id,
+                    &prefill_tokens[restored_prefill_tokens..],
+                    cache_prefill_chunk_tokens,
+                    cache_operation,
+                )?;
             }
         }
+        ensure_cache_operation_active(runtime, session_id, cache_operation)?;
         cache_stats.matched_prefix_tokens = saturating_u32(restored_prefill_tokens);
         cache_stats.suffix_prefill_tokens =
             saturating_u32(prefill_tokens.len().saturating_sub(restored_prefill_tokens));

--- a/crates/skippy-server/src/frontend/tests/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/tests/prefix_cache.rs
@@ -73,6 +73,23 @@ fn resident_capacity_rejection_is_side_effect_free_and_retryable() {
 }
 
 #[test]
+fn resident_capacity_unknown_fails_closed() {
+    let config = prefix_cache_test_config();
+    let kv = KvStageIntegration::from_config(&config)
+        .unwrap()
+        .expect("resident prefix cache enabled");
+    let mut runtime = crate::runtime_state::RuntimeState::new_modelless_for_test(1);
+
+    let decision = kv
+        .admit_resident_capacity(&mut runtime, "unknown", 1, 0, 0, None)
+        .unwrap();
+
+    assert!(!decision.capacity_known);
+    assert!(!decision.admitted);
+    assert_eq!(decision.admission_deficit_tokens, 1);
+}
+
+#[test]
 fn resident_capacity_admission_evicts_for_the_aggregate_active_four_wave() {
     let config = StageConfig {
         ctx_size: 131_072,

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -16,6 +16,7 @@ use super::{
     EXACT_STATE_RECORD_CAPACITY, KvStageIntegration, PendingExactStateRecord, RadixExactEntry,
     ResidentSequencePool, StageKvMode, StagePrefixCachePayload,
     model_capability::{ModelKvCapability, inspect_model_kv_capability},
+    output_tokens::OutputTokenCache,
 };
 
 #[cfg(test)]
@@ -78,29 +79,31 @@ impl KvStageIntegration {
         let worker_exact_state_records_dropped = exact_state_records_dropped.clone();
         let exact_state_records_pending = Arc::new(std::sync::atomic::AtomicUsize::new(0));
         let worker_exact_state_records_pending = exact_state_records_pending.clone();
+        let exact_state_record_worker_healthy = Arc::new(std::sync::atomic::AtomicBool::new(true));
+        let worker_exact_state_record_worker_healthy = exact_state_record_worker_healthy.clone();
+        let exact_state_record_worker_panics = Arc::new(std::sync::atomic::AtomicU64::new(0));
+        let worker_exact_state_record_worker_panics = exact_state_record_worker_panics.clone();
         std::thread::Builder::new()
             .name(format!("skippy-exact-cache-{}", config.stage_id))
             .spawn(move || {
                 while let Ok(pending) = exact_state_record_rx.recv() {
-                    let page_id = pending.page_id.clone();
-                    if store_exact_radix_record(
-                        &worker_radix,
-                        &worker_exact_blobs,
-                        exact_max_entries,
-                        exact_max_bytes,
+                    super::run_exact_state_record_job(
+                        &worker_inflight_records,
+                        &worker_exact_state_records_dropped,
+                        &worker_exact_state_records_pending,
+                        &worker_exact_state_record_worker_healthy,
+                        &worker_exact_state_record_worker_panics,
                         pending,
-                    )
-                    .is_err()
-                    {
-                        worker_exact_state_records_dropped
-                            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
-                    }
-                    worker_inflight_records
-                        .lock()
-                        .unwrap_or_else(std::sync::PoisonError::into_inner)
-                        .remove(&page_id);
-                    worker_exact_state_records_pending
-                        .fetch_sub(1, std::sync::atomic::Ordering::Release);
+                        |pending| {
+                            store_exact_radix_record(
+                                &worker_radix,
+                                &worker_exact_blobs,
+                                exact_max_entries,
+                                exact_max_bytes,
+                                pending,
+                            )
+                        },
+                    );
                 }
             })?;
         Ok(Some(Self {
@@ -124,8 +127,10 @@ impl KvStageIntegration {
             exact_state_records_queued,
             exact_state_records_dropped,
             exact_state_records_pending,
-            first_tokens: Arc::new(Mutex::new(BTreeMap::new())),
-            replay_tokens: Arc::new(Mutex::new(BTreeMap::new())),
+            exact_state_record_worker_healthy,
+            exact_state_record_worker_panics,
+            cache_healthy: Arc::new(std::sync::atomic::AtomicBool::new(true)),
+            output_tokens: Arc::new(Mutex::new(OutputTokenCache::new(exact_max_entries))),
             split_prefill_tokens: Arc::new(Mutex::new(BTreeMap::new())),
         }))
     }
@@ -193,7 +198,7 @@ fn store_exact_radix_record(
             &mut blobs
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner),
-        );
+        )?;
         return Err(error);
     }
     if !released.is_empty() {
@@ -201,7 +206,7 @@ fn store_exact_radix_record(
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
         for payload in released {
-            payload.release_from(&mut blobs);
+            payload.release_from(&mut blobs)?;
         }
     }
     while max_bytes > 0
@@ -222,7 +227,7 @@ fn store_exact_radix_record(
             &mut blobs
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner),
-        );
+        )?;
     }
     Ok(())
 }

--- a/crates/skippy-server/src/kv_integration/exact_state.rs
+++ b/crates/skippy-server/src/kv_integration/exact_state.rs
@@ -158,12 +158,20 @@ impl KvStageIntegration {
                 Ok(restored_payload) => restored_payload,
                 Err(error) => {
                     drop(lease);
-                    if deterministic_failure {
-                        self.quarantine_exact_state_entry(
+                    if deterministic_failure
+                        && let Err(quarantine_error) = self.quarantine_exact_state_entry(
                             &identity.namespace,
                             &lookup.stored_tokens,
                             &lookup.value.page_id,
-                        )?;
+                        )
+                    {
+                        eprintln!(
+                            "skippy exact-state quarantine failed for page {}: {quarantine_error:#}",
+                            lookup.value.page_id
+                        );
+                        return Err(error.context(format!(
+                            "failed to fully quarantine corrupt exact-state entry: {quarantine_error:#}"
+                        )));
                     }
                     return Err(error);
                 }

--- a/crates/skippy-server/src/kv_integration/exact_state.rs
+++ b/crates/skippy-server/src/kv_integration/exact_state.rs
@@ -163,7 +163,7 @@ impl KvStageIntegration {
                             &identity.namespace,
                             &lookup.stored_tokens,
                             &lookup.value.page_id,
-                        );
+                        )?;
                     }
                     return Err(error);
                 }
@@ -191,22 +191,27 @@ impl KvStageIntegration {
         Ok(None)
     }
 
-    fn quarantine_exact_state_entry(&self, namespace: &str, tokens: &[i32], page_id: &str) -> bool {
+    fn quarantine_exact_state_entry(
+        &self,
+        namespace: &str,
+        tokens: &[i32],
+        page_id: &str,
+    ) -> Result<bool> {
         let removed = self
             .radix
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .remove_recurrent_if(namespace, tokens, |entry| entry.page_id == page_id);
         let Some(entry) = removed else {
-            return false;
+            return Ok(false);
         };
         entry.payload.release_from(
             &mut self
                 .exact_blobs
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner),
-        );
-        true
+        )?;
+        Ok(true)
     }
 
     pub fn record_exact_state(

--- a/crates/skippy-server/src/kv_integration/exact_state.rs
+++ b/crates/skippy-server/src/kv_integration/exact_state.rs
@@ -165,10 +165,14 @@ impl KvStageIntegration {
                             &lookup.value.page_id,
                         )
                     {
-                        eprintln!(
-                            "skippy exact-state quarantine failed for page {}: {quarantine_error:#}",
-                            lookup.value.page_id
-                        );
+                        let _ =
+                            mesh_llm_events::emit_event(mesh_llm_events::OutputEvent::Warning {
+                                message: "Skippy exact-state quarantine failed".to_string(),
+                                context: Some(format!(
+                                    "page_id={} error={quarantine_error:#}",
+                                    lookup.value.page_id
+                                )),
+                            });
                         return Err(error.context(format!(
                             "failed to fully quarantine corrupt exact-state entry: {quarantine_error:#}"
                         )));

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -392,9 +392,12 @@ fn verify_resident_ownership(
         return Ok(());
     }
     if cache_healthy.swap(false, std::sync::atomic::Ordering::AcqRel) {
-        eprintln!(
-            "skippy kv cache disabled: resident ownership mismatch: radix_entries={resident_entries} allocated_sequences={allocated_sequences}"
-        );
+        let _ = mesh_llm_events::emit_event(mesh_llm_events::OutputEvent::Warning {
+            message: "Skippy KV cache disabled after resident ownership mismatch".to_string(),
+            context: Some(format!(
+                "radix_entries={resident_entries} allocated_sequences={allocated_sequences}"
+            )),
+        });
     }
     bail!(
         "resident cache ownership mismatch: radix_entries={resident_entries} allocated_sequences={allocated_sequences}"

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -2,7 +2,7 @@ use std::{
     collections::{BTreeMap, BTreeSet},
     sync::{
         Arc, Mutex,
-        atomic::{AtomicU64, AtomicUsize},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize},
         mpsc::{SyncSender, TrySendError},
     },
 };
@@ -27,6 +27,7 @@ mod config;
 mod exact_state;
 mod identity;
 mod model_capability;
+mod output_tokens;
 mod records;
 mod resident_prefix;
 
@@ -149,8 +150,10 @@ pub struct KvStageIntegration {
     pub(crate) exact_state_records_queued: Arc<AtomicU64>,
     pub(crate) exact_state_records_dropped: Arc<AtomicU64>,
     pub(crate) exact_state_records_pending: Arc<AtomicUsize>,
-    pub(crate) first_tokens: Arc<Mutex<BTreeMap<String, i32>>>,
-    pub(crate) replay_tokens: Arc<Mutex<BTreeMap<String, Vec<i32>>>>,
+    pub(crate) exact_state_record_worker_healthy: Arc<AtomicBool>,
+    pub(crate) exact_state_record_worker_panics: Arc<AtomicU64>,
+    pub(crate) cache_healthy: Arc<AtomicBool>,
+    pub(crate) output_tokens: Arc<Mutex<output_tokens::OutputTokenCache>>,
     pub(crate) split_prefill_tokens: Arc<Mutex<BTreeMap<String, Vec<i32>>>>,
 }
 
@@ -195,6 +198,8 @@ pub(crate) struct ResidentSequencePool {
     reserved_seq_count: i32,
     next_seq_id: i32,
     free_seq_ids: Vec<i32>,
+    allocated_seq_ids: BTreeSet<i32>,
+    quarantined_seq_ids: BTreeSet<i32>,
 }
 
 impl ResidentSequencePool {
@@ -203,29 +208,62 @@ impl ResidentSequencePool {
             reserved_seq_count,
             next_seq_id: reserved_seq_count,
             free_seq_ids: Vec::new(),
+            allocated_seq_ids: BTreeSet::new(),
+            quarantined_seq_ids: BTreeSet::new(),
         }
     }
 
     pub(crate) fn allocate(&mut self) -> Result<i32> {
         if let Some(seq_id) = self.free_seq_ids.pop() {
+            if !self.allocated_seq_ids.insert(seq_id) {
+                bail!("resident prefix sequence id {seq_id} is already allocated");
+            }
             return Ok(seq_id);
         }
         let seq_id = self.next_seq_id;
+        if seq_id < self.reserved_seq_count || seq_id >= skippy_cache::LLAMA_MAX_SEQ {
+            bail!("resident prefix sequence id capacity exhausted");
+        }
         self.next_seq_id = self
             .next_seq_id
             .checked_add(1)
             .ok_or_else(|| anyhow::anyhow!("resident prefix sequence id overflow"))?;
-        if seq_id < self.reserved_seq_count || seq_id >= skippy_cache::LLAMA_MAX_SEQ {
-            bail!("resident prefix sequence id capacity exhausted");
+        if !self.allocated_seq_ids.insert(seq_id) {
+            bail!("resident prefix sequence id {seq_id} is already allocated");
         }
         Ok(seq_id)
     }
 
-    fn release(&mut self, seq_id: i32) {
-        debug_assert!(seq_id >= self.reserved_seq_count);
-        debug_assert!(seq_id < skippy_cache::LLAMA_MAX_SEQ);
-        debug_assert!(!self.free_seq_ids.contains(&seq_id));
+    fn release(&mut self, seq_id: i32) -> Result<()> {
+        self.validate_allocated(seq_id)?;
+        self.allocated_seq_ids.remove(&seq_id);
         self.free_seq_ids.push(seq_id);
+        Ok(())
+    }
+
+    fn quarantine(&mut self, seq_id: i32) -> Result<()> {
+        self.validate_allocated(seq_id)?;
+        self.allocated_seq_ids.remove(&seq_id);
+        self.quarantined_seq_ids.insert(seq_id);
+        Ok(())
+    }
+
+    fn validate_allocated(&self, seq_id: i32) -> Result<()> {
+        if seq_id < self.reserved_seq_count || seq_id >= skippy_cache::LLAMA_MAX_SEQ {
+            bail!("resident prefix sequence id {seq_id} is out of range");
+        }
+        if !self.allocated_seq_ids.contains(&seq_id) {
+            bail!("resident prefix sequence id {seq_id} is not allocated");
+        }
+        Ok(())
+    }
+
+    fn stats(&self) -> (usize, usize, usize) {
+        (
+            self.allocated_seq_ids.len(),
+            self.free_seq_ids.len(),
+            self.quarantined_seq_ids.len(),
+        )
     }
 }
 
@@ -240,14 +278,65 @@ fn has_exact_state_record_capacity(pending_count: &AtomicUsize) -> bool {
     pending_count.load(std::sync::atomic::Ordering::Acquire) < EXACT_STATE_RECORD_CAPACITY
 }
 
+fn finish_exact_state_record(
+    inflight_records: &Mutex<BTreeSet<String>>,
+    pending_count: &AtomicUsize,
+    page_id: &str,
+) {
+    inflight_records
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .remove(page_id);
+    pending_count.fetch_sub(1, std::sync::atomic::Ordering::Release);
+}
+
+fn run_exact_state_record_job(
+    inflight_records: &Mutex<BTreeSet<String>>,
+    dropped: &AtomicU64,
+    pending_count: &AtomicUsize,
+    worker_healthy: &AtomicBool,
+    worker_panics: &AtomicU64,
+    pending: PendingExactStateRecord,
+    work: impl FnOnce(PendingExactStateRecord) -> Result<()>,
+) {
+    let page_id = pending.page_id.clone();
+    if !worker_healthy.load(std::sync::atomic::Ordering::Acquire) {
+        dropped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        finish_exact_state_record(inflight_records, pending_count, &page_id);
+        return;
+    }
+
+    match std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| work(pending))) {
+        Ok(Ok(())) => {}
+        Ok(Err(_)) => {
+            dropped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        }
+        Err(_) => {
+            dropped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            worker_panics.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            worker_healthy.store(false, std::sync::atomic::Ordering::Release);
+        }
+    }
+    finish_exact_state_record(inflight_records, pending_count, &page_id);
+}
+
 fn enqueue_exact_state_record(
     sender: &SyncSender<PendingExactStateRecord>,
     inflight_records: &Mutex<BTreeSet<String>>,
     queued: &AtomicU64,
     dropped: &AtomicU64,
     pending_count: &AtomicUsize,
+    worker_healthy: &AtomicBool,
     pending: PendingExactStateRecord,
 ) -> ExactStateRecordAdmission {
+    if !worker_healthy.load(std::sync::atomic::Ordering::Acquire) {
+        inflight_records
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .remove(&pending.page_id);
+        dropped.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        return ExactStateRecordAdmission::WorkerStopped;
+    }
     pending_count.fetch_add(1, std::sync::atomic::Ordering::Release);
     match sender.try_send(pending) {
         Ok(()) => {
@@ -280,6 +369,20 @@ pub(crate) struct ExactStateExtra {
     pub(crate) kv_desc: Option<RuntimeKvPageDesc>,
 }
 
+fn verify_resident_ownership(
+    cache_healthy: &AtomicBool,
+    resident_entries: usize,
+    allocated_sequences: usize,
+) -> Result<()> {
+    if resident_entries == allocated_sequences {
+        return Ok(());
+    }
+    cache_healthy.store(false, std::sync::atomic::Ordering::Release);
+    bail!(
+        "resident cache ownership mismatch: radix_entries={resident_entries} allocated_sequences={allocated_sequences}"
+    )
+}
+
 impl KvStageIntegration {
     pub fn mode(&self) -> StageKvMode {
         self.mode
@@ -290,17 +393,29 @@ impl KvStageIntegration {
     }
 
     pub fn should_lookup(&self) -> bool {
-        matches!(
-            self.mode,
-            StageKvMode::LookupRecord | StageKvMode::Correctness
-        )
+        self.cache_healthy
+            .load(std::sync::atomic::Ordering::Acquire)
+            && matches!(
+                self.mode,
+                StageKvMode::LookupRecord | StageKvMode::Correctness
+            )
     }
 
     pub fn should_record(&self) -> bool {
-        matches!(
-            self.mode,
-            StageKvMode::Record | StageKvMode::LookupRecord | StageKvMode::Correctness
-        )
+        self.cache_healthy
+            .load(std::sync::atomic::Ordering::Acquire)
+            && matches!(
+                self.mode,
+                StageKvMode::Record | StageKvMode::LookupRecord | StageKvMode::Correctness
+            )
+    }
+
+    pub(crate) fn verify_resident_ownership(
+        &self,
+        resident_entries: usize,
+        allocated_sequences: usize,
+    ) -> Result<()> {
+        verify_resident_ownership(&self.cache_healthy, resident_entries, allocated_sequences)
     }
 
     pub(crate) fn meets_shared_prefix_min_tokens(&self, matched_tokens: usize) -> bool {
@@ -308,6 +423,12 @@ impl KvStageIntegration {
     }
 
     pub fn try_begin_record(&self, page_id: &str) -> bool {
+        if !self
+            .exact_state_record_worker_healthy
+            .load(std::sync::atomic::Ordering::Acquire)
+        {
+            return false;
+        }
         self.inflight_records
             .lock()
             .expect("kv inflight record lock poisoned")
@@ -322,7 +443,9 @@ impl KvStageIntegration {
     }
 
     pub(crate) fn has_exact_state_record_capacity(&self) -> bool {
-        has_exact_state_record_capacity(&self.exact_state_records_pending)
+        self.exact_state_record_worker_healthy
+            .load(std::sync::atomic::Ordering::Acquire)
+            && has_exact_state_record_capacity(&self.exact_state_records_pending)
     }
 
     pub(crate) fn enqueue_exact_state_record(
@@ -335,6 +458,7 @@ impl KvStageIntegration {
             &self.exact_state_records_queued,
             &self.exact_state_records_dropped,
             &self.exact_state_records_pending,
+            &self.exact_state_record_worker_healthy,
             pending,
         )
     }
@@ -422,13 +546,46 @@ impl KvStageIntegration {
             .lock()
             .expect("resident activation cache lock poisoned");
         let activations = activations.stats();
-        let exact_blob_stats = self
-            .exact_blobs
+        let exact_blob_stats = self.exact_blobs.try_lock().ok().map(|blobs| {
+            (
+                blobs.physical_bytes(),
+                blobs.block_count(),
+                blobs.logical_ref_count(),
+            )
+        });
+        let exact_state_stats_busy = radix_stats.is_none() || exact_blob_stats.is_none();
+        let (exact_physical_bytes, exact_blocks, exact_block_refs) =
+            exact_blob_stats.unwrap_or_default();
+        let (resident_allocated_sequences, resident_free_sequences, resident_quarantined_sequences) =
+            self.resident_sequences
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .stats();
+        let resident_sequence_drift = radix
+            .resident_entries
+            .abs_diff(resident_allocated_sequences);
+        let (resident_capacity_reservations, resident_capacity_reserved_tokens) =
+            self.resident_capacity_reservations.stats();
+        let output_token_entries = self
+            .output_tokens
             .try_lock()
             .ok()
-            .map(|blobs| (blobs.physical_bytes(), blobs.block_count()));
-        let exact_state_stats_busy = radix_stats.is_none() || exact_blob_stats.is_none();
-        let (exact_physical_bytes, _) = exact_blob_stats.unwrap_or_default();
+            .map(|tokens| tokens.len())
+            .unwrap_or_default();
+        let (split_prefill_sessions, split_prefill_tokens) = self
+            .split_prefill_tokens
+            .try_lock()
+            .ok()
+            .map(|sessions| {
+                (
+                    sessions.len(),
+                    sessions
+                        .values()
+                        .map(Vec::len)
+                        .fold(0, usize::saturating_add),
+                )
+            })
+            .unwrap_or_default();
         vec![
             ("skippy.kv.mode", json!(format!("{:?}", self.mode))),
             ("skippy.kv.payload", json!(format!("{:?}", self.payload))),
@@ -492,6 +649,8 @@ impl KvStageIntegration {
                 "skippy.exact_cache.physical_bytes",
                 json!(exact_physical_bytes),
             ),
+            ("skippy.exact_cache.blocks", json!(exact_blocks)),
+            ("skippy.exact_cache.block_refs", json!(exact_block_refs)),
             (
                 "skippy.exact_cache.stats_busy",
                 json!(exact_state_stats_busy),
@@ -517,12 +676,73 @@ impl KvStageIntegration {
                         .load(std::sync::atomic::Ordering::Relaxed)
                 ),
             ),
+            (
+                "skippy.exact_cache.worker_healthy",
+                json!(
+                    self.exact_state_record_worker_healthy
+                        .load(std::sync::atomic::Ordering::Acquire)
+                ),
+            ),
+            (
+                "skippy.exact_cache.worker_panics",
+                json!(
+                    self.exact_state_record_worker_panics
+                        .load(std::sync::atomic::Ordering::Relaxed)
+                ),
+            ),
             ("skippy.exact_cache.max_bytes", json!(self.exact_max_bytes)),
             (
                 "skippy.exact_cache.max_entries",
                 json!(self.exact_max_entries),
             ),
+            (
+                "skippy.kv.output_token_entries",
+                json!(output_token_entries),
+            ),
+            (
+                "skippy.kv.split_prefill_sessions",
+                json!(split_prefill_sessions),
+            ),
+            (
+                "skippy.kv.split_prefill_tokens",
+                json!(split_prefill_tokens),
+            ),
+            (
+                "skippy.kv.split_prefill_bytes",
+                json!(split_prefill_tokens.saturating_mul(std::mem::size_of::<i32>())),
+            ),
+            (
+                "skippy.kv.resident_allocated_sequences",
+                json!(resident_allocated_sequences),
+            ),
+            (
+                "skippy.kv.resident_free_sequences",
+                json!(resident_free_sequences),
+            ),
+            (
+                "skippy.kv.resident_quarantined_sequences",
+                json!(resident_quarantined_sequences),
+            ),
+            (
+                "skippy.kv.resident_sequence_drift",
+                json!(resident_sequence_drift),
+            ),
+            (
+                "skippy.kv.capacity_reservations",
+                json!(resident_capacity_reservations),
+            ),
+            (
+                "skippy.kv.capacity_reserved_tokens",
+                json!(resident_capacity_reserved_tokens),
+            ),
             ("skippy.kv.correctness_mode", json!(self.correctness_mode)),
+            (
+                "skippy.kv.cache_healthy",
+                json!(
+                    self.cache_healthy
+                        .load(std::sync::atomic::Ordering::Acquire)
+                ),
+            ),
             (
                 "skippy.kv.trust_local_writes",
                 json!(self.trust_local_writes),
@@ -564,11 +784,10 @@ impl KvStageIntegration {
         {
             return false;
         }
-        self.first_tokens
+        self.output_tokens
             .lock()
-            .expect("first-token cache lock poisoned")
-            .insert(cache_key.to_string(), predicted)
-            .is_none()
+            .expect("output-token cache lock poisoned")
+            .record_first(cache_key, predicted)
     }
 
     /// Test-only compatibility helper for the identity-only cache probe.
@@ -584,11 +803,10 @@ impl KvStageIntegration {
         if !self.should_lookup() {
             return None;
         }
-        self.first_tokens
+        self.output_tokens
             .lock()
-            .expect("first-token cache lock poisoned")
-            .get(cache_key)
-            .copied()
+            .expect("output-token cache lock poisoned")
+            .lookup_first(cache_key)
     }
 
     pub fn record_cached_replay_tokens(
@@ -606,31 +824,20 @@ impl KvStageIntegration {
         {
             return None;
         }
-        let mut replay_tokens = self
-            .replay_tokens
+        self.output_tokens
             .lock()
-            .expect("replay-token cache lock poisoned");
-        let entry = replay_tokens.entry(cache_key.to_string()).or_default();
-        if entry.len() > previous.len() {
-            return Some(entry.len().min(max_replay_tokens));
-        }
-        if entry.as_slice() != previous {
-            return None;
-        }
-        entry.push(predicted);
-        Some(entry.len())
+            .expect("output-token cache lock poisoned")
+            .record_replay(cache_key, previous, predicted, max_replay_tokens)
     }
 
     pub fn lookup_cached_replay_tokens(&self, cache_key: &str, max_tokens: usize) -> Vec<i32> {
         if !self.should_lookup() || max_tokens == 0 {
             return Vec::new();
         }
-        self.replay_tokens
+        self.output_tokens
             .lock()
-            .expect("replay-token cache lock poisoned")
-            .get(cache_key)
-            .map(|tokens| tokens.iter().copied().take(max_tokens).collect())
-            .unwrap_or_default()
+            .expect("output-token cache lock poisoned")
+            .lookup_replay(cache_key, max_tokens)
     }
 }
 
@@ -650,13 +857,14 @@ mod exact_state_record_queue_tests {
     use skippy_cache::ExactStatePayload;
     use std::sync::{
         Arc, Mutex,
-        atomic::{AtomicU64, AtomicUsize, Ordering},
+        atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering},
         mpsc::sync_channel,
     };
 
     use super::{
         BTreeSet, EXACT_STATE_RECORD_CAPACITY, ExactStateExtra, ExactStateRecordAdmission,
         PendingExactStateRecord, enqueue_exact_state_record, has_exact_state_record_capacity,
+        run_exact_state_record_job,
     };
 
     fn pending(page_id: &str) -> PendingExactStateRecord {
@@ -686,6 +894,7 @@ mod exact_state_record_queue_tests {
         let queued = AtomicU64::new(0);
         let dropped = AtomicU64::new(0);
         let pending_count = AtomicUsize::new(0);
+        let worker_healthy = AtomicBool::new(true);
 
         assert_eq!(
             enqueue_exact_state_record(
@@ -694,6 +903,7 @@ mod exact_state_record_queue_tests {
                 &queued,
                 &dropped,
                 &pending_count,
+                &worker_healthy,
                 pending("dropped"),
             ),
             ExactStateRecordAdmission::DroppedFull
@@ -712,6 +922,7 @@ mod exact_state_record_queue_tests {
         let queued = AtomicU64::new(0);
         let dropped = AtomicU64::new(0);
         let pending_count = AtomicUsize::new(0);
+        let worker_healthy = AtomicBool::new(true);
 
         assert_eq!(
             enqueue_exact_state_record(
@@ -720,6 +931,7 @@ mod exact_state_record_queue_tests {
                 &queued,
                 &dropped,
                 &pending_count,
+                &worker_healthy,
                 pending("orphaned"),
             ),
             ExactStateRecordAdmission::WorkerStopped
@@ -738,6 +950,7 @@ mod exact_state_record_queue_tests {
         let dropped = AtomicU64::new(0);
         let pending_count = Arc::new(AtomicUsize::new(0));
         let worker_pending_count = pending_count.clone();
+        let worker_healthy = AtomicBool::new(true);
 
         assert_eq!(
             enqueue_exact_state_record(
@@ -746,6 +959,7 @@ mod exact_state_record_queue_tests {
                 &queued,
                 &dropped,
                 &pending_count,
+                &worker_healthy,
                 pending("page"),
             ),
             ExactStateRecordAdmission::Queued
@@ -764,6 +978,50 @@ mod exact_state_record_queue_tests {
         assert_eq!(queued.load(Ordering::Relaxed), 1);
         assert_eq!(dropped.load(Ordering::Relaxed), 0);
         assert_eq!(pending_count.load(Ordering::Relaxed), 0);
+    }
+
+    #[test]
+    fn worker_panic_fails_closed_and_releases_all_record_bookkeeping() {
+        let (sender, _receiver) = sync_channel(1);
+        let inflight = Mutex::new(BTreeSet::from(["panicked".to_string()]));
+        let queued = AtomicU64::new(0);
+        let dropped = AtomicU64::new(0);
+        let pending_count = AtomicUsize::new(1);
+        let worker_healthy = AtomicBool::new(true);
+        let worker_panics = AtomicU64::new(0);
+
+        run_exact_state_record_job(
+            &inflight,
+            &dropped,
+            &pending_count,
+            &worker_healthy,
+            &worker_panics,
+            pending("panicked"),
+            |_| panic!("injected exact-record worker failure"),
+        );
+
+        assert!(!worker_healthy.load(Ordering::Acquire));
+        assert_eq!(worker_panics.load(Ordering::Relaxed), 1);
+        assert_eq!(dropped.load(Ordering::Relaxed), 1);
+        assert_eq!(pending_count.load(Ordering::Acquire), 0);
+        assert!(inflight.lock().unwrap().is_empty());
+
+        inflight.lock().unwrap().insert("later".to_string());
+        assert_eq!(
+            enqueue_exact_state_record(
+                &sender,
+                &inflight,
+                &queued,
+                &dropped,
+                &pending_count,
+                &worker_healthy,
+                pending("later"),
+            ),
+            ExactStateRecordAdmission::WorkerStopped
+        );
+        assert!(inflight.lock().unwrap().is_empty());
+        assert_eq!(dropped.load(Ordering::Relaxed), 2);
+        assert_eq!(pending_count.load(Ordering::Acquire), 0);
     }
 }
 
@@ -785,5 +1043,27 @@ mod telemetry_error_class_tests {
             telemetry_error_class_from_message("arbitrary secret detail 123"),
             "internal"
         );
+    }
+}
+
+#[cfg(test)]
+mod resident_ownership_reconciliation_tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    use super::verify_resident_ownership;
+
+    #[test]
+    fn ownership_mismatch_permanently_disables_cache_operations() {
+        let healthy = AtomicBool::new(true);
+
+        let error = verify_resident_ownership(&healthy, 2, 1).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            "resident cache ownership mismatch: radix_entries=2 allocated_sequences=1"
+        );
+        assert!(!healthy.load(Ordering::Acquire));
+        verify_resident_ownership(&healthy, 1, 1).unwrap();
+        assert!(!healthy.load(Ordering::Acquire));
     }
 }

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -248,6 +248,12 @@ impl ResidentSequencePool {
         Ok(())
     }
 
+    fn force_quarantine(&mut self, seq_id: i32) {
+        self.allocated_seq_ids.remove(&seq_id);
+        self.free_seq_ids.retain(|candidate| *candidate != seq_id);
+        self.quarantined_seq_ids.insert(seq_id);
+    }
+
     fn validate_allocated(&self, seq_id: i32) -> Result<()> {
         if seq_id < self.reserved_seq_count || seq_id >= skippy_cache::LLAMA_MAX_SEQ {
             bail!("resident prefix sequence id {seq_id} is out of range");
@@ -265,6 +271,14 @@ impl ResidentSequencePool {
             self.quarantined_seq_ids.len(),
         )
     }
+}
+
+fn lock_resident_sequences(
+    sequences: &Mutex<ResidentSequencePool>,
+) -> std::sync::MutexGuard<'_, ResidentSequencePool> {
+    sequences
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -377,7 +391,11 @@ fn verify_resident_ownership(
     if resident_entries == allocated_sequences {
         return Ok(());
     }
-    cache_healthy.store(false, std::sync::atomic::Ordering::Release);
+    if cache_healthy.swap(false, std::sync::atomic::Ordering::AcqRel) {
+        eprintln!(
+            "skippy kv cache disabled: resident ownership mismatch: radix_entries={resident_entries} allocated_sequences={allocated_sequences}"
+        );
+    }
     bail!(
         "resident cache ownership mismatch: radix_entries={resident_entries} allocated_sequences={allocated_sequences}"
     )
@@ -557,10 +575,7 @@ impl KvStageIntegration {
         let (exact_physical_bytes, exact_blocks, exact_block_refs) =
             exact_blob_stats.unwrap_or_default();
         let (resident_allocated_sequences, resident_free_sequences, resident_quarantined_sequences) =
-            self.resident_sequences
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .stats();
+            lock_resident_sequences(&self.resident_sequences).stats();
         let resident_sequence_drift = radix
             .resident_entries
             .abs_diff(resident_allocated_sequences);
@@ -1048,9 +1063,12 @@ mod telemetry_error_class_tests {
 
 #[cfg(test)]
 mod resident_ownership_reconciliation_tests {
-    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{
+        Arc, Mutex,
+        atomic::{AtomicBool, Ordering},
+    };
 
-    use super::verify_resident_ownership;
+    use super::{ResidentSequencePool, lock_resident_sequences, verify_resident_ownership};
 
     #[test]
     fn ownership_mismatch_permanently_disables_cache_operations() {
@@ -1065,5 +1083,36 @@ mod resident_ownership_reconciliation_tests {
         assert!(!healthy.load(Ordering::Acquire));
         verify_resident_ownership(&healthy, 1, 1).unwrap();
         assert!(!healthy.load(Ordering::Acquire));
+    }
+
+    #[test]
+    fn poisoned_resident_sequence_lock_recovers_without_reusing_state() {
+        let sequences = Arc::new(Mutex::new(ResidentSequencePool::new(4)));
+        let poisoned = sequences.clone();
+        assert!(
+            std::thread::spawn(move || {
+                let mut guard = poisoned.lock().unwrap();
+                guard.allocate().unwrap();
+                panic!("poison resident sequence pool for test");
+            })
+            .join()
+            .is_err()
+        );
+
+        let mut guard = lock_resident_sequences(&sequences);
+        assert_eq!(guard.stats(), (1, 0, 0));
+        assert_eq!(guard.allocate().unwrap(), 5);
+    }
+
+    #[test]
+    fn forced_quarantine_removes_a_sequence_from_every_reusable_set() {
+        let mut sequences = ResidentSequencePool::new(4);
+        let seq_id = sequences.allocate().unwrap();
+        sequences.release(seq_id).unwrap();
+
+        sequences.force_quarantine(seq_id);
+
+        assert_eq!(sequences.stats(), (0, 0, 1));
+        assert_eq!(sequences.allocate().unwrap(), seq_id + 1);
     }
 }

--- a/crates/skippy-server/src/kv_integration/output_tokens.rs
+++ b/crates/skippy-server/src/kv_integration/output_tokens.rs
@@ -1,0 +1,162 @@
+use std::collections::BTreeMap;
+
+#[derive(Debug, Default)]
+struct OutputTokenEntry {
+    first: Option<i32>,
+    replay: Vec<i32>,
+    last_used: u64,
+}
+
+/// Sampling-aware output accelerators with one shared entry budget.
+///
+/// First-token and exact-replay data for the same prompt/sampling key share an
+/// entry. The LRU cap is intentionally independent of the radix population:
+/// failed or skipped KV records must not let auxiliary output metadata grow
+/// without bound.
+#[derive(Debug)]
+pub(crate) struct OutputTokenCache {
+    max_entries: usize,
+    clock: u64,
+    entries: BTreeMap<String, OutputTokenEntry>,
+}
+
+impl OutputTokenCache {
+    pub(super) fn new(max_entries: usize) -> Self {
+        Self {
+            max_entries,
+            clock: 0,
+            entries: BTreeMap::new(),
+        }
+    }
+
+    pub(super) fn record_first(&mut self, cache_key: &str, predicted: i32) -> bool {
+        if self.max_entries == 0 {
+            return false;
+        }
+        let last_used = self.next_clock();
+        let entry = self.entries.entry(cache_key.to_string()).or_default();
+        entry.last_used = last_used;
+        let inserted = entry.first.replace(predicted).is_none();
+        self.enforce_capacity();
+        inserted
+    }
+
+    pub(super) fn lookup_first(&mut self, cache_key: &str) -> Option<i32> {
+        let last_used = self.next_clock();
+        let entry = self.entries.get_mut(cache_key)?;
+        entry.last_used = last_used;
+        entry.first
+    }
+
+    pub(super) fn record_replay(
+        &mut self,
+        cache_key: &str,
+        previous: &[i32],
+        predicted: i32,
+        max_replay_tokens: usize,
+    ) -> Option<usize> {
+        if self.max_entries == 0 || max_replay_tokens == 0 || previous.len() >= max_replay_tokens {
+            return None;
+        }
+        let last_used = self.next_clock();
+        let recorded = {
+            let entry = self.entries.entry(cache_key.to_string()).or_default();
+            entry.last_used = last_used;
+            if entry.replay.len() > previous.len() {
+                Some(entry.replay.len().min(max_replay_tokens))
+            } else if entry.replay.as_slice() != previous {
+                None
+            } else {
+                entry.replay.push(predicted);
+                Some(entry.replay.len())
+            }
+        };
+        self.enforce_capacity();
+        recorded
+    }
+
+    pub(super) fn lookup_replay(&mut self, cache_key: &str, max_tokens: usize) -> Vec<i32> {
+        if max_tokens == 0 {
+            return Vec::new();
+        }
+        let last_used = self.next_clock();
+        let Some(entry) = self.entries.get_mut(cache_key) else {
+            return Vec::new();
+        };
+        entry.last_used = last_used;
+        entry.replay.iter().copied().take(max_tokens).collect()
+    }
+
+    fn next_clock(&mut self) -> u64 {
+        self.clock = self.clock.saturating_add(1);
+        self.clock
+    }
+
+    fn enforce_capacity(&mut self) {
+        while self.entries.len() > self.max_entries {
+            let Some(victim) = self
+                .entries
+                .iter()
+                .min_by_key(|(_, entry)| entry.last_used)
+                .map(|(key, _)| key.clone())
+            else {
+                break;
+            };
+            self.entries.remove(&victim);
+        }
+    }
+
+    pub(super) fn len(&self) -> usize {
+        self.entries.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::OutputTokenCache;
+
+    #[test]
+    fn unique_prompt_churn_never_exceeds_the_shared_entry_cap() {
+        let mut cache = OutputTokenCache::new(8);
+
+        for index in 0..2_048 {
+            let key = format!("prompt-{index}");
+            assert!(cache.record_first(&key, index));
+            assert_eq!(cache.record_replay(&key, &[], index, 4), Some(1));
+            assert!(cache.len() <= 8);
+        }
+
+        assert_eq!(cache.len(), 8);
+        assert_eq!(cache.lookup_first("prompt-0"), None);
+        assert_eq!(cache.lookup_replay("prompt-2047", 4), vec![2_047]);
+    }
+
+    #[test]
+    fn first_and_replay_tokens_share_one_lru_entry() {
+        let mut cache = OutputTokenCache::new(1);
+
+        assert!(cache.record_first("shared", 7));
+        assert_eq!(cache.record_replay("shared", &[], 8, 4), Some(1));
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.lookup_first("shared"), Some(7));
+        assert_eq!(cache.lookup_replay("shared", 4), vec![8]);
+
+        assert!(cache.record_first("replacement", 9));
+        assert_eq!(cache.len(), 1);
+        assert_eq!(cache.lookup_first("shared"), None);
+    }
+
+    #[test]
+    fn lookups_refresh_lru_recency() {
+        let mut cache = OutputTokenCache::new(2);
+        assert!(cache.record_first("old", 1));
+        assert!(cache.record_first("new", 2));
+        assert_eq!(cache.lookup_first("old"), Some(1));
+
+        assert!(cache.record_first("newest", 3));
+
+        assert_eq!(cache.lookup_first("new"), None);
+        assert_eq!(cache.lookup_first("old"), Some(1));
+        assert_eq!(cache.lookup_first("newest"), Some(3));
+    }
+}

--- a/crates/skippy-server/src/kv_integration/resident_prefix.rs
+++ b/crates/skippy-server/src/kv_integration/resident_prefix.rs
@@ -30,6 +30,22 @@ pub(crate) struct ResidentCapacityReservations {
     entries: Arc<Mutex<BTreeMap<String, ResidentCapacityReservationEntry>>>,
 }
 
+impl ResidentCapacityReservations {
+    pub(crate) fn stats(&self) -> (usize, u64) {
+        let entries = self
+            .entries
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        (
+            entries.len(),
+            entries
+                .values()
+                .map(|entry| entry.target_session_tokens)
+                .fold(0, u64::saturating_add),
+        )
+    }
+}
+
 /// Keeps one request's projected KV demand visible until its runtime session
 /// has either materialized those cells or completed cleanup.
 pub(crate) struct ResidentCapacityReservation {
@@ -166,13 +182,15 @@ impl KvStageIntegration {
         if capacity_tokens == 0 {
             return Ok(ResidentCapacityDecision {
                 enabled: true,
-                admitted: true,
+                capacity_known: false,
+                admitted: false,
                 active_tokens,
                 request_tokens,
                 inflight_reservations,
                 inflight_outstanding_tokens,
                 minimum_free_tokens,
                 target_free_tokens,
+                admission_deficit_tokens: request_tokens,
                 ..ResidentCapacityDecision::default()
             });
         }
@@ -272,7 +290,7 @@ impl KvStageIntegration {
                         victim.value.seq_id
                     )
                 })?;
-            sequences.release(removed.value.seq_id);
+            sequences.release(removed.value.seq_id)?;
             #[cfg(test)]
             let used_after = if runtime.is_modelless_for_test() {
                 active_tokens.saturating_add(radix.stats().resident_tokens)
@@ -300,6 +318,7 @@ impl KvStageIntegration {
             .saturating_add(minimum_free)
             .saturating_sub(capacity_tokens);
         decision.admitted = decision.admission_deficit_tokens == 0;
+        self.verify_resident_ownership(radix.stats().resident_entries, sequences.stats().0)?;
         Ok(decision)
     }
 
@@ -429,6 +448,7 @@ impl KvStageIntegration {
             evicted_entries = evicted_entries.saturating_add(1);
             evicted_tokens = evicted_tokens.saturating_add(removed.value.token_count);
         }
+        self.verify_resident_ownership(radix.stats().resident_entries, sequences.stats().0)?;
         Ok(ResidentPrefixEviction {
             target_tokens,
             evicted_entries,
@@ -519,6 +539,7 @@ impl KvStageIntegration {
                 radix.resident_exact(&identity.namespace, &identity.token_ids[..token_count])
             {
                 let stats = radix.stats();
+                self.verify_resident_ownership(stats.resident_entries, sequences.stats().0)?;
                 return Ok(Some(ResidentPrefixRecord {
                     page_id: existing.value.page_id,
                     token_count,
@@ -555,10 +576,18 @@ impl KvStageIntegration {
             sequences.allocate()?
         };
         if let Err(error) = runtime.save_resident_prefix(session_id, seq_id, token_count as u64) {
-            self.resident_sequences
+            if let Err(release_error) = self
+                .resident_sequences
                 .lock()
                 .expect("resident sequence pool lock poisoned")
-                .release(seq_id);
+                .release(seq_id)
+            {
+                return Err(error).with_context(|| {
+                    format!(
+                        "release resident sequence {seq_id} after native save failed: {release_error:#}"
+                    )
+                });
+            }
             return Err(error);
         }
         let mut radix = self
@@ -588,6 +617,7 @@ impl KvStageIntegration {
                 .resident_exact(&identity.namespace, &identity.token_ids[..token_count])
                 .context("occupied resident radix entry disappeared after rejected insert")?;
             let stats = radix.stats();
+            self.verify_resident_ownership(stats.resident_entries, sequences.stats().0)?;
             return Ok(Some(ResidentPrefixRecord {
                 page_id: existing.value.page_id,
                 token_count,
@@ -600,6 +630,7 @@ impl KvStageIntegration {
             }));
         }
         let stats = radix.stats();
+        self.verify_resident_ownership(stats.resident_entries, sequences.stats().0)?;
         Ok(Some(ResidentPrefixRecord {
             page_id: identity.page_id.clone(),
             token_count,
@@ -660,7 +691,7 @@ fn evict_one_resident(
         .evict_resident_candidate(&victim.namespace, &victim.tokens)
         .expect("selected radix resident victim should exist");
     debug_assert_eq!(removed.value.page_id, victim.value.page_id);
-    sequences.release(removed.value.seq_id);
+    sequences.release(removed.value.seq_id)?;
     Ok(Some(removed))
 }
 
@@ -686,19 +717,28 @@ fn insert_saved_resident(
     match radix.insert_resident_if_vacant(namespace, tokens, logical_bytes, entry) {
         Ok(None) => Ok(true),
         Ok(Some(rejected)) => {
-            drop_native(rejected.seq_id)?;
-            sequences.release(rejected.seq_id);
+            if let Err(error) = drop_native(rejected.seq_id) {
+                sequences.quarantine(rejected.seq_id)?;
+                return Err(error).with_context(|| {
+                    format!(
+                        "quarantine native resident sequence {} after duplicate radix insert",
+                        rejected.seq_id
+                    )
+                });
+            }
+            sequences.release(rejected.seq_id)?;
             Ok(false)
         }
         Err(error) => {
             if let Err(native_error) = drop_native(seq_id) {
+                sequences.quarantine(seq_id)?;
                 return Err(native_error).with_context(|| {
                     format!(
                         "roll back native resident sequence {seq_id} after radix insert failed: {error:#}"
                     )
                 });
             }
-            sequences.release(seq_id);
+            sequences.release(seq_id)?;
             Err(error)
         }
     }
@@ -955,6 +995,50 @@ mod proactive_eviction_tests {
         assert_eq!(dropped, Some(seq_id));
         assert_eq!(sequences.allocate().unwrap(), seq_id);
         assert_eq!(radix.stats().resident_entries, 0);
+    }
+
+    #[test]
+    fn failed_native_rollback_quarantines_sequence_capacity() {
+        let mut radix = skippy_cache::UnifiedRadixCache::new();
+        let mut sequences = ResidentSequencePool::new(4);
+        let seq_id = sequences.allocate().unwrap();
+
+        let error = insert_saved_resident(
+            &mut radix,
+            &mut sequences,
+            "stage".to_string(),
+            &[],
+            0,
+            RadixResidentEntry {
+                page_id: "page".to_string(),
+                seq_id,
+                token_count: 0,
+                recompute_cost: 0,
+            },
+            |_| anyhow::bail!("native drop failed"),
+        )
+        .unwrap_err();
+
+        assert!(format!("{error:#}").contains("native drop failed"));
+        assert!(sequences.quarantined_seq_ids.contains(&seq_id));
+        assert_eq!(sequences.allocate().unwrap(), seq_id + 1);
+        assert_eq!(radix.stats().resident_entries, 0);
+    }
+
+    #[test]
+    fn duplicate_sequence_release_fails_without_free_list_corruption() {
+        let mut sequences = ResidentSequencePool::new(4);
+        let seq_id = sequences.allocate().unwrap();
+
+        sequences.release(seq_id).unwrap();
+        let error = sequences.release(seq_id).unwrap_err();
+
+        assert_eq!(
+            error.to_string(),
+            format!("resident prefix sequence id {seq_id} is not allocated")
+        );
+        assert_eq!(sequences.allocate().unwrap(), seq_id);
+        assert_eq!(sequences.allocate().unwrap(), seq_id + 1);
     }
 
     #[test]

--- a/crates/skippy-server/src/kv_integration/resident_prefix.rs
+++ b/crates/skippy-server/src/kv_integration/resident_prefix.rs
@@ -10,7 +10,7 @@ use crate::runtime_state::RuntimeState;
 
 use super::{
     KvStageIntegration, PrefillKvIdentity, RadixResidentEntry, ResidentPrefixRecord,
-    ResidentPrefixRestore, ResidentSequencePool, StagePrefixCachePayload,
+    ResidentPrefixRestore, ResidentSequencePool, StagePrefixCachePayload, lock_resident_sequences,
 };
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -257,10 +257,7 @@ impl KvStageIntegration {
             required_eviction_tokens,
             ..ResidentCapacityDecision::default()
         };
-        let mut sequences = self
-            .resident_sequences
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut sequences = lock_resident_sequences(&self.resident_sequences);
         for ranked_victim in ranked {
             if used_tokens
                 .saturating_add(request_tokens)
@@ -432,10 +429,7 @@ impl KvStageIntegration {
             .radix
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut sequences = self
-            .resident_sequences
-            .lock()
-            .expect("resident sequence pool lock poisoned");
+        let mut sequences = lock_resident_sequences(&self.resident_sequences);
         let mut evicted_entries = 0usize;
         let mut evicted_tokens = 0u64;
         while evicted_tokens < target_tokens {
@@ -531,10 +525,7 @@ impl KvStageIntegration {
                 .radix
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            let mut sequences = self
-                .resident_sequences
-                .lock()
-                .expect("resident sequence pool lock poisoned");
+            let mut sequences = lock_resident_sequences(&self.resident_sequences);
             if let Some(existing) =
                 radix.resident_exact(&identity.namespace, &identity.token_ids[..token_count])
             {
@@ -576,15 +567,12 @@ impl KvStageIntegration {
             sequences.allocate()?
         };
         if let Err(error) = runtime.save_resident_prefix(session_id, seq_id, token_count as u64) {
-            if let Err(release_error) = self
-                .resident_sequences
-                .lock()
-                .expect("resident sequence pool lock poisoned")
-                .release(seq_id)
-            {
+            let mut sequences = lock_resident_sequences(&self.resident_sequences);
+            if let Err(release_error) = sequences.release(seq_id) {
+                sequences.force_quarantine(seq_id);
                 return Err(error).with_context(|| {
                     format!(
-                        "release resident sequence {seq_id} after native save failed: {release_error:#}"
+                        "quarantined resident sequence {seq_id} after native save and release failed: {release_error:#}"
                     )
                 });
             }
@@ -594,10 +582,7 @@ impl KvStageIntegration {
             .radix
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        let mut sequences = self
-            .resident_sequences
-            .lock()
-            .expect("resident sequence pool lock poisoned");
+        let mut sequences = lock_resident_sequences(&self.resident_sequences);
         let inserted = insert_saved_resident(
             &mut radix,
             &mut sequences,

--- a/crates/skippy-server/src/runtime_state/lane_lifecycle.rs
+++ b/crates/skippy-server/src/runtime_state/lane_lifecycle.rs
@@ -199,9 +199,12 @@ impl RuntimeState {
                 Err(reset_err) => {
                     lane_discarded = true;
                     let reason = format!("reset() failed ({reset_err:#})");
-                    eprintln!(
-                        "skippy::runtime_state: drop_session_timed: discarding lane {lane_index} for session {session_id}: {reason}"
-                    );
+                    let _ = mesh_llm_events::emit_event(mesh_llm_events::OutputEvent::Warning {
+                        message: "Discarding Skippy runtime lane after reset failure".to_string(),
+                        context: Some(format!(
+                            "lane_index={lane_index} session_id={session_id} reason={reason}"
+                        )),
+                    });
                     lane_discard_reason = Some(reason);
                     drop(lane_session);
                     self.free_lane_indices.push(lane_index);

--- a/crates/skippy-server/src/runtime_state/lane_lifecycle.rs
+++ b/crates/skippy-server/src/runtime_state/lane_lifecycle.rs
@@ -1,5 +1,76 @@
 use super::*;
 
+trait RestoreRollback {
+    fn drop_dirty_session(&mut self, session_id: &str) -> Result<()>;
+    fn reacquire_clean_session(&mut self, session_id: &str) -> Result<()>;
+    fn restored_native_position(&mut self, session_id: &str) -> Result<u64>;
+    fn restored_token_count(&self, session_id: &str) -> u64;
+    fn discard_dirty_session(&mut self, session_id: &str);
+}
+
+fn rollback_restore_failure(
+    runtime: &mut impl RestoreRollback,
+    session_id: &str,
+    restore_error: anyhow::Error,
+) -> anyhow::Error {
+    if let Err(cleanup_error) = runtime.drop_dirty_session(session_id) {
+        runtime.discard_dirty_session(session_id);
+        return anyhow::anyhow!(
+            "cache restore failed ({restore_error:#}); could not clean native session {session_id}: {cleanup_error:#}"
+        );
+    }
+
+    if let Err(reacquire_error) = runtime.reacquire_clean_session(session_id) {
+        runtime.discard_dirty_session(session_id);
+        return anyhow::anyhow!(
+            "cache restore failed ({restore_error:#}); could not reacquire a clean native session {session_id}: {reacquire_error:#}"
+        );
+    }
+
+    let native_position = match runtime.restored_native_position(session_id) {
+        Ok(position) => position,
+        Err(position_error) => {
+            runtime.discard_dirty_session(session_id);
+            return anyhow::anyhow!(
+                "cache restore failed ({restore_error:#}); could not verify clean native session {session_id}: {position_error:#}"
+            );
+        }
+    };
+    if native_position != 0 || runtime.restored_token_count(session_id) != 0 {
+        runtime.discard_dirty_session(session_id);
+        return anyhow::anyhow!(
+            "cache restore failed ({restore_error:#}); rollback left native session {session_id} at position {native_position}"
+        );
+    }
+
+    restore_error.context(format!(
+        "cache restore transaction rolled back for session {session_id}"
+    ))
+}
+
+impl RestoreRollback for RuntimeState {
+    fn drop_dirty_session(&mut self, session_id: &str) -> Result<()> {
+        self.drop_session_timed(session_id).map(|_| ())
+    }
+
+    fn reacquire_clean_session(&mut self, session_id: &str) -> Result<()> {
+        self.ensure_session_active(session_id)
+    }
+
+    fn restored_native_position(&mut self, session_id: &str) -> Result<u64> {
+        self.active_session(session_id)
+            .and_then(|session| session.native_position())
+    }
+
+    fn restored_token_count(&self, session_id: &str) -> u64 {
+        self.session_token_count(session_id).unwrap_or_default()
+    }
+
+    fn discard_dirty_session(&mut self, session_id: &str) {
+        self.force_discard_session(session_id);
+    }
+}
+
 impl RuntimeState {
     /// Run a cache restore as a transaction over the native session.
     ///
@@ -21,47 +92,7 @@ impl RuntimeState {
             return result;
         };
 
-        let cleanup = self.drop_session_timed(session_id);
-        if let Err(cleanup_error) = cleanup {
-            // `drop_session_timed` currently contains its own discard path,
-            // but keep this fallback defensive: a future reset implementation
-            // may fail before removing the lane.  Do not leave a potentially
-            // dirty native session available to the cache-off fallback.
-            self.force_discard_session(session_id);
-            return Err(anyhow::anyhow!(
-                "cache restore failed ({restore_error:#}); could not clean native session {session_id}: {cleanup_error:#}"
-            ));
-        }
-
-        if let Err(reacquire_error) = self.ensure_session_active(session_id) {
-            self.force_discard_session(session_id);
-            return Err(anyhow::anyhow!(
-                "cache restore failed ({restore_error:#}); could not reacquire a clean native session {session_id}: {reacquire_error:#}"
-            ));
-        }
-
-        let native_position = match self
-            .active_session(session_id)
-            .and_then(|session| session.native_position())
-        {
-            Ok(position) => position,
-            Err(position_error) => {
-                self.force_discard_session(session_id);
-                return Err(anyhow::anyhow!(
-                    "cache restore failed ({restore_error:#}); could not verify clean native session {session_id}: {position_error:#}"
-                ));
-            }
-        };
-        if native_position != 0 || self.session_token_count(session_id).unwrap_or_default() != 0 {
-            self.force_discard_session(session_id);
-            return Err(anyhow::anyhow!(
-                "cache restore failed ({restore_error:#}); rollback left native session {session_id} at position {native_position}"
-            ));
-        }
-
-        Err(restore_error.context(format!(
-            "cache restore transaction rolled back for session {session_id}"
-        )))
+        Err(rollback_restore_failure(self, session_id, restore_error))
     }
 
     /// Remove a session even when the normal reset path itself failed.  The
@@ -629,6 +660,107 @@ fn create_indexed_lane_resource<T>(
 mod tests {
     use super::*;
     use anyhow::{Result, bail};
+
+    #[derive(Default)]
+    struct FakeRestoreRollback {
+        cleanup_error: Option<&'static str>,
+        reacquire_error: Option<&'static str>,
+        position_error: Option<&'static str>,
+        native_position: u64,
+        token_count: u64,
+        discarded: bool,
+    }
+
+    impl RestoreRollback for FakeRestoreRollback {
+        fn drop_dirty_session(&mut self, _session_id: &str) -> Result<()> {
+            match self.cleanup_error {
+                Some(message) => bail!(message),
+                None => Ok(()),
+            }
+        }
+
+        fn reacquire_clean_session(&mut self, _session_id: &str) -> Result<()> {
+            match self.reacquire_error {
+                Some(message) => bail!(message),
+                None => Ok(()),
+            }
+        }
+
+        fn restored_native_position(&mut self, _session_id: &str) -> Result<u64> {
+            match self.position_error {
+                Some(message) => bail!(message),
+                None => Ok(self.native_position),
+            }
+        }
+
+        fn restored_token_count(&self, _session_id: &str) -> u64 {
+            self.token_count
+        }
+
+        fn discard_dirty_session(&mut self, _session_id: &str) {
+            self.discarded = true;
+        }
+    }
+
+    #[test]
+    fn restore_rollback_returns_original_error_after_proving_a_clean_lane() {
+        let mut runtime = FakeRestoreRollback::default();
+
+        let error = rollback_restore_failure(
+            &mut runtime,
+            "lane-a",
+            anyhow::anyhow!("injected import failure"),
+        );
+
+        assert_eq!(
+            error.to_string(),
+            "cache restore transaction rolled back for session lane-a"
+        );
+        assert!(format!("{error:#}").contains("injected import failure"));
+        assert!(!runtime.discarded);
+    }
+
+    #[test]
+    fn restore_rollback_discards_when_cleanup_or_reacquire_fails() {
+        for mut runtime in [
+            FakeRestoreRollback {
+                cleanup_error: Some("cleanup failed"),
+                ..FakeRestoreRollback::default()
+            },
+            FakeRestoreRollback {
+                reacquire_error: Some("reacquire failed"),
+                ..FakeRestoreRollback::default()
+            },
+        ] {
+            let error =
+                rollback_restore_failure(&mut runtime, "lane-a", anyhow::anyhow!("restore failed"));
+            assert!(format!("{error:#}").contains("restore failed"));
+            assert!(runtime.discarded);
+        }
+    }
+
+    #[test]
+    fn restore_rollback_discards_unverifiable_or_dirty_lanes() {
+        for mut runtime in [
+            FakeRestoreRollback {
+                position_error: Some("position unavailable"),
+                ..FakeRestoreRollback::default()
+            },
+            FakeRestoreRollback {
+                native_position: 1,
+                ..FakeRestoreRollback::default()
+            },
+            FakeRestoreRollback {
+                token_count: 1,
+                ..FakeRestoreRollback::default()
+            },
+        ] {
+            let error =
+                rollback_restore_failure(&mut runtime, "lane-a", anyhow::anyhow!("restore failed"));
+            assert!(format!("{error:#}").contains("restore failed"));
+            assert!(runtime.discarded);
+        }
+    }
 
     #[test]
     fn prefix_restore_moves_tracked_position_backwards() {

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4394,11 +4394,5 @@
       "line": 869,
       "macro_name": "eprintln!"
     }
-  ],
-  "crates/skippy-server/src/runtime_state/lane_lifecycle.rs": [
-    {
-      "line": 171,
-      "macro_name": "eprintln!"
-    }
   ]
 }


### PR DESCRIPTION
## Summary

This PR is stacked on #1569 and implements the next KV/scheduler robustness layer from the end-to-end review.

- bound first-token and replay metadata with one shared sampling-aware LRU budget
- clear orphaned split-prefill state during abnormal binary connection cleanup
- make blob release validation atomic across composite KV/recurrent payloads and reject accounting underflow
- prevent replacement of recurrent radix entries while restore references are active
- track resident sequence allocation explicitly, quarantine failed native rollbacks, and fail cache-off on ownership drift
- expose exact-record worker health, recover bookkeeping after panics, and reject later work fail-closed
- attach request IDs, cancellation, and absolute deadlines to cache runtime work; checkpoint long prefills and deferred suffix chunks
- carry those deadlines and cancellation tokens through queued direct iterations, reject stale work before native execution, and suppress late results
- add reconciliation telemetry for radix/blob refs, resident sequences, auxiliary maps, reservations, and worker/cache health

The proposed largest-contiguous-span admission gate was deliberately removed during review. llama.cpp normal allocation uses `find_slot(..., false)` and Mesh prefills are chunked, so requiring the whole request to fit a contiguous span would reject valid fragmented capacity.

## Validation

Exact head: `789a385b20f90d005dcc42e5d64d3983f67cb0ca`

- `cargo fmt --all -- --check`
- `cargo test -p skippy-cache --quiet`: 56 passed
- `cargo test -p skippy-server --lib`: 644 passed, 3 ignored
- `cargo test -p skippy-scheduler --quiet`: 38 unit + 8 integration passed
- warning-denying Clippy for `skippy-cache` and `skippy-server`
- shipped `mesh-llm` check passes; shipped warning-denying Clippy remains blocked by the same 28 unrelated `unfulfilled_lint_expectations` inherited from the stacked base
- scheduler lab release benchmark completed all scenarios
- deterministic llama replay: upstream `cc83d7b4824f73cfdda4dfbb47ee39804f71b328` -> patched `dca0b2e68f749d5d1a66cac6d8bb88ea5b5cbd6f`; static Metal build completed all 377 steps
- pre-review P1 release binaries:
  - `skippy-correctness`: `d280d0f2965dde447ecd300dc241b5967bca017612c3b48e5c3d6b84e7de1ffa`
  - `skippy-server`: `e3d9af2f76307fafe61554b225fb790d397ae6a7d533114cab63ae0747eee491`
- live two-lane cache gate passed for dense Qwen3 ResidentKv, Falcon-H1 KvRecurrent, and Qwen3Next KvRecurrent; every case matched suffix prefill and 2/2 repeated cache hits
  - gate JSON: `c1ac00ba484dd1bd5d98609f008bf36ce296681dc8b603b351e68422e6772d01`
  - table: `8454fcb2cb7bcdc50fe1503bd2819810e2b759978844eb48ffa2e264e836ef60`
- review follow-up adds deterministic rollback-branch tests, poison-safe resident ownership locking, permanent quarantine after cleanup double-failure, typed operator warnings, and original-error preservation when corrupt exact-state quarantine also fails
- the exact review-fix head is under GitHub CI; the complete server suite, formatting, warning-denying Clippy, console-output ratchet, and stack ancestry are green

## CUDA promotion evidence

The pre-rebase `e698b266` CUDA release binary is `3f551f67ddd511f33226153e5417e14c0308822aa6e726f2e898127e14b95723`. The capacity-matched Thoughtworks replay completed 12/12 cells and 1,792/1,792 requests with zero failures:

| concurrency | raw llama.cpp | Mesh | vLLM | SGLang |
|---:|---:|---:|---:|---:|
| 64 | 17.4 | **469.4** | 281.8 | 256.4 |
| 128 | 15.7 | **714.3** | 427.7 | 412.2 |
| 256 | 15.4 | **736.8** | 577.2 | 609.9 |

Full-run artifact hashes:

- `summary/thoughtworks.csv`: `64ecaa7c4fdb9cfa41cc434cb3960bf695799101a23d69287d832044203521a5`
- `summary/REPORT.md`: `408953ca045e30c4ecfe9432327a985d32c9737cf42b1753feed6dd9015e989f`
- `artifact-sha256.txt`: `4a1c60a176637ef88328e3c3a2f818f334f064db02aa1da16a30e17e44373a8c`

The full run's c256 Mesh row was lower than the earlier #1569 promotion run, so it was not accepted without investigation. A focused exact-P1 repeat recovered to 770.0 tok/s with 256/256 requests and zero failures. A consecutive same-host, same-config exact-P0 control produced 785.6 tok/s, a 2.0% branch delta. Both had 767/768 resident hits and approximately 47 mean suffix-prefill tokens; P1 had slightly better generation p50/p95, while a synchronized p99/max tail wave accounted for the remaining aggregate difference. This is treated as report-only run variance, not a correctness failure, and motivates the proposed repeated-run longitudinal performance gate rather than a single-sample threshold.

Focused artifact hashes:

- P1 repeat CSV: `5b80d9a57893b47f701e4946df7d32c65bd3ed4651175a6bc062451951432221`
- P1 repeat report: `263bb987cdf041c2f14b5d23c5d688ec98eaf67d3b257d95f375e695b297c3f6`
- P1 repeat manifest: `3685c7e5ed8970a5f67115eb21d4bd1043ee3c5261a6de03e8277474859c2cef`
- P0 control CSV: `50bfcb04d5567c903d1c611795cd181bc8a1e85170d859ff49be378fcb77f667`
- P0 control report: `5e151cf0d019346da2dfd5ff1b9ac828bcfb83b0380f945964181f282890cd2a`
- P0 control manifest: `1952f21b498dacfec69d07d809508cb9a421febcd0e169816016b648d5a25f45`

Every listed artifact manifest verifies, and no benchmark/backend process remains after teardown.

