### PR TITLE
Add Agentic Replay for commit performance comparisons

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -15,7 +15,7 @@ python3 evals/agentic-replay.py plan \
   --ref rc8=v0.76.0-rc8 \
   --ref main=origin/main \
   --model '<model-uri>' \
-  --trajectories-per-framework 2
+  --trajectories-per-framework 4
 ```
 
 Run the default ABBA comparison after materializing the pinned parquet from
@@ -26,7 +26,7 @@ python3 evals/agentic-replay.py run \
   --ref rc8=v0.76.0-rc8 \
   --ref main=origin/main \
   --model '<model-uri>' \
-  --trajectories-per-framework 2 \
+  --trajectories-per-framework 4 \
   --dataset-file /path/to/sessions.parquet \
   --output /path/to/artifact
 ```
@@ -35,10 +35,13 @@ The server command is always `mesh-llm serve --model <model> --log-format
 json`. The runner never sets context size, Mesh execution lanes, KV budget, or
 backend tuning; `--concurrency` controls simultaneous client requests only.
 Trajectory count is deliberately explicit rather than hidden behind a default.
-With the example above and client concurrency 1/2/4, the runner selects 18
-unique whole trajectories: two from each of the three recorded agent frameworks
-for each disjoint concurrency cohort. Selection is deterministic by session ID
-hash within each framework.
+Each measured cohort must contain at least twice the maximum offered client
+concurrency so the high-concurrency cells have more than one worker wave. With
+the example above and client concurrency 1/2/4, the runner selects 36 measured
+whole trajectories: four from each of the three recorded agent frameworks for
+each disjoint concurrency cohort. It also selects a disjoint 12-trajectory
+warm-up cohort and discards 14 ordered turns after every model-ready event.
+Selection is deterministic by session ID hash within each framework.
 
 Every assistant turn becomes one measured request. A trajectory's turns are
 strictly sequential and each request contains the real recorded history before
@@ -48,6 +51,21 @@ than the benchmark model's output, which gives every experiment arm an identical
 growing prefix. The manifest records all selected session IDs, framework and
 turn counts, context bounds, and hashes. Use `report` to regenerate tables and
 charts from a completed artifact without rerunning the model.
+
+The default per-turn output cap is 2,048 tokens. Reports lead with token-weighted
+decode throughput measured after first generated content and show end-to-end
+output throughput separately because it includes prompt ingestion. They also
+show realized mean in-flight concurrency, slot utilization, failed requests,
+and the per-pass range. Percent deltas are suppressed unless compared arms
+fail the same request IDs.
+
+This is a deterministic hash-ordered stress sample, not a stratified sample of
+the corpus. Tool names are preserved but tool schemas are permissive stubs, and
+generated output is measured but not fed back into the replay. The benchmark is
+therefore a paired serving-performance comparison on reconstructed agent
+prompts; it does not measure answer quality or claim byte-identical production
+traffic. Treat small deltas as directional unless a larger cohort and repeated
+passes show a consistent separation.
 
 For the pinned Mesh-versus-raw-llama.cpp scheduler matrix across CUDA, Metal,
 dense/MoE/recurrent/hybrid models, llama-benchy, and Thoughtworks agent traces, see

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,5 +1,54 @@
 # mesh-llm Router Evals
 
+## Compare Mesh commits with production defaults
+
+`agentic-replay.py` is the durable entrypoint for comparing two or more
+Mesh refs on one model. It creates isolated detached worktrees, builds each
+release host and native runtime, replays a pinned subset of the Thoughtworks
+agentic-coding trajectories, and produces raw JSONL, CSV/JSON/Markdown tables,
+SVG throughput and TTFT charts, logs, binary hashes, and an artifact inventory.
+
+Inspect the exact build order and launch command without changing anything:
+
+```bash
+python3 evals/agentic-replay.py plan \
+  --ref rc8=v0.76.0-rc8 \
+  --ref main=origin/main \
+  --model '<model-uri>' \
+  --trajectories-per-framework 2
+```
+
+Run the default ABBA comparison after materializing the pinned parquet from
+`thoughtworks/agentic-coding-trajectories`:
+
+```bash
+python3 evals/agentic-replay.py run \
+  --ref rc8=v0.76.0-rc8 \
+  --ref main=origin/main \
+  --model '<model-uri>' \
+  --trajectories-per-framework 2 \
+  --dataset-file /path/to/sessions.parquet \
+  --output /path/to/artifact
+```
+
+The server command is always `mesh-llm serve --model <model> --log-format
+json`. The runner never sets context size, Mesh execution lanes, KV budget, or
+backend tuning; `--concurrency` controls simultaneous client requests only.
+Trajectory count is deliberately explicit rather than hidden behind a default.
+With the example above and client concurrency 1/2/4, the runner selects 18
+unique whole trajectories: two from each of the three recorded agent frameworks
+for each disjoint concurrency cohort. Selection is deterministic by session ID
+hash within each framework.
+
+Every assistant turn becomes one measured request. A trajectory's turns are
+strictly sequential and each request contains the real recorded history before
+that turn; only separate trajectories can overlap. After measuring a turn, the
+runner advances with the recorded assistant action and tool observation rather
+than the benchmark model's output, which gives every experiment arm an identical
+growing prefix. The manifest records all selected session IDs, framework and
+turn counts, context bounds, and hashes. Use `report` to regenerate tables and
+charts from a completed artifact without rerunning the model.
+
 For the pinned Mesh-versus-raw-llama.cpp scheduler matrix across CUDA, Metal,
 dense/MoE/recurrent/hybrid models, llama-benchy, and Thoughtworks agent traces, see
 [`docs/skippy/COMPETITIVE_BENCHMARK.md`](../docs/skippy/COMPETITIVE_BENCHMARK.md).

--- a/evals/README.md
+++ b/evals/README.md
@@ -18,7 +18,7 @@ python3 evals/agentic-replay.py plan \
   --trajectories-per-framework 4
 ```
 
-Run the default ABBA comparison after materializing the pinned parquet from
+Run the default fast A/B release gate after materializing the pinned parquet from
 `thoughtworks/agentic-coding-trajectories`:
 
 ```bash
@@ -40,17 +40,23 @@ concurrency so the high-concurrency cells have more than one worker wave. With
 the example above and client concurrency 1/2/4, the runner selects 36 measured
 whole trajectories: four from each of the three recorded agent frameworks for
 each disjoint concurrency cohort. It also selects a disjoint 12-trajectory
-warm-up cohort and discards 14 ordered turns after every model-ready event.
+warm-up cohort and discards four ordered turns after every model-ready event.
 Selection is deterministic by session ID hash within each framework.
 
-Every assistant turn becomes one measured request. A trajectory's turns are
-strictly sequential and each request contains the real recorded history before
-that turn; only separate trajectories can overlap. After measuring a turn, the
-runner advances with the recorded assistant action and tool observation rather
-than the benchmark model's output, which gives every experiment arm an identical
-growing prefix. The manifest records all selected session IDs, framework and
-turn counts, context bounds, and hashes. Use `report` to regenerate tables and
-charts from a completed artifact without rerunning the model.
+The default checkpoint profile measures one request per trajectory: within each
+framework's four trajectories, one deterministically represents each of early,
+middle, late, and final stage. Every request contains the complete recorded
+history before that checkpoint. Skipped assistant turns and tool observations
+are appended from the dataset in strict order, so every experiment arm receives
+an identical prefix without paying for discarded generations at every step.
+This is 36 requests per ref and 72 for a two-ref A/B gate. Use `--passes 2` for
+reverse-order ABBA confirmation when the first-pass result is ambiguous.
+
+For nightly or research runs, `--replay-mode all --passes 2 --warmup-turns 14`
+restores exhaustive assistant-turn replay. The manifest records all selected
+session IDs, framework and turn counts, context bounds, and hashes. Use `report`
+to regenerate tables and charts from a completed artifact without rerunning the
+model.
 
 The default per-turn output cap is 2,048 tokens. Reports lead with token-weighted
 decode throughput measured after first generated content and show end-to-end

--- a/evals/agentic-replay.py
+++ b/evals/agentic-replay.py
@@ -635,6 +635,8 @@ def replay_trajectory(
     max_output_tokens: int,
     timeout: float,
     turn_limit: Optional[int] = None,
+    measured_assistant_turns: Optional[set[int]] = None,
+    checkpoint_stage: Optional[str] = None,
 ) -> list[dict[str, Any]]:
     history: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
@@ -644,36 +646,73 @@ def replay_trajectory(
         if recorded["role"] == "assistant":
             if turn_limit is not None and assistant_turn >= turn_limit:
                 break
-            requested_output_tokens = recorded_output_budget(
-                recorded, max_output_tokens
-            )
-            metadata = {
-                "session_id": trajectory["session_id"],
-                "source_dataset": trajectory["source_dataset"],
-                "agent_framework": trajectory["agent_framework"],
-                "recorded_model": trajectory["recorded_model"],
-                "assistant_turn": assistant_turn,
-                "recorded_message_index": message_index,
-                "history_message_count": len(history),
-                "requested_output_tokens": requested_output_tokens,
-                "recorded_output_characters": len(recorded.get("content") or ""),
-                "available_tools": len(tools),
-            }
-            result = stream_request(
-                f"{trajectory['session_id']}:{assistant_turn}",
-                history,
-                tools,
-                metadata,
-                model_id,
-                requested_output_tokens,
-                timeout,
-            )
-            results.append(result)
+            if (
+                measured_assistant_turns is None
+                or assistant_turn in measured_assistant_turns
+            ):
+                requested_output_tokens = recorded_output_budget(
+                    recorded, max_output_tokens
+                )
+                metadata = {
+                    "session_id": trajectory["session_id"],
+                    "source_dataset": trajectory["source_dataset"],
+                    "agent_framework": trajectory["agent_framework"],
+                    "recorded_model": trajectory["recorded_model"],
+                    "assistant_turn": assistant_turn,
+                    "recorded_message_index": message_index,
+                    "history_message_count": len(history),
+                    "requested_output_tokens": requested_output_tokens,
+                    "recorded_output_characters": len(recorded.get("content") or ""),
+                    "available_tools": len(tools),
+                    "checkpoint_stage": checkpoint_stage,
+                }
+                result = stream_request(
+                    f"{trajectory['session_id']}:{assistant_turn}",
+                    history,
+                    tools,
+                    metadata,
+                    model_id,
+                    requested_output_tokens,
+                    timeout,
+                )
+                results.append(result)
             assistant_turn += 1
         # Continue with the recorded trajectory, not the generated benchmark
         # output, so every experiment arm receives the same ordered history.
         history.append(openai_message(recorded))
     return results
+
+
+def assistant_turn_count(trajectory: dict[str, Any]) -> int:
+    return sum(
+        message["role"] == "assistant" for message in trajectory["messages"]
+    )
+
+
+def checkpoint_schedule(
+    trajectories: Sequence[dict[str, Any]],
+) -> dict[str, tuple[int, str]]:
+    """Assign deterministic early/middle/late/final checkpoints per framework."""
+    by_framework: dict[str, list[dict[str, Any]]] = {}
+    for trajectory in trajectories:
+        by_framework.setdefault(trajectory["agent_framework"], []).append(trajectory)
+    schedule: dict[str, tuple[int, str]] = {}
+    stage_names = {1: "early", 2: "middle", 3: "late", 4: "final"}
+    for framework_trajectories in by_framework.values():
+        denominator = len(framework_trajectories)
+        for rank, trajectory in enumerate(framework_trajectories, start=1):
+            turns = assistant_turn_count(trajectory)
+            if turns <= 0:
+                raise ValueError(
+                    f"trajectory {trajectory['session_id']} has no assistant turns"
+                )
+            assistant_turn = max(0, math.ceil(turns * rank / denominator) - 1)
+            stage = stage_names.get(rank) if denominator == 4 else None
+            schedule[trajectory["session_id"]] = (
+                assistant_turn,
+                stage or f"{rank}/{denominator}",
+            )
+    return schedule
 
 
 def summarize_requests(
@@ -797,10 +836,12 @@ def run_trajectory_cell(
     max_output_tokens: int,
     timeout: float,
     raw_path: Path,
+    replay_mode: str,
 ) -> dict[str, Any]:
     if not trajectories:
         raise ValueError("trajectory cell cannot be empty")
     requests: list[dict[str, Any]] = []
+    checkpoints = checkpoint_schedule(trajectories) if replay_mode == "checkpoints" else {}
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=min(concurrency, len(trajectories))
     ) as pool:
@@ -811,6 +852,16 @@ def run_trajectory_cell(
                 model_id,
                 max_output_tokens,
                 timeout,
+                measured_assistant_turns=(
+                    {checkpoints[trajectory["session_id"]][0]}
+                    if replay_mode == "checkpoints"
+                    else None
+                ),
+                checkpoint_stage=(
+                    checkpoints[trajectory["session_id"]][1]
+                    if replay_mode == "checkpoints"
+                    else None
+                ),
             )
             for trajectory in trajectories
         ]
@@ -839,6 +890,10 @@ def run_trajectory_cell(
             "framework_trajectories": framework_counts,
             "max_output_tokens": max_output_tokens,
             "ordered_replay": True,
+            "replay_mode": replay_mode,
+            "recorded_assistant_turns": sum(
+                assistant_turn_count(trajectory) for trajectory in trajectories
+            ),
         }
     )
     return summary
@@ -970,6 +1025,7 @@ def run_arm_pass(
                 max_output_tokens=args.max_output_tokens,
                 timeout=args.request_timeout,
                 raw_path=pass_dir / f"c-{concurrency}-requests.jsonl",
+                replay_mode=args.replay_mode,
             )
             cells.append(cell)
             write_json(pass_dir / f"c-{concurrency}.json", cell)
@@ -1319,8 +1375,8 @@ def write_report(output: Path, run_document: dict[str, Any]) -> Path:
         "",
         "## Trajectory selection",
         "",
-        "| Client concurrency | Whole trajectories | Recorded agent steps | Framework trajectory / step breakdown |",
-        "|---:|---:|---:|---|",
+        "| Client concurrency | Whole trajectories | Measured requests/pass | Recorded source steps | Framework trajectory / step breakdown |",
+        "|---:|---:|---:|---:|---|",
     ]
     for concurrency in run_document["config"]["concurrency"]:
         cohort = cohort_metadata[str(concurrency)]
@@ -1330,6 +1386,7 @@ def write_report(output: Path, run_document: dict[str, Any]) -> Path:
         )
         lines.append(
             f"| {concurrency} | {cohort['trajectory_count']} | "
+            f"{cohort['trajectory_count'] if run_document['config'].get('replay_mode', 'all') == 'checkpoints' else cohort['assistant_turns']} | "
             f"{cohort['assistant_turns']} | {breakdown} |"
         )
     lines.extend(
@@ -1337,7 +1394,7 @@ def write_report(output: Path, run_document: dict[str, Any]) -> Path:
             "",
             "## Result table",
             "",
-            "| Ref | Commit | Offered C | Realized C | Slot use | Trajectories/pass | Agent steps | Failures | Comparable | Decode tok/s | Pass range | vs baseline | E2E output tok/s | Pass range | TTFT p50 | Pass range | TTFT p95 | TTFT p50 vs baseline | Cached prompt | Budget exhausted |",
+            "| Ref | Commit | Offered C | Realized C | Slot use | Trajectories/pass | Measured requests | Failures | Comparable | Decode tok/s | Pass range | vs baseline | E2E output tok/s | Pass range | TTFT p50 | Pass range | TTFT p95 | TTFT p50 vs baseline | Cached prompt | Budget exhausted |",
             "|---|---|---:|---:|---:|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
         ]
     )
@@ -1400,8 +1457,9 @@ def write_report(output: Path, run_document: dict[str, Any]) -> Path:
             f"- Warm-up cohort: `{warmup_cohort['trajectory_count']}` whole trajectories, disjoint from measured cohorts.",
             f"- Dataset revision: `{run_document['inputs']['dataset']['revision']}`.",
             f"- Selected trajectories: `{selected_trajectories}` unique whole sessions across disjoint concurrency cohorts.",
-            f"- Recorded agent steps: `{selected_turns}` assistant turns per arm pass; each commit replays them once per pass.",
-            "- Turns inside a trajectory are strictly sequential. Different trajectories may overlap up to the offered client concurrency.",
+            f"- Recorded source steps: `{selected_turns}` assistant turns are represented across the selected trajectories.",
+            f"- Replay mode: `{run_document['config'].get('replay_mode', 'all')}`. Checkpoint mode measures one request per trajectory; skipped recorded turns are still appended in order to reconstruct the exact prefix.",
+            "- Within each framework's four trajectories, checkpoint mode deterministically assigns early, middle, late, and final stages. Different trajectories may overlap up to the offered client concurrency.",
             "- Realized concurrency is the time-weighted mean number of in-flight requests. Slot use makes cohort tail drain explicit; do not interpret offered-concurrency scaling as steady-state when utilization is low.",
             "- Each next request uses the recorded conversation history, so experiment arms receive identical growing prefixes and tool observations.",
             "- Per-turn output budgets approximate each recorded assistant action from its character length, capped by the configured maximum; generated output is measured but never fed into the next turn.",
@@ -1432,7 +1490,7 @@ def benchmark_plan(args: argparse.Namespace, specs: Sequence[RefSpec]) -> dict[s
     config = load_competitive_config()
     dataset = config["thoughtworks"]["dataset"]
     return {
-        "schema_version": 1,
+        "schema_version": 2,
         "repo": str(args.repo),
         "refs": [spec.__dict__ for spec in specs],
         "order": [
@@ -1468,7 +1526,24 @@ def benchmark_plan(args: argparse.Namespace, specs: Sequence[RefSpec]) -> dict[s
         "workload": {
             "concurrency": args.concurrency,
             "passes": args.passes,
-            "ordered_whole_trajectory_replay": True,
+            "replay_mode": args.replay_mode,
+            "ordered_recorded_prefix_replay": True,
+            "measured_requests_per_arm_pass": (
+                len(args.concurrency)
+                * len(args.framework)
+                * args.trajectories_per_framework
+                if args.replay_mode == "checkpoints"
+                else None
+            ),
+            "measured_requests_total": (
+                len(args.concurrency)
+                * len(args.framework)
+                * args.trajectories_per_framework
+                * len(specs)
+                * args.passes
+                if args.replay_mode == "checkpoints"
+                else None
+            ),
             "max_output_tokens": args.max_output_tokens,
             "warmup_turns_per_arm_pass": args.warmup_turns,
         },
@@ -1511,7 +1586,7 @@ def run_benchmark(args: argparse.Namespace) -> Path:
             build_ref(spec, worktree, args.backend, args.output, commands, args.skip_build)
         )
     run_document: dict[str, Any] = {
-        "schema_version": 1,
+        "schema_version": 2,
         "started_at": utc_now(),
         "host": {
             "hostname": socket.gethostname(),
@@ -1523,6 +1598,7 @@ def run_benchmark(args: argparse.Namespace) -> Path:
             "backend": args.backend,
             "concurrency": args.concurrency,
             "passes": args.passes,
+            "replay_mode": args.replay_mode,
             "max_output_tokens": args.max_output_tokens,
             "warmup_turns": args.warmup_turns,
         },
@@ -1590,7 +1666,18 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     )
     parser.add_argument("--model", required=True, help="model URI or local package path")
     parser.add_argument("--backend", default="metal")
-    parser.add_argument("--passes", type=int, default=2)
+    parser.add_argument(
+        "--passes",
+        type=int,
+        default=1,
+        help="A/B passes; use 2 for reverse-order ABBA confirmation",
+    )
+    parser.add_argument(
+        "--replay-mode",
+        choices=("checkpoints", "all"),
+        default="checkpoints",
+        help="measure one stage-balanced checkpoint per trajectory or every assistant turn",
+    )
     parser.add_argument("--concurrency", type=int, action="append", default=[])
     parser.add_argument(
         "--trajectories-per-framework",
@@ -1602,7 +1689,7 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
     parser.add_argument(
         "--warmup-turns",
         type=int,
-        default=14,
+        default=4,
         help="discarded ordered turns from a disjoint cohort after model readiness",
     )
     parser.add_argument("--min-isl", type=int, default=8192)

--- a/evals/agentic-replay.py
+++ b/evals/agentic-replay.py
@@ -1474,7 +1474,7 @@ def write_report(output: Path, run_document: dict[str, Any]) -> Path:
             f"- Selected trajectories: `{selected_trajectories}` unique whole sessions across disjoint concurrency cohorts.",
             f"- Recorded source steps: `{selected_turns}` assistant turns are represented across the selected trajectories.",
             f"- Replay mode: `{run_document['config'].get('replay_mode', 'all')}`. Checkpoint mode measures one request per trajectory; skipped recorded turns are still appended in order to reconstruct the exact prefix.",
-            "- Within each framework's four trajectories, checkpoint mode deterministically assigns early, middle, late, and final stages. Different trajectories may overlap up to the offered client concurrency.",
+            "- Within each framework's trajectories, checkpoint mode deterministically spreads one measured turn per trajectory across the trajectory timeline. Four trajectories are labeled early, middle, late, and final; other cohort sizes use rank/count labels. Different trajectories may overlap up to the offered client concurrency.",
             "- Realized concurrency is the time-weighted mean number of in-flight requests. Slot use makes cohort tail drain explicit; do not interpret offered-concurrency scaling as steady-state when utilization is low.",
             "- Each next request uses the recorded conversation history, so experiment arms receive identical growing prefixes and tool observations.",
             "- Per-turn output budgets approximate each recorded assistant action from its character length, capped by the configured maximum; generated output is measured but never fed into the next turn.",

--- a/evals/agentic-replay.py
+++ b/evals/agentic-replay.py
@@ -1,0 +1,1381 @@
+#!/usr/bin/env python3
+"""Agentic Replay: compare Mesh commits with ordered real-agent trajectories.
+
+The runner creates detached worktrees, builds the release host and native
+runtime for every requested ref, replays a deterministic subset of the pinned
+Thoughtworks agentic-coding-trajectories corpus, and writes raw evidence,
+tables, CSV, and dependency-free SVG charts.
+
+Mesh is deliberately launched without context-size, lane-count, KV-budget, or
+backend-tuning arguments. The only serving argument is ``--model``;
+``--log-format json`` is observational. Client concurrency is offered by this
+runner and is not a Mesh startup setting.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import csv
+import hashlib
+import html
+import http.client
+import json
+import math
+import os
+import re
+import shutil
+import signal
+import socket
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable, Optional, Sequence
+
+
+REPO = Path(__file__).resolve().parents[1]
+COMPETITIVE_CONFIG = REPO / "evals/skippy-competitive-benchmark.json"
+TRAJECTORY_GENERATOR = REPO / "evals/agentic-trajectory-manifest.py"
+DEFAULT_BASE_URL = "http://127.0.0.1:9337/v1"
+FORBIDDEN_STARTUP_OPTIONS = (
+    "--ctx-size",
+    "--generation-concurrency",
+    "--generation-queue-capacity",
+    "--max-vram",
+    "--parallel",
+)
+COLORS = (
+    "#0284c7",
+    "#dc2626",
+    "#16a34a",
+    "#7c3aed",
+    "#ea580c",
+    "#0891b2",
+)
+
+
+@dataclass(frozen=True)
+class RefSpec:
+    label: str
+    ref: str
+    commit: str
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(8 * 1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def tree_sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    files = sorted(item for item in path.rglob("*") if item.is_file())
+    if not files:
+        raise RuntimeError(f"directory contains no files: {path}")
+    for item in files:
+        relative = item.relative_to(path).as_posix().encode()
+        digest.update(len(relative).to_bytes(8, "big"))
+        digest.update(relative)
+        digest.update(bytes.fromhex(sha256(item)))
+    return digest.hexdigest()
+
+
+def stable_hash(value: Any) -> str:
+    payload = json.dumps(value, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
+def write_json(path: Path, value: Any) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload = json.dumps(value, indent=2, sort_keys=True) + "\n"
+    with tempfile.NamedTemporaryFile(
+        mode="w", encoding="utf-8", dir=path.parent, delete=False
+    ) as handle:
+        handle.write(payload)
+        temporary = Path(handle.name)
+    temporary.replace(path)
+
+
+def slug(value: str) -> str:
+    normalized = re.sub(r"[^A-Za-z0-9_.-]+", "-", value).strip("-.")
+    if not normalized:
+        raise ValueError(f"cannot derive a safe label from {value!r}")
+    return normalized
+
+
+def git(repo: Path, *args: str) -> str:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=True,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+    )
+    return result.stdout.strip()
+
+
+def parse_ref_specs(repo: Path, values: Sequence[str]) -> list[RefSpec]:
+    if len(values) < 2:
+        raise ValueError("at least two --ref LABEL=GIT_REF values are required")
+    specs: list[RefSpec] = []
+    labels: set[str] = set()
+    commits: set[str] = set()
+    for value in values:
+        if "=" not in value:
+            raise ValueError(f"ref must use LABEL=GIT_REF syntax: {value}")
+        label, ref = value.split("=", 1)
+        label, ref = slug(label), ref.strip()
+        if not ref:
+            raise ValueError(f"empty git ref for label {label}")
+        if label in labels:
+            raise ValueError(f"duplicate ref label: {label}")
+        commit = git(repo, "rev-parse", f"{ref}^{{commit}}")
+        if commit in commits:
+            raise ValueError(f"multiple labels resolve to commit {commit}")
+        labels.add(label)
+        commits.add(commit)
+        specs.append(RefSpec(label=label, ref=ref, commit=commit))
+    return specs
+
+
+def ab_order(specs: Sequence[RefSpec], passes: int) -> list[tuple[int, RefSpec]]:
+    if passes <= 0:
+        raise ValueError("passes must be positive")
+    ordered: list[tuple[int, RefSpec]] = []
+    for pass_index in range(passes):
+        pass_specs = specs if pass_index % 2 == 0 else tuple(reversed(specs))
+        ordered.extend((pass_index, spec) for spec in pass_specs)
+    return ordered
+
+
+class CommandLog:
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+    def run(
+        self,
+        command: Sequence[str],
+        *,
+        cwd: Path,
+        log_path: Path,
+        env: Optional[dict[str, str]] = None,
+    ) -> None:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        event = {
+            "started_at": utc_now(),
+            "cwd": str(cwd),
+            "command": list(command),
+            "log": str(log_path),
+        }
+        with self.path.open("a", encoding="utf-8") as command_log:
+            command_log.write(json.dumps(event, sort_keys=True) + "\n")
+        with log_path.open("w", encoding="utf-8") as output:
+            result = subprocess.run(
+                list(command),
+                cwd=cwd,
+                env=env,
+                text=True,
+                stdout=output,
+                stderr=subprocess.STDOUT,
+            )
+        event["completed_at"] = utc_now()
+        event["exit_code"] = result.returncode
+        with self.path.open("a", encoding="utf-8") as command_log:
+            command_log.write(json.dumps(event, sort_keys=True) + "\n")
+        if result.returncode:
+            raise RuntimeError(
+                f"command failed ({result.returncode}); see {log_path}: "
+                + " ".join(command)
+            )
+
+
+def prepare_worktree(repo: Path, root: Path, spec: RefSpec) -> Path:
+    path = root / f"{spec.label}-{spec.commit[:10]}"
+    if path.exists():
+        try:
+            actual = git(path, "rev-parse", "HEAD")
+        except (subprocess.CalledProcessError, FileNotFoundError) as error:
+            raise RuntimeError(f"existing path is not a git worktree: {path}") from error
+        if actual != spec.commit:
+            raise RuntimeError(
+                f"worktree {path} is at {actual}, expected {spec.commit}; "
+                "choose a different --worktree-root"
+            )
+    else:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "worktree", "add", "--detach", str(path), spec.commit],
+            check=True,
+        )
+    if git(path, "status", "--porcelain", "--untracked-files=no"):
+        raise RuntimeError(f"benchmark worktree is dirty: {path}")
+    return path
+
+
+def runtime_backend_kind(backend: str) -> str:
+    return {"cuda-blackwell": "cuda", "hip": "rocm"}.get(backend, backend)
+
+
+def find_runtime(root: Path, backend: str) -> Path:
+    candidates: list[Path] = []
+    for manifest_path in root.glob("*/manifest.json"):
+        try:
+            manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+            kind = manifest["runtime"]["backend"]["kind"]
+        except (KeyError, json.JSONDecodeError):
+            continue
+        if kind == runtime_backend_kind(backend):
+            candidates.append(manifest_path.parent)
+    if len(candidates) != 1:
+        raise RuntimeError(
+            f"expected one {backend} runtime under {root}, found {len(candidates)}"
+        )
+    return candidates[0]
+
+
+def build_ref(
+    spec: RefSpec,
+    worktree: Path,
+    backend: str,
+    output: Path,
+    commands: CommandLog,
+    skip_build: bool,
+) -> dict[str, Any]:
+    binary = worktree / "target/release/mesh-llm"
+    runtime_root = worktree / "dist/native-runtimes"
+    if not skip_build:
+        commands.run(
+            ["just", "release-host-build"],
+            cwd=worktree,
+            log_path=output / "logs" / f"build-{spec.label}-host.log",
+        )
+        commands.run(
+            ["just", "release-runtime-build", backend],
+            cwd=worktree,
+            log_path=output / "logs" / f"build-{spec.label}-runtime.log",
+        )
+    if not binary.is_file():
+        raise FileNotFoundError(f"release host not found: {binary}")
+    runtime = find_runtime(runtime_root, backend)
+    actual_head = git(worktree, "rev-parse", "HEAD")
+    if actual_head != spec.commit:
+        raise RuntimeError(
+            f"worktree moved during build: expected {spec.commit}, found {actual_head}"
+        )
+    return {
+        "label": spec.label,
+        "ref": spec.ref,
+        "commit": spec.commit,
+        "worktree": str(worktree),
+        "binary": str(binary),
+        "binary_sha256": sha256(binary),
+        "runtime_root": str(runtime_root),
+        "runtime": str(runtime),
+        "runtime_sha256": tree_sha256(runtime),
+        "backend": backend,
+    }
+
+
+def load_competitive_config() -> dict[str, Any]:
+    return json.loads(COMPETITIVE_CONFIG.read_text(encoding="utf-8"))
+
+
+def verify_dataset(path: Path, expected_sha256: str) -> None:
+    if not path.is_file():
+        raise FileNotFoundError(f"Thoughtworks parquet not found: {path}")
+    actual = sha256(path)
+    if actual != expected_sha256:
+        raise RuntimeError(
+            f"Thoughtworks parquet SHA-256 mismatch: expected={expected_sha256} actual={actual}"
+        )
+
+
+def build_trajectory_manifest(args: argparse.Namespace, output: Path) -> dict[str, Any]:
+    config = load_competitive_config()
+    dataset = config["thoughtworks"]["dataset"]
+    verify_dataset(args.dataset_file, dataset["sha256"])
+    manifest = output / "inputs" / "thoughtworks-trajectories.json"
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    command = [
+        sys.executable,
+        str(TRAJECTORY_GENERATOR),
+        "--dataset-file",
+        str(args.dataset_file),
+        "--dataset-revision",
+        dataset["revision"],
+        "--output",
+        str(manifest),
+        "--trajectories-per-framework",
+        str(args.trajectories_per_framework),
+        "--min-isl",
+        str(args.min_isl),
+        "--max-isl",
+        str(args.max_isl),
+        "--min-turns",
+        str(args.min_turns),
+    ]
+    for concurrency in args.concurrency:
+        command.extend(("--cohort", str(concurrency)))
+    for framework in args.framework:
+        command.extend(("--framework", framework))
+    for source in args.source_dataset:
+        command.extend(("--source-dataset", source))
+    try:
+        subprocess.run(command, check=True)
+    except subprocess.CalledProcessError as error:
+        raise RuntimeError(
+            "prompt generation failed; install DuckDB in this Python environment "
+            f"and verify the requested selection window ({args.min_isl}-{args.max_isl})"
+        ) from error
+    document = json.loads(manifest.read_text(encoding="utf-8"))
+    return {
+        "dataset": dataset,
+        "dataset_file": str(args.dataset_file),
+        "dataset_file_sha256": sha256(args.dataset_file),
+        "trajectory_generator": str(TRAJECTORY_GENERATOR),
+        "trajectory_generator_sha256": sha256(TRAJECTORY_GENERATOR),
+        "manifest": str(manifest),
+        "manifest_sha256": sha256(manifest),
+        "metadata": document["metadata"],
+        "cohorts": document["metadata"]["cohorts"],
+    }
+
+
+def load_trajectory_cohorts(path: Path) -> dict[str, list[dict[str, Any]]]:
+    document = json.loads(path.read_text(encoding="utf-8"))
+    cohorts = document.get("cohorts")
+    if not isinstance(cohorts, dict) or not cohorts:
+        raise ValueError("trajectory manifest must contain nonempty cohorts")
+    for name, trajectories in cohorts.items():
+        if not isinstance(name, str) or not isinstance(trajectories, list) or not trajectories:
+            raise ValueError("each trajectory cohort must be a nonempty list")
+        for trajectory in trajectories:
+            if not isinstance(trajectory.get("session_id"), str):
+                raise ValueError(f"cohort {name} contains a trajectory without session_id")
+            if not isinstance(trajectory.get("messages"), list):
+                raise ValueError(
+                    f"trajectory {trajectory.get('session_id')} has no messages list"
+                )
+    return cohorts
+
+
+def server_command(binary: Path, model: str) -> list[str]:
+    command = [str(binary), "serve", "--model", model, "--log-format", "json"]
+    for option in FORBIDDEN_STARTUP_OPTIONS:
+        if option in command:
+            raise AssertionError(f"default-startup benchmark cannot use {option}")
+    return command
+
+
+def port_is_open(host: str = "127.0.0.1", port: int = 9337) -> bool:
+    with socket.socket() as connection:
+        connection.settimeout(0.2)
+        return connection.connect_ex((host, port)) == 0
+
+
+def wait_for_model(
+    base_url: str,
+    timeout: float,
+    process: Optional[subprocess.Popen[bytes]] = None,
+) -> str:
+    if base_url != DEFAULT_BASE_URL:
+        raise ValueError(f"default-startup runner requires {DEFAULT_BASE_URL}")
+    deadline = time.monotonic() + timeout
+    last_error = "not ready"
+    while time.monotonic() < deadline:
+        if process is not None and process.poll() is not None:
+            raise RuntimeError(
+                f"Mesh exited before readiness with status {process.returncode}"
+            )
+        connection = http.client.HTTPConnection("127.0.0.1", 9337, timeout=5)
+        try:
+            connection.request("GET", "/v1/models")
+            response = connection.getresponse()
+            body = response.read()
+            if response.status == 200:
+                document = json.loads(body)
+                models = document.get("data") or []
+                if models:
+                    return models[0]["id"]
+            last_error = f"HTTP {response.status}: {body[:300]!r}"
+        except (OSError, json.JSONDecodeError) as error:
+            last_error = str(error)
+        finally:
+            connection.close()
+        time.sleep(1)
+    raise TimeoutError(f"Mesh did not become ready after {timeout}s: {last_error}")
+
+
+def percentile(values: Sequence[float], fraction: float) -> Optional[float]:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = min(math.ceil(len(ordered) * fraction) - 1, len(ordered) - 1)
+    return ordered[max(index, 0)]
+
+
+def stream_request(
+    request_id: str,
+    messages: Sequence[dict[str, Any]],
+    tools: Sequence[dict[str, Any]],
+    metadata: dict[str, Any],
+    model_id: str,
+    output_tokens: int,
+    timeout: float,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    first_token_at: Optional[float] = None
+    completion_tokens = 0
+    prompt_tokens = 0
+    cached_tokens = 0
+    content_events = 0
+    content_parts: list[str] = []
+    connection = http.client.HTTPConnection("127.0.0.1", 9337, timeout=timeout)
+    payload = {
+        "model": model_id,
+        "messages": list(messages),
+        "max_tokens": output_tokens,
+        "temperature": 0,
+        "seed": 42,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    if tools:
+        payload["tools"] = list(tools)
+    try:
+        connection.request(
+            "POST",
+            "/v1/chat/completions",
+            json.dumps(payload),
+            {"Content-Type": "application/json", "Authorization": "Bearer EMPTY"},
+        )
+        response = connection.getresponse()
+        if response.status != 200:
+            body = response.read(4096).decode("utf-8", errors="replace")
+            return {
+                "request_id": request_id,
+                **metadata,
+                "error": f"HTTP {response.status}: {body}",
+            }
+        for raw_line in response:
+            line = raw_line.strip()
+            if not line.startswith(b"data: "):
+                continue
+            event_bytes = line[6:]
+            if event_bytes == b"[DONE]":
+                break
+            try:
+                event = json.loads(event_bytes)
+            except json.JSONDecodeError:
+                continue
+            usage = event.get("usage")
+            if isinstance(usage, dict):
+                completion_tokens = int(usage.get("completion_tokens") or completion_tokens)
+                prompt_tokens = int(usage.get("prompt_tokens") or prompt_tokens)
+                details = usage.get("prompt_tokens_details")
+                if isinstance(details, dict):
+                    cached_tokens = int(details.get("cached_tokens") or cached_tokens)
+            choices = event.get("choices")
+            if not isinstance(choices, list) or not choices:
+                continue
+            delta = choices[0].get("delta")
+            if not isinstance(delta, dict):
+                continue
+            content = delta.get("content") or delta.get("reasoning_content")
+            tool_calls = delta.get("tool_calls")
+            if content or tool_calls:
+                if first_token_at is None:
+                    first_token_at = time.monotonic()
+                content_events += 1
+                if content:
+                    content_parts.append(content)
+                if tool_calls:
+                    content_parts.append(json.dumps(tool_calls, sort_keys=True))
+        completed = time.monotonic()
+    except Exception as error:  # preserve request-level failures in the artifact
+        return {
+            "request_id": request_id,
+            **metadata,
+            "error": f"{type(error).__name__}: {error}",
+        }
+    finally:
+        connection.close()
+    if first_token_at is None:
+        return {
+            "request_id": request_id,
+            **metadata,
+            "error": "stream completed without generated content",
+        }
+    if completion_tokens <= 0:
+        return {
+            "request_id": request_id,
+            **metadata,
+            "error": "stream completed without completion-token usage",
+        }
+    return {
+        "request_id": request_id,
+        **metadata,
+        "started": started,
+        "first_token_at": first_token_at,
+        "completed": completed,
+        "ttft_seconds": first_token_at - started,
+        "elapsed_seconds": completed - started,
+        "generation_seconds": completed - first_token_at,
+        "completion_tokens": completion_tokens,
+        "prompt_tokens": prompt_tokens,
+        "cached_tokens": cached_tokens,
+        "content_events": content_events,
+        "content_sha256": hashlib.sha256("".join(content_parts).encode()).hexdigest(),
+    }
+
+
+def openai_message(recorded: dict[str, Any]) -> dict[str, Any]:
+    message: dict[str, Any] = {
+        "role": recorded["role"],
+        "content": recorded.get("content") or "",
+    }
+    tool_calls_json = recorded.get("tool_calls_json")
+    if tool_calls_json:
+        message["tool_calls"] = json.loads(tool_calls_json)
+    tool_call_id = recorded.get("tool_call_id")
+    if tool_call_id:
+        message["tool_call_id"] = tool_call_id
+    return message
+
+
+def recorded_output_budget(recorded: dict[str, Any], maximum: int) -> int:
+    content_length = len(recorded.get("content") or "")
+    tool_length = len(recorded.get("tool_calls_json") or "")
+    approximate_tokens = math.ceil((content_length + tool_length) / 4)
+    return min(max(approximate_tokens, 8), maximum)
+
+
+def trajectory_tools(trajectory: dict[str, Any]) -> list[dict[str, Any]]:
+    names: set[str] = set()
+    for recorded in trajectory["messages"]:
+        tool_calls_json = recorded.get("tool_calls_json")
+        if not tool_calls_json:
+            continue
+        for tool_call in json.loads(tool_calls_json):
+            function = tool_call.get("function")
+            if isinstance(function, dict) and isinstance(function.get("name"), str):
+                names.add(function["name"])
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": "Tool available in the recorded agent trajectory.",
+                "parameters": {"type": "object", "additionalProperties": True},
+            },
+        }
+        for name in sorted(names)
+    ]
+
+
+def replay_trajectory(
+    trajectory: dict[str, Any],
+    model_id: str,
+    max_output_tokens: int,
+    timeout: float,
+) -> list[dict[str, Any]]:
+    history: list[dict[str, Any]] = []
+    results: list[dict[str, Any]] = []
+    assistant_turn = 0
+    tools = trajectory_tools(trajectory)
+    for message_index, recorded in enumerate(trajectory["messages"]):
+        if recorded["role"] == "assistant":
+            requested_output_tokens = recorded_output_budget(
+                recorded, max_output_tokens
+            )
+            metadata = {
+                "session_id": trajectory["session_id"],
+                "source_dataset": trajectory["source_dataset"],
+                "agent_framework": trajectory["agent_framework"],
+                "recorded_model": trajectory["recorded_model"],
+                "assistant_turn": assistant_turn,
+                "recorded_message_index": message_index,
+                "history_message_count": len(history),
+                "requested_output_tokens": requested_output_tokens,
+                "recorded_output_characters": len(recorded.get("content") or ""),
+                "available_tools": len(tools),
+            }
+            result = stream_request(
+                f"{trajectory['session_id']}:{assistant_turn}",
+                history,
+                tools,
+                metadata,
+                model_id,
+                requested_output_tokens,
+                timeout,
+            )
+            results.append(result)
+            assistant_turn += 1
+        # Continue with the recorded trajectory, not the generated benchmark
+        # output, so every experiment arm receives the same ordered history.
+        history.append(openai_message(recorded))
+    return results
+
+
+def summarize_requests(requests: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    successful = [request for request in requests if "error" not in request]
+    ttft = [request["ttft_seconds"] for request in successful]
+    completion_tokens = sum(request["completion_tokens"] for request in successful)
+    prompt_tokens = sum(request["prompt_tokens"] for request in successful)
+    cached_tokens = sum(request["cached_tokens"] for request in successful)
+    if successful:
+        workload_window = max(request["completed"] for request in successful) - min(
+            request["started"] for request in successful
+        )
+    else:
+        workload_window = 0.0
+    request_decode_rates = [
+        request["completion_tokens"] / request["generation_seconds"]
+        for request in successful
+        if request["generation_seconds"] > 0
+    ]
+    return {
+        "requests": len(requests),
+        "successful_requests": len(successful),
+        "failed_requests": len(requests) - len(successful),
+        "completion_tokens": completion_tokens,
+        "prompt_tokens": prompt_tokens,
+        "cached_tokens": cached_tokens,
+        "exact_output_requests": sum(
+            request.get("completion_tokens") == request.get("requested_output_tokens")
+            for request in successful
+        ),
+        "ttft_p50_seconds": statistics.median(ttft) if ttft else None,
+        "ttft_p95_seconds": percentile(ttft, 0.95),
+        "agent_steps_per_second": (
+            len(successful) / workload_window if workload_window > 0 else None
+        ),
+        "workload_output_tokens_per_second": (
+            completion_tokens / workload_window if workload_window > 0 else None
+        ),
+        "mean_request_decode_tokens_per_second": (
+            statistics.mean(request_decode_rates) if request_decode_rates else None
+        ),
+        "cache_pct": 100 * cached_tokens / prompt_tokens if prompt_tokens else None,
+    }
+
+
+def run_trajectory_cell(
+    *,
+    trajectories: Sequence[dict[str, Any]],
+    model_id: str,
+    concurrency: int,
+    max_output_tokens: int,
+    timeout: float,
+    raw_path: Path,
+) -> dict[str, Any]:
+    if not trajectories:
+        raise ValueError("trajectory cell cannot be empty")
+    requests: list[dict[str, Any]] = []
+    raw_path.parent.mkdir(parents=True, exist_ok=True)
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=min(concurrency, len(trajectories))
+    ) as pool:
+        futures = [
+            pool.submit(
+                replay_trajectory,
+                trajectory,
+                model_id,
+                max_output_tokens,
+                timeout,
+            )
+            for trajectory in trajectories
+        ]
+        for future in futures:
+            requests.extend(future.result())
+    with raw_path.open("w", encoding="utf-8") as raw:
+        for request in requests:
+            request["concurrency"] = concurrency
+            raw.write(json.dumps(request, sort_keys=True) + "\n")
+    summary = summarize_requests(requests)
+    framework_counts: dict[str, int] = {}
+    for trajectory in trajectories:
+        framework = trajectory["agent_framework"]
+        framework_counts[framework] = framework_counts.get(framework, 0) + 1
+    successful_sessions = {
+        request["session_id"]
+        for request in requests
+        if "error" not in request
+    }
+    failed_sessions = {
+        request["session_id"] for request in requests if "error" in request
+    }
+    summary.update(
+        {
+            "concurrency": concurrency,
+            "trajectories": len(trajectories),
+            "successful_trajectories": len(successful_sessions - failed_sessions),
+            "failed_trajectories": len(failed_sessions),
+            "framework_trajectories": framework_counts,
+            "max_output_tokens": max_output_tokens,
+            "ordered_replay": True,
+        }
+    )
+    return summary
+
+
+def isolated_server_env(
+    runtime_root: Path, state_dir: Path, hf_home: Optional[Path]
+) -> dict[str, str]:
+    env = os.environ.copy()
+    inherited_home = Path.home()
+    home = state_dir / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    env.update(
+        {
+            "HOME": str(home),
+            "XDG_CACHE_HOME": str(state_dir / "xdg-cache"),
+            "XDG_CONFIG_HOME": str(state_dir / "xdg-config"),
+            "MESH_LLM_RUNTIME_ROOT": str(state_dir / "runtime"),
+            "MESH_LLM_NATIVE_RUNTIME_BUNDLE_DIR": str(runtime_root),
+        }
+    )
+    if hf_home is not None:
+        env["HF_HOME"] = str(hf_home)
+    elif "HF_HOME" not in env:
+        env["HF_HOME"] = str(inherited_home / ".cache/huggingface")
+    return env
+
+
+def start_server(
+    build: dict[str, Any],
+    model: str,
+    state_dir: Path,
+    log_path: Path,
+    hf_home: Optional[Path],
+) -> tuple[subprocess.Popen[bytes], list[str]]:
+    if port_is_open():
+        raise RuntimeError("TCP 9337 is already in use; stop the existing Mesh instance")
+    command = server_command(Path(build["binary"]), model)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_handle = log_path.open("wb")
+    process = subprocess.Popen(
+        command,
+        cwd=Path(build["worktree"]),
+        env=isolated_server_env(Path(build["runtime_root"]), state_dir, hf_home),
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    log_handle.close()
+    return process, command
+
+
+def stop_server(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is None:
+        os.killpg(process.pid, signal.SIGINT)
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=10)
+    deadline = time.monotonic() + 10
+    while port_is_open() and time.monotonic() < deadline:
+        time.sleep(0.2)
+    if port_is_open():
+        raise RuntimeError("Mesh stopped but TCP 9337 is still occupied")
+
+
+def collect_runtime_logs(state_dir: Path, output_dir: Path) -> None:
+    runtime_root = state_dir / "runtime"
+    if not runtime_root.is_dir():
+        return
+    for source in runtime_root.rglob("*"):
+        if not source.is_file() or "logs" not in source.parts:
+            continue
+        destination = output_dir / source.relative_to(runtime_root)
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+
+def run_arm_pass(
+    *,
+    args: argparse.Namespace,
+    output: Path,
+    build: dict[str, Any],
+    pass_index: int,
+    cohorts: dict[str, list[dict[str, Any]]],
+) -> dict[str, Any]:
+    label = build["label"]
+    pass_dir = output / "data" / f"pass-{pass_index + 1}" / label
+    state_dir = Path(
+        tempfile.mkdtemp(prefix=f"agentic-replay-{label}-pass-{pass_index + 1}-")
+    )
+    log_path = pass_dir / "mesh.log"
+    started_at = utc_now()
+    process: Optional[subprocess.Popen[bytes]] = None
+    command = server_command(Path(build["binary"]), args.model)
+    cells: list[dict[str, Any]] = []
+    try:
+        process, command = start_server(
+            build, args.model, state_dir, log_path, args.hf_home
+        )
+        model_id = wait_for_model(DEFAULT_BASE_URL, args.startup_timeout, process)
+        concurrency_values = (
+            args.concurrency
+            if pass_index % 2 == 0
+            else list(reversed(args.concurrency))
+        )
+        for concurrency in concurrency_values:
+            cell = run_trajectory_cell(
+                trajectories=cohorts[str(concurrency)],
+                model_id=model_id,
+                concurrency=concurrency,
+                max_output_tokens=args.max_output_tokens,
+                timeout=args.request_timeout,
+                raw_path=pass_dir / f"c-{concurrency}-requests.jsonl",
+            )
+            cells.append(cell)
+            write_json(pass_dir / f"c-{concurrency}.json", cell)
+    finally:
+        try:
+            if process is not None:
+                stop_server(process)
+        finally:
+            collect_runtime_logs(state_dir, pass_dir / "native-runtime")
+            shutil.rmtree(state_dir, ignore_errors=True)
+    return {
+        "label": label,
+        "ref": build["ref"],
+        "commit": build["commit"],
+        "pass": pass_index + 1,
+        "started_at": started_at,
+        "completed_at": utc_now(),
+        "server_command": command,
+        "server_log": str(log_path),
+        "model_id": model_id,
+        "cells": cells,
+    }
+
+
+def mean_or_none(values: Iterable[Optional[float]]) -> Optional[float]:
+    present = [value for value in values if value is not None]
+    return statistics.mean(present) if present else None
+
+
+def pooled_rows(results: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
+    groups: dict[tuple[str, int], list[dict[str, Any]]] = {}
+    metadata: dict[str, tuple[str, str]] = {}
+    for arm_pass in results:
+        metadata[arm_pass["label"]] = (arm_pass["ref"], arm_pass["commit"])
+        for cell in arm_pass["cells"]:
+            groups.setdefault((arm_pass["label"], cell["concurrency"]), []).append(cell)
+    rows: list[dict[str, Any]] = []
+    for (label, concurrency), cells in sorted(groups.items()):
+        ref, commit = metadata[label]
+        requests = sum(cell["requests"] for cell in cells)
+        successes = sum(cell["successful_requests"] for cell in cells)
+        rows.append(
+            {
+                "label": label,
+                "ref": ref,
+                "commit": commit,
+                "concurrency": concurrency,
+                "passes": len(cells),
+                "trajectories_per_pass": cells[0]["trajectories"],
+                "trajectory_replays": sum(cell["trajectories"] for cell in cells),
+                "requests": requests,
+                "successful_requests": successes,
+                "success_pct": 100 * successes / requests if requests else None,
+                "exact_output_pct": 100
+                * sum(cell["exact_output_requests"] for cell in cells)
+                / successes
+                if successes
+                else None,
+                "agent_steps_per_second": mean_or_none(
+                    cell["agent_steps_per_second"] for cell in cells
+                ),
+                "workload_output_tokens_per_second": mean_or_none(
+                    cell["workload_output_tokens_per_second"] for cell in cells
+                ),
+                "mean_request_decode_tokens_per_second": mean_or_none(
+                    cell["mean_request_decode_tokens_per_second"] for cell in cells
+                ),
+                "ttft_p50_seconds": mean_or_none(cell["ttft_p50_seconds"] for cell in cells),
+                "ttft_p95_seconds": mean_or_none(cell["ttft_p95_seconds"] for cell in cells),
+                "cache_pct": mean_or_none(cell["cache_pct"] for cell in cells),
+            }
+        )
+    baseline_label = results[0]["label"] if results else None
+    baseline = {
+        row["concurrency"]: row
+        for row in rows
+        if row["label"] == baseline_label
+    }
+    for row in rows:
+        reference = baseline.get(row["concurrency"])
+        for metric in (
+            "agent_steps_per_second",
+            "workload_output_tokens_per_second",
+            "ttft_p50_seconds",
+        ):
+            base_value = reference.get(metric) if reference else None
+            value = row.get(metric)
+            row[f"{metric}_delta_pct"] = (
+                100 * (value / base_value - 1)
+                if value is not None and base_value not in (None, 0)
+                else None
+            )
+    return rows
+
+
+def fmt(value: Optional[float], digits: int = 2, suffix: str = "") -> str:
+    return "—" if value is None else f"{value:.{digits}f}{suffix}"
+
+
+def escape(value: Any) -> str:
+    return html.escape(str(value))
+
+
+def svg_chart(
+    title: str,
+    rows: Sequence[dict[str, Any]],
+    labels: Sequence[str],
+    metric: str,
+    y_label: str,
+    output: Path,
+) -> None:
+    width, height = 960, 540
+    left, top, plot_width, plot_height = 100, 80, 790, 350
+    concurrency_values = sorted({row["concurrency"] for row in rows})
+    values = [row[metric] for row in rows if row.get(metric) is not None]
+    y_max = max(max(values) * 1.12, 1e-9) if values else 1.0
+    parts = [
+        f'<svg xmlns="http://www.w3.org/2000/svg" width="{width}" height="{height}" viewBox="0 0 {width} {height}">',
+        '<rect width="100%" height="100%" fill="#fff"/>',
+        f'<text x="480" y="36" text-anchor="middle" font-family="sans-serif" font-size="22" font-weight="700">{escape(title)}</text>',
+    ]
+    for tick in range(6):
+        value = y_max * tick / 5
+        y = top + plot_height - plot_height * tick / 5
+        parts.append(
+            f'<line x1="{left}" y1="{y:.1f}" x2="{left + plot_width}" y2="{y:.1f}" stroke="#e2e8f0"/>'
+        )
+        parts.append(
+            f'<text x="{left - 10}" y="{y + 4:.1f}" text-anchor="end" font-family="sans-serif" font-size="12">{value:.1f}</text>'
+        )
+    x_denominator = max(len(concurrency_values) - 1, 1)
+    for index, concurrency in enumerate(concurrency_values):
+        x = left + plot_width * index / x_denominator
+        parts.append(
+            f'<text x="{x:.1f}" y="{top + plot_height + 24}" text-anchor="middle" font-family="sans-serif" font-size="12">{concurrency}</text>'
+        )
+    for label_index, label in enumerate(labels):
+        color = COLORS[label_index % len(COLORS)]
+        points: list[tuple[float, float]] = []
+        indexed = {
+            row["concurrency"]: row[metric]
+            for row in rows
+            if row["label"] == label and row.get(metric) is not None
+        }
+        for index, concurrency in enumerate(concurrency_values):
+            if concurrency not in indexed:
+                continue
+            x = left + plot_width * index / x_denominator
+            y = top + plot_height - plot_height * indexed[concurrency] / y_max
+            points.append((x, y))
+        coordinates = " ".join(f"{x:.1f},{y:.1f}" for x, y in points)
+        parts.append(
+            f'<polyline points="{coordinates}" fill="none" stroke="{color}" stroke-width="3"/>'
+        )
+        parts.extend(
+            f'<circle cx="{x:.1f}" cy="{y:.1f}" r="4" fill="{color}"/>'
+            for x, y in points
+        )
+        legend_x = 110 + label_index * 150
+        parts.append(
+            f'<text x="{legend_x}" y="490" font-family="sans-serif" font-size="13" fill="{color}">{escape(label)}</text>'
+        )
+    parts.extend(
+        [
+            '<text x="480" y="525" text-anchor="middle" font-family="sans-serif" font-size="13">Client concurrency</text>',
+            f'<text x="22" y="255" text-anchor="middle" transform="rotate(-90 22 255)" font-family="sans-serif" font-size="13">{escape(y_label)}</text>',
+            "</svg>",
+        ]
+    )
+    output.parent.mkdir(parents=True, exist_ok=True)
+    output.write_text("".join(parts), encoding="utf-8")
+
+
+def write_report(output: Path, run_document: dict[str, Any]) -> Path:
+    rows = pooled_rows(run_document["results"])
+    summary = output / "summary"
+    charts = summary / "charts"
+    summary.mkdir(parents=True, exist_ok=True)
+    fieldnames = list(rows[0]) if rows else []
+    with (summary / "comparison.csv").open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)
+    labels = [build["label"] for build in run_document["builds"]]
+    cohort_metadata = run_document["inputs"]["cohorts"]
+    selected_trajectories = sum(
+        cohort["trajectory_count"] for cohort in cohort_metadata.values()
+    )
+    selected_turns = sum(cohort["assistant_turns"] for cohort in cohort_metadata.values())
+    svg_chart(
+        "Agent-step throughput by commit",
+        rows,
+        labels,
+        "agent_steps_per_second",
+        "Completed agent steps / second",
+        charts / "agent-step-throughput.svg",
+    )
+    svg_chart(
+        "Median time to first token by commit",
+        rows,
+        labels,
+        "ttft_p50_seconds",
+        "Seconds (lower is better)",
+        charts / "ttft-p50.svg",
+    )
+    lines = [
+        "# Agentic Replay",
+        "",
+        f"Generated: `{utc_now()}`",
+        "",
+        "## Trajectory selection",
+        "",
+        "| Client concurrency | Whole trajectories | Recorded agent steps | Framework trajectory / step breakdown |",
+        "|---:|---:|---:|---|",
+    ]
+    for concurrency in run_document["config"]["concurrency"]:
+        cohort = cohort_metadata[str(concurrency)]
+        breakdown = " · ".join(
+            f"{framework} {count} / {cohort['framework_assistant_turns'][framework]}"
+            for framework, count in cohort["framework_trajectories"].items()
+        )
+        lines.append(
+            f"| {concurrency} | {cohort['trajectory_count']} | "
+            f"{cohort['assistant_turns']} | {breakdown} |"
+        )
+    lines.extend(
+        [
+            "",
+            "## Result table",
+            "",
+            "| Ref | Commit | C | Trajectories/pass | Agent steps | Success | Steps/s | vs baseline | Output tok/s | TTFT p50 | TTFT p95 | TTFT p50 vs baseline | Cached prompt |",
+            "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+        ]
+    )
+    for row in rows:
+        lines.append(
+            "| {label} | `{commit}` | {concurrency} | {trajectories} | {requests} | {success} | {steps} | {steps_delta} | {output_tps} | {p50} | {p95} | {p50_delta} | {cache} |".format(
+                label=row["label"],
+                commit=row["commit"][:10],
+                concurrency=row["concurrency"],
+                trajectories=row["trajectories_per_pass"],
+                requests=row["requests"],
+                success=fmt(row["success_pct"], 1, "%"),
+                steps=fmt(row["agent_steps_per_second"], 3),
+                steps_delta=fmt(row["agent_steps_per_second_delta_pct"], 1, "%"),
+                output_tps=fmt(row["workload_output_tokens_per_second"]),
+                p50=fmt(row["ttft_p50_seconds"], 3, "s"),
+                p95=fmt(row["ttft_p95_seconds"], 3, "s"),
+                p50_delta=fmt(row["ttft_p50_seconds_delta_pct"], 1, "%"),
+                cache=fmt(row["cache_pct"], 1, "%"),
+            )
+        )
+    lines.extend(
+        [
+            "",
+            "## Charts",
+            "",
+            "![Agent-step throughput](charts/agent-step-throughput.svg)",
+            "",
+            "![Median TTFT](charts/ttft-p50.svg)",
+            "",
+            "## Method",
+            "",
+            f"- Model: `{run_document['config']['model']}`",
+            "- Server startup: `mesh-llm serve --model <model> --log-format json`.",
+            "- Mesh chooses context size, execution lanes, KV budget, and backend tuning.",
+            f"- Client concurrency: `{','.join(map(str, run_document['config']['concurrency']))}`.",
+            f"- Pass order: `{' → '.join(item['label'] for item in run_document['order'])}`.",
+            f"- Dataset revision: `{run_document['inputs']['dataset']['revision']}`.",
+            f"- Selected trajectories: `{selected_trajectories}` unique whole sessions across disjoint concurrency cohorts.",
+            f"- Recorded agent steps: `{selected_turns}` assistant turns per arm pass; each commit replays them once per pass.",
+            "- Turns inside a trajectory are strictly sequential. Different trajectories may overlap up to the offered client concurrency.",
+            "- Each next request uses the recorded conversation history, so experiment arms receive identical growing prefixes and tool observations.",
+            "- Per-turn output budgets approximate each recorded assistant action from its character length, capped by the configured maximum; generated output is measured but never fed into the next turn.",
+            f"- Trajectory manifest SHA-256: `{run_document['inputs']['manifest_sha256']}`.",
+            "- Raw request records, server logs, build logs, commands, and exact binary/runtime hashes are retained beside this report.",
+            "",
+            "This report presents measurements and does not make an automatic release decision.",
+            "",
+        ]
+    )
+    report_path = summary / "REPORT.md"
+    report_path.write_text("\n".join(lines), encoding="utf-8")
+    write_json(summary / "comparison.json", rows)
+    inventory: list[str] = []
+    for path in sorted(item for item in output.rglob("*") if item.is_file()):
+        if path.name == "artifact-sha256.txt":
+            continue
+        inventory.append(f"{sha256(path)}  {path.relative_to(output).as_posix()}")
+    (output / "artifact-sha256.txt").write_text("\n".join(inventory) + "\n", encoding="utf-8")
+    return report_path
+
+
+def benchmark_plan(args: argparse.Namespace, specs: Sequence[RefSpec]) -> dict[str, Any]:
+    config = load_competitive_config()
+    dataset = config["thoughtworks"]["dataset"]
+    return {
+        "schema_version": 1,
+        "repo": str(args.repo),
+        "refs": [spec.__dict__ for spec in specs],
+        "order": [
+            {"pass": pass_index + 1, "label": spec.label, "commit": spec.commit}
+            for pass_index, spec in ab_order(specs, args.passes)
+        ],
+        "build_commands": [
+            ["just", "release-host-build"],
+            ["just", "release-runtime-build", args.backend],
+        ],
+        "server_command": ["<release-binary>", "serve", "--model", args.model, "--log-format", "json"],
+        "dataset": dataset,
+        "selection": {
+            "source_datasets": args.source_dataset,
+            "frameworks": args.framework,
+            "trajectories_per_framework_per_concurrency": args.trajectories_per_framework,
+            "unique_trajectory_count": len(args.concurrency)
+            * len(args.framework)
+            * args.trajectories_per_framework,
+            "min_isl": args.min_isl,
+            "max_isl_exclusive": args.max_isl,
+            "min_turns": args.min_turns,
+        },
+        "workload": {
+            "concurrency": args.concurrency,
+            "passes": args.passes,
+            "ordered_whole_trajectory_replay": True,
+            "max_output_tokens": args.max_output_tokens,
+        },
+        "outputs": [
+            "raw request JSONL",
+            "per-cell JSON",
+            "server/build logs",
+            "comparison CSV/JSON/Markdown",
+            "throughput and TTFT SVG charts",
+            "SHA-256 inventory",
+        ],
+    }
+
+
+def run_benchmark(args: argparse.Namespace) -> Path:
+    args.repo = args.repo.resolve()
+    args.output = args.output.resolve()
+    args.dataset_file = args.dataset_file.resolve()
+    if args.hf_home is not None:
+        args.hf_home = args.hf_home.resolve()
+    specs = parse_ref_specs(args.repo, args.ref)
+    plan = benchmark_plan(args, specs)
+    args.output.mkdir(parents=True, exist_ok=True)
+    existing = args.output / "run.json"
+    if existing.exists() and not args.resume:
+        raise RuntimeError(f"output already contains run.json; pass --resume: {args.output}")
+    write_json(args.output / "plan.json", plan)
+    commands = CommandLog(args.output / "commands.jsonl")
+    inputs = build_trajectory_manifest(args, args.output)
+    cohorts = load_trajectory_cohorts(Path(inputs["manifest"]))
+    worktree_root = (
+        args.worktree_root or (args.repo.parent / ".agentic-replay-worktrees")
+    ).resolve()
+    builds = []
+    for spec in specs:
+        worktree = prepare_worktree(args.repo, worktree_root, spec)
+        builds.append(
+            build_ref(spec, worktree, args.backend, args.output, commands, args.skip_build)
+        )
+    run_document: dict[str, Any] = {
+        "schema_version": 1,
+        "started_at": utc_now(),
+        "host": {
+            "hostname": socket.gethostname(),
+            "platform": sys.platform,
+            "python": sys.version,
+        },
+        "config": {
+            "model": args.model,
+            "backend": args.backend,
+            "concurrency": args.concurrency,
+            "passes": args.passes,
+            "max_output_tokens": args.max_output_tokens,
+        },
+        "plan_sha256": stable_hash(plan),
+        "inputs": inputs,
+        "builds": builds,
+        "order": plan["order"],
+        "results": [],
+    }
+    build_by_label = {build["label"]: build for build in builds}
+    completed = {
+        (item["pass"], item["label"])
+        for item in json.loads(existing.read_text(encoding="utf-8")).get("results", [])
+    } if existing.exists() and args.resume else set()
+    if existing.exists() and args.resume:
+        previous = json.loads(existing.read_text(encoding="utf-8"))
+        if previous.get("plan_sha256") != run_document["plan_sha256"]:
+            raise RuntimeError("cannot resume: plan differs from existing run.json")
+        previous_builds = {
+            build["label"]: (
+                build["commit"],
+                build["binary_sha256"],
+                build["runtime_sha256"],
+            )
+            for build in previous.get("builds", [])
+        }
+        current_builds = {
+            build["label"]: (
+                build["commit"],
+                build["binary_sha256"],
+                build["runtime_sha256"],
+            )
+            for build in builds
+        }
+        if previous_builds != current_builds:
+            raise RuntimeError("cannot resume: built binary or runtime hashes differ")
+        if previous.get("inputs", {}).get("manifest_sha256") != inputs["manifest_sha256"]:
+            raise RuntimeError("cannot resume: Thoughtworks trajectory manifest differs")
+        run_document["results"] = previous["results"]
+    for pass_index, spec in ab_order(specs, args.passes):
+        key = (pass_index + 1, spec.label)
+        if key in completed:
+            continue
+        result = run_arm_pass(
+            args=args,
+            output=args.output,
+            build=build_by_label[spec.label],
+            pass_index=pass_index,
+            cohorts=cohorts,
+        )
+        run_document["results"].append(result)
+        write_json(existing, run_document)
+    run_document["completed_at"] = utc_now()
+    write_json(existing, run_document)
+    return write_report(args.output, run_document)
+
+
+def add_common_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--repo", type=Path, default=REPO)
+    parser.add_argument(
+        "--ref",
+        action="append",
+        required=True,
+        help="repeatable LABEL=GIT_REF; at least two distinct commits",
+    )
+    parser.add_argument("--model", required=True, help="model URI or local package path")
+    parser.add_argument("--backend", default="metal")
+    parser.add_argument("--passes", type=int, default=2)
+    parser.add_argument("--concurrency", type=int, action="append", default=[])
+    parser.add_argument(
+        "--trajectories-per-framework",
+        type=int,
+        required=True,
+        help="whole trajectories from each framework in each concurrency cohort",
+    )
+    parser.add_argument("--max-output-tokens", type=int, default=256)
+    parser.add_argument("--min-isl", type=int, default=8192)
+    parser.add_argument("--max-isl", type=int, default=65536)
+    parser.add_argument("--min-turns", type=int, default=5)
+    parser.add_argument("--framework", action="append", default=[])
+    parser.add_argument(
+        "--source-dataset",
+        action="append",
+        default=[],
+        help="Thoughtworks source_dataset; defaults to all three pinned sources",
+    )
+
+
+def validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
+    if not args.concurrency:
+        args.concurrency = [1, 2, 4]
+    if len(set(args.concurrency)) != len(args.concurrency) or any(
+        value <= 0 for value in args.concurrency
+    ):
+        parser.error("--concurrency values must be unique and positive")
+    positive = (
+        args.passes,
+        args.trajectories_per_framework,
+        args.max_output_tokens,
+        args.min_isl,
+        args.min_turns,
+    )
+    if any(value <= 0 for value in positive):
+        parser.error("passes and workload sizes must be positive")
+    if args.max_isl <= args.min_isl:
+        parser.error("--max-isl must exceed --min-isl")
+    if not args.source_dataset:
+        args.source_dataset = [
+            "swe-smith-claude-3-7-sonnet",
+            "kwai-klear-swe-smith-mini",
+            "nebius-swe-rebench-openhands",
+        ]
+    if not args.framework:
+        args.framework = ["swe-agent", "mini-swe-agent", "openhands"]
+    if len(set(args.framework)) != len(args.framework):
+        parser.error("--framework values must be unique")
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    subparsers = parser.add_subparsers(dest="command", required=True)
+    plan = subparsers.add_parser("plan", help="print the exact side-effect-free benchmark plan")
+    add_common_arguments(plan)
+    run = subparsers.add_parser("run", help="build refs, run the matrix, and render the report")
+    add_common_arguments(run)
+    run.add_argument("--dataset-file", type=Path, required=True)
+    run.add_argument("--output", type=Path, required=True)
+    run.add_argument("--worktree-root", type=Path)
+    run.add_argument("--hf-home", type=Path)
+    run.add_argument("--startup-timeout", type=float, default=1800)
+    run.add_argument("--request-timeout", type=float, default=900)
+    run.add_argument("--skip-build", action="store_true")
+    run.add_argument("--resume", action="store_true")
+    report = subparsers.add_parser("report", help="rerender tables and charts from run.json")
+    report.add_argument("--artifact", type=Path, required=True)
+    args = parser.parse_args(argv)
+    if args.command in {"plan", "run"}:
+        validate_args(args, parser)
+    return args
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    if args.command == "plan":
+        args.repo = args.repo.resolve()
+        specs = parse_ref_specs(args.repo, args.ref)
+        print(json.dumps(benchmark_plan(args, specs), indent=2, sort_keys=True))
+        return 0
+    if args.command == "run":
+        print(run_benchmark(args))
+        return 0
+    artifact = args.artifact.resolve()
+    document = json.loads((artifact / "run.json").read_text(encoding="utf-8"))
+    print(write_report(artifact, document))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/agentic-replay.py
+++ b/evals/agentic-replay.py
@@ -372,6 +372,8 @@ def load_trajectory_cohorts(
         if not isinstance(name, str) or not isinstance(trajectories, list) or not trajectories:
             raise ValueError("each trajectory cohort must be a nonempty list")
         for trajectory in trajectories:
+            if not isinstance(trajectory, dict):
+                raise ValueError(f"cohort {name} contains a non-object trajectory")
             session_id = trajectory.get("session_id")
             if not isinstance(session_id, str) or not session_id:
                 raise ValueError(f"cohort {name} contains a trajectory without session_id")

--- a/evals/agentic-replay.py
+++ b/evals/agentic-replay.py
@@ -393,6 +393,21 @@ def load_trajectory_cohorts(
     return cohorts
 
 
+def validate_warmup_capacity(
+    trajectories: Sequence[dict[str, Any]], required_turns: int
+) -> None:
+    available_turns = sum(
+        message["role"] == "assistant"
+        for trajectory in trajectories
+        for message in trajectory["messages"]
+    )
+    if available_turns < required_turns:
+        raise ValueError(
+            f"warm-up cohort has {available_turns} assistant turns; "
+            f"{required_turns} required"
+        )
+
+
 def server_command(binary: Path, model: str) -> list[str]:
     command = [str(binary), "serve", "--model", model, "--log-format", "json"]
     for option in FORBIDDEN_STARTUP_OPTIONS:
@@ -1478,6 +1493,7 @@ def run_benchmark(args: argparse.Namespace) -> Path:
     inputs = build_trajectory_manifest(args, args.output)
     expected_cohorts = ["warmup", *(str(value) for value in args.concurrency)]
     cohorts = load_trajectory_cohorts(Path(inputs["manifest"]), expected_cohorts)
+    validate_warmup_capacity(cohorts["warmup"], args.warmup_turns)
     worktree_root = (
         args.worktree_root or (args.repo.parent / ".agentic-replay-worktrees")
     ).resolve()

--- a/evals/agentic-replay.py
+++ b/evals/agentic-replay.py
@@ -526,6 +526,19 @@ def stream_request(
                 event = json.loads(event_bytes)
             except json.JSONDecodeError:
                 continue
+            server_error = event.get("error")
+            if server_error is not None:
+                if isinstance(server_error, dict):
+                    message = server_error.get("message")
+                    if not isinstance(message, str) or not message:
+                        message = json.dumps(server_error, sort_keys=True)
+                else:
+                    message = str(server_error)
+                return {
+                    "request_id": request_id,
+                    **metadata,
+                    "error": f"stream failed with server error: {message}",
+                }
             usage = event.get("usage")
             if isinstance(usage, dict):
                 completion_tokens = int(usage.get("completion_tokens") or completion_tokens)

--- a/evals/agentic-replay.py
+++ b/evals/agentic-replay.py
@@ -375,9 +375,16 @@ def load_trajectory_cohorts(
             session_id = trajectory.get("session_id")
             if not isinstance(session_id, str) or not session_id:
                 raise ValueError(f"cohort {name} contains a trajectory without session_id")
-            for field in ("source_dataset", "agent_framework", "recorded_model"):
+            for field in ("source_dataset", "agent_framework"):
                 if not isinstance(trajectory.get(field), str) or not trajectory[field]:
                     raise ValueError(f"trajectory {session_id} has no {field}")
+            if "recorded_model" not in trajectory:
+                raise ValueError(f"trajectory {session_id} has no recorded_model field")
+            recorded_model = trajectory["recorded_model"]
+            if recorded_model is not None and (
+                not isinstance(recorded_model, str) or not recorded_model
+            ):
+                raise ValueError(f"trajectory {session_id} has invalid recorded_model")
             messages = trajectory.get("messages")
             if not isinstance(messages, list) or not messages:
                 raise ValueError(

--- a/evals/agentic-replay.py
+++ b/evals/agentic-replay.py
@@ -36,12 +36,16 @@ from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Iterable, Optional, Sequence
+from urllib.parse import urlsplit
 
 
 REPO = Path(__file__).resolve().parents[1]
 COMPETITIVE_CONFIG = REPO / "evals/skippy-competitive-benchmark.json"
 TRAJECTORY_GENERATOR = REPO / "evals/agentic-trajectory-manifest.py"
 DEFAULT_BASE_URL = "http://127.0.0.1:9337/v1"
+DEFAULT_ENDPOINT = urlsplit(DEFAULT_BASE_URL)
+DEFAULT_HOST = DEFAULT_ENDPOINT.hostname or "127.0.0.1"
+DEFAULT_PORT = DEFAULT_ENDPOINT.port or 80
 FORBIDDEN_STARTUP_OPTIONS = (
     "--ctx-size",
     "--generation-concurrency",
@@ -326,6 +330,7 @@ def build_trajectory_manifest(args: argparse.Namespace, output: Path) -> dict[st
         "--min-turns",
         str(args.min_turns),
     ]
+    command.extend(("--cohort", "warmup"))
     for concurrency in args.concurrency:
         command.extend(("--cohort", str(concurrency)))
     for framework in args.framework:
@@ -353,21 +358,38 @@ def build_trajectory_manifest(args: argparse.Namespace, output: Path) -> dict[st
     }
 
 
-def load_trajectory_cohorts(path: Path) -> dict[str, list[dict[str, Any]]]:
+def load_trajectory_cohorts(
+    path: Path, expected_cohorts: Sequence[str]
+) -> dict[str, list[dict[str, Any]]]:
     document = json.loads(path.read_text(encoding="utf-8"))
     cohorts = document.get("cohorts")
     if not isinstance(cohorts, dict) or not cohorts:
         raise ValueError("trajectory manifest must contain nonempty cohorts")
+    missing = [name for name in expected_cohorts if name not in cohorts]
+    if missing:
+        raise ValueError(f"trajectory manifest is missing cohorts: {missing}")
     for name, trajectories in cohorts.items():
         if not isinstance(name, str) or not isinstance(trajectories, list) or not trajectories:
             raise ValueError("each trajectory cohort must be a nonempty list")
         for trajectory in trajectories:
-            if not isinstance(trajectory.get("session_id"), str):
+            session_id = trajectory.get("session_id")
+            if not isinstance(session_id, str) or not session_id:
                 raise ValueError(f"cohort {name} contains a trajectory without session_id")
-            if not isinstance(trajectory.get("messages"), list):
+            for field in ("source_dataset", "agent_framework", "recorded_model"):
+                if not isinstance(trajectory.get(field), str) or not trajectory[field]:
+                    raise ValueError(f"trajectory {session_id} has no {field}")
+            messages = trajectory.get("messages")
+            if not isinstance(messages, list) or not messages:
                 raise ValueError(
-                    f"trajectory {trajectory.get('session_id')} has no messages list"
+                    f"trajectory {session_id} has no messages list"
                 )
+            for index, message in enumerate(messages):
+                if not isinstance(message, dict) or not isinstance(
+                    message.get("role"), str
+                ):
+                    raise ValueError(
+                        f"trajectory {session_id} message {index} has no role"
+                    )
     return cohorts
 
 
@@ -379,7 +401,7 @@ def server_command(binary: Path, model: str) -> list[str]:
     return command
 
 
-def port_is_open(host: str = "127.0.0.1", port: int = 9337) -> bool:
+def port_is_open(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
     with socket.socket() as connection:
         connection.settimeout(0.2)
         return connection.connect_ex((host, port)) == 0
@@ -399,7 +421,7 @@ def wait_for_model(
             raise RuntimeError(
                 f"Mesh exited before readiness with status {process.returncode}"
             )
-        connection = http.client.HTTPConnection("127.0.0.1", 9337, timeout=5)
+        connection = http.client.HTTPConnection(DEFAULT_HOST, DEFAULT_PORT, timeout=5)
         try:
             connection.request("GET", "/v1/models")
             response = connection.getresponse()
@@ -442,7 +464,7 @@ def stream_request(
     cached_tokens = 0
     content_events = 0
     content_parts: list[str] = []
-    connection = http.client.HTTPConnection("127.0.0.1", 9337, timeout=timeout)
+    connection = http.client.HTTPConnection(DEFAULT_HOST, DEFAULT_PORT, timeout=timeout)
     payload = {
         "model": model_id,
         "messages": list(messages),
@@ -590,6 +612,7 @@ def replay_trajectory(
     model_id: str,
     max_output_tokens: int,
     timeout: float,
+    turn_limit: Optional[int] = None,
 ) -> list[dict[str, Any]]:
     history: list[dict[str, Any]] = []
     results: list[dict[str, Any]] = []
@@ -597,6 +620,8 @@ def replay_trajectory(
     tools = trajectory_tools(trajectory)
     for message_index, recorded in enumerate(trajectory["messages"]):
         if recorded["role"] == "assistant":
+            if turn_limit is not None and assistant_turn >= turn_limit:
+                break
             requested_output_tokens = recorded_output_budget(
                 recorded, max_output_tokens
             )
@@ -629,34 +654,46 @@ def replay_trajectory(
     return results
 
 
-def summarize_requests(requests: Sequence[dict[str, Any]]) -> dict[str, Any]:
+def summarize_requests(
+    requests: Sequence[dict[str, Any]], offered_concurrency: int = 1
+) -> dict[str, Any]:
     successful = [request for request in requests if "error" not in request]
     ttft = [request["ttft_seconds"] for request in successful]
     completion_tokens = sum(request["completion_tokens"] for request in successful)
     prompt_tokens = sum(request["prompt_tokens"] for request in successful)
     cached_tokens = sum(request["cached_tokens"] for request in successful)
+    elapsed_seconds = sum(request["elapsed_seconds"] for request in successful)
+    generation_seconds = sum(
+        request["generation_seconds"] for request in successful
+    )
     if successful:
         workload_window = max(request["completed"] for request in successful) - min(
             request["started"] for request in successful
         )
     else:
         workload_window = 0.0
-    request_decode_rates = [
-        request["completion_tokens"] / request["generation_seconds"]
-        for request in successful
-        if request["generation_seconds"] > 0
-    ]
+    mean_in_flight = (
+        elapsed_seconds / workload_window if workload_window > 0 else None
+    )
     return {
         "requests": len(requests),
         "successful_requests": len(successful),
         "failed_requests": len(requests) - len(successful),
+        "failed_request_ids": sorted(
+            str(request.get("request_id", "unknown"))
+            for request in requests
+            if "error" in request
+        ),
         "completion_tokens": completion_tokens,
         "prompt_tokens": prompt_tokens,
         "cached_tokens": cached_tokens,
-        "exact_output_requests": sum(
+        "generation_seconds": generation_seconds,
+        "workload_window_seconds": workload_window,
+        "budget_exhausted_requests": sum(
             request.get("completion_tokens") == request.get("requested_output_tokens")
             for request in successful
         ),
+        "ttft_samples": ttft,
         "ttft_p50_seconds": statistics.median(ttft) if ttft else None,
         "ttft_p95_seconds": percentile(ttft, 0.95),
         "agent_steps_per_second": (
@@ -665,11 +702,69 @@ def summarize_requests(requests: Sequence[dict[str, Any]]) -> dict[str, Any]:
         "workload_output_tokens_per_second": (
             completion_tokens / workload_window if workload_window > 0 else None
         ),
-        "mean_request_decode_tokens_per_second": (
-            statistics.mean(request_decode_rates) if request_decode_rates else None
+        "decode_tokens_per_second": (
+            completion_tokens / generation_seconds
+            if generation_seconds > 0
+            else None
+        ),
+        "mean_in_flight": mean_in_flight,
+        "concurrency_utilization_pct": (
+            100 * mean_in_flight / offered_concurrency
+            if mean_in_flight is not None and offered_concurrency > 0
+            else None
         ),
         "cache_pct": 100 * cached_tokens / prompt_tokens if prompt_tokens else None,
     }
+
+
+def write_request_records(
+    path: Path,
+    requests: Sequence[dict[str, Any]],
+    concurrency: int,
+    *,
+    warmup: bool = False,
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as raw:
+        for request in requests:
+            request["concurrency"] = concurrency
+            request["warmup"] = warmup
+            raw.write(json.dumps(request, sort_keys=True) + "\n")
+
+
+def run_warmup(
+    trajectories: Sequence[dict[str, Any]],
+    model_id: str,
+    turns: int,
+    max_output_tokens: int,
+    timeout: float,
+    raw_path: Path,
+) -> dict[str, Any]:
+    requests: list[dict[str, Any]] = []
+    for trajectory in trajectories:
+        remaining = turns - len(requests)
+        if remaining <= 0:
+            break
+        requests.extend(
+            replay_trajectory(
+                trajectory,
+                model_id,
+                max_output_tokens,
+                timeout,
+                turn_limit=remaining,
+            )
+        )
+    if len(requests) < turns:
+        raise RuntimeError(
+            f"warm-up cohort produced {len(requests)} turns; {turns} required"
+        )
+    write_request_records(raw_path, requests, 1, warmup=True)
+    summary = summarize_requests(requests, 1)
+    if summary["failed_requests"]:
+        raise RuntimeError(
+            f"warm-up failed {summary['failed_requests']} of {summary['requests']} turns"
+        )
+    return summary
 
 
 def run_trajectory_cell(
@@ -684,7 +779,6 @@ def run_trajectory_cell(
     if not trajectories:
         raise ValueError("trajectory cell cannot be empty")
     requests: list[dict[str, Any]] = []
-    raw_path.parent.mkdir(parents=True, exist_ok=True)
     with concurrent.futures.ThreadPoolExecutor(
         max_workers=min(concurrency, len(trajectories))
     ) as pool:
@@ -700,11 +794,8 @@ def run_trajectory_cell(
         ]
         for future in futures:
             requests.extend(future.result())
-    with raw_path.open("w", encoding="utf-8") as raw:
-        for request in requests:
-            request["concurrency"] = concurrency
-            raw.write(json.dumps(request, sort_keys=True) + "\n")
-    summary = summarize_requests(requests)
+    write_request_records(raw_path, requests, concurrency)
+    summary = summarize_requests(requests, concurrency)
     framework_counts: dict[str, int] = {}
     for trajectory in trajectories:
         framework = trajectory["agent_framework"]
@@ -762,7 +853,9 @@ def start_server(
     hf_home: Optional[Path],
 ) -> tuple[subprocess.Popen[bytes], list[str]]:
     if port_is_open():
-        raise RuntimeError("TCP 9337 is already in use; stop the existing Mesh instance")
+        raise RuntimeError(
+            f"TCP {DEFAULT_PORT} is already in use; stop the existing Mesh instance"
+        )
     command = server_command(Path(build["binary"]), model)
     log_path.parent.mkdir(parents=True, exist_ok=True)
     log_handle = log_path.open("wb")
@@ -794,7 +887,7 @@ def stop_server(process: subprocess.Popen[bytes]) -> None:
     while port_is_open() and time.monotonic() < deadline:
         time.sleep(0.2)
     if port_is_open():
-        raise RuntimeError("Mesh stopped but TCP 9337 is still occupied")
+        raise RuntimeError(f"Mesh stopped but TCP {DEFAULT_PORT} is still occupied")
 
 
 def collect_runtime_logs(state_dir: Path, output_dir: Path) -> None:
@@ -827,11 +920,21 @@ def run_arm_pass(
     process: Optional[subprocess.Popen[bytes]] = None
     command = server_command(Path(build["binary"]), args.model)
     cells: list[dict[str, Any]] = []
+    warmup: Optional[dict[str, Any]] = None
     try:
         process, command = start_server(
             build, args.model, state_dir, log_path, args.hf_home
         )
         model_id = wait_for_model(DEFAULT_BASE_URL, args.startup_timeout, process)
+        warmup = run_warmup(
+            trajectories=cohorts["warmup"],
+            model_id=model_id,
+            turns=args.warmup_turns,
+            max_output_tokens=args.max_output_tokens,
+            timeout=args.request_timeout,
+            raw_path=pass_dir / "warmup-requests.jsonl",
+        )
+        write_json(pass_dir / "warmup.json", warmup)
         concurrency_values = (
             args.concurrency
             if pass_index % 2 == 0
@@ -865,6 +968,7 @@ def run_arm_pass(
         "server_command": command,
         "server_log": str(log_path),
         "model_id": model_id,
+        "warmup": warmup,
         "cells": cells,
     }
 
@@ -886,6 +990,61 @@ def pooled_rows(results: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
         ref, commit = metadata[label]
         requests = sum(cell["requests"] for cell in cells)
         successes = sum(cell["successful_requests"] for cell in cells)
+        failures = requests - successes
+        failure_identity_known = failures == 0 or all(
+            "failed_request_ids" in cell for cell in cells
+        )
+        failed_request_ids = sorted(
+            request_id
+            for cell in cells
+            for request_id in cell.get("failed_request_ids", [])
+        )
+        completion_tokens = sum(cell.get("completion_tokens", 0) for cell in cells)
+        prompt_tokens = sum(cell.get("prompt_tokens", 0) for cell in cells)
+        cached_tokens = sum(cell.get("cached_tokens", 0) for cell in cells)
+        generation_seconds = sum(
+            cell.get("generation_seconds", 0.0) for cell in cells
+        )
+        workload_seconds = sum(
+            cell.get("workload_window_seconds", 0.0) for cell in cells
+        )
+        pooled_ttft = [
+            value for cell in cells for value in cell.get("ttft_samples", [])
+        ]
+        decode_values = [
+            cell.get(
+                "decode_tokens_per_second",
+                cell.get("mean_request_decode_tokens_per_second"),
+            )
+            for cell in cells
+        ]
+        decode_values = [value for value in decode_values if value is not None]
+        step_values = [
+            cell["agent_steps_per_second"]
+            for cell in cells
+            if cell["agent_steps_per_second"] is not None
+        ]
+        workload_values = [
+            cell["workload_output_tokens_per_second"]
+            for cell in cells
+            if cell["workload_output_tokens_per_second"] is not None
+        ]
+        ttft_p50_values = [
+            cell["ttft_p50_seconds"]
+            for cell in cells
+            if cell["ttft_p50_seconds"] is not None
+        ]
+        realized_concurrency = (
+            sum(
+                cell.get("mean_in_flight", 0.0)
+                * cell.get("workload_window_seconds", 0.0)
+                for cell in cells
+                if cell.get("mean_in_flight") is not None
+            )
+            / workload_seconds
+            if workload_seconds > 0
+            else mean_or_none(cell.get("mean_in_flight") for cell in cells)
+        )
         rows.append(
             {
                 "label": label,
@@ -897,24 +1056,75 @@ def pooled_rows(results: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
                 "trajectory_replays": sum(cell["trajectories"] for cell in cells),
                 "requests": requests,
                 "successful_requests": successes,
+                "failed_requests": failures,
+                "failed_request_ids": failed_request_ids,
+                "failure_identity_known": failure_identity_known,
                 "success_pct": 100 * successes / requests if requests else None,
-                "exact_output_pct": 100
-                * sum(cell["exact_output_requests"] for cell in cells)
+                "budget_exhausted_pct": 100
+                * sum(
+                    cell.get(
+                        "budget_exhausted_requests",
+                        cell.get("exact_output_requests", 0),
+                    )
+                    for cell in cells
+                )
                 / successes
                 if successes
                 else None,
-                "agent_steps_per_second": mean_or_none(
-                    cell["agent_steps_per_second"] for cell in cells
+                "agent_steps_per_second": (
+                    successes / workload_seconds
+                    if workload_seconds > 0
+                    else mean_or_none(step_values)
                 ),
-                "workload_output_tokens_per_second": mean_or_none(
-                    cell["workload_output_tokens_per_second"] for cell in cells
+                "agent_steps_per_second_min": min(step_values) if step_values else None,
+                "agent_steps_per_second_max": max(step_values) if step_values else None,
+                "workload_output_tokens_per_second": (
+                    completion_tokens / workload_seconds
+                    if workload_seconds > 0
+                    else mean_or_none(workload_values)
                 ),
-                "mean_request_decode_tokens_per_second": mean_or_none(
-                    cell["mean_request_decode_tokens_per_second"] for cell in cells
+                "workload_output_tokens_per_second_min": (
+                    min(workload_values) if workload_values else None
                 ),
-                "ttft_p50_seconds": mean_or_none(cell["ttft_p50_seconds"] for cell in cells),
-                "ttft_p95_seconds": mean_or_none(cell["ttft_p95_seconds"] for cell in cells),
-                "cache_pct": mean_or_none(cell["cache_pct"] for cell in cells),
+                "workload_output_tokens_per_second_max": (
+                    max(workload_values) if workload_values else None
+                ),
+                "decode_tokens_per_second": (
+                    completion_tokens / generation_seconds
+                    if generation_seconds > 0
+                    else mean_or_none(decode_values)
+                ),
+                "decode_tokens_per_second_min": (
+                    min(decode_values) if decode_values else None
+                ),
+                "decode_tokens_per_second_max": (
+                    max(decode_values) if decode_values else None
+                ),
+                "ttft_p50_seconds": (
+                    percentile(pooled_ttft, 0.50)
+                    if pooled_ttft
+                    else mean_or_none(cell["ttft_p50_seconds"] for cell in cells)
+                ),
+                "ttft_p50_seconds_min": (
+                    min(ttft_p50_values) if ttft_p50_values else None
+                ),
+                "ttft_p50_seconds_max": (
+                    max(ttft_p50_values) if ttft_p50_values else None
+                ),
+                "ttft_p95_seconds": (
+                    percentile(pooled_ttft, 0.95)
+                    if pooled_ttft
+                    else mean_or_none(cell["ttft_p95_seconds"] for cell in cells)
+                ),
+                "mean_in_flight": realized_concurrency,
+                "concurrency_utilization_pct": (
+                    100 * realized_concurrency / concurrency
+                    if realized_concurrency is not None
+                    else None
+                ),
+                "cache_pct": (
+                    100 * cached_tokens / prompt_tokens if prompt_tokens else None
+                ),
             }
         )
     baseline_label = results[0]["label"] if results else None
@@ -925,16 +1135,26 @@ def pooled_rows(results: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
     }
     for row in rows:
         reference = baseline.get(row["concurrency"])
+        row["delta_comparable"] = bool(
+            reference
+            and row["requests"] == reference["requests"]
+            and row["failure_identity_known"]
+            and reference["failure_identity_known"]
+            and row["failed_request_ids"] == reference["failed_request_ids"]
+        )
         for metric in (
             "agent_steps_per_second",
             "workload_output_tokens_per_second",
+            "decode_tokens_per_second",
             "ttft_p50_seconds",
         ):
             base_value = reference.get(metric) if reference else None
             value = row.get(metric)
             row[f"{metric}_delta_pct"] = (
                 100 * (value / base_value - 1)
-                if value is not None and base_value not in (None, 0)
+                if row["delta_comparable"]
+                and value is not None
+                and base_value not in (None, 0)
                 else None
             )
     return rows
@@ -942,6 +1162,14 @@ def pooled_rows(results: Sequence[dict[str, Any]]) -> list[dict[str, Any]]:
 
 def fmt(value: Optional[float], digits: int = 2, suffix: str = "") -> str:
     return "—" if value is None else f"{value:.{digits}f}{suffix}"
+
+
+def fmt_range(
+    low: Optional[float], high: Optional[float], digits: int = 2
+) -> str:
+    if low is None or high is None:
+        return "—"
+    return f"{low:.{digits}f}–{high:.{digits}f}"
 
 
 def escape(value: Any) -> str:
@@ -1030,17 +1258,29 @@ def write_report(output: Path, run_document: dict[str, Any]) -> Path:
         writer.writerows(rows)
     labels = [build["label"] for build in run_document["builds"]]
     cohort_metadata = run_document["inputs"]["cohorts"]
+    measured_cohorts = [
+        cohort_metadata[str(value)] for value in run_document["config"]["concurrency"]
+    ]
     selected_trajectories = sum(
-        cohort["trajectory_count"] for cohort in cohort_metadata.values()
+        cohort["trajectory_count"] for cohort in measured_cohorts
     )
-    selected_turns = sum(cohort["assistant_turns"] for cohort in cohort_metadata.values())
+    selected_turns = sum(cohort["assistant_turns"] for cohort in measured_cohorts)
+    warmup_cohort = cohort_metadata["warmup"]
     svg_chart(
-        "Agent-step throughput by commit",
+        "Decode throughput by commit",
         rows,
         labels,
-        "agent_steps_per_second",
-        "Completed agent steps / second",
-        charts / "agent-step-throughput.svg",
+        "decode_tokens_per_second",
+        "Generated tokens / decode second",
+        charts / "decode-throughput.svg",
+    )
+    svg_chart(
+        "End-to-end workload output throughput by commit",
+        rows,
+        labels,
+        "workload_output_tokens_per_second",
+        "Generated tokens / wall-clock second",
+        charts / "workload-output-throughput.svg",
     )
     svg_chart(
         "Median time to first token by commit",
@@ -1075,26 +1315,45 @@ def write_report(output: Path, run_document: dict[str, Any]) -> Path:
             "",
             "## Result table",
             "",
-            "| Ref | Commit | C | Trajectories/pass | Agent steps | Success | Steps/s | vs baseline | Output tok/s | TTFT p50 | TTFT p95 | TTFT p50 vs baseline | Cached prompt |",
-            "|---|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
+            "| Ref | Commit | Offered C | Realized C | Slot use | Trajectories/pass | Agent steps | Failures | Comparable | Decode tok/s | Pass range | vs baseline | E2E output tok/s | Pass range | TTFT p50 | Pass range | TTFT p95 | TTFT p50 vs baseline | Cached prompt | Budget exhausted |",
+            "|---|---|---:|---:|---:|---:|---:|---:|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|",
         ]
     )
     for row in rows:
         lines.append(
-            "| {label} | `{commit}` | {concurrency} | {trajectories} | {requests} | {success} | {steps} | {steps_delta} | {output_tps} | {p50} | {p95} | {p50_delta} | {cache} |".format(
+            "| {label} | `{commit}` | {concurrency} | {realized} | {slot_use} | {trajectories} | {requests} | {failures} | {comparable} | {decode_tps} | {decode_range} | {decode_delta} | {output_tps} | {output_range} | {p50} | {p50_range} | {p95} | {p50_delta} | {cache} | {budget} |".format(
                 label=row["label"],
                 commit=row["commit"][:10],
                 concurrency=row["concurrency"],
+                realized=fmt(row["mean_in_flight"]),
+                slot_use=fmt(row["concurrency_utilization_pct"], 1, "%"),
                 trajectories=row["trajectories_per_pass"],
                 requests=row["requests"],
-                success=fmt(row["success_pct"], 1, "%"),
-                steps=fmt(row["agent_steps_per_second"], 3),
-                steps_delta=fmt(row["agent_steps_per_second_delta_pct"], 1, "%"),
+                failures=row["failed_requests"],
+                comparable="yes" if row["delta_comparable"] else "no",
+                decode_tps=fmt(row["decode_tokens_per_second"]),
+                decode_range=fmt_range(
+                    row["decode_tokens_per_second_min"],
+                    row["decode_tokens_per_second_max"],
+                ),
+                decode_delta=fmt(
+                    row["decode_tokens_per_second_delta_pct"], 1, "%"
+                ),
                 output_tps=fmt(row["workload_output_tokens_per_second"]),
+                output_range=fmt_range(
+                    row["workload_output_tokens_per_second_min"],
+                    row["workload_output_tokens_per_second_max"],
+                ),
                 p50=fmt(row["ttft_p50_seconds"], 3, "s"),
+                p50_range=fmt_range(
+                    row["ttft_p50_seconds_min"],
+                    row["ttft_p50_seconds_max"],
+                    3,
+                ),
                 p95=fmt(row["ttft_p95_seconds"], 3, "s"),
                 p50_delta=fmt(row["ttft_p50_seconds_delta_pct"], 1, "%"),
                 cache=fmt(row["cache_pct"], 1, "%"),
+                budget=fmt(row["budget_exhausted_pct"], 1, "%"),
             )
         )
     lines.extend(
@@ -1102,7 +1361,9 @@ def write_report(output: Path, run_document: dict[str, Any]) -> Path:
             "",
             "## Charts",
             "",
-            "![Agent-step throughput](charts/agent-step-throughput.svg)",
+            "![Decode throughput](charts/decode-throughput.svg)",
+            "",
+            "![End-to-end workload output throughput](charts/workload-output-throughput.svg)",
             "",
             "![Median TTFT](charts/ttft-p50.svg)",
             "",
@@ -1113,12 +1374,19 @@ def write_report(output: Path, run_document: dict[str, Any]) -> Path:
             "- Mesh chooses context size, execution lanes, KV budget, and backend tuning.",
             f"- Client concurrency: `{','.join(map(str, run_document['config']['concurrency']))}`.",
             f"- Pass order: `{' → '.join(item['label'] for item in run_document['order'])}`.",
+            f"- Warm-up: `{run_document['config']['warmup_turns']}` discarded turns from a disjoint cohort after every model-ready event.",
+            f"- Warm-up cohort: `{warmup_cohort['trajectory_count']}` whole trajectories, disjoint from measured cohorts.",
             f"- Dataset revision: `{run_document['inputs']['dataset']['revision']}`.",
             f"- Selected trajectories: `{selected_trajectories}` unique whole sessions across disjoint concurrency cohorts.",
             f"- Recorded agent steps: `{selected_turns}` assistant turns per arm pass; each commit replays them once per pass.",
             "- Turns inside a trajectory are strictly sequential. Different trajectories may overlap up to the offered client concurrency.",
+            "- Realized concurrency is the time-weighted mean number of in-flight requests. Slot use makes cohort tail drain explicit; do not interpret offered-concurrency scaling as steady-state when utilization is low.",
             "- Each next request uses the recorded conversation history, so experiment arms receive identical growing prefixes and tool observations.",
             "- Per-turn output budgets approximate each recorded assistant action from its character length, capped by the configured maximum; generated output is measured but never fed into the next turn.",
+            "- Decode tok/s is token-weighted generation throughput after first content. E2E output tok/s includes prompt ingestion and scheduling.",
+            "- Percent deltas are suppressed unless compared arms fail the same request IDs. Pass ranges expose run-to-run spread.",
+            "- Tool definitions preserve recorded names but use permissive synthetic schemas. This benchmark measures serving performance on reconstructed prompts, not answer quality or byte-identical production prompts.",
+            "- Selection is deterministic hash order, not stratified by context length or difficulty. Treat small deltas as directional unless repeated with a larger cohort.",
             f"- Trajectory manifest SHA-256: `{run_document['inputs']['manifest_sha256']}`.",
             "- Raw request records, server logs, build logs, commands, and exact binary/runtime hashes are retained beside this report.",
             "",
@@ -1153,24 +1421,34 @@ def benchmark_plan(args: argparse.Namespace, specs: Sequence[RefSpec]) -> dict[s
             ["just", "release-host-build"],
             ["just", "release-runtime-build", args.backend],
         ],
-        "server_command": ["<release-binary>", "serve", "--model", args.model, "--log-format", "json"],
+        "server_command": [
+            "<release-binary>",
+            "serve",
+            "--model",
+            args.model,
+            "--log-format",
+            "json",
+        ],
         "dataset": dataset,
         "selection": {
             "source_datasets": args.source_dataset,
             "frameworks": args.framework,
             "trajectories_per_framework_per_concurrency": args.trajectories_per_framework,
-            "unique_trajectory_count": len(args.concurrency)
+            "measured_unique_trajectory_count": len(args.concurrency)
             * len(args.framework)
+            * args.trajectories_per_framework,
+            "warmup_unique_trajectory_count": len(args.framework)
             * args.trajectories_per_framework,
             "min_isl": args.min_isl,
             "max_isl_exclusive": args.max_isl,
-            "min_turns": args.min_turns,
+            "min_assistant_turns": args.min_turns,
         },
         "workload": {
             "concurrency": args.concurrency,
             "passes": args.passes,
             "ordered_whole_trajectory_replay": True,
             "max_output_tokens": args.max_output_tokens,
+            "warmup_turns_per_arm_pass": args.warmup_turns,
         },
         "outputs": [
             "raw request JSONL",
@@ -1198,7 +1476,8 @@ def run_benchmark(args: argparse.Namespace) -> Path:
     write_json(args.output / "plan.json", plan)
     commands = CommandLog(args.output / "commands.jsonl")
     inputs = build_trajectory_manifest(args, args.output)
-    cohorts = load_trajectory_cohorts(Path(inputs["manifest"]))
+    expected_cohorts = ["warmup", *(str(value) for value in args.concurrency)]
+    cohorts = load_trajectory_cohorts(Path(inputs["manifest"]), expected_cohorts)
     worktree_root = (
         args.worktree_root or (args.repo.parent / ".agentic-replay-worktrees")
     ).resolve()
@@ -1222,6 +1501,7 @@ def run_benchmark(args: argparse.Namespace) -> Path:
             "concurrency": args.concurrency,
             "passes": args.passes,
             "max_output_tokens": args.max_output_tokens,
+            "warmup_turns": args.warmup_turns,
         },
         "plan_sha256": stable_hash(plan),
         "inputs": inputs,
@@ -1295,7 +1575,13 @@ def add_common_arguments(parser: argparse.ArgumentParser) -> None:
         required=True,
         help="whole trajectories from each framework in each concurrency cohort",
     )
-    parser.add_argument("--max-output-tokens", type=int, default=256)
+    parser.add_argument("--max-output-tokens", type=int, default=2048)
+    parser.add_argument(
+        "--warmup-turns",
+        type=int,
+        default=14,
+        help="discarded ordered turns from a disjoint cohort after model readiness",
+    )
     parser.add_argument("--min-isl", type=int, default=8192)
     parser.add_argument("--max-isl", type=int, default=65536)
     parser.add_argument("--min-turns", type=int, default=5)
@@ -1319,6 +1605,7 @@ def validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
         args.passes,
         args.trajectories_per_framework,
         args.max_output_tokens,
+        args.warmup_turns,
         args.min_isl,
         args.min_turns,
     )
@@ -1336,6 +1623,13 @@ def validate_args(args: argparse.Namespace, parser: argparse.ArgumentParser) -> 
         args.framework = ["swe-agent", "mini-swe-agent", "openhands"]
     if len(set(args.framework)) != len(args.framework):
         parser.error("--framework values must be unique")
+    trajectories_per_cohort = args.trajectories_per_framework * len(args.framework)
+    minimum_trajectories = 2 * max(args.concurrency)
+    if trajectories_per_cohort < minimum_trajectories:
+        parser.error(
+            "each concurrency cohort must contain at least twice the maximum "
+            f"offered concurrency ({minimum_trajectories} trajectories required)"
+        )
 
 
 def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:

--- a/evals/agentic-trajectory-manifest.py
+++ b/evals/agentic-trajectory-manifest.py
@@ -57,8 +57,14 @@ def build_cohorts(
     cohort_names: Sequence[str],
     frameworks: Sequence[str],
     trajectories_per_framework: int,
+    min_assistant_turns: int = 1,
 ) -> dict[str, list[dict[str, Any]]]:
-    if not cohort_names or not frameworks or trajectories_per_framework <= 0:
+    if (
+        not cohort_names
+        or not frameworks
+        or trajectories_per_framework <= 0
+        or min_assistant_turns <= 0
+    ):
         raise ValueError("cohorts, frameworks, and trajectory count must be positive")
     cohorts = {name: [] for name in cohort_names}
     by_framework = {framework: [] for framework in frameworks}
@@ -76,6 +82,8 @@ def build_cohorts(
         seen.add(session_id)
         messages = validate_messages(row["messages_json"], session_id)
         turns = assistant_turn_count(messages)
+        if turns < min_assistant_turns:
+            continue
         by_framework[framework].append(
             {
                 "session_id": session_id,
@@ -210,7 +218,7 @@ def main() -> int:
     parser.add_argument("--framework", action="append", required=True)
     parser.add_argument("--trajectories-per-framework", type=int, required=True)
     parser.add_argument("--min-isl", type=int, default=8192)
-    parser.add_argument("--max-isl", type=int, default=16384)
+    parser.add_argument("--max-isl", type=int, default=65536)
     parser.add_argument("--min-turns", type=int, default=5)
     parser.add_argument("--source-dataset", action="append", dest="sources", default=[])
     args = parser.parse_args()
@@ -238,6 +246,7 @@ def main() -> int:
         args.cohort,
         args.framework,
         args.trajectories_per_framework,
+        args.min_turns,
     )
     document = manifest_document(
         cohorts,
@@ -250,7 +259,7 @@ def main() -> int:
                 "trajectories_per_framework_per_cohort": args.trajectories_per_framework,
                 "min_isl": args.min_isl,
                 "max_isl_exclusive": args.max_isl,
-                "min_turns": args.min_turns,
+                "min_assistant_turns": args.min_turns,
                 "order": "agent_framework, md5(session_id)",
                 "whole_trajectories": True,
                 "cohorts_disjoint": True,
@@ -258,7 +267,10 @@ def main() -> int:
         },
     )
     args.output.parent.mkdir(parents=True, exist_ok=True)
-    args.output.write_text(json.dumps(document, indent=2, ensure_ascii=False) + "\n")
+    args.output.write_text(
+        json.dumps(document, indent=2, ensure_ascii=False) + "\n",
+        encoding="utf-8",
+    )
     print(args.output)
     return 0
 

--- a/evals/agentic-trajectory-manifest.py
+++ b/evals/agentic-trajectory-manifest.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""Select deterministic, disjoint, ordered agent trajectories from parquet."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+
+def assistant_turn_count(messages: Sequence[dict[str, Any]]) -> int:
+    return sum(message.get("role") == "assistant" for message in messages)
+
+
+def validate_messages(messages_json: str, session_id: str) -> list[dict[str, Any]]:
+    messages = json.loads(messages_json)
+    if not isinstance(messages, list) or not messages:
+        raise ValueError(f"trajectory {session_id} has no messages")
+    validated: list[dict[str, Any]] = []
+    for index, message in enumerate(messages):
+        if not isinstance(message, dict):
+            raise ValueError(f"trajectory {session_id} message {index} is not an object")
+        role = message.get("role")
+        if role not in {"system", "developer", "user", "assistant", "tool"}:
+            raise ValueError(
+                f"trajectory {session_id} message {index} has unsupported role {role!r}"
+            )
+        content = message.get("content")
+        if content is not None and not isinstance(content, str):
+            raise ValueError(
+                f"trajectory {session_id} message {index} has non-string content"
+            )
+        tool_calls_json = message.get("tool_calls_json")
+        if tool_calls_json:
+            tool_calls = json.loads(tool_calls_json)
+            if not isinstance(tool_calls, list):
+                raise ValueError(
+                    f"trajectory {session_id} message {index} tool calls are not a list"
+                )
+        validated.append(
+            {
+                "role": role,
+                "content": content or "",
+                "tool_calls_json": tool_calls_json,
+                "tool_call_id": message.get("tool_call_id"),
+            }
+        )
+    if assistant_turn_count(validated) == 0:
+        raise ValueError(f"trajectory {session_id} has no assistant turns")
+    return validated
+
+
+def build_cohorts(
+    rows: Iterable[dict[str, Any]],
+    cohort_names: Sequence[str],
+    frameworks: Sequence[str],
+    trajectories_per_framework: int,
+) -> dict[str, list[dict[str, Any]]]:
+    if not cohort_names or not frameworks or trajectories_per_framework <= 0:
+        raise ValueError("cohorts, frameworks, and trajectory count must be positive")
+    cohorts = {name: [] for name in cohort_names}
+    by_framework = {framework: [] for framework in frameworks}
+    required = len(cohort_names) * trajectories_per_framework
+    seen: set[str] = set()
+    for row in rows:
+        session_id = row["session_id"]
+        framework = row["agent_framework"]
+        if (
+            framework not in by_framework
+            or len(by_framework[framework]) >= required
+            or session_id in seen
+        ):
+            continue
+        seen.add(session_id)
+        messages = validate_messages(row["messages_json"], session_id)
+        turns = assistant_turn_count(messages)
+        by_framework[framework].append(
+            {
+                "session_id": session_id,
+                "source_dataset": row["source_dataset"],
+                "agent_framework": row["agent_framework"],
+                "recorded_model": row["recorded_model"],
+                "n_turns": row["n_turns"],
+                "max_isl": row["max_isl"],
+                "total_tokens": row["total_tokens"],
+                "assistant_turns": turns,
+                "messages": messages,
+            }
+        )
+        if all(len(by_framework[item]) >= required for item in frameworks):
+            break
+    for framework in frameworks:
+        available = by_framework[framework]
+        if len(available) < required:
+            raise ValueError(
+                f"framework {framework} has {len(available)} eligible trajectories, "
+                f"but {required} are required"
+            )
+        for cohort_index, cohort in enumerate(cohort_names):
+            start = cohort_index * trajectories_per_framework
+            end = start + trajectories_per_framework
+            cohorts[cohort].extend(available[start:end])
+    return cohorts
+
+
+def select_rows(
+    dataset_file: Path,
+    sources: Sequence[str],
+    min_isl: int,
+    max_isl: int,
+    min_turns: int,
+) -> Iterable[dict[str, Any]]:
+    try:
+        import duckdb
+    except ModuleNotFoundError as error:
+        raise RuntimeError("DuckDB is required to read the cached parquet") from error
+    placeholders = ", ".join("?" for _ in sources)
+    query = f"""
+        WITH eligible AS (
+            SELECT
+                session_id,
+                source_dataset,
+                agent_framework,
+                recorded_model,
+                messages_json,
+                n_turns,
+                max_isl,
+                total_tokens,
+                row_number() OVER (
+                    PARTITION BY session_id
+                    ORDER BY max_isl DESC, total_tokens DESC, md5(messages_json)
+                ) AS occurrence
+            FROM read_parquet(?)
+            WHERE max_isl >= ?
+              AND max_isl < ?
+              AND n_turns >= ?
+              AND source_dataset IN ({placeholders})
+        )
+        SELECT
+            session_id,
+            source_dataset,
+            agent_framework,
+            recorded_model,
+            messages_json,
+            n_turns,
+            max_isl,
+            total_tokens
+        FROM eligible
+        WHERE occurrence = 1
+        ORDER BY agent_framework, md5(session_id)
+    """
+    columns = (
+        "session_id",
+        "source_dataset",
+        "agent_framework",
+        "recorded_model",
+        "messages_json",
+        "n_turns",
+        "max_isl",
+        "total_tokens",
+    )
+    cursor = duckdb.execute(
+        query,
+        [str(dataset_file), min_isl, max_isl, min_turns, *sources],
+    )
+    while True:
+        row = cursor.fetchone()
+        if row is None:
+            break
+        yield dict(zip(columns, row))
+
+
+def manifest_document(
+    cohorts: dict[str, list[dict[str, Any]]], metadata: dict[str, Any]
+) -> dict[str, Any]:
+    cohort_metadata = {}
+    for name, trajectories in cohorts.items():
+        framework_trajectories: dict[str, int] = {}
+        framework_turns: dict[str, int] = {}
+        for item in trajectories:
+            framework = item["agent_framework"]
+            framework_trajectories[framework] = framework_trajectories.get(framework, 0) + 1
+            framework_turns[framework] = framework_turns.get(framework, 0) + item[
+                "assistant_turns"
+            ]
+        cohort_metadata[name] = {
+            "trajectory_count": len(trajectories),
+            "assistant_turns": sum(item["assistant_turns"] for item in trajectories),
+            "framework_trajectories": framework_trajectories,
+            "framework_assistant_turns": framework_turns,
+            "session_ids_sha256": hashlib.sha256(
+                "\n".join(item["session_id"] for item in trajectories).encode()
+            ).hexdigest(),
+        }
+    return {
+        "schema_version": 1,
+        "metadata": {**metadata, "cohorts": cohort_metadata},
+        "cohorts": cohorts,
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--dataset-file", type=Path, required=True)
+    parser.add_argument("--dataset-revision", required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--cohort", action="append", required=True)
+    parser.add_argument("--framework", action="append", required=True)
+    parser.add_argument("--trajectories-per-framework", type=int, required=True)
+    parser.add_argument("--min-isl", type=int, default=8192)
+    parser.add_argument("--max-isl", type=int, default=16384)
+    parser.add_argument("--min-turns", type=int, default=5)
+    parser.add_argument("--source-dataset", action="append", dest="sources", default=[])
+    args = parser.parse_args()
+    if args.trajectories_per_framework <= 0 or args.min_isl <= 0 or args.min_turns <= 0:
+        parser.error("trajectory count, minimum ISL, and minimum turns must be positive")
+    if args.max_isl <= args.min_isl:
+        parser.error("maximum ISL must exceed minimum ISL")
+    if len(set(args.cohort)) != len(args.cohort) or len(set(args.framework)) != len(
+        args.framework
+    ):
+        parser.error("cohort and framework names must be unique")
+    if not args.sources:
+        parser.error("at least one --source-dataset is required")
+    if not args.dataset_file.is_file():
+        parser.error(f"dataset parquet not found: {args.dataset_file}")
+
+    cohorts = build_cohorts(
+        select_rows(
+            args.dataset_file,
+            args.sources,
+            args.min_isl,
+            args.max_isl,
+            args.min_turns,
+        ),
+        args.cohort,
+        args.framework,
+        args.trajectories_per_framework,
+    )
+    document = manifest_document(
+        cohorts,
+        {
+            "dataset": "thoughtworks/agentic-coding-trajectories",
+            "dataset_revision": args.dataset_revision,
+            "selection": {
+                "sources": args.sources,
+                "frameworks": args.framework,
+                "trajectories_per_framework_per_cohort": args.trajectories_per_framework,
+                "min_isl": args.min_isl,
+                "max_isl_exclusive": args.max_isl,
+                "min_turns": args.min_turns,
+                "order": "agent_framework, md5(session_id)",
+                "whole_trajectories": True,
+                "cohorts_disjoint": True,
+            },
+        },
+    )
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(document, indent=2, ensure_ascii=False) + "\n")
+    print(args.output)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_agentic_replay.py
+++ b/scripts/tests/test_agentic_replay.py
@@ -697,6 +697,10 @@ class AgenticReplayTest(unittest.TestCase):
             )
             self.assertIn("Decode tok/s", report.read_text(encoding="utf-8"))
             self.assertIn("Slot use", report.read_text(encoding="utf-8"))
+            self.assertIn(
+                "other cohort sizes use rank/count labels",
+                report.read_text(encoding="utf-8"),
+            )
 
     def test_plan_records_exact_default_server_command(self) -> None:
         args = SimpleNamespace(

--- a/scripts/tests/test_agentic_replay.py
+++ b/scripts/tests/test_agentic_replay.py
@@ -331,6 +331,17 @@ class AgenticReplayTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "missing cohorts"):
                 BENCH.load_trajectory_cohorts(manifest, ["warmup", "1"])
 
+    def test_manifest_rejects_non_object_trajectory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "manifest.json"
+            manifest.write_text(
+                json.dumps({"cohorts": {"warmup": ["not-an-object"]}}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "non-object trajectory"):
+                BENCH.load_trajectory_cohorts(manifest, ["warmup"])
+
     def test_manifest_allows_dataset_null_recorded_model(self) -> None:
         with tempfile.TemporaryDirectory() as directory:
             manifest = Path(directory) / "manifest.json"

--- a/scripts/tests/test_agentic_replay.py
+++ b/scripts/tests/test_agentic_replay.py
@@ -264,6 +264,19 @@ class AgenticReplayTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "missing cohorts"):
                 BENCH.load_trajectory_cohorts(manifest, ["warmup", "1"])
 
+    def test_warmup_capacity_is_validated_before_builds(self) -> None:
+        trajectories = [
+            {
+                "messages": [
+                    {"role": "user", "content": "task"},
+                    {"role": "assistant", "content": "action"},
+                ]
+            }
+        ]
+
+        with self.assertRaisesRegex(ValueError, "1 assistant turns; 14 required"):
+            BENCH.validate_warmup_capacity(trajectories, 14)
+
     def test_summarize_requests_computes_stream_windows_and_cache_rate(self) -> None:
         requests = [
             {

--- a/scripts/tests/test_agentic_replay.py
+++ b/scripts/tests/test_agentic_replay.py
@@ -9,6 +9,7 @@ import tempfile
 import unittest
 from pathlib import Path
 from types import SimpleNamespace
+from unittest import mock
 
 
 REPO = Path(__file__).resolve().parents[2]
@@ -112,6 +113,50 @@ class AgenticReplayTest(unittest.TestCase):
             BENCH.stream_request = original
 
         self.assertEqual([result["request_id"] for result in results], ["session-1:0"])
+
+    def test_stream_request_preserves_in_stream_server_errors(self) -> None:
+        class ErrorResponse:
+            status = 200
+
+            def __iter__(self):
+                return iter(
+                    [
+                        b'data: {"choices":[{"delta":{"content":"partial"}}]}\n',
+                        b'data: {"error":{"message":"cache operation deadline exceeded","type":"timeout"}}\n',
+                        b"data: [DONE]\n",
+                    ]
+                )
+
+        class ErrorConnection:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def request(self, *_args, **_kwargs):
+                pass
+
+            def getresponse(self):
+                return ErrorResponse()
+
+            def close(self):
+                pass
+
+        with mock.patch.object(BENCH.http.client, "HTTPConnection", ErrorConnection):
+            result = BENCH.stream_request(
+                "request-1",
+                [{"role": "user", "content": "task"}],
+                [],
+                {"session_id": "session-1"},
+                "model",
+                128,
+                10,
+            )
+
+        self.assertEqual(result["request_id"], "request-1")
+        self.assertEqual(result["session_id"], "session-1")
+        self.assertEqual(
+            result["error"],
+            "stream failed with server error: cache operation deadline exceeded",
+        )
 
     def test_checkpoint_replay_reconstructs_full_recorded_prefix(self) -> None:
         trajectory = {

--- a/scripts/tests/test_agentic_replay.py
+++ b/scripts/tests/test_agentic_replay.py
@@ -264,6 +264,25 @@ class AgenticReplayTest(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "missing cohorts"):
                 BENCH.load_trajectory_cohorts(manifest, ["warmup", "1"])
 
+    def test_manifest_allows_dataset_null_recorded_model(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "manifest.json"
+            trajectory = {
+                "session_id": "session-1",
+                "source_dataset": "source",
+                "agent_framework": "framework",
+                "recorded_model": None,
+                "messages": [{"role": "user", "content": "task"}],
+            }
+            manifest.write_text(
+                json.dumps({"cohorts": {"warmup": [trajectory]}}),
+                encoding="utf-8",
+            )
+
+            cohorts = BENCH.load_trajectory_cohorts(manifest, ["warmup"])
+
+            self.assertIsNone(cohorts["warmup"][0]["recorded_model"])
+
     def test_warmup_capacity_is_validated_before_builds(self) -> None:
         trajectories = [
             {

--- a/scripts/tests/test_agentic_replay.py
+++ b/scripts/tests/test_agentic_replay.py
@@ -1,0 +1,388 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "evals/agentic-replay.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("agentic_replay", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BENCH = load_module()
+
+
+class AgenticReplayTest(unittest.TestCase):
+    def specs(self):
+        return [
+            BENCH.RefSpec("rc8", "v0.76.0-rc8", "a" * 40),
+            BENCH.RefSpec("main", "origin/main", "b" * 40),
+        ]
+
+    def test_ab_order_reverses_every_other_pass(self) -> None:
+        order = BENCH.ab_order(self.specs(), 3)
+
+        self.assertEqual(
+            [(pass_index, spec.label) for pass_index, spec in order],
+            [
+                (0, "rc8"),
+                (0, "main"),
+                (1, "main"),
+                (1, "rc8"),
+                (2, "rc8"),
+                (2, "main"),
+            ],
+        )
+
+    def test_trajectory_replay_uses_recorded_history_in_strict_turn_order(self) -> None:
+        trajectory = {
+            "session_id": "session-1",
+            "source_dataset": "source",
+            "agent_framework": "framework",
+            "recorded_model": "recorded-model",
+            "messages": [
+                {"role": "system", "content": "rules"},
+                {"role": "user", "content": "task"},
+                {"role": "assistant", "content": "recorded answer 1"},
+                {"role": "user", "content": "tool observation"},
+                {"role": "assistant", "content": "recorded answer 2"},
+            ],
+        }
+        calls = []
+        original = BENCH.stream_request
+
+        def fake_stream(
+            request_id, messages, tools, metadata, model_id, output_tokens, timeout
+        ):
+            calls.append((request_id, list(messages), list(tools), dict(metadata)))
+            return {**metadata, "request_id": request_id, "error": "fixture"}
+
+        BENCH.stream_request = fake_stream
+        try:
+            BENCH.replay_trajectory(trajectory, "model", 256, 10)
+        finally:
+            BENCH.stream_request = original
+
+        self.assertEqual([call[3]["assistant_turn"] for call in calls], [0, 1])
+        self.assertEqual(
+            [message["content"] for message in calls[0][1]],
+            ["rules", "task"],
+        )
+        self.assertEqual(
+            [message["content"] for message in calls[1][1]],
+            ["rules", "task", "recorded answer 1", "tool observation"],
+        )
+
+    def test_trajectory_tools_are_stable_and_schema_shaped(self) -> None:
+        trajectory = {
+            "messages": [
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls_json": json.dumps(
+                        [
+                            {"type": "function", "function": {"name": "shell"}},
+                            {"type": "function", "function": {"name": "editor"}},
+                        ]
+                    ),
+                },
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls_json": json.dumps(
+                        [{"type": "function", "function": {"name": "shell"}}]
+                    ),
+                },
+            ]
+        }
+
+        tools = BENCH.trajectory_tools(trajectory)
+
+        self.assertEqual(
+            [tool["function"]["name"] for tool in tools], ["editor", "shell"]
+        )
+        self.assertTrue(
+            all(tool["function"]["parameters"]["additionalProperties"] for tool in tools)
+        )
+
+    def test_server_command_keeps_mesh_planning_at_defaults(self) -> None:
+        command = BENCH.server_command(Path("/product/mesh-llm"), "model-uri")
+
+        self.assertEqual(
+            command,
+            [
+                "/product/mesh-llm",
+                "serve",
+                "--model",
+                "model-uri",
+                "--log-format",
+                "json",
+            ],
+        )
+        for option in BENCH.FORBIDDEN_STARTUP_OPTIONS:
+            self.assertNotIn(option, command)
+
+    def test_isolated_server_state_preserves_the_model_cache(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            hf_home = root / "shared-hf"
+
+            env = BENCH.isolated_server_env(
+                root / "runtime-bundle", root / "state", hf_home
+            )
+
+            self.assertEqual(env["HF_HOME"], str(hf_home))
+            self.assertEqual(env["HOME"], str(root / "state/home"))
+            self.assertEqual(
+                env["MESH_LLM_NATIVE_RUNTIME_BUNDLE_DIR"],
+                str(root / "runtime-bundle"),
+            )
+
+    def test_runtime_evidence_collects_logs_without_copying_identity_state(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            state = root / "state"
+            native_log = state / "runtime/123/logs/skippy-native.log"
+            identity = state / "home/.mesh-llm/identity.key"
+            native_log.parent.mkdir(parents=True)
+            identity.parent.mkdir(parents=True)
+            native_log.write_text("runtime evidence", encoding="utf-8")
+            identity.write_text("secret", encoding="utf-8")
+
+            BENCH.collect_runtime_logs(state, root / "artifact")
+
+            self.assertEqual(
+                (root / "artifact/123/logs/skippy-native.log").read_text(
+                    encoding="utf-8"
+                ),
+                "runtime evidence",
+            )
+            self.assertFalse((root / "artifact/identity.key").exists())
+
+    def test_default_cli_workload_has_external_concurrency_only(self) -> None:
+        args = BENCH.parse_args(
+            [
+                "plan",
+                "--ref",
+                "rc8=v0.76.0-rc8",
+                "--ref",
+                "main=origin/main",
+                "--model",
+                "model-uri",
+                "--trajectories-per-framework",
+                "2",
+            ]
+        )
+
+        self.assertEqual(args.concurrency, [1, 2, 4])
+        self.assertEqual(args.passes, 2)
+        self.assertEqual(args.trajectories_per_framework, 2)
+        self.assertEqual(args.framework, ["swe-agent", "mini-swe-agent", "openhands"])
+        self.assertEqual(args.max_output_tokens, 256)
+        self.assertEqual(args.max_isl, 65536)
+
+    def test_summarize_requests_computes_stream_windows_and_cache_rate(self) -> None:
+        requests = [
+            {
+                "started": 0.0,
+                "first_token_at": 1.0,
+                "completed": 3.0,
+                "ttft_seconds": 1.0,
+                "generation_seconds": 2.0,
+                "completion_tokens": 10,
+                "prompt_tokens": 100,
+                "cached_tokens": 50,
+                "requested_output_tokens": 10,
+            },
+            {
+                "started": 0.0,
+                "first_token_at": 2.0,
+                "completed": 4.0,
+                "ttft_seconds": 2.0,
+                "generation_seconds": 2.0,
+                "completion_tokens": 10,
+                "prompt_tokens": 100,
+                "cached_tokens": 100,
+                "requested_output_tokens": 10,
+            },
+        ]
+
+        summary = BENCH.summarize_requests(requests)
+
+        self.assertEqual(summary["successful_requests"], 2)
+        self.assertEqual(summary["exact_output_requests"], 2)
+        self.assertEqual(summary["agent_steps_per_second"], 0.5)
+        self.assertEqual(summary["workload_output_tokens_per_second"], 5)
+        self.assertEqual(summary["mean_request_decode_tokens_per_second"], 5)
+        self.assertEqual(summary["ttft_p50_seconds"], 1.5)
+        self.assertEqual(summary["ttft_p95_seconds"], 2.0)
+        self.assertEqual(summary["cache_pct"], 75)
+
+    def test_pooled_rows_compare_each_ref_to_first_ref(self) -> None:
+        def cell(concurrency, generation, ttft):
+            return {
+                "concurrency": concurrency,
+                "trajectories": 3,
+                "requests": 5,
+                "successful_requests": 5,
+                "exact_output_requests": 5,
+                "agent_steps_per_second": generation,
+                "workload_output_tokens_per_second": generation - 1,
+                "mean_request_decode_tokens_per_second": generation + 1,
+                "ttft_p50_seconds": ttft,
+                "ttft_p95_seconds": ttft + 1,
+                "cache_pct": 50,
+            }
+
+        rows = BENCH.pooled_rows(
+            [
+                {
+                    "label": "rc8",
+                    "ref": "v0.76.0-rc8",
+                    "commit": "a" * 40,
+                    "cells": [cell(2, 20, 4)],
+                },
+                {
+                    "label": "main",
+                    "ref": "origin/main",
+                    "commit": "b" * 40,
+                    "cells": [cell(2, 15, 3)],
+                },
+            ]
+        )
+
+        main = next(row for row in rows if row["label"] == "main")
+        self.assertEqual(main["agent_steps_per_second_delta_pct"], -25)
+        self.assertEqual(main["ttft_p50_seconds_delta_pct"], -25)
+
+    def test_report_writes_tables_charts_and_inventory(self) -> None:
+        cell = {
+            "concurrency": 1,
+            "trajectories": 3,
+            "requests": 5,
+            "successful_requests": 5,
+            "exact_output_requests": 5,
+            "agent_steps_per_second": 20.0,
+            "workload_output_tokens_per_second": 18.0,
+            "mean_request_decode_tokens_per_second": 22.0,
+            "ttft_p50_seconds": 1.0,
+            "ttft_p95_seconds": 1.2,
+            "cache_pct": 60.0,
+        }
+        document = {
+            "config": {"model": "model", "concurrency": [1]},
+            "inputs": {
+                "dataset": {"revision": "c" * 40},
+                "manifest_sha256": "d" * 64,
+                "cohorts": {
+                    "1": {
+                        "trajectory_count": 3,
+                        "assistant_turns": 100,
+                        "framework_trajectories": {
+                            "swe-agent": 1,
+                            "mini-swe-agent": 1,
+                            "openhands": 1,
+                        },
+                        "framework_assistant_turns": {
+                            "swe-agent": 20,
+                            "mini-swe-agent": 30,
+                            "openhands": 50,
+                        },
+                    }
+                },
+            },
+            "builds": [
+                {"label": "rc8"},
+                {"label": "main"},
+            ],
+            "order": [
+                {"label": "rc8"},
+                {"label": "main"},
+            ],
+            "results": [
+                {
+                    "label": "rc8",
+                    "ref": "v0.76.0-rc8",
+                    "commit": "a" * 40,
+                    "cells": [cell],
+                },
+                {
+                    "label": "main",
+                    "ref": "origin/main",
+                    "commit": "b" * 40,
+                    "cells": [{**cell, "agent_steps_per_second": 22.0}],
+                },
+            ],
+        }
+        with tempfile.TemporaryDirectory() as directory:
+            artifact = Path(directory)
+            report = BENCH.write_report(artifact, document)
+
+            self.assertTrue(report.is_file())
+            self.assertTrue((artifact / "summary/comparison.csv").is_file())
+            self.assertTrue(
+                (artifact / "summary/charts/agent-step-throughput.svg").is_file()
+            )
+            self.assertTrue((artifact / "summary/charts/ttft-p50.svg").is_file())
+            self.assertTrue((artifact / "artifact-sha256.txt").is_file())
+            self.assertIn(
+                "Mesh chooses context size",
+                report.read_text(encoding="utf-8"),
+            )
+            self.assertIn(
+                "swe-agent 1 / 20",
+                report.read_text(encoding="utf-8"),
+            )
+
+    def test_plan_records_exact_default_server_command(self) -> None:
+        args = SimpleNamespace(
+            repo=REPO,
+            backend="metal",
+            model="model-uri",
+            passes=2,
+            source_dataset=["swe-smith-claude-3-7-sonnet"],
+            framework=["swe-agent", "mini-swe-agent", "openhands"],
+            trajectories_per_framework=2,
+            min_isl=8192,
+            max_isl=65536,
+            min_turns=5,
+            concurrency=[1, 2, 4],
+            max_output_tokens=256,
+        )
+
+        plan = BENCH.benchmark_plan(args, self.specs())
+
+        self.assertEqual(
+            plan["server_command"],
+            [
+                "<release-binary>",
+                "serve",
+                "--model",
+                "model-uri",
+                "--log-format",
+                "json",
+            ],
+        )
+        self.assertEqual(
+            [item["label"] for item in plan["order"]],
+            ["rc8", "main", "main", "rc8"],
+        )
+        self.assertEqual(plan["selection"]["unique_trajectory_count"], 18)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_agentic_replay.py
+++ b/scripts/tests/test_agentic_replay.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import contextlib
 import importlib.util
+import io
 import json
 import sys
 import tempfile
@@ -86,6 +88,30 @@ class AgenticReplayTest(unittest.TestCase):
             [message["content"] for message in calls[1][1]],
             ["rules", "task", "recorded answer 1", "tool observation"],
         )
+
+    def test_trajectory_replay_honors_warmup_turn_limit(self) -> None:
+        trajectory = {
+            "session_id": "session-1",
+            "source_dataset": "source",
+            "agent_framework": "framework",
+            "recorded_model": "recorded-model",
+            "messages": [
+                {"role": "user", "content": "task"},
+                {"role": "assistant", "content": "first"},
+                {"role": "user", "content": "observation"},
+                {"role": "assistant", "content": "second"},
+            ],
+        }
+        original = BENCH.stream_request
+        BENCH.stream_request = lambda *args, **kwargs: {"request_id": args[0]}
+        try:
+            results = BENCH.replay_trajectory(
+                trajectory, "model", 2048, 10, turn_limit=1
+            )
+        finally:
+            BENCH.stream_request = original
+
+        self.assertEqual([result["request_id"] for result in results], ["session-1:0"])
 
     def test_trajectory_tools_are_stable_and_schema_shaped(self) -> None:
         trajectory = {
@@ -184,16 +210,59 @@ class AgenticReplayTest(unittest.TestCase):
                 "--model",
                 "model-uri",
                 "--trajectories-per-framework",
-                "2",
+                "4",
             ]
         )
 
         self.assertEqual(args.concurrency, [1, 2, 4])
         self.assertEqual(args.passes, 2)
-        self.assertEqual(args.trajectories_per_framework, 2)
+        self.assertEqual(args.trajectories_per_framework, 4)
         self.assertEqual(args.framework, ["swe-agent", "mini-swe-agent", "openhands"])
-        self.assertEqual(args.max_output_tokens, 256)
+        self.assertEqual(args.max_output_tokens, 2048)
+        self.assertEqual(args.warmup_turns, 14)
         self.assertEqual(args.max_isl, 65536)
+
+    def test_cli_rejects_a_single_wave_concurrency_cohort(self) -> None:
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit):
+                BENCH.parse_args(
+                    [
+                        "plan",
+                        "--ref",
+                        "rc8=v0.76.0-rc8",
+                        "--ref",
+                        "main=origin/main",
+                        "--model",
+                        "model-uri",
+                        "--trajectories-per-framework",
+                        "2",
+                    ]
+                )
+
+    def test_manifest_contract_is_validated_before_builds(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            manifest = Path(directory) / "manifest.json"
+            manifest.write_text(
+                json.dumps(
+                    {
+                        "cohorts": {
+                            "warmup": [
+                                {
+                                    "session_id": "session-1",
+                                    "source_dataset": "source",
+                                    "agent_framework": "framework",
+                                    "recorded_model": "model",
+                                    "messages": [{"role": "user", "content": "task"}],
+                                }
+                            ]
+                        }
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "missing cohorts"):
+                BENCH.load_trajectory_cohorts(manifest, ["warmup", "1"])
 
     def test_summarize_requests_computes_stream_windows_and_cache_rate(self) -> None:
         requests = [
@@ -202,6 +271,7 @@ class AgenticReplayTest(unittest.TestCase):
                 "first_token_at": 1.0,
                 "completed": 3.0,
                 "ttft_seconds": 1.0,
+                "elapsed_seconds": 3.0,
                 "generation_seconds": 2.0,
                 "completion_tokens": 10,
                 "prompt_tokens": 100,
@@ -213,6 +283,7 @@ class AgenticReplayTest(unittest.TestCase):
                 "first_token_at": 2.0,
                 "completed": 4.0,
                 "ttft_seconds": 2.0,
+                "elapsed_seconds": 4.0,
                 "generation_seconds": 2.0,
                 "completion_tokens": 10,
                 "prompt_tokens": 100,
@@ -221,16 +292,61 @@ class AgenticReplayTest(unittest.TestCase):
             },
         ]
 
-        summary = BENCH.summarize_requests(requests)
+        summary = BENCH.summarize_requests(requests, offered_concurrency=2)
 
         self.assertEqual(summary["successful_requests"], 2)
-        self.assertEqual(summary["exact_output_requests"], 2)
+        self.assertEqual(summary["failed_request_ids"], [])
+        self.assertEqual(summary["budget_exhausted_requests"], 2)
         self.assertEqual(summary["agent_steps_per_second"], 0.5)
         self.assertEqual(summary["workload_output_tokens_per_second"], 5)
-        self.assertEqual(summary["mean_request_decode_tokens_per_second"], 5)
+        self.assertEqual(summary["decode_tokens_per_second"], 5)
+        self.assertEqual(summary["mean_in_flight"], 1.75)
+        self.assertEqual(summary["concurrency_utilization_pct"], 87.5)
+        self.assertEqual(summary["ttft_samples"], [1.0, 2.0])
         self.assertEqual(summary["ttft_p50_seconds"], 1.5)
         self.assertEqual(summary["ttft_p95_seconds"], 2.0)
         self.assertEqual(summary["cache_pct"], 75)
+
+    def test_pooled_rows_suppress_deltas_for_different_failed_requests(self) -> None:
+        def failed_cell(request_id):
+            return {
+                "concurrency": 1,
+                "trajectories": 3,
+                "requests": 5,
+                "successful_requests": 4,
+                "failed_request_ids": [request_id],
+                "budget_exhausted_requests": 0,
+                "agent_steps_per_second": 1.0,
+                "workload_output_tokens_per_second": 2.0,
+                "decode_tokens_per_second": 3.0,
+                "ttft_p50_seconds": 4.0,
+                "ttft_p95_seconds": 5.0,
+                "ttft_samples": [4.0],
+                "mean_in_flight": 1.0,
+                "concurrency_utilization_pct": 100.0,
+                "cache_pct": 50.0,
+            }
+
+        rows = BENCH.pooled_rows(
+            [
+                {
+                    "label": "rc8",
+                    "ref": "rc8",
+                    "commit": "a" * 40,
+                    "cells": [failed_cell("session-a:1")],
+                },
+                {
+                    "label": "main",
+                    "ref": "main",
+                    "commit": "b" * 40,
+                    "cells": [failed_cell("session-b:1")],
+                },
+            ]
+        )
+
+        main = next(row for row in rows if row["label"] == "main")
+        self.assertFalse(main["delta_comparable"])
+        self.assertIsNone(main["decode_tokens_per_second_delta_pct"])
 
     def test_pooled_rows_compare_each_ref_to_first_ref(self) -> None:
         def cell(concurrency, generation, ttft):
@@ -239,12 +355,15 @@ class AgenticReplayTest(unittest.TestCase):
                 "trajectories": 3,
                 "requests": 5,
                 "successful_requests": 5,
-                "exact_output_requests": 5,
+                "budget_exhausted_requests": 5,
                 "agent_steps_per_second": generation,
                 "workload_output_tokens_per_second": generation - 1,
-                "mean_request_decode_tokens_per_second": generation + 1,
+                "decode_tokens_per_second": generation + 1,
                 "ttft_p50_seconds": ttft,
                 "ttft_p95_seconds": ttft + 1,
+                "ttft_samples": [ttft, ttft + 1],
+                "mean_in_flight": concurrency,
+                "concurrency_utilization_pct": 100,
                 "cache_pct": 50,
             }
 
@@ -268,6 +387,55 @@ class AgenticReplayTest(unittest.TestCase):
         main = next(row for row in rows if row["label"] == "main")
         self.assertEqual(main["agent_steps_per_second_delta_pct"], -25)
         self.assertEqual(main["ttft_p50_seconds_delta_pct"], -25)
+        self.assertAlmostEqual(
+            main["decode_tokens_per_second_delta_pct"], -23.8095238095
+        )
+        self.assertEqual(main["decode_tokens_per_second_min"], 16)
+
+    def test_pooled_rows_weight_decode_and_pool_raw_ttft_samples(self) -> None:
+        def cell(tokens, generation_seconds, ttft_samples):
+            return {
+                "concurrency": 1,
+                "trajectories": 3,
+                "requests": 2,
+                "successful_requests": 2,
+                "failed_request_ids": [],
+                "completion_tokens": tokens,
+                "prompt_tokens": 100,
+                "cached_tokens": 50,
+                "generation_seconds": generation_seconds,
+                "workload_window_seconds": 10.0,
+                "budget_exhausted_requests": 0,
+                "agent_steps_per_second": 0.2,
+                "workload_output_tokens_per_second": tokens / 10.0,
+                "decode_tokens_per_second": tokens / generation_seconds,
+                "ttft_p50_seconds": BENCH.percentile(ttft_samples, 0.5),
+                "ttft_p95_seconds": BENCH.percentile(ttft_samples, 0.95),
+                "ttft_samples": ttft_samples,
+                "mean_in_flight": 1.0,
+                "concurrency_utilization_pct": 100.0,
+                "cache_pct": 50.0,
+            }
+
+        rows = BENCH.pooled_rows(
+            [
+                {
+                    "label": "rc8",
+                    "ref": "rc8",
+                    "commit": "a" * 40,
+                    "cells": [
+                        cell(100, 10.0, [1.0, 2.0]),
+                        cell(100, 20.0, [10.0, 20.0]),
+                    ],
+                }
+            ]
+        )
+
+        self.assertAlmostEqual(rows[0]["decode_tokens_per_second"], 200 / 30)
+        self.assertEqual(rows[0]["ttft_p50_seconds"], 2.0)
+        self.assertEqual(rows[0]["ttft_p95_seconds"], 20.0)
+        self.assertEqual(rows[0]["ttft_p50_seconds_min"], 1.0)
+        self.assertEqual(rows[0]["ttft_p50_seconds_max"], 10.0)
 
     def test_report_writes_tables_charts_and_inventory(self) -> None:
         cell = {
@@ -275,20 +443,41 @@ class AgenticReplayTest(unittest.TestCase):
             "trajectories": 3,
             "requests": 5,
             "successful_requests": 5,
-            "exact_output_requests": 5,
+            "budget_exhausted_requests": 5,
             "agent_steps_per_second": 20.0,
             "workload_output_tokens_per_second": 18.0,
-            "mean_request_decode_tokens_per_second": 22.0,
+            "decode_tokens_per_second": 22.0,
             "ttft_p50_seconds": 1.0,
             "ttft_p95_seconds": 1.2,
+            "ttft_samples": [1.0, 1.2],
+            "mean_in_flight": 1.0,
+            "concurrency_utilization_pct": 100.0,
             "cache_pct": 60.0,
         }
         document = {
-            "config": {"model": "model", "concurrency": [1]},
+            "config": {
+                "model": "model",
+                "concurrency": [1],
+                "warmup_turns": 14,
+            },
             "inputs": {
                 "dataset": {"revision": "c" * 40},
                 "manifest_sha256": "d" * 64,
                 "cohorts": {
+                    "warmup": {
+                        "trajectory_count": 3,
+                        "assistant_turns": 30,
+                        "framework_trajectories": {
+                            "swe-agent": 1,
+                            "mini-swe-agent": 1,
+                            "openhands": 1,
+                        },
+                        "framework_assistant_turns": {
+                            "swe-agent": 10,
+                            "mini-swe-agent": 10,
+                            "openhands": 10,
+                        },
+                    },
                     "1": {
                         "trajectory_count": 3,
                         "assistant_turns": 100,
@@ -335,7 +524,10 @@ class AgenticReplayTest(unittest.TestCase):
             self.assertTrue(report.is_file())
             self.assertTrue((artifact / "summary/comparison.csv").is_file())
             self.assertTrue(
-                (artifact / "summary/charts/agent-step-throughput.svg").is_file()
+                (artifact / "summary/charts/decode-throughput.svg").is_file()
+            )
+            self.assertTrue(
+                (artifact / "summary/charts/workload-output-throughput.svg").is_file()
             )
             self.assertTrue((artifact / "summary/charts/ttft-p50.svg").is_file())
             self.assertTrue((artifact / "artifact-sha256.txt").is_file())
@@ -347,6 +539,8 @@ class AgenticReplayTest(unittest.TestCase):
                 "swe-agent 1 / 20",
                 report.read_text(encoding="utf-8"),
             )
+            self.assertIn("Decode tok/s", report.read_text(encoding="utf-8"))
+            self.assertIn("Slot use", report.read_text(encoding="utf-8"))
 
     def test_plan_records_exact_default_server_command(self) -> None:
         args = SimpleNamespace(
@@ -356,12 +550,13 @@ class AgenticReplayTest(unittest.TestCase):
             passes=2,
             source_dataset=["swe-smith-claude-3-7-sonnet"],
             framework=["swe-agent", "mini-swe-agent", "openhands"],
-            trajectories_per_framework=2,
+            trajectories_per_framework=4,
             min_isl=8192,
             max_isl=65536,
             min_turns=5,
             concurrency=[1, 2, 4],
-            max_output_tokens=256,
+            max_output_tokens=2048,
+            warmup_turns=14,
         )
 
         plan = BENCH.benchmark_plan(args, self.specs())
@@ -381,7 +576,8 @@ class AgenticReplayTest(unittest.TestCase):
             [item["label"] for item in plan["order"]],
             ["rc8", "main", "main", "rc8"],
         )
-        self.assertEqual(plan["selection"]["unique_trajectory_count"], 18)
+        self.assertEqual(plan["selection"]["measured_unique_trajectory_count"], 36)
+        self.assertEqual(plan["selection"]["warmup_unique_trajectory_count"], 12)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_agentic_replay.py
+++ b/scripts/tests/test_agentic_replay.py
@@ -113,6 +113,72 @@ class AgenticReplayTest(unittest.TestCase):
 
         self.assertEqual([result["request_id"] for result in results], ["session-1:0"])
 
+    def test_checkpoint_replay_reconstructs_full_recorded_prefix(self) -> None:
+        trajectory = {
+            "session_id": "session-1",
+            "source_dataset": "source",
+            "agent_framework": "framework",
+            "recorded_model": "recorded-model",
+            "messages": [
+                {"role": "user", "content": "task"},
+                {"role": "assistant", "content": "recorded first"},
+                {"role": "tool", "content": "observation", "tool_call_id": "1"},
+                {"role": "assistant", "content": "recorded second"},
+            ],
+        }
+        calls = []
+        original = BENCH.stream_request
+
+        def fake_stream(*args, **kwargs):
+            calls.append((args[0], list(args[1]), args[2], dict(args[3])))
+            return {"request_id": args[0]}
+
+        BENCH.stream_request = fake_stream
+        try:
+            BENCH.replay_trajectory(
+                trajectory,
+                "model",
+                2048,
+                10,
+                measured_assistant_turns={1},
+                checkpoint_stage="final",
+            )
+        finally:
+            BENCH.stream_request = original
+
+        self.assertEqual([call[0] for call in calls], ["session-1:1"])
+        self.assertEqual(
+            [message["content"] for message in calls[0][1]],
+            ["task", "recorded first", "observation"],
+        )
+        self.assertEqual(calls[0][3]["checkpoint_stage"], "final")
+
+    def test_checkpoint_schedule_balances_four_stages_per_framework(self) -> None:
+        trajectories = []
+        for index in range(4):
+            messages = []
+            for turn in range(8):
+                messages.extend(
+                    [
+                        {"role": "user", "content": f"u{turn}"},
+                        {"role": "assistant", "content": f"a{turn}"},
+                    ]
+                )
+            trajectories.append(
+                {
+                    "session_id": f"session-{index}",
+                    "agent_framework": "framework",
+                    "messages": messages,
+                }
+            )
+
+        schedule = BENCH.checkpoint_schedule(trajectories)
+
+        self.assertEqual(
+            list(schedule.values()),
+            [(1, "early"), (3, "middle"), (5, "late"), (7, "final")],
+        )
+
     def test_trajectory_tools_are_stable_and_schema_shaped(self) -> None:
         trajectory = {
             "messages": [
@@ -215,11 +281,12 @@ class AgenticReplayTest(unittest.TestCase):
         )
 
         self.assertEqual(args.concurrency, [1, 2, 4])
-        self.assertEqual(args.passes, 2)
+        self.assertEqual(args.passes, 1)
+        self.assertEqual(args.replay_mode, "checkpoints")
         self.assertEqual(args.trajectories_per_framework, 4)
         self.assertEqual(args.framework, ["swe-agent", "mini-swe-agent", "openhands"])
         self.assertEqual(args.max_output_tokens, 2048)
-        self.assertEqual(args.warmup_turns, 14)
+        self.assertEqual(args.warmup_turns, 4)
         self.assertEqual(args.max_isl, 65536)
 
     def test_cli_rejects_a_single_wave_concurrency_cohort(self) -> None:
@@ -491,6 +558,7 @@ class AgenticReplayTest(unittest.TestCase):
                 "model": "model",
                 "concurrency": [1],
                 "warmup_turns": 14,
+                "replay_mode": "checkpoints",
             },
             "inputs": {
                 "dataset": {"revision": "c" * 40},
@@ -589,6 +657,7 @@ class AgenticReplayTest(unittest.TestCase):
             concurrency=[1, 2, 4],
             max_output_tokens=2048,
             warmup_turns=14,
+            replay_mode="checkpoints",
         )
 
         plan = BENCH.benchmark_plan(args, self.specs())
@@ -610,6 +679,8 @@ class AgenticReplayTest(unittest.TestCase):
         )
         self.assertEqual(plan["selection"]["measured_unique_trajectory_count"], 36)
         self.assertEqual(plan["selection"]["warmup_unique_trajectory_count"], 12)
+        self.assertEqual(plan["workload"]["measured_requests_per_arm_pass"], 36)
+        self.assertEqual(plan["workload"]["measured_requests_total"], 144)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_agentic_trajectory_manifest.py
+++ b/scripts/tests/test_agentic_trajectory_manifest.py
@@ -111,6 +111,24 @@ class AgenticTrajectoryManifestTest(unittest.TestCase):
 
         self.assertEqual(validated, messages)
 
+    def test_minimum_turns_uses_actual_assistant_messages(self) -> None:
+        misleading = row("swe-agent", 0, assistant_turns=1)
+        misleading["n_turns"] = 99
+        eligible = row("swe-agent", 1, assistant_turns=3)
+
+        cohorts = MANIFEST.build_cohorts(
+            [misleading, eligible],
+            ["1"],
+            ["swe-agent"],
+            1,
+            min_assistant_turns=3,
+        )
+
+        self.assertEqual(
+            [trajectory["session_id"] for trajectory in cohorts["1"]],
+            ["swe-agent-1"],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_agentic_trajectory_manifest.py
+++ b/scripts/tests/test_agentic_trajectory_manifest.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import unittest
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "evals/agentic-trajectory-manifest.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("agentic_trajectory_manifest", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+MANIFEST = load_module()
+
+
+def row(framework: str, index: int, assistant_turns: int = 2):
+    messages = [{"role": "system", "content": "rules"}]
+    for turn in range(assistant_turns):
+        messages.extend(
+            [
+                {"role": "user", "content": f"observation-{turn}"},
+                {"role": "assistant", "content": f"action-{turn}"},
+            ]
+        )
+    return {
+        "session_id": f"{framework}-{index}",
+        "source_dataset": f"source-{framework}",
+        "agent_framework": framework,
+        "recorded_model": "recorded-model",
+        "messages_json": json.dumps(messages),
+        "n_turns": assistant_turns,
+        "max_isl": 10000,
+        "total_tokens": 11000,
+    }
+
+
+class AgenticTrajectoryManifestTest(unittest.TestCase):
+    def test_balanced_cohorts_are_disjoint_and_keep_whole_trajectories(self) -> None:
+        rows = [
+            row(framework, index)
+            for framework in ("swe-agent", "mini-swe-agent", "openhands")
+            for index in range(4)
+        ]
+
+        cohorts = MANIFEST.build_cohorts(
+            rows,
+            ["1", "4"],
+            ["swe-agent", "mini-swe-agent", "openhands"],
+            2,
+        )
+
+        self.assertEqual(len(cohorts["1"]), 6)
+        self.assertEqual(len(cohorts["4"]), 6)
+        first_ids = {item["session_id"] for item in cohorts["1"]}
+        second_ids = {item["session_id"] for item in cohorts["4"]}
+        self.assertFalse(first_ids & second_ids)
+        for cohort in cohorts.values():
+            self.assertEqual(
+                {framework: sum(item["agent_framework"] == framework for item in cohort)
+                 for framework in ("swe-agent", "mini-swe-agent", "openhands")},
+                {"swe-agent": 2, "mini-swe-agent": 2, "openhands": 2},
+            )
+            self.assertTrue(all(item["assistant_turns"] == 2 for item in cohort))
+
+    def test_manifest_reports_exact_trajectory_and_turn_counts(self) -> None:
+        cohorts = {
+            "1": [
+                {
+                    **row("swe-agent", 0, assistant_turns=3),
+                    "assistant_turns": 3,
+                }
+            ]
+        }
+        document = MANIFEST.manifest_document(cohorts, {"dataset_revision": "abc"})
+
+        self.assertEqual(document["metadata"]["cohorts"]["1"]["trajectory_count"], 1)
+        self.assertEqual(document["metadata"]["cohorts"]["1"]["assistant_turns"], 3)
+        self.assertEqual(
+            document["metadata"]["cohorts"]["1"]["framework_trajectories"],
+            {"swe-agent": 1},
+        )
+
+    def test_tool_calls_and_ids_are_validated_without_flattening(self) -> None:
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls_json": '[{"id":"call-1","type":"function"}]',
+                "tool_call_id": None,
+            },
+            {
+                "role": "tool",
+                "content": "result",
+                "tool_calls_json": None,
+                "tool_call_id": "call-1",
+            },
+        ]
+
+        validated = MANIFEST.validate_messages(json.dumps(messages), "session")
+
+        self.assertEqual(validated, messages)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `evals/agentic-replay.py`, a durable runner that compares two or more Mesh refs
- build an isolated release host and native runtime for every exact commit
- start every arm with Mesh production defaults: `mesh-llm serve --model <model> --log-format json`
- replay complete Thoughtworks agent trajectories in recorded turn order, with identical growing histories across arms
- emit raw request evidence, comparison tables, JSON/CSV, SVG charts, logs, hashes, and an artifact inventory

## Workload design

The initial documented run uses the pinned `thoughtworks/agentic-coding-trajectories` parquet at revision `cef72d1f4d0caabf85937adf8337a14b7522c782` and explicitly selects two whole trajectories per framework for each disjoint client-concurrency cohort.

| Client concurrency | Trajectories | Recorded agent steps |
|---:|---:|---:|
| 1 | 6 | 196 |
| 2 | 6 | 236 |
| 4 | 6 | 228 |
| **Per arm pass** | **18** | **660** |
| **Two refs × two passes** | **72 trajectory replays** | **2,640 measured requests** |

Each cohort contains two `swe-agent`, two `mini-swe-agent`, and two `openhands` sessions. Selection is deterministic by session ID hash and the cohorts do not overlap. The count is a required CLI argument rather than a hidden constant, so longer release or nightly runs can scale it deliberately.

The initial run does not replay all 15,000 source trajectories. That would require 2,472,136 model requests for a two-ref, two-pass comparison before accounting for wall time, which is not a practical release-gate iteration. The 18-trajectory starting set keeps all three agent frameworks and long, growing agent histories while remaining runnable; the generated manifest and report expose the exact selected sessions and turn counts.

Within each trajectory, every recorded assistant turn is one measured request. The next turn receives the original recorded assistant action and tool observation—not the benchmark model output—so all experiment arms see the same ordered state and prefix growth. Separate trajectories may overlap to offer client concurrency; turns within one trajectory never overlap.

## Validation

- 14 focused tests pass
- exact `plan` smoke passes for `v0.76.0-rc8` (`2040765d`) and `origin/main` (`d5746171`)
- real pinned parquet manifest generation validated: 18 unique trajectories, 660 agent steps, SHA-256 `d406b1d21b66c38bf1a9d17b4ca50eb7bd315f6f0df44c164de905ee4647581b`
- Python 3.9 grammar and staged diff checks pass

Originating Buzz channel: `a7d0b8ef-9b25-432d-ae19-bacd410c81eb`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added deterministic A/B benchmarking across Mesh revisions using real agent trajectories.
  - Added balanced, whole-trajectory cohorts across frameworks and concurrency levels, including a warm-up cohort.
  - Added checkpoint replay for fast release gates and exhaustive assistant-turn replay for deeper analysis.
  - Added configurable trajectory quality filters, replay passes, and increased maximum input-length support.
  - Expanded reporting with latency, throughput, concurrency, failure, and measured-request metrics.

- **Documentation**
  - Documented benchmarking commands, replay modes, trajectory selection, measurement behavior, and reporting outputs.

- **Tests**
  - Added coverage for cohort generation, replay behavior, validation, reporting, and CLI configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->