### PR TITLE
Reuse warm prefixes across agent sessions

### DIFF
--- a/crates/mesh-client/src/network/affinity.rs
+++ b/crates/mesh-client/src/network/affinity.rs
@@ -83,7 +83,12 @@ pub(crate) fn extract_session_hint_from_body(body: &Value) -> Option<String> {
 }
 
 fn routing_keys(parsed_body: Option<&Value>) -> RoutingKeys {
-    shared_affinity::routing_keys(parsed_body, &["user", "session_id"], false)
+    shared_affinity::routing_keys(
+        parsed_body,
+        &["prompt_cache_key"],
+        &["user", "session_id"],
+        false,
+    )
 }
 
 #[cfg(test)]
@@ -176,7 +181,7 @@ mod tests {
     }
 
     #[test]
-    fn test_routing_keys_prefix_is_namespaced_by_first_user() {
+    fn test_routing_keys_prefix_is_shared_across_first_users() {
         let req_a = parse_body(
             r#"{"tools":[{"type":"function","function":{"name":"run"}}],"messages":[{"role":"system","content":"You are an agent."},{"role":"user","content":"fix bug A"}]}"#,
         );
@@ -187,7 +192,7 @@ mod tests {
         let keys_a = routing_keys(Some(&req_a));
         let keys_b = routing_keys(Some(&req_b));
 
-        assert_ne!(keys_a.prefix_hash, keys_b.prefix_hash);
+        assert_eq!(keys_a.prefix_hash, keys_b.prefix_hash);
         assert_eq!(keys_a.sticky_hash, None);
         assert_eq!(keys_b.sticky_hash, None);
     }

--- a/crates/mesh-llm-host-runtime/src/network/affinity.rs
+++ b/crates/mesh-llm-host-runtime/src/network/affinity.rs
@@ -243,6 +243,21 @@ impl AffinityRouter {
         }
     }
 
+    pub(crate) fn forget_cache_lease(&self, model: &str, prefix_hash: u64) -> bool {
+        let mut state = self.inner.lock().unwrap();
+        let key = CacheLeaseKey {
+            model: model.to_string(),
+            prefix_hash,
+        };
+        let removed = state.cache_leases.remove(&key).is_some();
+        if removed
+            && let Some(position) = state.cache_lease_lru.iter().position(|item| item == &key)
+        {
+            state.cache_lease_lru.remove(position);
+        }
+        removed
+    }
+
     pub(crate) fn forget_cache_leases_for_target(
         &self,
         target: &election::InferenceTarget,
@@ -325,10 +340,7 @@ pub use shared_affinity::{PreparedTargets, TargetSelection};
 
 #[cfg(test)]
 pub(crate) fn extract_session_hint_from_body(body: &Value) -> Option<String> {
-    shared_affinity::extract_session_hint_from_body(
-        body,
-        &["prompt_cache_key", "user", "session_id"],
-    )
+    shared_affinity::extract_session_hint_from_body(body, &["user", "session_id"])
 }
 
 #[cfg(test)]
@@ -339,7 +351,8 @@ fn scaffold_prefix_hash_from_body(body: &Value) -> Option<u64> {
 fn routing_keys(parsed_body: Option<&Value>) -> RoutingKeys {
     shared_affinity::routing_keys(
         parsed_body,
-        &["prompt_cache_key", "user", "session_id"],
+        &["prompt_cache_key"],
+        &["user", "session_id"],
         true,
     )
 }
@@ -369,6 +382,15 @@ impl crate::mesh::Node {
                 suffix_prefill_tokens,
                 queue_delay_micros,
             );
+    }
+
+    /// Remove provider-refuted local cache evidence immediately instead of
+    /// waiting for its bounded gossip TTL to expire.
+    pub(crate) fn invalidate_local_cache_evidence(&self, model: &str, prefix_hash: u64) -> bool {
+        self.cache_affinity_inventory
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .invalidate(model, prefix_hash)
     }
 
     /// Probe bounded local and peer advertisements for the exact request
@@ -527,12 +549,12 @@ mod tests {
     }
 
     #[test]
-    fn test_extract_session_hint_from_body_prompt_cache_key_preferred() {
+    fn test_extract_session_hint_from_body_user_preferred() {
         let body =
             parse_body(r#"{"prompt_cache_key":"cache-1","user":"bob","session_id":"sess-1"}"#);
         assert_eq!(
             extract_session_hint_from_body(&body),
-            Some("cache-1".to_string())
+            Some("bob".to_string())
         );
     }
 
@@ -595,7 +617,26 @@ mod tests {
     }
 
     #[test]
-    fn test_routing_keys_prefix_is_namespaced_by_first_user() {
+    fn exact_cache_lease_invalidation_preserves_other_prefixes() {
+        let affinity = AffinityRouter::with_config(true, true);
+        let target = remote(1);
+        affinity.remember_cache_lease(TEST_MODEL, 7, &target);
+        affinity.remember_cache_lease(TEST_MODEL, 8, &target);
+
+        assert!(affinity.forget_cache_lease(TEST_MODEL, 7));
+        assert!(!affinity.forget_cache_lease(TEST_MODEL, 7));
+        assert_eq!(
+            affinity.lookup_cache_lease(TEST_MODEL, 7, std::slice::from_ref(&target)),
+            None
+        );
+        assert_eq!(
+            affinity.lookup_cache_lease(TEST_MODEL, 8, std::slice::from_ref(&target)),
+            Some(target)
+        );
+    }
+
+    #[test]
+    fn test_routing_keys_prefix_is_shared_across_first_users() {
         let req_a = parse_body(
             r#"{"tools":[{"type":"function","function":{"name":"run"}}],"messages":[{"role":"system","content":"You are an agent."},{"role":"user","content":"fix bug A"}]}"#,
         );
@@ -606,7 +647,7 @@ mod tests {
         let keys_a = routing_keys(Some(&req_a));
         let keys_b = routing_keys(Some(&req_b));
 
-        assert_ne!(keys_a.prefix_hash, keys_b.prefix_hash);
+        assert_eq!(keys_a.prefix_hash, keys_b.prefix_hash);
         assert_eq!(keys_a.sticky_hash, None);
         assert_eq!(keys_b.sticky_hash, None);
     }
@@ -723,6 +764,24 @@ mod tests {
             node.select_cache_target("qwen", 0xfeed_beef, &candidates)
                 .await,
             Some(election::InferenceTarget::Local(9337))
+        );
+    }
+
+    #[tokio::test]
+    async fn provider_confirmed_local_miss_invalidates_evidence() {
+        let node =
+            crate::mesh::Node::new_for_tests(crate::mesh::NodeRole::Host { http_port: 9337 })
+                .await
+                .expect("test node");
+        let candidates = vec![remote(1), election::InferenceTarget::Local(9337)];
+
+        node.record_local_cache_hit("qwen", 0xfeed_beef, 512, 24, 0);
+        assert!(node.invalidate_local_cache_evidence("qwen", 0xfeed_beef));
+
+        assert_eq!(
+            node.select_cache_target("qwen", 0xfeed_beef, &candidates)
+                .await,
+            None
         );
     }
 

--- a/crates/mesh-llm-host-runtime/src/network/affinity.rs
+++ b/crates/mesh-llm-host-runtime/src/network/affinity.rs
@@ -68,6 +68,7 @@ struct AffinityState {
     auto_lru: VecDeque<u64>,
     cache_leases: HashMap<CacheLeaseKey, CacheLeaseEntry>,
     cache_lease_lru: VecDeque<CacheLeaseKey>,
+    cache_lease_epoch: u64,
 }
 
 #[derive(Clone)]
@@ -211,6 +212,7 @@ impl AffinityRouter {
         Some(target)
     }
 
+    #[cfg(test)]
     pub(crate) fn remember_cache_lease(
         &self,
         model: &str,
@@ -218,33 +220,31 @@ impl AffinityRouter {
         target: &election::InferenceTarget,
     ) {
         let mut state = self.inner.lock().unwrap();
-        state.prune_cache_leases();
-        let key = CacheLeaseKey {
-            model: model.to_string(),
-            prefix_hash,
-        };
-        state.cache_leases.insert(
-            key.clone(),
-            CacheLeaseEntry {
-                target: target.clone(),
-                expires_at: Instant::now() + CACHE_LEASE_TTL,
-            },
-        );
-        if let Some(position) = state.cache_lease_lru.iter().position(|item| item == &key) {
-            state.cache_lease_lru.remove(position);
+        state.remember_cache_lease(model, prefix_hash, target);
+    }
+
+    pub(crate) fn cache_lease_epoch(&self) -> u64 {
+        self.inner.lock().unwrap().cache_lease_epoch
+    }
+
+    pub(crate) fn remember_cache_lease_if_epoch(
+        &self,
+        model: &str,
+        prefix_hash: u64,
+        target: &election::InferenceTarget,
+        expected_epoch: u64,
+    ) -> bool {
+        let mut state = self.inner.lock().unwrap();
+        if state.cache_lease_epoch != expected_epoch {
+            return false;
         }
-        state.cache_lease_lru.push_back(key);
-        while state.cache_leases.len() > CACHE_LEASE_MAX_ENTRIES {
-            if let Some(oldest) = state.cache_lease_lru.pop_front() {
-                state.cache_leases.remove(&oldest);
-            } else {
-                break;
-            }
-        }
+        state.remember_cache_lease(model, prefix_hash, target);
+        true
     }
 
     pub(crate) fn forget_cache_lease(&self, model: &str, prefix_hash: u64) -> bool {
         let mut state = self.inner.lock().unwrap();
+        state.cache_lease_epoch = state.cache_lease_epoch.wrapping_add(1);
         let key = CacheLeaseKey {
             model: model.to_string(),
             prefix_hash,
@@ -263,6 +263,7 @@ impl AffinityRouter {
         target: &election::InferenceTarget,
     ) -> usize {
         let mut state = self.inner.lock().unwrap();
+        state.cache_lease_epoch = state.cache_lease_epoch.wrapping_add(1);
         let before = state.cache_leases.len();
         state
             .cache_leases
@@ -279,12 +280,20 @@ impl AffinityRouter {
 
 /// Compute the session-level key used to cache an auto-routed model choice.
 ///
-/// Prefers an explicit cache/session hint from the request body (e.g.
-/// OpenAI-style `prompt_cache_key` or `user` fields), then falls back to the same
-/// prefix/first-user-message hash sticky routing already uses. That way
-/// turn 2+ of a chat reliably maps to the same key.
+/// Prefers the OpenAI-style `prompt_cache_key`, then falls back to an explicit
+/// `user` or `session_id` hint. The cache key remains valid for model-choice
+/// memory without also becoming a sticky target-routing key.
 pub fn auto_model_session_key(parsed_body: Option<&Value>) -> Option<u64> {
-    routing_keys(parsed_body).sticky_hash
+    let routing = routing_keys(parsed_body);
+    if parsed_body.is_some_and(|body| {
+        body.get("prompt_cache_key")
+            .and_then(Value::as_str)
+            .is_some()
+    }) {
+        routing.prefix_hash
+    } else {
+        routing.sticky_hash
+    }
 }
 
 impl Default for AffinityRouter {
@@ -294,6 +303,37 @@ impl Default for AffinityRouter {
 }
 
 impl AffinityState {
+    fn remember_cache_lease(
+        &mut self,
+        model: &str,
+        prefix_hash: u64,
+        target: &election::InferenceTarget,
+    ) {
+        self.prune_cache_leases();
+        let key = CacheLeaseKey {
+            model: model.to_string(),
+            prefix_hash,
+        };
+        self.cache_leases.insert(
+            key.clone(),
+            CacheLeaseEntry {
+                target: target.clone(),
+                expires_at: Instant::now() + CACHE_LEASE_TTL,
+            },
+        );
+        if let Some(position) = self.cache_lease_lru.iter().position(|item| item == &key) {
+            self.cache_lease_lru.remove(position);
+        }
+        self.cache_lease_lru.push_back(key);
+        while self.cache_leases.len() > CACHE_LEASE_MAX_ENTRIES {
+            if let Some(oldest) = self.cache_lease_lru.pop_front() {
+                self.cache_leases.remove(&oldest);
+            } else {
+                break;
+            }
+        }
+    }
+
     fn prune_auto_expired(&mut self) {
         let now = Instant::now();
         while let Some(key) = self.auto_lru.front().copied() {
@@ -636,6 +676,20 @@ mod tests {
     }
 
     #[test]
+    fn cache_lease_invalidation_fences_a_stale_selection() {
+        let affinity = AffinityRouter::with_config(true, true);
+        let target = remote(1);
+        let selection_epoch = affinity.cache_lease_epoch();
+
+        assert!(!affinity.forget_cache_lease(TEST_MODEL, 7));
+        assert!(!affinity.remember_cache_lease_if_epoch(TEST_MODEL, 7, &target, selection_epoch));
+        assert_eq!(
+            affinity.lookup_cache_lease(TEST_MODEL, 7, std::slice::from_ref(&target)),
+            None
+        );
+    }
+
+    #[test]
     fn test_routing_keys_prefix_is_shared_across_first_users() {
         let req_a = parse_body(
             r#"{"tools":[{"type":"function","function":{"name":"run"}}],"messages":[{"role":"system","content":"You are an agent."},{"role":"user","content":"fix bug A"}]}"#,
@@ -931,6 +985,18 @@ mod tests {
         let key = auto_model_session_key(Some(&body)).expect("expected a session key");
         let sticky = routing_keys(Some(&body)).sticky_hash.unwrap();
         assert_eq!(key, sticky);
+    }
+
+    #[test]
+    fn prompt_cache_key_remains_an_auto_model_session_key() {
+        let body = parse_body(
+            r#"{"prompt_cache_key":"cache-1","messages":[{"role":"user","content":"hi"}]}"#,
+        );
+        let routing = routing_keys(Some(&body));
+
+        assert_eq!(auto_model_session_key(Some(&body)), routing.prefix_hash);
+        assert!(routing.prefix_hash.is_some());
+        assert_eq!(routing.sticky_hash, None);
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport.rs
@@ -604,11 +604,12 @@ async fn order_mesh_target_hosts(
         prepared.cache_target = match affinity.lookup_cache_lease(name, prefix_hash, &candidates) {
             Some(target) => Some(target),
             None => {
+                let lease_epoch = affinity.cache_lease_epoch();
                 let selected = node
                     .select_cache_target(name, prefix_hash, &candidates)
                     .await;
                 if let Some(target) = selected.as_ref() {
-                    affinity.remember_cache_lease(name, prefix_hash, target);
+                    affinity.remember_cache_lease_if_epoch(name, prefix_hash, target, lease_epoch);
                 }
                 selected
             }

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport_route_model.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport_route_model.rs
@@ -175,6 +175,7 @@ async fn route_model_request_inner(args: RouteModelRequestArgs<'_>) -> RouteDisp
             model,
             &target,
             &selection,
+            affinity,
             attempt_result,
             &mut state,
         ) {
@@ -257,6 +258,7 @@ fn handle_route_model_attempt_result(
     model: &str,
     target: &election::InferenceTarget,
     selection: &TargetSelection,
+    affinity: &AffinityRouter,
     attempt_result: RouteAttemptResult,
     state: &mut RouteModelState,
 ) -> RouteModelDisposition {
@@ -268,6 +270,7 @@ fn handle_route_model_attempt_result(
                     model,
                     target,
                     selection,
+                    affinity,
                     state,
                 },
                 status_code,
@@ -309,6 +312,7 @@ struct DeliveredRouteModelContext<'a> {
     model: &'a str,
     target: &'a election::InferenceTarget,
     selection: &'a TargetSelection,
+    affinity: &'a AffinityRouter,
     state: &'a RouteModelState,
 }
 
@@ -317,26 +321,7 @@ fn handle_delivered_route_model_attempt(
     status_code: u16,
     usage: Option<TokenUsage>,
 ) -> RouteModelDisposition {
-    if (200..400).contains(&status_code)
-        && let (Some(prefix_hash), election::InferenceTarget::Local(_), Some(usage)) = (
-            context.selection.prefix_hash,
-            context.target,
-            usage.as_ref(),
-        )
-        && let Some(cached_tokens) = usage.cached_prompt_tokens.filter(|count| *count > 0)
-    {
-        let suffix = usage
-            .prompt_tokens
-            .unwrap_or(cached_tokens)
-            .saturating_sub(cached_tokens);
-        context.node.record_local_cache_hit(
-            context.model,
-            prefix_hash,
-            u32::try_from(cached_tokens).unwrap_or(u32::MAX),
-            u32::try_from(suffix).unwrap_or(u32::MAX),
-            0,
-        );
-    }
+    update_local_cache_evidence(&context, status_code, usage.as_ref());
     context.node.record_routed_request(
         Some(context.model),
         context.state.attempts,
@@ -354,6 +339,53 @@ fn handle_delivered_route_model_attempt(
             RouteDispatchOutcome::RespondedWithUsage { status_code, usage }
         }),
     )
+}
+
+fn update_local_cache_evidence(
+    context: &DeliveredRouteModelContext<'_>,
+    status_code: u16,
+    usage: Option<&TokenUsage>,
+) {
+    if !(200..400).contains(&status_code) {
+        return;
+    }
+    let (Some(prefix_hash), election::InferenceTarget::Local(_), Some(cached_tokens)) = (
+        context.selection.prefix_hash,
+        context.target,
+        usage.and_then(|usage| usage.cached_prompt_tokens),
+    ) else {
+        return;
+    };
+    if cached_tokens > 0 {
+        let suffix = usage
+            .and_then(|usage| usage.prompt_tokens)
+            .unwrap_or(cached_tokens)
+            .saturating_sub(cached_tokens);
+        context.node.record_local_cache_hit(
+            context.model,
+            prefix_hash,
+            u32::try_from(cached_tokens).unwrap_or(u32::MAX),
+            u32::try_from(suffix).unwrap_or(u32::MAX),
+            0,
+        );
+        return;
+    }
+
+    let inventory_invalidated = context
+        .node
+        .invalidate_local_cache_evidence(context.model, prefix_hash);
+    let lease_invalidated = context
+        .affinity
+        .forget_cache_lease(context.model, prefix_hash);
+    if inventory_invalidated || lease_invalidated {
+        tracing::debug!(
+            model = context.model,
+            prefix_hash,
+            inventory_invalidated,
+            lease_invalidated,
+            "invalidated cache affinity after authoritative local miss"
+        );
+    }
 }
 
 fn handle_retryable_route_model_context(
@@ -435,4 +467,108 @@ fn record_route_model_attempt(
         attempt_outcome_for_result(attempt_result),
         completion_tokens_for_result(attempt_result),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn local_cache_context(
+        prefix_hash: u64,
+    ) -> (
+        mesh::Node,
+        AffinityRouter,
+        election::InferenceTarget,
+        TargetSelection,
+        RouteModelState,
+    ) {
+        let node = mesh::Node::new_for_tests(mesh::NodeRole::Host { http_port: 9337 })
+            .await
+            .expect("test node");
+        let affinity = AffinityRouter::with_config(true, true);
+        let target = election::InferenceTarget::Local(9337);
+        let selection = TargetSelection {
+            target: target.clone(),
+            prefix_hash: Some(prefix_hash),
+            cache_target: Some(target.clone()),
+        };
+        let state = RouteModelState {
+            route_started: Instant::now(),
+            attempts: 1,
+            refreshed: false,
+        };
+        (node, affinity, target, selection, state)
+    }
+
+    #[tokio::test]
+    async fn authoritative_local_miss_invalidates_inventory_and_lease() {
+        let prefix_hash = 0xfeed_beef;
+        let (node, affinity, target, selection, state) = local_cache_context(prefix_hash).await;
+        node.record_local_cache_hit("qwen", prefix_hash, 512, 24, 0);
+        affinity.remember_cache_lease("qwen", prefix_hash, &target);
+        let context = DeliveredRouteModelContext {
+            node: &node,
+            model: "qwen",
+            target: &target,
+            selection: &selection,
+            affinity: &affinity,
+            state: &state,
+        };
+
+        update_local_cache_evidence(
+            &context,
+            200,
+            Some(&TokenUsage {
+                prompt_tokens: Some(536),
+                cached_prompt_tokens: Some(0),
+                ..TokenUsage::default()
+            }),
+        );
+
+        assert_eq!(
+            node.select_cache_target("qwen", prefix_hash, std::slice::from_ref(&target))
+                .await,
+            None
+        );
+        assert_eq!(
+            affinity.lookup_cache_lease("qwen", prefix_hash, std::slice::from_ref(&target)),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn missing_cache_usage_does_not_refute_positive_evidence() {
+        let prefix_hash = 0xfeed_beef;
+        let (node, affinity, target, selection, state) = local_cache_context(prefix_hash).await;
+        node.record_local_cache_hit("qwen", prefix_hash, 512, 24, 0);
+        affinity.remember_cache_lease("qwen", prefix_hash, &target);
+        let context = DeliveredRouteModelContext {
+            node: &node,
+            model: "qwen",
+            target: &target,
+            selection: &selection,
+            affinity: &affinity,
+            state: &state,
+        };
+
+        update_local_cache_evidence(
+            &context,
+            200,
+            Some(&TokenUsage {
+                prompt_tokens: Some(536),
+                cached_prompt_tokens: None,
+                ..TokenUsage::default()
+            }),
+        );
+
+        assert_eq!(
+            node.select_cache_target("qwen", prefix_hash, std::slice::from_ref(&target))
+                .await,
+            Some(target.clone())
+        );
+        assert_eq!(
+            affinity.lookup_cache_lease("qwen", prefix_hash, std::slice::from_ref(&target)),
+            Some(target)
+        );
+    }
 }

--- a/crates/mesh-llm-host-runtime/src/network/openai/transport_route_model.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/transport_route_model.rs
@@ -70,11 +70,12 @@ async fn cache_target_for_request(
         return Some(target);
     }
 
+    let lease_epoch = affinity.cache_lease_epoch();
     let selected = node
         .select_cache_target(model, prefix_hash, candidates)
         .await;
     if let Some(target) = selected.as_ref() {
-        affinity.remember_cache_lease(model, prefix_hash, target);
+        affinity.remember_cache_lease_if_epoch(model, prefix_hash, target, lease_epoch);
     }
     selected
 }
@@ -349,31 +350,33 @@ fn update_local_cache_evidence(
     if !(200..400).contains(&status_code) {
         return;
     }
-    let (Some(prefix_hash), election::InferenceTarget::Local(_), Some(cached_tokens)) = (
+    let (Some(prefix_hash), Some(cached_tokens)) = (
         context.selection.prefix_hash,
-        context.target,
         usage.and_then(|usage| usage.cached_prompt_tokens),
     ) else {
         return;
     };
     if cached_tokens > 0 {
-        let suffix = usage
-            .and_then(|usage| usage.prompt_tokens)
-            .unwrap_or(cached_tokens)
-            .saturating_sub(cached_tokens);
-        context.node.record_local_cache_hit(
-            context.model,
-            prefix_hash,
-            u32::try_from(cached_tokens).unwrap_or(u32::MAX),
-            u32::try_from(suffix).unwrap_or(u32::MAX),
-            0,
-        );
+        if matches!(context.target, election::InferenceTarget::Local(_)) {
+            let suffix = usage
+                .and_then(|usage| usage.prompt_tokens)
+                .unwrap_or(cached_tokens)
+                .saturating_sub(cached_tokens);
+            context.node.record_local_cache_hit(
+                context.model,
+                prefix_hash,
+                u32::try_from(cached_tokens).unwrap_or(u32::MAX),
+                u32::try_from(suffix).unwrap_or(u32::MAX),
+                0,
+            );
+        }
         return;
     }
 
-    let inventory_invalidated = context
-        .node
-        .invalidate_local_cache_evidence(context.model, prefix_hash);
+    let inventory_invalidated = matches!(context.target, election::InferenceTarget::Local(_))
+        && context
+            .node
+            .invalidate_local_cache_evidence(context.model, prefix_hash);
     let lease_invalidated = context
         .affinity
         .forget_cache_lease(context.model, prefix_hash);
@@ -383,7 +386,7 @@ fn update_local_cache_evidence(
             prefix_hash,
             inventory_invalidated,
             lease_invalidated,
-            "invalidated cache affinity after authoritative local miss"
+            "invalidated cache affinity after authoritative miss"
         );
     }
 }
@@ -472,9 +475,11 @@ fn record_route_model_attempt(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use iroh::SecretKey;
 
-    async fn local_cache_context(
+    async fn cache_context(
         prefix_hash: u64,
+        target: election::InferenceTarget,
     ) -> (
         mesh::Node,
         AffinityRouter,
@@ -486,7 +491,6 @@ mod tests {
             .await
             .expect("test node");
         let affinity = AffinityRouter::with_config(true, true);
-        let target = election::InferenceTarget::Local(9337);
         let selection = TargetSelection {
             target: target.clone(),
             prefix_hash: Some(prefix_hash),
@@ -503,7 +507,8 @@ mod tests {
     #[tokio::test]
     async fn authoritative_local_miss_invalidates_inventory_and_lease() {
         let prefix_hash = 0xfeed_beef;
-        let (node, affinity, target, selection, state) = local_cache_context(prefix_hash).await;
+        let (node, affinity, target, selection, state) =
+            cache_context(prefix_hash, election::InferenceTarget::Local(9337)).await;
         node.record_local_cache_hit("qwen", prefix_hash, 512, 24, 0);
         affinity.remember_cache_lease("qwen", prefix_hash, &target);
         let context = DeliveredRouteModelContext {
@@ -537,9 +542,50 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn authoritative_remote_miss_invalidates_lease_but_not_local_inventory() {
+        let prefix_hash = 0xfeed_beef;
+        let mut bytes = [0u8; 32];
+        bytes[0] = 1;
+        let remote = election::InferenceTarget::Remote(SecretKey::from_bytes(&bytes).public());
+        let (node, affinity, target, selection, state) = cache_context(prefix_hash, remote).await;
+        let local = election::InferenceTarget::Local(9337);
+        node.record_local_cache_hit("qwen", prefix_hash, 512, 24, 0);
+        affinity.remember_cache_lease("qwen", prefix_hash, &target);
+        let context = DeliveredRouteModelContext {
+            node: &node,
+            model: "qwen",
+            target: &target,
+            selection: &selection,
+            affinity: &affinity,
+            state: &state,
+        };
+
+        update_local_cache_evidence(
+            &context,
+            200,
+            Some(&TokenUsage {
+                prompt_tokens: Some(536),
+                cached_prompt_tokens: Some(0),
+                ..TokenUsage::default()
+            }),
+        );
+
+        assert_eq!(
+            affinity.lookup_cache_lease("qwen", prefix_hash, std::slice::from_ref(&target)),
+            None
+        );
+        assert_eq!(
+            node.select_cache_target("qwen", prefix_hash, std::slice::from_ref(&local))
+                .await,
+            Some(local)
+        );
+    }
+
+    #[tokio::test]
     async fn missing_cache_usage_does_not_refute_positive_evidence() {
         let prefix_hash = 0xfeed_beef;
-        let (node, affinity, target, selection, state) = local_cache_context(prefix_hash).await;
+        let (node, affinity, target, selection, state) =
+            cache_context(prefix_hash, election::InferenceTarget::Local(9337)).await;
         node.record_local_cache_hit("qwen", prefix_hash, 512, 24, 0);
         affinity.remember_cache_lease("qwen", prefix_hash, &target);
         let context = DeliveredRouteModelContext {

--- a/crates/mesh-llm-routing/src/affinity.rs
+++ b/crates/mesh-llm-routing/src/affinity.rs
@@ -61,9 +61,9 @@ macro_rules! impl_affinity_stats_snapshot {
 /// Request-derived hashes used by prefix and sticky routing.
 #[derive(Clone, Debug, Default, PartialEq, Eq)]
 pub struct RoutingKeys {
-    /// Explicit cache/session hint hash, when one was supplied.
+    /// Explicit session hint hash, when one was supplied.
     pub session_hash: Option<u64>,
-    /// Stable prompt/tool scaffold hash, when one was found.
+    /// Explicit cache key or stable prompt/tool scaffold hash.
     pub prefix_hash: Option<u64>,
     /// Hash used for explicit deterministic session routing.
     pub sticky_hash: Option<u64>,
@@ -185,6 +185,7 @@ pub fn extract_session_hint_from_body(body: &Value, keys: &[&str]) -> Option<Str
 /// Compute request routing keys with consumer-selected compatibility policy.
 pub fn routing_keys(
     parsed_body: Option<&Value>,
+    cache_hint_keys: &[&str],
     session_hint_keys: &[&str],
     prefix_fallback_to_first_user: bool,
 ) -> RoutingKeys {
@@ -194,24 +195,14 @@ pub fn routing_keys(
 
     let session_hash = extract_session_hint_from_body(body, session_hint_keys)
         .map(|hint| hash_bytes(hint.as_bytes()));
+    let explicit_cache_hash = extract_session_hint_from_body(body, cache_hint_keys)
+        .map(|hint| hash_bytes(hint.as_bytes()));
     let scaffold_hash = scaffold_prefix_hash_from_body(body, prefix_fallback_to_first_user);
-    let first_user_hash = first_user_hash_from_body(body);
-    // Namespace evidence by an explicit session hint when present. Otherwise
-    // combine scaffold and first-user hashes so unrelated requests with the
-    // same tools cannot claim one another's cache receipt.
-    let prefix_hash = session_hash.or_else(|| {
-        let mut hash = 0u64;
-        let mut found = false;
-        if let Some(scaffold_hash) = scaffold_hash {
-            hash = hash_combine(hash, scaffold_hash);
-            found = true;
-        }
-        if let Some(user_hash) = first_user_hash {
-            hash = hash_combine(hash, user_hash);
-            found = true;
-        }
-        found.then_some(hash)
-    });
+    // Cache evidence follows the reusable prefix, not the conversation. An
+    // explicit cache key is the caller's stronger statement of reuse identity;
+    // otherwise the stable system/tool scaffold identifies work that can be
+    // shared across users and sessions. Session hints remain sticky-only.
+    let prefix_hash = explicit_cache_hash.or(scaffold_hash);
     // Cache locality must not become an implicit sticky policy. Without a
     // caller-provided session hint, stale or absent cache evidence falls back
     // to the normal load-aware target picker.
@@ -521,41 +512,78 @@ mod tests {
     }
 
     #[test]
-    fn routing_key_policies_preserve_host_and_client_differences() {
+    fn routing_key_policies_separate_cache_and_session_hints() {
         let body = parse_body(
             r#"{"prompt_cache_key":"cache","user":"user","messages":[{"role":"user","content":"hello"}]}"#,
         );
         let host = routing_keys(
             Some(&body),
-            &["prompt_cache_key", "user", "session_id"],
+            &["prompt_cache_key"],
+            &["user", "session_id"],
             true,
         );
-        let client = routing_keys(Some(&body), &["user", "session_id"], false);
-
-        assert_ne!(host.session_hash, client.session_hash);
-        assert_eq!(
-            host.session_hash,
-            Some(hash_bytes(b"cache")),
-            "host keeps prompt_cache_key compatibility"
+        let client = routing_keys(
+            Some(&body),
+            &["prompt_cache_key"],
+            &["user", "session_id"],
+            false,
         );
+
+        assert_eq!(host.prefix_hash, Some(hash_bytes(b"cache")));
+        assert_eq!(client.prefix_hash, host.prefix_hash);
+        assert_eq!(host.session_hash, Some(hash_bytes(b"user")));
         assert_eq!(client.session_hash, Some(hash_bytes(b"user")));
+        assert_eq!(host.sticky_hash, host.session_hash);
+        assert_ne!(host.prefix_hash, host.sticky_hash);
 
         let user_only = parse_body(r#"{"messages":[{"role":"user","content":"hello"}]}"#);
         assert!(
             routing_keys(
                 Some(&user_only),
-                &["prompt_cache_key", "user", "session_id"],
+                &["prompt_cache_key"],
+                &["user", "session_id"],
                 true,
             )
             .prefix_hash
             .is_some()
         );
         assert!(
-            routing_keys(Some(&user_only), &["user", "session_id"], false)
-                .prefix_hash
-                .is_some(),
-            "the cache namespace includes the first user turn even when the raw scaffold is empty"
+            routing_keys(
+                Some(&user_only),
+                &["prompt_cache_key"],
+                &["user", "session_id"],
+                false,
+            )
+            .prefix_hash
+            .is_none(),
+            "the client does not invent evidence when no reusable scaffold exists"
         );
+    }
+
+    #[test]
+    fn shared_scaffold_reuses_evidence_across_users_and_tasks() {
+        let first = parse_body(
+            r#"{"user":"session-a","tools":[{"type":"function","function":{"name":"run"}}],"messages":[{"role":"system","content":"agent"},{"role":"user","content":"task a"}]}"#,
+        );
+        let second = parse_body(
+            r#"{"user":"session-b","tools":[{"type":"function","function":{"name":"run"}}],"messages":[{"role":"system","content":"agent"},{"role":"user","content":"task b"}]}"#,
+        );
+        let first = routing_keys(
+            Some(&first),
+            &["prompt_cache_key"],
+            &["user", "session_id"],
+            true,
+        );
+        let second = routing_keys(
+            Some(&second),
+            &["prompt_cache_key"],
+            &["user", "session_id"],
+            true,
+        );
+
+        assert_eq!(first.prefix_hash, second.prefix_hash);
+        assert_ne!(first.session_hash, second.session_hash);
+        assert_ne!(first.sticky_hash, second.sticky_hash);
     }
 
     #[test]
@@ -569,7 +597,8 @@ mod tests {
         );
         let keys = routing_keys(
             Some(&body),
-            &["prompt_cache_key", "user", "session_id"],
+            &["prompt_cache_key"],
+            &["user", "session_id"],
             true,
         );
         let affinity = AffinityRouter::with_config(true, true);
@@ -600,7 +629,8 @@ mod tests {
         );
         let keys = routing_keys(
             Some(&body),
-            &["prompt_cache_key", "user", "session_id"],
+            &["prompt_cache_key"],
+            &["user", "session_id"],
             true,
         );
         let affinity = AffinityRouter::with_config(true, true);
@@ -626,12 +656,12 @@ mod tests {
         targets
             .targets
             .insert("qwen".to_string(), vec![first.clone(), second.clone()]);
-        let body = parse_body(
-            r#"{"prompt_cache_key":"session-a","messages":[{"role":"user","content":"task"}]}"#,
-        );
+        let body =
+            parse_body(r#"{"user":"session-a","messages":[{"role":"user","content":"task"}]}"#);
         let keys = routing_keys(
             Some(&body),
-            &["prompt_cache_key", "user", "session_id"],
+            &["prompt_cache_key"],
+            &["user", "session_id"],
             true,
         );
         let affinity = AffinityRouter::with_config(true, true);
@@ -656,7 +686,8 @@ mod tests {
         );
         let keys = routing_keys(
             Some(&body),
-            &["prompt_cache_key", "user", "session_id"],
+            &["prompt_cache_key"],
+            &["user", "session_id"],
             true,
         );
         let affinity = AffinityRouter::with_config(true, true);


### PR DESCRIPTION
Agent requests that share the same stable system/tool scaffold can now reuse cache-affinity evidence across different users and task prompts. Conversation stickiness remains keyed independently, so sharing warm-prefix evidence no longer collapses distinct sessions onto one sticky identity.

An authoritative successful local response reporting zero cached prompt tokens now removes both the advertised positive entry and the short routing lease immediately. Missing cache usage remains non-authoritative and does not destroy valid evidence.

## Migration note

**`prompt_cache_key` no longer drives session stickiness.** Before this PR, `prompt_cache_key` was the first entry in `session_hint_keys`, so it acted as both a cache-affinity key and a session-sticky routing hint. After this PR it is used only to derive the prefix hash; `user` and `session_id` are the sole session-stickiness keys. Operators or callers that relied on `prompt_cache_key` to pin a session to a specific node will silently lose that behavior — sessions will be routed to whichever node holds the warmest prefix for the key, which may differ across requests.

## Architecture

- separate explicit `prompt_cache_key` identity from `user` / `session_id` stickiness
- key implicit cache evidence by the stable system/developer/tool scaffold, falling back to the first user prompt only where the host compatibility policy already allows it
- honor explicit prompt cache keys consistently in host and embedded-client routing
- invalidate the model/prefix inventory entry and exact short lease after an authoritative local miss

## Protocol

No wire-format change. Existing salted cache-affinity advertisements remain compatible with mixed-version peers; only the local derivation and invalidation policy changes.

## Validation

- `cargo test -p mesh-llm-routing --lib` — 18 passed
- `cargo test -p mesh-llm-client --lib` — 92 passed
- `cargo test -p mesh-llm-host-runtime --lib -- --quiet` — 2,902 passed, 8 ignored
- `cargo check -p mesh-llm-routing`
- `cargo check -p mesh-llm-client`
- `cargo check -p mesh-llm-host-runtime`
- `cargo check -p mesh-llm`
- warning-denying Clippy passed for routing and client
- host-runtime and shipped-binary Clippy pass after allowing the pre-existing `unfulfilled_lint_expectations` warnings; the strict command fails on those untouched baseline expectations
- `cargo fmt --all --check`

PR #1578 remains the independent exact-commit Agentic Replay benchmark foundation and will be run over this stack after the cache-specific workload assertions are added.

Originating Buzz channel: `10b70ee2-a3fa-41e2-a87f-b5b53792a7c1`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved prompt-cache routing so requests with the same cache key can share cached prefixes across different users.
  * Kept session-based routing separate from prompt-cache routing for more predictable session affinity.
  * Improved cache lease handling to prevent stale routing decisions after cache invalidation.
  * Updated local and remote cache evidence handling to preserve accurate local cache state.
* **Tests**
  * Added coverage for cache invalidation, concurrent routing changes, and cross-user prompt-cache reuse.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->