### PR TITLE
Fix split speculative decoding: verify-window double-record and backend-sampling rejection

### DIFF
--- a/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/connection.rs
@@ -508,7 +508,19 @@ fn handle_binary_connection_messages(
                             Ok((sessions_before, sessions_after, eviction, result))
                         })
                         .map_err(|error| anyhow::anyhow!(format!("{error:#}")))
-                        .context("execute scheduler-owned binary stage message")?;
+                        .with_context(|| {
+                            format!(
+                                "execute scheduler-owned binary stage message \
+                                 kind={:?} pos_start={} token_count={} tokens={} \
+                                 executable_tokens={} activation_bytes={}",
+                                message.kind,
+                                message.pos_start,
+                                message.token_count,
+                                message.tokens.len(),
+                                executable_token_ids.len(),
+                                input_activation_bytes,
+                            )
+                        })?;
                     runtime_lock_wait_ms = outcome.runtime_lock_wait_ms;
                     runtime_lock_hold_ms = outcome.runtime_lock_hold_ms;
                     runtime_lock_acquires = 1;

--- a/third_party/llama.cpp/patches/0043-skippy-record-verify-batches-once-on-activation-inpu.patch
+++ b/third_party/llama.cpp/patches/0043-skippy-record-verify-batches-once-on-activation-inpu.patch
@@ -1,0 +1,52 @@
+From f7b4211b767bcf63a6dd4286629b5d7c18f17cc2 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Tue, 1 Sep 2026 20:04:15 +1000
+Subject: [PATCH] skippy: record verify batches once on activation-input stages
+
+Sampled verification exposes each input to the sampler exactly once and
+in causal order as its row is sampled. The token-batch path rewinds the
+eager append its decode performs before doing so; #1408 established that
+the activation-frame path must NOT rewind, because its decode did not
+append. #1420 then re-added an eager append inside
+skippy_verify_activation_frame, assuming the rewind was still there.
+
+With both in place, every verify input on an activation-input stage
+that owns the output layers -- i.e. the final stage of any multi-node
+split -- is inserted into token_history twice and fed to
+llama_sampler_accept twice, double-applying repetition penalties,
+grammar state and RNG draws. Single-node serving is unaffected because
+it takes the token-batch path.
+
+Drop the eager append and leave verification as the single recorder for
+this path, restoring the invariant #1408 documented.
+---
+ src/skippy/activation.cpp | 13 ++++++-------
+ 1 file changed, 6 insertions(+), 7 deletions(-)
+
+diff --git a/src/skippy/activation.cpp b/src/skippy/activation.cpp
+index 58da7bc25..beecb2204 100644
+--- a/src/skippy/activation.cpp
++++ b/src/skippy/activation.cpp
+@@ -826,13 +826,12 @@ enum skippy_status skippy_verify_activation_frame(
+         status = skippy_mtp_sync_target_inputs(
+                 session, token_ids, mtp_input_embeddings, token_count, token_start, out_error);
+     }
+-    if (status == SKIPPY_STATUS_OK && token_ids != nullptr) {
+-        // Sampled verification rewinds the eagerly decoded suffix before it
+-        // exposes inputs causally to the sampler. Keep activation-input stages
+-        // aligned with the token-input verification path by recording that
+-        // suffix here first.
+-        skippy_record_tokens(session, token_ids, token_count);
+-    }
++    // Deliberately does NOT record the batch into token_history. Sampled
++    // verification exposes each input exactly once and in causal order as its
++    // row is sampled (see skippy_verify_tokens_frame_sampled), and for
++    // activation-input stages it does not rewind first — the token-batch path
++    // rewinds only because its decode appends eagerly. Recording here as well
++    // would feed every input to the sampler chain twice.
+     return status;
+ }
+ 
+-- 
+2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0044-skippy-carry-batch-placement-in-decode-batch-failure.patch
+++ b/third_party/llama.cpp/patches/0044-skippy-carry-batch-placement-in-decode-batch-failure.patch
@@ -1,0 +1,48 @@
+From 8ecf5c931cdad8709fa39fcb2018a12f3352ad2e Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Tue, 1 Sep 2026 21:29:55 +1000
+Subject: [PATCH] skippy: carry batch placement in decode-batch failures
+
+llama.cpp's own diagnostics go to its log callback, which stage hosts
+do not always surface, so a remote llama_decode failure previously
+reduced to the bare string 'llama_decode failed'. Include the return
+code, batch shape and the session/memory positions so the violated
+invariant is visible from the wire error alone.
+---
+ src/skippy/activation.cpp | 20 +++++++++++++++++++-
+ 1 file changed, 19 insertions(+), 1 deletion(-)
+
+diff --git a/src/skippy/activation.cpp b/src/skippy/activation.cpp
+index beecb2204..d59562c9c 100644
+--- a/src/skippy/activation.cpp
++++ b/src/skippy/activation.cpp
+@@ -375,7 +375,25 @@ enum skippy_status skippy_decode_batch(
+     const int32_t rc = llama_decode(session->ctx, batch);
+     skippy_glm_dsa_op_timing_end(session);
+     if (rc != 0) {
+-        skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "llama_decode failed");
++        // llama.cpp's own diagnostics go to its log callback, which stage
++        // hosts may not surface; carry the batch and session placement in the
++        // error so a remote failure names the violated invariant.
++        llama_memory_t memory = session->ctx->get_memory();
++        const llama_pos mem_pos_max = memory != nullptr ? memory->seq_pos_max(session->seq_id) : -1;
++        const llama_pos batch_pos0 = batch.pos != nullptr && batch.n_tokens > 0 ? batch.pos[0] : -1;
++        char detail[256];
++        std::snprintf(
++                detail,
++                sizeof(detail),
++                "llama_decode failed rc=%d n_tokens=%d embd=%d pos0=%d n_past=%d seq=%d mem_pos_max=%d",
++                rc,
++                batch.n_tokens,
++                batch.embd != nullptr ? 1 : 0,
++                batch_pos0,
++                session->n_past,
++                session->seq_id,
++                mem_pos_max);
++        skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, detail);
+         return SKIPPY_STATUS_RUNTIME_ERROR;
+     }
+     skippy_mark_context_work_pending(session->stage_model);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0045-skippy-let-sampled-verify-windows-coexist-with-backe.patch
+++ b/third_party/llama.cpp/patches/0045-skippy-let-sampled-verify-windows-coexist-with-backe.patch
@@ -1,0 +1,127 @@
+From cf4943f670d5f448e51bedfdaedb64208e7c6254 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Tue, 1 Sep 2026 21:37:06 +1000
+Subject: [PATCH] skippy: let sampled verify windows coexist with backend
+ sampling
+
+Backend (in-graph) sampling limited every decode on the context to one
+output row per sequence the moment ANY sequence had a sampler attached,
+and a sampled verify window must output every row. On a split's output
+stage this rejected the first window of every speculative generation
+with llama_decode rc=-1 whenever another lane's session still held an
+offloaded chain.
+
+Three coordinated changes:
+
+- verification: detach this session's backend sampler before executing
+  a sampled window and fall back to CPU-chain row sampling; the chain
+  itself is untouched and row sampling consumes it exactly as it does
+  for configs that never qualified for offload.
+- sampling: a chain may be backend-initialized at most once
+  (llama_sampler_chain_backend_init asserts on reuse), so track the
+  detach as 'retired' on the session, have refresh_backend_sampling
+  respect it, and clear it only when a fresh chain is built. Without
+  this the next session reset re-attached the spent chain and aborted
+  the stage.
+- llama_context::decode: scope the one-output-per-sequence rejection to
+  sequences that actually have a sampler attached, so a sampler on one
+  lane cannot reject another lane's multi-output verify batch.
+---
+ src/llama-context.cpp       |  6 +++++-
+ src/skippy/runtime_types.h  |  5 +++++
+ src/skippy/sampling.cpp     |  7 +++++--
+ src/skippy/verification.cpp | 17 +++++++++++++++++
+ 4 files changed, 32 insertions(+), 3 deletions(-)
+
+diff --git a/src/llama-context.cpp b/src/llama-context.cpp
+index 1d319e5fc..756d09a14 100644
+--- a/src/llama-context.cpp
++++ b/src/llama-context.cpp
+@@ -1730,7 +1730,11 @@ int llama_context::decode(const llama_batch & batch_inp) {
+                 const llama_seq_id seq_id = batch_inp.seq_id ? batch_inp.seq_id[i][s] : 0;
+ 
+                 seq_output_count[seq_id]++;
+-                if (seq_output_count[seq_id] > 1) {
++                // Only sequences that actually have a backend sampler attached
++                // are limited to one output row; a sampler on some other
++                // sequence of this context must not reject a multi-output
++                // batch (e.g. speculative verification) for this one.
++                if (seq_output_count[seq_id] > 1 && sampling.samplers.count(seq_id) > 0) {
+                     LLAMA_LOG_ERROR("%s: backend sampling requires at most one output token per sequence (seq_id %d had %d)\n",
+                             __func__, seq_id, seq_output_count[seq_id]);
+                     return -1;
+diff --git a/src/skippy/runtime_types.h b/src/skippy/runtime_types.h
+index dbe7ab2e4..5180bfa24 100644
+--- a/src/skippy/runtime_types.h
++++ b/src/skippy/runtime_types.h
+@@ -126,6 +126,11 @@ struct skippy_session {
+     llama_sampler * sampling_chain = nullptr;
+     llama_sampler * grammar_sampler = nullptr;
+     bool sampling_backend_enabled = false;
++    // A sampler chain may be backend-initialized at most once
++    // (llama_sampler_chain_backend_init asserts on reuse). Once a chain is
++    // detached -- e.g. so a sampled verify window can output every row --
++    // it must never be re-attached; only building a fresh chain clears this.
++    bool sampling_backend_retired = false;
+     skippy_sampling_config sampling_config = {};
+     bool sampling_config_valid = false;
+     std::string chat_sampling_metadata;
+diff --git a/src/skippy/sampling.cpp b/src/skippy/sampling.cpp
+index 567388f6d..774ac807c 100644
+--- a/src/skippy/sampling.cpp
++++ b/src/skippy/sampling.cpp
+@@ -323,6 +323,7 @@ void skippy_clear_chat_sampling(skippy_session * session) {
+     session->sampling_chain = nullptr;
+     session->grammar_sampler = nullptr;
+     session->sampling_backend_enabled = false;
++    session->sampling_backend_retired = false;
+     session->sampling_config = {};
+     session->sampling_config_valid = false;
+     session->chat_sampling_metadata.clear();
+@@ -709,11 +710,13 @@ static bool skippy_ensure_plain_sampling_chain(
+ void skippy_refresh_backend_sampling(
+         skippy_session * session,
+         const skippy_sampling_config * sampling) {
+-    if (session == nullptr || session->sampling_backend_enabled) {
++    if (session == nullptr || session->sampling_backend_enabled || session->sampling_backend_retired) {
+         // Backend initialization belongs to the sampler-chain lifetime. The
+         // scheduler may reset and reuse the same chain on every iteration;
+         // attaching it again violates llama_sampler_chain's one-shot init
+-        // contract.
++        // contract. A retired chain was detached mid-lifetime (sampled verify
++        // windows need every output row, which backend sampling forbids) and
++        // must likewise never be re-attached.
+         return;
+     }
+     session->sampling_backend_enabled = false;
+diff --git a/src/skippy/verification.cpp b/src/skippy/verification.cpp
+index 9ab6b0712..be29b2ff8 100644
+--- a/src/skippy/verification.cpp
++++ b/src/skippy/verification.cpp
+@@ -137,6 +137,23 @@ enum skippy_status skippy_verify_tokens_frame_sampled(
+         }
+     }
+ 
++    if (session->stage_model->config.include_output && session->sampling_backend_enabled) {
++        // Backend (in-graph) sampling permits at most one output row per
++        // sequence per decode, but sampled verification must output every row
++        // of the window, so llama_decode would reject the batch outright.
++        // Detach the backend sampler and fall back to CPU-chain sampling for
++        // this session: the chain itself is untouched and the row sampling
++        // below consumes it through skippy_sample_token_ith. A later sampling
++        // reconfiguration may re-attach; the next window detaches again.
++        llama_set_sampler(session->ctx, session->seq_id, nullptr);
++        session->sampling_backend_enabled = false;
++        // The detached chain has already been backend-initialized and
++        // llama_sampler_chain_backend_init asserts on reuse, so retire it
++        // from offload for the rest of its lifetime; a rebuilt chain may
++        // offload again.
++        session->sampling_backend_retired = true;
++    }
++
+     const bool activation_input = skippy_is_filtered(session) && session->stage_model->config.layer_start > 0;
+     status = skippy_checkpoint_verify_window(
+             session,
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
## What

Follow-up to #1577, which fixed the driver-side classifier but was merged while the investigation was still running the stage-side failures to ground. With #1577 alone, split speculation still dies at its first verify window — the stage fails `llama_decode` and the driver times out. This PR fixes the two remaining native defects; with it, split speculation completes end-to-end on the two-node lab repro: **7/7 generations green, 0 decode failures, 0 GGML asserts**, where before 0/6 survived the first window.

## Defect A — verify inputs recorded twice on activation-input stages (patch 0043)

#1408 established that activation-frame verification must not rewind `token_history`, because its decode does not eagerly append. #1420 then re-added an eager append inside `skippy_verify_activation_frame`, assuming that rewind still existed. With both in place, every verify input on an activation-input stage that owns the output layers — the **final stage of any split** — was inserted into `token_history` twice and fed to `llama_sampler_accept` twice, double-applying repetition penalties, grammar state and RNG draws. Single-node serving takes the token-batch path and was unaffected.

Fix: drop the eager append; verification is the single recorder for this path, restoring the invariant #1408 documented.

## Defect B — backend sampling rejected multi-output verify batches (patch 0045)

Backend (in-graph) sampling registers a sampler on the context, and `llama_context::decode` limited **every** decode on that context to one output row per sequence — the check fired if *any* sequence had a sampler attached. A sampled verify window must output every row, so the first window failed with `rc=-1`. Diagnosed via the new self-describing errors (below): `llama_decode failed rc=-1 n_tokens=10 embd=1 pos0=32 n_past=32 seq=9 mem_pos_max=31` — positions perfectly consistent, batch well-formed, rejected purely for the sampler workaround, triggered by an *idle lane's* offloaded chain.

Three coordinated changes:

- **verification** detaches this session's backend sampler before executing a window and falls back to CPU-chain row sampling — the chain is untouched and row sampling consumes it exactly as it does for configs that never qualified for offload;
- a chain may be backend-initialized at most once (`llama_sampler_chain_backend_init` asserts on reuse), so the detach is tracked as **retired** on the session; `refresh_backend_sampling` respects it and only a freshly-built chain clears it. Without this, the next session reset re-attached the spent chain and aborted the stage on the assert (reproduced);
- `llama_context::decode` scopes the one-output-per-sequence rejection to sequences that **actually have a sampler attached**, so an idle lane's chain can no longer reject another lane's verify batch. This piece looks upstreamable — the check's own `TODO: avoid this workaround` marks it as known-temporary.

## Diagnostics that made this findable (kept)

- Stage execution errors name the failing message: `kind=VerifyWindow pos_start=32 token_count=10 ...` (Rust).
- Native decode-batch failures carry the return code, batch shape and session/memory positions (patch 0044) — stage hosts don't forward llama.cpp's log callback, so without this the wire error was just `llama_decode failed`.

## Validation

Two Mac minis (M1 + M4), Qwen3-8B Q4_K_M split 19/17 layers, `--speculative-strategy ngram-suffix` (5/32/48, window 32), temperature 0:

| build | result |
|---|---|
| #1577 only | classifier error gone; every windowed generation times out on stage `llama_decode failed` |
| + defect A fix | unchanged (A corrupts sampling state; B is the crash) |
| + defect B detach only | crash moves to `llama_sampler_chain_backend_init called twice` abort on session reset |
| + retired flag | first window still rejected by an idle lane's sampler; 5/6 pass after its lane dies |
| **this PR (all of the above + per-sequence scoping)** | **7/7 generations complete, 0 decode failures, 0 asserts** |

Single-node speculation: 5/5 clean before and after — the defects are split-only; no regression.

`cargo test -p skippy-server` (649) and `-p skippy-prompt` (24) green; patch queue re-applies cleanly.

## Note for reviewers

Throughput with suffix speculation on this freeform workload is ~12.2–12.4 tok/s vs 13.8 plain decode on the same split — the machinery now *works*, but the suffix proposer's accept rate on freeform text doesn't pay for the windows at this scale (single-node shows the same shape: 15.3 vs 20.1). This is a correctness fix, not a speed claim.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented duplicate token history entries and sampler effects during multi-stage verification.
  - Enabled sampled verification windows to work alongside backend sampling.
  - Improved handling of decode failures, including cases with missing memory or position data.

- **Diagnostics**
  - Expanded runtime error details with message metadata, token counts, activation sizes, batch information, and return codes to make failures easier to investigate.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->