### PR TITLE
fix(runtime): merge bundled and release runtime catalogs during selection

### DIFF
--- a/crates/mesh-llm-runtime-install/src/install.rs
+++ b/crates/mesh-llm-runtime-install/src/install.rs
@@ -23,7 +23,10 @@ pub async fn install_native_runtime(
             manifest_path: options.manifest_path.clone(),
             manifest_url: options.manifest_url.clone(),
             bundle_dirs: options.bundle_dirs.clone(),
-            allow_default_manifest_url: true,
+            // Offline installs (`allow_download: false`) must not reach out
+            // for the default catalog either; bundles and the cache are the
+            // only sources then. Explicit manifest URLs are still honoured.
+            allow_default_manifest_url: options.allow_download,
         })
         .await?;
     if manifest.artifacts.is_empty() {

--- a/crates/mesh-llm-runtime-install/src/install.rs
+++ b/crates/mesh-llm-runtime-install/src/install.rs
@@ -14,6 +14,10 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
+/// Installs the native runtime selected by `options`: loads the merged
+/// runtime catalog (release manifest plus bundle directories), resolves the
+/// best candidate for this host, then serves it in place from a bundle, from
+/// the cache, or through a verified download.
 pub async fn install_native_runtime(
     options: NativeRuntimeInstallOptions,
 ) -> Result<NativeRuntimeInstallOutcome> {

--- a/crates/mesh-llm-runtime-install/src/lib.rs
+++ b/crates/mesh-llm-runtime-install/src/lib.rs
@@ -22,7 +22,10 @@ pub use cache::{
     native_runtime_cache, native_runtime_versions_match_current_sdk,
 };
 pub use install::install_native_runtime;
-pub use manifest::{default_manifest_url, default_release_manifest_url, load_release_manifest};
+pub use manifest::{
+    NativeRuntimeCatalogSources, default_manifest_url, default_release_manifest_url,
+    load_release_manifest,
+};
 pub use types::{
     CURRENT_MESH_VERSION, NATIVE_RUNTIME_CACHE_DIR_ENV, NATIVE_RUNTIME_MANIFEST_URL_ENV,
     NativeRuntimeBundleInstallPolicy, NativeRuntimeDownloadProgress,
@@ -40,14 +43,17 @@ pub(crate) use install::{
 };
 #[cfg(test)]
 pub(crate) use manifest::{
-    manifest_url, release_manifest_checksum_url, url_without_query,
-    verify_release_manifest_checksum,
+    load_release_manifest_with_sources, manifest_url, release_manifest_checksum_url,
+    url_without_query, verify_release_manifest_checksum,
 };
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use mesh_llm_native_runtime::{NativeRuntimeBackend, NativeRuntimePlatform};
+    use mesh_llm_native_runtime::{
+        CudaRuntimeRequirements, HostCudaProfile, NativeRuntimeBackend, NativeRuntimeBackendKind,
+        NativeRuntimePlatform,
+    };
     use sha2::Digest;
     use std::path::{Path, PathBuf};
     use std::sync::{Arc, Mutex};
@@ -477,7 +483,29 @@ mod tests {
     }
 
     #[test]
-    fn default_manifest_url_is_skipped_for_bundle_only_resolution() {
+    fn default_manifest_url_is_still_consulted_when_bundle_dirs_exist() {
+        let _guard = MANIFEST_ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(NATIVE_RUNTIME_MANIFEST_URL_ENV);
+        }
+
+        let options = NativeRuntimeManifestOptions {
+            mesh_version: "0.67.0".to_string(),
+            bundle_dirs: vec![PathBuf::from("runtime-bundle")],
+            allow_default_manifest_url: true,
+            ..Default::default()
+        };
+
+        assert_eq!(
+            manifest_url(&options).as_deref(),
+            Some(
+                "https://github.com/Mesh-LLM/mesh-llm/releases/download/v0.67.0/native-runtimes.json"
+            )
+        );
+    }
+
+    #[test]
+    fn default_manifest_url_is_skipped_when_not_allowed() {
         let _guard = MANIFEST_ENV_LOCK.lock().unwrap();
         unsafe {
             std::env::remove_var(NATIVE_RUNTIME_MANIFEST_URL_ENV);
@@ -485,6 +513,7 @@ mod tests {
 
         let options = NativeRuntimeManifestOptions {
             bundle_dirs: vec![PathBuf::from("runtime-bundle")],
+            allow_default_manifest_url: false,
             ..Default::default()
         };
 
@@ -645,5 +674,342 @@ mod tests {
         unsafe {
             std::env::remove_var(NATIVE_RUNTIME_MANIFEST_URL_ENV);
         }
+    }
+
+    fn write_bundle(dir: &Path, artifact: &NativeRuntimeArtifact) {
+        std::fs::create_dir_all(dir.join("lib")).unwrap();
+        for library in &artifact.libraries {
+            std::fs::write(dir.join(library), b"bundled runtime").unwrap();
+        }
+        NativeRuntimeManifest {
+            runtime: artifact.clone(),
+        }
+        .write_to_dir(dir)
+        .unwrap();
+    }
+
+    fn windows_cpu_bundle_artifact() -> NativeRuntimeArtifact {
+        let mut artifact = artifact_with_sha(None);
+        artifact.id = "meshllm-native-runtime-windows-x86_64-cpu".to_string();
+        artifact.platform = NativeRuntimePlatform {
+            os: "windows".to_string(),
+            arch: "x86_64".to_string(),
+            target: Some("x86_64-pc-windows-msvc".to_string()),
+        };
+        artifact.libraries = vec!["lib/llama.dll".to_string()];
+        artifact.url = None;
+        artifact.sha256 = None;
+        artifact
+    }
+
+    fn windows_cuda_release_artifact() -> NativeRuntimeArtifact {
+        let mut artifact = artifact_with_sha(None);
+        artifact.id = "meshllm-native-runtime-windows-x86_64-cuda12".to_string();
+        artifact.platform = NativeRuntimePlatform {
+            os: "windows".to_string(),
+            arch: "x86_64".to_string(),
+            target: Some("x86_64-pc-windows-msvc".to_string()),
+        };
+        artifact.backend = NativeRuntimeBackend {
+            kind: NativeRuntimeBackendKind::Cuda,
+            cuda: Some(CudaRuntimeRequirements {
+                toolkit_major: 12,
+                min_driver: None,
+                gpu_arches: vec!["86".to_string(), "89".to_string()],
+            }),
+            rocm: None,
+            vulkan: None,
+        };
+        artifact.libraries = vec![
+            "lib/llama.dll".to_string(),
+            "lib/cudart64_12.dll".to_string(),
+            "lib/cublas64_12.dll".to_string(),
+            "lib/cublasLt64_12.dll".to_string(),
+        ];
+        artifact.url = Some("https://example.invalid/windows-cuda12.tar.gz".to_string());
+        artifact
+    }
+
+    fn release_manifest_file(dir: &Path, artifacts: Vec<NativeRuntimeArtifact>) -> PathBuf {
+        let path = dir.join("native-runtimes.json");
+        let manifest = NativeRuntimeReleaseManifest {
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            skippy_abi: current_skippy_abi_version(),
+            artifacts,
+        };
+        std::fs::write(&path, serde_json::to_string_pretty(&manifest).unwrap()).unwrap();
+        path
+    }
+
+    fn block_on_load(
+        options: NativeRuntimeManifestOptions,
+    ) -> anyhow::Result<(NativeRuntimeReleaseManifest, NativeRuntimeCatalogSources)> {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(load_release_manifest_with_sources(options))
+    }
+
+    #[test]
+    fn bundle_artifacts_are_merged_with_the_release_manifest() {
+        let _guard = MANIFEST_ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(NATIVE_RUNTIME_MANIFEST_URL_ENV);
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("native-runtimes/cpu");
+        let mut bundled = windows_cpu_bundle_artifact();
+        bundled.mesh_version = Some("0.1.0-stale".to_string());
+        bundled.skippy_abi = "0.0.1".to_string();
+        write_bundle(&bundle, &bundled);
+        let manifest_path =
+            release_manifest_file(temp.path(), vec![windows_cuda_release_artifact()]);
+
+        let (manifest, sources) = block_on_load(NativeRuntimeManifestOptions {
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            manifest_path: Some(manifest_path.clone()),
+            bundle_dirs: vec![bundle.clone()],
+            allow_default_manifest_url: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let ids: Vec<&str> = manifest.artifacts.iter().map(|a| a.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "meshllm-native-runtime-windows-x86_64-cuda12",
+                "meshllm-native-runtime-windows-x86_64-cpu"
+            ]
+        );
+        // The release manifest describes the release; a stale bundle must not
+        // rewrite its version or ABI once a manifest was loaded.
+        assert_eq!(manifest.mesh_version, CURRENT_MESH_VERSION);
+        assert_eq!(manifest.skippy_abi, current_skippy_abi_version());
+        assert_eq!(
+            sources.manifest_path.as_deref(),
+            Some(manifest_path.as_path())
+        );
+        assert_eq!(sources.bundle_dirs, vec![bundle.canonicalize().unwrap()]);
+        assert!(sources.remote_error.is_none());
+    }
+
+    #[test]
+    fn bundle_only_load_takes_release_identity_from_the_bundle() {
+        let _guard = MANIFEST_ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(NATIVE_RUNTIME_MANIFEST_URL_ENV);
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("native-runtimes/cpu");
+        let mut bundled = windows_cpu_bundle_artifact();
+        bundled.mesh_version = Some("0.66.0".to_string());
+        bundled.skippy_abi = "0.1.9".to_string();
+        write_bundle(&bundle, &bundled);
+
+        let (manifest, sources) = block_on_load(NativeRuntimeManifestOptions {
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            bundle_dirs: vec![bundle],
+            allow_default_manifest_url: false,
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(manifest.mesh_version, "0.66.0");
+        assert_eq!(manifest.skippy_abi, "0.1.9");
+        assert_eq!(manifest.artifacts.len(), 1);
+        assert!(sources.manifest_url.is_none());
+        assert!(sources.remote_error.is_none());
+    }
+
+    #[test]
+    fn remote_fetch_failure_falls_back_to_bundles() {
+        let _guard = MANIFEST_ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(NATIVE_RUNTIME_MANIFEST_URL_ENV);
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("native-runtimes/cpu");
+        write_bundle(&bundle, &windows_cpu_bundle_artifact());
+
+        let (manifest, sources) = block_on_load(NativeRuntimeManifestOptions {
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            manifest_url: Some("http://127.0.0.1:9/native-runtimes.json?token=secret".to_string()),
+            bundle_dirs: vec![bundle.clone()],
+            allow_default_manifest_url: true,
+            ..Default::default()
+        })
+        .expect("bundles must carry the load when the remote catalog is unreachable");
+
+        assert_eq!(manifest.artifacts.len(), 1);
+        assert_eq!(
+            manifest.artifacts[0].id,
+            "meshllm-native-runtime-windows-x86_64-cpu"
+        );
+        assert_eq!(
+            sources.manifest_url.as_deref(),
+            Some("http://127.0.0.1:9/native-runtimes.json")
+        );
+        let remote_error = sources.remote_error.expect("the fetch failure is recorded");
+        assert!(!remote_error.contains("token=secret"), "{remote_error}");
+        assert_eq!(sources.bundle_dirs, vec![bundle.canonicalize().unwrap()]);
+    }
+
+    #[test]
+    fn remote_fetch_failure_without_bundles_is_an_error() {
+        let _guard = MANIFEST_ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(NATIVE_RUNTIME_MANIFEST_URL_ENV);
+        }
+
+        let err = block_on_load(NativeRuntimeManifestOptions {
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            manifest_url: Some("http://127.0.0.1:9/native-runtimes.json".to_string()),
+            bundle_dirs: Vec::new(),
+            allow_default_manifest_url: true,
+            ..Default::default()
+        })
+        .unwrap_err();
+
+        assert!(
+            err.to_string().contains("native runtime"),
+            "unexpected error: {err:#}"
+        );
+    }
+
+    #[test]
+    fn adjacent_windows_cpu_bundle_does_not_hide_a_remote_cuda_candidate() {
+        let _guard = MANIFEST_ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(NATIVE_RUNTIME_MANIFEST_URL_ENV);
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("native-runtimes/cpu");
+        write_bundle(&bundle, &windows_cpu_bundle_artifact());
+        let manifest_path =
+            release_manifest_file(temp.path(), vec![windows_cuda_release_artifact()]);
+        let (manifest, sources) = block_on_load(NativeRuntimeManifestOptions {
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            manifest_path: Some(manifest_path),
+            bundle_dirs: vec![bundle],
+            allow_default_manifest_url: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+        // A Windows host with a CUDA 13 driver and an Ada GPU, as seen from
+        // the official zip layout: bundled cpu runtime next to the binary,
+        // cuda12 runtime only in the release catalog.
+        let profile = HostRuntimeProfile {
+            os: "windows".to_string(),
+            arch: "x86_64".to_string(),
+            target_triple: Some("x86_64-pc-windows-msvc".to_string()),
+            available_flavors: std::collections::BTreeSet::from([
+                NativeRuntimeBackendKind::Cpu,
+                NativeRuntimeBackendKind::Cuda,
+            ]),
+            gpus: Vec::new(),
+            cuda: Some(HostCudaProfile {
+                toolkit_majors: std::collections::BTreeSet::new(),
+                driver_max_major: Some(13),
+                driver_version: None,
+                gpu_arches: std::collections::BTreeSet::from(["89".to_string()]),
+            }),
+            rocm: None,
+            vulkan: None,
+        };
+        let cache = native_runtime_cache(Some(&temp.path().join("cache"))).unwrap();
+        let resolver = NativeRuntimeResolver::new(CURRENT_MESH_VERSION, profile, manifest, cache)
+            .with_skippy_abi_version(current_skippy_abi_version())
+            .with_bundle_dirs(sources.bundle_dirs);
+
+        let evaluated = resolver.evaluate(&RuntimeSelection::Recommended).unwrap();
+        let compatible: Vec<&str> = evaluated
+            .iter()
+            .filter(|candidate| candidate.compatible)
+            .map(|candidate| candidate.artifact.id.as_str())
+            .collect();
+        assert!(
+            compatible.contains(&"meshllm-native-runtime-windows-x86_64-cuda12"),
+            "the remote cuda runtime must stay visible next to the bundled cpu runtime: {evaluated:?}"
+        );
+        assert!(compatible.contains(&"meshllm-native-runtime-windows-x86_64-cpu"));
+
+        let resolution = resolver
+            .resolve(&RuntimeSelection::Backend {
+                kind: NativeRuntimeBackendKind::Cuda,
+                cuda_toolkit_major: None,
+            })
+            .unwrap();
+        assert_eq!(
+            resolution.selected.id,
+            "meshllm-native-runtime-windows-x86_64-cuda12"
+        );
+        assert!(
+            matches!(resolution.source, NativeRuntimeSource::Download { .. }),
+            "{:?}",
+            resolution.source
+        );
+    }
+
+    #[test]
+    fn a_runtime_that_is_both_bundled_and_published_is_listed_once_and_served_from_the_bundle() {
+        let _guard = MANIFEST_ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(NATIVE_RUNTIME_MANIFEST_URL_ENV);
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("native-runtimes/cpu");
+        let bundled = windows_cpu_bundle_artifact();
+        write_bundle(&bundle, &bundled);
+        // The release catalog publishes the same cpu runtime as a download.
+        let mut published = bundled.clone();
+        published.url = Some("https://example.invalid/windows-cpu.tar.gz".to_string());
+        published.sha256 = Some("b".repeat(64));
+        let manifest_path = release_manifest_file(
+            temp.path(),
+            vec![published, windows_cuda_release_artifact()],
+        );
+
+        let (manifest, sources) = block_on_load(NativeRuntimeManifestOptions {
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            manifest_path: Some(manifest_path),
+            bundle_dirs: vec![bundle.clone()],
+            allow_default_manifest_url: true,
+            ..Default::default()
+        })
+        .unwrap();
+
+        let cpu_entries = manifest
+            .artifacts
+            .iter()
+            .filter(|artifact| artifact.id == "meshllm-native-runtime-windows-x86_64-cpu")
+            .count();
+        assert_eq!(cpu_entries, 1, "{:?}", manifest.artifacts);
+
+        let profile = HostRuntimeProfile {
+            os: "windows".to_string(),
+            arch: "x86_64".to_string(),
+            target_triple: Some("x86_64-pc-windows-msvc".to_string()),
+            available_flavors: std::collections::BTreeSet::from([NativeRuntimeBackendKind::Cpu]),
+            gpus: Vec::new(),
+            cuda: None,
+            rocm: None,
+            vulkan: None,
+        };
+        let cache = native_runtime_cache(Some(&temp.path().join("cache"))).unwrap();
+        let resolution = NativeRuntimeResolver::new(CURRENT_MESH_VERSION, profile, manifest, cache)
+            .with_skippy_abi_version(current_skippy_abi_version())
+            .with_bundle_dirs(sources.bundle_dirs)
+            .resolve(&RuntimeSelection::Id(
+                "meshllm-native-runtime-windows-x86_64-cpu".to_string(),
+            ))
+            .unwrap();
+        assert!(
+            matches!(resolution.source, NativeRuntimeSource::Bundle { ref path } if path == &bundle.canonicalize().unwrap()),
+            "the bundled copy must win over the download: {:?}",
+            resolution.source
+        );
     }
 }

--- a/crates/mesh-llm-runtime-install/src/lib.rs
+++ b/crates/mesh-llm-runtime-install/src/lib.rs
@@ -676,6 +676,8 @@ mod tests {
         }
     }
 
+    /// Writes a runtime bundle directory for `artifact`: its manifest plus
+    /// placeholder library files.
     fn write_bundle(dir: &Path, artifact: &NativeRuntimeArtifact) {
         std::fs::create_dir_all(dir.join("lib")).unwrap();
         for library in &artifact.libraries {
@@ -688,6 +690,8 @@ mod tests {
         .unwrap();
     }
 
+    /// The Windows CPU runtime as shipped next to the executable: bundled,
+    /// with no download URL.
     fn windows_cpu_bundle_artifact() -> NativeRuntimeArtifact {
         let mut artifact = artifact_with_sha(None);
         artifact.id = "meshllm-native-runtime-windows-x86_64-cpu".to_string();
@@ -702,6 +706,8 @@ mod tests {
         artifact
     }
 
+    /// The Windows CUDA 12 runtime as published in the release catalog:
+    /// download only.
     fn windows_cuda_release_artifact() -> NativeRuntimeArtifact {
         let mut artifact = artifact_with_sha(None);
         artifact.id = "meshllm-native-runtime-windows-x86_64-cuda12".to_string();
@@ -730,6 +736,8 @@ mod tests {
         artifact
     }
 
+    /// Writes a release manifest listing `artifacts` under `dir` and returns
+    /// its path.
     fn release_manifest_file(dir: &Path, artifacts: Vec<NativeRuntimeArtifact>) -> PathBuf {
         let path = dir.join("native-runtimes.json");
         let manifest = NativeRuntimeReleaseManifest {
@@ -741,6 +749,7 @@ mod tests {
         path
     }
 
+    /// Runs the async catalog load to completion on a throwaway runtime.
     fn block_on_load(
         options: NativeRuntimeManifestOptions,
     ) -> anyhow::Result<(NativeRuntimeReleaseManifest, NativeRuntimeCatalogSources)> {

--- a/crates/mesh-llm-runtime-install/src/manifest.rs
+++ b/crates/mesh-llm-runtime-install/src/manifest.rs
@@ -42,29 +42,89 @@ pub async fn load_release_manifest(
     Ok(load_release_manifest_with_bundle_dirs(options).await?.0)
 }
 
+/// Which catalogs a merged manifest load consulted, so callers can explain a
+/// selection (or a rejection) in terms of where the candidates came from.
+#[derive(Clone, Debug, Default, Eq, PartialEq)]
+pub struct NativeRuntimeCatalogSources {
+    /// Explicit `--manifest` file that was read.
+    pub manifest_path: Option<PathBuf>,
+    /// Remote manifest URL that was consulted (explicit, environment, or the
+    /// default release URL).
+    pub manifest_url: Option<String>,
+    /// Why the remote manifest could not be used, when bundled artifacts
+    /// carried the load instead. `None` when the fetch succeeded or was not
+    /// attempted.
+    pub remote_error: Option<String>,
+    /// Bundle directories whose artifacts were merged in.
+    pub bundle_dirs: Vec<PathBuf>,
+}
+
 pub(crate) async fn load_release_manifest_with_bundle_dirs(
-    mut options: NativeRuntimeManifestOptions,
+    options: NativeRuntimeManifestOptions,
 ) -> Result<(NativeRuntimeReleaseManifest, Vec<PathBuf>)> {
+    let (manifest, sources) = load_release_manifest_with_sources(options).await?;
+    Ok((manifest, sources.bundle_dirs))
+}
+
+/// Merges every catalog the options allow: an explicit manifest file, else a
+/// remote manifest (explicit URL, environment URL, or the default release
+/// URL), plus every discovered bundle directory.
+///
+/// Precedence:
+/// 1. An explicit manifest file is required: a read failure is an error.
+/// 2. A remote manifest is consulted even when bundle directories exist, so
+///    an adjacent bundle cannot hide downloadable runtimes. If the fetch
+///    fails and bundles were discovered, the bundles carry the load and the
+///    failure is recorded in `NativeRuntimeCatalogSources::remote_error`.
+///    Without bundles the fetch failure is an error, as before.
+/// 3. Bundle artifacts are appended after the manifest artifacts. The
+///    manifest's `mesh_version` and `skippy_abi` win when a manifest was
+///    loaded; bundle values only describe the release when no manifest was
+///    available at all.
+///
+/// Candidates with the same identity coming from several sources are
+/// deduplicated downstream by the resolver, which also prefers a bundled copy
+/// over a download for the same artifact.
+pub(crate) async fn load_release_manifest_with_sources(
+    mut options: NativeRuntimeManifestOptions,
+) -> Result<(NativeRuntimeReleaseManifest, NativeRuntimeCatalogSources)> {
     options.bundle_dirs = discover_native_runtime_bundle_dirs(&options.bundle_dirs)?;
+    let mut sources = NativeRuntimeCatalogSources {
+        bundle_dirs: options.bundle_dirs.clone(),
+        ..Default::default()
+    };
     let mut artifacts = Vec::new();
     let mut mesh_version = options.mesh_version.clone();
     let mut skippy_abi = current_skippy_abi_version();
-    if let Some(path) = options.manifest_path {
+    let mut manifest_loaded = false;
+    if let Some(path) = options.manifest_path.take() {
         let manifest = NativeRuntimeReleaseManifest::read_from_path(&path)?;
+        sources.manifest_path = Some(path);
         mesh_version = manifest.mesh_version.clone();
         skippy_abi = manifest.skippy_abi.clone();
         artifacts.extend(manifest.artifacts);
+        manifest_loaded = true;
     } else if let Some(url) = manifest_url(&options) {
-        let manifest = download_release_manifest(&url).await?;
-        mesh_version = manifest.mesh_version.clone();
-        skippy_abi = manifest.skippy_abi.clone();
-        artifacts.extend(manifest.artifacts);
+        sources.manifest_url = Some(url_without_query(&url));
+        match download_release_manifest(&url).await {
+            Ok(manifest) => {
+                mesh_version = manifest.mesh_version.clone();
+                skippy_abi = manifest.skippy_abi.clone();
+                artifacts.extend(manifest.artifacts);
+                manifest_loaded = true;
+            }
+            Err(err) if !options.bundle_dirs.is_empty() => {
+                sources.remote_error = Some(format!("{err:#}"));
+            }
+            Err(err) => return Err(err),
+        }
     }
     append_bundle_artifacts(
         &mut artifacts,
         &mut mesh_version,
         &mut skippy_abi,
         &options.bundle_dirs,
+        manifest_loaded,
     )?;
     Ok((
         NativeRuntimeReleaseManifest {
@@ -72,7 +132,7 @@ pub(crate) async fn load_release_manifest_with_bundle_dirs(
             skippy_abi,
             artifacts,
         },
-        options.bundle_dirs,
+        sources,
     ))
 }
 
@@ -186,7 +246,12 @@ pub(crate) fn manifest_url(options: &NativeRuntimeManifestOptions) -> Option<Str
                 .filter(|value| !value.trim().is_empty())
         })
         .or_else(|| {
-            (options.allow_default_manifest_url && options.bundle_dirs.is_empty())
+            // Bundle directories no longer suppress the default catalog: an
+            // adjacent CPU bundle must not hide downloadable GPU runtimes
+            // (#1612). Offline hosts fall back to the bundles when the fetch
+            // fails, see `load_release_manifest_with_sources`.
+            options
+                .allow_default_manifest_url
                 .then(|| request_default_manifest_url(&options.mesh_version))
         })
 }
@@ -196,17 +261,36 @@ pub(crate) fn append_bundle_artifacts(
     mesh_version: &mut String,
     skippy_abi: &mut String,
     bundle_dirs: &[PathBuf],
+    manifest_loaded: bool,
 ) -> Result<()> {
     for dir in bundle_dirs {
         let manifest = NativeRuntimeManifest::read_from_dir(dir)
             .with_context(|| format!("read bundled native runtime {}", dir.display()))?;
-        if let Some(version) = &manifest.runtime.mesh_version {
-            *mesh_version = version.clone();
+        // A loaded release manifest describes the release; a bundle only
+        // stands in for it when no manifest was available at all.
+        if !manifest_loaded {
+            if let Some(version) = &manifest.runtime.mesh_version {
+                *mesh_version = version.clone();
+            }
+            *skippy_abi = manifest.runtime.skippy_abi.clone();
         }
-        *skippy_abi = manifest.runtime.skippy_abi.clone();
-        artifacts.push(manifest.runtime);
+        // The same runtime can be both bundled and published. Keep one entry
+        // so listings stay unambiguous; the resolver still prefers the bundle
+        // directory as the source for that identity.
+        let duplicate = artifacts
+            .iter()
+            .any(|existing| same_artifact_identity(existing, &manifest.runtime));
+        if !duplicate {
+            artifacts.push(manifest.runtime);
+        }
     }
     Ok(())
+}
+
+fn same_artifact_identity(left: &NativeRuntimeArtifact, right: &NativeRuntimeArtifact) -> bool {
+    left.id == right.id
+        && left.mesh_version == right.mesh_version
+        && left.skippy_abi == right.skippy_abi
 }
 
 pub(crate) fn normalize_sha256(value: &str) -> Result<String> {

--- a/crates/mesh-llm-runtime-install/src/manifest.rs
+++ b/crates/mesh-llm-runtime-install/src/manifest.rs
@@ -36,6 +36,8 @@ pub(crate) fn request_default_manifest_url(mesh_version: &str) -> String {
     }
 }
 
+/// Loads the merged runtime catalog for `options` and returns the manifest
+/// alone. See `load_release_manifest_with_sources` for the discovery rules.
 pub async fn load_release_manifest(
     options: NativeRuntimeManifestOptions,
 ) -> Result<NativeRuntimeReleaseManifest> {
@@ -59,6 +61,8 @@ pub struct NativeRuntimeCatalogSources {
     pub bundle_dirs: Vec<PathBuf>,
 }
 
+/// Like `load_release_manifest_with_sources`, returning only the bundle
+/// directories that were merged in, for callers that resolve bundles by path.
 pub(crate) async fn load_release_manifest_with_bundle_dirs(
     options: NativeRuntimeManifestOptions,
 ) -> Result<(NativeRuntimeReleaseManifest, Vec<PathBuf>)> {
@@ -236,6 +240,10 @@ fn redact_url_userinfo(url: &str) -> String {
     )
 }
 
+/// Picks the remote catalog URL to consult: the explicit option, then the
+/// `MESH_LLM_NATIVE_RUNTIME_MANIFEST_URL` override, then the default release
+/// URL when `allow_default_manifest_url` is set. `None` means no remote
+/// catalog is consulted.
 pub(crate) fn manifest_url(options: &NativeRuntimeManifestOptions) -> Option<String> {
     options
         .manifest_url
@@ -256,6 +264,12 @@ pub(crate) fn manifest_url(options: &NativeRuntimeManifestOptions) -> Option<Str
         })
 }
 
+/// Appends the runtime described by each bundle directory to `artifacts`.
+///
+/// When no release manifest was loaded, the bundles also supply the release
+/// identity (`mesh_version` and `skippy_abi`). A runtime that is both bundled
+/// and already listed by the manifest is kept once; the resolver still serves
+/// that identity from the bundle directory.
 pub(crate) fn append_bundle_artifacts(
     artifacts: &mut Vec<NativeRuntimeArtifact>,
     mesh_version: &mut String,
@@ -287,6 +301,8 @@ pub(crate) fn append_bundle_artifacts(
     Ok(())
 }
 
+/// Two catalog entries describe the same runtime when their id and release
+/// identity (`mesh_version`, `skippy_abi`) match, whichever source listed them.
 fn same_artifact_identity(left: &NativeRuntimeArtifact, right: &NativeRuntimeArtifact) -> bool {
     left.id == right.id
         && left.mesh_version == right.mesh_version

--- a/docs/design/NATIVE_RUNTIMES.md
+++ b/docs/design/NATIVE_RUNTIMES.md
@@ -150,10 +150,25 @@ The CLI and Rust SDK install API resolve manifests in this order:
 https://github.com/Mesh-LLM/mesh-llm/releases/download/v<mesh_version>/native-runtimes.json
 ```
 
-Bundled runtime directories are always appended to the candidate manifest. When
-only bundle directories are provided, the default release URL is not fetched.
-This lets packaged apps stay offline while the same code path can still inspect
-or install release artifacts for normal crates.io consumers.
+Bundled runtime directories are always appended to the candidate manifest, and
+they no longer suppress the release catalog: an adjacent bundle (the cpu runtime
+shipped next to the Windows binary, an app-embedded runtime) must not hide the
+downloadable GPU runtimes. The merged catalog follows these rules:
+
+- An explicit manifest path is required: a read failure is an error.
+- The default release URL is consulted only when downloads are allowed
+  (`allow_download`, the default). Packaged apps that must stay offline set
+  downloads to false and get the bundle-only behavior, without any network
+  access. Explicit and environment manifest URLs are always honoured.
+- If the remote fetch fails and bundle directories were discovered, the bundles
+  carry the load and the failure is recorded in the catalog sources
+  (`NativeRuntimeCatalogSources::remote_error`) instead of aborting. Without
+  bundles the fetch failure is an error, as before.
+- The loaded manifest's `mesh_version` and `skippy_abi` describe the release; a
+  bundle's values only stand in when no manifest could be loaded at all.
+- Candidates present in several sources are deduplicated by identity by the
+  resolver, which prefers a bundled copy, then the cache, then a download for
+  the same artifact.
 
 ## Upgrade And Pruning
 

--- a/scripts/check-env-mutation-contract.py
+++ b/scripts/check-env-mutation-contract.py
@@ -69,7 +69,7 @@ KNOWN_UNAUDITED_MUTATION_COUNTS = {
     "crates/mesh-llm-host-runtime/src/runtime/tests/auto_join.rs": 1,
     "crates/mesh-llm-host-runtime/src/runtime/tests/mod.rs": 2,
     "crates/mesh-llm-host-runtime/src/runtime/tests/startup_models.rs": 2,
-    "crates/mesh-llm-runtime-install/src/lib.rs": 8,
+    "crates/mesh-llm-runtime-install/src/lib.rs": 15,
     "crates/mesh-llm/src/commands/plugin_cli.rs": 3,
     "crates/model-hf/src/cache_paths.rs": 2,
 }

--- a/scripts/tests/test_env_mutation_contract.py
+++ b/scripts/tests/test_env_mutation_contract.py
@@ -28,7 +28,7 @@ class EnvironmentMutationContractTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("35 Rust files", result.stdout)
-        self.assertIn("193 mutation sites", result.stdout)
+        self.assertIn("200 mutation sites", result.stdout)
         self.assertIn("18 contract-audited files", result.stdout)
 
     def test_unregistered_mutation_file_is_rejected_by_repository_discovery(self) -> None:

--- a/website/src/docs/pages/CLI.md
+++ b/website/src/docs/pages/CLI.md
@@ -584,9 +584,11 @@ mesh-llm runtime drain-model --endpoint '<control-endpoint>' --instance-id '<ins
 ```
 
 Plain `mesh-llm runtime list` lists locally discoverable native runtimes. Use
-`mesh-llm runtime list --available` to list release-manifest or bundled
-runtimes instead. `--installed` is the explicit compatibility spelling for the
-default local-discovery behavior.
+`mesh-llm runtime list --available` to list the release-manifest and bundled
+runtimes together: an adjacent bundle (for example the cpu runtime shipped
+next to the Windows binary) no longer hides the downloadable GPU runtimes of
+the release catalog. `--installed` is the explicit compatibility spelling for
+the default local-discovery behavior.
 
 Use `--json` for machine-readable output. Runtime selection is constrained by
 the running Mesh version, platform, backend, and Skippy ABI.


### PR DESCRIPTION
Refs #1612 (part 1 of 2: precedence and merge; diagnostics follow in a second PR)

An adjacent native runtime bundle used to suppress the default release manifest entirely (`manifest_url` returned `None` as soon as `bundle_dirs` was non-empty). The official Windows product layout ships a cpu runtime next to the binary, so from that layout `runtime list --available` showed only the bundled cpu entry and `runtime install cuda` failed with `no compatible native runtime found for Skippy ABI 0.1.44 on windows/x86_64`, on rc7, rc8 and rc9 (#1511, #1615).

Changes, all in `mesh-llm-runtime-install` plus docs:

- `manifest_url` no longer skips the default release URL when bundle directories exist; explicit path, explicit URL and environment URL keep their precedence
- `load_release_manifest_with_sources` (new) merges the loaded manifest with the discovered bundles and returns a `NativeRuntimeCatalogSources` summary (manifest path or URL consulted, remote error if any, bundle directories) for the diagnostics follow-up
- if the remote fetch fails and bundles were discovered, the bundles carry the load and the failure is recorded instead of aborting; without bundles the failure is still an error
- a loaded manifest's `mesh_version` and `skippy_abi` now describe the release; a bundle's values only stand in when no manifest could be loaded (a stale adjacent bundle used to rewrite both)
- a runtime that is both bundled and published is listed once; the resolver already prefers the bundle directory as the source for that identity
- `install_native_runtime` gates the default catalog on `allow_download`, so offline installs (the startup offline paths, packaged apps that set downloads to false as the SDK doc already tells them) never touch the network
- `docs/design/NATIVE_RUNTIMES.md` documents the precedence and fallback rules; the CLI page notes that `--available` now lists both catalogs

Tests (39 pass in the crate on Windows): the rewritten bundle-only precedence test, merge keeps the release identity, bundle-only load takes it from the bundle, remote failure falls back to bundles (with the URL query redacted in the recorded error), remote failure without bundles stays an error, the #1612 scenario itself (adjacent Windows cpu bundle plus a remote cuda12 candidate against a synthetic Windows host profile with a CUDA 13 driver and SM 89: both candidates evaluated, cuda selected as a download), and the bundled-and-published dedup case resolving to the bundle.

End to end on the machine from #1615, using the official `mesh-llm-v0.76.0-rc9-x86_64-pc-windows-msvc.zip` layout with this host binary dropped in:

```
stock rc9   runtime list --available   1 entry  (bundled cpu)
this branch runtime list --available   cpu, cuda12, rocm, vulkan for windows, all compatible
this branch runtime install cuda       resolves the release artifact: "already installed" from the
                                       rc9 cache, and a real 782 MiB download plus install with an
                                       empty --cache-dir
```

Not in this PR: the "which catalogs were consulted and why" diagnostics and the explicit-selection failure reporting (checklist items 5 and 9), which build on the sources summary added here.

Local gates: `cargo test --locked -p mesh-llm-runtime-install --lib --features skippy-ffi/dynamic-runtime`, `cargo fmt --check`, `cargo clippy --no-deps -p mesh-llm-runtime-install --all-targets --features skippy-ffi/dynamic-runtime -- -D warnings`, `repo-consistency no-console-print`, all clean. CodeRabbit findings will be addressed before human review.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Offline installations no longer access the default release catalog when downloads are disabled.
  * Explicit catalog URLs remain available when configured.
  * Bundled runtimes no longer hide downloadable runtimes from the available-runtime list.
  * Remote catalog failures no longer block installations when bundled runtimes are available.
  * Duplicate runtime entries are removed, prioritizing bundled and cached copies.

* **Documentation**
  * Updated CLI documentation to clarify available runtime sources.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->