### PR TITLE
ci(perf): allow trusted manual benchmark runs

### DIFF
--- a/.github/workflows/nightly-competitive-benchmark.yml
+++ b/.github/workflows/nightly-competitive-benchmark.yml
@@ -3,10 +3,11 @@ name: Nightly Competitive Benchmark
 on:
   schedule:
     - cron: "17 11 * * *"
+  workflow_dispatch:
 
-# Scheduled workflows execute the definition from the default branch. This file intentionally has
-# no workflow_dispatch entry because a manually selected ref could otherwise execute untrusted
-# workflow content on the persistent GPU runner. Runner-group policy remains the external backstop.
+# Scheduled workflows execute the definition from the default branch. A manual dispatch is allowed
+# only when the selected workflow ref is main, so caller-selected branch content never acquires the
+# persistent GPU runner. The checkout is independently pinned to main with read-only credentials.
 permissions:
   contents: read
 
@@ -16,7 +17,13 @@ concurrency:
 
 jobs:
   benchmark:
-    if: ${{ github.event_name == 'schedule' && github.ref == 'refs/heads/main' && vars.MESH_NIGHTLY_COMPETITIVE_ENABLED == '1' }}
+    if: >-
+      github.repository == 'Mesh-LLM/mesh-llm' &&
+      github.ref == 'refs/heads/main' &&
+      (
+        github.event_name == 'workflow_dispatch' ||
+        (github.event_name == 'schedule' && vars.MESH_NIGHTLY_COMPETITIVE_ENABLED == '1')
+      )
     runs-on: ${{ fromJSON('["self-hosted","Linux","X64","amd64","gpu-nvidia","mesh-llm-amd64","mesh-llm"]') }}
     timeout-minutes: 780
     env:

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -334,7 +334,9 @@ Thoughtworks cell with `scripts/performance-history.py`. When
 `MESH_PERFORMANCE_HISTORY_ENABLED=1`, set
 `MESH_PERFORMANCE_HISTORY_DATASET=meshllm/performance-history` and provide the
 write token as the `MESH_PERFORMANCE_HISTORY_HF_TOKEN` GitHub secret. The
-workflow downloads prior immutable JSONL shards, requires the Hub schema to
+workflow runs on its daily schedule or by a manual dispatch explicitly
+selected from `main`; non-`main` dispatches cannot acquire the persistent GPU
+runner. It downloads prior immutable JSONL shards, requires the Hub schema to
 match `ci/performance-history/schema.json`, reports only exact-cohort drift,
 and uploads one source/run-addressed shard. Three prior complete matching runs
 are required before performance drift is classified; thresholds remain

--- a/scripts/tests/test_kv_nightly_workflow_contract.py
+++ b/scripts/tests/test_kv_nightly_workflow_contract.py
@@ -37,11 +37,17 @@ class KvNightlyWorkflowContractTests(unittest.TestCase):
         self.assertIn("runs-on: ubuntu-24.04", workflow)
         self.assertNotIn("runner_label", workflow)
 
-    def test_performance_history_uses_immutable_shards_on_trusted_schedule(self) -> None:
+    def test_performance_history_uses_immutable_shards_on_trusted_main(self) -> None:
         workflow = COMPETITIVE.read_text(encoding="utf-8")
         self.assertIn("on:\n  schedule:", workflow)
-        self.assertNotIn("workflow_dispatch:", workflow)
+        self.assertIn("workflow_dispatch:", workflow)
+        self.assertIn("github.event_name == 'workflow_dispatch'", workflow)
+        self.assertIn("github.repository == 'Mesh-LLM/mesh-llm'", workflow)
+        self.assertIn("github.ref == 'refs/heads/main'", workflow)
         self.assertIn("ref: main", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertNotIn("\n  pull_request:", workflow)
+        self.assertNotIn("\n  push:", workflow)
         self.assertIn("MESH_PERFORMANCE_HISTORY_HF_TOKEN", workflow)
         self.assertIn("MESH_PERFORMANCE_HISTORY_DATASET", workflow)
         self.assertIn("scripts/performance-history.py", workflow)

--- a/scripts/tests/test_skippy_competitive_benchmark.py
+++ b/scripts/tests/test_skippy_competitive_benchmark.py
@@ -29,14 +29,20 @@ BENCH = load_module()
 
 
 class CompetitiveBenchmarkTest(unittest.TestCase):
-    def test_nightly_workflow_is_schedule_only_and_capacity_matched(self) -> None:
+    def test_nightly_workflow_is_trusted_main_only_and_capacity_matched(self) -> None:
         workflow = (
             REPO / ".github" / "workflows" / "nightly-competitive-benchmark.yml"
         ).read_text(encoding="utf-8")
 
-        self.assertNotIn("workflow_dispatch:", workflow)
+        self.assertIn("workflow_dispatch:", workflow)
         self.assertIn("github.event_name == 'schedule'", workflow)
+        self.assertIn("github.event_name == 'workflow_dispatch'", workflow)
+        self.assertIn("github.repository == 'Mesh-LLM/mesh-llm'", workflow)
         self.assertIn("github.ref == 'refs/heads/main'", workflow)
+        self.assertIn("ref: main", workflow)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertNotIn("\n  pull_request:", workflow)
+        self.assertNotIn("\n  push:", workflow)
         self.assertIn("--capacity-match-comparison-kv", workflow)
 
     def test_checked_in_plan_covers_both_platforms_all_models_and_full_ladder(self) -> None:


### PR DESCRIPTION
## Summary

- allow `Nightly Competitive Benchmark` to be started from the Actions UI
- permit the persistent NVIDIA job only when the selected workflow ref is `main` in `Mesh-LLM/mesh-llm`
- keep checkout pinned to trusted `main` with read-only, non-persistent credentials
- retain the existing schedule and concurrency lock, so manual and scheduled benchmarks cannot overlap

This is the small follow-up requested after #1572 merged. Non-`main` manual dispatches are skipped before acquiring the self-hosted GPU runner.

## Validation

Exact head: `32cec3ad20fc1b09b23a0888773b41219d2e11af`

- `just ci-validate`: 734 tests passed, 7 skipped
- `actionlint` passed
- all repository consistency gates passed
- focused workflow/benchmark contracts: 31 passed
- clean diff and worktree

The runner selector remains:

`self-hosted`, `Linux`, `X64`, `amd64`, `gpu-nvidia`, `mesh-llm-amd64`, `mesh-llm`

Completed Actions jobs confirm that this exact label set has matching runners. Physical GPU identity is still captured and included in the performance-history cohort key, so different machines are not compared.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to manually trigger competitive benchmark runs from the trusted main branch.
  * Scheduled benchmark runs remain gated by the configured enablement setting.

* **Documentation**
  * Clarified that manual performance-history runs must be selected from the main branch.

* **Tests**
  * Updated workflow checks to verify trusted repository, main-branch execution, secure checkout, and restricted triggers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->