### PR TITLE
chore(build): clean warning and deprecation noise

### DIFF
--- a/.github/actions/restore-smoke-inputs/action.yml
+++ b/.github/actions/restore-smoke-inputs/action.yml
@@ -40,7 +40,7 @@ runs:
   using: composite
   steps:
     - name: Download built mesh-llm artifact
-      uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.artifact_name }}
         path: ${{ inputs.artifact_path }}

--- a/.github/workflows/ci-linux-host-slice.yml
+++ b/.github/workflows/ci-linux-host-slice.yml
@@ -132,7 +132,7 @@ jobs:
           allow_depot_remote_cache: ${{ needs.runner_policy.outputs.allow_depot_remote_cache }}
           allow_native_github_cache: ${{ needs.runner_policy.outputs.allow_native_github_cache }}
       - name: Download immutable UI distribution
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.ui_artifact_name }}
           path: crates/mesh-llm-ui/dist

--- a/.github/workflows/ci-linux-product-slice.yml
+++ b/.github/workflows/ci-linux-product-slice.yml
@@ -99,11 +99,11 @@ jobs:
           persist-credentials: false
       - name: Verify product composition environment
         run: verify-runner-image public cpu
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ci-host-linux-${{ matrix.runtime.architecture }}
           path: host-input
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ci-runtime-linux-${{ matrix.runtime.architecture }}-${{ matrix.runtime.backend }}
           path: runtime-input

--- a/.github/workflows/ci-macos-host-slice.yml
+++ b/.github/workflows/ci-macos-host-slice.yml
@@ -106,7 +106,7 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
       - if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true
         with:
           workspaces: . -> target
@@ -117,7 +117,7 @@ jobs:
       - name: Install host linker
         uses: ./.github/actions/setup-macos-lld
       - name: Download immutable UI distribution
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.ui_artifact_name }}
           path: crates/mesh-llm-ui/dist

--- a/.github/workflows/ci-macos-product-slice.yml
+++ b/.github/workflows/ci-macos-product-slice.yml
@@ -90,11 +90,11 @@ jobs:
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ci-host-macos-${{ matrix.runtime.architecture }}
           path: host-input
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ci-runtime-macos-${{ matrix.runtime.architecture }}-${{ matrix.runtime.backend }}
           path: runtime-input

--- a/.github/workflows/ci-platform-checks-slice.yml
+++ b/.github/workflows/ci-platform-checks-slice.yml
@@ -119,7 +119,7 @@ jobs:
         if: ${{ matrix.check.platform == 'windows' }}
         with:
           python-version: "3.x"
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
         if: ${{ matrix.check.platform == 'windows' }}
       - uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         if: ${{ matrix.check.platform == 'windows' }}

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -143,7 +143,7 @@ jobs:
         if: ${{ contains(toJson(matrix.batch.crates), 'skippy-quantize') || contains(toJson(matrix.batch.crates), 'skippy-runtime') || contains(toJson(matrix.batch.crates), 'skippy-model-package') || contains(toJson(matrix.batch.crates), 'skippy-ffi') }}
         run: scripts/prepare-llama.sh pinned
       - name: Download immutable static ABI input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.static_abi_artifact_name }}
           path: ${{ runner.temp }}/static-abi-input

--- a/.github/workflows/ci-windows-host-slice.yml
+++ b/.github/workflows/ci-windows-host-slice.yml
@@ -111,13 +111,13 @@ jobs:
         with:
           python-version: "3.x"
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_depot_remote_cache: ${{ needs.runner_policy.outputs.allow_depot_remote_cache }}
           allow_native_github_cache: ${{ needs.runner_policy.outputs.allow_native_github_cache }}
       - if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true
         with:
           workspaces: . -> target
@@ -129,7 +129,7 @@ jobs:
         with:
           arch: x64
       - name: Download immutable UI distribution
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.ui_artifact_name }}
           path: crates/mesh-llm-ui/dist

--- a/.github/workflows/ci-windows-product-slice.yml
+++ b/.github/workflows/ci-windows-product-slice.yml
@@ -90,11 +90,11 @@ jobs:
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ci-host-windows-${{ matrix.runtime.architecture }}
           path: host-input
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ci-runtime-windows-${{ matrix.runtime.architecture }}-${{ matrix.runtime.backend }}
           path: runtime-input

--- a/.github/workflows/ci-windows-runtime-slice.yml
+++ b/.github/workflows/ci-windows-runtime-slice.yml
@@ -115,7 +115,7 @@ jobs:
         with:
           python-version: "3.x"
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_depot_remote_cache: ${{ needs.runner_policy.outputs.allow_depot_remote_cache }}

--- a/.github/workflows/depot-registry-canary.yml
+++ b/.github/workflows/depot-registry-canary.yml
@@ -147,7 +147,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Download pull observations
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: depot-registry-pull-*
           path: registry-pull-observations

--- a/.github/workflows/hf-download-smoke.yml
+++ b/.github/workflows/hf-download-smoke.yml
@@ -63,11 +63,11 @@ jobs:
           [target.x86_64-unknown-linux-gnu]
           rustflags = ["-C", "link-arg=-fuse-ld=lld"]
           EOF
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_native_github_cache: "true"
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: . -> target
           cache-bin: "false"

--- a/.github/workflows/native-sdk-artifact.yml
+++ b/.github/workflows/native-sdk-artifact.yml
@@ -268,7 +268,7 @@ jobs:
 
       - name: Download immutable static ABI input
         if: ${{ inputs.static_abi_artifact_name != '' }}
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.static_abi_artifact_name }}
           path: ${{ inputs.static_abi_artifact_path }}
@@ -349,7 +349,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
 
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
       - uses: ./.github/actions/configure-sccache-gha
         with:

--- a/.github/workflows/node-sdk-addon-artifact.yml
+++ b/.github/workflows/node-sdk-addon-artifact.yml
@@ -188,7 +188,7 @@ jobs:
           node-version: 24
           package-manager-cache: false
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_depot_remote_cache: "false"
@@ -298,7 +298,7 @@ jobs:
           node-version: 24
           package-manager-cache: false
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_depot_remote_cache: "false"

--- a/.github/workflows/pr_cleanup.yml
+++ b/.github/workflows/pr_cleanup.yml
@@ -191,7 +191,7 @@ jobs:
       # Deletes remain serial inside each worker so every host keeps the same
       # rate-limited request shape as the previous single-runner cleanup.
       - name: Download cache deletion plan
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: pr-cache-cleanup-plan-${{ github.event.inputs.pr_number || github.event.pull_request.number }}
           path: cache-cleanup-plan
@@ -608,7 +608,7 @@ jobs:
       actions: read
     steps:
       - name: Download cache deletion results
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         continue-on-error: true
         with:
           pattern: pr-cache-cleanup-result-${{ github.event.inputs.pr_number || github.event.pull_request.number }}-*

--- a/.github/workflows/queue-unsloth-layer-packages.yml
+++ b/.github/workflows/queue-unsloth-layer-packages.yml
@@ -69,7 +69,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
 
-      - uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+      - uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         with:
           workspaces: . -> target
           prefix-key: mesh-llm-rust-${{ hashFiles('.github/cache-version.txt') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -235,7 +235,7 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
 
@@ -251,7 +251,7 @@ jobs:
 
       - uses: taiki-e/install-action@3d23c1bbdafe696dfccad2664945a04f47d03dc3 # just
 
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_depot_remote_cache: ${{ needs.metadata.outputs.allow_depot_remote_cache }}
@@ -330,12 +330,12 @@ jobs:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
       - name: Download immutable host input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: host-input-${{ matrix.host_target }}
           path: host-input
       - name: Download immutable runtime input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.runtime_artifact }}
           path: runtime-input
@@ -501,7 +501,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
 
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_depot_remote_cache: ${{ needs.metadata.outputs.allow_depot_remote_cache }}
@@ -834,7 +834,7 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
@@ -886,11 +886,11 @@ jobs:
         with:
           persist-credentials: false
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: host-input-linux-aarch64
           path: host-input
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-native-runtime-linux-aarch64-cpu
           path: runtime-input
@@ -941,7 +941,7 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-linux-arm64
           path: release-linux-arm64
@@ -1001,12 +1001,12 @@ jobs:
       - name: Verify prebuilt backend environment
         run: verify-runner-image public cuda
       - name: Download immutable host input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: host-input-linux-aarch64
           path: host-input
       - name: Download immutable runtime input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-native-runtime-linux-aarch64-cuda-${{ matrix.cuda_version == '12.9.2' && '12' || '13' }}
           path: runtime-input
@@ -1085,12 +1085,12 @@ jobs:
       - name: Verify prebuilt backend environment
         run: verify-runner-image public cuda
       - name: Download immutable host input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: host-input-linux-x86_64
           path: host-input
       - name: Download immutable runtime input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-native-runtime-linux-x86_64-cuda-${{ matrix.cuda_major }}
           path: runtime-input
@@ -1158,12 +1158,12 @@ jobs:
       - name: Verify prebuilt backend environment
         run: verify-runner-image public rocm
       - name: Download immutable host input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: host-input-linux-x86_64
           path: host-input
       - name: Download immutable runtime input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-native-runtime-linux-x86_64-rocm
           path: runtime-input
@@ -1229,12 +1229,12 @@ jobs:
       - name: Verify prebuilt backend environment
         run: verify-runner-image public vulkan
       - name: Download immutable host input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: host-input-linux-x86_64
           path: host-input
       - name: Download immutable runtime input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-native-runtime-linux-x86_64-vulkan
           path: runtime-input
@@ -1292,7 +1292,7 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
       - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
@@ -1306,7 +1306,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.x'
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Prepare dispatched release version
         if: github.event_name == 'workflow_dispatch'
         shell: bash
@@ -1364,12 +1364,12 @@ jobs:
         with:
           python-version: '3.x'
       - name: Download immutable host input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: host-input-windows-x86_64
           path: host-input
       - name: Download immutable runtime input
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ matrix.runtime_artifact }}
           path: runtime-input
@@ -1418,11 +1418,11 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.x'
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: host-input-windows-x86_64
           path: host-input
-      - uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: release-native-runtime-windows-x86_64-cpu
           path: runtime-input
@@ -1476,7 +1476,7 @@ jobs:
         with:
           python-version: '3.x'
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Resolve Windows native toolchain epoch
         id: native_toolchain
         uses: ./.github/actions/resolve-native-toolchain-epoch
@@ -1553,7 +1553,7 @@ jobs:
         with:
           python-version: '3.x'
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Resolve Windows native toolchain epoch
         id: native_toolchain
         uses: ./.github/actions/resolve-native-toolchain-epoch
@@ -1691,7 +1691,7 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         if: github.event_name == 'workflow_dispatch'
         with:
           version: 10
@@ -1709,7 +1709,7 @@ jobs:
         if: github.event_name == 'workflow_dispatch'
 
       - name: Download release artifacts
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           path: release-artifacts
           pattern: release-*
@@ -1758,14 +1758,14 @@ jobs:
 
       - name: Download generated SwiftPM manifest
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: swift-package-manifest
           path: generated-swift-manifest
 
       - name: Download generated Swift binding
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: generated-swift-binding-release-swift-sdk
           path: generated-swift-binding

--- a/.github/workflows/sdk-smoke.yml
+++ b/.github/workflows/sdk-smoke.yml
@@ -126,7 +126,7 @@ jobs:
           persist-credentials: false
 
       - name: Download immutable UI distribution
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.ui_artifact_name }}
           path: crates/mesh-llm-ui/dist
@@ -169,14 +169,14 @@ jobs:
 
       - name: Download immutable Swift SDK input
         if: ${{ inputs.sdk_kind == 'swift' }}
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.swift_artifact_name }}
           path: ${{ inputs.swift_artifact_path }}
 
       - name: Download immutable generated Swift binding
         if: ${{ inputs.sdk_kind == 'swift' }}
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: generated-swift-binding-${{ inputs.swift_artifact_name }}
           path: sdk-artifacts/swift-generated-binding
@@ -215,7 +215,7 @@ jobs:
 
       - name: Download immutable Kotlin native SDK input
         if: ${{ inputs.sdk_kind == 'kotlin' }}
-        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: ${{ inputs.kotlin_artifact_name }}
           path: ${{ inputs.kotlin_artifact_path }}
@@ -235,7 +235,7 @@ jobs:
           distribution: temurin
           java-version: '21'
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         # Only the uncontained swift row (macos-15) needs this; rust/kotlin
         # get pnpm from the image.
         if: job.container.id == ''
@@ -253,7 +253,7 @@ jobs:
         if: ${{ inputs.sdk_kind == 'rust' }}
 
       - if: ${{ inputs.sdk_kind == 'rust' }}
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true
         with:
           workspaces: . -> target

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -146,7 +146,7 @@ jobs:
             exit 1
           fi
 
-      - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4.3.0
+      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
         with:
           version: 10
 
@@ -161,7 +161,7 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@4cda84d5c5c54efe2404f9d843567869ab1699d4 # stable 2026-07-16
 
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
 
       - uses: ./.github/actions/configure-sccache-gha
         with:
@@ -180,7 +180,7 @@ jobs:
           include_tool_versions: "true"
 
       - if: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
-        uses: Swatinem/rust-cache@e18b497796c12c097a38f9edb9d0641fb99eee32 # v2 snapshot 2026-03-12
+        uses: Swatinem/rust-cache@6323deb102c322ba6fcbdcafc7e3dddab59af2b6 # v2.9.2
         continue-on-error: true
         with:
           workspaces: . -> target

--- a/.github/workflows/windows-warm-caches.yml
+++ b/.github/workflows/windows-warm-caches.yml
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.x'
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Resolve Windows native toolchain epoch
         id: native_toolchain
         uses: ./.github/actions/resolve-native-toolchain-epoch
@@ -150,7 +150,7 @@ jobs:
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
           python-version: '3.x'
-      - uses: mozilla-actions/sccache-action@7d986dd989559c6ecdb630a3fd2557667be217ad # v0.0.9
+      - uses: mozilla-actions/sccache-action@fc920bf0ec8de6ee65d409111f7ec508035751ba # v0.0.11
       - name: Resolve Windows native toolchain epoch
         id: native_toolchain
         uses: ./.github/actions/resolve-native-toolchain-epoch

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3824,7 +3824,7 @@ dependencies = [
  "rpassword",
  "serde",
  "serde_json",
- "serde_yaml",
+ "serde_yaml_ng",
  "serial_test",
  "strum",
  "tempfile",
@@ -7190,10 +7190,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_yaml_ng"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "7b4db627b98b36d4203a7b458cf3573730f2bb591b28871d916dfa9efabfd41f"
 dependencies = [
  "indexmap",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -92,12 +92,9 @@ cognitive_complexity = "warn"
 too_many_lines = "warn"
 
 # Do not remove this section: direct GGUF debug startup spends most of its time
-# hashing the source model via sha2/sha2-asm before native skippy model open,
-# so keep those crates near release speed in dev builds.
+# hashing the source model via sha2 before native skippy model open, so keep
+# that crate near release speed in dev builds.
 [profile.dev.package.sha2]
-opt-level = 3
-
-[profile.dev.package.sha2-asm]
 opt-level = 3
 
 # Tightened release profile for shipped binaries.

--- a/crates/mesh-llm-commands/Cargo.toml
+++ b/crates/mesh-llm-commands/Cargo.toml
@@ -42,7 +42,7 @@ reqwest = { version = "0.12", features = ["blocking", "json"] }
 serde.workspace = true
 serde_json.workspace = true
 strum = { workspace = true }
-serde_yaml = "0.9"
+serde_yaml = { package = "serde_yaml_ng", version = "0.10" }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 toml = "0.9"

--- a/crates/mesh-llm-config/src/model.rs
+++ b/crates/mesh-llm-config/src/model.rs
@@ -1398,8 +1398,8 @@ pub struct LoggingConfig {
     #[serde(default)]
     pub webhook: LoggingWebhookConfig,
 
-    /// Security audit stream configuration. Nested under [logging] so the
-    /// logging master switch (logging.enabled) gates the audit stream too.
+    /// Security audit stream configuration. Nested under `[logging]` so the
+    /// logging master switch (`logging.enabled`) gates the audit stream too.
     #[serde(default)]
     pub audit: AuditConfig,
 }

--- a/crates/mesh-llm-events/src/logging/events.rs
+++ b/crates/mesh-llm-events/src/logging/events.rs
@@ -52,7 +52,7 @@ impl TokenUsage {
     }
 }
 
-/// Lifecycle event payloads carried inside [`CanonicalEnvelope`].
+/// Lifecycle event payloads carried inside `CanonicalEnvelope`.
 ///
 /// Bounded metadata only — never raw request/response payloads or secrets.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]

--- a/crates/mesh-llm-gpu-bench/native/hip/membench-fingerprint.hip
+++ b/crates/mesh-llm-gpu-bench/native/hip/membench-fingerprint.hip
@@ -281,11 +281,11 @@ int main(int argc, char** argv) {
             if (dev < deviceCount - 1) printf("\n");
         }
 
-        hipFree(dSrc);
-        hipFree(dSink);
-        hipFree(dComputeSink);
-        hipEventDestroy(evStart);
-        hipEventDestroy(evStop);
+        check(hipFree(dSrc), "hipFree src");
+        check(hipFree(dSink), "hipFree sink");
+        check(hipFree(dComputeSink), "hipFree compute sink");
+        check(hipEventDestroy(evStart), "hipEventDestroy start");
+        check(hipEventDestroy(evStop), "hipEventDestroy stop");
     }
 
     return 0;

--- a/crates/mesh-llm-host-runtime/src/lib.rs
+++ b/crates/mesh-llm-host-runtime/src/lib.rs
@@ -1,4 +1,8 @@
 #![recursion_limit = "256"]
+#![allow(
+    unfulfilled_lint_expectations,
+    reason = "workspace feature unification can make compatibility helpers live"
+)]
 
 mod api;
 mod capture;

--- a/crates/mesh-mixture-of-agents/src/arbiter.rs
+++ b/crates/mesh-mixture-of-agents/src/arbiter.rs
@@ -4,7 +4,7 @@
 //! Models are only called (via the reducer) when there's genuine ambiguity.
 //!
 //! This arbiter handles the text path only. Tool-bearing turns take the
-//! asymmetric actor path in [`crate::tool_turn`], where the best tool-caller
+//! asymmetric actor path in `crate::tool_turn`, where the best tool-caller
 //! acts and references only advise — so no tool proposal ever reaches here.
 //! Any tool-shaped text on the text path was demoted to `Uncertainty` by
 //! `enforce_tool_call_contract` (tools disabled ⇒ empty allow-list).

--- a/crates/mesh-mixture-of-agents/src/context.rs
+++ b/crates/mesh-mixture-of-agents/src/context.rs
@@ -373,7 +373,7 @@ analysis: what the request is really asking, and what you would do. Be concise."
 ///   the tests" role-plays the actor instead of advising it;
 /// * the tool-call transcript — it anchors every advisor on the trajectory
 ///   already taken, collapsing the error-independence aggregation depends on;
-/// * any instruction to emit a tool call (see [`REFERENCE_PREAMBLE`]).
+/// * any instruction to emit a tool call (see `REFERENCE_PREAMBLE`).
 ///
 /// The view is uniform across advisors (no per-role trimming) and is a stable
 /// function of the history, so it caches across iterations.

--- a/crates/mesh-mixture-of-agents/src/lib.rs
+++ b/crates/mesh-mixture-of-agents/src/lib.rs
@@ -27,8 +27,8 @@
 //! Modules:
 //! - [`backend`] — `ModelBackend` trait, `HttpBackend`, `SamplingParams`,
 //!   `ModelEntry`
-//! - [`reducer`] — reducer candidate ordering, hedged ladder
-//! - [`fanout`] — incremental worker gathering with early-exit
+//! - `reducer` — reducer candidate ordering, hedged ladder
+//! - `fanout` — incremental worker gathering with early-exit
 //! - [`arbiter`] — deterministic arbitration + early-exit consensus
 //! - [`normalize`] — 3-tier dirty-output parsing
 //! - [`session`] — canonical transcript + turn classification

--- a/crates/mesh-mixture-of-agents/src/normalize.rs
+++ b/crates/mesh-mixture-of-agents/src/normalize.rs
@@ -465,7 +465,7 @@ fn extract_json_object(text: &str) -> Option<String> {
     None
 }
 
-/// Clean passthrough content for display: strip think tags, orphan </think>,
+/// Clean passthrough content for display: strip think tags, orphan `</think>`,
 /// and any KV envelope lines (kind:/confidence:/payload:) that leaked.
 pub fn strip_passthrough_content(text: &str) -> String {
     let stripped = strip_thinking_tags(text);

--- a/crates/skippy-cache/src/config.rs
+++ b/crates/skippy-cache/src/config.rs
@@ -20,7 +20,7 @@ pub struct ResidentCacheConfig {
     /// Set this to a fraction of the model's `n_ctx`. A value of 0 disables
     /// the cap and behaves like the legacy unbounded-by-tokens cache. The cap is
     /// only useful when `n_ctx` is comfortably larger than
-    /// `min_tokens`; see [`derive_max_resident_tokens`] for the floor.
+    /// `min_tokens`; see `derive_max_resident_tokens` for the floor.
     pub max_resident_tokens: u64,
 }
 

--- a/crates/skippy-ffi/build.rs
+++ b/crates/skippy-ffi/build.rs
@@ -323,8 +323,8 @@ fn ensure_static_native_ready(
         );
     }
 
-    println!(
-        "cargo:warning=building patched llama.cpp ABI for mesh-llm SDK ({backend}) at {}",
+    eprintln!(
+        "building patched llama.cpp ABI for mesh-llm SDK ({backend}) at {}",
         build_dir.display()
     );
     run_native_script(

--- a/crates/skippy-server/src/frontend/generation/cache_hints.rs
+++ b/crates/skippy-server/src/frontend/generation/cache_hints.rs
@@ -31,7 +31,7 @@ pub const CONTEXT_BUDGET_MAX_TOKENS: u32 = u32::MAX;
 ///
 /// When the configured context window is smaller than this value, the
 /// request is silently clamped to whatever remaining budget exists
-/// rather than rejected — see [`GenerationTokenLimit::resolve`].
+/// rather than rejected — see `GenerationTokenLimit::resolve`.
 pub const DEFAULT_EMBEDDED_MAX_TOKENS: u32 = 4096;
 pub(in crate::frontend) const GENERATION_TOKEN_BUDGET_TIMEOUT: Duration = Duration::from_secs(10);
 pub(in crate::frontend) const GENERATION_RETRY_AFTER_SECS: u64 = 1;

--- a/scripts/generate-skippy-api-doc.py
+++ b/scripts/generate-skippy-api-doc.py
@@ -74,7 +74,9 @@ def parse_header(path: Path) -> Header:
         raise ValueError(f"missing @brief for {path}")
 
     functions: list[Function] = []
-    function_pattern = re.compile(r"LLAMA_API\s+.*?;", re.DOTALL)
+    function_pattern = re.compile(
+        r"(?:LLAMA_API|SKIPPY_COMMON_API)\s+.*?;", re.DOTALL
+    )
     for match in function_pattern.finditer(text):
         declaration = normalize_declaration(match.group(0))
         name_match = re.search(r"\b(skippy_[a-zA-Z0-9_]+)\s*\(", declaration)

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -1210,7 +1210,7 @@ class CiArtifactActionTests(unittest.TestCase):
         )
         self.assertIn(
             "actions/download-artifact@"
-            "37930b1c2abaa49bbe596cd826c3c89aef350131",
+            "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
             consumer_workflow,
         )
         self.assertIn(
@@ -1745,7 +1745,7 @@ class CiArtifactActionTests(unittest.TestCase):
         )
         self.assertIn(
             "actions/download-artifact@"
-            "37930b1c2abaa49bbe596cd826c3c89aef350131",
+            "3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c",
             consumer_workflow,
         )
         self.assertIn("persist-credentials: false", consumer_workflow)

--- a/scripts/tests/test_depot_registry_canary_workflow.py
+++ b/scripts/tests/test_depot_registry_canary_workflow.py
@@ -40,7 +40,7 @@ class DepotRegistryCanaryWorkflowTests(unittest.TestCase):
 
     def test_canary_uses_pinned_artifact_actions(self) -> None:
         self.assertIn("actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f", self.workflow)
-        self.assertIn("actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131", self.workflow)
+        self.assertIn("actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c", self.workflow)
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_generate_skippy_api_doc.py
+++ b/scripts/tests/test_generate_skippy_api_doc.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import importlib.util
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts" / "generate-skippy-api-doc.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("generate_skippy_api_doc", SCRIPT)
+    module = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class GenerateSkippyApiDocTests(unittest.TestCase):
+    def test_parses_exports_from_llama_and_common_libraries(self) -> None:
+        generator = load_module()
+        with tempfile.TemporaryDirectory(prefix="mesh-skippy-api-doc-") as temp_dir:
+            header_path = Path(temp_dir) / "sample.h"
+            header_path.write_text(
+                """/**
+ * @file sample.h
+ * @brief Test exports from both native libraries.
+ */
+
+/** @brief Exported by llama. */
+LLAMA_API int skippy_llama_export(void);
+
+/** @brief Exported by llama-common. */
+SKIPPY_COMMON_API int skippy_common_export(void);
+""",
+                encoding="utf-8",
+            )
+
+            header = generator.parse_header(header_path)
+
+        self.assertEqual(
+            [function.name for function in header.functions],
+            ["skippy_llama_export", "skippy_common_export"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_sccache_evidence.py
+++ b/scripts/tests/test_sccache_evidence.py
@@ -437,7 +437,7 @@ class SccacheEvidenceTests(unittest.TestCase):
 
         self.assertIn(
             "uses: Swatinem/rust-cache@"
-            "e18b497796c12c097a38f9edb9d0641fb99eee32",
+            "6323deb102c322ba6fcbdcafc7e3dddab59af2b6",
             swift,
         )
         self.assertIn("shared-key: swift-sdk", swift)

--- a/third_party/llama.cpp/patches/0052-build-skippy-fix-exported-declaration-warnings.patch
+++ b/third_party/llama.cpp/patches/0052-build-skippy-fix-exported-declaration-warnings.patch
@@ -1,0 +1,197 @@
+From c7dac9e0e74b2c856b54317fced6bb3a5cc9a4aa Mon Sep 17 00:00:00 2001
+From: scama
+ <a1860575018c4680d5669dd7bc3bd356b478bccb8d42e194df46304a5e25f49a@meshllm.communities.buzz.xyz>
+Date: Thu, 3 Sep 2026 08:48:28 +1000
+Subject: [PATCH] build(skippy): fix exported declaration warnings
+
+---
+ common/CMakeLists.txt                 |  1 +
+ common/ngram-cache.cpp                | 10 +++++-----
+ common/stage-chat.cpp                 |  4 ++--
+ include/skippy/common.h               | 12 ++++++++++++
+ include/skippy/speculative_decoding.h | 10 +++++-----
+ include/skippy/tokenization.h         |  4 ++--
+ src/skippy/tokenization.cpp           |  2 ++
+ 7 files changed, 29 insertions(+), 14 deletions(-)
+
+diff --git a/common/CMakeLists.txt b/common/CMakeLists.txt
+index 9757ba821..6d139e7bb 100644
+--- a/common/CMakeLists.txt
++++ b/common/CMakeLists.txt
+@@ -139,6 +139,7 @@ endif()
+ 
+ if (BUILD_SHARED_LIBS)
+     set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
++    target_compile_definitions(${TARGET} PRIVATE SKIPPY_COMMON_BUILD)
+ 
+     # TODO: make fine-grained exports in the future
+     set_target_properties(${TARGET} PROPERTIES WINDOWS_EXPORT_ALL_SYMBOLS ON)
+diff --git a/common/ngram-cache.cpp b/common/ngram-cache.cpp
+index ae4f910f7..bc3ab811b 100644
+--- a/common/ngram-cache.cpp
++++ b/common/ngram-cache.cpp
+@@ -72,7 +72,7 @@ static enum skippy_status skippy_ngram_cache_update(
+     return SKIPPY_STATUS_OK;
+ }
+ 
+-extern "C" enum skippy_status skippy_ngram_cache_create(
++extern "C" SKIPPY_COMMON_API enum skippy_status skippy_ngram_cache_create(
+         uint16_t ngram_min,
+         uint16_t ngram_max,
+         struct skippy_ngram_cache ** out_cache,
+@@ -84,11 +84,11 @@ extern "C" enum skippy_status skippy_ngram_cache_create(
+     return SKIPPY_STATUS_OK;
+ }
+ 
+-extern "C" void skippy_ngram_cache_free(struct skippy_ngram_cache * cache) {
++extern "C" SKIPPY_COMMON_API void skippy_ngram_cache_free(struct skippy_ngram_cache * cache) {
+     delete cache;
+ }
+ 
+-extern "C" enum skippy_status skippy_ngram_cache_reset(
++extern "C" SKIPPY_COMMON_API enum skippy_status skippy_ngram_cache_reset(
+         struct skippy_ngram_cache * cache,
+         const llama_token * token_ids,
+         size_t token_count,
+@@ -96,7 +96,7 @@ extern "C" enum skippy_status skippy_ngram_cache_reset(
+     return skippy_ngram_cache_update(cache, token_ids, token_count, true);
+ }
+ 
+-extern "C" enum skippy_status skippy_ngram_cache_append(
++extern "C" SKIPPY_COMMON_API enum skippy_status skippy_ngram_cache_append(
+         struct skippy_ngram_cache * cache,
+         const llama_token * token_ids,
+         size_t token_count,
+@@ -104,7 +104,7 @@ extern "C" enum skippy_status skippy_ngram_cache_append(
+     return skippy_ngram_cache_update(cache, token_ids, token_count, false);
+ }
+ 
+-extern "C" enum skippy_status skippy_ngram_cache_draft(
++extern "C" SKIPPY_COMMON_API enum skippy_status skippy_ngram_cache_draft(
+         struct skippy_ngram_cache * cache,
+         const llama_token * continuation_prefix,
+         size_t continuation_prefix_count,
+diff --git a/common/stage-chat.cpp b/common/stage-chat.cpp
+index b3f2ef4c9..180c0a884 100644
+--- a/common/stage-chat.cpp
++++ b/common/stage-chat.cpp
+@@ -164,7 +164,7 @@ static json skippy_common_chat_metadata_json(
+     };
+ }
+ 
+-enum skippy_status skippy_apply_chat_template_json(
++extern "C" SKIPPY_COMMON_API enum skippy_status skippy_apply_chat_template_json(
+         struct skippy_model * model,
+         const char * messages_json,
+         const char * tools_json,
+@@ -305,7 +305,7 @@ enum skippy_status skippy_apply_chat_template_json(
+     return skippy_common_success(out_error);
+ }
+ 
+-enum skippy_status skippy_parse_chat_response_json(
++extern "C" SKIPPY_COMMON_API enum skippy_status skippy_parse_chat_response_json(
+         const char * generated_text,
+         const char * metadata_json,
+         bool is_partial,
+diff --git a/include/skippy/common.h b/include/skippy/common.h
+index 68a1dee71..389f02f47 100644
+--- a/include/skippy/common.h
++++ b/include/skippy/common.h
+@@ -15,6 +15,18 @@
+ #include "stddef.h"
+ #include "stdint.h"
+ 
++#if defined(LLAMA_SHARED) && defined(_WIN32) && !defined(__MINGW32__)
++#    ifdef SKIPPY_COMMON_BUILD
++#        define SKIPPY_COMMON_API __declspec(dllexport)
++#    else
++#        define SKIPPY_COMMON_API __declspec(dllimport)
++#    endif
++#elif defined(LLAMA_SHARED)
++#    define SKIPPY_COMMON_API __attribute__((visibility("default")))
++#else
++#    define SKIPPY_COMMON_API
++#endif
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+diff --git a/include/skippy/speculative_decoding.h b/include/skippy/speculative_decoding.h
+index 3953ed990..0b5994482 100644
+--- a/include/skippy/speculative_decoding.h
++++ b/include/skippy/speculative_decoding.h
+@@ -30,31 +30,31 @@ struct skippy_native_mtp_draft {
+ // supplies optional provisional tokens (such as native MTP output) used only
+ // while drafting; it never mutates the cache.
+ /** @brief Creates a request-local n-gram proposal cache. */
+-LLAMA_API enum skippy_status skippy_ngram_cache_create(
++SKIPPY_COMMON_API enum skippy_status skippy_ngram_cache_create(
+         uint16_t ngram_min,
+         uint16_t ngram_max,
+         struct skippy_ngram_cache ** out_cache,
+         struct skippy_error ** out_error);
+ 
+ /** @brief Releases an n-gram proposal cache. */
+-LLAMA_API void skippy_ngram_cache_free(struct skippy_ngram_cache * cache);
++SKIPPY_COMMON_API void skippy_ngram_cache_free(struct skippy_ngram_cache * cache);
+ 
+ /** @brief Replaces committed history in an n-gram proposal cache. */
+-LLAMA_API enum skippy_status skippy_ngram_cache_reset(
++SKIPPY_COMMON_API enum skippy_status skippy_ngram_cache_reset(
+         struct skippy_ngram_cache * cache,
+         const llama_token * token_ids,
+         size_t token_count,
+         struct skippy_error ** out_error);
+ 
+ /** @brief Appends newly committed tokens to an n-gram proposal cache. */
+-LLAMA_API enum skippy_status skippy_ngram_cache_append(
++SKIPPY_COMMON_API enum skippy_status skippy_ngram_cache_append(
+         struct skippy_ngram_cache * cache,
+         const llama_token * token_ids,
+         size_t token_count,
+         struct skippy_error ** out_error);
+ 
+ /** @brief Drafts tokens from committed history plus an optional provisional prefix. */
+-LLAMA_API enum skippy_status skippy_ngram_cache_draft(
++SKIPPY_COMMON_API enum skippy_status skippy_ngram_cache_draft(
+         struct skippy_ngram_cache * cache,
+         const llama_token * continuation_prefix,
+         size_t continuation_prefix_count,
+diff --git a/include/skippy/tokenization.h b/include/skippy/tokenization.h
+index 80b91879d..c9697cf6c 100644
+--- a/include/skippy/tokenization.h
++++ b/include/skippy/tokenization.h
+@@ -44,7 +44,7 @@ LLAMA_API const struct llama_model * skippy_model_native_model(
+         const struct skippy_model * model);
+ 
+ /** @brief Renders OpenAI-style JSON messages through the model chat template. */
+-LLAMA_API enum skippy_status skippy_apply_chat_template_json(
++SKIPPY_COMMON_API enum skippy_status skippy_apply_chat_template_json(
+         struct skippy_model * model,
+         const char * messages_json,
+         const char * tools_json,
+@@ -69,7 +69,7 @@ LLAMA_API enum skippy_status skippy_apply_chat_template_json(
+         struct skippy_error ** out_error);
+ 
+ /** @brief Parses generated chat text and template metadata into an OpenAI message. */
+-LLAMA_API enum skippy_status skippy_parse_chat_response_json(
++SKIPPY_COMMON_API enum skippy_status skippy_parse_chat_response_json(
+         const char * generated_text,
+         const char * metadata_json,
+         bool is_partial,
+diff --git a/src/skippy/tokenization.cpp b/src/skippy/tokenization.cpp
+index 5b885bf68..54753a161 100644
+--- a/src/skippy/tokenization.cpp
++++ b/src/skippy/tokenization.cpp
+@@ -17,6 +17,8 @@ extern "C" LLAMA_API void * skippy_model_chat_templates_get_or_init(
+         struct skippy_model * model,
+         skippy_chat_templates_create_fn create,
+         skippy_chat_templates_free_fn free_templates);
++extern "C" LLAMA_API void skippy_model_chat_templates_lock(struct skippy_model * model);
++extern "C" LLAMA_API void skippy_model_chat_templates_unlock(struct skippy_model * model);
+ 
+ extern "C" LLAMA_API void * skippy_model_chat_templates_get_or_init(
+         struct skippy_model * model,
+-- 
+2.54.0 (Apple Git-157)
+

--- a/third_party/llama.cpp/patches/0053-build-clean-Apple-Silicon-native-warnings.patch
+++ b/third_party/llama.cpp/patches/0053-build-clean-Apple-Silicon-native-warnings.patch
@@ -1,0 +1,56 @@
+From 27003be3218d7701a723fa879d7ff8330b1bfeb6 Mon Sep 17 00:00:00 2001
+From: scama
+ <a1860575018c4680d5669dd7bc3bd356b478bccb8d42e194df46304a5e25f49a@meshllm.communities.buzz.xyz>
+Date: Thu, 3 Sep 2026 09:02:08 +1000
+Subject: [PATCH] build: clean Apple Silicon native warnings
+
+---
+ ggml/src/ggml-metal/ggml-metal-device.m | 4 +++-
+ src/models/inkling.cpp                  | 3 ---
+ 2 files changed, 3 insertions(+), 4 deletions(-)
+
+diff --git a/ggml/src/ggml-metal/ggml-metal-device.m b/ggml/src/ggml-metal/ggml-metal-device.m
+index c2dbfc6ad..2f9acd002 100644
+--- a/ggml/src/ggml-metal/ggml-metal-device.m
++++ b/ggml/src/ggml-metal/ggml-metal-device.m
+@@ -1346,7 +1346,7 @@ ggml_metal_device_t ggml_metal_device_init(int device, int n_devices) {
+ #endif
+ 
+                 dev->props.use_shared_buffers = dev->props.has_unified_memory;
+-#if TARGET_OS_OSX
++#if TARGET_OS_OSX && !defined(__aarch64__)
+                 // In case of eGPU, shared memory may be preferable.
+                 dev->props.use_shared_buffers |= [dev->mtl_device location] == MTLDeviceLocationExternal;
+ #endif
+@@ -1406,12 +1406,14 @@ ggml_metal_device_t ggml_metal_device_init(int device, int n_devices) {
+                         }
+                     }
+ 
++#if !defined(__aarch64__)
+                     for (int i = MTLGPUFamilyCommon1 + 5; i >= MTLGPUFamilyCommon1; --i) {
+                         if ([dev->mtl_device supportsFamily:i]) {
+                             GGML_LOG_INFO("%s: GPU family: MTLGPUFamilyCommon%d (%d)\n", __func__, i - (int) MTLGPUFamilyCommon1 + 1, i);
+                             break;
+                         }
+                     }
++#endif
+ 
+                     for (int i = MTLGPUFamilyMetal3_GGML + 5; i >= MTLGPUFamilyMetal3_GGML; --i) {
+                         if ([dev->mtl_device supportsFamily:i]) {
+diff --git a/src/models/inkling.cpp b/src/models/inkling.cpp
+index 5dba09c1d..619bc3e73 100644
+--- a/src/models/inkling.cpp
++++ b/src/models/inkling.cpp
+@@ -254,9 +254,6 @@ llama_model_inkling::graph::graph(const llama_model & model, const llm_graph_par
+     GGML_ASSERT(ubatch.equal_seqs());
+     GGML_ASSERT(ubatch.n_tokens == n_seq_tokens * n_seqs);
+ 
+-    const uint32_t n_kv_flash_base = cparams.flash_attn ? mctx_attn->get_base()->get_n_kv_pos_contiguous() : 0;
+-    const uint32_t n_kv_flash_swa  = cparams.flash_attn ? mctx_attn->get_swa ()->get_n_kv_pos_contiguous() : 0;
+-
+     bool has_global = false;
+     bool needs_rel_idx_local  = false;
+     bool needs_rel_idx_global = false;
+-- 
+2.54.0 (Apple Git-157)
+

--- a/website/package.json
+++ b/website/package.json
@@ -5,6 +5,11 @@
   "engines": {
     "node": ">=20"
   },
+  "allowScripts": {
+    "@parcel/watcher@2.5.1": true,
+    "fsevents@2.3.3": true,
+    "fsevents@2.3.2": true
+  },
   "scripts": {
     "generate:cli": "node ./scripts/generate-cli-inventory.mjs",
     "check:cli": "node ./scripts/generate-cli-inventory.mjs --check",

--- a/website/src/docs/pages/skippy-api.md
+++ b/website/src/docs/pages/skippy-api.md
@@ -990,7 +990,7 @@ LLAMA_API enum skippy_status skippy_session_signal_window(
 Creates a request-local n-gram proposal cache.
 
 ```cpp
-LLAMA_API enum skippy_status skippy_ngram_cache_create(
+SKIPPY_COMMON_API enum skippy_status skippy_ngram_cache_create(
          uint16_t ngram_min,
         uint16_t ngram_max,
         struct skippy_ngram_cache ** out_cache,
@@ -1003,7 +1003,7 @@ LLAMA_API enum skippy_status skippy_ngram_cache_create(
 Releases an n-gram proposal cache.
 
 ```cpp
-LLAMA_API void skippy_ngram_cache_free(
+SKIPPY_COMMON_API void skippy_ngram_cache_free(
         struct skippy_ngram_cache * cache);
 ```
 
@@ -1013,7 +1013,7 @@ LLAMA_API void skippy_ngram_cache_free(
 Replaces committed history in an n-gram proposal cache.
 
 ```cpp
-LLAMA_API enum skippy_status skippy_ngram_cache_reset(
+SKIPPY_COMMON_API enum skippy_status skippy_ngram_cache_reset(
          struct skippy_ngram_cache * cache,
         const llama_token * token_ids,
         size_t token_count,
@@ -1026,7 +1026,7 @@ LLAMA_API enum skippy_status skippy_ngram_cache_reset(
 Appends newly committed tokens to an n-gram proposal cache.
 
 ```cpp
-LLAMA_API enum skippy_status skippy_ngram_cache_append(
+SKIPPY_COMMON_API enum skippy_status skippy_ngram_cache_append(
          struct skippy_ngram_cache * cache,
         const llama_token * token_ids,
         size_t token_count,
@@ -1039,7 +1039,7 @@ LLAMA_API enum skippy_status skippy_ngram_cache_append(
 Drafts tokens from committed history plus an optional provisional prefix.
 
 ```cpp
-LLAMA_API enum skippy_status skippy_ngram_cache_draft(
+SKIPPY_COMMON_API enum skippy_status skippy_ngram_cache_draft(
          struct skippy_ngram_cache * cache,
         const llama_token * continuation_prefix,
         size_t continuation_prefix_count,
@@ -1319,7 +1319,7 @@ LLAMA_API const struct llama_model * skippy_model_native_model(
 Renders OpenAI-style JSON messages through the model chat template.
 
 ```cpp
-LLAMA_API enum skippy_status skippy_apply_chat_template_json(
+SKIPPY_COMMON_API enum skippy_status skippy_apply_chat_template_json(
          struct skippy_model * model,
         const char * messages_json,
         const char * tools_json,
@@ -1350,7 +1350,7 @@ LLAMA_API enum skippy_status skippy_apply_chat_template_json(
 Parses generated chat text and template metadata into an OpenAI message.
 
 ```cpp
-LLAMA_API enum skippy_status skippy_parse_chat_response_json(
+SKIPPY_COMMON_API enum skippy_status skippy_parse_chat_response_json(
          const char * generated_text,
         const char * metadata_json,
         bool is_partial,


### PR DESCRIPTION
## Summary

- upgrade repository-wide action pins to Node 24-capable releases where upstream versions exist
- replace deprecated `serde_yaml` with the maintained `serde_yaml_ng` drop-in package and remove the stale `sha2-asm` profile override
- clean Rustdoc, Cargo build-script, HIP cleanup, and feature-unified lint noise
- add durable llama.cpp patches for exported declaration, Windows DLL linkage, Apple Metal deprecation, and unused Inkling warnings
- approve the exact optional npm install scripts used by the website dependency tree

## Validation

- `just ci-validate` — 736 tests passed, 7 skipped; all consistency checks passed
- affected full Rust package suites, including 2,898 host-runtime tests and 651 static Skippy server tests
- affected-package clippy with `-D warnings` on dynamic and static feature graphs
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps`
- clean pinned llama.cpp patch application plus CPU/static and Metal/dynamic native builds
- `npm ci`, website `npm run build`, and full `just build`
- exact-HEAD system suite after rebasing onto current main — 188 tests passed

## Remaining upstream/tool notices

- `ilammy/msvc-dev-cmd@v1.13.0` still targets Node 20 and has no newer upstream release to pin.
- The local macOS build still reports optional OpenMP absence and the existing Vite large-chunk advisory; neither is a compiler deprecation or repository-owned correctness warning.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Memory benchmark cleanup failures now report errors with context instead of being silently ignored.
  - Apple Silicon builds avoid unsupported GPU shared-memory selection and unnecessary warnings.

- **Build & Compatibility**
  - Native library exports are now correctly exposed for downstream integrations.
  - Build progress is reported more cleanly without unnecessary Cargo warnings.
  - Website installation now supports required native setup scripts.

- **Documentation**
  - Improved formatting and corrected references across configuration and API documentation.

- **Chores**
  - Updated CI and release workflows to use newer, pinned automation actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
