### PR TITLE
perf(skippy): cut per-token split decode overhead (~10%)

### DIFF
--- a/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
@@ -7,7 +7,7 @@ use super::control_messages::{
 use super::message_receive::{next_connection_session_id, receive_next_message};
 use super::reply::reply_window_for_message;
 use super::reply::send_stage_reply;
-use super::session_lifecycle::align_session_to_target;
+use super::session_lifecycle::{align_session_to_target, record_session_auto_align};
 use super::session_tracker::{
     ConnectionSessionOwnership, ConnectionSessionTracker, combine_connection_and_cleanup_results,
     release_tracked_connection_sessions,
@@ -467,6 +467,17 @@ fn handle_binary_connection_messages(
                     runtime_lock_acquires = 1;
                     decode_batch_size = outcome.batch_size;
                     decode_batch_wait_ms = outcome.batch_wait_ms;
+                    // The batched frame aligns the session internally from its
+                    // target token count, so surface that trim on the same
+                    // counter and event as the explicit alignment paths. It is
+                    // fused into the decode, so it reports no standalone elapsed.
+                    if let Some(align) = outcome.session_alignment.as_ref() {
+                        let observation =
+                            record_session_auto_align(telemetry, &session_key, align, 0.0);
+                        session_auto_align_count = observation.count;
+                        session_auto_align_ms = observation.elapsed_ms;
+                        session_auto_align_trimmed_tokens = observation.trimmed_tokens;
+                    }
                     (outcome.predicted, Vec::new(), outcome.output, None)
                 } else {
                     let eviction_plan = binary_proactive_eviction_plan(

--- a/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
@@ -7,7 +7,7 @@ use super::control_messages::{
 use super::message_receive::{next_connection_session_id, receive_next_message};
 use super::reply::reply_window_for_message;
 use super::reply::send_stage_reply;
-use super::session_lifecycle::align_session_to_message;
+use super::session_lifecycle::align_session_to_target;
 use super::session_tracker::{
     ConnectionSessionOwnership, ConnectionSessionTracker, combine_connection_and_cleanup_results,
     release_tracked_connection_sessions,
@@ -22,6 +22,7 @@ use super::telemetry::{
 };
 use crate::binary_transport::BinaryStageExecutionOptions;
 use crate::binary_transport::WireCondition;
+use crate::binary_transport::binary_kv::BinaryKvLookupResult;
 use crate::binary_transport::binary_kv::accumulate_shared_prefill_tokens;
 use crate::binary_transport::binary_kv::add_binary_record_stats;
 use crate::binary_transport::binary_kv::emit_binary_proactive_eviction;
@@ -320,26 +321,16 @@ fn handle_binary_connection_messages(
         }
 
         let token_ids = token_sideband_or_fill(&message)?;
-        let align_config = config.clone();
-        let align_telemetry = telemetry.clone();
-        let align_session_key = session_key.clone();
-        let align_message = message.clone();
-        let auto_align = iteration_scheduler
-            .execute_runtime("binary-session-align", move |runtime| {
-                align_session_to_message(
-                    &align_config,
-                    runtime,
-                    &align_telemetry,
-                    &align_session_key,
-                    session_id,
-                    &align_message,
-                )
-                .map_err(|error| openai_frontend::OpenAiError::backend(format!("{error:#}")))
-            })
-            .map_err(|error| anyhow::anyhow!(format!("{error:#}")))?;
-        let session_auto_align_count = auto_align.count;
-        let session_auto_align_ms = auto_align.elapsed_ms;
-        let session_auto_align_trimmed_tokens = auto_align.trimmed_tokens;
+        // Session alignment must run on the scheduler before any lookup or
+        // compute touches the runtime, but it does not deserve its own
+        // scheduler round-trip: it rides inside the first runtime closure
+        // that executes for this message (lookup when the prefix cache will
+        // run one, otherwise the compute dispatch, and the batched decode
+        // path aligns internally from its target token count).
+        let align_target = message.authoritative_session_position();
+        let mut session_auto_align_count = 0usize;
+        let mut session_auto_align_ms = 0.0;
+        let mut session_auto_align_trimmed_tokens = 0u64;
         if message.kind.is_prefill()
             && let Some(cache) = kv
         {
@@ -351,26 +342,48 @@ fn handle_binary_connection_messages(
             );
         }
         let mut message_reply_stats = StageReplyStats::default();
-        let lookup_config = config.clone();
-        let lookup_kv = kv.cloned();
-        let lookup_telemetry = telemetry.clone();
-        let lookup_session_key = session_key.clone();
-        let lookup_message = message.clone();
-        let lookup_token_ids = token_ids.clone();
-        let lookup_result = iteration_scheduler
-            .execute_runtime("binary-prefix-lookup", move |runtime| {
-                Ok(maybe_lookup_binary_prefill(
-                    &lookup_config,
-                    runtime,
-                    lookup_kv.as_ref(),
-                    &lookup_telemetry,
-                    &lookup_session_key,
-                    &lookup_message,
-                    &lookup_token_ids,
-                    output_activation_width,
-                ))
-            })
-            .map_err(|error| anyhow::anyhow!(format!("{error:#}")))?;
+        let lookup_needed = kv.is_some_and(|cache| cache.should_lookup())
+            && message.kind.is_prefill()
+            && !message.kind.requires_predicted_reply()
+            && !token_ids.is_empty();
+        let lookup_result = if lookup_needed {
+            let lookup_config = config.clone();
+            let lookup_kv = kv.cloned();
+            let lookup_telemetry = telemetry.clone();
+            let lookup_session_key = session_key.clone();
+            let lookup_message = message.clone();
+            let lookup_token_ids = token_ids.clone();
+            let (auto_align, lookup_result) = iteration_scheduler
+                .execute_runtime("binary-prefix-lookup", move |runtime| {
+                    let auto_align = align_session_to_target(
+                        runtime,
+                        &lookup_telemetry,
+                        &lookup_session_key,
+                        align_target,
+                    )
+                    .map_err(|error| openai_frontend::OpenAiError::backend(format!("{error:#}")))?;
+                    Ok((
+                        auto_align,
+                        maybe_lookup_binary_prefill(
+                            &lookup_config,
+                            runtime,
+                            lookup_kv.as_ref(),
+                            &lookup_telemetry,
+                            &lookup_session_key,
+                            &lookup_message,
+                            &lookup_token_ids,
+                            output_activation_width,
+                        ),
+                    ))
+                })
+                .map_err(|error| anyhow::anyhow!(format!("{error:#}")))?;
+            session_auto_align_count = auto_align.count;
+            session_auto_align_ms = auto_align.elapsed_ms;
+            session_auto_align_trimmed_tokens = auto_align.trimmed_tokens;
+            lookup_result
+        } else {
+            BinaryKvLookupResult::default()
+        };
         message_reply_stats.merge(lookup_result.stats);
         let restored_prefill =
             lookup_result.restored_tokens >= token_ids.len() && !token_ids.is_empty();
@@ -474,9 +487,26 @@ fn handle_binary_connection_messages(
                     let scheduler_message = message.clone();
                     let scheduler_token_ids = executable_token_ids.to_vec();
                     let scheduler_kv = kv.cloned();
+                    let scheduler_telemetry = telemetry.clone();
+                    let align_in_compute = !lookup_needed;
+                    let collect_session_stats = telemetry.is_debug_enabled();
                     let outcome = iteration_scheduler
                         .execute_runtime_timed("binary-stage-execute", move |runtime| {
-                            let sessions_before = runtime.session_stats();
+                            let auto_align = if align_in_compute {
+                                align_session_to_target(
+                                    runtime,
+                                    &scheduler_telemetry,
+                                    &scheduler_session_key,
+                                    align_target,
+                                )
+                                .map_err(|error| {
+                                    openai_frontend::OpenAiError::backend(format!("{error:#}"))
+                                })?
+                            } else {
+                                Default::default()
+                            };
+                            let sessions_before =
+                                collect_session_stats.then(|| runtime.session_stats());
                             let eviction = if eviction_plan.required {
                                 Some(
                                     evict_binary_resident_prefix_for_decode(
@@ -507,8 +537,15 @@ fn handle_binary_connection_messages(
                             .map_err(|error| {
                                 openai_frontend::OpenAiError::backend(format!("{error:#}"))
                             })?;
-                            let sessions_after = runtime.session_stats();
-                            Ok((sessions_before, sessions_after, eviction, result))
+                            let sessions_after =
+                                collect_session_stats.then(|| runtime.session_stats());
+                            Ok((
+                                auto_align,
+                                sessions_before,
+                                sessions_after,
+                                eviction,
+                                result,
+                            ))
                         })
                         .map_err(|error| anyhow::anyhow!(format!("{error:#}")))
                         .with_context(|| {
@@ -527,9 +564,15 @@ fn handle_binary_connection_messages(
                     runtime_lock_wait_ms = outcome.runtime_lock_wait_ms;
                     runtime_lock_hold_ms = outcome.runtime_lock_hold_ms;
                     runtime_lock_acquires = 1;
-                    let (sessions_before, sessions_after, eviction, result) = outcome.value;
-                    runtime_sessions_before = Some(sessions_before);
-                    runtime_sessions_after = Some(sessions_after);
+                    let (auto_align, sessions_before, sessions_after, eviction, result) =
+                        outcome.value;
+                    if align_in_compute {
+                        session_auto_align_count = auto_align.count;
+                        session_auto_align_ms = auto_align.elapsed_ms;
+                        session_auto_align_trimmed_tokens = auto_align.trimmed_tokens;
+                    }
+                    runtime_sessions_before = sessions_before;
+                    runtime_sessions_after = sessions_after;
                     proactive_eviction = eviction;
                     result
                 };
@@ -663,7 +706,13 @@ fn handle_binary_connection_messages(
                 .then_some(accumulated_prefill_tokens.as_deref())
                 .flatten()
         });
-        if let Some(full_prompt_tokens) = completed_prompt_tokens {
+        // The record helper's own no-record gates are runtime-free; checking
+        // them here keeps the recorder's scheduler round-trip (and the
+        // message/token clones feeding it) off the per-token path whenever
+        // the prefix cache would not record anyway.
+        let full_prefill_record_needed = kv.is_some_and(|cache| cache.should_record())
+            && completed_prompt_tokens.is_some_and(|tokens| !tokens.is_empty());
+        if full_prefill_record_needed && let Some(full_prompt_tokens) = completed_prompt_tokens {
             let record_config = config.clone();
             let record_kv = kv.cloned();
             let record_telemetry = telemetry.clone();

--- a/crates/skippy-server/src/binary_transport/binary_messaging/session_lifecycle.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/session_lifecycle.rs
@@ -1,5 +1,5 @@
 use crate::binary_transport::stage_execution::elapsed_ms;
-use crate::runtime_state::RuntimeState;
+use crate::runtime_state::{RuntimeSessionAlignStats, RuntimeState};
 use crate::telemetry::Telemetry;
 use anyhow::{Context, Result};
 use serde_json::json;
@@ -11,6 +11,46 @@ pub(super) struct SessionAutoAlignObservation {
     pub(super) count: usize,
     pub(super) elapsed_ms: f64,
     pub(super) trimmed_tokens: u64,
+}
+
+/// Emit the auto-align debug event for a completed trim and build its
+/// observation. Shared so every alignment path reports the same counter and the
+/// same event attributes, whether the trim ran through an explicit
+/// [`align_session_to_target`] call (lookup/compute paths, which time it) or was
+/// fused into a batched decode frame (which reports no standalone elapsed).
+pub(super) fn record_session_auto_align(
+    telemetry: &Telemetry,
+    session_key: &str,
+    align: &RuntimeSessionAlignStats,
+    elapsed_ms: f64,
+) -> SessionAutoAlignObservation {
+    let trimmed_tokens = align
+        .before_token_count
+        .saturating_sub(align.after_token_count);
+    telemetry.emit_debug(
+        "stage.binary_session_auto_align",
+        BTreeMap::from([
+            ("skippy.session_id".to_string(), json!(session_key)),
+            (
+                "llama_stage.session_auto_align_before_tokens".to_string(),
+                json!(align.before_token_count),
+            ),
+            (
+                "llama_stage.session_auto_align_after_tokens".to_string(),
+                json!(align.after_token_count),
+            ),
+            (
+                "llama_stage.session_auto_align_trimmed_tokens".to_string(),
+                json!(trimmed_tokens),
+            ),
+            ("llama_stage.elapsed_ms".to_string(), json!(elapsed_ms)),
+        ]),
+    );
+    SessionAutoAlignObservation {
+        count: 1,
+        elapsed_ms,
+        trimmed_tokens,
+    }
 }
 
 /// Trims a stage session that is ahead of the message's authoritative
@@ -33,27 +73,10 @@ pub(super) fn align_session_to_target(
     let Some(align) = align else {
         return Ok(SessionAutoAlignObservation::default());
     };
-    let elapsed_ms = elapsed_ms(started);
-    telemetry.emit_debug(
-        "stage.binary_session_auto_align",
-        BTreeMap::from([
-            ("skippy.session_id".to_string(), json!(session_key)),
-            (
-                "llama_stage.session_auto_align_before_tokens".to_string(),
-                json!(align.before_token_count),
-            ),
-            (
-                "llama_stage.session_auto_align_after_tokens".to_string(),
-                json!(align.after_token_count),
-            ),
-            ("llama_stage.elapsed_ms".to_string(), json!(elapsed_ms)),
-        ]),
-    );
-    Ok(SessionAutoAlignObservation {
-        count: 1,
-        elapsed_ms,
-        trimmed_tokens: align
-            .before_token_count
-            .saturating_sub(align.after_token_count),
-    })
+    Ok(record_session_auto_align(
+        telemetry,
+        session_key,
+        &align,
+        elapsed_ms(started),
+    ))
 }

--- a/crates/skippy-server/src/binary_transport/binary_messaging/session_lifecycle.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/session_lifecycle.rs
@@ -1,10 +1,9 @@
-use crate::binary_transport::stage_execution::{binary_message_attrs, elapsed_ms};
+use crate::binary_transport::stage_execution::elapsed_ms;
 use crate::runtime_state::RuntimeState;
 use crate::telemetry::Telemetry;
 use anyhow::{Context, Result};
 use serde_json::json;
-use skippy_protocol::StageConfig;
-use skippy_protocol::binary::StageWireMessage;
+use std::collections::BTreeMap;
 use std::time::Instant;
 
 #[derive(Default)]
@@ -14,15 +13,17 @@ pub(super) struct SessionAutoAlignObservation {
     pub(super) trimmed_tokens: u64,
 }
 
-pub(super) fn align_session_to_message(
-    config: &StageConfig,
+/// Trims a stage session that is ahead of the message's authoritative
+/// position. Callers run this inside a scheduler runtime closure they already
+/// own for the message, so alignment does not cost its own scheduler
+/// round-trip on the per-token path.
+pub(super) fn align_session_to_target(
     runtime: &mut RuntimeState,
     telemetry: &Telemetry,
     session_key: &str,
-    session_id: u64,
-    message: &StageWireMessage,
+    target_token_count: Option<u64>,
 ) -> Result<SessionAutoAlignObservation> {
-    let Some(target_token_count) = message.authoritative_session_position() else {
+    let Some(target_token_count) = target_token_count else {
         return Ok(SessionAutoAlignObservation::default());
     };
     let started = Instant::now();
@@ -33,17 +34,21 @@ pub(super) fn align_session_to_message(
         return Ok(SessionAutoAlignObservation::default());
     };
     let elapsed_ms = elapsed_ms(started);
-    let mut attrs = binary_message_attrs(config, session_id, message);
-    attrs.insert(
-        "llama_stage.session_auto_align_before_tokens".to_string(),
-        json!(align.before_token_count),
+    telemetry.emit_debug(
+        "stage.binary_session_auto_align",
+        BTreeMap::from([
+            ("skippy.session_id".to_string(), json!(session_key)),
+            (
+                "llama_stage.session_auto_align_before_tokens".to_string(),
+                json!(align.before_token_count),
+            ),
+            (
+                "llama_stage.session_auto_align_after_tokens".to_string(),
+                json!(align.after_token_count),
+            ),
+            ("llama_stage.elapsed_ms".to_string(), json!(elapsed_ms)),
+        ]),
     );
-    attrs.insert(
-        "llama_stage.session_auto_align_after_tokens".to_string(),
-        json!(align.after_token_count),
-    );
-    attrs.insert("llama_stage.elapsed_ms".to_string(), json!(elapsed_ms));
-    telemetry.emit_debug("stage.binary_session_auto_align", attrs);
     Ok(SessionAutoAlignObservation {
         count: 1,
         elapsed_ms,

--- a/crates/skippy-server/src/binary_transport/direct_return.rs
+++ b/crates/skippy-server/src/binary_transport/direct_return.rs
@@ -6,7 +6,7 @@ use std::{
         Arc, Mutex,
         atomic::{AtomicBool, Ordering},
         mpsc,
-        mpsc::{RecvTimeoutError, TryRecvError},
+        mpsc::RecvTimeoutError,
     },
     thread::{self, JoinHandle},
     time::Duration,
@@ -275,16 +275,8 @@ impl PredictionReturnReceiver {
         validate_expected_reply(reply, std::slice::from_ref(&expected)).map(Some)
     }
 
-    pub(crate) fn try_recv_one_of(&self, expected: &[WireReplyKind]) -> Result<Option<StageReply>> {
-        let Some(reply) = self.try_recv()? else {
-            return Ok(None);
-        };
-        validate_expected_reply(reply, expected).map(Some)
-    }
-
     /// Event-driven bounded wait: blocks on the return channel and wakes the
-    /// moment a reply is delivered, unlike `try_recv_one_of` which only
-    /// samples. Returns `None` on timeout.
+    /// moment a reply is delivered. Returns `None` on timeout.
     pub(crate) fn recv_one_of_timeout(
         &self,
         expected: &[WireReplyKind],
@@ -299,17 +291,6 @@ impl PredictionReturnReceiver {
             }
         };
         validate_expected_reply(reply, expected).map(Some)
-    }
-
-    fn try_recv(&self) -> Result<Option<StageReply>> {
-        match self.receiver.try_recv() {
-            Ok(Ok(reply)) => Ok(Some(reply)),
-            Ok(Err(error)) => Err(anyhow!(error)),
-            Err(TryRecvError::Empty) => Ok(None),
-            Err(TryRecvError::Disconnected) => {
-                Err(anyhow!("prediction return channel disconnected"))
-            }
-        }
     }
 }
 

--- a/crates/skippy-server/src/binary_transport/direct_return.rs
+++ b/crates/skippy-server/src/binary_transport/direct_return.rs
@@ -282,6 +282,25 @@ impl PredictionReturnReceiver {
         validate_expected_reply(reply, expected).map(Some)
     }
 
+    /// Event-driven bounded wait: blocks on the return channel and wakes the
+    /// moment a reply is delivered, unlike `try_recv_one_of` which only
+    /// samples. Returns `None` on timeout.
+    pub(crate) fn recv_one_of_timeout(
+        &self,
+        expected: &[WireReplyKind],
+        timeout: Duration,
+    ) -> Result<Option<StageReply>> {
+        let reply = match self.receiver.recv_timeout(timeout) {
+            Ok(Ok(reply)) => reply,
+            Ok(Err(error)) => return Err(anyhow!(error)),
+            Err(RecvTimeoutError::Timeout) => return Ok(None),
+            Err(RecvTimeoutError::Disconnected) => {
+                return Err(anyhow!("prediction return channel disconnected"));
+            }
+        };
+        validate_expected_reply(reply, expected).map(Some)
+    }
+
     fn try_recv(&self) -> Result<Option<StageReply>> {
         match self.receiver.try_recv() {
             Ok(Ok(reply)) => Ok(Some(reply)),

--- a/crates/skippy-server/src/frontend/embedded_execution.rs
+++ b/crates/skippy-server/src/frontend/embedded_execution.rs
@@ -445,12 +445,11 @@ fn poll_direct_or_downstream_reply_with_timeouts(
             // `peek` only proves that the first byte has arrived. Tunnelled
             // replies may be fragmented, so decode the complete frame under
             // the remainder of the bounded fallback deadline rather than the
-            // nonblocking mode used for the availability check.
+            // short read timeout used for the availability check.
             let remaining = reply_timeout.saturating_sub(started.elapsed());
             if remaining.is_zero() {
                 break Err(timeout_error());
             }
-            timeout_restore.prepare_blocking_read()?;
             downstream
                 .set_read_timeout(Some(remaining))
                 .map_err(openai_io_error)?;
@@ -478,6 +477,15 @@ fn downstream_reply_available(downstream: &TcpStream) -> OpenAiResult<bool> {
     }
 }
 
+/// Availability peeks run under a short read timeout rather than nonblocking
+/// mode. `O_NONBLOCK` lives on the shared open-file description, so setting it
+/// on this socket would also make writes on any `try_clone()` handle — such as
+/// an `AsyncForwarder` worker forwarding activations to the next stage — fail
+/// with `WouldBlock` once the send buffer fills. A read timeout (`SO_RCVTIMEO`)
+/// affects receives only, so a concurrent cloned writer keeps blocking
+/// semantics.
+const DIRECT_RETURN_PEEK_TIMEOUT: Duration = Duration::from_millis(1);
+
 struct DirectReturnFallbackTimeout {
     downstream: TcpStream,
     previous_timeout: Option<Duration>,
@@ -485,13 +493,15 @@ struct DirectReturnFallbackTimeout {
 }
 
 impl DirectReturnFallbackTimeout {
-    /// Puts the downstream socket into nonblocking mode so availability peeks
-    /// return immediately while the reply wait blocks on the direct-return
-    /// channel instead.
+    /// Give the downstream socket a short read timeout so availability peeks
+    /// return promptly while the reply wait blocks on the direct-return channel,
+    /// without toggling nonblocking mode on the shared file description.
     fn install(downstream: &TcpStream) -> OpenAiResult<Self> {
         let previous_timeout = downstream.read_timeout().map_err(openai_io_error)?;
         let restore_stream = downstream.try_clone().map_err(openai_io_error)?;
-        downstream.set_nonblocking(true).map_err(openai_io_error)?;
+        downstream
+            .set_read_timeout(Some(DIRECT_RETURN_PEEK_TIMEOUT))
+            .map_err(openai_io_error)?;
         Ok(Self {
             downstream: restore_stream,
             previous_timeout,
@@ -499,17 +509,7 @@ impl DirectReturnFallbackTimeout {
         })
     }
 
-    /// Leave nonblocking mode before handing the socket to a frame decode.
-    fn prepare_blocking_read(&mut self) -> OpenAiResult<()> {
-        self.downstream
-            .set_nonblocking(false)
-            .map_err(openai_io_error)
-    }
-
     fn restore(&mut self) -> OpenAiResult<()> {
-        self.downstream
-            .set_nonblocking(false)
-            .map_err(openai_io_error)?;
         self.downstream
             .set_read_timeout(self.previous_timeout)
             .map_err(openai_io_error)?;
@@ -521,7 +521,6 @@ impl DirectReturnFallbackTimeout {
 impl Drop for DirectReturnFallbackTimeout {
     fn drop(&mut self) {
         if !self.restored {
-            let _ = self.downstream.set_nonblocking(false);
             let _ = self.downstream.set_read_timeout(self.previous_timeout);
         }
     }
@@ -628,6 +627,48 @@ mod tests {
         let client = TcpStream::connect(listener.local_addr().unwrap()).unwrap();
         let (server, _) = listener.accept().unwrap();
         (client, server)
+    }
+
+    #[test]
+    fn fallback_guard_keeps_a_cloned_writer_blocking() {
+        use std::io::{Read, Write};
+        // AsyncForwarder clones the downstream socket and writes frames from a
+        // separate worker thread. The fallback-wait guard must not toggle
+        // O_NONBLOCK on the shared open-file description, or those writes would
+        // fail with WouldBlock once the send buffer fills instead of blocking.
+        // A read timeout (SO_RCVTIMEO) affects receives only, so the writer is
+        // unaffected. Regression for michaelneale's review on #1575.
+        const PAYLOAD: usize = 8 * 1024 * 1024;
+        let (downstream, peer) = connected_stream_pair();
+        let writer = downstream.try_clone().unwrap();
+
+        // Peer starts reading only after a delay, forcing the send buffer to
+        // fill so a correct blocking write_all must wait rather than error.
+        let reader = std::thread::spawn(move || {
+            let mut peer = peer;
+            std::thread::sleep(Duration::from_millis(100));
+            let mut sink = vec![0u8; 1 << 16];
+            let mut total = 0usize;
+            while total < PAYLOAD {
+                match peer.read(&mut sink) {
+                    Ok(0) => break,
+                    Ok(n) => total += n,
+                    Err(error) => panic!("peer read failed: {error}"),
+                }
+            }
+            total
+        });
+
+        let guard = DirectReturnFallbackTimeout::install(&downstream).unwrap();
+        let mut writer = writer;
+        // Must block until the peer drains, not fail with WouldBlock (os err 35).
+        writer
+            .write_all(&vec![0u8; PAYLOAD])
+            .expect("cloned writer must keep blocking semantics under the guard");
+        drop(guard);
+        drop(writer);
+        drop(downstream);
+        assert_eq!(reader.join().unwrap(), PAYLOAD);
     }
 
     #[test]

--- a/crates/skippy-server/src/frontend/embedded_execution.rs
+++ b/crates/skippy-server/src/frontend/embedded_execution.rs
@@ -399,20 +399,26 @@ fn poll_direct_or_downstream_reply(
     let mut timeout_restore = DirectReturnFallbackTimeout::install(downstream)?;
     let started = Instant::now();
     let reply_timeout = stage_reply_timeout();
+    // The direct-return sink is the standard reply path, so block on its
+    // channel and wake the moment the reply lands instead of sampling it
+    // between bounded peeks: sampling quantized every reply wait to the poll
+    // interval and cost a uniform 0..poll of added latency per token. The
+    // tunnelled downstream fallback is checked without blocking each slice,
+    // so a fallback reply is still detected within one poll interval.
     let result = loop {
         if let Some(reply) = prediction_return
-            .try_recv_one_of(expected_replies)
+            .recv_one_of_timeout(expected_replies, DIRECT_RETURN_FALLBACK_POLL)
             .map_err(openai_backend_error)?
         {
             break Ok(reply);
         }
         if downstream_reply_available(downstream)? {
             // `peek` only proves that the first byte has arrived. Tunnelled
-            // replies may be fragmented, so retaining the short poll timeout
-            // while decoding the complete frame turns an ordinary partial
-            // arrival into EWOULDBLOCK. Once downstream wins the race, give
-            // the frame the remainder of the bounded fallback deadline.
+            // replies may be fragmented, so decode the complete frame under
+            // the remainder of the bounded fallback deadline rather than the
+            // nonblocking mode used for the availability check.
             let remaining = reply_timeout.saturating_sub(started.elapsed());
+            timeout_restore.prepare_blocking_read()?;
             downstream
                 .set_read_timeout(Some(remaining.max(DIRECT_RETURN_FALLBACK_POLL)))
                 .map_err(openai_io_error)?;
@@ -452,12 +458,13 @@ struct DirectReturnFallbackTimeout {
 }
 
 impl DirectReturnFallbackTimeout {
+    /// Puts the downstream socket into nonblocking mode so availability peeks
+    /// return immediately while the reply wait blocks on the direct-return
+    /// channel instead.
     fn install(downstream: &TcpStream) -> OpenAiResult<Self> {
         let previous_timeout = downstream.read_timeout().map_err(openai_io_error)?;
         let restore_stream = downstream.try_clone().map_err(openai_io_error)?;
-        downstream
-            .set_read_timeout(Some(DIRECT_RETURN_FALLBACK_POLL))
-            .map_err(openai_io_error)?;
+        downstream.set_nonblocking(true).map_err(openai_io_error)?;
         Ok(Self {
             downstream: restore_stream,
             previous_timeout,
@@ -465,7 +472,17 @@ impl DirectReturnFallbackTimeout {
         })
     }
 
+    /// Leave nonblocking mode before handing the socket to a frame decode.
+    fn prepare_blocking_read(&mut self) -> OpenAiResult<()> {
+        self.downstream
+            .set_nonblocking(false)
+            .map_err(openai_io_error)
+    }
+
     fn restore(&mut self) -> OpenAiResult<()> {
+        self.downstream
+            .set_nonblocking(false)
+            .map_err(openai_io_error)?;
         self.downstream
             .set_read_timeout(self.previous_timeout)
             .map_err(openai_io_error)?;
@@ -477,6 +494,7 @@ impl DirectReturnFallbackTimeout {
 impl Drop for DirectReturnFallbackTimeout {
     fn drop(&mut self) {
         if !self.restored {
+            let _ = self.downstream.set_nonblocking(false);
             let _ = self.downstream.set_read_timeout(self.previous_timeout);
         }
     }
@@ -588,13 +606,6 @@ mod tests {
     #[test]
     fn direct_return_fallback_timeout_restores_on_drop_after_early_exit() {
         let (stream, _peer) = connected_stream_pair();
-        // Socket timeout readback may be rounded to the OS timer granularity.
-        // Capture the effective values so the test verifies install and restore
-        // without assuming the kernel preserves the requested duration exactly.
-        stream
-            .set_read_timeout(Some(DIRECT_RETURN_FALLBACK_POLL))
-            .unwrap();
-        let effective_poll = stream.read_timeout().unwrap();
         stream
             .set_read_timeout(Some(Duration::from_millis(123)))
             .unwrap();
@@ -602,10 +613,89 @@ mod tests {
 
         {
             let _restore = DirectReturnFallbackTimeout::install(&stream).unwrap();
-            assert_eq!(stream.read_timeout().unwrap(), effective_poll);
+            // Nonblocking mode makes an availability peek on a silent socket
+            // return immediately instead of blocking out the read timeout.
+            let started = Instant::now();
+            let mut byte = [0u8; 1];
+            let peek = stream.peek(&mut byte);
+            assert!(matches!(
+                peek,
+                Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock
+            ));
+            assert!(started.elapsed() < Duration::from_millis(50));
         }
 
+        // Drop restores blocking mode and the original read timeout.
         assert_eq!(stream.read_timeout().unwrap(), effective_original);
+        let started = Instant::now();
+        let mut byte = [0u8; 1];
+        let peek = stream.peek(&mut byte);
+        assert!(matches!(
+            peek,
+            Err(ref error) if matches!(error.kind(), std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut)
+        ));
+        assert!(started.elapsed() >= Duration::from_millis(100));
+    }
+
+    #[test]
+    fn direct_return_reply_wakes_the_wait_immediately() {
+        let request_id = 71;
+        let session_id = 73;
+        let hub = Arc::new(PredictionReturnHub::default());
+        let receiver = hub.register(request_id, session_id).unwrap();
+        let (mut downstream, _peer) = connected_stream_pair();
+
+        // Feed replies through the real return-stream reader: the sink writer
+        // half sends framed replies, the attached reader delivers them to the
+        // hub channel the wait blocks on.
+        let (sink_writer, sink_reader) = connected_stream_pair();
+        receiver.attach_opened_stream(sink_reader);
+        let sink_writer = Arc::new(std::sync::Mutex::new(sink_writer));
+
+        let mut max_wake_ms = 0.0_f64;
+        for _ in 0..5 {
+            let writer = sink_writer.clone();
+            let sent_at = Arc::new(std::sync::Mutex::new(None::<Instant>));
+            let sent_at_writer = sent_at.clone();
+            let sender = std::thread::spawn(move || {
+                std::thread::sleep(Duration::from_millis(20));
+                let mut stream = writer.lock().unwrap();
+                *sent_at_writer.lock().unwrap() = Some(Instant::now());
+                skippy_protocol::binary::send_reply_message(
+                    &mut *stream,
+                    &StageReply {
+                        kind: WireReplyKind::PredictedToken,
+                        predicted: 5,
+                        predicted_tokens: vec![5],
+                        native_mtp_draft: None,
+                        window: Default::default(),
+                        stats: StageReplyStats::default(),
+                    },
+                )
+                .unwrap();
+            });
+
+            let reply = receive_embedded_stage_reply_one_of(
+                &mut downstream,
+                Some(&receiver),
+                &[WireReplyKind::PredictedToken],
+            )
+            .unwrap();
+            let received_at = Instant::now();
+            sender.join().unwrap();
+            assert_eq!(reply.predicted, 5);
+            let wake_ms = received_at
+                .duration_since(sent_at.lock().unwrap().unwrap())
+                .as_secs_f64()
+                * 1000.0;
+            max_wake_ms = max_wake_ms.max(wake_ms);
+        }
+        // The wait must be event-driven: a sampling loop quantizes wake-up to
+        // its poll interval (10ms) and reliably exceeds this bound.
+        assert!(
+            max_wake_ms < 8.0,
+            "direct return wake took {max_wake_ms:.2}ms; reply wait is polling, not event-driven"
+        );
     }
 
     #[test]

--- a/crates/skippy-server/src/frontend/embedded_execution.rs
+++ b/crates/skippy-server/src/frontend/embedded_execution.rs
@@ -401,23 +401,25 @@ fn poll_direct_or_downstream_reply(
         prediction_return,
         expected_replies,
         DIRECT_RETURN_FALLBACK_POLL,
+        DIRECT_RETURN_PEEK_TIMEOUT,
         stage_reply_timeout(),
     )
 }
 
-// The fallback poll interval is injectable so a test can widen it and assert the
-// direct-return wake fires well inside one interval — proving the wait is
-// event-driven rather than quantized to the poll — without depending on
-// sub-poll scheduler latency, which a loaded or virtualized CI runner cannot
-// guarantee.
+// The fallback poll and availability-peek intervals are injectable so tests can
+// widen them: a wide fallback poll proves the wake is event-driven rather than
+// quantized to the poll (without depending on sub-poll scheduler latency), and a
+// wide peek interval proves the peek is bounded by the remaining reply deadline
+// rather than overrunning it by a fixed interval.
 fn poll_direct_or_downstream_reply_with_timeouts(
     downstream: &mut TcpStream,
     prediction_return: &PredictionReturnReceiver,
     expected_replies: &[WireReplyKind],
     fallback_poll: Duration,
+    peek_timeout: Duration,
     reply_timeout: Duration,
 ) -> OpenAiResult<StageReply> {
-    let mut timeout_restore = DirectReturnFallbackTimeout::install(downstream)?;
+    let mut timeout_restore = DirectReturnFallbackTimeout::install(downstream, peek_timeout)?;
     let started = Instant::now();
     let timeout_error = || {
         OpenAiError::backend(format!(
@@ -441,6 +443,16 @@ fn poll_direct_or_downstream_reply_with_timeouts(
         {
             break Ok(reply);
         }
+        // The channel wait above may have consumed the deadline; recompute the
+        // budget and bound the availability peek by it so the whole wait honours
+        // `reply_timeout` rather than overrunning by a fixed peek interval.
+        let remaining = reply_timeout.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            break Err(timeout_error());
+        }
+        downstream
+            .set_read_timeout(Some(remaining.min(peek_timeout)))
+            .map_err(openai_io_error)?;
         if downstream_reply_available(downstream)? {
             // `peek` only proves that the first byte has arrived. Tunnelled
             // replies may be fragmented, so decode the complete frame under
@@ -496,11 +508,11 @@ impl DirectReturnFallbackTimeout {
     /// Give the downstream socket a short read timeout so availability peeks
     /// return promptly while the reply wait blocks on the direct-return channel,
     /// without toggling nonblocking mode on the shared file description.
-    fn install(downstream: &TcpStream) -> OpenAiResult<Self> {
+    fn install(downstream: &TcpStream, peek_timeout: Duration) -> OpenAiResult<Self> {
         let previous_timeout = downstream.read_timeout().map_err(openai_io_error)?;
         let restore_stream = downstream.try_clone().map_err(openai_io_error)?;
         downstream
-            .set_read_timeout(Some(DIRECT_RETURN_PEEK_TIMEOUT))
+            .set_read_timeout(Some(peek_timeout))
             .map_err(openai_io_error)?;
         Ok(Self {
             downstream: restore_stream,
@@ -659,7 +671,8 @@ mod tests {
             total
         });
 
-        let guard = DirectReturnFallbackTimeout::install(&downstream).unwrap();
+        let guard =
+            DirectReturnFallbackTimeout::install(&downstream, DIRECT_RETURN_PEEK_TIMEOUT).unwrap();
         let mut writer = writer;
         // Must block until the peer drains, not fail with WouldBlock (os err 35).
         writer
@@ -680,15 +693,22 @@ mod tests {
         let effective_original = stream.read_timeout().unwrap();
 
         {
-            let _restore = DirectReturnFallbackTimeout::install(&stream).unwrap();
-            // Nonblocking mode makes an availability peek on a silent socket
-            // return immediately instead of blocking out the read timeout.
+            let _restore =
+                DirectReturnFallbackTimeout::install(&stream, DIRECT_RETURN_PEEK_TIMEOUT).unwrap();
+            // The short read timeout makes an availability peek on a silent
+            // socket return promptly instead of blocking out the original read
+            // timeout. A timed-out peek surfaces as WouldBlock on Unix and
+            // TimedOut on Windows.
             let started = Instant::now();
             let mut byte = [0u8; 1];
             let peek = stream.peek(&mut byte);
             assert!(matches!(
                 peek,
-                Err(ref error) if error.kind() == std::io::ErrorKind::WouldBlock
+                Err(ref error)
+                    if matches!(
+                        error.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    )
             ));
             assert!(started.elapsed() < Duration::from_millis(50));
         }
@@ -757,6 +777,7 @@ mod tests {
                 &receiver,
                 &[WireReplyKind::PredictedToken],
                 WIDE_FALLBACK_POLL,
+                DIRECT_RETURN_PEEK_TIMEOUT,
                 stage_reply_timeout(),
             )
             .unwrap();
@@ -784,7 +805,12 @@ mod tests {
     #[test]
     fn direct_return_fallback_wait_stays_within_reply_deadline() {
         const REPLY_TIMEOUT: Duration = Duration::from_millis(50);
-        const WIDE_FALLBACK_POLL: Duration = Duration::from_secs(2);
+        // A short fallback poll guarantees the loop reaches an availability peek
+        // with time still on the clock, and a peek interval far larger than the
+        // deadline means an unbounded peek would overrun by ~2s. Bounding the
+        // peek by the remaining budget keeps the whole wait near REPLY_TIMEOUT.
+        const SHORT_FALLBACK_POLL: Duration = Duration::from_millis(10);
+        const WIDE_PEEK_POLL: Duration = Duration::from_secs(2);
         let hub = Arc::new(PredictionReturnHub::default());
         let receiver = hub.register(81, 83).unwrap();
         let (mut downstream, _peer) = connected_stream_pair();
@@ -794,7 +820,8 @@ mod tests {
             &mut downstream,
             &receiver,
             &[WireReplyKind::PredictedToken],
-            WIDE_FALLBACK_POLL,
+            SHORT_FALLBACK_POLL,
+            WIDE_PEEK_POLL,
             REPLY_TIMEOUT,
         )
         .unwrap_err();
@@ -803,8 +830,8 @@ mod tests {
         assert!(error.to_string().contains("timed out waiting for one of"));
         assert!(elapsed >= REPLY_TIMEOUT);
         assert!(
-            elapsed < Duration::from_millis(750),
-            "reply wait took {elapsed:?} with a {REPLY_TIMEOUT:?} deadline and {WIDE_FALLBACK_POLL:?} fallback poll"
+            elapsed < Duration::from_millis(400),
+            "reply wait took {elapsed:?} with a {REPLY_TIMEOUT:?} deadline and {WIDE_PEEK_POLL:?} peek interval; the availability peek is not bounded by the remaining budget"
         );
         assert_eq!(downstream.read_timeout().unwrap(), None);
     }

--- a/crates/skippy-server/src/frontend/embedded_execution.rs
+++ b/crates/skippy-server/src/frontend/embedded_execution.rs
@@ -396,11 +396,12 @@ fn poll_direct_or_downstream_reply(
     prediction_return: &PredictionReturnReceiver,
     expected_replies: &[WireReplyKind],
 ) -> OpenAiResult<StageReply> {
-    poll_direct_or_downstream_reply_with_fallback_poll(
+    poll_direct_or_downstream_reply_with_timeouts(
         downstream,
         prediction_return,
         expected_replies,
         DIRECT_RETURN_FALLBACK_POLL,
+        stage_reply_timeout(),
     )
 }
 
@@ -409,15 +410,20 @@ fn poll_direct_or_downstream_reply(
 // event-driven rather than quantized to the poll — without depending on
 // sub-poll scheduler latency, which a loaded or virtualized CI runner cannot
 // guarantee.
-fn poll_direct_or_downstream_reply_with_fallback_poll(
+fn poll_direct_or_downstream_reply_with_timeouts(
     downstream: &mut TcpStream,
     prediction_return: &PredictionReturnReceiver,
     expected_replies: &[WireReplyKind],
     fallback_poll: Duration,
+    reply_timeout: Duration,
 ) -> OpenAiResult<StageReply> {
     let mut timeout_restore = DirectReturnFallbackTimeout::install(downstream)?;
     let started = Instant::now();
-    let reply_timeout = stage_reply_timeout();
+    let timeout_error = || {
+        OpenAiError::backend(format!(
+            "timed out waiting for one of {expected_replies:?} from direct return or downstream"
+        ))
+    };
     // The direct-return sink is the standard reply path, so block on its
     // channel and wake the moment the reply lands instead of sampling it
     // between bounded peeks: sampling quantized every reply wait to the poll
@@ -425,8 +431,12 @@ fn poll_direct_or_downstream_reply_with_fallback_poll(
     // tunnelled downstream fallback is checked without blocking each slice,
     // so a fallback reply is still detected within one poll interval.
     let result = loop {
+        let remaining = reply_timeout.saturating_sub(started.elapsed());
+        if remaining.is_zero() {
+            break Err(timeout_error());
+        }
         if let Some(reply) = prediction_return
-            .recv_one_of_timeout(expected_replies, fallback_poll)
+            .recv_one_of_timeout(expected_replies, remaining.min(fallback_poll))
             .map_err(openai_backend_error)?
         {
             break Ok(reply);
@@ -437,16 +447,14 @@ fn poll_direct_or_downstream_reply_with_fallback_poll(
             // the remainder of the bounded fallback deadline rather than the
             // nonblocking mode used for the availability check.
             let remaining = reply_timeout.saturating_sub(started.elapsed());
+            if remaining.is_zero() {
+                break Err(timeout_error());
+            }
             timeout_restore.prepare_blocking_read()?;
             downstream
-                .set_read_timeout(Some(remaining.max(fallback_poll)))
+                .set_read_timeout(Some(remaining))
                 .map_err(openai_io_error)?;
             break receive_downstream_stage_reply_one_of(downstream, expected_replies);
-        }
-        if started.elapsed() >= reply_timeout {
-            break Err(OpenAiError::backend(format!(
-                "timed out waiting for one of {expected_replies:?} from direct return or downstream"
-            )));
         }
     };
     timeout_restore.restore()?;
@@ -703,11 +711,12 @@ mod tests {
             // delivery. Asserting the wake lands well inside that interval proves
             // it is event-driven without pinning an absolute sub-poll latency
             // that a loaded CI runner cannot honour.
-            let reply = poll_direct_or_downstream_reply_with_fallback_poll(
+            let reply = poll_direct_or_downstream_reply_with_timeouts(
                 &mut downstream,
                 &receiver,
                 &[WireReplyKind::PredictedToken],
                 WIDE_FALLBACK_POLL,
+                stage_reply_timeout(),
             )
             .unwrap();
             let received_at = Instant::now();
@@ -729,6 +738,34 @@ mod tests {
             "direct return wake took {max_wake_ms:.2}ms with a {}ms fallback poll; reply wait is polling, not event-driven",
             WIDE_FALLBACK_POLL.as_millis()
         );
+    }
+
+    #[test]
+    fn direct_return_fallback_wait_stays_within_reply_deadline() {
+        const REPLY_TIMEOUT: Duration = Duration::from_millis(50);
+        const WIDE_FALLBACK_POLL: Duration = Duration::from_secs(2);
+        let hub = Arc::new(PredictionReturnHub::default());
+        let receiver = hub.register(81, 83).unwrap();
+        let (mut downstream, _peer) = connected_stream_pair();
+
+        let started = Instant::now();
+        let error = poll_direct_or_downstream_reply_with_timeouts(
+            &mut downstream,
+            &receiver,
+            &[WireReplyKind::PredictedToken],
+            WIDE_FALLBACK_POLL,
+            REPLY_TIMEOUT,
+        )
+        .unwrap_err();
+        let elapsed = started.elapsed();
+
+        assert!(error.to_string().contains("timed out waiting for one of"));
+        assert!(elapsed >= REPLY_TIMEOUT);
+        assert!(
+            elapsed < Duration::from_millis(750),
+            "reply wait took {elapsed:?} with a {REPLY_TIMEOUT:?} deadline and {WIDE_FALLBACK_POLL:?} fallback poll"
+        );
+        assert_eq!(downstream.read_timeout().unwrap(), None);
     }
 
     #[test]

--- a/crates/skippy-server/src/frontend/embedded_execution.rs
+++ b/crates/skippy-server/src/frontend/embedded_execution.rs
@@ -396,6 +396,25 @@ fn poll_direct_or_downstream_reply(
     prediction_return: &PredictionReturnReceiver,
     expected_replies: &[WireReplyKind],
 ) -> OpenAiResult<StageReply> {
+    poll_direct_or_downstream_reply_with_fallback_poll(
+        downstream,
+        prediction_return,
+        expected_replies,
+        DIRECT_RETURN_FALLBACK_POLL,
+    )
+}
+
+// The fallback poll interval is injectable so a test can widen it and assert the
+// direct-return wake fires well inside one interval — proving the wait is
+// event-driven rather than quantized to the poll — without depending on
+// sub-poll scheduler latency, which a loaded or virtualized CI runner cannot
+// guarantee.
+fn poll_direct_or_downstream_reply_with_fallback_poll(
+    downstream: &mut TcpStream,
+    prediction_return: &PredictionReturnReceiver,
+    expected_replies: &[WireReplyKind],
+    fallback_poll: Duration,
+) -> OpenAiResult<StageReply> {
     let mut timeout_restore = DirectReturnFallbackTimeout::install(downstream)?;
     let started = Instant::now();
     let reply_timeout = stage_reply_timeout();
@@ -407,7 +426,7 @@ fn poll_direct_or_downstream_reply(
     // so a fallback reply is still detected within one poll interval.
     let result = loop {
         if let Some(reply) = prediction_return
-            .recv_one_of_timeout(expected_replies, DIRECT_RETURN_FALLBACK_POLL)
+            .recv_one_of_timeout(expected_replies, fallback_poll)
             .map_err(openai_backend_error)?
         {
             break Ok(reply);
@@ -420,7 +439,7 @@ fn poll_direct_or_downstream_reply(
             let remaining = reply_timeout.saturating_sub(started.elapsed());
             timeout_restore.prepare_blocking_read()?;
             downstream
-                .set_read_timeout(Some(remaining.max(DIRECT_RETURN_FALLBACK_POLL)))
+                .set_read_timeout(Some(remaining.max(fallback_poll)))
                 .map_err(openai_io_error)?;
             break receive_downstream_stage_reply_one_of(downstream, expected_replies);
         }
@@ -639,6 +658,9 @@ mod tests {
 
     #[test]
     fn direct_return_reply_wakes_the_wait_immediately() {
+        // Far wider than the production 10ms fallback poll so an event-driven
+        // wake and a polling wake sit orders of magnitude apart.
+        const WIDE_FALLBACK_POLL: Duration = Duration::from_millis(1000);
         let request_id = 71;
         let session_id = 73;
         let hub = Arc::new(PredictionReturnHub::default());
@@ -675,10 +697,17 @@ mod tests {
                 .unwrap();
             });
 
-            let reply = receive_embedded_stage_reply_one_of(
+            // Inject a deliberately wide fallback poll so the two behaviours are
+            // far apart: a polling wait would take up to WIDE_FALLBACK_POLL to
+            // notice the reply, while an event-driven wait wakes on channel
+            // delivery. Asserting the wake lands well inside that interval proves
+            // it is event-driven without pinning an absolute sub-poll latency
+            // that a loaded CI runner cannot honour.
+            let reply = poll_direct_or_downstream_reply_with_fallback_poll(
                 &mut downstream,
-                Some(&receiver),
+                &receiver,
                 &[WireReplyKind::PredictedToken],
+                WIDE_FALLBACK_POLL,
             )
             .unwrap();
             let received_at = Instant::now();
@@ -690,11 +719,15 @@ mod tests {
                 * 1000.0;
             max_wake_ms = max_wake_ms.max(wake_ms);
         }
-        // The wait must be event-driven: a sampling loop quantizes wake-up to
-        // its poll interval (10ms) and reliably exceeds this bound.
+        // Event-driven wake fires on channel delivery; a polling wait would
+        // quantize to WIDE_FALLBACK_POLL (1000ms). The 100ms bound sits an order
+        // of magnitude below the poll yet far above channel-delivery + scheduler
+        // latency on a loaded runner, so it fails a polling regression without
+        // flaking on a correct implementation.
         assert!(
-            max_wake_ms < 8.0,
-            "direct return wake took {max_wake_ms:.2}ms; reply wait is polling, not event-driven"
+            max_wake_ms < 100.0,
+            "direct return wake took {max_wake_ms:.2}ms with a {}ms fallback poll; reply wait is polling, not event-driven",
+            WIDE_FALLBACK_POLL.as_millis()
         );
     }
 


### PR DESCRIPTION
## What

Two per-token overhead fixes in the split stage decode path. **~10% faster split decode**, independent of transport.

This PR was originally `--trusted-lan` direct TCP transport; that half has been dropped for now (see below). What remains is the part that actually moved the numbers.

> Stacked on #1581 (split speculative-decode correctness). Review/merge that first; this branch is based on it, so the diff here is only the two perf commits below.

## The per-token fixes

The final-stage serial-decode loop paid two avoidable costs on every token:

1. **Poll-quantized reply wait.** The embedded driver raced the direct-return channel against the tunnelled downstream fallback by sampling the channel between 10ms blocking peeks on the downstream socket. Every token whose reply arrived on the direct-return sink — the standard path — paid a uniform 0–10ms poll-quantization penalty (~5ms/token, measured as a 6.9ms toll against a 0.9ms wire floor). Now it blocks on the return channel and wakes at channel-send latency, checking the fallback with a nonblocking peek each slice.

2. **Four scheduler round-trips where one does work.** The loop made a standalone session-align hop, a prefix-cache lookup that cannot apply to decode messages, the compute dispatch, and a full-prefill record that no-ops unless the cache is recording — three of them cloning the full wire message (activation payload + token history) across the scheduler channel. Now: session alignment rides inside the first runtime closure the message already owns; the lookup and record hops evaluate their runtime-free gates before dispatching (costing nothing when the cache is disabled or the message kind can't use them); session stats are collected only when debug telemetry is on.

## Numbers

Two Mac minis (M1 16GB + M4 16GB), wired Ethernet, Qwen3-8B Q4_K_M split 19/17 layers, 192-token generations at temperature 0, rates from `usage` over wall time, 5 runs per cell:

| tok/s | before | after |
|---|---|---|
| split decode | 12.50–12.65 | 13.65–13.87 |

- **~10% gain, transport-independent.** In the original measurement the tunnel and direct-TCP columns moved by the same amount — the win is the per-token work, not the wire.
- **The split now runs at its compute floor.** Layer-weighted single-node ideal for this pair is (19/36)×93.1ms + (17/36)×49.8ms ≈ 72.6 ms/token; the split measures 72.1–72.7. Everything above stage compute is one ~1ms wire round-trip.

## Why `--trusted-lan` was dropped

On a healthy LAN, direct TCP and the mesh tunnel are at parity once the per-token overhead above is removed — confirmed again on a Qwen3-30B-A3B split (tunnel ~21 tok/s vs direct-LAN ~20 tok/s; the ~0.5–0.8 ms/token transport delta is noise at 30B decode rates). The transport's remaining value is narrow — immunity to control-path degradation (when UDP holepunching is blocked, iroh pins to a ~240ms relay and tunnel decode collapses; direct TCP can't be relay-pinned) — so it's parked on the `parked/trusted-lan-transport` branch to return once we test the regime where it earns its keep, rather than carrying 57 files of transport surface for a healthy-LAN wash.

## Testing

- `cargo check -p skippy-server` clean; `cargo fmt --check` clean.
- `skippy-server` suite green (651 passed / 0 failed), including the event-driven reply-wait sub-poll wake-latency regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved session alignment for more accurate message processing.
  * Reduced unnecessary cache lookups, telemetry collection, and prefill recording when not required.

* **Bug Fixes**
  * Prediction responses now wake immediately when available instead of relying on polling.
  * Improved timeout handling to respect response deadlines and prevent unnecessary delays.
  * Improved fallback response checks while preserving reliable connection behavior.

* **Tests**
  * Added coverage for response wakeups, timeout behavior, fragmented responses, and connection blocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->