### PR TITLE
fix(serving): prompt-scaled cache-work deadline and surfaced stream errors

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/response/common.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/common.rs
@@ -6,6 +6,22 @@ use crate::network::target_health::TargetHealthOutcome;
 use mesh_llm_events::logging::events::TokenUsage;
 use mesh_llm_events::logging::identifiers::RequestId;
 
+/// Detect an OpenAI-shaped error body carried as an SSE `data:` frame.
+///
+/// Embedded backends report mid-stream failures this way: HTTP stays 200 and
+/// the terminal failure is a `{"error": {...}}` JSON frame. Recognizing it
+/// lets stream relays distinguish a failed stream from a completed one in the
+/// operations log instead of silently counting a contentless stream as
+/// delivered.
+pub(in crate::network::openai::response) fn sse_data_frame_is_openai_error(data: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<serde_json::Value>(data) else {
+        return false;
+    };
+    value
+        .get("error")
+        .is_some_and(|error| error.is_object() || error.is_string())
+}
+
 #[derive(Clone, Copy)]
 pub(in crate::network::openai) struct RouteAttemptLoggingContext<'a> {
     pub(in crate::network::openai) request_id: RequestId,

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/stream_translation.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/stream_translation.rs
@@ -3,6 +3,7 @@ use super::probe::{ResponseProbe, response_is_event_stream, try_parse_response_h
 use super::relay::{relay_error_response, relay_success_response};
 use crate::logging::{OpenAiRouteObserver, OpenAiStreamArtifactCapture};
 use crate::network::openai::client_stream::ClientStream;
+use crate::network::openai::response::common::sse_data_frame_is_openai_error;
 use crate::network::openai::response_adapter;
 use crate::network::openai::tool_call_ids::ChatStreamNormalizationState;
 use anyhow::{Context, Result, anyhow};
@@ -102,6 +103,7 @@ pub(in crate::network::openai::response) async fn relay_normalized_chat_completi
 
     let mut done_seen = false;
     let mut first_chunk_seen = false;
+    let mut upstream_error_seen = false;
     loop {
         let mut processed = 0usize;
         while let Some(frame_end_rel) = carry[processed..].find("\n\n") {
@@ -123,11 +125,20 @@ pub(in crate::network::openai::response) async fn relay_normalized_chat_completi
                 break;
             }
 
+            if !upstream_error_seen && sse_data_frame_is_openai_error(&data) {
+                // The upstream backend frames failures as OpenAI error bodies
+                // inside a 200 stream. Relay the frame untouched, but do not
+                // let it count as stream progress or terminal success.
+                upstream_error_seen = true;
+            }
             if let Some(usage) = parse_token_usage_from_json_body(data.as_bytes()) {
                 observed_usage = Some(usage);
             }
             let normalized = state.normalize_data(&data);
             write_captured_sse_event(tcp_stream, &mut response_capture, None, &normalized).await?;
+            if upstream_error_seen {
+                continue;
+            }
             if first_chunk_seen {
                 route_observer.stream_chunk();
             } else {
@@ -161,6 +172,13 @@ pub(in crate::network::openai::response) async fn relay_normalized_chat_completi
         route_observer.stream_error("upstream_stream_incomplete");
         return Err(anyhow!("upstream chat stream ended before [DONE]"));
     }
+    if upstream_error_seen {
+        route_observer.stream_error("upstream_stream_error");
+        return Ok(RouteAttemptResult::Delivered {
+            status_code: 200,
+            usage: None,
+        });
+    }
     route_observer.complete_stream_response_capture(response_capture);
     route_observer.stream_completed(observed_usage);
     Ok(RouteAttemptResult::Delivered {
@@ -187,6 +205,46 @@ pub(in crate::network::openai::response) async fn relay_translated_responses_str
             || data.contains("\"usage\"")
     }
 
+    #[derive(Debug, Default)]
+    struct TranslatedStreamProgress {
+        done_seen: bool,
+        first_chunk_seen: bool,
+        upstream_error_seen: bool,
+    }
+
+    async fn relay_translated_frame(
+        tcp_stream: &mut ClientStream,
+        response_capture: &mut Option<OpenAiStreamArtifactCapture>,
+        state: &mut ResponsesStreamRelayState,
+        progress: &mut TranslatedStreamProgress,
+        route_observer: &OpenAiRouteObserver<'_>,
+        data: &str,
+    ) -> Result<()> {
+        if data == "[DONE]" {
+            progress.done_seen = true;
+            return Ok(());
+        }
+        if sse_data_frame_is_openai_error(&data) {
+            // The upstream backend framed a mid-stream failure. Relay the
+            // frame as-is so the client still sees the error body, but do
+            // not treat it as stream progress or terminal success.
+            write_captured_sse_event(tcp_stream, response_capture, Some("error"), &data).await?;
+            progress.upstream_error_seen = true;
+            return Ok(());
+        }
+        if !should_parse_stream_chunk(&data, state.model.is_empty(), state.usage.is_none()) {
+            return Ok(());
+        }
+        process_translated_responses_frame(tcp_stream, response_capture, state, &data).await?;
+        if progress.first_chunk_seen {
+            route_observer.stream_chunk();
+        } else {
+            route_observer.stream_first_token();
+            progress.first_chunk_seen = true;
+        }
+        Ok(())
+    }
+
     if retry_policy.context_overflow && probe.retryable_context_overflow {
         return Ok(RouteAttemptResult::RetryableContextOverflow);
     }
@@ -205,8 +263,7 @@ pub(in crate::network::openai::response) async fn relay_translated_responses_str
     let mut response_capture = route_observer.begin_stream_response_capture();
     route_observer.stream_started(None);
 
-    let mut done_seen = false;
-    let mut first_chunk_seen = false;
+    let mut progress = TranslatedStreamProgress::default();
     loop {
         let mut processed = 0usize;
         while let Some(frame_end_rel) = carry[processed..].find("\n\n") {
@@ -222,34 +279,24 @@ pub(in crate::network::openai::response) async fn relay_translated_responses_str
                 continue;
             }
             let data = data_lines.join("\n");
-            if data == "[DONE]" {
-                done_seen = true;
-                break;
-            }
-
-            if !should_parse_stream_chunk(&data, state.model.is_empty(), state.usage.is_none()) {
-                continue;
-            }
-
-            process_translated_responses_frame(
+            relay_translated_frame(
                 tcp_stream,
                 &mut response_capture,
                 &mut state,
+                &mut progress,
+                &route_observer,
                 &data,
             )
             .await?;
-            if first_chunk_seen {
-                route_observer.stream_chunk();
-            } else {
-                route_observer.stream_first_token();
-                first_chunk_seen = true;
+            if progress.done_seen {
+                break;
             }
         }
         if processed > 0 {
             carry = carry[processed..].to_string();
         }
 
-        if done_seen {
+        if progress.done_seen {
             break;
         }
 
@@ -266,9 +313,19 @@ pub(in crate::network::openai::response) async fn relay_translated_responses_str
         }
     }
 
-    if !done_seen {
+    if !progress.done_seen {
         route_observer.stream_error("upstream_stream_incomplete");
         return Err(anyhow!("upstream Responses stream ended before [DONE]"));
+    }
+    if progress.upstream_error_seen {
+        write_captured_sse_event(tcp_stream, &mut response_capture, Some("done"), "[DONE]").await?;
+        let _ = tcp_stream.write_all(b"0\r\n\r\n").await;
+        let _ = tcp_stream.shutdown().await;
+        route_observer.stream_error("upstream_stream_error");
+        return Ok(RouteAttemptResult::Delivered {
+            status_code: 200,
+            usage: None,
+        });
     }
     finish_translated_responses_stream(tcp_stream, &mut response_capture, &mut state).await?;
     write_captured_sse_event(tcp_stream, &mut response_capture, Some("done"), "[DONE]").await?;
@@ -567,6 +624,7 @@ async fn emit_translated_stream_done_event(
 mod tests {
     use super::*;
     use crate::logging::{ArtifactUnavailableReason, OpenAiArtifactCapture};
+    use crate::network::openai::response::common::sse_data_frame_is_openai_error;
     use mesh_llm_events::logging::identifiers::RequestId;
     use std::sync::{Arc, Mutex};
     use tokio::net::TcpListener;
@@ -860,5 +918,78 @@ mod tests {
         assert!(route_result.is_err());
         assert!(!body.contains("response.completed"));
         assert!(!body.contains("data: [DONE]"));
+    }
+
+    #[tokio::test]
+    async fn upstream_error_frame_is_relayed_but_not_recorded_as_completed() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let (mut upstream_writer, mut upstream_reader) = tokio::io::duplex(64 * 1024);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_task = tokio::spawn(async move {
+            let (client_socket, _) = listener.accept().await.unwrap();
+            let mut client_socket: ClientStream = client_socket.into();
+            let probe = ResponseProbe {
+                buffered: b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n".to_vec(),
+                header_end: b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n".len(),
+                status_code: 200,
+                retryable_context_overflow: false,
+            };
+            relay_normalized_chat_completion_stream(
+                &mut client_socket,
+                &mut upstream_reader,
+                probe,
+                ResponseRetryPolicy::next_target_available(false),
+                OpenAiRouteObserver::default(),
+            )
+            .await
+            .expect("relay")
+        });
+
+        let error_frame = r#"{"error":{"message":"cache runtime operation req-1 exceeded its deadline","type":"server_error","param":null,"code":"timeout"}}"#;
+        upstream_writer
+            .write_all(format!("data: {error_frame}\n\n").as_bytes())
+            .await
+            .unwrap();
+        upstream_writer
+            .write_all(b"data: [DONE]\n\n")
+            .await
+            .unwrap();
+        upstream_writer.shutdown().await.unwrap();
+
+        let mut client = ClientStream::connect(addr).await.unwrap();
+        let mut output = Vec::new();
+        client.read_to_end(&mut output).await.unwrap();
+        let route_result = server_task.await.expect("server task");
+        let body = String::from_utf8_lossy(&output);
+
+        // The error frame is relayed to the client untouched...
+        assert!(body.contains("exceeded its deadline"));
+        assert!(body.contains("data: [DONE]"));
+
+        // ...but the attempt no longer reports usage-backed success.
+        assert_eq!(
+            route_result,
+            RouteAttemptResult::Delivered {
+                status_code: 200,
+                usage: None,
+            }
+        );
+    }
+
+    #[test]
+    fn openai_error_frames_are_detected_across_shapes() {
+        assert!(sse_data_frame_is_openai_error(
+            r#"{"error":{"message":"boom","type":"server_error","code":"timeout"}}"#
+        ));
+        assert!(sse_data_frame_is_openai_error(
+            r#"{"error":"plain string"}"#
+        ));
+        assert!(!sse_data_frame_is_openai_error(
+            r#"{"choices":[{"delta":{"content":"hi"}}]}"#
+        ));
+        assert!(!sse_data_frame_is_openai_error("[DONE]"));
+        assert!(!sse_data_frame_is_openai_error("not json"));
     }
 }

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/stream_translation.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/stream_translation.rs
@@ -224,18 +224,18 @@ pub(in crate::network::openai::response) async fn relay_translated_responses_str
             progress.done_seen = true;
             return Ok(());
         }
-        if sse_data_frame_is_openai_error(&data) {
+        if sse_data_frame_is_openai_error(data) {
             // The upstream backend framed a mid-stream failure. Relay the
             // frame as-is so the client still sees the error body, but do
             // not treat it as stream progress or terminal success.
-            write_captured_sse_event(tcp_stream, response_capture, Some("error"), &data).await?;
+            write_captured_sse_event(tcp_stream, response_capture, Some("error"), data).await?;
             progress.upstream_error_seen = true;
             return Ok(());
         }
-        if !should_parse_stream_chunk(&data, state.model.is_empty(), state.usage.is_none()) {
+        if !should_parse_stream_chunk(data, state.model.is_empty(), state.usage.is_none()) {
             return Ok(());
         }
-        process_translated_responses_frame(tcp_stream, response_capture, state, &data).await?;
+        process_translated_responses_frame(tcp_stream, response_capture, state, data).await?;
         if progress.first_chunk_seen {
             route_observer.stream_chunk();
         } else {

--- a/crates/mesh-llm-host-runtime/src/network/openai/response/stream_translation.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/response/stream_translation.rs
@@ -168,16 +168,19 @@ pub(in crate::network::openai::response) async fn relay_normalized_chat_completi
 
     let _ = tcp_stream.write_all(b"0\r\n\r\n").await;
     let _ = tcp_stream.shutdown().await;
-    if !done_seen {
-        route_observer.stream_error("upstream_stream_incomplete");
-        return Err(anyhow!("upstream chat stream ended before [DONE]"));
-    }
     if upstream_error_seen {
+        // An embedded upstream error frame is terminal even when the upstream
+        // never sent [DONE]: report the failure reason it carried rather than
+        // a generic incomplete-stream truncation.
         route_observer.stream_error("upstream_stream_error");
         return Ok(RouteAttemptResult::Delivered {
             status_code: 200,
             usage: None,
         });
+    }
+    if !done_seen {
+        route_observer.stream_error("upstream_stream_incomplete");
+        return Err(anyhow!("upstream chat stream ended before [DONE]"));
     }
     route_observer.complete_stream_response_capture(response_capture);
     route_observer.stream_completed(observed_usage);
@@ -313,10 +316,6 @@ pub(in crate::network::openai::response) async fn relay_translated_responses_str
         }
     }
 
-    if !progress.done_seen {
-        route_observer.stream_error("upstream_stream_incomplete");
-        return Err(anyhow!("upstream Responses stream ended before [DONE]"));
-    }
     if progress.upstream_error_seen {
         write_captured_sse_event(tcp_stream, &mut response_capture, Some("done"), "[DONE]").await?;
         let _ = tcp_stream.write_all(b"0\r\n\r\n").await;
@@ -326,6 +325,10 @@ pub(in crate::network::openai::response) async fn relay_translated_responses_str
             status_code: 200,
             usage: None,
         });
+    }
+    if !progress.done_seen {
+        route_observer.stream_error("upstream_stream_incomplete");
+        return Err(anyhow!("upstream Responses stream ended before [DONE]"));
     }
     finish_translated_responses_stream(tcp_stream, &mut response_capture, &mut state).await?;
     write_captured_sse_event(tcp_stream, &mut response_capture, Some("done"), "[DONE]").await?;
@@ -969,6 +972,112 @@ mod tests {
         assert!(body.contains("data: [DONE]"));
 
         // ...but the attempt no longer reports usage-backed success.
+        assert_eq!(
+            route_result,
+            RouteAttemptResult::Delivered {
+                status_code: 200,
+                usage: None,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn upstream_error_frame_without_done_is_terminal_not_incomplete() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let (mut upstream_writer, mut upstream_reader) = tokio::io::duplex(64 * 1024);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let server_task = tokio::spawn(async move {
+            let (client_socket, _) = listener.accept().await.unwrap();
+            let mut client_socket: ClientStream = client_socket.into();
+            let probe = ResponseProbe {
+                buffered: b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n".to_vec(),
+                header_end: b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n".len(),
+                status_code: 200,
+                retryable_context_overflow: false,
+            };
+            relay_normalized_chat_completion_stream(
+                &mut client_socket,
+                &mut upstream_reader,
+                probe,
+                ResponseRetryPolicy::next_target_available(false),
+                OpenAiRouteObserver::default(),
+            )
+            .await
+            .expect("relay")
+        });
+
+        let error_frame = r#"{"error":{"message":"cache runtime operation req-1 exceeded its deadline","type":"server_error","param":null,"code":"timeout"}}"#;
+        upstream_writer
+            .write_all(format!("data: {error_frame}\n\n").as_bytes())
+            .await
+            .unwrap();
+        // The upstream dies without ever sending [DONE].
+        upstream_writer.shutdown().await.unwrap();
+
+        let mut client = ClientStream::connect(addr).await.unwrap();
+        let mut output = Vec::new();
+        client.read_to_end(&mut output).await.unwrap();
+        let route_result = server_task.await.expect("server task");
+        let body = String::from_utf8_lossy(&output);
+
+        // The error frame still reaches the client...
+        assert!(body.contains("exceeded its deadline"));
+        // ...and the embedded error is terminal: the attempt is delivered
+        // (client saw the failure) rather than misreported as an
+        // incomplete-stream truncation error.
+        assert_eq!(
+            route_result,
+            RouteAttemptResult::Delivered {
+                status_code: 200,
+                usage: None,
+            }
+        );
+    }
+
+    #[tokio::test]
+    async fn translated_upstream_error_frame_without_done_is_terminal_not_incomplete() {
+        use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+        let (mut upstream_writer, mut upstream_reader) = tokio::io::duplex(64 * 1024);
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        let header = b"HTTP/1.1 200 OK\r\nContent-Type: text/event-stream\r\nTransfer-Encoding: chunked\r\n\r\n";
+        let server_task = tokio::spawn(async move {
+            let (client_socket, _) = listener.accept().await.unwrap();
+            let mut client_socket: ClientStream = client_socket.into();
+            let probe = ResponseProbe {
+                buffered: header.to_vec(),
+                header_end: header.len(),
+                status_code: 200,
+                retryable_context_overflow: false,
+            };
+            relay_translated_responses_stream(
+                &mut client_socket,
+                &mut upstream_reader,
+                probe,
+                ResponseRetryPolicy::next_target_available(false),
+                OpenAiRouteObserver::default(),
+            )
+            .await
+            .expect("relay")
+        });
+
+        let error_frame = r#"{"error":{"message":"cache runtime operation req-2 exceeded its deadline","type":"server_error","param":null,"code":"timeout"}}"#;
+        upstream_writer
+            .write_all(format!("data: {error_frame}\n\n").as_bytes())
+            .await
+            .unwrap();
+        upstream_writer.shutdown().await.unwrap();
+
+        let mut client = ClientStream::connect(addr).await.unwrap();
+        let mut output = Vec::new();
+        client.read_to_end(&mut output).await.unwrap();
+        let route_result = server_task.await.expect("server task");
+        let body = String::from_utf8_lossy(&output);
+
+        assert!(body.contains("exceeded its deadline"));
         assert_eq!(
             route_result,
             RouteAttemptResult::Delivered {

--- a/crates/skippy-server/README.md
+++ b/crates/skippy-server/README.md
@@ -132,7 +132,13 @@ deadline handling.
   `--generation-queue-capacity` independently bounds additional waiting
   requests (default `clamp(8 * lanes, 16, 256)`), while
   `--generation-admission-timeout-secs` bounds predicted and actual queue wait
-  (default 60 seconds). Embedded serving exposes the same controls with the
+  (default 60 seconds). KV restore and prefill-record work runs on a separate
+  prompt-scaled deadline (admission timeout plus about one minute per 4,000
+  prompt tokens, clamped to 30 minutes), so a legitimate prompt-sized prefill
+  is not
+  killed by the queue-wait bound; when that work deadline does expire the
+  request fails with a `timeout` error frame in the stream, not an empty
+  response. Embedded serving exposes the same controls with the
   `--openai-` prefix. Keep all three explicit in benchmark reports because
   they determine active execution, overload behavior, and tail latency.
 - `serve-openai` and embedded stage-0 OpenAI serving emit OpenAI-surface

--- a/crates/skippy-server/README.md
+++ b/crates/skippy-server/README.md
@@ -133,12 +133,12 @@ deadline handling.
   requests (default `clamp(8 * lanes, 16, 256)`), while
   `--generation-admission-timeout-secs` bounds predicted and actual queue wait
   (default 60 seconds). KV restore and prefill-record work runs on a separate
-  prompt-scaled deadline (admission timeout plus about one minute per 4,000
-  prompt tokens, clamped to 30 minutes), so a legitimate prompt-sized prefill
-  is not
-  killed by the queue-wait bound; when that work deadline does expire the
-  request fails with a `timeout` error frame in the stream, not an empty
-  response. Embedded serving exposes the same controls with the
+  prompt-scaled deadline: admission timeout plus about one minute per 4,000
+  prompt tokens, clamped to at least 60 seconds and at most 30 minutes. A
+  legitimate prompt-sized prefill is therefore not killed by the queue-wait
+  bound; when the work deadline does expire the request fails with a
+  `timeout` error frame in the stream, not an empty response. Embedded serving
+  exposes the same controls with the
   `--openai-` prefix. Keep all three explicit in benchmark reports because
   they determine active execution, overload behavior, and tail latency.
 - `serve-openai` and embedded stage-0 OpenAI serving emit OpenAI-surface

--- a/crates/skippy-server/src/frontend/iteration_scheduler.rs
+++ b/crates/skippy-server/src/frontend/iteration_scheduler.rs
@@ -43,6 +43,16 @@ const DIRECT_ITERATION_COALESCE_WINDOW: Duration = Duration::from_millis(2);
 const CACHE_AGING_COST_PER_TURN: u64 = 4_096;
 const SAFE_MODE_ENV: &str = "SKIPPY_ITERATION_SCHEDULER_SAFE_MODE";
 
+/// Conservative single-stream prefill floor used to bound cache-runtime work.
+/// Real Apple-Silicon prefill runs 200-400 tok/s, so an eighth of that leaves
+/// headroom for slower stages without letting a legitimate prompt-sized
+/// prefill die on the admission timeout.
+const PREFILL_WORK_TOKENS_PER_SEC: f64 = 64.0;
+
+/// Minimum and maximum prompt-scaled cache-runtime work budget.
+const PREFILL_WORK_MIN: Duration = Duration::from_secs(60);
+const PREFILL_WORK_MAX: Duration = Duration::from_secs(30 * 60);
+
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub(super) struct ScheduledGenerationStats {
     pub(super) prompt_ms: f64,
@@ -103,6 +113,23 @@ pub(crate) struct CacheAwareRuntimeRequest<'a> {
     pub(crate) priority: u64,
     pub(crate) payload: StagePrefixCachePayload,
     pub(crate) refresh_affinity: CacheAffinityRefresh,
+}
+
+/// Deadline for one cache-runtime operation.
+///
+/// `admission_timeout` bounds only queue wait. Cache-aware operations run the
+/// whole prefill inside the scheduler worker, so the work deadline adds a
+/// finite prompt-scaled budget to prevent a wedged operation holding a lane
+/// forever.
+pub(crate) fn cache_operation_deadline(
+    admission_timeout: Duration,
+    prompt_tokens: usize,
+) -> Instant {
+    let prompt_budget = Duration::from_secs_f64(prompt_tokens as f64 / PREFILL_WORK_TOKENS_PER_SEC)
+        .clamp(PREFILL_WORK_MIN, PREFILL_WORK_MAX);
+    let now = Instant::now();
+    now.checked_add(admission_timeout.saturating_add(prompt_budget))
+        .unwrap_or_else(|| now + PREFILL_WORK_MAX)
 }
 
 struct IterationSchedulerShared {
@@ -1919,6 +1946,32 @@ fn stage_recurrent_bytes_per_native_sequence(config: &StageConfig) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cache_operation_deadline_scales_with_prompt_and_stays_bounded() {
+        let admission = Duration::from_secs(60);
+
+        // A small prompt still gets a full minute of work budget on top of the
+        // admission wait, so short prefills never inherit the queue-timeout wall.
+        let small = cache_operation_deadline(admission, 128);
+        assert!(small.duration_since(Instant::now()) >= Duration::from_secs(119));
+
+        // A 60k-token agentic-history prompt earns admission plus a
+        // prompt-scaled prefill budget, not 60 seconds flat.
+        let large = cache_operation_deadline(admission, 60_000);
+        assert!(
+            large.duration_since(Instant::now()) >= Duration::from_secs(60 + 60),
+            "60k-token prompt must get more than the bare admission timeout"
+        );
+
+        // The work budget stays finite so a wedged operation still fails.
+        let huge = cache_operation_deadline(admission, usize::MAX);
+        assert!(
+            huge.duration_since(Instant::now())
+                <= admission + PREFILL_WORK_MAX + Duration::from_secs(5),
+            "deadline must remain bounded"
+        );
+    }
 
     fn direct_iteration(session_id: &str, token_count: usize) -> DirectIteration {
         let (reply, _result) = std_mpsc::sync_channel(1);

--- a/crates/skippy-server/src/frontend/iteration_scheduler.rs
+++ b/crates/skippy-server/src/frontend/iteration_scheduler.rs
@@ -154,7 +154,7 @@ fn ensure_direct_iteration_active(
         ));
     }
     if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
-        return Err(OpenAiError::backend(
+        return Err(OpenAiError::timeout(
             "cache operation deadline exceeded during scheduler iteration",
         ));
     }
@@ -212,7 +212,7 @@ impl CacheRuntimeContext {
                 "cache runtime operation {} was cancelled",
                 self.operation_id
             ))),
-            CACHE_OPERATION_DEADLINE_EXCEEDED => Err(OpenAiError::backend(format!(
+            CACHE_OPERATION_DEADLINE_EXCEEDED => Err(OpenAiError::timeout(format!(
                 "cache runtime operation {} exceeded its deadline",
                 self.operation_id
             ))),

--- a/crates/skippy-server/src/frontend/iteration_scheduler.rs
+++ b/crates/skippy-server/src/frontend/iteration_scheduler.rs
@@ -745,6 +745,34 @@ impl IterationScheduler {
         })?
     }
 
+    /// Deadline-bounded variant of [`Self::execute_runtime_timed`] for
+    /// cache-side work (KV record/evict, checkpoint export) that must not
+    /// hold a scheduler lane or a caller past the cache operation deadline.
+    /// Unlike [`Self::execute_cache_aware_runtime_timed`] the operation does
+    /// not join the radix-affinity cache queue; it runs on the plain runtime
+    /// command path as soon as the scheduler can take it.
+    pub(crate) fn execute_runtime_timed_bounded<T>(
+        &self,
+        label: &'static str,
+        operation_id: String,
+        deadline: Instant,
+        cancellation: Option<&openai_frontend::CancellationToken>,
+        operation: impl FnOnce(&mut RuntimeState) -> OpenAiResult<T> + Send + 'static,
+    ) -> OpenAiResult<SchedulerRuntimeOutcome<T>>
+    where
+        T: Send + 'static,
+    {
+        let (runtime_operation, result, control) = cache_runtime_operation(
+            label,
+            operation_id,
+            deadline,
+            cancellation,
+            |runtime, _control| operation(runtime),
+        );
+        self.enqueue_command(SchedulerCommand::ExecuteRuntime(runtime_operation))?;
+        wait_for_cache_runtime(result, &control)
+    }
+
     /// Queue cache restore/prefill work by stage-local radix affinity while
     /// retaining aging and decode-turn fairness.
     pub(crate) fn execute_cache_aware_runtime_timed<T>(

--- a/crates/skippy-server/src/frontend/iteration_scheduler.rs
+++ b/crates/skippy-server/src/frontend/iteration_scheduler.rs
@@ -43,16 +43,6 @@ const DIRECT_ITERATION_COALESCE_WINDOW: Duration = Duration::from_millis(2);
 const CACHE_AGING_COST_PER_TURN: u64 = 4_096;
 const SAFE_MODE_ENV: &str = "SKIPPY_ITERATION_SCHEDULER_SAFE_MODE";
 
-/// Conservative single-stream prefill floor used to bound cache-runtime work.
-/// Real Apple-Silicon prefill runs 200-400 tok/s, so an eighth of that leaves
-/// headroom for slower stages without letting a legitimate prompt-sized
-/// prefill die on the admission timeout.
-const PREFILL_WORK_TOKENS_PER_SEC: f64 = 64.0;
-
-/// Minimum and maximum prompt-scaled cache-runtime work budget.
-const PREFILL_WORK_MIN: Duration = Duration::from_secs(60);
-const PREFILL_WORK_MAX: Duration = Duration::from_secs(30 * 60);
-
 #[derive(Debug, Clone, Copy, Default, PartialEq)]
 pub(super) struct ScheduledGenerationStats {
     pub(super) prompt_ms: f64,
@@ -113,23 +103,6 @@ pub(crate) struct CacheAwareRuntimeRequest<'a> {
     pub(crate) priority: u64,
     pub(crate) payload: StagePrefixCachePayload,
     pub(crate) refresh_affinity: CacheAffinityRefresh,
-}
-
-/// Deadline for one cache-runtime operation.
-///
-/// `admission_timeout` bounds only queue wait. Cache-aware operations run the
-/// whole prefill inside the scheduler worker, so the work deadline adds a
-/// finite prompt-scaled budget to prevent a wedged operation holding a lane
-/// forever.
-pub(crate) fn cache_operation_deadline(
-    admission_timeout: Duration,
-    prompt_tokens: usize,
-) -> Instant {
-    let prompt_budget = Duration::from_secs_f64(prompt_tokens as f64 / PREFILL_WORK_TOKENS_PER_SEC)
-        .clamp(PREFILL_WORK_MIN, PREFILL_WORK_MAX);
-    let now = Instant::now();
-    now.checked_add(admission_timeout.saturating_add(prompt_budget))
-        .unwrap_or_else(|| now + PREFILL_WORK_MAX)
 }
 
 struct IterationSchedulerShared {
@@ -1946,32 +1919,6 @@ fn stage_recurrent_bytes_per_native_sequence(config: &StageConfig) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn cache_operation_deadline_scales_with_prompt_and_stays_bounded() {
-        let admission = Duration::from_secs(60);
-
-        // A small prompt still gets a full minute of work budget on top of the
-        // admission wait, so short prefills never inherit the queue-timeout wall.
-        let small = cache_operation_deadline(admission, 128);
-        assert!(small.duration_since(Instant::now()) >= Duration::from_secs(119));
-
-        // A 60k-token agentic-history prompt earns admission plus a
-        // prompt-scaled prefill budget, not 60 seconds flat.
-        let large = cache_operation_deadline(admission, 60_000);
-        assert!(
-            large.duration_since(Instant::now()) >= Duration::from_secs(60 + 60),
-            "60k-token prompt must get more than the bare admission timeout"
-        );
-
-        // The work budget stays finite so a wedged operation still fails.
-        let huge = cache_operation_deadline(admission, usize::MAX);
-        assert!(
-            huge.duration_since(Instant::now())
-                <= admission + PREFILL_WORK_MAX + Duration::from_secs(5),
-            "deadline must remain bounded"
-        );
-    }
 
     fn direct_iteration(session_id: &str, token_count: usize) -> DirectIteration {
         let (reply, _result) = std_mpsc::sync_channel(1);

--- a/crates/skippy-server/src/frontend/local_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation.rs
@@ -1,3 +1,4 @@
+mod cache_deadline;
 mod decode_step;
 mod linear_decode;
 mod native_mtp_decode;

--- a/crates/skippy-server/src/frontend/local_generation/cache_deadline.rs
+++ b/crates/skippy-server/src/frontend/local_generation/cache_deadline.rs
@@ -1,0 +1,63 @@
+use std::time::{Duration, Instant};
+
+/// Conservative single-stream prefill floor used to bound KV restore and
+/// prefill-record work. Real Apple-Silicon prefill runs 200-400 tok/s, so an
+/// eighth of that leaves headroom for slower stages without letting a
+/// legitimate prompt-sized prefill die on the admission timeout.
+const PREFILL_WORK_TOKENS_PER_SEC: f64 = 64.0;
+
+/// Minimum and maximum prompt-scaled prefill work budget.
+const PREFILL_WORK_MIN: Duration = Duration::from_secs(60);
+const PREFILL_WORK_MAX: Duration = Duration::from_secs(30 * 60);
+
+/// Deadline for one request's KV-restore + prefill-record work.
+///
+/// `generation_admission_timeout` bounds how long a request may wait to be
+/// admitted (queue wait); it was never sized for the work itself. Cache-aware
+/// operations run the whole prefill inside the scheduler worker, so a
+/// prompt-sized prefill can legitimately take minutes on a large model. The
+/// work deadline therefore adds a prompt-scaled budget on top of the admission
+/// timeout while staying finite so a wedged runtime operation still fails
+/// instead of holding a lane forever.
+pub(super) fn cache_operation_deadline(
+    admission_timeout: Duration,
+    prompt_tokens: usize,
+) -> Instant {
+    let prompt_budget = Duration::from_secs_f64(prompt_tokens as f64 / PREFILL_WORK_TOKENS_PER_SEC)
+        .clamp(PREFILL_WORK_MIN, PREFILL_WORK_MAX);
+    let now = Instant::now();
+    now.checked_add(admission_timeout.saturating_add(prompt_budget))
+        .unwrap_or_else(|| now + PREFILL_WORK_MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{PREFILL_WORK_MAX, cache_operation_deadline};
+    use std::time::{Duration, Instant};
+
+    #[test]
+    fn cache_operation_deadline_scales_with_prompt_and_stays_bounded() {
+        let admission = Duration::from_secs(60);
+
+        // A small prompt still gets a full minute of work budget on top of the
+        // admission wait, so short prefills never inherit the queue-timeout wall.
+        let small = cache_operation_deadline(admission, 128);
+        assert!(small.duration_since(Instant::now()) >= Duration::from_secs(119));
+
+        // A 60k-token agentic-history prompt (the replay workload that failed at
+        // 60s) earns admission + a prompt-scaled prefill budget, not 60s flat.
+        let large = cache_operation_deadline(admission, 60_000);
+        assert!(
+            large.duration_since(Instant::now()) >= Duration::from_secs(60 + 60),
+            "60k-token prompt must get more than the bare admission timeout"
+        );
+
+        // The work budget stays finite so a wedged operation still fails.
+        let huge = cache_operation_deadline(admission, usize::MAX);
+        assert!(
+            huge.duration_since(Instant::now())
+                <= admission + PREFILL_WORK_MAX + Duration::from_secs(5),
+            "deadline must remain bounded"
+        );
+    }
+}

--- a/crates/skippy-server/src/frontend/local_generation/resident_prefill.rs
+++ b/crates/skippy-server/src/frontend/local_generation/resident_prefill.rs
@@ -94,7 +94,7 @@ fn ensure_suffix_prefill_active(
         ));
     }
     if Instant::now() >= deadline {
-        return Err(OpenAiError::backend(
+        return Err(OpenAiError::timeout(
             "cache operation deadline exceeded during deferred suffix prefill",
         ));
     }

--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -898,25 +898,30 @@ impl StageOpenAiBackend {
                 let scheduler_backend = self.clone();
                 let scheduler_session_id = session_id.to_string();
                 let scheduler_ids = request.ids.clone();
-                if let Ok(checkpoint_outcome) = self.iteration_scheduler.execute_runtime_timed(
-                    "feature-kv-shared-checkpoint",
-                    move |runtime| {
-                        let recorded = scheduler_backend.record_exact_state_at_tokens(
-                            runtime,
-                            &scheduler_session_id,
-                            &scheduler_ids,
-                            &checkpoint_tokens,
-                            "shared_prefill_checkpoint",
-                        );
-                        Ok((
-                            recorded,
-                            scheduler_backend
-                                .telemetry
-                                .is_debug_enabled()
-                                .then(|| runtime.session_stats()),
-                        ))
-                    },
-                ) {
+                if let Ok(checkpoint_outcome) =
+                    self.iteration_scheduler.execute_runtime_timed_bounded(
+                        "feature-kv-shared-checkpoint",
+                        request.ids.request_id_string(),
+                        cache_operation_deadline,
+                        request.cancellation,
+                        move |runtime| {
+                            let recorded = scheduler_backend.record_exact_state_at_tokens(
+                                runtime,
+                                &scheduler_session_id,
+                                &scheduler_ids,
+                                &checkpoint_tokens,
+                                "shared_prefill_checkpoint",
+                            );
+                            Ok((
+                                recorded,
+                                scheduler_backend
+                                    .telemetry
+                                    .is_debug_enabled()
+                                    .then(|| runtime.session_stats()),
+                            ))
+                        },
+                    )
+                {
                     let (recorded, sessions_after) = checkpoint_outcome.value;
                     runtime_lock_wait_ms += checkpoint_outcome.runtime_lock_wait_ms;
                     runtime_lock_hold_ms += checkpoint_outcome.runtime_lock_hold_ms;
@@ -962,25 +967,30 @@ impl StageOpenAiBackend {
                 let scheduler_backend = self.clone();
                 let scheduler_session_id = session_id.to_string();
                 let scheduler_ids = request.ids.clone();
-                if let Ok(final_record_outcome) = self.iteration_scheduler.execute_runtime_timed(
-                    "feature-kv-final-state",
-                    move |runtime| {
-                        let recorded = scheduler_backend.record_exact_state_at_tokens(
-                            runtime,
-                            &scheduler_session_id,
-                            &scheduler_ids,
-                            &final_prompt_tokens,
-                            "final_prefill_state",
-                        );
-                        Ok((
-                            recorded,
-                            scheduler_backend
-                                .telemetry
-                                .is_debug_enabled()
-                                .then(|| runtime.session_stats()),
-                        ))
-                    },
-                ) {
+                if let Ok(final_record_outcome) =
+                    self.iteration_scheduler.execute_runtime_timed_bounded(
+                        "feature-kv-final-state",
+                        request.ids.request_id_string(),
+                        cache_operation_deadline,
+                        request.cancellation,
+                        move |runtime| {
+                            let recorded = scheduler_backend.record_exact_state_at_tokens(
+                                runtime,
+                                &scheduler_session_id,
+                                &scheduler_ids,
+                                &final_prompt_tokens,
+                                "final_prefill_state",
+                            );
+                            Ok((
+                                recorded,
+                                scheduler_backend
+                                    .telemetry
+                                    .is_debug_enabled()
+                                    .then(|| runtime.session_stats()),
+                            ))
+                        },
+                    )
+                {
                     let (recorded, sessions_after) = final_record_outcome.value;
                     runtime_lock_wait_ms += final_record_outcome.runtime_lock_wait_ms;
                     runtime_lock_hold_ms += final_record_outcome.runtime_lock_hold_ms;
@@ -996,8 +1006,11 @@ impl StageOpenAiBackend {
                 let scheduler_session_id = session_id.to_string();
                 let scheduler_ids = request.ids.clone();
                 let emit_debug = self.telemetry.is_debug_enabled();
-                let record_outcome = self.iteration_scheduler.execute_runtime_timed(
+                let record_outcome = self.iteration_scheduler.execute_runtime_timed_bounded(
                     "feature-kv-record",
+                    request.ids.request_id_string(),
+                    cache_operation_deadline,
+                    request.cancellation,
                     move |runtime| {
                         let record = scheduler_backend.record_and_evict_kv(
                             runtime,

--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -17,7 +17,6 @@ use crate::frontend::iteration_scheduler::CacheRuntimeContext;
 use crate::frontend::iteration_scheduler::DirectIterationChannel;
 use crate::frontend::iteration_scheduler::ScheduledGenerationRequest;
 use crate::frontend::iteration_scheduler::ScheduledResumeRequest;
-use crate::frontend::iteration_scheduler::cache_operation_deadline;
 use crate::frontend::linear_proposal::greedy_linear_proposal_admitted;
 use crate::frontend::util::openai_backend_error;
 use crate::frontend::util::saturating_u32;

--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -1,3 +1,4 @@
+use super::cache_deadline::cache_operation_deadline;
 use super::native_mtp_decode::NativeMtpSpanProgress;
 use crate::frontend::NativeMtpDecodeOptions;
 use crate::frontend::NativeMtpDraft;
@@ -35,7 +36,7 @@ use skippy_runtime::SamplingConfig;
 use std::cell::RefCell;
 use std::collections::BTreeMap;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
+use std::time::Duration;
 
 use super::{LocalGenerationReceiptFinalization, prompt_fits_single_prefill_sample};
 
@@ -102,33 +103,6 @@ fn ensure_cache_operation_active(
         return Err(error);
     }
     Ok(())
-}
-
-/// Conservative single-stream prefill floor used to bound KV restore and
-/// prefill-record work. Real Apple-Silicon prefill runs 200-400 tok/s, so an
-/// eighth of that leaves headroom for slower stages without letting a
-/// legitimate prompt-sized prefill die on the admission timeout.
-const PREFILL_WORK_TOKENS_PER_SEC: f64 = 64.0;
-
-/// Minimum and maximum prompt-scaled prefill work budget.
-const PREFILL_WORK_MIN: Duration = Duration::from_secs(60);
-const PREFILL_WORK_MAX: Duration = Duration::from_secs(30 * 60);
-
-/// Deadline for one request's KV-restore + prefill-record work.
-///
-/// `generation_admission_timeout` bounds how long a request may wait to be
-/// admitted (queue wait); it was never sized for the work itself. Cache-aware
-/// operations run the whole prefill inside the scheduler worker, so a
-/// prompt-sized prefill can legitimately take minutes on a large model. The
-/// work deadline therefore adds a prompt-scaled budget on top of the admission
-/// timeout while staying finite so a wedged runtime operation still fails
-/// instead of holding a lane forever.
-fn cache_operation_deadline(admission_timeout: Duration, prompt_tokens: usize) -> Instant {
-    let prompt_budget = Duration::from_secs_f64(prompt_tokens as f64 / PREFILL_WORK_TOKENS_PER_SEC)
-        .clamp(PREFILL_WORK_MIN, PREFILL_WORK_MAX);
-    let now = Instant::now();
-    now.checked_add(admission_timeout.saturating_add(prompt_budget))
-        .unwrap_or_else(|| now + PREFILL_WORK_MAX)
 }
 
 fn prefill_cache_chunks(
@@ -2187,33 +2161,6 @@ fn default_local_text_serving_selects_iteration_scheduler() {
     assert!(!scheduler_generation_driver_eligible(
         0, false, false, false, false, "disabled", false,
     ));
-}
-
-#[cfg(test)]
-#[test]
-fn cache_operation_deadline_scales_with_prompt_and_stays_bounded() {
-    let admission = Duration::from_secs(60);
-
-    // A small prompt still gets a full minute of work budget on top of the
-    // admission wait, so short prefills never inherit the queue-timeout wall.
-    let small = cache_operation_deadline(admission, 128);
-    assert!(small.duration_since(Instant::now()) >= Duration::from_secs(119));
-
-    // A 60k-token agentic-history prompt (the replay workload that failed at
-    // 60s) earns admission + a prompt-scaled prefill budget, not 60s flat.
-    let large = cache_operation_deadline(admission, 60_000);
-    assert!(
-        large.duration_since(Instant::now()) >= Duration::from_secs(60 + 60),
-        "60k-token prompt must get more than the bare admission timeout"
-    );
-
-    // The work budget stays finite so a wedged operation still fails.
-    let huge = cache_operation_deadline(admission, usize::MAX);
-    assert!(
-        huge.duration_since(Instant::now())
-            <= admission + PREFILL_WORK_MAX + Duration::from_secs(5),
-        "deadline must remain bounded"
-    );
 }
 
 #[cfg(test)]

--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -104,6 +104,33 @@ fn ensure_cache_operation_active(
     Ok(())
 }
 
+/// Conservative single-stream prefill floor used to bound KV restore and
+/// prefill-record work. Real Apple-Silicon prefill runs 200-400 tok/s, so an
+/// eighth of that leaves headroom for slower stages without letting a
+/// legitimate prompt-sized prefill die on the admission timeout.
+const PREFILL_WORK_TOKENS_PER_SEC: f64 = 64.0;
+
+/// Minimum and maximum prompt-scaled prefill work budget.
+const PREFILL_WORK_MIN: Duration = Duration::from_secs(60);
+const PREFILL_WORK_MAX: Duration = Duration::from_secs(30 * 60);
+
+/// Deadline for one request's KV-restore + prefill-record work.
+///
+/// `generation_admission_timeout` bounds how long a request may wait to be
+/// admitted (queue wait); it was never sized for the work itself. Cache-aware
+/// operations run the whole prefill inside the scheduler worker, so a
+/// prompt-sized prefill can legitimately take minutes on a large model. The
+/// work deadline therefore adds a prompt-scaled budget on top of the admission
+/// timeout while staying finite so a wedged runtime operation still fails
+/// instead of holding a lane forever.
+fn cache_operation_deadline(admission_timeout: Duration, prompt_tokens: usize) -> Instant {
+    let prompt_budget = Duration::from_secs_f64(prompt_tokens as f64 / PREFILL_WORK_TOKENS_PER_SEC)
+        .clamp(PREFILL_WORK_MIN, PREFILL_WORK_MAX);
+    let now = Instant::now();
+    now.checked_add(admission_timeout.saturating_add(prompt_budget))
+        .unwrap_or_else(|| now + PREFILL_WORK_MAX)
+}
+
 fn prefill_cache_chunks(
     runtime: &mut RuntimeState,
     session_id: &str,
@@ -777,9 +804,10 @@ impl StageOpenAiBackend {
         let scheduler_prefill_tokens = Arc::clone(&prefill_tokens);
         let record_prefill_tokens = Arc::clone(&prefill_tokens);
         let mut scheduler_cache_stats = std::mem::take(cache_stats);
-        let cache_operation_deadline = Instant::now()
-            .checked_add(self.generation_admission_timeout)
-            .ok_or_else(|| OpenAiError::backend("cache operation deadline overflow"))?;
+        let cache_operation_deadline = cache_operation_deadline(
+            self.generation_admission_timeout,
+            request.prompt_token_ids.len(),
+        );
         let outcome = self.iteration_scheduler.execute_cache_aware_runtime_timed(
             "feature-kv-restore-prefill-record",
             super::super::iteration_scheduler::CacheAwareRuntimeRequest {
@@ -2146,6 +2174,33 @@ fn default_local_text_serving_selects_iteration_scheduler() {
     assert!(!scheduler_generation_driver_eligible(
         0, false, false, false, false, "disabled", false,
     ));
+}
+
+#[cfg(test)]
+#[test]
+fn cache_operation_deadline_scales_with_prompt_and_stays_bounded() {
+    let admission = Duration::from_secs(60);
+
+    // A small prompt still gets a full minute of work budget on top of the
+    // admission wait, so short prefills never inherit the queue-timeout wall.
+    let small = cache_operation_deadline(admission, 128);
+    assert!(small.duration_since(Instant::now()) >= Duration::from_secs(119));
+
+    // A 60k-token agentic-history prompt (the replay workload that failed at
+    // 60s) earns admission + a prompt-scaled prefill budget, not 60s flat.
+    let large = cache_operation_deadline(admission, 60_000);
+    assert!(
+        large.duration_since(Instant::now()) >= Duration::from_secs(60 + 60),
+        "60k-token prompt must get more than the bare admission timeout"
+    );
+
+    // The work budget stays finite so a wedged operation still fails.
+    let huge = cache_operation_deadline(admission, usize::MAX);
+    assert!(
+        huge.duration_since(Instant::now())
+            <= admission + PREFILL_WORK_MAX + Duration::from_secs(5),
+        "deadline must remain bounded"
+    );
 }
 
 #[cfg(test)]

--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -17,6 +17,7 @@ use crate::frontend::iteration_scheduler::CacheRuntimeContext;
 use crate::frontend::iteration_scheduler::DirectIterationChannel;
 use crate::frontend::iteration_scheduler::ScheduledGenerationRequest;
 use crate::frontend::iteration_scheduler::ScheduledResumeRequest;
+use crate::frontend::iteration_scheduler::cache_operation_deadline;
 use crate::frontend::linear_proposal::greedy_linear_proposal_admitted;
 use crate::frontend::util::openai_backend_error;
 use crate::frontend::util::saturating_u32;


### PR DESCRIPTION
## Problem (fix 1)

`generation_admission_timeout` (default 60s) is meant to bound queue wait only, but it was also used as the deadline for KV-restore + prefill-record cache-runtime work. Legitimate prompt-sized prefills (e.g. 60k-token agentic-replay histories) were killed at 60s mid-prefill. The resulting error was framed as a generic `backend`/service_unavailable error inside a 200 SSE stream; the gateway logged it as `request_stream_completed`, and the eval harness reported "stream completed without generated content".

## Changes

**skippy-server**
- New `cache_operation_deadline(admission_timeout, prompt_tokens)`: admission timeout + prompt-scaled prefill budget (64 tok/s conservative floor ≈ 1/8 of observed 200–400 tok/s Apple-Silicon prefill), clamped to [60s, 30min], overflow-safe. Wedged operations still fail, bounded.
- Deadline-exceeded errors in `iteration_scheduler` (2 sites) and `resident_prefill` (1 site) map to `OpenAiError::timeout` instead of `OpenAiError::backend` (message strings unchanged, so string-matching tests still pass).
- The deferred KV record paths (`feature-kv-record`, `feature-kv-shared-checkpoint`, `feature-kv-final-state`) ran on plain `execute_runtime_timed`, whose unbounded `recv()` could hold a lane past every deadline when the runtime wedges mid-record. New `IterationScheduler::execute_runtime_timed_bounded` wraps the same runtime-command path in a `CacheRuntimeContext`, so the waiter returns `OpenAiError::timeout` at the cache operation deadline and honors cancellation; the three call sites are converted (best-effort semantics unchanged).
- README documents the new prompt-scaled deadline semantics.

**mesh-llm-host-runtime**
- New `sse_data_frame_is_openai_error()` detects `{"error": {...}}` / `{"error": "..."}` JSON SSE frames.
- Both stream relays (`relay_normalized_chat_completion_stream`, `relay_translated_responses_stream`) recognize upstream SSE error frames: relay to the client untouched (translated path emits `event: error`, no synthesized `response.completed` tail, still writes `data: [DONE]`), skip first-token/chunk counting, and record `stream_error("upstream_stream_error")` returning `Delivered{200, usage: None}` instead of `stream_completed` with usage — mid-stream retry is impossible, but the ops log now tells the truth. An embedded error frame is terminal even when the upstream closes without `[DONE]`: both relays check the error flag before the incomplete-stream path, so the ops log reports `upstream_stream_error` rather than a misleading `upstream_stream_incomplete`.
- `relay_translated_responses_stream` frame handling extracted into `relay_translated_frame` to stay under the cognitive-complexity lint.

## Tests

- New: `cache_operation_deadline_scales_with_prompt_and_stays_bounded`, `upstream_error_frame_is_relayed_but_not_recorded_as_completed`, `upstream_error_frame_without_done_is_terminal_not_incomplete`, `translated_upstream_error_frame_without_done_is_terminal_not_incomplete`, `openai_error_frames_are_detected_across_shapes`.
- Validated with the CI toolchain (rust 1.97.0, which is where the original push failed clippy): full suites green — `mesh-llm-host-runtime` 2889 passed / 0 failed; `skippy-server` 643 passed / 0 failed; all three clippy batches (`mesh-llm-host-runtime`, `skippy-server`, `mesh-llm`/`mesh-llm-ffi`/etc.) clean with `-D warnings`; fmt clean. (llama static ABI rebuilt locally with brew llvm + `-DGGML_OPENMP=OFF`.)

## Notes

- The evals-side fix (capture in-stream error frames in `agentic-replay.py` so the failure reason becomes "stream failed with server error") targets `evals/agentic-replay.py`, which only exists on #1578's branch — being handed to @scam there rather than riding this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Streaming responses now correctly relay embedded upstream errors instead of reporting successful completion.
  - Error frames remain available to clients, with clear stream termination even when upstream streams end unexpectedly.
  - Deadline-exceeded operations are now reported as timeouts rather than generic backend errors.
  - Prompt-sized KV restore and prefill operations receive appropriately scaled, bounded processing time.
  - Expired work now returns a timeout error frame instead of an empty response.

- **Documentation**
  - Documented prompt-scaled deadlines and timeout behavior for KV restore and prefill operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
