### PR TITLE
Prevent false Iroh diagnoses on macOS LAN tests

### DIFF
--- a/.agents/skills/deploy-macos/SKILL.md
+++ b/.agents/skills/deploy-macos/SKILL.md
@@ -66,18 +66,24 @@ scp -P <SSH_PORT> /tmp/mesh-llm-bundle.tar.gz user@host:
 ssh -p <SSH_PORT> user@host 'mkdir -p ~/bin && tar xzf mesh-llm-bundle.tar.gz -C ~/bin --strip-components=1'
 ```
 
-### Fix macOS quarantine — ALWAYS after scp
+### Clear quarantine and sign the final remote binary — ALWAYS after scp
 
-Files transferred via scp get provenance/quarantine xattrs that make macOS
-SIGKILL the binary on launch (exit 137). After every scp:
+Files transferred via scp can carry provenance/quarantine xattrs that make
+macOS SIGKILL the binary on launch (exit 137). Clear those attributes before
+signing, then sign the final remote binary once with the stable Apple-issued
+development identity used for that build:
 
 ```bash
-codesign -s - ~/bin/mesh-llm
 xattr -cr ~/bin/mesh-llm
+codesign --force --sign "<APPLE_DEVELOPMENT_IDENTITY>" ~/bin/mesh-llm
+codesign --verify --verbose=2 ~/bin/mesh-llm
+codesign -dv --verbose=4 ~/bin/mesh-llm 2>&1 | tee /tmp/mesh-llm-codesign.txt
 ```
 
-Verify: `xattr ~/bin/mesh-llm` should print nothing. Note codesign changes the
-file hash — don't compare local vs remote hashes after signing.
+`xattr ~/bin/mesh-llm` should print nothing. Do not ad-hoc sign the
+binary: that identity is not stable across builds and can invalidate the Local
+Network privacy decision. Signing changes the file hash, so do not compare
+local and remote hashes afterward.
 
 Verify the version on the remote matches what you built:
 
@@ -108,13 +114,17 @@ For the first multi-node run of an exact app/binary identity:
    supported command to query or reset an individual program from the
    undetermined state, so scripts must not claim this check passed merely
    because a raw UDP probe worked.
-4. For first repro/debug runs over SSH, use a held foreground TTY as described
-   by `remote-observable-process`; do not begin with launchd or detached
-   `nohup`. Apple documents Terminal/SSH command-line tools as automatically
-   allowed, while a helper/service can inherit a different responsible app.
+4. Authorize the exact launch context that will run the test. For a
+   CLI-launched repro over SSH, use the held foreground TTY described by
+   `remote-observable-process`. If a per-user launchd agent or GUI app will run
+   the workload, launch that exact agent/app while a user is logged in and
+   accept its prompt before diagnosis; an SSH TTY does not authorize a
+   different responsible app.
 5. Treat the network preflight as passed only after both nodes report an iroh
-   **direct** path to the intended LAN address (`direct_addr_available=true`,
-   `observed_via_relay=false`). An invite containing a LAN candidate, a raw UDP
+   **direct** path, `observed_via_relay=false`, and an
+   `observed_direct_remote_addr` whose IP matches the intended LAN address of
+   the peer. `direct_addr_available=true` alone only proves that some direct
+   address was observed. An invitation containing a LAN candidate, a raw UDP
    probe, or a working relay path does not prove the deployed process has Local
    Network access.
 
@@ -195,7 +205,7 @@ A clean stop removes the instance runtime dir under `~/.mesh-llm/runtime/`.
 
 | Symptom | Cause | Fix |
 |---|---|---|
-| Exit 137 immediately after scp | macOS quarantine/provenance xattr | `codesign -s - <bin>; xattr -cr <dir>` |
+| Exit 137 immediately after scp | macOS quarantine/provenance xattr | Clear xattrs, sign once with the stable Apple-issued development identity, and verify as above |
 | `mesh-llm: command not found` over SSH | `~/.local/bin` not on non-interactive PATH | Full path or `bash -lc` |
 | Empty `/v1/models` | Model still downloading/loading | Wait; watch skippy-native.log |
 | "No inference server available" | Election in progress or load failed | Check stderr + skippy-native.log |

--- a/.agents/skills/deploy-macos/SKILL.md
+++ b/.agents/skills/deploy-macos/SKILL.md
@@ -85,6 +85,44 @@ Verify the version on the remote matches what you built:
 ~/bin/mesh-llm --version
 ```
 
+### Authorize macOS Local Network access — BEFORE remote diagnosis
+
+macOS Local Network privacy is keyed to the **responsible code** and its code
+signature. Replacing or ad-hoc re-signing a development binary can therefore
+change the identity whose decision macOS remembers. A GUI app or launch agent
+may show a blocking Local Network alert on the logged-in desktop even though
+the same network is reachable from an interactive shell.
+
+For the first multi-node run of an exact app/binary identity:
+
+1. Sign it once with the stable Apple-issued development identity used for that
+   build. Do not repeatedly ad-hoc re-sign it between attempts. Verify with
+   `codesign --verify --verbose=2 <path>` and record
+   `codesign -dv --verbose=4 <path> 2>&1` in the lab evidence.
+2. Launch it once from the same responsible app/service context intended for
+   the test while a user is logged in at the Mac. Trigger a mesh join or mDNS
+   operation, then accept the Local Network alert on that Mac. Repeat on every
+   Mac participating in the test.
+3. Check **System Settings > Privacy & Security > Local Network**. If the
+   responsible app is listed, make sure access is enabled. macOS offers no
+   supported command to query or reset an individual program from the
+   undetermined state, so scripts must not claim this check passed merely
+   because a raw UDP probe worked.
+4. For first repro/debug runs over SSH, use a held foreground TTY as described
+   by `remote-observable-process`; do not begin with launchd or detached
+   `nohup`. Apple documents Terminal/SSH command-line tools as automatically
+   allowed, while a helper/service can inherit a different responsible app.
+5. Treat the network preflight as passed only after both nodes report an iroh
+   **direct** path to the intended LAN address (`direct_addr_available=true`,
+   `observed_via_relay=false`). An invite containing a LAN candidate, a raw UDP
+   probe, or a working relay path does not prove the deployed process has Local
+   Network access.
+
+If no alert appears, keep the process alive after its first failed LAN
+operation: macOS can fail to display the alert for very short-lived processes.
+Do not debug iroh candidate selection until this gate is complete. See Apple
+TN3179, [Understanding local network privacy](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy).
+
 ## Launch
 
 Serve a model and join the public mesh:

--- a/.agents/skills/remote-observable-process/SKILL.md
+++ b/.agents/skills/remote-observable-process/SKILL.md
@@ -12,6 +12,15 @@ process needs to behave like it was launched by an operator in a terminal, be
 observed after launch, expose readiness, keep running beyond one command, or be
 stopped cleanly later.
 
+## macOS Local Network privacy gate
+
+Before using a remote macOS node for LAN, mDNS, or split-inference diagnosis,
+complete the `deploy-macos` skill's Local Network privacy preflight for the exact
+signed app/binary identity and launch context on every Mac. A raw UDP probe, a
+LAN address in an invite, or relay connectivity is not proof that the deployed
+process was authorized. Do not collect performance data until both nodes report
+the intended LAN peer as an iroh direct path.
+
 ## Rule
 
 For environment-sensitive processes, prefer SSH with a TTY and an interactive

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -676,16 +676,22 @@ bash -c './target/debug/mesh-llm serve --model "..." --auto > /tmp/mesh.log 2>&1
 3. Kill ALL processes on ALL nodes — `pkill -9 -f mesh-llm`
 4. Verify clean — `ps -eo pid,args | grep -E 'mesh-llm' | grep -v grep` must be empty.
 5. Deploy bundle — scp + tar + codesign on remote nodes.
-6. Verify version — `mesh-llm --version` on every node.
+6. On every macOS node, complete the `deploy-macos` skill's Local Network
+   privacy preflight for the exact signed identity and launch context. Clear any
+   blocking desktop alert before remote diagnosis.
+7. Verify version — `mesh-llm --version` on every node.
 
 ### After starting nodes
-7. Verify exactly 1 mesh-llm process per node.
-8. Verify no external llama serving child processes are required.
-9. `curl -s http://localhost:3131/api/status` returns valid JSON on every node.
-10. Check `/api/status` peers for new version string.
-11. Verify expected peer count.
-12. Test inference through every model in `/v1/models`.
-13. Test `/v1/` passthrough on port 3131.
+8. Verify exactly 1 mesh-llm process per node.
+9. Verify no external llama serving child processes are required.
+10. `curl -s http://localhost:3131/api/status` returns valid JSON on every node.
+11. Check `/api/status` peers for new version string.
+12. Verify expected peer count.
+13. For same-LAN tests, require a direct iroh path to the intended LAN address
+    from both nodes before attributing failures to candidate selection or
+    collecting performance data.
+14. Test inference through every model in `/v1/models`.
+15. Test `/v1/` passthrough on port 3131.
 
 ### Debugging Embedded Runtime Startup
 

--- a/docs/MESHES.md
+++ b/docs/MESHES.md
@@ -137,6 +137,23 @@ relay/public candidates; `--mesh-discovery-mode mdns` keeps startup LAN-only.
 Use `--listen-all` only for the local HTTP API/console listener; it does not
 select the mesh QUIC interface.
 
+### macOS Local Network privacy preflight
+
+Before interpreting a same-LAN join failure on macOS, complete the Local Network
+privacy gate in the repository's `deploy-macos` skill on **every** participating
+Mac. Run the exact signed app/binary identity from the same app, service, or
+interactive context that the test will use, and clear any Local Network alert on
+the logged-in desktop. A raw UDP test or an invite that contains the expected
+LAN candidate is not sufficient: the deployed process can still be blocked.
+
+For a split run, collect a path observation from both nodes before collecting
+performance data. The expected steady state is `path_type=direct`, an
+`observed_direct_remote_addr` on the intended LAN, and
+`observed_via_relay=false`. If the path stays relayed or unknown, classify the
+run as a networking preflight failure until Local Network authorization and the
+responsible code identity have been checked; do not attribute it to Iroh path
+selection first.
+
 ## Publish your own mesh
 
 ```bash

--- a/docs/SKIPPY_SPLITS.md
+++ b/docs/SKIPPY_SPLITS.md
@@ -69,6 +69,16 @@ mesh-llm serve \
 For hosts with more than one network interface, add `--bind-ip <lan-ip>` on
 each node so the invite token and gossip advertise the routable address.
 
+On macOS, authorize Local Network access for the exact signed app/binary identity
+on **every** node before diagnosing a failed split. Run it from the same
+app/service context intended for the test and clear any blocking alert on the
+logged-in desktop; see the repository's `deploy-macos` skill and
+[Meshes: macOS Local Network privacy preflight](MESHES.md#macos-local-network-privacy-preflight).
+A raw UDP probe and a correct LAN candidate in the invite do not prove that the
+deployed process is authorized. Before recording throughput, require a path
+observation from both nodes showing `path_type=direct`, the intended LAN
+`observed_direct_remote_addr`, and `observed_via_relay=false`.
+
 Once both stages are ready:
 
 ```bash


### PR DESCRIPTION
macOS operators and lab runners now have an explicit Local Network privacy gate before diagnosing same-LAN Mesh or Skippy failures.

## What changed

- explains that macOS tracks Local Network permission by responsible code and code signature
- requires the exact signed app/binary to be launched from its intended context and approved on every participating Mac
- warns that raw UDP reachability and advertised LAN candidates do not prove the deployed process is authorized
- requires both nodes to report a direct Iroh path to the intended LAN address before benchmarking or blaming candidate selection
- links the rule into the macOS deploy, remote-process, Mesh, Skippy split, and mandatory deploy guidance

Apple reference: [TN3179: Understanding local network privacy](https://developer.apple.com/documentation/technotes/tn3179-understanding-local-network-privacy)

## Validation

- `git diff --check`
- documentation-only change; no runtime tests required
- live RC8 M5↔M4 retest after clearing both blocking Local Network dialogs changed the observed path from relay-only (~200 ms) to direct LAN (7–14 ms) without binary or networking-flag changes

## Credits

Mic identified the blocked permission dialogs and the recurring procedural failure mode.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added macOS Local Network privacy preflight guidance for deployment and remote diagnosis.
  * Documented stable signing verification and authorization for the exact app, binary, and launch context.
  * Added requirements to clear blocking alerts and verify direct LAN connectivity before troubleshooting path selection or collecting performance data.
  * Clarified process-count, serving-process, and connectivity checks for mesh and split-run workflows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->