### PR TITLE
Make pre-commit validation change-scoped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -562,12 +562,13 @@ Before committing, run the local checks most likely to fail in CI for the files 
 
 ### Minimum validation by change type
 
-Choose validation from the changed surface, not merely from the directory that contains the changed file. A Python, shell, documentation, or configuration file under a Rust crate does not by itself require Cargo validation.
+Choose validation from the changed surface, not merely from the directory that contains the changed file. A non-Rust file under a Rust crate does not require Cargo validation only when it cannot affect Cargo metadata, build scripts, generated Rust, or the shipped binary. Treat Cargo and build configuration changes as Rust-impacting.
 
 - Rust change — format the changed Rust files and run `cargo check -p <touched-crate>` plus `cargo clippy -p <touched-crate> --all-targets -- -D warnings` (and both commands with `-p mesh-llm` if you touched anything reachable from the shipped binary).
-- Python-only change — run `python3 -m py_compile` for the changed modules and `python3 -m unittest` for the nearest relevant test modules. Run the full `scripts/tests` suite only for shared script infrastructure, CI planning, or broad cross-script changes.
+- Python-only change — pass every changed module explicitly to `python3 -m py_compile <changed-module.py>...` and run `python3 -m unittest <nearest-test-module>...` for the nearest relevant tests. Run the full `scripts/tests` suite only for shared script infrastructure, CI planning, or broad cross-script changes.
 - UI-only change — run `just build`.
-- Documentation, configuration, or shell-only change — run the targeted formatter, generator check, contract test, or syntax check for the changed surface.
+- CI workflow, planner fixture, or CI script change — run `just ci-validate` plus any additional checks required by the CI section below.
+- Documentation, non-build configuration, or non-CI shell-only change — run the targeted formatter, generator check, contract test, or syntax check for the changed surface.
 - Mixed change — run the union of the checks required for each changed surface.
 
 Do not rerun otherwise unchanged validation solely because a commit is about to be pushed. Rerun affected checks when the validated diff or commit has changed.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -560,11 +560,17 @@ you want quiet output, use `--log-format json` and parse what you need.
 
 Before committing, run the local checks most likely to fail in CI for the files you touched. Do not rely on CI to catch basic formatting, compile, or stale UI build issues.
 
-### Minimum bar before every commit
+### Minimum validation by change type
 
-- Rust-only change — format the changed Rust files and run `cargo check -p <touched-crate>` plus `cargo clippy -p <touched-crate> --all-targets -- -D warnings` (and both commands with `-p mesh-llm` if you touched anything reachable from the shipped binary).
+Choose validation from the changed surface, not merely from the directory that contains the changed file. A Python, shell, documentation, or configuration file under a Rust crate does not by itself require Cargo validation.
+
+- Rust change — format the changed Rust files and run `cargo check -p <touched-crate>` plus `cargo clippy -p <touched-crate> --all-targets -- -D warnings` (and both commands with `-p mesh-llm` if you touched anything reachable from the shipped binary).
+- Python-only change — run `python3 -m py_compile` for the changed modules and `python3 -m unittest` for the nearest relevant test modules. Run the full `scripts/tests` suite only for shared script infrastructure, CI planning, or broad cross-script changes.
 - UI-only change — run `just build`.
-- Mixed Rust and UI change — run `just build`.
+- Documentation, configuration, or shell-only change — run the targeted formatter, generator check, contract test, or syntax check for the changed surface.
+- Mixed change — run the union of the checks required for each changed surface.
+
+Do not rerun otherwise unchanged validation solely because a commit is about to be pushed. Rerun affected checks when the validated diff or commit has changed.
 
 ### Rust changes
 


### PR DESCRIPTION
Agents now choose pre-commit validation from the files and behavior actually changed, so Python-only and other non-Rust edits no longer imply Cargo checks merely because they live under a Rust crate.

## Summary

- define explicit validation guidance for Rust, Python, UI, documentation/configuration/shell, and mixed changes
- keep full Rust validation scoped to Rust and the existing high-risk Rust surfaces
- clarify that unchanged validation does not need to be repeated solely before push

## Validation

- `git diff --check`
- reviewed the final single-file diff against `origin/main`
- Cargo and Rust tests not run because this is an `AGENTS.md`-only documentation change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified pre-commit validation requirements for files within Rust crates and build or Cargo configuration changes.
  * Updated Python-only guidance to require explicit validation of each changed module and its nearest tests.
  * Added validation guidance for CI workflow, planner fixture, and CI script changes.
  * Narrowed documentation, configuration, and shell-only exemptions to exclude build and CI-related changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->