### PR TITLE
ci: register skippy-model ownership

### DIFF
--- a/ci/ownership.yml
+++ b/ci/ownership.yml
@@ -186,6 +186,7 @@
         "crates/model-package/**",
         "crates/model-ref/**",
         "crates/model-resolver/**",
+        "crates/skippy-model/**",
         "scripts/ci-hf-download-smoke.sh"
       ]
     },
@@ -309,6 +310,7 @@
         "model-package",
         "model-ref",
         "model-resolver",
+        "skippy-model",
         "skippy-quantize"
       ]
     },


### PR DESCRIPTION
## Summary

- Register the new `crates/skippy-model/**` path with the model-artifacts CI ownership domain.
- Register the `skippy-model` crate with that domain's affected-Cargo routing.

This is intentionally catalog-only. The protected PR planner requires `ci/ownership.yml` to match the default branch byte-for-byte, so this registration must land before the dependent SafeTensors runtime PR can be rebased and validated.

## Verification

At `da9c461af030eed1e7b71fbe34377a20653450c0`:

- `just ci-crate-lists`
- `python3 -m unittest scripts.tests.test_plan_ci scripts.tests.test_cli_inventory_contract scripts.tests.test_ci_lane_workflows` — 58 passed
- `git diff --check origin/main...HEAD`
- clean worktree and commit attribution verified


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project ownership mapping for the `skippy-model` crate under the model-download domain.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->