### PR TITLE
Windows nodes without a GPU can serve and join splits

### DIFF
--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -187,7 +187,13 @@ fn read_system_ram_bytes() -> u64 {
     .unwrap_or(0)
 }
 
-#[cfg(all(target_os = "linux", any(feature = "skippy-devices", test)))]
+/// CPU-only nodes have no VRAM to advertise, so they budget from system RAM
+/// instead. Without this a GPU-less node reports zero capacity, which reads as
+/// `missing_vram` to split planning and fails the local capacity gate.
+#[cfg(all(
+    any(target_os = "linux", target_os = "windows"),
+    any(feature = "skippy-devices", test)
+))]
 fn apply_cpu_only_runtime_budget(survey: &mut HardwareSurvey, metrics: &[Metric], system_ram: u64) {
     if metrics.contains(&Metric::VramBytes) && system_ram > 0 {
         survey.vram_bytes = (system_ram as f64 * 0.75) as u64;
@@ -233,6 +239,11 @@ fn read_windows_total_ram_bytes() -> Option<u64> {
         "Get-CimInstance Win32_ComputerSystem | Select-Object -ExpandProperty TotalPhysicalMemory",
     )?;
     parse_windows_total_physical_memory(&output)
+}
+
+#[cfg(target_os = "windows")]
+fn read_system_ram_bytes() -> u64 {
+    read_windows_total_ram_bytes().unwrap_or(0)
 }
 
 /// Per-GPU VRAM in adapter order.
@@ -305,13 +316,13 @@ fn apply_skippy_backend_devices_to_survey(survey: &mut HardwareSurvey, metrics: 
     let gpus = match skippy_devices::gpu_facts() {
         Ok(gpus) => gpus,
         Err(_) => {
-            #[cfg(target_os = "linux")]
+            #[cfg(any(target_os = "linux", target_os = "windows"))]
             apply_cpu_only_runtime_budget(survey, metrics, read_system_ram_bytes());
             return true;
         }
     };
     if gpus.is_empty() {
-        #[cfg(target_os = "linux")]
+        #[cfg(any(target_os = "linux", target_os = "windows"))]
         apply_cpu_only_runtime_budget(survey, metrics, read_system_ram_bytes());
         return true;
     }
@@ -630,7 +641,7 @@ impl Collector for DefaultCollector {
             any(not(feature = "skippy-devices"), feature = "dynamic-native-runtime")
         ))]
         {
-            let system_ram = read_windows_total_ram_bytes().unwrap_or(0);
+            let system_ram = read_system_ram_bytes();
             let want_gpu_info =
                 metrics.contains(&Metric::GpuName) || metrics.contains(&Metric::GpuCount);
             let want_vram = metrics.contains(&Metric::VramBytes);

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -641,7 +641,7 @@ fn test_hardware_survey_default() {
     assert!(s.gpus.is_empty());
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 #[test]
 fn test_cpu_only_runtime_budget_uses_system_ram_when_vram_requested() {
     let mut survey = HardwareSurvey::default();
@@ -653,7 +653,7 @@ fn test_cpu_only_runtime_budget_uses_system_ram_when_vram_requested() {
     assert!(survey.gpus.is_empty());
 }
 
-#[cfg(target_os = "linux")]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
 #[test]
 fn test_cpu_only_runtime_budget_respects_requested_metrics() {
     let mut survey = HardwareSurvey::default();
@@ -663,7 +663,28 @@ fn test_cpu_only_runtime_budget_respects_requested_metrics() {
     assert_eq!(survey.vram_bytes, 0);
 }
 
-#[cfg(all(target_os = "linux", feature = "skippy-devices"))]
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[test]
+fn test_cpu_only_runtime_budget_without_system_ram_leaves_capacity_zero() {
+    let mut survey = HardwareSurvey::default();
+
+    apply_cpu_only_runtime_budget(&mut survey, &[Metric::VramBytes], 0);
+
+    assert_eq!(survey.vram_bytes, 0);
+}
+
+/// Every platform with a CPU-only budget needs a working RAM probe; a probe
+/// that returns 0 leaves GPU-less nodes advertising no capacity at all.
+#[cfg(any(target_os = "linux", target_os = "windows"))]
+#[test]
+fn test_system_ram_probe_reports_installed_memory() {
+    assert!(read_system_ram_bytes() > 0);
+}
+
+#[cfg(all(
+    any(target_os = "linux", target_os = "windows"),
+    feature = "skippy-devices"
+))]
 #[test]
 fn test_skippy_backend_error_uses_cpu_only_budget_without_legacy_fallback() {
     skippy_devices::set_test_gpu_facts_result(Err(anyhow::anyhow!("boom")));
@@ -684,7 +705,10 @@ fn test_skippy_backend_error_uses_cpu_only_budget_without_legacy_fallback() {
     assert!(survey.vram_bytes > 0);
 }
 
-#[cfg(all(target_os = "linux", feature = "skippy-devices"))]
+#[cfg(all(
+    any(target_os = "linux", target_os = "windows"),
+    feature = "skippy-devices"
+))]
 #[test]
 fn test_skippy_backend_empty_result_uses_cpu_only_budget_without_legacy_fallback() {
     skippy_devices::set_test_gpu_facts_result(Ok(vec![]));


### PR DESCRIPTION
A Windows machine without a GPU can now serve and take part in splits.

Before this change a GPU-less Windows node advertised `0.00 GB` of capacity, so:

- plain local serving refused to start — `local model requires 5.53 GB but this process has 0.00 GB` — even with tens of GB of free RAM
- the split planner permanently excluded the node with `missing_vram`, and no flag could fix it (`--max-vram` is a ceiling, so `min(0, cap)` is still 0)

Now a Windows node with no usable GPU budgets 75% of its system RAM as compute
capacity, exactly like a CPU-only Linux node already did. The same 33.5 GB
machine that reported 0.00 GB reports ~25 GB, opens a 5.53 GB model on CPU, and
is eligible for split participation.

Fixes #1566.

## What changed

`crates/mesh-llm-system/src/hardware/mod.rs` had the CPU-only RAM budget behind
`#[cfg(target_os = "linux")]` — both the helper and the two call sites in
`apply_skippy_backend_devices_to_survey` (the `gpu_facts()` error branch and the
empty-GPU-list branch). Windows fell through to `vram_bytes = 0`.

- adds a Windows `read_system_ram_bytes()` that wraps the `read_windows_total_ram_bytes()`
  probe already living in the same file
- widens `apply_cpu_only_runtime_budget` and both call sites to
  `any(target_os = "linux", target_os = "windows")`
- points the legacy Windows collector block at the same `read_system_ram_bytes()`
  helper it now shares with Linux (identical behavior, one probe entry point per
  platform)

macOS is deliberately untouched: Metal is always present there, so the CPU-only
branch is unreachable in practice.

## Follow-up, not in this PR

A few lines below the fix, the RAM-offload estimate for **GPU** nodes still
hardcodes `system_ram = 0` off Linux, so a Windows node *with* a GPU
under-advertises capacity. That one changes advertised capacity for GPU nodes
across the mesh and deserves its own change with its own validation — the
reporter scoped it out for the same reason.

## Validation

Regression tests (`crates/mesh-llm-system/src/hardware/tests.rs`):

- the two existing CPU-only budget tests and the two skippy-backend fallback
  tests now compile and run on Windows as well as Linux (they were
  compile-skipped on Windows before)
- new: zero system RAM leaves capacity at 0 (no bogus budget from a failed probe)
- new: `read_system_ram_bytes()` reports installed memory on every platform that
  has a CPU-only budget — this is the check that would have caught the missing
  Windows probe, and it runs on the Linux test lane

Local (macOS host):

```
cargo fmt --all --check
cargo clippy -p mesh-llm-system --all-targets -- -D warnings
cargo clippy -p mesh-llm-system --all-targets --features dynamic-native-runtime -- -D warnings
cargo test -p mesh-llm-system                                  # 181 passed
cargo test -p mesh-llm-system --features dynamic-native-runtime # 185 passed
cargo check -p mesh-llm
cargo clippy -p mesh-llm --all-targets -- -D warnings
```

The Windows code path cannot be compiled from a macOS host, so the Windows CI
lane is the compile gate here. The reporter validated the same behavior change
on Windows 11 hardware by backporting it onto `v0.76.0-rc8`: stock rc8 fails the
capacity gate with 0.00 GB, patched rc8 opens the same model on CPU, with the
mesh-llm-system suite green on Windows.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KneDsA7cmu2XA4RnaenRf1
