### PR TITLE
Fix speculative decoding over multi-node splits

### DIFF
--- a/crates/skippy-prompt/src/prompt_cli/speculative.rs
+++ b/crates/skippy-prompt/src/prompt_cli/speculative.rs
@@ -186,13 +186,18 @@ fn classify_verify_window<F>(
 where
     F: FnMut(i32) -> Result<bool>,
 {
-    if predicted_tokens.len() < draft_tokens.len() {
+    if predicted_tokens.is_empty() && !draft_tokens.is_empty() {
         bail!(
-            "verify window returned too few tokens: got {} expected {}",
-            predicted_tokens.len(),
+            "verify window returned no tokens for {} draft tokens",
             draft_tokens.len()
         );
     }
+    // A reply shorter than the draft is the runtime's sampler guard, not an
+    // error: with a stateful sampler, verification stops at the first
+    // mismatched row so the sampler never absorbs the rejected suffix. Every
+    // returned token is authoritative, so a short reply classifies exactly
+    // like a full reply whose mismatch sits at its final row.
+    let short_reply = predicted_tokens.len() < draft_tokens.len();
 
     let mut accepted_before_reject = 0usize;
     let mut commit_count = 0usize;
@@ -223,6 +228,18 @@ where
         };
         return Ok(VerifyWindowDecision {
             kind,
+            accepted_before_reject,
+            commit_count,
+        });
+    }
+
+    if short_reply {
+        // The runtime only truncates at a mismatched row, so the loop above
+        // normally returns from its reject arm first. If every returned row
+        // matched anyway, the committed prefix is still all verified accepts;
+        // the unverified draft tail is simply dropped and re-proposed.
+        return Ok(VerifyWindowDecision {
+            kind: VerifyWindowDecisionKind::EarlyReject,
             accepted_before_reject,
             commit_count,
         });

--- a/crates/skippy-prompt/src/prompt_cli/tests.rs
+++ b/crates/skippy-prompt/src/prompt_cli/tests.rs
@@ -136,11 +136,24 @@ mod speculative_tests {
     }
 
     #[test]
-    fn classify_verify_window_requires_complete_predictions() {
-        let err = classify_verify_window(&[10, 11, 12], &[10, 11], 0, 16, |_| Ok(false)).unwrap_err();
+    fn classify_verify_window_accepts_a_sampler_guarded_short_reply() {
+        // With a stateful sampler the runtime stops at the first mismatched
+        // row and returns a short reply; every returned token is
+        // authoritative, so it classifies as an early reject at its final row.
+        let decision =
+            classify_verify_window(&[10, 11, 12, 13], &[10, 42], 0, 16, |_| Ok(false)).unwrap();
+        assert_eq!(
+            decision,
+            VerifyWindowDecision {
+                kind: VerifyWindowDecisionKind::EarlyReject,
+                accepted_before_reject: 1,
+                commit_count: 2,
+            }
+        );
+
+        let err = classify_verify_window(&[10, 11, 12], &[], 0, 16, |_| Ok(false)).unwrap_err();
         assert!(
-            err.to_string()
-                .contains("verify window returned too few tokens"),
+            err.to_string().contains("returned no tokens"),
             "{err:#}"
         );
     }

--- a/crates/skippy-server/src/frontend/speculative.rs
+++ b/crates/skippy-server/src/frontend/speculative.rs
@@ -324,6 +324,77 @@ mod standalone_speculative_config_tests {
     }
 
     #[test]
+    fn short_reply_classifies_as_early_reject_at_its_final_row() {
+        // A stateful sampler stops verification at the first mismatched row,
+        // so the runtime legally returns fewer predictions than the draft:
+        // the matched prefix plus the correction.
+        let decision = classify_verify_window(&[10, 20, 30, 40], &[10, 99], 0, 16, |_| Ok(false))
+            .expect("classify short reply");
+
+        assert_eq!(
+            decision,
+            VerifyWindowDecision {
+                kind: VerifyWindowDecisionKind::EarlyReject,
+                accepted_before_reject: 1,
+                commit_count: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn short_reply_rejecting_the_first_row_commits_only_the_correction() {
+        let decision = classify_verify_window(&[10, 20, 30], &[99], 0, 16, |_| Ok(false))
+            .expect("classify first-row short reply");
+
+        assert_eq!(
+            decision,
+            VerifyWindowDecision {
+                kind: VerifyWindowDecisionKind::EarlyReject,
+                accepted_before_reject: 0,
+                commit_count: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn short_reply_correction_hitting_eog_stops_the_request() {
+        let decision =
+            classify_verify_window(&[10, 20, 30, 40], &[10, 77], 0, 16, |token| Ok(token == 77))
+                .expect("classify short reply with eog correction");
+
+        assert_eq!(
+            decision,
+            VerifyWindowDecision {
+                kind: VerifyWindowDecisionKind::EarlyRejectStop,
+                accepted_before_reject: 1,
+                commit_count: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn fully_matched_short_reply_commits_its_verified_prefix() {
+        let decision = classify_verify_window(&[10, 20, 30], &[10, 20], 0, 16, |_| Ok(false))
+            .expect("classify fully-matched short reply");
+
+        assert_eq!(
+            decision,
+            VerifyWindowDecision {
+                kind: VerifyWindowDecisionKind::EarlyReject,
+                accepted_before_reject: 2,
+                commit_count: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn empty_reply_for_a_nonempty_draft_is_an_error() {
+        let error = classify_verify_window(&[10, 20], &[], 0, 16, |_| Ok(false))
+            .expect_err("empty reply must error");
+        assert!(error.to_string().contains("returned no tokens"));
+    }
+
+    #[test]
     fn acceptance_threshold_accepts_exact_boundary_and_empty_window() {
         assert!(acceptance_threshold_met(2, 4, 0.5));
         assert!(acceptance_threshold_met(0, 0, 1.0));
@@ -1059,13 +1130,19 @@ pub(super) fn classify_verify_window<F>(
 where
     F: FnMut(i32) -> OpenAiResult<bool>,
 {
-    if predicted_tokens.len() < draft_tokens.len() {
+    if predicted_tokens.is_empty() && !draft_tokens.is_empty() {
         return Err(OpenAiError::backend(format!(
-            "verify window returned too few tokens: got {} expected {}",
-            predicted_tokens.len(),
+            "verify window returned no tokens for {} draft tokens",
             draft_tokens.len()
         )));
     }
+    // A reply shorter than the draft is the runtime's sampler guard, not an
+    // error: with a stateful sampler (grammar, penalties, RNG) verification
+    // stops at the first mismatched row so the sampler never absorbs tokens
+    // from the rejected suffix. Every returned token is authoritative — the
+    // matched prefix plus the correction row — so a short reply classifies
+    // exactly like a full reply whose mismatch sits at its final row.
+    let short_reply = predicted_tokens.len() < draft_tokens.len();
 
     let mut accepted_before_reject = 0usize;
     let mut commit_count = 0usize;
@@ -1096,6 +1173,18 @@ where
         };
         return Ok(VerifyWindowDecision {
             kind,
+            accepted_before_reject,
+            commit_count,
+        });
+    }
+
+    if short_reply {
+        // The runtime only truncates at a mismatched row, so the loop above
+        // normally returns from its reject arm first. If every returned row
+        // matched anyway, the committed prefix is still all verified accepts;
+        // the unverified draft tail is simply dropped and re-proposed.
+        return Ok(VerifyWindowDecision {
+            kind: VerifyWindowDecisionKind::EarlyReject,
             accepted_before_reject,
             commit_count,
         });


### PR DESCRIPTION
## What

Speculative decoding over a multi-node split failed on every generation that formed a verify window. Running it to ground found **three coordinated defects** — one in the driver's classifier, two in the native runtime — and this PR fixes all three. With it, split speculation completes end-to-end: on the two-node lab repro, 7/7 generations green with zero decode failures and zero asserts, where previously 0/6 survived the first window.

## Defect 1 — the classifier rejected sampler-guarded short replies

With a stateful sampler (grammar, penalties, or an RNG chain), `skippy_verify_tokens_frame_sampled` deliberately stops sampling at the first mismatched row so the sampler never absorbs tokens from a rejected suffix, and returns a **short** prediction list — the matched prefix plus the correction. That's correct, documented behavior. The driver's `classify_verify_window` hard-errored on any reply shorter than the draft (`verify window returned too few tokens: got 2 expected 10`). `mesh-llm serve` merges model-package sampling defaults over the request, so real serving always has a sampler chain — bare-greedy bench rigs never truncate, which is why this path looked healthy.

**Fix:** a short reply classifies exactly like a full reply whose mismatch sits at its final row: the returned rows commit (accepted prefix + correction) and the unverified draft tail is dropped and re-proposed. An empty reply for a non-empty draft is still an error. Applied to both classifier copies (`skippy-server` frontend and `skippy-prompt`), with regression tests for the short-reply shapes.

## Defect 2 — verify inputs recorded twice on activation-input stages (patch 0043)

#1408 established that activation-frame verification must not rewind `token_history`, because its decode does not eagerly append. #1420 then re-added an eager append inside `skippy_verify_activation_frame`, assuming that rewind still existed. With both in place, every verify input on an activation-input stage that owns the output layers — i.e. the **final stage of any split** — was inserted into `token_history` twice and fed to `llama_sampler_accept` twice, double-applying repetition penalties, grammar state and RNG draws. Single-node serving takes the token-batch path and was unaffected.

**Fix:** drop the eager append; verification is the single recorder for this path, restoring the invariant #1408 documented.

## Defect 3 — backend sampling rejected multi-output verify batches (patch 0045)

Backend (in-graph) sampling registers a sampler on the context, and `llama_context::decode` then limited **every** decode on that context to one output row per sequence — the check fired if *any* sequence had a sampler attached. A sampled verify window must output every row, so the first window failed `llama_decode` with `rc=-1` (surfaced only as `RuntimeError: llama_decode failed`, since stage hosts don't forward llama.cpp's log callback) and the driver timed out waiting for the reply. Three coordinated changes:

- **verification** detaches this session's backend sampler before executing a window and falls back to CPU-chain row sampling — the chain is untouched and row sampling consumes it exactly as it does for configs that never qualified for offload;
- a chain may be backend-initialized at most once (`llama_sampler_chain_backend_init` asserts on reuse), so the detach is tracked as **retired** on the session; `refresh_backend_sampling` respects it and only a freshly-built chain clears it. Without this, the next session reset re-attached the spent chain and aborted the stage on the assert;
- `llama_context::decode` scopes the one-output-per-sequence rejection to sequences that **actually have a sampler attached**, so an idle lane's offloaded chain can no longer reject another lane's verify batch.

Also included: stage execution errors now name the failing message (`kind/pos_start/token_count/...`), and native decode-batch failures carry the return code, batch shape and session/memory positions (patch 0044) — both of which were what made defect 3 findable from wire errors alone.

## Validation

Two Mac minis (M1 + M4), Qwen3-8B Q4_K_M split 19/17 layers, `--speculative-strategy ngram-suffix` (5/32/48, window 32), temperature 0:

| build | result |
|---|---|
| before (any commit) | 0/6 windowed generations survive — `too few tokens` 502 on the first window |
| after defect-1 fix only | classifier error gone; stage dies with `llama_decode failed` |
| after defects 1–3 | **7/7 generations complete, 0 decode failures, 0 GGML asserts** |

Single-node speculation: 5/5 clean (15.2–15.5 tok/s) — unaffected by the split-only defects, confirms no regression.

`cargo test -p skippy-server` (649) and `-p skippy-prompt` (24) green at the final commit.

## Notes for reviewers

- Throughput with suffix speculation on this freeform workload is ~12.2–12.4 tok/s vs 13.8 plain decode on the same split — the machinery now *works*, but the suffix proposer's accept rate on freeform text doesn't pay for the windows at this scale (single-node shows the same shape: 15.3 vs 20.1). Correctness fix, not a speed claim.
- The `llama-context.cpp` change (per-sequence scoping of the backend-sampling output limit) looks upstreamable; its own `TODO: avoid this workaround` suggests the coarse check was known-temporary.
