### PR TITLE
chore(system): silence cfg-gated macOS clippy warnings

### DIFF
--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -327,6 +327,10 @@ fn apply_skippy_backend_devices_to_survey(survey: &mut HardwareSurvey, metrics: 
 }
 
 #[cfg(any(feature = "skippy-devices", test))]
+#[cfg_attr(
+    not(any(feature = "skippy-devices", target_os = "linux", target_os = "windows")),
+    allow(dead_code)
+)]
 fn cpu_only_budget_system_ram() -> u64 {
     #[cfg(any(target_os = "linux", target_os = "windows"))]
     {
@@ -348,6 +352,10 @@ fn apply_gpu_probe_outcome_to_survey<E>(
     survey: &mut HardwareSurvey,
     metrics: &[Metric],
     probe: Result<Vec<GpuFacts>, E>,
+    #[cfg_attr(
+        not(any(target_os = "linux", target_os = "windows")),
+        allow(unused_variables)
+    )]
     cpu_only_system_ram: impl FnOnce() -> u64,
 ) -> bool {
     let gpus = match probe {


### PR DESCRIPTION
## Problem

macOS clippy runs with `-D warnings` fail in `crates/mesh-llm-system/src/hardware/mod.rs`:

- `unused variable: cpu_only_system_ram` — the closure parameter of `apply_gpu_probe_outcome_to_survey` is only consumed on the linux/windows CPU-only fallback branches
- `function cpu_only_budget_system_ram is never used` (plain `--all-targets` without features) — its only caller is `#[cfg(feature = "skippy-devices")]`

## Fix

Gate the `allow` attributes to exactly the configurations where the code is dead:

- `#[cfg_attr(not(any(target_os = "linux", target_os = "windows")), allow(unused_variables))]` on the parameter
- `#[cfg_attr(not(any(feature = "skippy-devices", target_os = "linux", target_os = "windows")), allow(dead_code))]` on the helper

On linux/windows the lint stays live, so a genuinely unused variable there still fails the build.

## Verification

- `cargo clippy -p mesh-llm-system --all-targets` — clean (both warning kinds gone)
- `cargo clippy -p mesh-llm-system --all-targets --features skippy-devices` — clean
- `cargo test -p mesh-llm-system` — 182 passed / 0 failed
- `cargo fmt --check -p mesh-llm-system` — clean

Follow-up to #1590 (James's "two things" ask in the fix-1 thread).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Suppressed platform-specific compiler warnings during builds.
  * No user-facing behavior or functionality has changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->