### PR TITLE
fix(bench): tolerate rejected direct-return writes

### DIFF
--- a/crates/skippy-bench/src/direct_return_listener.rs
+++ b/crates/skippy-bench/src/direct_return_listener.rs
@@ -431,7 +431,19 @@ mod tests {
         let mut client = TcpStream::connect(listener.local_addr()).unwrap();
         recv_ready(&mut client).unwrap();
         write_stage_message(&mut client, &open_message(999, 999)).unwrap();
-        send_reply_predicted_with_stats(&mut client, 7, Default::default()).unwrap();
+        // The listener rejects the unregistered open and closes without
+        // reading a reply. Depending on when the peer close is observed, this
+        // write either completes from the local socket buffer or reports the
+        // expected terminal connection error.
+        if let Err(error) = send_reply_predicted_with_stats(&mut client, 7, Default::default()) {
+            assert!(
+                matches!(
+                    error.kind(),
+                    ErrorKind::BrokenPipe | ErrorKind::ConnectionReset
+                ),
+                "unexpected reply write error after unregistered open: {error}"
+            );
+        }
 
         assert!(
             receiver


### PR DESCRIPTION
## Summary

- treat a peer close after an unregistered prediction-return open as an expected rejection outcome in the regression test
- preserve the waiter-isolation assertion and continue rejecting any unrelated socket error

## Root cause

The listener intentionally rejects unknown request/session IDs immediately after reading the open frame and closes without reading the following reply. On Linux, that close can race the test client's multi-write reply encoding and surface as `ECONNRESET`; macOS commonly buffers the complete write first. The production listener behaved correctly, but the test unconditionally unwrapped the client write.

Fixes the failure in https://github.com/Mesh-LLM/mesh-llm/actions/runs/33596394080/job/100141030408.

## Validation

- `cargo test -p skippy-bench -- --test-threads=1` (84 passed)
- `cargo clippy -p skippy-bench --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Updated connection-handling test coverage to accept either a successful reply write or an expected terminal connection error when an unregistered connection is closed.
  - Preserved verification that registered waiters do not receive an unexpected reply.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->