### PR TITLE
fix(llama): rebase patch queue onto upstream 0df974d777

### DIFF
--- a/third_party/llama.cpp/patches/0001-Add-staged-model-graph-and-family-support.patch
+++ b/third_party/llama.cpp/patches/0001-Add-staged-model-graph-and-family-support.patch
@@ -1,7 +1,7 @@
-From d76bf95a279692cf6512010d499100b7df73ff5c Mon Sep 17 00:00:00 2001
+From f69831197e469d2c76ef34b39d7617885e626fab Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 8 Aug 2026 16:02:19 +1000
-Subject: [PATCH 01/32] Add staged model graph and family support
+Subject: [PATCH 01/51] Add staged model graph and family support
 
 ---
  include/llama.h                |   7 +
@@ -15,7 +15,7 @@ Subject: [PATCH 01/32] Add staged model graph and family support
  src/llama-hparams.h            |  30 +-
  src/llama-kv-cache.cpp         | 966 ++++++++++++++++++++++++++++++++-
  src/llama-kv-cache.h           |  58 +-
- src/llama-kv-cells.h           |  80 ++-
+ src/llama-kv-cells.h           |  59 +-
  src/llama-memory-recurrent.cpp |   9 +-
  src/llama-model-loader.cpp     | 182 ++++++-
  src/llama-model-loader.h       |  16 +
@@ -42,7 +42,7 @@ Subject: [PATCH 01/32] Add staged model graph and family support
  src/models/command-r.cpp       |  20 +-
  src/models/dbrx.cpp            |  18 +-
  src/models/deci.cpp            |  18 +-
- src/models/deepseek2.cpp       | 647 +++++++++++-----------
+ src/models/deepseek2.cpp       | 642 +++++++++++-----------
  src/models/deepseek32.cpp      |  16 +-
  src/models/dots1.cpp           |  18 +-
  src/models/dream.cpp           |  18 +-
@@ -107,7 +107,7 @@ Subject: [PATCH 01/32] Add staged model graph and family support
  src/models/qwen35.cpp          |  29 +-
  src/models/qwen35moe.cpp       |  27 +-
  src/models/qwen3moe.cpp        |  18 +-
- src/models/qwen3next.cpp       | 351 +++---------
+ src/models/qwen3next.cpp       | 345 +++---------
  src/models/qwen3vl.cpp         |  25 +-
  src/models/qwen3vlmoe.cpp      |  22 +-
  src/models/refact.cpp          |  18 +-
@@ -123,7 +123,7 @@ Subject: [PATCH 01/32] Add staged model graph and family support
  src/models/starcoder2.cpp      |  20 +-
  src/models/step35.cpp          |  32 +-
  src/models/xverse.cpp          |  18 +-
- 119 files changed, 4268 insertions(+), 1545 deletions(-)
+ 119 files changed, 4253 insertions(+), 1528 deletions(-)
 
 diff --git a/include/llama.h b/include/llama.h
 index ef7a012c4..26096355b 100644
@@ -144,7 +144,7 @@ index ef7a012c4..26096355b 100644
              const struct llama_model * model,
                          const char * path_model);
 diff --git a/src/llama-arch.cpp b/src/llama-arch.cpp
-index 5e61f61f7..37b2d3147 100644
+index 446de4ae2..7e83bb1d2 100644
 --- a/src/llama-arch.cpp
 +++ b/src/llama-arch.cpp
 @@ -72,7 +72,6 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
@@ -203,7 +203,7 @@ index 5e61f61f7..37b2d3147 100644
      // sentence-transformers dense modules feature dims
      { LLM_KV_DENSE_2_FEAT_IN,        "%s.dense_2_feat_in"  },
      { LLM_KV_DENSE_2_FEAT_OUT,       "%s.dense_2_feat_out" },
-@@ -659,9 +668,19 @@ static const std::map<llm_tensor, const char *> LLM_TENSOR_NAMES = {
+@@ -660,9 +669,19 @@ static const std::map<llm_tensor, const char *> LLM_TENSOR_NAMES = {
      { LLM_TENSOR_SHORTCONV_CONV,                         "blk.%d.shortconv.conv" },
      { LLM_TENSOR_SHORTCONV_INPROJ,                       "blk.%d.shortconv.in_proj" },
      { LLM_TENSOR_SHORTCONV_OUTPROJ,                      "blk.%d.shortconv.out_proj" },
@@ -223,7 +223,7 @@ index 5e61f61f7..37b2d3147 100644
      { LLM_TENSOR_VISEXP_ATTN_QKV,                        "blk.%d.vis_attn_qkv" },
      { LLM_TENSOR_VISEXP_ATTN_OUT,                        "blk.%d.vis_attn_output" },
      { LLM_TENSOR_VISEXP_FFN_GATE,                        "blk.%d.vis_gate" },
-@@ -893,6 +912,9 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
+@@ -894,6 +913,9 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
      {LLM_TENSOR_FFN_UP_EXPS,                {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT_ID}},
      {LLM_TENSOR_FFN_GATE_UP_EXPS,           {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT_ID}},
      {LLM_TENSOR_FFN_DOWN_CHEXPS,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT_ID}},
@@ -233,7 +233,7 @@ index 5e61f61f7..37b2d3147 100644
      {LLM_TENSOR_FFN_GATE_CHEXPS,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT_ID}},
      {LLM_TENSOR_FFN_UP_CHEXPS,              {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT_ID}},
      {LLM_TENSOR_FFN_EXP_PROBS_B,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_ADD}},
-@@ -934,6 +956,13 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
+@@ -936,6 +958,13 @@ static const std::map<llm_tensor, llm_tensor_info> LLM_TENSOR_INFOS = {
      {LLM_TENSOR_SHORTCONV_CONV,             {LLM_TENSOR_LAYER_REPEATING, GGML_OP_SSM_CONV}},
      {LLM_TENSOR_SHORTCONV_INPROJ,           {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
      {LLM_TENSOR_SHORTCONV_OUTPROJ,          {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
@@ -247,7 +247,7 @@ index 5e61f61f7..37b2d3147 100644
      {LLM_TENSOR_VISEXP_ATTN_QKV,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
      {LLM_TENSOR_VISEXP_ATTN_OUT,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
      {LLM_TENSOR_VISEXP_FFN_GATE,            {LLM_TENSOR_LAYER_REPEATING, GGML_OP_MUL_MAT}},
-@@ -1078,6 +1107,7 @@ bool llm_arch_is_hybrid(const llm_arch & arch) {
+@@ -1080,6 +1109,7 @@ bool llm_arch_is_hybrid(const llm_arch & arch) {
          case LLM_ARCH_QWEN4EXP:
          case LLM_ARCH_DEEPSEEK4:
          case LLM_ARCH_MINIMAX_01:
@@ -255,16 +255,16 @@ index 5e61f61f7..37b2d3147 100644
              return true;
          default:
              return false;
-@@ -1142,6 +1172,7 @@ bool llm_arch_supports_sm_tensor(const llm_arch & arch) {
-         case LLM_ARCH_BAILINGMOE3:
+@@ -1146,6 +1176,7 @@ bool llm_arch_supports_sm_tensor(const llm_arch & arch) {
          case LLM_ARCH_KIMI_K3:
          case LLM_ARCH_QWEN3TTS:
+         case LLM_ARCH_QWEN4EXP:   // TODO: fix test-llama-archs
 +        case LLM_ARCH_INKLING:
              return false;
          default:
              return true;
 diff --git a/src/llama-arch.h b/src/llama-arch.h
-index ca7d55a5f..644fac937 100644
+index 0c0b99483..fe95cde69 100644
 --- a/src/llama-arch.h
 +++ b/src/llama-arch.h
 @@ -77,7 +77,6 @@ enum llm_arch {
@@ -331,9 +331,9 @@ index ca7d55a5f..644fac937 100644
 +    LLM_TENSOR_FFN_GATE_SHEXPS,
 +    LLM_TENSOR_FFN_UP_SHEXPS,
      LLM_TENSOR_FFN_EXP_PROBS_B,
+     LLM_TENSOR_FFN_EXP_PROBS_B_VL,
      LLM_TENSOR_FFN_LATENT_DOWN,
-     LLM_TENSOR_FFN_LATENT_UP,
-@@ -661,6 +673,14 @@ enum llm_tensor {
+@@ -662,6 +674,14 @@ enum llm_tensor {
      LLM_TENSOR_SHORTCONV_CONV,
      LLM_TENSOR_SHORTCONV_INPROJ,
      LLM_TENSOR_SHORTCONV_OUTPROJ,
@@ -349,7 +349,7 @@ index ca7d55a5f..644fac937 100644
      LLM_TENSOR_VISEXP_ATTN_OUT,
      LLM_TENSOR_VISEXP_FFN_GATE,
 diff --git a/src/llama-context.cpp b/src/llama-context.cpp
-index 9aed80133..af3fe661f 100644
+index 3cc27717e..4c082bade 100644
 --- a/src/llama-context.cpp
 +++ b/src/llama-context.cpp
 @@ -121,9 +121,8 @@ llama_context::llama_context(
@@ -362,9 +362,9 @@ index 9aed80133..af3fe661f 100644
 +    cparams.embeddings_layer_inp.resize(hparams.n_layer(), false);
 +    embd_layer_inp.resize(hparams.n_layer());
  
-     cparams.ctx_type     = params.ctx_type;
-     cparams.pooling_type = params.pooling_type;
-@@ -160,6 +159,12 @@ llama_context::llama_context(
+     cparams.ctx_type          = params.ctx_type;
+     cparams.rope_scaling_type = params.rope_scaling_type;
+@@ -161,6 +160,12 @@ llama_context::llama_context(
          }
      }
  
@@ -374,9 +374,9 @@ index 9aed80133..af3fe661f 100644
 +        cparams.ctx_other = params.ctx_other;
 +    }
 +
-     auto rope_scaling_type = params.rope_scaling_type;
-     if (rope_scaling_type == LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED) {
-         rope_scaling_type = hparams.rope_scaling_type_train;
+     if (cparams.rope_scaling_type == LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED) {
+         cparams.rope_scaling_type = hparams.rope_scaling_type_train;
+     }
 @@ -303,19 +308,18 @@ llama_context::llama_context(
          }
      }
@@ -409,7 +409,7 @@ index 9aed80133..af3fe661f 100644
  
      if (cparams.n_ctx_seq < hparams.n_ctx_train) {
          LLAMA_LOG_INFO("%s: n_ctx_seq (%u) < n_ctx_train (%u) -- the full capacity of the model will not be utilized\n",
-@@ -503,6 +507,22 @@ llama_context::~llama_context() {
+@@ -504,6 +508,22 @@ llama_context::~llama_context() {
  
  void llama_context::resolve_fused_ops(const llama_memory_context_i * mctx, uint32_t n_seqs) {
      const char * func = __func__;
@@ -432,7 +432,7 @@ index 9aed80133..af3fe661f 100644
      auto resolve = [&](const llm_fused_op_probe & probe, bool & enabled) {
          if (!enabled) {
              return;
-@@ -1177,7 +1197,7 @@ void llama_context::set_embeddings_nextn(bool value, bool masked) {
+@@ -1178,7 +1198,7 @@ void llama_context::set_embeddings_nextn(bool value, bool masked) {
  void llama_context::set_embeddings_layer_inp(uint32_t lid, bool enable) {
      LLAMA_LOG_DEBUG("%s: lid = %d, enable = %d\n", __func__, lid, enable);
  
@@ -441,7 +441,7 @@ index 9aed80133..af3fe661f 100644
  
      cparams.embeddings_layer_inp[lid] = enable;
  
-@@ -1243,7 +1263,7 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
+@@ -1244,7 +1264,7 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
      if (sampler && can_offload) {
          auto * buft = ggml_backend_dev_buffer_type(model.dev_output());
  
@@ -450,7 +450,7 @@ index 9aed80133..af3fe661f 100644
  
          sampling.samplers[seq_id] = sampler;
  
-@@ -1433,6 +1453,10 @@ int llama_context::encode(const llama_batch & batch_inp) {
+@@ -1434,6 +1454,10 @@ int llama_context::encode(const llama_batch & batch_inp) {
      // micro-batching is not possible for non-causal encoding, so we process the batch in a single shot
      GGML_ASSERT(cparams.n_ubatch >= n_tokens && "encoder requires n_ubatch >= n_tokens");
  
@@ -461,7 +461,7 @@ index 9aed80133..af3fe661f 100644
      // TODO: this clear of the buffer can easily be forgotten - need something better
      // sync first so any in-flight async copies into embd_seq complete before it is freed
      if (!embd_seq.empty()) {
-@@ -1440,10 +1464,6 @@ int llama_context::encode(const llama_batch & batch_inp) {
+@@ -1441,10 +1465,6 @@ int llama_context::encode(const llama_batch & batch_inp) {
      }
      embd_seq.clear();
  
@@ -472,7 +472,7 @@ index 9aed80133..af3fe661f 100644
      sched_reserve();
  
      n_queued_tokens += n_tokens;
-@@ -1588,38 +1608,108 @@ int llama_context::encode(const llama_batch & batch_inp) {
+@@ -1589,38 +1609,108 @@ int llama_context::encode(const llama_batch & batch_inp) {
      return 0;
  }
  
@@ -600,17 +600,19 @@ index 9aed80133..af3fe661f 100644
      }
  }
  
-@@ -1659,8 +1749,7 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1660,10 +1750,9 @@ int llama_context::decode(const llama_batch & batch_inp) {
      const auto & hparams = model.hparams;
  
      const int64_t n_vocab = vocab.n_tokens();
 -    const bool    mtp_embd = cparams.ctx_type == LLAMA_CONTEXT_TYPE_MTP && batch_inp.embd;
--    const int64_t n_embd  = mtp_embd ? hparams.n_embd_out() : hparams.n_embd_inp();
-+    const int64_t n_embd  = hparams.n_embd_inp();
+     // DFlash embd batches carry the fused target features at the encoder input width
+     const bool    dflash_embd = model.arch == LLM_ARCH_DFLASH && batch_inp.embd;
+-    const int64_t n_embd  = mtp_embd ? hparams.n_embd_out() : dflash_embd ? hparams.n_embd_inp_enc() : hparams.n_embd_inp();
++    const int64_t n_embd  = dflash_embd ? hparams.n_embd_inp_enc() : hparams.n_embd_inp();
  
      // when computing embeddings, all tokens are output
      const bool output_all   = cparams.embeddings;
-@@ -1668,12 +1757,12 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1671,12 +1760,12 @@ int llama_context::decode(const llama_batch & batch_inp) {
  
      const uint32_t n_seq_max = cparams.kv_unified ? LLAMA_MAX_SEQ : cparams.n_seq_max;
  
@@ -626,7 +628,7 @@ index 9aed80133..af3fe661f 100644
                  continue;
              }
  
-@@ -1682,17 +1771,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1685,17 +1774,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
              for (int32_t s = 0; s < ns; ++s) {
                  const llama_seq_id seq_id = batch_inp.seq_id ? batch_inp.seq_id[i][s] : 0;
  
@@ -647,7 +649,7 @@ index 9aed80133..af3fe661f 100644
                      return -1;
                  }
              }
-@@ -1720,18 +1802,17 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1723,18 +1805,17 @@ int llama_context::decode(const llama_batch & batch_inp) {
  
      GGML_ASSERT((cparams.causal_attn || cparams.n_ubatch >= n_tokens_all) && "non-causal attention requires n_ubatch >= n_tokens");
  
@@ -671,7 +673,7 @@ index 9aed80133..af3fe661f 100644
      output_swaps.clear();
  
      sched_reserve();
-@@ -1792,11 +1873,6 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1795,11 +1876,6 @@ int llama_context::decode(const llama_batch & batch_inp) {
          return -2;
      };
  
@@ -683,7 +685,7 @@ index 9aed80133..af3fe661f 100644
      int64_t n_outputs_prev = 0;
      int64_t n_tokens_prev  = 0;
  
-@@ -1957,20 +2033,36 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1960,20 +2036,36 @@ int llama_context::decode(const llama_batch & batch_inp) {
  
                  const uint32_t n_embd  = hparams.n_embd_out();
                  float * embd_nextn_out = embd_nextn.data + offset*n_embd;
@@ -726,7 +728,7 @@ index 9aed80133..af3fe661f 100644
          }
  
          n_outputs_prev += n_outputs;
-@@ -2228,9 +2320,9 @@ void llama_context::extract_layer_inputs(const llm_graph_result * res, size_t to
+@@ -2231,9 +2323,9 @@ void llama_context::extract_layer_inputs(const llm_graph_result * res, size_t to
  }
  
  void llama_context::output_reorder() {
@@ -739,7 +741,7 @@ index 9aed80133..af3fe661f 100644
  
      for (size_t s = 0; s < output_swaps.size(); ++s) {
          const uint64_t i0 = output_swaps[s].i0;
-@@ -2243,6 +2335,7 @@ void llama_context::output_reorder() {
+@@ -2246,6 +2338,7 @@ void llama_context::output_reorder() {
          }
  
          if (embd.size > 0) {
@@ -747,7 +749,7 @@ index 9aed80133..af3fe661f 100644
              for (uint64_t k = 0; k < n_embd_out; k++) {
                  std::swap(embd.data[i0*n_embd_out + k], embd.data[i1*n_embd_out + k]);
              }
-@@ -2300,31 +2393,18 @@ void llama_context::output_reorder() {
+@@ -2303,31 +2396,18 @@ void llama_context::output_reorder() {
  //
  
  uint32_t llama_context::graph_max_nodes(uint32_t n_tokens) const {
@@ -786,7 +788,7 @@ index 9aed80133..af3fe661f 100644
      }
  
      uint32_t n_sampling_nodes = 0;
-@@ -2369,7 +2449,6 @@ static void ubatch_prepare_reserve(
+@@ -2372,7 +2452,6 @@ static void ubatch_prepare_reserve(
          }
      }
  
@@ -794,7 +796,7 @@ index 9aed80133..af3fe661f 100644
      std::vector<uint32_t> sampler_seqs;
      std::vector<bool> has_sampler(n_seqs, false);
      for (const auto & entry : samplers) {
-@@ -2377,38 +2456,37 @@ static void ubatch_prepare_reserve(
+@@ -2380,38 +2459,37 @@ static void ubatch_prepare_reserve(
          if (seq_id < 0 || (uint32_t) seq_id >= n_seqs) {
              continue;
          }
@@ -837,7 +839,7 @@ index 9aed80133..af3fe661f 100644
  ggml_cgraph * llama_context::graph_reserve(
          uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx, bool split_only, size_t * sizes) {
      LLAMA_LOG_DEBUG("%s: reserving a graph for ubatch with n_tokens = %4u, n_seqs = %2u, n_outputs = %4u\n", __func__, n_tokens, n_seqs, n_outputs);
-@@ -3597,7 +3675,6 @@ llama_context_params llama_context_default_params() {
+@@ -3620,7 +3698,6 @@ llama_context_params llama_context_default_params() {
          /*.n_seq_max                   =*/ 1,
          /*.n_rs_seq                    =*/ 0,
          /*.n_outputs_max               =*/ 0,
@@ -845,7 +847,7 @@ index 9aed80133..af3fe661f 100644
          /*.n_threads                   =*/ GGML_DEFAULT_N_THREADS, // TODO: better default
          /*.n_threads_batch             =*/ GGML_DEFAULT_N_THREADS,
          /*.ctx_type                    =*/ LLAMA_CONTEXT_TYPE_DEFAULT,
-@@ -3667,22 +3744,6 @@ llama_context * llama_init_from_model(
+@@ -3690,22 +3767,6 @@ llama_context * llama_init_from_model(
          }
      }
  
@@ -868,7 +870,7 @@ index 9aed80133..af3fe661f 100644
      if (params.flash_attn_type != LLAMA_FLASH_ATTN_TYPE_DISABLED && ggml_is_quantized(params.type_k)) {
          const uint32_t blck_size = ggml_blck_size(params.type_k);
          for (uint32_t il = 0; il < model->hparams.n_layer(); ++il) {
-@@ -3705,6 +3766,11 @@ llama_context * llama_init_from_model(
+@@ -3728,6 +3789,11 @@ llama_context * llama_init_from_model(
          }
      }
  
@@ -880,7 +882,7 @@ index 9aed80133..af3fe661f 100644
      if (params.pooling_type != LLAMA_POOLING_TYPE_UNSPECIFIED &&
          params.pooling_type != model->hparams.pooling_type) {
          //user-specified pooling-type is different from the model default
-@@ -3712,9 +3778,8 @@ llama_context * llama_init_from_model(
+@@ -3735,9 +3801,8 @@ llama_context * llama_init_from_model(
                         model->hparams.pooling_type, params.pooling_type);
      }
  
@@ -891,7 +893,7 @@ index 9aed80133..af3fe661f 100644
          LLAMA_LOG_WARN("%s: context type MTP requested but model doesn't contain MTP layers\n", __func__);
          return nullptr;
      }
-@@ -4213,6 +4278,9 @@ int32_t llama_decode(
+@@ -4244,6 +4309,9 @@ int32_t llama_decode(
          llama_context * ctx,
            llama_batch   batch) {
      const int ret = ctx->decode(batch);
@@ -923,7 +925,7 @@ index bf91daa8b..20c121b24 100644
      // returns the result of ggml_backend_sched_graph_compute_async execution
      ggml_status graph_compute(ggml_cgraph * gf, bool batched);
 diff --git a/src/llama-graph.cpp b/src/llama-graph.cpp
-index 8fca8e1bc..df0c3019b 100644
+index 274a62643..d08104618 100644
 --- a/src/llama-graph.cpp
 +++ b/src/llama-graph.cpp
 @@ -24,6 +24,85 @@
@@ -1379,7 +1381,7 @@ index 8fca8e1bc..df0c3019b 100644
      if (w_s) {
          res = ggml_mul(ctx0, res, w_s);
      }
-@@ -2330,28 +2552,32 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
+@@ -2325,28 +2547,32 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
      {
          auto & cur = inps[0];
  
@@ -1429,7 +1431,7 @@ index 8fca8e1bc..df0c3019b 100644
          }
      }
  
-@@ -2365,7 +2591,13 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
+@@ -2360,7 +2586,13 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
      assert(ggml_are_same_shape (inps[0], inps[1]));
      assert(ggml_are_same_stride(inps[0], inps[1]));
  
@@ -1444,7 +1446,7 @@ index 8fca8e1bc..df0c3019b 100644
  
      if (n_embd_inp != n_embd) {
          cur = ggml_view_2d(ctx0, cur, n_embd, n_tokens, cur->nb[1], 0);
-@@ -2373,10 +2605,15 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
+@@ -2368,10 +2600,15 @@ ggml_tensor * llm_graph_context::build_inp_embd(ggml_tensor * tok_embd) const {
  
      res->t_inp_embd = cur;
  
@@ -1461,7 +1463,7 @@ index 8fca8e1bc..df0c3019b 100644
          if (!ggml_is_contiguous(cur)) {
              cur = ggml_cont(ctx0, cur);
          }
-@@ -2561,9 +2798,26 @@ ggml_tensor * llm_graph_context::build_attn_mha(
+@@ -2557,9 +2794,26 @@ ggml_tensor * llm_graph_context::build_attn_mha(
  
      ggml_tensor * cur;
  
@@ -1490,7 +1492,7 @@ index 8fca8e1bc..df0c3019b 100644
  
          if (v_trans) {
              v = ggml_transpose(ctx0, v);
-@@ -2578,7 +2832,7 @@ ggml_tensor * llm_graph_context::build_attn_mha(
+@@ -2574,7 +2828,7 @@ ggml_tensor * llm_graph_context::build_attn_mha(
              v = ggml_cast(ctx0, v, GGML_TYPE_F16);
          }
  
@@ -1499,7 +1501,7 @@ index 8fca8e1bc..df0c3019b 100644
                                    hparams.attn_soft_cap ? hparams.f_attn_logit_softcapping : 0.0f);
          res->add_fused_node({LLM_FUSED_OP_FLASH_ATTN, cur, il});
  
-@@ -2977,6 +3231,8 @@ ggml_tensor * llm_graph_context::build_attn(
+@@ -2975,6 +3229,8 @@ ggml_tensor * llm_graph_context::build_attn(
  
      const auto & kq_mask = inp->get_kq_mask_mla();
  
@@ -1509,7 +1511,7 @@ index 8fca8e1bc..df0c3019b 100644
      ggml_tensor * kq_mask_all = ggml_fill(ctx0, kq_mask, -INFINITY);
  
 diff --git a/src/llama-graph.h b/src/llama-graph.h
-index b388e028c..15fc4fa83 100644
+index dddfdac7b..2d3b07930 100644
 --- a/src/llama-graph.h
 +++ b/src/llama-graph.h
 @@ -32,6 +32,80 @@ class llama_memory_recurrent_context;
@@ -1690,10 +1692,10 @@ index b388e028c..15fc4fa83 100644
      // do mat_mul_id, while optionally apply lora and per-expert scale
      ggml_tensor * build_lora_mm_id(
 diff --git a/src/llama-hparams.cpp b/src/llama-hparams.cpp
-index 6a820c61c..9fbce9bdf 100644
+index 7df82ffe2..5f32a8e34 100644
 --- a/src/llama-hparams.cpp
 +++ b/src/llama-hparams.cpp
-@@ -181,6 +181,11 @@ uint32_t llama_hparams::n_embd_v_gqa_max() const {
+@@ -197,6 +197,11 @@ uint32_t llama_hparams::n_embd_v_gqa_max() const {
  }
  
  uint32_t llama_hparams::n_embd_r() const {
@@ -1706,7 +1708,7 @@ index 6a820c61c..9fbce9bdf 100644
          // for RWKV models
          return token_shift_count * n_embd;
 diff --git a/src/llama-hparams.h b/src/llama-hparams.h
-index 1411692a8..402015415 100644
+index 2f238a174..ccb617b87 100644
 --- a/src/llama-hparams.h
 +++ b/src/llama-hparams.h
 @@ -57,10 +57,6 @@ struct llama_hparams {
@@ -1718,9 +1720,9 @@ index 1411692a8..402015415 100644
 -    // per-token adapter selection. -1 when the model has no such layer.
 -    int32_t  router_layer = -1;
      uint32_t n_expert = 0;
-     uint32_t n_expert_used = 0;
      uint32_t n_rel_attn_bkts = 0;
-@@ -88,6 +84,17 @@ struct llama_hparams {
+ 
+@@ -87,6 +83,17 @@ struct llama_hparams {
  
      uint32_t n_shortconv_l_cache  = 0;
  
@@ -1738,7 +1740,7 @@ index 1411692a8..402015415 100644
      std::array<uint32_t, LLAMA_MAX_LAYERS> n_head_arr;
      std::array<uint32_t, LLAMA_MAX_LAYERS> n_head_kv_arr;
      std::array<uint32_t, LLAMA_MAX_LAYERS> n_ff_arr;
-@@ -264,6 +271,16 @@ struct llama_hparams {
+@@ -271,6 +278,16 @@ struct llama_hparams {
      // MSA
      uint32_t indexer_block_size  = 0;
      uint32_t indexer_local_blocks = 0;
@@ -1755,7 +1757,7 @@ index 1411692a8..402015415 100644
  
      // Indexer is "full" (1) or "shared" (0)
      // Shared indexers reuse top-k from previous full layer
-@@ -412,6 +429,9 @@ struct llama_hparams {
+@@ -423,6 +440,9 @@ struct llama_hparams {
      uint32_t n_embd_k_gqa_max() const;
      uint32_t n_embd_v_gqa_max() const;
  
@@ -1765,7 +1767,7 @@ index 1411692a8..402015415 100644
      // dimension of the rolling state embeddings
      // corresponds to Mamba's conv_states size or RWKV's token_shift states size
      uint32_t n_embd_r() const;
-@@ -429,8 +449,6 @@ struct llama_hparams {
+@@ -440,8 +460,6 @@ struct llama_hparams {
  
      bool has_kv(uint32_t il) const;
  
@@ -1775,7 +1777,7 @@ index 1411692a8..402015415 100644
      uint32_t n_layer() const;
  
 diff --git a/src/llama-kv-cache.cpp b/src/llama-kv-cache.cpp
-index 8fafcd153..10de4e126 100644
+index f22054c3d..15c33568b 100644
 --- a/src/llama-kv-cache.cpp
 +++ b/src/llama-kv-cache.cpp
 @@ -4,6 +4,7 @@
@@ -1785,8 +1787,8 @@ index 8fafcd153..10de4e126 100644
 +#include "skippy.h"
  
  #include <algorithm>
- #include <array>
-@@ -115,7 +116,7 @@ llama_kv_cache::llama_kv_cache(
+ #include <cassert>
+@@ -114,7 +115,7 @@ llama_kv_cache::llama_kv_cache(
          auto it = ctx_map.find(buft);
          if (it == ctx_map.end()) {
              ggml_init_params params = {
@@ -1795,7 +1797,7 @@ index 8fafcd153..10de4e126 100644
                  /*.mem_buffer =*/ NULL,
                  /*.no_alloc   =*/ true,
              };
-@@ -198,12 +199,10 @@ llama_kv_cache::llama_kv_cache(
+@@ -197,12 +198,10 @@ llama_kv_cache::llama_kv_cache(
              n_embd_head_k_all = -1;
          }
  
@@ -1812,7 +1814,7 @@ index 8fafcd153..10de4e126 100644
          }
  
          // [TAG_V_CACHE_VARIABLE]
-@@ -245,9 +244,25 @@ llama_kv_cache::llama_kv_cache(
+@@ -244,9 +243,25 @@ llama_kv_cache::llama_kv_cache(
              v_stream.push_back(has_v ? ggml_view_2d(ctx, v, n_embd_v_gqa, kv_size, v->nb[1], s*v->nb[2]) : nullptr);
          }
  
@@ -1839,7 +1841,7 @@ index 8fafcd153..10de4e126 100644
      }
  
      if (reuse) {
-@@ -296,13 +311,24 @@ llama_kv_cache::llama_kv_cache(
+@@ -295,13 +310,24 @@ llama_kv_cache::llama_kv_cache(
      }
  
      {
@@ -1870,7 +1872,7 @@ index 8fafcd153..10de4e126 100644
      }
  
      // TODO: refactor [TAG_KV_CACHE_SHARE_CELLS]
-@@ -397,6 +423,39 @@ bool llama_kv_cache::seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos p1) {
+@@ -396,6 +422,39 @@ bool llama_kv_cache::seq_rm(llama_seq_id seq_id, llama_pos p0, llama_pos p1) {
          p1 = std::numeric_limits<llama_pos>::max();
      }
  
@@ -1910,7 +1912,7 @@ index 8fafcd153..10de4e126 100644
      if (seq_id >= 0) {
          auto & cells = v_cells[seq_to_stream[seq_id]];
          auto & head  = v_heads[seq_to_stream[seq_id]];
-@@ -742,11 +801,28 @@ llama_memory_context_ptr llama_kv_cache::init_full() {
+@@ -741,11 +800,28 @@ llama_memory_context_ptr llama_kv_cache::init_full() {
  }
  
  llama_memory_context_ptr llama_kv_cache::init_update(llama_context * lctx, bool optimize) {
@@ -1942,7 +1944,7 @@ index 8fafcd153..10de4e126 100644
  }
  
  llama_kv_cache::slot_info_vec_t llama_kv_cache::prepare(const std::vector<llama_ubatch> & ubatches) {
-@@ -851,6 +927,10 @@ bool llama_kv_cache::update(llama_context * lctx, bool do_shift, const stream_co
+@@ -850,6 +926,10 @@ bool llama_kv_cache::update(llama_context * lctx, bool do_shift, const stream_co
                  if (layer.v_stream[ssrc]) {
                      ggml_backend_tensor_copy(layer.v_stream[ssrc], layer.v_stream[sdst]);
                  }
@@ -1953,7 +1955,7 @@ index 8fafcd153..10de4e126 100644
              }
          }
      }
-@@ -999,6 +1079,44 @@ llama_kv_cache::slot_info llama_kv_cache::find_slot(const llama_ubatch & ubatch,
+@@ -998,6 +1078,44 @@ llama_kv_cache::slot_info llama_kv_cache::find_slot(const llama_ubatch & ubatch,
  
          const auto & cells = v_cells[seq_to_stream[seq_id]];
  
@@ -1998,7 +2000,7 @@ index 8fafcd153..10de4e126 100644
          uint32_t head_cur = v_heads[seq_to_stream[seq_id]];
  
          // if we have enough unused cells before the current head ->
-@@ -1007,11 +1125,6 @@ llama_kv_cache::slot_info llama_kv_cache::find_slot(const llama_ubatch & ubatch,
+@@ -1006,11 +1124,6 @@ llama_kv_cache::slot_info llama_kv_cache::find_slot(const llama_ubatch & ubatch,
              head_cur = 0;
          }
  
@@ -2010,7 +2012,7 @@ index 8fafcd153..10de4e126 100644
          uint32_t n_tested = 0;
  
          // for continuous slots, we test that all tokens in the ubatch fit, starting from the current head
-@@ -1118,6 +1231,15 @@ void llama_kv_cache::apply_ubatch(const slot_info & sinfo, const llama_ubatch &
+@@ -1117,6 +1230,15 @@ void llama_kv_cache::apply_ubatch(const slot_info & sinfo, const llama_ubatch &
  
              const auto idx = sinfo.idxs[s][ii];
  
@@ -2026,7 +2028,7 @@ index 8fafcd153..10de4e126 100644
              if (!cells.is_empty(idx)) {
                  assert(cells.seq_count(idx) == 1);
  
-@@ -1174,7 +1296,8 @@ void llama_kv_cache::apply_ubatch(const slot_info & sinfo, const llama_ubatch &
+@@ -1173,7 +1295,8 @@ void llama_kv_cache::apply_ubatch(const slot_info & sinfo, const llama_ubatch &
              LLAMA_LOG_DEBUG("%s: purging positions [%d, %d] of sequence %d from KV cache\n",
                      __func__, cells.seq_pos_min(s), seq_pos_max_rm[s], s);
  
@@ -2036,7 +2038,7 @@ index 8fafcd153..10de4e126 100644
          }
      }
  
-@@ -1186,6 +1309,93 @@ void llama_kv_cache::apply_ubatch(const slot_info & sinfo, const llama_ubatch &
+@@ -1185,6 +1308,93 @@ void llama_kv_cache::apply_ubatch(const slot_info & sinfo, const llama_ubatch &
      }
  }
  
@@ -2130,7 +2132,7 @@ index 8fafcd153..10de4e126 100644
  bool llama_kv_cache::get_can_shift() const {
      // Step35 uses per-layer RoPE dims; K-shift assumes a single global n_rot.
      if (model.arch == LLM_ARCH_STEP35) {
-@@ -1194,6 +1404,12 @@ bool llama_kv_cache::get_can_shift() const {
+@@ -1193,6 +1403,12 @@ bool llama_kv_cache::get_can_shift() const {
      if (hparams.n_pos_per_embd() > 1) {
          return false;
      }
@@ -2143,7 +2145,7 @@ index 8fafcd153..10de4e126 100644
      return true;
  }
  
-@@ -1248,6 +1464,455 @@ const llama_kv_cells & llama_kv_cache::get_cells(llama_seq_id seq_id) const {
+@@ -1247,6 +1463,455 @@ const llama_kv_cells & llama_kv_cache::get_cells(llama_seq_id seq_id) const {
      return v_cells[seq_to_stream[seq_id]];
  }
  
@@ -2599,7 +2601,7 @@ index 8fafcd153..10de4e126 100644
  uint32_t llama_kv_cache::get_n_kv(const slot_info & sinfo) const {
      uint32_t result = 0;
  
-@@ -1264,6 +1929,49 @@ uint32_t llama_kv_cache::get_n_kv(const slot_info & sinfo) const {
+@@ -1263,6 +1928,49 @@ uint32_t llama_kv_cache::get_n_kv(const slot_info & sinfo) const {
      return result;
  }
  
@@ -2649,7 +2651,7 @@ index 8fafcd153..10de4e126 100644
  ggml_tensor * llama_kv_cache::get_k(ggml_context * ctx, int32_t il, uint32_t n_kv, const slot_info & sinfo) const {
      const int32_t ikv = map_layer_ids.at(il);
  
-@@ -1316,6 +2024,23 @@ ggml_tensor * llama_kv_cache::get_v(ggml_context * ctx, int32_t il, uint32_t n_k
+@@ -1315,6 +2023,23 @@ ggml_tensor * llama_kv_cache::get_v(ggml_context * ctx, int32_t il, uint32_t n_k
              ggml_row_size(v->type, kv_size*n_embd_v_gqa)*sinfo.s0);
  }
  
@@ -2673,7 +2675,7 @@ index 8fafcd153..10de4e126 100644
  ggml_tensor * llama_kv_cache::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il, const slot_info & sinfo) const {
      GGML_UNUSED(sinfo);
  
-@@ -1417,6 +2142,28 @@ ggml_tensor * llama_kv_cache::build_input_k_idxs(ggml_context * ctx, const llama
+@@ -1416,6 +2141,28 @@ ggml_tensor * llama_kv_cache::build_input_k_idxs(ggml_context * ctx, const llama
      return k_idxs;
  }
  
@@ -2702,7 +2704,7 @@ index 8fafcd153..10de4e126 100644
  ggml_tensor * llama_kv_cache::build_input_v_idxs(ggml_context * ctx, const llama_ubatch & ubatch) const {
      const uint32_t n_tokens = ubatch.n_tokens;
  
-@@ -1803,6 +2550,39 @@ void llama_kv_cache::set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch
+@@ -1804,6 +2551,39 @@ void llama_kv_cache::set_input_pos_bucket(ggml_tensor * dst, const llama_ubatch
      }
  }
  
@@ -2742,7 +2744,7 @@ index 8fafcd153..10de4e126 100644
  void llama_kv_cache::set_input_k_rot(ggml_tensor * dst) const {
      GGML_ASSERT(ggml_backend_buffer_is_host(dst->buffer));
  
-@@ -1960,6 +2740,18 @@ size_t llama_kv_cache::size_v_bytes() const {
+@@ -1913,6 +2693,18 @@ size_t llama_kv_cache::size_v_bytes() const {
      return size_v_bytes;
  }
  
@@ -2761,7 +2763,7 @@ index 8fafcd153..10de4e126 100644
  ggml_tensor * llama_kv_cache::build_rope_shift(
          const llama_cparams & cparams,
                 ggml_context * ctx,
-@@ -2058,10 +2850,6 @@ ggml_cgraph * llama_kv_cache::build_graph_shift(llm_graph_result * res, llama_co
+@@ -2011,10 +2803,6 @@ ggml_cgraph * llama_kv_cache::build_graph_shift(llm_graph_result * res, llama_co
      for (const auto & layer : layers) {
          const uint32_t il = layer.il;
  
@@ -2772,7 +2774,7 @@ index 8fafcd153..10de4e126 100644
          const int64_t n_head_kv    = hparams.n_head_kv(il);
          const int64_t n_embd_k_gqa = hparams.n_embd_k_gqa(il);
  
-@@ -2308,6 +3096,36 @@ void llama_kv_cache::state_write_data(llama_io_write_i & io, const cell_ranges_t
+@@ -2261,6 +3049,36 @@ void llama_kv_cache::state_write_data(llama_io_write_i & io, const cell_ranges_t
          }
      }
  
@@ -2809,7 +2811,7 @@ index 8fafcd153..10de4e126 100644
      if (!v_trans) {
          for (const auto & layer : layers) {
              const uint32_t il = layer.il;
-@@ -2594,6 +3412,68 @@ bool llama_kv_cache::state_read_data(llama_io_read_i & io, uint32_t strm, uint32
+@@ -2572,6 +3390,68 @@ bool llama_kv_cache::state_read_data(llama_io_read_i & io, uint32_t strm, uint32
          }
      }
  
@@ -2878,7 +2880,7 @@ index 8fafcd153..10de4e126 100644
      if (!this->v_trans) {
          for (const auto & layer : layers) {
              const uint32_t il = layer.il;
-@@ -2725,8 +3605,9 @@ llama_kv_cache_context::llama_kv_cache_context(
+@@ -2682,8 +3562,9 @@ llama_kv_cache_context::llama_kv_cache_context(
          llama_kv_cache * kv,
          llama_context * lctx,
          bool do_shift,
@@ -2890,7 +2892,7 @@ index 8fafcd153..10de4e126 100644
          status = LLAMA_MEMORY_STATUS_NO_UPDATE;
      }
  }
-@@ -2779,6 +3660,21 @@ uint32_t llama_kv_cache_context::get_n_kv() const {
+@@ -2736,6 +3617,21 @@ uint32_t llama_kv_cache_context::get_n_kv() const {
      return n_kv;
  }
  
@@ -2912,7 +2914,7 @@ index 8fafcd153..10de4e126 100644
  ggml_type llama_kv_cache_context::type_k() const {
      return kv->type_k();
  }
-@@ -2795,6 +3691,10 @@ ggml_tensor * llama_kv_cache_context::get_v(ggml_context * ctx, int32_t il) cons
+@@ -2752,6 +3648,10 @@ ggml_tensor * llama_kv_cache_context::get_v(ggml_context * ctx, int32_t il) cons
      return kv->get_v(ctx, il, n_kv, sinfos[i_cur]);
  }
  
@@ -2923,7 +2925,7 @@ index 8fafcd153..10de4e126 100644
  ggml_tensor * llama_kv_cache_context::cpy_k(ggml_context * ctx, ggml_tensor * k_cur, ggml_tensor * k_idxs, int32_t il) const {
      return kv->cpy_k(ctx, k_cur, k_idxs, il, sinfos[i_cur]);
  }
-@@ -2803,6 +3703,10 @@ ggml_tensor * llama_kv_cache_context::cpy_v(ggml_context * ctx, ggml_tensor * v_
+@@ -2760,6 +3660,10 @@ ggml_tensor * llama_kv_cache_context::cpy_v(ggml_context * ctx, ggml_tensor * v_
      return kv->cpy_v(ctx, v_cur, v_idxs, il, sinfos[i_cur]);
  }
  
@@ -2934,7 +2936,7 @@ index 8fafcd153..10de4e126 100644
  ggml_tensor * llama_kv_cache_context::build_input_k_idxs(ggml_context * ctx, const llama_ubatch & ubatch) const {
      return kv->build_input_k_idxs(ctx, ubatch);
  }
-@@ -2839,6 +3743,10 @@ void llama_kv_cache_context::set_input_pos_bucket(ggml_tensor * dst, const llama
+@@ -2796,6 +3700,10 @@ void llama_kv_cache_context::set_input_pos_bucket(ggml_tensor * dst, const llama
      kv->set_input_pos_bucket(dst, ubatch);
  }
  
@@ -3135,18 +3137,10 @@ index c4d8699de..0268c7c34 100644
      //
      // update context
 diff --git a/src/llama-kv-cells.h b/src/llama-kv-cells.h
-index 5167c037d..8997a7dba 100644
+index 5d567a6ed..775e81dbf 100644
 --- a/src/llama-kv-cells.h
 +++ b/src/llama-kv-cells.h
-@@ -49,6 +49,7 @@ public:
- 
-         for (uint32_t s = 0; s < LLAMA_MAX_SEQ; ++s) {
-             seq_pos[s].clear();
-+            seq_pos_index_mismatch[s] = 0;
-         }
-     }
- 
-@@ -101,24 +102,32 @@ public:
+@@ -103,24 +103,32 @@ public:
      }
  
      // move cell isrc to idst (used during defrag)
@@ -3193,108 +3187,36 @@ index 5167c037d..8997a7dba 100644
  
      // copy the state of cells [i, i + n) (used for save/restore the state of the cells)
      llama_kv_cells cp(uint32_t i, uint32_t n) const {
-@@ -246,7 +255,7 @@ public:
-         assert(seq_id >= 0);
- 
-         seq[i].reset(seq_id);
--        seq_pos_dec(seq_id, pos[i]);
-+        seq_pos_dec(seq_id, pos[i], i);
- 
-         if (seq[i].none()) {
-             pos[i] = -1;
-@@ -270,7 +279,7 @@ public:
-             seq[i].reset();
- 
-             seq[i].set(seq_id);
--            seq_pos_inc(seq_id, pos[i]);
-+            seq_pos_inc(seq_id, pos[i], i);
- 
-             return false;
-         }
-@@ -339,7 +348,7 @@ public:
-         assert(!seq[i].test(seq_id));
- 
-         seq[i].set(seq_id);
--        seq_pos_inc(seq_id, pos[i]);
-+        seq_pos_inc(seq_id, pos[i], i);
-     }
- 
-     // return the sequence id of this cell
-@@ -386,6 +395,23 @@ public:
+@@ -386,6 +394,29 @@ public:
          return seq_pos[seq_id].rbegin()->first;
      }
  
 +    // Whether every position for seq_id is stored in the cell with the same
 +    // index and the represented positions form the dense range [0, max].
-+    // The mismatch count is maintained with the existing seq_pos index so this
-+    // check remains O(1) on the graph-build path.
++    // The (pos, cell) pairs in the seq_pos index are ordered by position, so
++    // the check is a single ordered scan on the graph-build path.
 +    bool seq_pos_is_cell_contiguous(llama_seq_id seq_id) const {
 +        assert(seq_id >= 0);
 +        assert(seq_id < LLAMA_MAX_SEQ);
 +
 +        const auto & positions = seq_pos[seq_id];
-+        if (positions.empty() || seq_pos_index_mismatch[seq_id] != 0) {
++        if (positions.empty()) {
 +            return false;
 +        }
-+        const llama_pos pos_max = positions.rbegin()->first;
-+        return positions.begin()->first == 0 && pos_max >= 0 &&
-+               positions.size() == static_cast<size_t>(pos_max) + 1;
++
++        llama_pos expected = 0;
++        for (const auto & [pos, cell] : positions) {
++            if (pos != expected || pos != static_cast<llama_pos>(cell)) {
++                return false;
++            }
++            ++expected;
++        }
++        return true;
 +    }
 +
      // note: call only if the cell is not empty
      llama_pos pos_get(uint32_t i) const {
          assert(i < pos.size());
-@@ -525,26 +551,38 @@ private:
-     //
-     std::map<llama_pos, int> seq_pos[LLAMA_MAX_SEQ];
- 
-+    // Number of cells for each sequence whose physical cell index differs
-+    // from its logical position.
-+    uint32_t seq_pos_index_mismatch[LLAMA_MAX_SEQ] = {};
-+
-     // helper functions for updating `seq_pos`, once cell at a time:
- 
--    void seq_pos_dec(llama_seq_id s, llama_pos p) {
-+    void seq_pos_dec(llama_seq_id s, llama_pos p, uint32_t i) {
-         auto it = seq_pos[s].find(p);
-         assert(it != seq_pos[s].end());
- 
-+        if (p != static_cast<llama_pos>(i)) {
-+            assert(seq_pos_index_mismatch[s] > 0);
-+            --seq_pos_index_mismatch[s];
-+        }
-+
-         if (--it->second == 0) {
-             seq_pos[s].erase(it);
-         }
-     }
- 
--    void seq_pos_inc(llama_seq_id s, llama_pos p) {
-+    void seq_pos_inc(llama_seq_id s, llama_pos p, uint32_t i) {
-         seq_pos[s][p]++;
-+        if (p != static_cast<llama_pos>(i)) {
-+            ++seq_pos_index_mismatch[s];
-+        }
-     }
- 
-     // remove cell i
-     void seq_pos_rm(uint32_t i) {
-         for (int s = 0; s < LLAMA_MAX_SEQ; ++s) {
-             if (seq[i].test(s)) {
--                seq_pos_dec(s, pos[i]);
-+                seq_pos_dec(s, pos[i], i);
-             }
-         }
-     }
-@@ -553,7 +591,7 @@ private:
-     void seq_pos_add(uint32_t i) {
-         for (int s = 0; s < LLAMA_MAX_SEQ; ++s) {
-             if (seq[i].test(s)) {
--                seq_pos_inc(s, pos[i]);
-+                seq_pos_inc(s, pos[i], i);
-             }
-         }
-     }
 diff --git a/src/llama-memory-recurrent.cpp b/src/llama-memory-recurrent.cpp
 index 57919accf..ff489d954 100644
 --- a/src/llama-memory-recurrent.cpp
@@ -3330,7 +3252,7 @@ index 57919accf..ff489d954 100644
      }
      if (cell_count > size) {
 diff --git a/src/llama-model-loader.cpp b/src/llama-model-loader.cpp
-index 1b1f852a0..2e985874e 100644
+index 49f3c4f8e..502ee292c 100644
 --- a/src/llama-model-loader.cpp
 +++ b/src/llama-model-loader.cpp
 @@ -18,6 +18,25 @@ static const size_t kiB = 1024;
@@ -3419,7 +3341,7 @@ index 1b1f852a0..2e985874e 100644
              // make sure the main file is loaded first
              uint16_t idx = 0;
              const std::string kv_split_no = llm_kv(LLM_KV_SPLIT_NO);
-@@ -1103,14 +1162,101 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1144,14 +1203,101 @@ struct ggml_tensor * llama_model_loader::create_tensor(
          return it->second.get();
      };
  
@@ -3444,13 +3366,13 @@ index 1b1f852a0..2e985874e 100644
 +    auto stage_filter_excludes = [&](ggml_tensor * t_meta) -> bool {
 +        if (!g_skippy_filter.enabled) {
 +            return false;
-+        }
-+
+         }
+ 
 +        llm_tensor tn_tensor = tn.tensor;
 +        if (tn.tensor == LLM_TENSOR_TOKEN_EMBD && (flags & TENSOR_DUPLICATED)) {
 +            tn_tensor = LLM_TENSOR_OUTPUT;
-         }
- 
++        }
++
 +        llm_tensor_info info;
 +        try {
 +            info = llm_tensor_info_for(tn_tensor);
@@ -3526,7 +3448,7 @@ index 1b1f852a0..2e985874e 100644
          // some models use the token embedding tensor as the output, but since these are used in different layers and with different ops
          // the tensor is duplicated
          // to handle this, we check if the tensor is duplicated, and if so, we assume that it is being loaded as the output tensor
-@@ -1126,6 +1272,20 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1167,6 +1313,20 @@ struct ggml_tensor * llama_model_loader::create_tensor(
              throw std::runtime_error(format("missing tensor info mapping for %s", tn.str().c_str()));
          }
  
@@ -3547,7 +3469,7 @@ index 1b1f852a0..2e985874e 100644
          // skip unused tensors
          if (info.op == GGML_OP_NONE || (flags & TENSOR_SKIP)) {
              const size_t nbytes = ggml_nbytes(t_meta);
-@@ -1282,6 +1442,16 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1327,6 +1487,16 @@ struct ggml_tensor * llama_model_loader::create_tensor(
      }
  
      LLAMA_LOG_DEBUG("%s: loading tensor %s\n", __func__, tn.str().c_str());
@@ -3565,11 +3487,11 @@ index 1b1f852a0..2e985874e 100644
      if (cur == NULL) {
          return NULL;
 diff --git a/src/llama-model-loader.h b/src/llama-model-loader.h
-index 20f744253..392c1e929 100644
+index 9e51d0ce7..12785b98b 100644
 --- a/src/llama-model-loader.h
 +++ b/src/llama-model-loader.h
-@@ -14,12 +14,26 @@
- #include <map>
+@@ -15,12 +15,26 @@
+ #include <set>
  #include <stdexcept>
  #include <unordered_map>
 +#include <unordered_set>
@@ -3595,7 +3517,7 @@ index 20f744253..392c1e929 100644
  enum llama_fver {
      GGUF_FILE_VERSION_V1 = 1,
      GGUF_FILE_VERSION_V2 = 2,
-@@ -97,6 +111,7 @@ struct llama_model_loader {
+@@ -125,6 +139,7 @@ struct llama_model_loader {
  
      std::map<std::string, llama_tensor_weight, weight_name_comparer> weights_map;
      std::unordered_map<std::string, llama_model_kv_override> kv_overrides;
@@ -3603,7 +3525,7 @@ index 20f744253..392c1e929 100644
      const llama_model_tensor_buft_override * tensor_buft_overrides;
  
      gguf_context_ptr metadata_ptr;
-@@ -134,6 +149,7 @@ struct llama_model_loader {
+@@ -177,6 +192,7 @@ struct llama_model_loader {
          void * set_tensor_data_ud,
          const std::string & fname,
          std::vector<std::string> & splits, // optional, only need if the split does not follow naming scheme
@@ -3612,7 +3534,7 @@ index 20f744253..392c1e929 100644
          llama_load_mode load_mode,
          bool check_tensors,
 diff --git a/src/llama-model-saver.cpp b/src/llama-model-saver.cpp
-index 8860bd3f4..fe0efd30e 100644
+index 919e90ecc..efb212ee3 100644
 --- a/src/llama-model-saver.cpp
 +++ b/src/llama-model-saver.cpp
 @@ -32,6 +32,7 @@ bool llama_model_saver_supports_arch(llm_arch arch) {
@@ -3624,7 +3546,7 @@ index 8860bd3f4..fe0efd30e 100644
          default:
              return true;
 diff --git a/src/llama-model.cpp b/src/llama-model.cpp
-index 65a6702ce..6ac2fa322 100644
+index 6344f2d8a..cad8e2924 100644
 --- a/src/llama-model.cpp
 +++ b/src/llama-model.cpp
 @@ -42,8 +42,6 @@
@@ -3654,7 +3576,7 @@ index 65a6702ce..6ac2fa322 100644
          default:
              throw std::runtime_error(std::string("unsupported model architecture: '") + llm_arch_name(arch) + "'");
      }
-@@ -948,7 +946,6 @@ const char * llm_type_name(llm_type type) {
+@@ -949,7 +947,6 @@ const char * llm_type_name(llm_type type) {
          case LLM_TYPE_100B_A6B:      return "100B.A6B";
          case LLM_TYPE_102B_A12B:     return "102B.A12B";
          case LLM_TYPE_106B_A12B:     return "106B.A12B";
@@ -3662,7 +3584,7 @@ index 65a6702ce..6ac2fa322 100644
          case LLM_TYPE_120B_A12B:     return "120B.A12B";
          case LLM_TYPE_122B_A10B:     return "122B.A10B";
          case LLM_TYPE_124B_A5_1B:    return "124B.A5.1B";
-@@ -1273,6 +1270,7 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
+@@ -1284,6 +1281,7 @@ void llama_model_base::load_hparams(llama_model_loader & ml) {
      std::fill(hparams.is_swa_impl.begin(),   hparams.is_swa_impl.end(), 0);
      std::fill(hparams.is_recr_impl.begin(),  hparams.is_recr_impl.end(),  llm_arch_is_recurrent(ml.get_arch()) ? 1 : 0);
      std::fill(hparams.is_indexer_full_impl.begin(), hparams.is_indexer_full_impl.end(), 0);
@@ -3670,7 +3592,7 @@ index 65a6702ce..6ac2fa322 100644
  
      std::fill(hparams.xielu_alpha_n.begin(), hparams.xielu_alpha_n.end(), 0.0f);
      std::fill(hparams.xielu_alpha_p.begin(), hparams.xielu_alpha_p.end(), 0.0f);
-@@ -1466,13 +1464,29 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
+@@ -1477,13 +1475,29 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
  
      const int i_gpu_start = std::max(n_layer_all + 1 - n_gpu_layers, 0);
      const int act_gpu_layers = devices.empty() ? 0 : std::min(n_gpu_layers, n_layer_all + 1);
@@ -3701,7 +3623,7 @@ index 65a6702ce..6ac2fa322 100644
          auto * dev = devices.at(layer_gpu).dev;
          LLAMA_LOG_DEBUG("load_tensors: layer %3d assigned to device %s, is_swa = %d\n", il, ggml_backend_dev_name(dev), is_swa);
          return {dev, &pimpl->gpu_buft_list.at(dev)};
-@@ -1556,13 +1570,13 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
+@@ -1567,13 +1581,13 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
              }
  
              // MoE expert weight scales (per-expert, shape {n_expert})
@@ -3718,7 +3640,7 @@ index 65a6702ce..6ac2fa322 100644
                  layer.ffn_up_exps_s = create_tensor(tn(LLM_TENSOR_FFN_UP_EXPS, "scale", i), {n_expert}, TENSOR_NOT_REQUIRED);
              }
  
-@@ -1663,7 +1677,7 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
+@@ -1674,7 +1688,7 @@ bool llama_model_base::load_tensors(llama_model_loader & ml) {
              }
          }
      }
@@ -3727,7 +3649,7 @@ index 65a6702ce..6ac2fa322 100644
  
      // Tied NVFP4 output is valid when no separate LM-head scale tensors are present.
      // If sidecar scales exist, the output weight must be an actual output tensor.
-@@ -2063,7 +2077,6 @@ void llama_model::print_info() const {
+@@ -2087,7 +2101,6 @@ void llama_model::print_info() const {
                  arch == LLM_ARCH_GRANITE ||
                  arch == LLM_ARCH_GRANITE_MOE ||
                  arch == LLM_ARCH_GRANITE_HYBRID ||
@@ -3735,7 +3657,7 @@ index 65a6702ce..6ac2fa322 100644
                  arch == LLM_ARCH_NEMOTRON_H_MOE) {
              LLAMA_LOG_INFO("%s: f_embedding_scale     = %f\n", __func__, hparams.f_embedding_scale);
              LLAMA_LOG_INFO("%s: f_residual_scale      = %f\n", __func__, hparams.f_residual_scale);
-@@ -2203,6 +2216,22 @@ ggml_tensor * llama_model::get_rope_factors(const llama_cparams & cparams, int i
+@@ -2227,6 +2240,22 @@ ggml_tensor * llama_model::get_rope_factors(const llama_cparams & cparams, int i
      return layers[il].rope_short;
  }
  
@@ -3758,7 +3680,7 @@ index 65a6702ce..6ac2fa322 100644
  llama_memory_i * llama_model::create_memory(const llama_memory_params & params, const llama_cparams & cparams) const {
      llama_memory_i * res;
  
-@@ -2226,28 +2255,6 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2250,28 +2279,6 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
              {
                  res = nullptr;
              } break;
@@ -3787,7 +3709,7 @@ index 65a6702ce..6ac2fa322 100644
          case LLM_ARCH_GLM_DSA:
          case LLM_ARCH_DEEPSEEK32:
              {
-@@ -2443,7 +2450,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2467,7 +2474,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
                              std::max((uint32_t) 1, cparams.n_seq_max),
                              cparams.n_seq_max,
                              cparams.n_rs_seq,
@@ -3796,7 +3718,7 @@ index 65a6702ce..6ac2fa322 100644
                  } else if (llm_arch_is_hybrid(arch) && !mtp_on_hybrid_qwen && !mtp_on_hybrid_nemotron) {
                      // The main difference between hybrid architectures is the
                      // layer filters, so pick the right one here
-@@ -2454,8 +2461,19 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2478,8 +2485,19 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
                      llama_memory_hybrid::layer_filter_cb filter_idx  = nullptr;
                      const bool needs_mem_idx = (arch == LLM_ARCH_QWEN4EXP);
                      if (arch == LLM_ARCH_FALCON_H1) {
@@ -3816,7 +3738,7 @@ index 65a6702ce..6ac2fa322 100644
                      } else if (arch == LLM_ARCH_NEMOTRON_H || arch == LLM_ARCH_NEMOTRON_H_MOE) {
                          filter_attn = [&](uint32_t il) {
                              return !hparams.is_recr(il) && hparams.n_ff(il) == 0;
-@@ -2479,6 +2497,20 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2503,6 +2521,20 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
                          }
                      }
  
@@ -3837,7 +3759,7 @@ index 65a6702ce..6ac2fa322 100644
                      if (hparams.swa_type != LLAMA_SWA_TYPE_NONE) {
                          // Use hybrid-iswa for hybrid models with SWA
                          res = new llama_memory_hybrid_iswa(
-@@ -2561,9 +2593,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2585,9 +2617,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
                          filter = [&](uint32_t il) { return il >= hparams.n_layer(); };
                      }
  
@@ -3848,7 +3770,7 @@ index 65a6702ce..6ac2fa322 100644
                          if (params.ctx_type == LLAMA_CONTEXT_TYPE_MTP) {
                              filter = [&](uint32_t il) { return il >= hparams.n_layer(); };
                          } else {
-@@ -2571,7 +2601,34 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2595,7 +2625,34 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
                          }
                      }
  
@@ -3884,7 +3806,7 @@ index 65a6702ce..6ac2fa322 100644
                          GGML_ASSERT(hparams.is_swa_any());
  
                          if (arch == LLM_ARCH_GEMMA4_ASSISTANT) {
-@@ -2692,7 +2749,6 @@ llama_model_params llama_model_default_params() {
+@@ -2716,7 +2773,6 @@ llama_model_params llama_model_default_params() {
          /*.use_extra_bufts             =*/ true,
          /*.no_host                     =*/ false,
          /*.no_alloc                    =*/ false,
@@ -3892,7 +3814,7 @@ index 65a6702ce..6ac2fa322 100644
      };
  
      return result;
-@@ -2813,6 +2869,7 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
+@@ -2837,6 +2893,7 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
          case LLM_ARCH_NEMOTRON_H_MOE:
          case LLM_ARCH_KIMI_LINEAR:
          case LLM_ARCH_KIMI_K3:
@@ -3900,7 +3822,7 @@ index 65a6702ce..6ac2fa322 100644
              return LLAMA_ROPE_TYPE_NONE;
  
          // use what we call a normal RoPE, operating on pairs of consecutive head values
-@@ -2835,7 +2892,6 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
+@@ -2859,7 +2916,6 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
          case LLM_ARCH_DEEPSEEK2OCR:
          case LLM_ARCH_DEEPSEEK32:
          case LLM_ARCH_DEEPSEEK4:
@@ -3908,7 +3830,7 @@ index 65a6702ce..6ac2fa322 100644
          case LLM_ARCH_PLM:
          case LLM_ARCH_CHATGLM:
          case LLM_ARCH_GRANITE:
-@@ -3147,23 +3203,9 @@ void llama_model_base::create_tensor_qkv(llama_layer & layer, int bid,
+@@ -3171,23 +3227,9 @@ void llama_model_base::create_tensor_qkv(llama_layer & layer, int bid,
          int64_t n_embd_, int64_t n_embd_q_, int64_t n_embd_k_, int64_t n_embd_v_,
          int flags) {
      const int64_t n_embd_qkv = n_embd_q_ + n_embd_k_ + n_embd_v_;
@@ -3934,7 +3856,7 @@ index 65a6702ce..6ac2fa322 100644
          layer.wqkv_b = create_tensor(tn(LLM_TENSOR_ATTN_QKV, "bias", bid), {n_embd_qkv}, TENSOR_NOT_REQUIRED | TENSOR_SKIP_IF_VIRTUAL);
      } else {
          layer.wq = create_tensor(tn(LLM_TENSOR_ATTN_Q, "weight", bid), {n_embd_, n_embd_q_}, flags);
-@@ -3183,38 +3225,3 @@ const int32_t * llama_model_target_layer_ids(const struct llama_model * model) {
+@@ -3207,38 +3249,3 @@ const int32_t * llama_model_target_layer_ids(const struct llama_model * model) {
  uint32_t llama_model_target_layer_ids_n(const struct llama_model * model) {
      return (uint32_t) model->target_layer_ids.size();
  }
@@ -3974,10 +3896,10 @@ index 65a6702ce..6ac2fa322 100644
 -    return (uint32_t) nelements;
 -}
 diff --git a/src/llama-model.h b/src/llama-model.h
-index 38066538e..dea1118d8 100644
+index 4c4a30e01..b12bf93cb 100644
 --- a/src/llama-model.h
 +++ b/src/llama-model.h
-@@ -133,7 +133,6 @@ enum llm_type {
+@@ -134,7 +134,6 @@ enum llm_type {
      LLM_TYPE_100B_A6B,
      LLM_TYPE_102B_A12B, // Solar-Open
      LLM_TYPE_106B_A12B, // GLM-4.5-Air
@@ -3985,7 +3907,7 @@ index 38066538e..dea1118d8 100644
      LLM_TYPE_120B_A12B, // Nemotron 3 Super
      LLM_TYPE_122B_A10B, // Qwen3.5
      LLM_TYPE_124B_A5_1B, // Ling-3.0-flash
-@@ -229,24 +228,6 @@ struct llama_layer_nextn {
+@@ -230,24 +229,6 @@ struct llama_layer_nextn {
      struct ggml_tensor * shared_head_norm      = nullptr;
  };
  
@@ -4010,7 +3932,7 @@ index 38066538e..dea1118d8 100644
  struct llama_layer {
      // normalization
      struct ggml_tensor * attn_norm       = nullptr;
-@@ -588,6 +569,15 @@ struct llama_layer {
+@@ -590,6 +571,15 @@ struct llama_layer {
  
      struct llama_layer_nextn nextn;
  
@@ -4027,7 +3949,7 @@ index 38066538e..dea1118d8 100644
  };
  
 diff --git a/src/llama-quant.cpp b/src/llama-quant.cpp
-index c414caa17..6eb900794 100644
+index 34ff25db5..b23dbea1b 100644
 --- a/src/llama-quant.cpp
 +++ b/src/llama-quant.cpp
 @@ -324,6 +324,16 @@ static bool tensor_allows_quantization(const llama_model_quantize_params * param
@@ -4047,7 +3969,7 @@ index c414caa17..6eb900794 100644
      // do not quantize MiniMax's indexer projection weights, they are tiny
      quantize &= name.find("indexer.k_proj.weight") == std::string::npos;
      quantize &= name.find("indexer.q_proj.weight") == std::string::npos;
-@@ -916,7 +926,7 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
+@@ -935,7 +945,7 @@ static void llama_model_quantize_impl(const std::string & fname_inp, const std::
      const llama_model_kv_override * kv_overrides = params->kv_overrides;
      std::vector<std::string> splits = {};
      llama_model_loader ml(/*metadata*/ nullptr, /*set_tensor_data*/ nullptr, /*set_tensor_data_ud*/ nullptr,
@@ -4097,7 +4019,7 @@ index b7c289263..65e43f671 100644
  
  struct LLM_KV;
 diff --git a/src/llama.cpp b/src/llama.cpp
-index 6ec5d315d..a0f12a7db 100644
+index 633db658c..8ccca59b6 100644
 --- a/src/llama.cpp
 +++ b/src/llama.cpp
 @@ -313,9 +313,9 @@ static bool llama_prepare_model_devices(const llama_model_params & params, llama
@@ -4111,7 +4033,7 @@ index 6ec5d315d..a0f12a7db 100644
 +        llama_model_loader ml(metadata, set_tensor_data, set_tensor_data_ud, fname, splits, ordered_parts, file, params.load_mode,
              params.check_tensors, params.no_alloc, params.load_mtp, params.kv_overrides, params.tensor_buft_overrides);
  
-         ml.lazy_mode = params.lazy_mode;
+         ml.lazy.mode = params.lazy_mode;
 @@ -382,6 +382,7 @@ static struct llama_model * llama_model_load_from_file_impl(
          void * set_tensor_data_ud,
          const std::string & path_model,
@@ -4191,7 +4113,7 @@ index 6ec5d315d..a0f12a7db 100644
  }
 -
 diff --git a/src/models/afmoe.cpp b/src/models/afmoe.cpp
-index 063b21425..b388e586a 100644
+index cf0220367..3825ea97c 100644
 --- a/src/models/afmoe.cpp
 +++ b/src/models/afmoe.cpp
 @@ -113,7 +113,12 @@ llama_model_afmoe::graph::graph(const llama_model & model, const llm_graph_param
@@ -4491,7 +4413,7 @@ index 585f36141..8e9dc3028 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/models/bailingmoe.cpp b/src/models/bailingmoe.cpp
-index 7faf73c83..3fa8e41d0 100644
+index 9d1073ae1..c32f1c525 100644
 --- a/src/models/bailingmoe.cpp
 +++ b/src/models/bailingmoe.cpp
 @@ -63,16 +63,21 @@ llama_model_bailingmoe::graph::graph(const llama_model & model, const llm_graph_
@@ -4534,10 +4456,10 @@ index 7faf73c83..3fa8e41d0 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/models/bailingmoe2.cpp b/src/models/bailingmoe2.cpp
-index 5000e9c6d..2d95fc677 100644
+index 24fc4e022..48e78d2de 100644
 --- a/src/models/bailingmoe2.cpp
 +++ b/src/models/bailingmoe2.cpp
-@@ -99,16 +99,21 @@ llama_model_bailingmoe2::graph::graph(const llama_model & model, const llm_graph
+@@ -96,16 +96,21 @@ llama_model_bailingmoe2::graph::graph(const llama_model & model, const llm_graph
      ggml_tensor * cur;
      ggml_tensor * inpL;
  
@@ -4562,7 +4484,7 @@ index 5000e9c6d..2d95fc677 100644
          ggml_tensor * inpSA = inpL;
  
          // norm
-@@ -141,7 +146,7 @@ llama_model_bailingmoe2::graph::graph(const llama_model & model, const llm_graph
+@@ -138,7 +143,7 @@ llama_model_bailingmoe2::graph::graph(const llama_model & model, const llm_graph
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f / sqrtf(float(n_embd_head)), il);
          }
  
@@ -4571,7 +4493,7 @@ index 5000e9c6d..2d95fc677 100644
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -199,6 +204,13 @@ llama_model_bailingmoe2::graph::graph(const llama_model & model, const llm_graph
+@@ -196,6 +201,13 @@ llama_model_bailingmoe2::graph::graph(const llama_model & model, const llm_graph
  
      cur = inpL;
  
@@ -4986,7 +4908,7 @@ index cdfcf29e0..d732efe45 100644
  
      cb(cur, "result_norm", -1);
 diff --git a/src/models/deepseek2.cpp b/src/models/deepseek2.cpp
-index e0e537e00..221584fcc 100644
+index 4628ff4da..787648c56 100644
 --- a/src/models/deepseek2.cpp
 +++ b/src/models/deepseek2.cpp
 @@ -20,6 +20,9 @@ void llama_model_deepseek2::load_arch_hparams(llama_model_loader & ml) {
@@ -4999,19 +4921,7 @@ index e0e537e00..221584fcc 100644
      if (hparams.expert_gating_func == LLAMA_EXPERT_GATING_FUNC_TYPE_NONE) {
          // for compatibility with existing DeepSeek V2 and V2.5 GGUFs
          // that have no expert_gating_func model parameter set
-@@ -37,11 +40,6 @@ void llama_model_deepseek2::load_arch_hparams(llama_model_loader & ml) {
-         hparams.rope_yarn_log_mul /= 0.1f;
-     }
- 
--    // NextN/MTP
--    ml.get_key(LLM_KV_NEXTN_PREDICT_LAYERS, hparams.n_layer_nextn, false);
--    GGML_ASSERT(hparams.n_layer_nextn == 0 ||
--        hparams.n_layer() + hparams.n_layer_nextn == hparams.n_layer_all);
--
-     // (optional) temperature tuning - used by mistral-large
-     ml.get_key(LLM_KV_ATTENTION_TEMPERATURE_SCALE,  hparams.f_attn_temp_scale,       false);
-     ml.get_key(LLM_KV_ATTENTION_TEMPERATURE_LENGTH, hparams.n_attn_temp_floor_scale, false); // FIXME why not use temperature_length?
-@@ -57,20 +55,10 @@ void llama_model_deepseek2::load_arch_hparams(llama_model_loader & ml) {
+@@ -52,20 +55,10 @@ void llama_model_deepseek2::load_arch_hparams(llama_model_loader & ml) {
      }
  }
  
@@ -5033,7 +4943,7 @@ index e0e537e00..221584fcc 100644
      const bool is_mla = hparams.is_mla();
  
      // note: these are the actual head sizes you get when treating as MHA or after "decompression" using wv_b for MLA
-@@ -98,43 +86,42 @@ void llama_model_deepseek2::load_arch_tensors(llama_model_loader & ml) {
+@@ -93,43 +86,42 @@ void llama_model_deepseek2::load_arch_tensors(llama_model_loader & ml) {
  
      for (int i = 0; i < n_layer_all; ++i) {
          auto & layer = layers[i];
@@ -5094,7 +5004,7 @@ index e0e537e00..221584fcc 100644
  
              if (n_expert == 0) {
                  throw std::runtime_error("n_expert must be > 0");
-@@ -144,23 +131,22 @@ void llama_model_deepseek2::load_arch_tensors(llama_model_loader & ml) {
+@@ -139,23 +131,22 @@ void llama_model_deepseek2::load_arch_tensors(llama_model_loader & ml) {
              }
  
              // MoE branch
@@ -5129,7 +5039,7 @@ index e0e537e00..221584fcc 100644
          }
      }
  }
-@@ -169,254 +155,8 @@ std::unique_ptr<llm_graph_context> llama_model_deepseek2::build_arch_graph(const
+@@ -164,254 +155,8 @@ std::unique_ptr<llm_graph_context> llama_model_deepseek2::build_arch_graph(const
      if (params.gtype == LLM_GRAPH_TYPE_DECODER_MTP) {
          return std::make_unique<graph_mtp>(*this, params);
      }
@@ -5208,7 +5118,7 @@ index e0e537e00..221584fcc 100644
 -    ggml_tensor * h_embd = inp->h;
 -
 -    res->add_input(std::move(inp));
--
+ 
 -    ggml_tensor * inp_pos     = build_inp_pos();
 -    ggml_tensor * inp_out_ids = build_inp_out_ids();
 -
@@ -5373,7 +5283,7 @@ index e0e537e00..221584fcc 100644
 -    ggml_tensor * head_s = layer.nextn.shared_head_head
 -            ? layer.nextn.shared_head_head_s
 -            : model.output_s;
- 
+-
 -    GGML_ASSERT(head_w && "GLM4 MTP: missing LM head (nextn.shared_head_head or model.output)");
 -
 -    cur = build_lora_mm(head_w, cur, head_s);
@@ -5385,7 +5295,7 @@ index e0e537e00..221584fcc 100644
  }
  
  llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_params & params) :
-@@ -450,8 +190,16 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -445,8 +190,16 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
      ggml_tensor * cur;
      ggml_tensor * inpL;
  
@@ -5403,7 +5313,7 @@ index e0e537e00..221584fcc 100644
  
      // (optional) temperature tuning - used by mistral-large
      ggml_tensor * inp_attn_scale = nullptr;
-@@ -462,12 +210,22 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -457,12 +210,22 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
  
@@ -5430,7 +5340,7 @@ index e0e537e00..221584fcc 100644
          ggml_tensor * inpSA = inpL;
  
          // norm
-@@ -551,21 +309,21 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -546,21 +309,21 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
              kv_cmpr = build_norm(kv_cmpr, model.layers[il].attn_kv_a_norm, nullptr, LLM_NORM_RMS, il);
              cb(kv_cmpr, "kv_cmpr", il);
  
@@ -5464,7 +5374,7 @@ index e0e537e00..221584fcc 100644
                  // {n_embd_head_qk_nope, n_tokens, n_head}
                  q_nope = ggml_permute(ctx0, q_nope, 0, 2, 1, 3);
                  cb(q_nope, "q_nope_perm", il);
-@@ -647,7 +405,7 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -642,7 +405,7 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
                              Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, kq_scale, il);
              }
          }
@@ -5473,7 +5383,7 @@ index e0e537e00..221584fcc 100644
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -705,12 +463,23 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -700,12 +463,23 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
      }
      cur = inpL;
  
@@ -5498,7 +5408,7 @@ index e0e537e00..221584fcc 100644
          cur = ggml_get_rows(ctx0, cur, inp_out_ids);
      }
  
-@@ -725,3 +494,257 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
+@@ -720,3 +494,257 @@ llama_model_deepseek2::graph::graph(const llama_model & model, const llm_graph_p
  
      ggml_build_forward_expand(gf, cur);
  }
@@ -5757,10 +5667,10 @@ index e0e537e00..221584fcc 100644
 +    ggml_build_forward_expand(gf, cur);
 +}
 diff --git a/src/models/deepseek32.cpp b/src/models/deepseek32.cpp
-index 2b82a780c..a475d0a6f 100644
+index 60cc17c49..bfeefa9e6 100644
 --- a/src/models/deepseek32.cpp
 +++ b/src/models/deepseek32.cpp
-@@ -210,6 +210,8 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
+@@ -206,6 +206,8 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
  
      ggml_tensor * inp_out_ids = build_inp_out_ids();
  
@@ -5769,7 +5679,7 @@ index 2b82a780c..a475d0a6f 100644
      for (int il = 0; il < n_layer; ++il) {
          ggml_tensor * inpSA = inpL;
  
-@@ -227,8 +229,15 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
+@@ -223,8 +225,15 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
  
              ggml_tensor * top_k = nullptr;
  
@@ -5786,7 +5696,7 @@ index 2b82a780c..a475d0a6f 100644
                  ggml_tensor * indexer_q = ggml_mul_mat(ctx0, model.layers[il].indexer_attn_q_b, qr);
                  cb(indexer_q, "indexer_q", il);
  
-@@ -324,6 +333,11 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
+@@ -320,6 +329,11 @@ llama_model_deepseek32::graph::graph(const llama_model & model, const llm_graph_
                  uint32_t n_top_k = indexer_score->ne[0] < n_indexer_top_k ? indexer_score->ne[0] : n_indexer_top_k;
                  top_k = ggml_cont(ctx0, ggml_top_k(ctx0, indexer_score, n_top_k));
                  cb(top_k, "top_k", il);
@@ -5799,7 +5709,7 @@ index 2b82a780c..a475d0a6f 100644
  
              ggml_tensor * q = ggml_mul_mat(ctx0, model.layers[il].wq_b, qr);
 diff --git a/src/models/dots1.cpp b/src/models/dots1.cpp
-index 07d6ab1b7..ea7e03b0c 100644
+index a3a85748e..e97f970c2 100644
 --- a/src/models/dots1.cpp
 +++ b/src/models/dots1.cpp
 @@ -81,16 +81,21 @@ llama_model_dots1::graph::graph(const llama_model & model, const llm_graph_param
@@ -5929,7 +5839,7 @@ index 8d9ff1386..66ec33e4c 100644
  
      cb(cur, "result_norm", -1);
 diff --git a/src/models/ernie4-5.cpp b/src/models/ernie4-5.cpp
-index 895cf690b..fff2c2476 100644
+index 7bf7be648..234cecbb5 100644
 --- a/src/models/ernie4-5.cpp
 +++ b/src/models/ernie4-5.cpp
 @@ -83,16 +83,21 @@ llama_model_ernie4_5::graph::graph(const llama_model & model, const llm_graph_pa
@@ -5972,10 +5882,10 @@ index 895cf690b..fff2c2476 100644
  
      cb(cur, "result_norm", -1);
 diff --git a/src/models/exaone-moe.cpp b/src/models/exaone-moe.cpp
-index 5aed93794..f5946ddfc 100644
+index 976ee050a..d7f4a3502 100644
 --- a/src/models/exaone-moe.cpp
 +++ b/src/models/exaone-moe.cpp
-@@ -120,16 +120,21 @@ llama_model_exaone_moe::graph::graph(const llama_model & model, const llm_graph_
+@@ -117,16 +117,21 @@ llama_model_exaone_moe::graph::graph(const llama_model & model, const llm_graph_
      ggml_tensor * cur;
      ggml_tensor * inpL;
  
@@ -6000,7 +5910,7 @@ index 5aed93794..f5946ddfc 100644
          ggml_tensor * inpSA = inpL;
  
          // use RoPE for SWA layers
-@@ -168,7 +173,7 @@ llama_model_exaone_moe::graph::graph(const llama_model & model, const llm_graph_
+@@ -165,7 +170,7 @@ llama_model_exaone_moe::graph::graph(const llama_model & model, const llm_graph_
                  Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f / sqrtf(float(n_embd_head)), il);
              cb(cur, "attn_out", il);
          }
@@ -6009,7 +5919,7 @@ index 5aed93794..f5946ddfc 100644
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -228,6 +233,13 @@ llama_model_exaone_moe::graph::graph(const llama_model & model, const llm_graph_
+@@ -225,6 +230,13 @@ llama_model_exaone_moe::graph::graph(const llama_model & model, const llm_graph_
      }
      cur = inpL;
  
@@ -6076,10 +5986,10 @@ index 676fb37b5..22daba948 100644
  
      cb(cur, "result_norm", -1);
 diff --git a/src/models/exaone4.cpp b/src/models/exaone4.cpp
-index a06819a67..7a97959b1 100644
+index 9ba978956..751411f22 100644
 --- a/src/models/exaone4.cpp
 +++ b/src/models/exaone4.cpp
-@@ -94,7 +94,12 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
+@@ -91,7 +91,12 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
      ggml_tensor * cur;
      ggml_tensor * inpL;
  
@@ -6093,7 +6003,7 @@ index a06819a67..7a97959b1 100644
  
      // inp_pos - contains the positions
      ggml_tensor * inp_pos = build_inp_pos();
-@@ -107,9 +112,9 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
+@@ -104,9 +109,9 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
      } else {
          inp_attn = build_attn_inp_kv();
      }
@@ -6105,7 +6015,7 @@ index a06819a67..7a97959b1 100644
          ggml_tensor * inpSA = inpL;
  
          // use RoPE for SWA layers or non-SWA models
-@@ -145,7 +150,7 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
+@@ -142,7 +147,7 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f / sqrtf(float(n_embd_head)), il);
              cb(cur, "attn_out", il);
          }
@@ -6114,7 +6024,7 @@ index a06819a67..7a97959b1 100644
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -176,6 +181,13 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
+@@ -173,6 +178,13 @@ llama_model_exaone4::graph<iswa>::graph(const llama_model & model, const llm_gra
      }
      cur = inpL;
  
@@ -6539,7 +6449,7 @@ index 83eb8250a..8e712f757 100644
          // Multimodal embedding path: use padding token (ID=0) embedding
          // TODO: verify if this is the correct behavior in transformers implementation
 diff --git a/src/models/gemma4.cpp b/src/models/gemma4.cpp
-index aa518c6df..4d37f766a 100644
+index c6dd7d1bf..a4658729f 100644
 --- a/src/models/gemma4.cpp
 +++ b/src/models/gemma4.cpp
 @@ -98,8 +98,9 @@ void llama_model_gemma4::load_arch_tensors(llama_model_loader &) {
@@ -6663,10 +6573,10 @@ index aa518c6df..4d37f766a 100644
          // Multimodal embedding path: use padding token (ID=0) embedding
          // TODO: verify if this is the correct behavior in transformers implementation
 diff --git a/src/models/glm4.cpp b/src/models/glm4.cpp
-index b4326c5f2..c4e951a1e 100644
+index 463be809d..6499f2319 100644
 --- a/src/models/glm4.cpp
 +++ b/src/models/glm4.cpp
-@@ -80,10 +80,18 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
+@@ -76,10 +76,18 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
      ggml_tensor * cur;
      ggml_tensor * inpL;
  
@@ -6687,7 +6597,7 @@ index b4326c5f2..c4e951a1e 100644
          // unfortunately, we need to forcefully stop here, to avoid users complaining about wrong results
          GGML_ABORT("This GGUF does not support multimodal. Please reconvert it.");
      }
-@@ -93,11 +101,11 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
+@@ -89,11 +97,11 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
  
      auto * inp_attn = build_attn_inp_kv();
  
@@ -6701,7 +6611,7 @@ index b4326c5f2..c4e951a1e 100644
          ggml_tensor * inpSA = inpL;
  
          // Pre-attention norm
-@@ -136,7 +144,7 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
+@@ -132,7 +140,7 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
                      model.layers[il].wo, NULL, model.layers[il].wo_s,
                      Qcur, Kcur, Vcur, nullptr, nullptr, nullptr, 1.0f / sqrtf(float(n_embd_head)), il);
          }
@@ -6710,7 +6620,7 @@ index b4326c5f2..c4e951a1e 100644
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -174,8 +182,17 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
+@@ -170,8 +178,17 @@ llama_model_glm4::graph::graph(const llama_model & model, const llm_graph_params
          // input for next layer
          inpL = cur;
      }
@@ -6945,7 +6855,7 @@ index 9e9f97e94..fee708146 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/models/grok.cpp b/src/models/grok.cpp
-index 42f38af67..53f683914 100644
+index cb6afc3a7..a9d644baf 100644
 --- a/src/models/grok.cpp
 +++ b/src/models/grok.cpp
 @@ -92,16 +92,21 @@ llama_model_grok::graph::graph(const llama_model & model, const llm_graph_params
@@ -6988,7 +6898,7 @@ index 42f38af67..53f683914 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/models/grovemoe.cpp b/src/models/grovemoe.cpp
-index 643a448e5..12fce2051 100644
+index f32f3e9ed..2e7505ec6 100644
 --- a/src/models/grovemoe.cpp
 +++ b/src/models/grovemoe.cpp
 @@ -75,16 +75,21 @@ llama_model_grovemoe::graph::graph(const llama_model & model, const llm_graph_pa
@@ -7031,7 +6941,7 @@ index 643a448e5..12fce2051 100644
  
      cb(cur, "result_norm", -1);
 diff --git a/src/models/hunyuan-moe.cpp b/src/models/hunyuan-moe.cpp
-index 4d55f5e7f..3abe5aef4 100644
+index cedc3b53e..f503bd828 100644
 --- a/src/models/hunyuan-moe.cpp
 +++ b/src/models/hunyuan-moe.cpp
 @@ -62,7 +62,12 @@ llama_model_hunyuan_moe::graph::graph(const llama_model & model, const llm_graph
@@ -7323,7 +7233,7 @@ index dba160b01..2b69aabab 100644
      cur = build_norm(inpL, model.output_norm, NULL, LLM_NORM_RMS, -1);
  
 diff --git a/src/models/kimi-linear.cpp b/src/models/kimi-linear.cpp
-index 367f6990d..2426dfa0f 100644
+index 601d1d9be..bc3a856f0 100644
 --- a/src/models/kimi-linear.cpp
 +++ b/src/models/kimi-linear.cpp
 @@ -236,7 +236,12 @@ llama_model_kimi_linear::graph::graph(const llama_model & model, const llm_graph
@@ -7373,7 +7283,7 @@ index 367f6990d..2426dfa0f 100644
      cur = build_norm(cur, model.output_norm, NULL, LLM_NORM_RMS, -1);
  
 diff --git a/src/models/laguna.cpp b/src/models/laguna.cpp
-index 82c9a9538..e23087c68 100644
+index 556400bfc..5bf022c18 100644
 --- a/src/models/laguna.cpp
 +++ b/src/models/laguna.cpp
 @@ -158,7 +158,12 @@ llama_model_laguna::graph::graph(const llama_model & model, const llm_graph_para
@@ -7420,7 +7330,7 @@ index 82c9a9538..e23087c68 100644
      cb(cur, "result_norm", -1);
      res->t_embd = cur;
 diff --git a/src/models/lfm2.cpp b/src/models/lfm2.cpp
-index 9a4295557..ebfa186e0 100644
+index 07b71ccd3..773b06fab 100644
 --- a/src/models/lfm2.cpp
 +++ b/src/models/lfm2.cpp
 @@ -233,7 +233,20 @@ llama_model_lfm2::graph<iswa>::graph(const llama_model & model, const llm_graph_
@@ -7485,7 +7395,7 @@ index 9a4295557..ebfa186e0 100644
      cb(cur, "result_norm", -1);
      res->t_embd = cur;
 diff --git a/src/models/llada-moe.cpp b/src/models/llada-moe.cpp
-index 2ae893864..6debd1303 100644
+index 0ee9ce1be..88fc2019c 100644
 --- a/src/models/llada-moe.cpp
 +++ b/src/models/llada-moe.cpp
 @@ -60,16 +60,21 @@ llama_model_llada_moe::graph::graph(const llama_model & model, const llm_graph_p
@@ -7616,7 +7526,7 @@ index 4bfebc884..23864f0dd 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/models/llama4.cpp b/src/models/llama4.cpp
-index 7194c72a5..1f3f1c358 100644
+index 8a812beff..ac7e0b692 100644
 --- a/src/models/llama4.cpp
 +++ b/src/models/llama4.cpp
 @@ -113,14 +113,30 @@ llama_model_llama4::graph<iswa>::graph(const llama_model & model, const llm_grap
@@ -7781,10 +7691,10 @@ index 0d94e9828..99e2c825e 100644
      cur = build_norm(inpL, model.output_norm, NULL, LLM_NORM_RMS, -1);
  
 diff --git a/src/models/mimo2.cpp b/src/models/mimo2.cpp
-index d50e186cc..04eaa2173 100644
+index 8772319f4..a0a3a5f62 100644
 --- a/src/models/mimo2.cpp
 +++ b/src/models/mimo2.cpp
-@@ -25,17 +25,9 @@ void llama_model_mimo2::load_arch_hparams(llama_model_loader & ml) {
+@@ -22,17 +22,9 @@ void llama_model_mimo2::load_arch_hparams(llama_model_loader & ml) {
      }
  }
  
@@ -7803,7 +7713,7 @@ index d50e186cc..04eaa2173 100644
      tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), {n_embd, n_vocab}, 0);
  
      // output
-@@ -48,46 +40,41 @@ void llama_model_mimo2::load_arch_tensors(llama_model_loader & ml) {
+@@ -45,46 +37,41 @@ void llama_model_mimo2::load_arch_tensors(llama_model_loader & ml) {
          uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(i);
          uint32_t n_head = hparams.n_head(i);
  
@@ -7834,7 +7744,7 @@ index d50e186cc..04eaa2173 100644
 +        layer.ffn_up   = create_tensor(tn(LLM_TENSOR_FFN_UP,   "weight", i), {n_embd,   n_ff}, TENSOR_NOT_REQUIRED | skip);
  
          // MoE branch
-         int64_t n_ff_exp = hparams.n_ff_exp;
+         int64_t n_ff_exp = hparams.n_ff_exp();
 -        layer.ffn_gate_inp  = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,  "weight", i), {n_embd, n_expert}, TENSOR_NOT_REQUIRED | flags);
 -        layer.ffn_gate_exps = create_tensor(tn(LLM_TENSOR_FFN_GATE_EXPS, "weight", i), {n_embd, n_ff_exp,   n_expert}, TENSOR_NOT_REQUIRED | flags);
 -        layer.ffn_down_exps = create_tensor(tn(LLM_TENSOR_FFN_DOWN_EXPS, "weight", i), {n_ff_exp,   n_embd, n_expert}, TENSOR_NOT_REQUIRED | flags);
@@ -7869,7 +7779,7 @@ index d50e186cc..04eaa2173 100644
      return std::make_unique<graph>(*this, params);
  }
  
-@@ -95,17 +82,20 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
+@@ -92,17 +79,20 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
      ggml_tensor * cur;
      ggml_tensor * inpL;
  
@@ -7897,7 +7807,7 @@ index d50e186cc..04eaa2173 100644
          ggml_tensor * inpSA = inpL;
  
          uint32_t n_head_l    = hparams.n_head(il);
-@@ -183,7 +173,7 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
+@@ -180,7 +170,7 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
              }
          }
  
@@ -7906,7 +7816,7 @@ index d50e186cc..04eaa2173 100644
              cur   = ggml_get_rows(ctx0,   cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -233,13 +223,11 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
+@@ -230,13 +220,11 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
  
      cur = inpL;
  
@@ -7925,7 +7835,7 @@ index d50e186cc..04eaa2173 100644
      }
  
      cur = build_norm(cur,
-@@ -257,143 +245,3 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
+@@ -254,143 +242,3 @@ llama_model_mimo2::graph::graph(const llama_model & model, const llm_graph_param
  
      ggml_build_forward_expand(gf, cur);
  }
@@ -8114,7 +8024,7 @@ index 7820d5224..f218063b3 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/models/minimax-m2.cpp b/src/models/minimax-m2.cpp
-index 86a8ae2b1..fe667d549 100644
+index c2e69bfaa..785f548af 100644
 --- a/src/models/minimax-m2.cpp
 +++ b/src/models/minimax-m2.cpp
 @@ -53,13 +53,18 @@ llama_model_minimax_m2::graph::graph(const llama_model & model, const llm_graph_
@@ -8274,10 +8184,10 @@ index d094fd9f8..3b008a5db 100644
  
      cb(cur, "result_norm", -1);
 diff --git a/src/models/nemotron-h.cpp b/src/models/nemotron-h.cpp
-index f02674c64..2cbfe4d91 100644
+index d2c48f125..8f98c7f14 100644
 --- a/src/models/nemotron-h.cpp
 +++ b/src/models/nemotron-h.cpp
-@@ -171,17 +171,21 @@ llama_model_nemotron_h::graph::graph(const llama_model & model, const llm_graph_
+@@ -183,17 +183,21 @@ llama_model_nemotron_h::graph::graph(const llama_model & model, const llm_graph_
      ggml_tensor * cur;
      ggml_tensor * inpL;
  
@@ -8303,7 +8213,7 @@ index f02674c64..2cbfe4d91 100644
          struct ggml_tensor * inpSA = inpL;
  
          // norm
-@@ -220,6 +224,13 @@ llama_model_nemotron_h::graph::graph(const llama_model & model, const llm_graph_
+@@ -232,6 +236,13 @@ llama_model_nemotron_h::graph::graph(const llama_model & model, const llm_graph_
          }
      }
  
@@ -8518,7 +8428,7 @@ index 1e2baeb20..4c6c4ef81 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/models/openai-moe.cpp b/src/models/openai-moe.cpp
-index c91bae1c3..8c4d7bed5 100644
+index c9f9b677d..0631de044 100644
 --- a/src/models/openai-moe.cpp
 +++ b/src/models/openai-moe.cpp
 @@ -65,16 +65,21 @@ llama_model_openai_moe::graph::graph(const llama_model & model, const llm_graph_
@@ -9031,7 +8941,7 @@ index e9c2ea80a..6362851e7 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/models/qwen2moe.cpp b/src/models/qwen2moe.cpp
-index e831ed11a..9f02cec3a 100644
+index 8bcb1017b..389e7c12d 100644
 --- a/src/models/qwen2moe.cpp
 +++ b/src/models/qwen2moe.cpp
 @@ -20,7 +20,10 @@ void llama_model_qwen2moe::load_arch_tensors(llama_model_loader &) {
@@ -9200,10 +9110,10 @@ index f4b2a2aeb..9991ce56b 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/models/qwen35.cpp b/src/models/qwen35.cpp
-index 309dd4324..e50b80219 100644
+index 0b9210981..e23d75191 100644
 --- a/src/models/qwen35.cpp
 +++ b/src/models/qwen35.cpp
-@@ -146,17 +146,29 @@ llama_model_qwen35::graph::graph(const llama_model & model, const llm_graph_para
+@@ -142,17 +142,29 @@ llama_model_qwen35::graph::graph(const llama_model & model, const llm_graph_para
      ggml_tensor * cur;
      ggml_tensor * inpL;
  
@@ -9237,7 +9147,7 @@ index 309dd4324..e50b80219 100644
          res->t_layer_inp[il] = inpL;
  
          ggml_tensor * inpSA = inpL;
-@@ -175,7 +187,7 @@ llama_model_qwen35::graph::graph(const llama_model & model, const llm_graph_para
+@@ -171,7 +183,7 @@ llama_model_qwen35::graph::graph(const llama_model & model, const llm_graph_para
              cur = build_layer_attn(inp->get_attn(), cur, inp_pos, sections, il);
          }
  
@@ -9246,7 +9156,7 @@ index 309dd4324..e50b80219 100644
              cur   = ggml_get_rows(ctx0, cur,   inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -207,6 +219,13 @@ llama_model_qwen35::graph::graph(const llama_model & model, const llm_graph_para
+@@ -203,6 +215,13 @@ llama_model_qwen35::graph::graph(const llama_model & model, const llm_graph_para
      }
      cur = inpL;
  
@@ -9261,10 +9171,10 @@ index 309dd4324..e50b80219 100644
  
      cb(cur, "h_nextn", -1);
 diff --git a/src/models/qwen35moe.cpp b/src/models/qwen35moe.cpp
-index 38f2a5798..99d667f56 100644
+index ed4083f12..9acb1241d 100644
 --- a/src/models/qwen35moe.cpp
 +++ b/src/models/qwen35moe.cpp
-@@ -169,17 +169,29 @@ llama_model_qwen35moe::graph::graph(const llama_model & model, const llm_graph_p
+@@ -165,17 +165,29 @@ llama_model_qwen35moe::graph::graph(const llama_model & model, const llm_graph_p
      ggml_tensor * cur;
      ggml_tensor * inpL;
  
@@ -9298,7 +9208,7 @@ index 38f2a5798..99d667f56 100644
          res->t_layer_inp[il] = inpL;
  
          ggml_tensor * inpSA = inpL;
-@@ -230,6 +242,13 @@ llama_model_qwen35moe::graph::graph(const llama_model & model, const llm_graph_p
+@@ -226,6 +238,13 @@ llama_model_qwen35moe::graph::graph(const llama_model & model, const llm_graph_p
      }
      cur = inpL;
  
@@ -9313,7 +9223,7 @@ index 38f2a5798..99d667f56 100644
      cur = build_norm(cur, model.output_norm, nullptr, LLM_NORM_RMS, -1);
  
 diff --git a/src/models/qwen3moe.cpp b/src/models/qwen3moe.cpp
-index 6f6df5390..ba08a4e1d 100644
+index a6a3381e5..847b34663 100644
 --- a/src/models/qwen3moe.cpp
 +++ b/src/models/qwen3moe.cpp
 @@ -68,16 +68,21 @@ llama_model_qwen3moe::graph::graph(const llama_model & model, const llm_graph_pa
@@ -9356,23 +9266,10 @@ index 6f6df5390..ba08a4e1d 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/models/qwen3next.cpp b/src/models/qwen3next.cpp
-index 0808fd87a..8c925a863 100644
+index eb823b8ea..5300bfafc 100644
 --- a/src/models/qwen3next.cpp
 +++ b/src/models/qwen3next.cpp
-@@ -13,11 +13,7 @@ void llama_model_qwen3next::load_arch_hparams(llama_model_loader & ml) {
-     ml.get_key(LLM_KV_SSM_TIME_STEP_RANK, hparams.ssm_dt_rank);
-     ml.get_key(LLM_KV_SSM_GROUP_COUNT,    hparams.ssm_n_group);
- 
--    // NextN/MTP: extra decoder block appended beyond the main stack
--    ml.get_key(LLM_KV_NEXTN_PREDICT_LAYERS, hparams.n_layer_nextn, false);
--    GGML_ASSERT(hparams.n_layer_nextn < hparams.n_layer_all && "n_layer_nextn must be < n_layer_all");
--
--    // Mark recurrent layers (linear attention layers).
-+    // Mark recurrent layers (linear attention layers)
-     if (!ml.get_key_or_arr(LLM_KV_ATTENTION_RECURRENT_LAYERS, hparams.is_recr_impl, hparams.n_layer_all, false)) {
-         uint32_t full_attn_interval = 4;
-         ml.get_key(LLM_KV_FULL_ATTENTION_INTERVAL, full_attn_interval, false);
-@@ -32,17 +28,13 @@ void llama_model_qwen3next::load_arch_hparams(llama_model_loader & ml) {
+@@ -28,17 +28,13 @@ void llama_model_qwen3next::load_arch_hparams(llama_model_loader & ml) {
      }
  }
  
@@ -9391,7 +9288,7 @@ index 0808fd87a..8c925a863 100644
      tok_embd = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), { n_embd, n_vocab }, 0);
  
      // output
-@@ -69,73 +61,49 @@ void llama_model_qwen3next::load_arch_tensors(llama_model_loader & ml) {
+@@ -65,73 +61,49 @@ void llama_model_qwen3next::load_arch_tensors(llama_model_loader & ml) {
      const int64_t qkvz_dim = key_dim * 2 + value_dim * 2;
      const int64_t ba_dim   = n_v_heads * 2;
  
@@ -9492,7 +9389,7 @@ index 0808fd87a..8c925a863 100644
      return std::make_unique<graph>(*this, params);
  }
  
-@@ -144,16 +112,27 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
+@@ -140,16 +112,27 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
      ggml_tensor * cur;
      ggml_tensor * inpL;
  
@@ -9525,7 +9422,7 @@ index 0808fd87a..8c925a863 100644
          res->t_layer_inp[il] = inpL;
  
          ggml_tensor * inpSA = inpL;
-@@ -172,7 +151,7 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
+@@ -168,7 +151,7 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
              cur = build_layer_attn(inp->get_attn(), cur, inp_pos, il);
          }
  
@@ -9534,7 +9431,7 @@ index 0808fd87a..8c925a863 100644
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -204,16 +183,16 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
+@@ -200,16 +183,16 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
      }
      cur = inpL;
  
@@ -9559,7 +9456,7 @@ index 0808fd87a..8c925a863 100644
      cb(cur, "result_norm", -1);
      res->t_embd = cur;
  
-@@ -226,6 +205,14 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
+@@ -222,6 +205,14 @@ llama_model_qwen3next::graph::graph(const llama_model & model, const llm_graph_p
      ggml_build_forward_expand(gf, cur);
  }
  
@@ -9574,7 +9471,7 @@ index 0808fd87a..8c925a863 100644
  ggml_tensor * llama_model_qwen3next::graph::build_norm_gated(
          ggml_tensor * input,
          ggml_tensor * weights,
-@@ -248,7 +235,7 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_attn(
+@@ -244,7 +235,7 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_attn(
      // Order: joint QG projection, QG split, Q norm, KV projection, K norm, RoPE, attention
  
      // Qwen3Next uses a single Q projection that outputs query + gate
@@ -9583,7 +9480,7 @@ index 0808fd87a..8c925a863 100644
      cb(Qcur_full, "Qcur_full", il);
  
      Qcur_full = ggml_reshape_4d(ctx0, Qcur_full, n_embd_head * 2, n_head, n_tokens, 1);
-@@ -264,10 +251,10 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_attn(
+@@ -260,10 +251,10 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_attn(
                       Qcur_full->nb[1], Qcur_full->nb[2], Qcur_full->nb[3], n_embd_head * ggml_element_size(Qcur_full));
      cb(gate, "gate", il);
  
@@ -9596,7 +9493,7 @@ index 0808fd87a..8c925a863 100644
      cb(Vcur, "Vcur", il);
  
      Kcur = ggml_reshape_3d(ctx0, Kcur, n_embd_head, n_head_kv, n_tokens);
-@@ -306,6 +293,8 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_attn(
+@@ -302,6 +293,8 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_attn(
      gate = ggml_sigmoid(ctx0, gate);
      cb(gate, "gate_sigmoid", il);
  
@@ -9605,7 +9502,7 @@ index 0808fd87a..8c925a863 100644
      cur = ggml_mul(ctx0, cur, gate);
      cb(cur, "attn_gated", il);
  
-@@ -580,19 +569,16 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_ffn(ggml_tensor * cur, c
+@@ -576,19 +569,16 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_ffn(ggml_tensor * cur, c
                  LLM_FFN_SILU, true,
                  hparams.expert_weights_scale,
                  LLAMA_EXPERT_GATING_FUNC_TYPE_SOFTMAX, il,
@@ -9629,7 +9526,7 @@ index 0808fd87a..8c925a863 100644
                      NULL,
                      LLM_FFN_SILU, LLM_FFN_PAR, il);
              cb(ffn_shexp, "ffn_shexp", il);
-@@ -626,198 +612,3 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_ffn(ggml_tensor * cur, c
+@@ -622,198 +612,3 @@ ggml_tensor * llama_model_qwen3next::graph::build_layer_ffn(ggml_tensor * cur, c
      }
      return cur;
  }
@@ -9901,7 +9798,7 @@ index 5596620f0..c6b48fd13 100644
      if (n_vocab_in > n_vocab_out) {
          // case: Qwen3TTS model with codec_head as output
 diff --git a/src/models/qwen3vlmoe.cpp b/src/models/qwen3vlmoe.cpp
-index 7c41592f7..33c961a41 100644
+index e7a81e32c..040e9da5e 100644
 --- a/src/models/qwen3vlmoe.cpp
 +++ b/src/models/qwen3vlmoe.cpp
 @@ -73,7 +73,12 @@ llama_model_qwen3vlmoe::graph::graph(const llama_model & model, const llm_graph_
@@ -10003,7 +9900,7 @@ index a46c358fa..0226a7fdf 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/models/rnd1.cpp b/src/models/rnd1.cpp
-index fc276ce59..8d39e03bb 100644
+index 553a75730..fbaa52bec 100644
 --- a/src/models/rnd1.cpp
 +++ b/src/models/rnd1.cpp
 @@ -71,7 +71,12 @@ llama_model_rnd1::graph::graph(const llama_model & model, const llm_graph_params
@@ -10275,7 +10172,7 @@ index 57de881a0..c49415551 100644
              model.output_norm, NULL,
              LLM_NORM_RMS, -1);
 diff --git a/src/models/smallthinker.cpp b/src/models/smallthinker.cpp
-index a8e3d957f..6a7c16032 100644
+index 680ffb8fd..37fbcbdc9 100644
 --- a/src/models/smallthinker.cpp
 +++ b/src/models/smallthinker.cpp
 @@ -83,7 +83,12 @@ llama_model_smallthinker::graph<iswa>::graph(const llama_model & model, const ll
@@ -10524,10 +10421,10 @@ index b81b46937..af2bc1128 100644
              model.output_norm, model.output_norm_b,
              LLM_NORM, -1);
 diff --git a/src/models/step35.cpp b/src/models/step35.cpp
-index 5b1d90258..3b264d9e1 100644
+index 53f3179c6..ac5cb129a 100644
 --- a/src/models/step35.cpp
 +++ b/src/models/step35.cpp
-@@ -196,13 +196,18 @@ llama_model_step35::graph::graph(const llama_model & model, const llm_graph_para
+@@ -192,13 +192,18 @@ llama_model_step35::graph::graph(const llama_model & model, const llm_graph_para
      ggml_tensor * cur;
      ggml_tensor * inpL;
  
@@ -10549,7 +10446,7 @@ index 5b1d90258..3b264d9e1 100644
          ggml_tensor * inpSA = inpL;
  
          const uint32_t n_head_l    = hparams.n_head(il);
-@@ -289,7 +294,7 @@ llama_model_step35::graph::graph(const llama_model & model, const llm_graph_para
+@@ -285,7 +290,7 @@ llama_model_step35::graph::graph(const llama_model & model, const llm_graph_para
              cb(cur, "attn_proj", il);
          }
  
@@ -10558,7 +10455,7 @@ index 5b1d90258..3b264d9e1 100644
              cur   = ggml_get_rows(ctx0, cur, inp_out_ids);
              inpSA = ggml_get_rows(ctx0, inpSA, inp_out_ids);
          }
-@@ -348,6 +353,13 @@ llama_model_step35::graph::graph(const llama_model & model, const llm_graph_para
+@@ -344,6 +349,13 @@ llama_model_step35::graph::graph(const llama_model & model, const llm_graph_para
  
      cur = inpL;
  
@@ -10572,7 +10469,7 @@ index 5b1d90258..3b264d9e1 100644
      cb(cur, "h_nextn", -1);
      res->t_h_nextn = cur;
  
-@@ -536,12 +548,16 @@ llama_model_step35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
+@@ -532,12 +544,16 @@ llama_model_step35::graph_mtp::graph_mtp(const llama_model & model, const llm_gr
      cur = ggml_add(ctx0, cur, ffn_inp);
      cb(cur, "mtp_post_ffn", il);
  

--- a/third_party/llama.cpp/patches/0002-Add-Inkling-model-and-multimodal-support.patch
+++ b/third_party/llama.cpp/patches/0002-Add-Inkling-model-and-multimodal-support.patch
@@ -1,7 +1,7 @@
-From fbd18ddd294ae993872acf4af149a0500783fec3 Mon Sep 17 00:00:00 2001
+From 07ebfdba75ac4439f1325c8e781b794c4d83f8c7 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 8 Aug 2026 16:02:19 +1000
-Subject: [PATCH 02/32] Add Inkling model and multimodal support
+Subject: [PATCH 02/51] Add Inkling model and multimodal support
 
 ---
  conversion/__init__.py         |   2 +
@@ -29,7 +29,7 @@ Subject: [PATCH 02/32] Add Inkling model and multimodal support
  create mode 100644 tools/mtmd/models/inkling.cpp
 
 diff --git a/conversion/__init__.py b/conversion/__init__.py
-index a5632fcc4..ea521a580 100644
+index ba73192ef..d676daee3 100644
 --- a/conversion/__init__.py
 +++ b/conversion/__init__.py
 @@ -125,6 +125,7 @@ TEXT_MODEL_MAP: dict[str, str] = {
@@ -40,7 +40,7 @@ index a5632fcc4..ea521a580 100644
      "InternLM2ForCausalLM": "internlm",
      "InternLM3ForCausalLM": "internlm",
      "JAISLMHeadModel": "jais",
-@@ -304,6 +305,7 @@ MMPROJ_MODEL_MAP: dict[str, str] = {
+@@ -306,6 +307,7 @@ MMPROJ_MODEL_MAP: dict[str, str] = {
      "GraniteSpeechPlusForConditionalGeneration": "granite",
      "HunYuanVLForConditionalGeneration": "hunyuan",
      "Idefics3ForConditionalGeneration": "smolvlm",
@@ -535,7 +535,7 @@ index 000000000..079842903
 +
 +        raise ValueError(f"unexpected Inkling vision tensor {name!r}")
 diff --git a/gguf-py/gguf/constants.py b/gguf-py/gguf/constants.py
-index c99feb3c7..be712cbc5 100644
+index b85f62a31..5bc135ff7 100644
 --- a/gguf-py/gguf/constants.py
 +++ b/gguf-py/gguf/constants.py
 @@ -625,6 +625,7 @@ class MODEL_ARCH(IntEnum):
@@ -546,7 +546,7 @@ index c99feb3c7..be712cbc5 100644
  
  
  class VISION_PROJECTOR_TYPE(IntEnum):
-@@ -872,6 +873,14 @@ class MODEL_TENSOR(IntEnum):
+@@ -873,6 +874,14 @@ class MODEL_TENSOR(IntEnum):
      SHORTCONV_CONV       = auto()
      SHORTCONV_INPROJ     = auto()
      SHORTCONV_OUTPROJ    = auto()
@@ -561,7 +561,7 @@ index c99feb3c7..be712cbc5 100644
      VISEXP_ATTN_QKV      = auto()
      VISEXP_ATTN_OUT      = auto()
      VISEXP_GATE          = auto()
-@@ -1374,6 +1383,7 @@ MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
+@@ -1378,6 +1387,7 @@ MODEL_ARCH_NAMES: dict[MODEL_ARCH, str] = {
      MODEL_ARCH.NANBEIGE:         "nanbeige",
      MODEL_ARCH.QWEN3TTS:         "qwen3tts",
      MODEL_ARCH.POCKETTTS:        "pockettts",
@@ -569,7 +569,7 @@ index c99feb3c7..be712cbc5 100644
  }
  
  VISION_PROJECTOR_TYPE_NAMES: dict[VISION_PROJECTOR_TYPE, str] = {
-@@ -1619,6 +1629,13 @@ TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
+@@ -1624,6 +1634,13 @@ TENSOR_NAMES: dict[MODEL_TENSOR, str] = {
      MODEL_TENSOR.SHORTCONV_CONV:            "blk.{bid}.shortconv.conv",
      MODEL_TENSOR.SHORTCONV_INPROJ:          "blk.{bid}.shortconv.in_proj",
      MODEL_TENSOR.SHORTCONV_OUTPROJ:         "blk.{bid}.shortconv.out_proj",
@@ -583,7 +583,7 @@ index c99feb3c7..be712cbc5 100644
      MODEL_TENSOR.VISEXP_ATTN_QKV:           "blk.{bid}.vis_attn_qkv",
      MODEL_TENSOR.VISEXP_ATTN_OUT:           "blk.{bid}.vis_attn_output",
      MODEL_TENSOR.VISEXP_GATE:               "blk.{bid}.vis_gate",
-@@ -4802,6 +4819,38 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
+@@ -4814,6 +4831,38 @@ MODEL_TENSORS: dict[MODEL_ARCH, list[MODEL_TENSOR]] = {
          MODEL_TENSOR.FFN_UP_EXP,
          MODEL_TENSOR.FFN_EXP_PROBS_B,
      ],
@@ -622,7 +622,7 @@ index c99feb3c7..be712cbc5 100644
      MODEL_ARCH.SMALLTHINKER: [
          MODEL_TENSOR.TOKEN_EMBD,
          MODEL_TENSOR.OUTPUT_NORM,
-@@ -5609,6 +5658,7 @@ class GGUFValueType(IntEnum):
+@@ -5621,6 +5670,7 @@ class GGUFValueType(IntEnum):
  
  
  class VisionProjectorType:
@@ -631,7 +631,7 @@ index c99feb3c7..be712cbc5 100644
      GEMMA3NV = "gemma3nv"
      GEMMA3NA = "gemma3na"
 diff --git a/gguf-py/gguf/tensor_mapping.py b/gguf-py/gguf/tensor_mapping.py
-index 861acfe18..103447d0d 100644
+index d644d502e..cb10b55fd 100644
 --- a/gguf-py/gguf/tensor_mapping.py
 +++ b/gguf-py/gguf/tensor_mapping.py
 @@ -63,6 +63,7 @@ class TensorNameMap:
@@ -650,7 +650,7 @@ index 861acfe18..103447d0d 100644
          ),
          MODEL_TENSOR.DENSE_2_OUT: (
              "dense_2_out",  # embeddinggemma
-@@ -2700,6 +2702,53 @@ class TensorNameMap:
+@@ -2723,6 +2725,53 @@ class TensorNameMap:
  
      # architecture-specific block mappings
      arch_block_mappings_cfg: dict[MODEL_ARCH, dict[MODEL_TENSOR, tuple[str, ...]]] = {
@@ -1952,10 +1952,10 @@ index 9b87a40d5..716f4a5e8 100644
      llama_model_smallthinker(const struct llama_model_params & params) : llama_model_base(params) {}
      void load_arch_hparams(llama_model_loader & ml) override;
 diff --git a/tools/mtmd/CMakeLists.txt b/tools/mtmd/CMakeLists.txt
-index e60c9c878..7b886d4e4 100644
+index 907468e87..392ffe068 100644
 --- a/tools/mtmd/CMakeLists.txt
 +++ b/tools/mtmd/CMakeLists.txt
-@@ -42,6 +42,7 @@ add_library(mtmd
+@@ -43,6 +43,7 @@ add_library(mtmd
              models/granite4-vision.cpp
              models/hunyuanvl.cpp
              models/internvl.cpp
@@ -1964,10 +1964,10 @@ index e60c9c878..7b886d4e4 100644
              models/kimik25.cpp
              models/nemotron-v2-vl.cpp
 diff --git a/tools/mtmd/clip-impl.h b/tools/mtmd/clip-impl.h
-index f6045093c..83caba9c2 100644
+index 72148a4d9..6adfddaaa 100644
 --- a/tools/mtmd/clip-impl.h
 +++ b/tools/mtmd/clip-impl.h
-@@ -371,6 +371,13 @@
+@@ -374,6 +374,13 @@
  #define TN_A_FFN_POST_NORM   "%s.blk.%d.ffn_post_norm.%s"
  #define TN_A_FFN_POST_NORM_1 "%s.blk.%d.ffn_post_norm_1.%s"
  
@@ -1981,7 +1981,7 @@ index f6045093c..83caba9c2 100644
  // mobilenetv5 (gemma3n) definitions
  #define TN_MNV5_STEM_CONV        "v.conv_stem.conv.weight"
  #define TN_MNV5_STEM_BIAS        "v.conv_stem.conv.bias"
-@@ -439,6 +446,7 @@
+@@ -442,6 +449,7 @@
  struct clip_ctx;
  
  enum projector_type {
@@ -1989,7 +1989,7 @@ index f6045093c..83caba9c2 100644
      PROJECTOR_TYPE_MLP,
      PROJECTOR_TYPE_MLP_NORM,
      PROJECTOR_TYPE_LDP,
-@@ -504,6 +512,7 @@ enum projector_type {
+@@ -508,6 +516,7 @@ enum projector_type {
  };
  
  static std::map<projector_type, std::string> PROJECTOR_TYPE_NAMES = {
@@ -1998,10 +1998,10 @@ index f6045093c..83caba9c2 100644
      { PROJECTOR_TYPE_LDP,               "ldp" },
      { PROJECTOR_TYPE_LDPV2,             "ldpv2"},
 diff --git a/tools/mtmd/clip-model.h b/tools/mtmd/clip-model.h
-index 060938d86..5aa659246 100644
+index f737ccc24..f47a30054 100644
 --- a/tools/mtmd/clip-model.h
 +++ b/tools/mtmd/clip-model.h
-@@ -546,6 +546,12 @@ struct clip_code2wav {
+@@ -550,6 +550,12 @@ struct clip_code2wav {
      ggml_tensor * dac_post_snake_beta  = nullptr;
      ggml_tensor * dac_post_conv_w      = nullptr;
      ggml_tensor * dac_post_conv_b      = nullptr;
@@ -2014,7 +2014,7 @@ index 060938d86..5aa659246 100644
  };
  
  struct clip_model {
-@@ -562,6 +568,12 @@ struct clip_model {
+@@ -566,6 +572,12 @@ struct clip_model {
      ggml_tensor * norm_embd_w = nullptr;
      ggml_tensor * norm_embd_b = nullptr;
  
@@ -2028,7 +2028,7 @@ index 060938d86..5aa659246 100644
      ggml_tensor * patch_norm_1_w = nullptr;
      ggml_tensor * patch_norm_1_b = nullptr;
 diff --git a/tools/mtmd/clip.cpp b/tools/mtmd/clip.cpp
-index 90de19575..2d01ad73c 100644
+index f2e487534..0d4208df4 100644
 --- a/tools/mtmd/clip.cpp
 +++ b/tools/mtmd/clip.cpp
 @@ -933,6 +933,10 @@ static std::unique_ptr<clip_graph> clip_get_graph_builder(clip_ctx * ctx, const
@@ -2042,7 +2042,7 @@ index 90de19575..2d01ad73c 100644
          case PROJECTOR_TYPE_GEMMA3:
          case PROJECTOR_TYPE_IDEFICS3:
          case PROJECTOR_TYPE_LFM2:
-@@ -1410,6 +1414,21 @@ struct clip_model_loader {
+@@ -1414,6 +1418,21 @@ struct clip_model_loader {
  
              // model-specific params
              switch (model.proj_type) {
@@ -2064,7 +2064,7 @@ index 90de19575..2d01ad73c 100644
                  case PROJECTOR_TYPE_MLP:
                  case PROJECTOR_TYPE_MLP_NORM:
                  case PROJECTOR_TYPE_LDP:
-@@ -2211,7 +2230,8 @@ struct clip_model_loader {
+@@ -2240,7 +2259,8 @@ struct clip_model_loader {
          const bool has_standard_layers = (
              model.proj_type != PROJECTOR_TYPE_GEMMA3NV &&
              model.proj_type != PROJECTOR_TYPE_QWEN3TTS_SPKENC &&
@@ -2074,7 +2074,7 @@ index 90de19575..2d01ad73c 100644
  
          // layers
          const int n_layers_to_load = has_standard_layers ? hparams.n_layer : 0;
-@@ -2305,6 +2325,23 @@ struct clip_model_loader {
+@@ -2334,6 +2354,23 @@ struct clip_model_loader {
  
  
          switch (model.proj_type) {
@@ -2098,7 +2098,7 @@ index 90de19575..2d01ad73c 100644
              case PROJECTOR_TYPE_MLP:
              case PROJECTOR_TYPE_MLP_NORM:
                  {
-@@ -3635,6 +3672,11 @@ struct clip_model_loader {
+@@ -3676,6 +3713,11 @@ struct clip_model_loader {
              LOG_INF("%s: warmup with audio size = %d\n", __func__, hparams.warmup_audio_size);
          }
          batch.entries.push_back(img);
@@ -2110,7 +2110,7 @@ index 90de19575..2d01ad73c 100644
          return batch;
      }
  
-@@ -4050,6 +4092,16 @@ int clip_n_output_tokens(const clip_ctx * ctx, const clip_image_f32 * img) {
+@@ -4091,6 +4133,16 @@ int clip_n_output_tokens(const clip_ctx * ctx, const clip_image_f32 * img) {
      projector_type proj = ctx->proj_type();
  
      switch (proj) {
@@ -2127,7 +2127,7 @@ index 90de19575..2d01ad73c 100644
          case PROJECTOR_TYPE_MLP:
          case PROJECTOR_TYPE_MLP_NORM:
          case PROJECTOR_TYPE_JANUS_PRO:
-@@ -4532,6 +4584,10 @@ bool clip_encode(struct clip_ctx * ctx, struct clip_encode_params * params) {
+@@ -4580,6 +4632,10 @@ bool clip_encode(struct clip_ctx * ctx, struct clip_encode_params * params) {
  
      // set input per projector
      switch (ctx->model.proj_type) {
@@ -2138,7 +2138,7 @@ index 90de19575..2d01ad73c 100644
          case PROJECTOR_TYPE_MUSE_GLIMMER:
              {
                  const int grid_w = pos_w;            // image_size_width  / patch_size
-@@ -5798,6 +5854,10 @@ bool clip_encode(struct clip_ctx * ctx, struct clip_encode_params * params) {
+@@ -5911,6 +5967,10 @@ bool clip_encode(struct clip_ctx * ctx, struct clip_encode_params * params) {
  
  int clip_n_mmproj_embd(const struct clip_ctx * ctx) {
      switch (ctx->model.proj_type) {
@@ -2262,7 +2262,7 @@ index 000000000..c072f66a2
 +    return gf;
 +}
 diff --git a/tools/mtmd/models/models.h b/tools/mtmd/models/models.h
-index 10546fa5d..0a72f12f8 100644
+index 5945c6d92..67d591790 100644
 --- a/tools/mtmd/models/models.h
 +++ b/tools/mtmd/models/models.h
 @@ -17,6 +17,17 @@ struct clip_graph_siglip : clip_graph {
@@ -2401,7 +2401,7 @@ index 0f47d4502..d7c679887 100644
      mtmd_audio_preprocessor_conformer(const clip_ctx * ctx) : mtmd_audio_preprocessor(ctx) {}
      void initialize() override;
 diff --git a/tools/mtmd/mtmd-image.h b/tools/mtmd/mtmd-image.h
-index 732e27379..22e4f9968 100644
+index 8758c6647..1f3240278 100644
 --- a/tools/mtmd/mtmd-image.h
 +++ b/tools/mtmd/mtmd-image.h
 @@ -26,6 +26,20 @@ struct mtmd_image_preproc_out {
@@ -2439,10 +2439,10 @@ index 732e27379..22e4f9968 100644
  // if image_resize_pad is true, the resized image will be padded, otherwise it will be either stretched or center-cropped depending on image_resize_pad
  // this is used by models with native support for dynamic image size, for example: Qwen-VL, Pixtral, Kimi-VL, etc
 diff --git a/tools/mtmd/mtmd.cpp b/tools/mtmd/mtmd.cpp
-index 5b306180d..8ea35863d 100644
+index a13b0556b..9769067cb 100644
 --- a/tools/mtmd/mtmd.cpp
 +++ b/tools/mtmd/mtmd.cpp
-@@ -629,6 +629,12 @@ struct mtmd_context {
+@@ -631,6 +631,12 @@ struct mtmd_context {
          projector_type proj = clip_get_projector_type(ctx_v);
  
          switch (proj) {
@@ -2455,7 +2455,7 @@ index 5b306180d..8ea35863d 100644
              case PROJECTOR_TYPE_MLP:
              case PROJECTOR_TYPE_MLP_NORM:
              case PROJECTOR_TYPE_LDP:
-@@ -921,6 +927,13 @@ struct mtmd_context {
+@@ -928,6 +934,13 @@ struct mtmd_context {
  
          // set preprocessor
          switch (proj) {
@@ -2469,7 +2469,7 @@ index 5b306180d..8ea35863d 100644
              case PROJECTOR_TYPE_QWEN2A:
              case PROJECTOR_TYPE_QWEN25O:
                  {
-@@ -1452,23 +1465,35 @@ struct mtmd_tokenizer {
+@@ -1491,23 +1504,35 @@ struct mtmd_tokenizer {
                  }
  
                  size_t n_tokens = 0;

--- a/third_party/llama.cpp/patches/0003-Add-Skippy-public-ABI-surface.patch
+++ b/third_party/llama.cpp/patches/0003-Add-Skippy-public-ABI-surface.patch
@@ -1,7 +1,7 @@
-From 621c17922f0c9d89b19c004693fc3990f680295e Mon Sep 17 00:00:00 2001
+From 466cc191bcb6f99ef0a9a797837f0b46f5e7eb58 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 8 Aug 2026 17:06:42 +1000
-Subject: [PATCH 03/32] Add Skippy public ABI surface
+Subject: [PATCH 03/51] Add Skippy public ABI surface
 
 ---
  include/skippy.h               |  18 ++++

--- a/third_party/llama.cpp/patches/0004-Add-Skippy-model-lifecycle-and-package-support.patch
+++ b/third_party/llama.cpp/patches/0004-Add-Skippy-model-lifecycle-and-package-support.patch
@@ -1,7 +1,7 @@
-From b99a5f3b87203b32cf612ea75a3a2817ba4e45b6 Mon Sep 17 00:00:00 2001
+From 359ce9e1aed27f4a22fa56685250a13af02d6f8e Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 8 Aug 2026 17:06:42 +1000
-Subject: [PATCH 04/32] Add Skippy model lifecycle and package support
+Subject: [PATCH 04/51] Add Skippy model lifecycle and package support
 
 ---
  src/skippy/devices.cpp                  | 106 +++

--- a/third_party/llama.cpp/patches/0005-Add-Skippy-session-and-state-management.patch
+++ b/third_party/llama.cpp/patches/0005-Add-Skippy-session-and-state-management.patch
@@ -1,7 +1,7 @@
-From 82c0b13af92b44f6a6a2489407d5e41ebc5ccab5 Mon Sep 17 00:00:00 2001
+From e79be0d251284a496da5a33b58a854dd1c991e90 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 8 Aug 2026 16:02:19 +1000
-Subject: [PATCH 05/32] Add Skippy session and state management
+Subject: [PATCH 05/51] Add Skippy session and state management
 
 ---
  include/skippy/signals.h                      |  44 +

--- a/third_party/llama.cpp/patches/0006-Add-Skippy-activation-frame-handling.patch
+++ b/third_party/llama.cpp/patches/0006-Add-Skippy-activation-frame-handling.patch
@@ -1,7 +1,7 @@
-From c996aaf7a8b792a475deae64e79e41324b651753 Mon Sep 17 00:00:00 2001
+From d5c3ba585c62f308c9d443ec30a7d193c925666e Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 8 Aug 2026 16:02:20 +1000
-Subject: [PATCH 06/32] Add Skippy activation frame handling
+Subject: [PATCH 06/51] Add Skippy activation frame handling
 
 ---
  include/skippy/activation.h      |  44 ++

--- a/third_party/llama.cpp/patches/0007-Add-Skippy-staged-execution-paths.patch
+++ b/third_party/llama.cpp/patches/0007-Add-Skippy-staged-execution-paths.patch
@@ -1,7 +1,7 @@
-From 8d0347202757bd65abc10ef6e0b87706105e4659 Mon Sep 17 00:00:00 2001
+From fe08d573ce1fffb9943a770be068045311d0e84e Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 8 Aug 2026 16:02:20 +1000
-Subject: [PATCH 07/32] Add Skippy staged execution paths
+Subject: [PATCH 07/51] Add Skippy staged execution paths
 
 ---
  include/skippy/execution.h      | 193 ++++++++++

--- a/third_party/llama.cpp/patches/0008-Add-Skippy-sampling-and-speculative-decoding.patch
+++ b/third_party/llama.cpp/patches/0008-Add-Skippy-sampling-and-speculative-decoding.patch
@@ -1,17 +1,17 @@
-From 5d986a73ec0432c375d9b9a2799a3bdd350fe7e2 Mon Sep 17 00:00:00 2001
+From 9ec8086a867201be3d2740e6dc18beb889049e62 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 8 Aug 2026 16:02:20 +1000
-Subject: [PATCH 08/32] Add Skippy sampling and speculative decoding
+Subject: [PATCH 08/51] Add Skippy sampling and speculative decoding
 
 ---
- common/ngram-cache.cpp                | 153 ++++++-
- include/skippy/sampling.h             |  33 ++
+ common/ngram-cache.cpp                | 153 +++++-
+ include/skippy/sampling.h             |  35 ++
  include/skippy/speculative_decoding.h |  60 +++
- src/skippy/sampling.cpp               | 629 ++++++++++++++++++++++++++
+ src/skippy/sampling.cpp               | 672 ++++++++++++++++++++++++++
  src/skippy/sampling_internal.h        |  42 ++
- src/skippy/speculative_decoding.cpp   | 524 +++++++++++++++++++++
+ src/skippy/speculative_decoding.cpp   | 524 ++++++++++++++++++++
  src/skippy/speculative_internal.h     |  28 ++
- 7 files changed, 1464 insertions(+), 5 deletions(-)
+ 7 files changed, 1509 insertions(+), 5 deletions(-)
  create mode 100644 include/skippy/sampling.h
  create mode 100644 include/skippy/speculative_decoding.h
  create mode 100644 src/skippy/sampling.cpp
@@ -330,7 +330,7 @@ index 000000000..67fc99716
 +#endif // SKIPPY_SPECULATIVE_DECODING_H
 diff --git a/src/skippy/sampling.cpp b/src/skippy/sampling.cpp
 new file mode 100644
-index 000000000..8440e5b97
+index 000000000..9a3a1c769
 --- /dev/null
 +++ b/src/skippy/sampling.cpp
 @@ -0,0 +1,672 @@
@@ -1620,3 +1620,4 @@ index 000000000..db0055657
 +        skippy_error ** out_error);
 -- 
 2.55.0
+

--- a/third_party/llama.cpp/patches/0009-Add-Skippy-tokenization-and-stage-chat.patch
+++ b/third_party/llama.cpp/patches/0009-Add-Skippy-tokenization-and-stage-chat.patch
@@ -1,13 +1,13 @@
-From c03954c5783aeefd40529495f4873eaf9838676b Mon Sep 17 00:00:00 2001
+From 07cce93d010051814c6add6119185d5628cfe40f Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 8 Aug 2026 16:02:20 +1000
-Subject: [PATCH 09/32] Add Skippy tokenization and stage chat
+Subject: [PATCH 09/51] Add Skippy tokenization and stage chat
 
 ---
- common/chat-auto-parser-generator.cpp |  51 ++---
+ common/chat-auto-parser-generator.cpp |  51 +++--
  common/chat-diff-analyzer.cpp         |  10 +-
- common/chat-peg-parser.cpp            |  31 ++-
- common/chat-peg-parser.h              |  11 +
+ common/chat-peg-parser.cpp            |  15 +-
+ common/chat-peg-parser.h              |   2 +-
  common/chat.cpp                       | 245 ++++++++++++++++++++-
  common/chat.h                         |   5 +-
  common/stage-chat.cpp                 | 296 ++++++++++++++++++++++++++
@@ -15,17 +15,17 @@ Subject: [PATCH 09/32] Add Skippy tokenization and stage chat
  include/skippy/tokenization.h         |  69 ++++++
  src/skippy/tokenization.cpp           | 137 ++++++++++++
  tests/test-chat-auto-parser.cpp       |  47 ++++
- tests/test-chat.cpp                   | 278 +++++++++++++++++++++++-
- 12 files changed, 1135 insertions(+), 47 deletions(-)
+ tests/test-chat.cpp                   | 285 ++++++++++++++++++++++++-
+ 12 files changed, 1128 insertions(+), 36 deletions(-)
  create mode 100644 common/stage-chat.cpp
  create mode 100644 include/skippy/tokenization.h
  create mode 100644 src/skippy/tokenization.cpp
 
 diff --git a/common/chat-auto-parser-generator.cpp b/common/chat-auto-parser-generator.cpp
-index af84ff323..422408d9e 100644
+index d7e117e4d..4707c524a 100644
 --- a/common/chat-auto-parser-generator.cpp
 +++ b/common/chat-auto-parser-generator.cpp
-@@ -23,6 +23,18 @@ static void foreach_function(const json & tools, const std::function<void(const
+@@ -22,6 +22,18 @@ static void foreach_function(const json & tools, const std::function<void(const
      }
  }
  
@@ -44,7 +44,7 @@ index af84ff323..422408d9e 100644
  namespace autoparser {
  
  parser_build_context::parser_build_context(common_chat_peg_builder & p, const generation_params & inputs) :
-@@ -103,7 +115,7 @@ common_chat_params peg_generator::generate_parser(const common_chat_template &
+@@ -102,7 +114,7 @@ common_chat_params peg_generator::generate_parser(const common_chat_template &
          // Set grammar triggers based on tool section markers (fall back to per-call markers)
          if (data.grammar_lazy) {
              data.grammar_triggers = {
@@ -53,7 +53,7 @@ index af84ff323..422408d9e 100644
              };
              if (autoparser.tools.format.openai_wrapper_trigger) {
                  // model emits the OpenAI function wrapper, trigger on it
-@@ -397,7 +409,9 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
+@@ -396,7 +408,9 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
          auto schema_info = common_schema_info();
          schema_info.resolve_refs(params);
  
@@ -64,7 +64,7 @@ index af84ff323..422408d9e 100644
          std::vector<common_peg_parser> required_parsers;
          std::vector<common_peg_parser> optional_parsers;
          for (const auto & [param_name, param_schema] : properties.items()) {
-@@ -422,22 +436,33 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
+@@ -421,22 +435,33 @@ common_peg_parser analyze_tools::build_tool_parser_tag_tagged(parser_build_conte
              }
          }
  
@@ -109,8 +109,6 @@ index af84ff323..422408d9e 100644
          }
  
          if (!arguments.start.empty()) {
-         tool_choice |= p.rule("tool-" + name, func_parser);
-
 diff --git a/common/chat-diff-analyzer.cpp b/common/chat-diff-analyzer.cpp
 index a7e370578..39ffa20f1 100644
 --- a/common/chat-diff-analyzer.cpp
@@ -152,12 +150,11 @@ index a7e370578..39ffa20f1 100644
      };
  
      template_params params_content_only;
-
 diff --git a/common/chat-peg-parser.cpp b/common/chat-peg-parser.cpp
-index 06737b165..2bbbb1d4e 100644
+index 79b97a80f..c38639d03 100644
 --- a/common/chat-peg-parser.cpp
 +++ b/common/chat-peg-parser.cpp
-@@ -388,11 +388,12 @@ void common_chat_peg_mapper::map(const common_peg_ast_node & node) {
+@@ -386,11 +386,12 @@ void common_chat_peg_mapper::map(const common_peg_ast_node & node) {
      }
  
      if (is_arg_name && current_tool) {
@@ -171,7 +168,7 @@ index 06737b165..2bbbb1d4e 100644
          ++arg_count;
  
          auto & target = args_target();
-@@ -669,10 +670,10 @@ common_peg_parser common_chat_peg_builder::build_json_tools_function_is_key(
+@@ -667,10 +668,10 @@ common_peg_parser common_chat_peg_builder::build_json_tools_function_is_key(
          // Arguments — either wrapped in args_key or parsed directly
          common_peg_parser args_parser = eps();
          if (args_key.empty()) {
@@ -184,7 +181,7 @@ index 06737b165..2bbbb1d4e 100644
          }
          inner_fields.push_back(args_parser);
  
-@@ -733,7 +734,7 @@ common_peg_parser common_chat_peg_builder::build_json_tools_nested_keys(
+@@ -731,7 +732,7 @@ common_peg_parser common_chat_peg_builder::build_json_tools_nested_keys(
          auto nested_name = literal("\"" + nested_name_field + "\"") + space() + literal(":") + space() +
                            atomic(literal("\"") + tool_name(literal(name)) + literal("\""));
          auto nested_args = literal("\"" + nested_args_field + "\"") + space() + literal(":") + space() +
@@ -193,7 +190,7 @@ index 06737b165..2bbbb1d4e 100644
  
          auto nested_object = literal("{") + space() +
                              nested_name + space() + literal(",") + space() +
-@@ -789,7 +790,9 @@ common_peg_parser common_chat_peg_builder::build_json_tools_flat_keys(
+@@ -787,7 +788,9 @@ common_peg_parser common_chat_peg_builder::build_json_tools_flat_keys(
  
      auto tool_choices    = choice();
      auto name_key_parser = literal("\"" + effective_name_key + "\"");
@@ -204,7 +201,7 @@ index 06737b165..2bbbb1d4e 100644
  
      for (const auto & tool_def : tools) {
          if (!tool_def.contains("function")) {
-@@ -802,7 +805,7 @@ common_peg_parser common_chat_peg_builder::build_json_tools_flat_keys(
+@@ -800,7 +803,7 @@ common_peg_parser common_chat_peg_builder::build_json_tools_flat_keys(
          auto tool_name_ = name_key_parser + space() + literal(":") + space() +
                           atomic(literal("\"") + tool_name(literal(name)) + literal("\""));
          auto tool_args_ = args_key_parser + space() + literal(":") + space() +
@@ -213,9 +210,8 @@ index 06737b165..2bbbb1d4e 100644
  
          // Build ID parsers if keys are provided
          common_peg_parser id_parser = eps();
-
 diff --git a/common/chat-peg-parser.h b/common/chat-peg-parser.h
-index 5d764dbaa..0e86e657d 100644
+index 114fa049f..7723d4e35 100644
 --- a/common/chat-peg-parser.h
 +++ b/common/chat-peg-parser.h
 @@ -5,6 +5,7 @@
@@ -234,7 +230,6 @@ index 5d764dbaa..0e86e657d 100644
      // Matches every parser exactly once, in any order.
      common_peg_parser permute(const std::string & rule_prefix, const std::vector<common_peg_parser> & parsers);
  
-
 diff --git a/common/chat.cpp b/common/chat.cpp
 index 743ecde0a..893667722 100644
 --- a/common/chat.cpp
@@ -533,7 +528,6 @@ index 743ecde0a..893667722 100644
      if (is_lfm2_template(src)) {
          LOG_DBG("Using specialized template: LFM2\n");
          return common_chat_params_init_lfm2(tmpl, params, /* tool_list_tokens = */ true);
-
 diff --git a/common/chat.h b/common/chat.h
 index cb39e3458..1826f5f47 100644
 --- a/common/chat.h
@@ -557,7 +551,6 @@ index cb39e3458..1826f5f47 100644
      }
  
      bool operator!=(const common_chat_msg & other) const { return !(*this == other); }
-
 diff --git a/common/stage-chat.cpp b/common/stage-chat.cpp
 new file mode 100644
 index 000000000..305b9d081
@@ -860,7 +853,6 @@ index 000000000..305b9d081
 +    skippy_common_copy_output(output, output_message_json);
 +    return skippy_common_success(out_error);
 +}
-
 diff --git a/include/skippy/common.h b/include/skippy/common.h
 index 1aecf7e67..ec9d59ec3 100644
 --- a/include/skippy/common.h
@@ -874,7 +866,6 @@ index 1aecf7e67..ec9d59ec3 100644
  
  enum skippy_feature {
      SKIPPY_FEATURE_RUNTIME_SLICE          = 1 << 0,
-
 diff --git a/include/skippy/tokenization.h b/include/skippy/tokenization.h
 new file mode 100644
 index 000000000..7b8c4dcc4
@@ -950,7 +941,6 @@ index 000000000..7b8c4dcc4
 +#endif
 +
 +#endif // SKIPPY_TOKENIZATION_H
-
 diff --git a/src/skippy/tokenization.cpp b/src/skippy/tokenization.cpp
 new file mode 100644
 index 000000000..89d69ff3a
@@ -1094,7 +1084,6 @@ index 000000000..89d69ff3a
 +
 +
 +} // extern "C"
-
 diff --git a/tests/test-chat-auto-parser.cpp b/tests/test-chat-auto-parser.cpp
 index 5aa948251..78df176dd 100644
 --- a/tests/test-chat-auto-parser.cpp
@@ -1176,9 +1165,8 @@ index 5aa948251..78df176dd 100644
  }
  
  static void test_cohere_reasoning_detection(testing & t) {
-
 diff --git a/tests/test-chat.cpp b/tests/test-chat.cpp
-index c4670da85..62ea85601 100644
+index 7918f0ffc..635e0d662 100644
 --- a/tests/test-chat.cpp
 +++ b/tests/test-chat.cpp
 @@ -436,6 +436,21 @@ static common_chat_tool special_function_tool{
@@ -1544,6 +1532,6 @@ index c4670da85..62ea85601 100644
          test_template_output_peg_parsers(detailed_debug);
          std::cout << "\n[chat] All template tests passed!" << '\n';
          return 0;
-
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
+

--- a/third_party/llama.cpp/patches/0010-Wire-staged-runtime-builds-and-tests.patch
+++ b/third_party/llama.cpp/patches/0010-Wire-staged-runtime-builds-and-tests.patch
@@ -1,7 +1,7 @@
-From 6ba1d0ce7e05173abc5f286d2b2d8d42cfe9b39f Mon Sep 17 00:00:00 2001
+From 05d84634e2eb27745f0c5ee29827741105281750 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 8 Aug 2026 16:02:20 +1000
-Subject: [PATCH 10/32] Wire staged runtime builds and tests
+Subject: [PATCH 10/51] Wire staged runtime builds and tests
 
 ---
  .scratch_port/analyze.py  |  96 ++++++++++++++++++

--- a/third_party/llama.cpp/patches/0011-skippy-retain-and-execute-final-stage-MTP-tensors.patch
+++ b/third_party/llama.cpp/patches/0011-skippy-retain-and-execute-final-stage-MTP-tensors.patch
@@ -1,7 +1,7 @@
-From 4ba8e7f58f92a96fcd9db898802692ce2bb3b0ff Mon Sep 17 00:00:00 2001
+From 9fdaf231b41b88c2cda075132efd7c074ace76d4 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 11 Aug 2026 16:14:30 -0400
-Subject: [PATCH 11/32] skippy: retain and execute final-stage MTP tensors
+Subject: [PATCH 11/51] skippy: retain and execute final-stage MTP tensors
 
 ---
  include/skippy/common.h      |  2 +-

--- a/third_party/llama.cpp/patches/0012-fixup-apply-staged-runtime-wiring-0011-onto-per-op-M.patch
+++ b/third_party/llama.cpp/patches/0012-fixup-apply-staged-runtime-wiring-0011-onto-per-op-M.patch
@@ -1,41 +1,41 @@
-From a50dd009619634b32d588f8af9d2c81984c9a648 Mon Sep 17 00:00:00 2001
+From d277f5c260a28b54388b1848c3d28e9d0ca5c901 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 25 Aug 2026 23:23:33 +1000
-Subject: [PATCH 12/32] fixup: apply staged runtime wiring (0011) onto per-op
+Subject: [PATCH 12/51] fixup: apply staged runtime wiring (0011) onto per-op
  Metal layout
 
 ---
  CMakeLists.txt                        |   5 ++
  common/CMakeLists.txt                 |   1 +
- ggml/src/ggml-metal/ggml-metal-impl.h |  61 ++++++++++---
+ ggml/src/ggml-metal/ggml-metal-impl.h |  61 ++++++++++++---
  include/skippy.h                      |   8 ++
- include/skippy/activation.h           |   9 ++
+ include/skippy/activation.h           |   9 +++
  include/skippy/common.h               |  12 +++
  include/skippy/devices.h              |   7 ++
  include/skippy/events.h               |  11 +++
- include/skippy/execution.h            |  19 ++++
+ include/skippy/execution.h            |  19 +++++
  include/skippy/model_package.h        |  15 ++++
- include/skippy/runtime.h              |  25 ++++++
+ include/skippy/runtime.h              |  25 +++++++
  include/skippy/sampling.h             |   6 ++
- include/skippy/signals.h              |   9 ++
+ include/skippy/signals.h              |   9 +++
  include/skippy/speculative_decoding.h |  11 +++
- include/skippy/state.h                |  19 ++++
+ include/skippy/state.h                |  19 +++++
  include/skippy/tokenization.h         |  11 +++
- src/CMakeLists.txt                    |  17 ++++
+ src/CMakeLists.txt                    |  17 +++++
  src/llama-arch.cpp                    |   6 ++
  src/llama-arch.h                      |   6 ++
- src/llama-context.cpp                 | 102 ++++++---------------
+ src/llama-context.cpp                 | 102 +++++++-------------------
  src/llama-hparams.cpp                 |  10 +++
  src/llama-hparams.h                   |   4 +
- src/llama-model.cpp                   |  70 +++++++++------
- src/llama-model.h                     |  19 ++++
+ src/llama-model.cpp                   |  70 +++++++++++-------
+ src/llama-model.h                     |  19 +++++
  src/models/glm-dsa.cpp                |   3 +
  src/models/models.h                   |   4 -
  src/skippy/sampling.cpp               |   2 +
  tests/CMakeLists.txt                  |   3 +
- tests/test-llama-archs.cpp            | 125 +++++++++++++++++++++++++-
- tools/mtmd/mtmd-image.cpp             |  72 +++++++++++++++
- 30 files changed, 548 insertions(+), 124 deletions(-)
+ tests/test-llama-archs.cpp            |  20 +++++
+ tools/mtmd/mtmd-image.cpp             |  72 ++++++++++++++++++
+ 30 files changed, 447 insertions(+), 120 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 1d4bcf45f..586bf97f6 100644
@@ -73,7 +73,7 @@ index 36f1e0cd5..9757ba821 100644
      speculative.h
      subproc.cpp
 diff --git a/ggml/src/ggml-metal/ggml-metal-impl.h b/ggml/src/ggml-metal/ggml-metal-impl.h
-index 49102afe9..c8057a232 100644
+index bdcd9c9e3..c9147ebf5 100644
 --- a/ggml/src/ggml-metal/ggml-metal-impl.h
 +++ b/ggml/src/ggml-metal/ggml-metal-impl.h
 @@ -992,6 +992,17 @@ typedef struct {
@@ -94,7 +94,7 @@ index 49102afe9..c8057a232 100644
  } ggml_metal_kargs_solve_tri;
  
  typedef struct {
-@@ -1204,20 +1215,46 @@ typedef struct {
+@@ -1215,20 +1226,46 @@ typedef struct {
  } ggml_metal_kargs_memset;
  
  typedef struct {
@@ -670,9 +670,7 @@ index 86bc95ede..adbc4d640 100644
  #include "common.h"
  
  #ifdef __cplusplus
-@@ -10,8 +15,9 @@ extern "C" {
- #define SKIPPY_MAX_LOGIT_BIAS 256
- #define SKIPPY_SAMPLING_FLAG_ENABLED (1u << 0)
+@@ -12,6 +17,7 @@ extern "C" {
  #define SKIPPY_SAMPLING_FLAG_IGNORE_EOS (1u << 1)
  
  
@@ -991,7 +989,7 @@ index 8922dc12a..7ee82c713 100644
              unicode-data.cpp
              unicode.cpp
 diff --git a/src/llama-arch.cpp b/src/llama-arch.cpp
-index 37b2d3147..c51057643 100644
+index 7e83bb1d2..224ef9dba 100644
 --- a/src/llama-arch.cpp
 +++ b/src/llama-arch.cpp
 @@ -72,6 +72,7 @@ static const std::map<llm_arch, const char *> LLM_ARCH_NAMES = {
@@ -1015,7 +1013,7 @@ index 37b2d3147..c51057643 100644
      { LLM_KV_INTERLEAVE_MOE_LAYER_STEP,         "%s.interleave_moe_layer_step"         },
      { LLM_KV_FULL_ATTENTION_INTERVAL,           "%s.full_attention_interval"           },
 diff --git a/src/llama-arch.h b/src/llama-arch.h
-index 644fac937..195dbe88d 100644
+index fe95cde69..a99b3d9e3 100644
 --- a/src/llama-arch.h
 +++ b/src/llama-arch.h
 @@ -77,6 +77,7 @@ enum llm_arch {
@@ -1039,10 +1037,10 @@ index 644fac937..195dbe88d 100644
      LLM_KV_INTERLEAVE_MOE_LAYER_STEP,
      LLM_KV_FULL_ATTENTION_INTERVAL,
 diff --git a/src/llama-context.cpp b/src/llama-context.cpp
-index af3fe661f..aa3d6230d 100644
+index 4c082bade..1fccc162d 100644
 --- a/src/llama-context.cpp
 +++ b/src/llama-context.cpp
-@@ -1263,7 +1263,7 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
+@@ -1264,7 +1264,7 @@ bool llama_context::set_sampler(llama_seq_id seq_id, llama_sampler * sampler) {
      if (sampler && can_offload) {
          auto * buft = ggml_backend_dev_buffer_type(model.dev_output());
  
@@ -1051,7 +1049,7 @@ index af3fe661f..aa3d6230d 100644
  
          sampling.samplers[seq_id] = sampler;
  
-@@ -1626,90 +1626,38 @@ static std::map<llama_seq_id, uint32_t> build_seq_to_output_row(const llama_ubat
+@@ -1627,90 +1627,38 @@ static std::map<llama_seq_id, uint32_t> build_seq_to_output_row(const llama_ubat
      return seq_to_row;
  }
  
@@ -1161,7 +1159,7 @@ index af3fe661f..aa3d6230d 100644
      }
  }
  
-@@ -2058,11 +2006,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -2061,11 +2009,10 @@ int llama_context::decode(const llama_batch & batch_inp) {
              const auto stride = n_vocab;
  
              // async copy the sampling data from the backend to the host
@@ -1177,7 +1175,7 @@ index af3fe661f..aa3d6230d 100644
          }
  
          n_outputs_prev += n_outputs;
-@@ -3675,6 +3622,7 @@ llama_context_params llama_context_default_params() {
+@@ -3698,6 +3645,7 @@ llama_context_params llama_context_default_params() {
          /*.n_seq_max                   =*/ 1,
          /*.n_rs_seq                    =*/ 0,
          /*.n_outputs_max               =*/ 0,
@@ -1186,10 +1184,10 @@ index af3fe661f..aa3d6230d 100644
          /*.n_threads_batch             =*/ GGML_DEFAULT_N_THREADS,
          /*.ctx_type                    =*/ LLAMA_CONTEXT_TYPE_DEFAULT,
 diff --git a/src/llama-hparams.cpp b/src/llama-hparams.cpp
-index 9fbce9bdf..351f18a25 100644
+index 5f32a8e34..e5a54de5c 100644
 --- a/src/llama-hparams.cpp
 +++ b/src/llama-hparams.cpp
-@@ -180,6 +180,16 @@ uint32_t llama_hparams::n_embd_v_gqa_max() const {
+@@ -196,6 +196,16 @@ uint32_t llama_hparams::n_embd_v_gqa_max() const {
      return val;
  }
  
@@ -1207,7 +1205,7 @@ index 9fbce9bdf..351f18a25 100644
      if (n_embd_r_impl != 0) {
          // explicit override (e.g. inkling: 4 packed shortconv streams per layer)
 diff --git a/src/llama-hparams.h b/src/llama-hparams.h
-index 402015415..d5b060efe 100644
+index ccb617b87..1b947078c 100644
 --- a/src/llama-hparams.h
 +++ b/src/llama-hparams.h
 @@ -57,6 +57,8 @@ struct llama_hparams {
@@ -1217,9 +1215,9 @@ index 402015415..d5b060efe 100644
 +
 +    int32_t router_layer = -1;
      uint32_t n_expert = 0;
-     uint32_t n_expert_used = 0;
      uint32_t n_rel_attn_bkts = 0;
-@@ -449,6 +451,8 @@ struct llama_hparams {
+ 
+@@ -460,6 +462,8 @@ struct llama_hparams {
  
      bool has_kv(uint32_t il) const;
  
@@ -1229,7 +1227,7 @@ index 402015415..d5b060efe 100644
      uint32_t n_layer() const;
  
 diff --git a/src/llama-model.cpp b/src/llama-model.cpp
-index 6ac2fa322..550dd6c15 100644
+index cad8e2924..2368c2608 100644
 --- a/src/llama-model.cpp
 +++ b/src/llama-model.cpp
 @@ -178,6 +178,8 @@ static llama_model * llama_model_mapping(llm_arch arch, const llama_model_params
@@ -1241,7 +1239,7 @@ index 6ac2fa322..550dd6c15 100644
          case LLM_ARCH_OPENELM:
              return new llama_model_openelm(params);
          case LLM_ARCH_GPTNEOX:
-@@ -2593,15 +2595,9 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2617,15 +2619,9 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
                          filter = [&](uint32_t il) { return il >= hparams.n_layer(); };
                      }
  
@@ -1260,7 +1258,7 @@ index 6ac2fa322..550dd6c15 100644
                          if (params.ctx_type == LLAMA_CONTEXT_TYPE_MTP) {
                              filter = [&](uint32_t il) { return il >= hparams.n_layer(); };
                          } else {
-@@ -2611,24 +2607,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
+@@ -2635,24 +2631,7 @@ llama_memory_i * llama_model::create_memory(const llama_memory_params & params,
  
                      filter = skippy_stage_memory_filter(std::move(filter), params.ctx_type);
  
@@ -1286,7 +1284,7 @@ index 6ac2fa322..550dd6c15 100644
                          GGML_ASSERT(hparams.is_swa_any());
  
                          if (arch == LLM_ARCH_GEMMA4_ASSISTANT) {
-@@ -2749,6 +2728,7 @@ llama_model_params llama_model_default_params() {
+@@ -2773,6 +2752,7 @@ llama_model_params llama_model_default_params() {
          /*.use_extra_bufts             =*/ true,
          /*.no_host                     =*/ false,
          /*.no_alloc                    =*/ false,
@@ -1294,7 +1292,7 @@ index 6ac2fa322..550dd6c15 100644
      };
  
      return result;
-@@ -2892,6 +2872,7 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
+@@ -2916,6 +2896,7 @@ llama_rope_type llama_model_rope_type(const llama_model * model) {
          case LLM_ARCH_DEEPSEEK2OCR:
          case LLM_ARCH_DEEPSEEK32:
          case LLM_ARCH_DEEPSEEK4:
@@ -1302,7 +1300,7 @@ index 6ac2fa322..550dd6c15 100644
          case LLM_ARCH_PLM:
          case LLM_ARCH_CHATGLM:
          case LLM_ARCH_GRANITE:
-@@ -3225,3 +3206,38 @@ const int32_t * llama_model_target_layer_ids(const struct llama_model * model) {
+@@ -3249,3 +3230,38 @@ const int32_t * llama_model_target_layer_ids(const struct llama_model * model) {
  uint32_t llama_model_target_layer_ids_n(const struct llama_model * model) {
      return (uint32_t) model->target_layer_ids.size();
  }
@@ -1342,10 +1340,10 @@ index 6ac2fa322..550dd6c15 100644
 +    return (uint32_t) nelements;
 +}
 diff --git a/src/llama-model.h b/src/llama-model.h
-index dea1118d8..468de3e56 100644
+index b12bf93cb..f05e46e5a 100644
 --- a/src/llama-model.h
 +++ b/src/llama-model.h
-@@ -133,6 +133,7 @@ enum llm_type {
+@@ -134,6 +134,7 @@ enum llm_type {
      LLM_TYPE_100B_A6B,
      LLM_TYPE_102B_A12B, // Solar-Open
      LLM_TYPE_106B_A12B, // GLM-4.5-Air
@@ -1353,7 +1351,7 @@ index dea1118d8..468de3e56 100644
      LLM_TYPE_120B_A12B, // Nemotron 3 Super
      LLM_TYPE_122B_A10B, // Qwen3.5
      LLM_TYPE_124B_A5_1B, // Ling-3.0-flash
-@@ -228,6 +229,24 @@ struct llama_layer_nextn {
+@@ -229,6 +230,24 @@ struct llama_layer_nextn {
      struct ggml_tensor * shared_head_norm      = nullptr;
  };
  
@@ -1379,10 +1377,10 @@ index dea1118d8..468de3e56 100644
      // normalization
      struct ggml_tensor * attn_norm       = nullptr;
 diff --git a/src/models/glm-dsa.cpp b/src/models/glm-dsa.cpp
-index 93a1448b4..000b95cdc 100644
+index 44d883274..a7b71f616 100644
 --- a/src/models/glm-dsa.cpp
 +++ b/src/models/glm-dsa.cpp
-@@ -218,6 +218,9 @@ llama_model_glm_dsa::graph::graph(const llama_model & model, const llm_graph_par
+@@ -212,6 +212,9 @@ llama_model_glm_dsa::graph::graph(const llama_model & model, const llm_graph_par
  
      // the indexer head layout is [rope | nope]
      GGML_ASSERT(hparams.n_rot() <= n_embd_indexer_head);
@@ -1408,10 +1406,10 @@ index 716f4a5e8..39a09fe21 100644
          graph(const llama_model & model, const llm_graph_params & params);
      };
 diff --git a/src/skippy/sampling.cpp b/src/skippy/sampling.cpp
-index 8440e5b97..74eb3aa59 100644
+index 9a3a1c769..1e342060c 100644
 --- a/src/skippy/sampling.cpp
 +++ b/src/skippy/sampling.cpp
-@@ -372,9 +372,11 @@ llama_sampler * skippy_build_sampling_chain(
+@@ -384,9 +384,11 @@ llama_sampler * skippy_build_sampling_chain(
      const int32_t penalty_last_n = sampling->penalty_last_n == 0 ? -1 : sampling->penalty_last_n;
      const float repeat_penalty = sampling->repeat_penalty == 0.0f ? 1.0f : sampling->repeat_penalty;
      if (repeat_penalty != 1.0f || sampling->frequency_penalty != 0.0f || sampling->presence_penalty != 0.0f) {
@@ -1424,7 +1422,7 @@ index 8440e5b97..74eb3aa59 100644
                          repeat_penalty,
                          sampling->frequency_penalty,
 diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
-index fe3d14ffc..9c6fc6828 100644
+index c46377c76..5dd7461a0 100644
 --- a/tests/CMakeLists.txt
 +++ b/tests/CMakeLists.txt
 @@ -152,6 +152,9 @@ llama_build(test-recurrent-state-rollback.cpp)
@@ -1438,170 +1436,10 @@ index fe3d14ffc..9c6fc6828 100644
      llama_build_and_test(test-unicode.cpp)
      llama_build_and_test(test-sampling.cpp)
 diff --git a/tests/test-llama-archs.cpp b/tests/test-llama-archs.cpp
-index 35a3286e4..906f00ef4 100644
+index b2ea245ab..aef3a07c8 100644
 --- a/tests/test-llama-archs.cpp
 +++ b/tests/test-llama-archs.cpp
-@@ -14,6 +14,7 @@
- #include <cinttypes>
- #include <cstddef>
- #include <cstdio>
-+#include <cstdlib>
- #include <cstring>
- #include <cstdint>
- #include <random>
-@@ -79,10 +80,24 @@ static std::vector<llama_token> get_tokens(const uint32_t n_tokens, const uint32
-     return ret;
- }
- 
--static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
-+enum class glm_dsa_indexshare_fixture {
-+    DEFAULT,
-+    CONFLICTING_METADATA,
-+    SHARED_FIRST,
-+    FULL_SHARED,
-+    FULL_SHARED_SHARED,
-+    PERIODIC_FULL_SHARED,
-+};
-+
-+static gguf_context_ptr get_gguf_ctx(
-+        const llm_arch arch,
-+        const bool moe,
-+        const glm_dsa_indexshare_fixture glm_dsa_indexshare = glm_dsa_indexshare_fixture::DEFAULT,
-+        const uint32_t context_length = 256,
-+        const uint32_t glm_dsa_indexer_top_k = 8) {
-     gguf_context_ptr ret(gguf_init_empty());
-     llama_model_saver ms(arch, ret.get());
--    const uint32_t n_ctx = 256;
-+    const uint32_t n_ctx = context_length;
- 
-     uint32_t n_vocab = 128;
-     uint32_t n_embd  = 256;
-@@ -262,9 +277,19 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
-     ms.add_kv(LLM_KV_ATTENTION_INDEXER_KEY_LENGTH,
-               arch == LLM_ARCH_QWEN4EXP ? n_embd_head : uint32_t(128));
- 
--    ms.add_kv(LLM_KV_ATTENTION_INDEXER_TOP_K,        uint32_t(8));
-+    ms.add_kv(LLM_KV_ATTENTION_INDEXER_TOP_K,        arch == LLM_ARCH_GLM_DSA ? glm_dsa_indexer_top_k : uint32_t(8));
-     ms.add_kv(LLM_KV_ATTENTION_INDEXER_BLOCK_SIZE,   uint32_t(4));
-     ms.add_kv(LLM_KV_ATTENTION_INDEXER_LOCAL_BLOCKS, uint32_t(1));
-+    if (arch == LLM_ARCH_GLM_DSA) {
-+        ms.add_kv(LLM_KV_ATTENTION_INDEXER_TOP_K_FREQUENCY, uint32_t(1));
-+        ms.add_kv(LLM_KV_ATTENTION_INDEXER_SKIP_TOP_K_OFFSET, uint32_t(0));
-+        std::vector<uint32_t> indexer_types;
-+        indexer_types.reserve(n_layer);
-+        for (uint32_t il = 0; il < n_layer; il++) {
-+            indexer_types.push_back(il % 2 ? 0 : 1);
-+        }
-+        ms.add_kv(LLM_KV_ATTENTION_INDEXER_TYPES, indexer_types);
-+    }
-     ms.add_kv(LLM_KV_ROPE_DIMENSION_SECTIONS, std::vector<uint32_t>({n_embd_head/4, n_embd_head/4, n_embd_head/4, n_embd_head/4}));
- 
-     if (arch == LLM_ARCH_DEEPSEEK4) {
-@@ -345,9 +370,57 @@ static bool silent_model_load_progress(float /*progress*/, void * /*user_data*/)
-     return true;
- }
- 
-+static void set_test_env(const char * name, const char * value) {
-+#if defined(_WIN32)
-+    _putenv_s(name, value);
-+#else
-+    setenv(name, value, true);
-+#endif
-+}
-+
-+static void unset_test_env(const char * name) {
-+#if defined(_WIN32)
-+    _putenv_s(name, "");
-+#else
-+    unsetenv(name);
-+#endif
-+}
-+
-+static bool test_env_enabled(const char * name) {
-+    const char * value = getenv(name);
-+    return value != nullptr && strcmp(value, "0") != 0 && strcmp(value, "false") != 0 && strcmp(value, "FALSE") != 0;
-+}
-+
-+class scoped_test_env {
-+public:
-+    scoped_test_env(const char * name, const char * value) : name(name) {
-+        const char * old_value = getenv(name);
-+        if (old_value != nullptr) {
-+            had_old_value = true;
-+            this->old_value = old_value;
-+        }
-+        set_test_env(name, value);
-+    }
-+
-+    ~scoped_test_env() {
-+        if (had_old_value) {
-+            set_test_env(name, old_value.c_str());
-+        } else {
-+            unset_test_env(name);
-+        }
-+    }
-+
-+private:
-+    const char * name;
-+    bool had_old_value = false;
-+    std::string old_value;
-+};
-+
- static std::pair<llama_model_ptr, llama_context_ptr> get_model_and_ctx(
-         struct gguf_context * gguf_ctx, FILE * file, const size_t seed, const std::vector<ggml_backend_dev_t> & devs,
--        const llama_split_mode split_mode = LLAMA_SPLIT_MODE_LAYER, bool encode = false) {
-+        const llama_split_mode split_mode = LLAMA_SPLIT_MODE_LAYER, bool encode = false,
-+        ggml_backend_sched_eval_callback cb_eval = nullptr, void * cb_eval_user_data = nullptr,
-+        const llama_flash_attn_type flash_attn_type = LLAMA_FLASH_ATTN_TYPE_AUTO) {
-     GGML_ASSERT((gguf_ctx == nullptr) != (file == nullptr));
-     llama_model_params model_params = llama_model_default_params();
-     model_params.progress_callback = silent_model_load_progress;
-@@ -363,6 +436,9 @@ static std::pair<llama_model_ptr, llama_context_ptr> get_model_and_ctx(
-     if (!encode) {
-         ctx_params.n_ubatch = 64;
-     }
-+    ctx_params.flash_attn_type = flash_attn_type;
-+    ctx_params.cb_eval = cb_eval;
-+    ctx_params.cb_eval_user_data = cb_eval_user_data;
- 
-     size_t tmp = seed;
-     llama_model_ptr model(gguf_ctx != nullptr ?
-@@ -378,6 +454,20 @@ static std::pair<llama_model_ptr, llama_context_ptr> get_model_and_ctx(
-     return std::make_pair(std::move(model), std::move(lctx));
- }
- 
-+static void decode_tokens(llama_context * lctx, const std::vector<llama_token> & tokens, llama_pos start_pos, bool output_all = true) {
-+    llama_batch batch = llama_batch_init(tokens.size(), 0, 1);
-+    for (size_t i = 0; i < tokens.size(); ++i) {
-+        const bool output = output_all || i + 1 == tokens.size();
-+        common_batch_add(batch, tokens[i], start_pos + (llama_pos) i, {0}, output);
-+    }
-+    batch.n_tokens = tokens.size();
-+    if (llama_decode(lctx, batch)) {
-+        llama_batch_free(batch);
-+        throw std::runtime_error("failed to decode batch");
-+    }
-+    llama_batch_free(batch);
-+}
-+
- static std::vector<float> get_logits(
-         llama_model * model, llama_context * lctx, const std::vector<llama_token> & tokens, bool encode = false) {
-     const uint32_t n_vocab  = llama_vocab_n_tokens(llama_model_get_vocab(model));
-@@ -517,6 +607,13 @@ static bool arch_supported(const llm_arch arch) {
-     if (arch == LLM_ARCH_DEEPSEEK2OCR) {
-         return false;
-     }
-+    if (arch == LLM_ARCH_DEEPSEEK4) {
-+        return false;
-+    }
-+    if (arch == LLM_ARCH_INKLING) {
-+        return false; // TODO fixture params for the arch-specific hparams (d_rel, rel_extent, shortconv, logit_scale_denom)
-+    }
-+
-     // FIXME: these hit scheduler/view-backed-output issues with WebGPU on CI.
- #ifdef GGML_USE_WEBGPU
-     if (arch == LLM_ARCH_DEEPSEEK32 || arch == LLM_ARCH_GLM_DSA || arch == LLM_ARCH_DOTS3NOTE || arch == LLM_ARCH_QWEN4EXP) {
-@@ -535,6 +632,20 @@ static bool arch_supported(const llm_arch arch) {
+@@ -559,6 +559,20 @@ static bool arch_supported(const llm_arch arch) {
      return true;
  }
  
@@ -1619,12 +1457,12 @@ index 35a3286e4..906f00ef4 100644
 +    return true;
 +}
 +
- static int save_models(const llm_arch target_arch, const size_t seed, const ggml_log_level log_level, const std::string & dir) {
+ static int save_models(const llm_arch target_arch, const size_t seed, const int verbosity, const std::string & dir) {
      struct user_data_t {
          struct {
-@@ -700,6 +811,12 @@ static int test_backends(const llm_arch target_arch, const size_t seed, const gg
-                 std::string status_roundtrip = "\033[1;33mSKIP\033[0m";
+@@ -735,6 +749,12 @@ static int test_backends(const llm_arch target_arch, const size_t seed, const in
                  char nmse_str[12] = {0};
+ 
                  bool skip = !arch_supported(arch) || (dc.split_mode == LLAMA_SPLIT_MODE_TENSOR && dc.devs.empty());
 +                if (arch == LLM_ARCH_GLM_DSA && !glm_dsa_backend_config_supported(dc.devs)) {
 +                    skip = true;
@@ -1636,7 +1474,7 @@ index 35a3286e4..906f00ef4 100644
                      if (logits_cpu.empty()) {
                          model_and_ctx_cpu = get_model_and_ctx(gguf_ctx.get(), nullptr, seed, {}, LLAMA_SPLIT_MODE_LAYER, encode);
 diff --git a/tools/mtmd/mtmd-image.cpp b/tools/mtmd/mtmd-image.cpp
-index 0dda8770f..ec9bc8f88 100644
+index 890578978..ae0c30171 100644
 --- a/tools/mtmd/mtmd-image.cpp
 +++ b/tools/mtmd/mtmd-image.cpp
 @@ -481,6 +481,78 @@ private:
@@ -1720,3 +1558,4 @@ index 0dda8770f..ec9bc8f88 100644
  //
 -- 
 2.55.0
+

--- a/third_party/llama.cpp/patches/0013-skippy-support-composite-ISWA-KV-pages.patch
+++ b/third_party/llama.cpp/patches/0013-skippy-support-composite-ISWA-KV-pages.patch
@@ -1,7 +1,7 @@
-From 1a4705add2cb65474e4735920db980892a6e4f11 Mon Sep 17 00:00:00 2001
+From 462315c1e77f82249fbbf35b9742ff7f2a672541 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 13 Aug 2026 22:32:25 +1000
-Subject: [PATCH 13/32] skippy: support composite ISWA KV pages
+Subject: [PATCH 13/51] skippy: support composite ISWA KV pages
 
 ---
  include/skippy/common.h                       |   2 +-
@@ -87,10 +87,10 @@ index 74f9ac52a..1c77c5450 100644
          struct skippy_session * session,
          const struct skippy_kv_page_desc * desc,
 diff --git a/src/llama-kv-cache.cpp b/src/llama-kv-cache.cpp
-index 10de4e126..0a363e9c9 100644
+index 15c33568b..411049cd2 100644
 --- a/src/llama-kv-cache.cpp
 +++ b/src/llama-kv-cache.cpp
-@@ -1464,6 +1464,26 @@ const llama_kv_cells & llama_kv_cache::get_cells(llama_seq_id seq_id) const {
+@@ -1463,6 +1463,26 @@ const llama_kv_cells & llama_kv_cache::get_cells(llama_seq_id seq_id) const {
      return v_cells[seq_to_stream[seq_id]];
  }
  
@@ -117,7 +117,7 @@ index 10de4e126..0a363e9c9 100644
  bool llama_kv_cache::stage_export_kv_page(
          llama_seq_id seq_id,
          int32_t layer_start,
-@@ -1637,12 +1657,14 @@ bool llama_kv_cache::stage_export_kv_page(
+@@ -1636,12 +1656,14 @@ bool llama_kv_cache::stage_export_kv_page(
          return false;
      }
  
@@ -135,7 +135,7 @@ index 10de4e126..0a363e9c9 100644
          }
      }
  
-@@ -1652,9 +1674,10 @@ bool llama_kv_cache::stage_export_kv_page(
+@@ -1651,9 +1673,10 @@ bool llama_kv_cache::stage_export_kv_page(
                  continue;
              }
              auto * v = layer->v_stream[strm];
@@ -149,7 +149,7 @@ index 10de4e126..0a363e9c9 100644
              }
          }
      } else {
-@@ -1665,10 +1688,11 @@ bool llama_kv_cache::stage_export_kv_page(
+@@ -1664,10 +1687,11 @@ bool llama_kv_cache::stage_export_kv_page(
              auto * v = layer->v_stream[strm];
              const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(layer->il);
              for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
@@ -165,7 +165,7 @@ index 10de4e126..0a363e9c9 100644
                  }
              }
          }
-@@ -1695,7 +1719,8 @@ bool llama_kv_cache::stage_import_kv_page(
+@@ -1694,7 +1718,8 @@ bool llama_kv_cache::stage_import_kv_page(
          const skippy_kv_page_desc & desc,
          const void * input,
          size_t input_bytes,
@@ -175,7 +175,7 @@ index 10de4e126..0a363e9c9 100644
      if (input == nullptr) {
          error = "input payload is required";
          return false;
-@@ -1706,7 +1731,7 @@ bool llama_kv_cache::stage_import_kv_page(
+@@ -1705,7 +1730,7 @@ bool llama_kv_cache::stage_import_kv_page(
      }
      if (desc.layer_start < 0 ||
              desc.layer_end <= desc.layer_start ||
@@ -184,7 +184,7 @@ index 10de4e126..0a363e9c9 100644
              desc.token_count == 0) {
          error = "invalid native KV page descriptor";
          return false;
-@@ -1795,6 +1820,9 @@ bool llama_kv_cache::stage_import_kv_page(
+@@ -1794,6 +1819,9 @@ bool llama_kv_cache::stage_import_kv_page(
          error = "native KV page descriptor payload size is inconsistent";
          return false;
      }
@@ -194,7 +194,7 @@ index 10de4e126..0a363e9c9 100644
  
      llama_ubatch ubatch = {};
      auto udata = std::make_shared<llama_ubatch::data_t>();
-@@ -1860,12 +1888,14 @@ bool llama_kv_cache::stage_import_kv_page(
+@@ -1859,12 +1887,14 @@ bool llama_kv_cache::stage_import_kv_page(
      }
      apply_ubatch(sinfo, ubatch);
  
@@ -212,7 +212,7 @@ index 10de4e126..0a363e9c9 100644
          }
      }
  
-@@ -1876,9 +1906,10 @@ bool llama_kv_cache::stage_import_kv_page(
+@@ -1875,9 +1905,10 @@ bool llama_kv_cache::stage_import_kv_page(
                  continue;
              }
              auto * v = layer->v_stream[strm];
@@ -226,7 +226,7 @@ index 10de4e126..0a363e9c9 100644
              }
          }
      } else {
-@@ -1889,10 +1920,11 @@ bool llama_kv_cache::stage_import_kv_page(
+@@ -1888,10 +1919,11 @@ bool llama_kv_cache::stage_import_kv_page(
              auto * v = layer->v_stream[strm];
              const uint32_t n_embd_v_gqa = hparams.n_embd_v_gqa(layer->il);
              for (uint32_t j = 0; j < n_embd_v_gqa; ++j) {
@@ -596,7 +596,7 @@ index 2bfd88523..5b64b97a9 100644
  }
  
 diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
-index 9c6fc6828..7420978ae 100644
+index 5dd7461a0..86fcc259a 100644
 --- a/tests/CMakeLists.txt
 +++ b/tests/CMakeLists.txt
 @@ -155,6 +155,7 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)

--- a/third_party/llama.cpp/patches/0014-skippy-roll-back-bounded-verify-windows-in-place.patch
+++ b/third_party/llama.cpp/patches/0014-skippy-roll-back-bounded-verify-windows-in-place.patch
@@ -1,7 +1,7 @@
-From 00b92d0847e6fe7a3cbc2de320ccb4572a92590f Mon Sep 17 00:00:00 2001
+From b4181033c1f155d2e9d216f579089d1eaaad8139 Mon Sep 17 00:00:00 2001
 From: Michael Neale <14976+michaelneale@users.noreply.github.com>
 Date: Tue, 18 Aug 2026 16:44:10 +1000
-Subject: [PATCH 14/32] skippy: roll back bounded verify windows in place
+Subject: [PATCH 14/51] skippy: roll back bounded verify windows in place
 
 Recurrent memory supports bounded in-place rollback through the RS
 snapshot index, but the verify window copied the whole sequence state to

--- a/third_party/llama.cpp/patches/0015-skippy-prune-unverified-MTP-proposal-rows-from-the-s.patch
+++ b/third_party/llama.cpp/patches/0015-skippy-prune-unverified-MTP-proposal-rows-from-the-s.patch
@@ -1,7 +1,7 @@
-From 4b3a781bc45230dd79f63e9320360147c1048aec Mon Sep 17 00:00:00 2001
+From fb95965ac53d18cb48dde0958b5e06c332063308 Mon Sep 17 00:00:00 2001
 From: Michael Neale <14976+michaelneale@users.noreply.github.com>
 Date: Tue, 18 Aug 2026 20:41:42 +1000
-Subject: [PATCH 15/32] skippy: prune unverified MTP proposal rows from the
+Subject: [PATCH 15/51] skippy: prune unverified MTP proposal rows from the
  sidecar cache
 
 A multi-token proposal against a sidecar KV cache of its own writes one

--- a/third_party/llama.cpp/patches/0016-skippy-add-mixed-iteration-batch-execution-ABI.patch
+++ b/third_party/llama.cpp/patches/0016-skippy-add-mixed-iteration-batch-execution-ABI.patch
@@ -1,14 +1,14 @@
-From dc22ebede056a87691e65cccef8b50960d0b0a48 Mon Sep 17 00:00:00 2001
+From 9c83c8fc946f2640952dd38e90f82a51cc98d4f5 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Mon, 24 Aug 2026 15:35:31 +1000
-Subject: [PATCH 16/32] skippy: add mixed iteration batch execution ABI
+Subject: [PATCH 16/51] skippy: add mixed iteration batch execution ABI
 
 ---
  include/skippy/common.h        |  11 +-
  include/skippy/execution.h     |  60 +++++-
  src/skippy/abi.cpp             |   3 +-
- src/skippy/execution-batch.cpp | 342 +++++++++++++++++++++++++++++++++
- 4 files changed, 410 insertions(+), 6 deletions(-)
+ src/skippy/execution-batch.cpp | 341 +++++++++++++++++++++++++++++++++
+ 4 files changed, 409 insertions(+), 6 deletions(-)
 
 diff --git a/include/skippy/common.h b/include/skippy/common.h
 index 012aceb9a..e7f322abf 100644
@@ -485,3 +485,4 @@ index a8694dbed..8f6facc96 100644
          const llama_token * token_ids,
 -- 
 2.55.0
+

--- a/third_party/llama.cpp/patches/0017-skippy-fix-verify-history-accounting-for-activation-.patch
+++ b/third_party/llama.cpp/patches/0017-skippy-fix-verify-history-accounting-for-activation-.patch
@@ -1,7 +1,7 @@
-From 2e513f89259a7d0a2c6b07416f0e04b83ea90c92 Mon Sep 17 00:00:00 2001
+From 44f6f544ec059c2f6fcf59be0a26b95489c8760f Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 22 Aug 2026 14:29:39 +1000
-Subject: [PATCH 17/32] skippy: fix verify history accounting for
+Subject: [PATCH 17/51] skippy: fix verify history accounting for
  activation-input stages
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8

--- a/third_party/llama.cpp/patches/0018-fixup-resolve-leftover-upstream-merge-breakage-in-me.patch
+++ b/third_party/llama.cpp/patches/0018-fixup-resolve-leftover-upstream-merge-breakage-in-me.patch
@@ -1,7 +1,7 @@
-From aed2113335677e1cac9f6beccd9efef9b26ff1b2 Mon Sep 17 00:00:00 2001
+From bb568c3749304a561dffa678fcd040cd5206a2b0 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 26 Aug 2026 05:32:28 +1000
-Subject: [PATCH 18/32] fixup: resolve leftover upstream-merge breakage in
+Subject: [PATCH 18/51] fixup: resolve leftover upstream-merge breakage in
  metal kargs, mtmd resize algo, common_json port
 
 ---
@@ -33,7 +33,7 @@ index 305b9d081..8aa563bef 100644
  static skippy_error * skippy_common_make_error(enum skippy_status status, const char * message) {
      skippy_error * error = new skippy_error{};
 diff --git a/ggml/src/ggml-metal/ggml-metal-impl.h b/ggml/src/ggml-metal/ggml-metal-impl.h
-index c8057a232..a018165de 100644
+index c9147ebf5..aef84ce0e 100644
 --- a/ggml/src/ggml-metal/ggml-metal-impl.h
 +++ b/ggml/src/ggml-metal/ggml-metal-impl.h
 @@ -992,18 +992,24 @@ typedef struct {
@@ -69,7 +69,7 @@ index c8057a232..a018165de 100644
  
  typedef struct {
      int32_t  ne00t;
-@@ -1214,49 +1220,6 @@ typedef struct {
+@@ -1225,49 +1231,6 @@ typedef struct {
      int64_t val;
  } ggml_metal_kargs_memset;
  
@@ -120,10 +120,10 @@ index c8057a232..a018165de 100644
      int32_t  n_tokens;
      int32_t  n_iter;
 diff --git a/tools/mtmd/clip.cpp b/tools/mtmd/clip.cpp
-index 2d01ad73c..4d641d197 100644
+index 0d4208df4..86d7e64e6 100644
 --- a/tools/mtmd/clip.cpp
 +++ b/tools/mtmd/clip.cpp
-@@ -1417,7 +1417,7 @@ struct clip_model_loader {
+@@ -1421,7 +1421,7 @@ struct clip_model_loader {
                  case PROJECTOR_TYPE_INKLING:
                      {
                          if (is_vision) {

--- a/third_party/llama.cpp/patches/0019-ggml-cache-compiled-Metal-pipelines-on-disk-via-MTLB.patch
+++ b/third_party/llama.cpp/patches/0019-ggml-cache-compiled-Metal-pipelines-on-disk-via-MTLB.patch
@@ -1,7 +1,7 @@
-From 68c74bd51c52ddee295bb3ea10fa6f9f5b351692 Mon Sep 17 00:00:00 2001
+From 2da5e3e7a681f128759f878506c24bd42c499415 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 26 Aug 2026 07:15:54 +1000
-Subject: [PATCH 19/32] ggml: cache compiled Metal pipelines on disk via
+Subject: [PATCH 19/51] ggml: cache compiled Metal pipelines on disk via
  MTLBinaryArchive
 
 Set GGML_METAL_PIPELINE_CACHE_DIR to a directory to persist compiled
@@ -16,10 +16,10 @@ behavior is then unchanged.
  1 file changed, 169 insertions(+), 4 deletions(-)
 
 diff --git a/ggml/src/ggml-metal/ggml-metal-device.m b/ggml/src/ggml-metal/ggml-metal-device.m
-index 41ce90dc8..c2dbfc6ad 100644
+index e20a4e891..5335c8d8d 100644
 --- a/ggml/src/ggml-metal/ggml-metal-device.m
 +++ b/ggml/src/ggml-metal/ggml-metal-device.m
-@@ -9,6 +9,7 @@
+@@ -10,6 +10,7 @@
  #include <Metal/Metal.h>
  
  #include <stdatomic.h>
@@ -27,7 +27,7 @@ index 41ce90dc8..c2dbfc6ad 100644
  
  #ifndef TARGET_OS_VISION
  #define TARGET_OS_VISION 0
-@@ -156,6 +157,11 @@ struct ggml_metal_library {
+@@ -163,6 +164,11 @@ struct ggml_metal_library {
      ggml_metal_device_t dev;
      ggml_metal_pipelines_t pipelines; // cache of compiled pipelines
  
@@ -39,8 +39,8 @@ index 41ce90dc8..c2dbfc6ad 100644
      NSLock * lock;
  };
  
-@@ -173,6 +179,98 @@ static void ggml_metal_library_build_index(ggml_metal_library_t lib) {
-     }
+@@ -192,6 +198,98 @@ static void ggml_metal_compile_options_set_lang(MTLCompileOptions * options, boo
+     options.languageVersion = (MTLLanguageVersion) MTLLanguageVersion4_0_GGML;
  }
  
 +// FNV-1a 64-bit, used to fingerprint the inputs that determine pipeline
@@ -138,7 +138,7 @@ index 41ce90dc8..c2dbfc6ad 100644
  // Parse a `#include "name"` line. Returns the quoted name in *include_name on
  // success. Whitespace-tolerant; ignores `#include <...>` (system headers).
  static bool ggml_metal_library_parse_quoted_include(NSString * line, NSString ** include_name) {
-@@ -283,12 +381,14 @@ static bool ggml_metal_library_compile_all(
+@@ -302,12 +400,14 @@ static bool ggml_metal_library_compile_all(
          id<MTLDevice> device,
          NSDictionary * prep,
          NSString * (^source_for_kind)(int kind, NSError ** err),
@@ -154,7 +154,7 @@ index 41ce90dc8..c2dbfc6ad 100644
  
      dispatch_group_t group = dispatch_group_create();
      dispatch_queue_t queue = dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0);
-@@ -307,6 +407,11 @@ static bool ggml_metal_library_compile_all(
+@@ -326,6 +426,11 @@ static bool ggml_metal_library_compile_all(
                  return;
              }
  
@@ -166,7 +166,7 @@ index 41ce90dc8..c2dbfc6ad 100644
              id<MTLLibrary> lib = nil;
  
              @autoreleasepool {
-@@ -340,6 +445,18 @@ static bool ggml_metal_library_compile_all(
+@@ -360,6 +465,18 @@ static bool ggml_metal_library_compile_all(
  
      const bool ok = !atomic_load(&any_failure);
  
@@ -185,7 +185,7 @@ index 41ce90dc8..c2dbfc6ad 100644
      if (ok) {
          const int64_t t_total = ggml_time_us() - t_start;
          int64_t t_max = 0;
-@@ -407,19 +524,23 @@ ggml_metal_library_t ggml_metal_library_init(ggml_metal_device_t dev) {
+@@ -467,19 +584,23 @@ ggml_metal_library_t ggml_metal_library_init(ggml_metal_device_t dev) {
  #undef X
      };
  
@@ -210,7 +210,7 @@ index 41ce90dc8..c2dbfc6ad 100644
      return res;
  #else
  #ifdef SWIFT_PACKAGE
-@@ -478,6 +599,9 @@ ggml_metal_library_t ggml_metal_library_init(ggml_metal_device_t dev) {
+@@ -531,6 +652,9 @@ ggml_metal_library_t ggml_metal_library_init(ggml_metal_device_t dev) {
          }
  
          GGML_LOG_INFO("%s: loaded in %.3f sec\n", __func__, (ggml_time_us() - t_start) / 1e6);
@@ -220,7 +220,7 @@ index 41ce90dc8..c2dbfc6ad 100644
          return res;
      }
  
-@@ -512,10 +636,11 @@ ggml_metal_library_t ggml_metal_library_init(ggml_metal_device_t dev) {
+@@ -565,10 +689,11 @@ ggml_metal_library_t ggml_metal_library_init(ggml_metal_device_t dev) {
          path_per_kind[kind] = [path_source retain];
      }
  
@@ -233,7 +233,7 @@ index 41ce90dc8..c2dbfc6ad 100644
  
      for (int kind = 0; kind < GGML_METAL_LIB_COUNT; ++kind) {
          [path_per_kind[kind] release];
-@@ -527,6 +652,8 @@ ggml_metal_library_t ggml_metal_library_init(ggml_metal_device_t dev) {
+@@ -580,6 +705,8 @@ ggml_metal_library_t ggml_metal_library_init(ggml_metal_device_t dev) {
          return NULL;
      }
  
@@ -242,7 +242,7 @@ index 41ce90dc8..c2dbfc6ad 100644
      return res;
  #endif
  }
-@@ -616,6 +743,13 @@ void ggml_metal_library_free(ggml_metal_library_t lib) {
+@@ -674,6 +801,13 @@ void ggml_metal_library_free(ggml_metal_library_t lib) {
  
      ggml_metal_pipelines_free(lib->pipelines);
  
@@ -256,7 +256,7 @@ index 41ce90dc8..c2dbfc6ad 100644
      [lib->lock release];
  
      free(lib);
-@@ -707,7 +841,32 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_compile_pipeline(ggml_
+@@ -767,7 +901,32 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_compile_pipeline(ggml_
          }
  
          id<MTLDevice> device = ggml_metal_device_get_obj(lib->dev);
@@ -290,7 +290,7 @@ index 41ce90dc8..c2dbfc6ad 100644
  
          [mtl_function release];
  
-@@ -741,6 +900,12 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_compile_pipeline(ggml_
+@@ -801,6 +960,12 @@ struct ggml_metal_pipeline_with_params ggml_metal_library_compile_pipeline(ggml_
          res.pipeline->obj = obj;
  
          ggml_metal_pipelines_add(lib->pipelines, name, res.pipeline);

--- a/third_party/llama.cpp/patches/0020-skippy-stage-filter-GLM4-MoE-graphs.patch
+++ b/third_party/llama.cpp/patches/0020-skippy-stage-filter-GLM4-MoE-graphs.patch
@@ -1,7 +1,7 @@
-From d4da38d76c7b0eb2f90e811c8b39a49138104cc9 Mon Sep 17 00:00:00 2001
+From a3a7a1a72933610a235c2fa04db7762eb51d9797 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 26 Aug 2026 14:39:57 +1000
-Subject: [PATCH 20/32] skippy: stage-filter GLM4 MoE graphs
+Subject: [PATCH 20/51] skippy: stage-filter GLM4 MoE graphs
 
 Build filtered GLM4 MoE contexts only across the retained trunk layer range. Feed activation input to mid-model stages and return their boundary tensor without touching the absent output head.
 ---
@@ -9,10 +9,10 @@ Build filtered GLM4 MoE contexts only across the retained trunk layer range. Fee
  1 file changed, 17 insertions(+), 4 deletions(-)
 
 diff --git a/src/models/glm4-moe.cpp b/src/models/glm4-moe.cpp
-index 83ea7f8ac..e323f4e7e 100644
+index d6ae5783c..8b236c567 100644
 --- a/src/models/glm4-moe.cpp
 +++ b/src/models/glm4-moe.cpp
-@@ -303,10 +303,15 @@ llama_model_glm4_moe::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -299,10 +299,15 @@ llama_model_glm4_moe::graph::graph(const llama_model & model, const llm_graph_pa
      ggml_tensor * cur;
      ggml_tensor * inpL;
  
@@ -30,7 +30,7 @@ index 83ea7f8ac..e323f4e7e 100644
          // unfortunately, we need to forcefully stop here, to avoid users complaining about wrong results
          GGML_ABORT("This GGUF does not support multimodal. Please reconvert it.");
      }
-@@ -316,10 +321,10 @@ llama_model_glm4_moe::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -312,10 +317,10 @@ llama_model_glm4_moe::graph::graph(const llama_model & model, const llm_graph_pa
  
      auto * inp_attn = build_attn_inp_kv();
  
@@ -43,7 +43,7 @@ index 83ea7f8ac..e323f4e7e 100644
          ggml_tensor * inpSA = inpL;
  
          // Pre-attention norm
-@@ -426,6 +431,14 @@ llama_model_glm4_moe::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -422,6 +427,14 @@ llama_model_glm4_moe::graph::graph(const llama_model & model, const llm_graph_pa
          inpL = cur;
      }
      cur = inpL;

--- a/third_party/llama.cpp/patches/0021-skippy-clamp-staged-Nemotron-H-trunk-graphs.patch
+++ b/third_party/llama.cpp/patches/0021-skippy-clamp-staged-Nemotron-H-trunk-graphs.patch
@@ -1,7 +1,7 @@
-From f5d9c94438903e4dcd59e783625f8f76a7761afb Mon Sep 17 00:00:00 2001
+From 97f040876b8e57b82b50127d280b90204d4411fa Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 26 Aug 2026 14:54:41 +1000
-Subject: [PATCH 21/32] skippy: clamp staged Nemotron H trunk graphs
+Subject: [PATCH 21/51] skippy: clamp staged Nemotron H trunk graphs
 
 Retain the final MTP layer in the runtime slice while limiting the main Nemotron H graph to executable trunk layers.
 ---
@@ -9,10 +9,10 @@ Retain the final MTP layer in the runtime slice while limiting the main Nemotron
  1 file changed, 2 insertions(+), 2 deletions(-)
 
 diff --git a/src/models/nemotron-h.cpp b/src/models/nemotron-h.cpp
-index 2cbfe4d91..e337da107 100644
+index 8f98c7f14..4f73b9995 100644
 --- a/src/models/nemotron-h.cpp
 +++ b/src/models/nemotron-h.cpp
-@@ -173,8 +173,8 @@ llama_model_nemotron_h::graph::graph(const llama_model & model, const llm_graph_
+@@ -185,8 +185,8 @@ llama_model_nemotron_h::graph::graph(const llama_model & model, const llm_graph_
  
      const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
      const bool stage_filtered = stage_filter.enabled;

--- a/third_party/llama.cpp/patches/0022-skippy-retain-Nemotron-MTP-shared-embeddings.patch
+++ b/third_party/llama.cpp/patches/0022-skippy-retain-Nemotron-MTP-shared-embeddings.patch
@@ -1,7 +1,7 @@
-From 81f6b9996cd83d88dacce8cb492a0eaebe22b519 Mon Sep 17 00:00:00 2001
+From 1c1a04d56997bdd26cdef01dd20e378c35c76e09 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 26 Aug 2026 14:59:37 +1000
-Subject: [PATCH 22/32] skippy: retain Nemotron MTP shared embeddings
+Subject: [PATCH 22/51] skippy: retain Nemotron MTP shared embeddings
 
 Keep the shared token embedding on the final staged loader only when the selected range includes the appended Nemotron-H MoE MTP block.
 ---
@@ -9,10 +9,10 @@ Keep the shared token embedding on the final staged loader only when the selecte
  1 file changed, 9 insertions(+)
 
 diff --git a/src/llama-model-loader.cpp b/src/llama-model-loader.cpp
-index 2e985874e..4e7bca8ea 100644
+index 502ee292c..5d0123c2b 100644
 --- a/src/llama-model-loader.cpp
 +++ b/src/llama-model-loader.cpp
-@@ -1223,6 +1223,15 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1264,6 +1264,15 @@ struct ggml_tensor * llama_model_loader::create_tensor(
                     (tn.tensor == LLM_TENSOR_ALTUP_PROJ && g_skippy_filter.include_embeddings) ||
                     (tn.tensor == LLM_TENSOR_ALTUP_UNEMBD_PROJ && g_skippy_filter.include_output);
          }

--- a/third_party/llama.cpp/patches/0023-skippy-derive-restored-position-from-native-memory.patch
+++ b/third_party/llama.cpp/patches/0023-skippy-derive-restored-position-from-native-memory.patch
@@ -1,8 +1,8 @@
-From 1c8337ab56b165bebd0ff096ad99362f3025cfcc Mon Sep 17 00:00:00 2001
+From 9091a1e591ae62d1b809f7458829c1f49c2b4832 Mon Sep 17 00:00:00 2001
 From: Scam
  <a1860575018c4680d5669dd7bc3bd356b478bccb8d42e194df46304a5e25f49a@meshllm.communities.buzz.xyz>
 Date: Thu, 27 Aug 2026 04:53:05 +1000
-Subject: [PATCH 23/32] skippy: derive restored position from native memory
+Subject: [PATCH 23/51] skippy: derive restored position from native memory
 
 ---
  src/skippy/state.cpp | 72 ++++++++++++++++++++++++++------------------

--- a/third_party/llama.cpp/patches/0024-skippy-defer-token-signals-in-legacy-batch-sampling.patch
+++ b/third_party/llama.cpp/patches/0024-skippy-defer-token-signals-in-legacy-batch-sampling.patch
@@ -1,8 +1,8 @@
-From 4ce9890d2fab930031ebd10e630f4de85bb4be0f Mon Sep 17 00:00:00 2001
+From 4269bbd6ad71254e6158fc4e8bad1bb26007f5e2 Mon Sep 17 00:00:00 2001
 From: Scam
  <44c96d97d4bda5bbcbd62565b0b19bb2e895e1fad5d9e9116f267909f1dae78e@meshllm.communities.buzz.xyz>
 Date: Thu, 27 Aug 2026 21:01:48 +1000
-Subject: [PATCH] skippy: defer token signals in legacy batch sampling
+Subject: [PATCH 24/51] skippy: defer token signals in legacy batch sampling
 
 ---
  src/skippy/execution-batch.cpp  | 1 -
@@ -34,5 +34,5 @@ index d899f0c17..57098af41 100644
          out_predicted_tokens[i] = skippy_sample_token_ith(session, request_sampling, i);
      }
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
 

--- a/third_party/llama.cpp/patches/0025-skippy-support-latent-experts-in-nemotron-MTP-block.patch
+++ b/third_party/llama.cpp/patches/0025-skippy-support-latent-experts-in-nemotron-MTP-block.patch
@@ -1,7 +1,7 @@
-From 6aeb4b2c6b3e03767b356068a9ce783e177f5f96 Mon Sep 17 00:00:00 2001
+From 3f302ba12cac3372a9673e8f5cbfd7e4cfdf0f0d Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 26 Aug 2026 14:37:39 +1000
-Subject: [PATCH 24/32] skippy: support latent experts in nemotron MTP block
+Subject: [PATCH 25/51] skippy: support latent experts in nemotron MTP block
 
 ---
  src/models/nemotron-h-moe.cpp | 12 +++++++++++-
@@ -40,10 +40,10 @@ index 4d03f49e0..3dc30c95c 100644
                  layer.ffn_up_shexp,   NULL, layer.ffn_up_shexp_s,
                  NULL,                 NULL, NULL,
 diff --git a/src/models/nemotron-h.cpp b/src/models/nemotron-h.cpp
-index e337da107..41f78b874 100644
+index 4f73b9995..3f101dd03 100644
 --- a/src/models/nemotron-h.cpp
 +++ b/src/models/nemotron-h.cpp
-@@ -152,6 +152,11 @@ void llama_model_nemotron_h::load_arch_tensors(llama_model_loader & ml) {
+@@ -164,6 +164,11 @@ void llama_model_nemotron_h::load_arch_tensors(llama_model_loader & ml) {
          layer.attn_post_norm  = create_tensor(tn(LLM_TENSOR_ATTN_POST_NORM,  "weight", i), {n_embd}, mtp_flags);
          layer.ffn_gate_inp    = create_tensor(tn(LLM_TENSOR_FFN_GATE_INP,    "weight", i), {n_embd, n_expert}, mtp_flags);
          layer.ffn_exp_probs_b = create_tensor(tn(LLM_TENSOR_FFN_EXP_PROBS_B, "bias",   i), {n_expert}, mtp_flags);

--- a/third_party/llama.cpp/patches/0026-skippy-allow-standalone-NextN-only-nemotron-MTP-draf.patch
+++ b/third_party/llama.cpp/patches/0026-skippy-allow-standalone-NextN-only-nemotron-MTP-draf.patch
@@ -1,7 +1,7 @@
-From dcc8fa3fb4376cbdea08d2e2ea4a69dd724f301f Mon Sep 17 00:00:00 2001
+From 44fc36f49f561d261b5af1e2b55e3f68a7db5378 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 26 Aug 2026 15:20:36 +1000
-Subject: [PATCH 25/32] skippy: allow standalone NextN-only nemotron MTP draft
+Subject: [PATCH 26/51] skippy: allow standalone NextN-only nemotron MTP draft
  models
 
 A NextN-only draft GGUF (converted with convert_hf_to_gguf.py --mtp)
@@ -58,10 +58,10 @@ index 3dc30c95c..ce1cec84f 100644
      cb(cur, "result_output", -1);
  
 diff --git a/src/models/nemotron-h.cpp b/src/models/nemotron-h.cpp
-index 41f78b874..165541bbd 100644
+index 3f101dd03..c0045311b 100644
 --- a/src/models/nemotron-h.cpp
 +++ b/src/models/nemotron-h.cpp
-@@ -53,14 +53,16 @@ void llama_model_nemotron_h::load_arch_tensors(llama_model_loader & ml) {
+@@ -62,14 +62,16 @@ void llama_model_nemotron_h::load_arch_tensors(llama_model_loader & ml) {
      const int64_t moe_n_embd = hparams.moe_latent_size > 0 ? hparams.moe_latent_size : n_embd;
  
      // embeddings

--- a/third_party/llama.cpp/patches/0027-skippy-vectorize-greedy-sampling-on-Apple.patch
+++ b/third_party/llama.cpp/patches/0027-skippy-vectorize-greedy-sampling-on-Apple.patch
@@ -1,29 +1,31 @@
-From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From 0be7697664872bd309f0caf034df62727e1771b1 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 27 Aug 2026 04:30:00 +0000
-Subject: [PATCH] skippy: vectorize greedy sampling on Apple
+Subject: [PATCH 27/51] skippy: vectorize greedy sampling on Apple
 
 ---
- src/CMakeLists.txt       |  5 +++++
+ src/CMakeLists.txt      |  5 +++++
  src/skippy/sampling.cpp | 20 ++++++++++++++++++++
  2 files changed, 25 insertions(+)
 
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 7ee82c713..a1f98c1f2 100644
+index 7ee82c713..33fc32b19 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
-@@ -81,0 +82,5 @@ target_link_libraries(llama PUBLIC ggml)
+@@ -85,3 +85,8 @@ if (BUILD_SHARED_LIBS)
+     target_compile_definitions(llama PRIVATE LLAMA_BUILD)
+     target_compile_definitions(llama PUBLIC  LLAMA_SHARED)
+ endif()
 +if (APPLE)
 +    find_library(SKIPPY_ACCELERATE_FRAMEWORK Accelerate REQUIRED)
 +    target_link_libraries(llama PRIVATE ${SKIPPY_ACCELERATE_FRAMEWORK})
 +endif()
 +
-
 diff --git a/src/skippy/sampling.cpp b/src/skippy/sampling.cpp
-index 74eb3aa59..7cf74c2ba 100644
+index 1e342060c..0538678f0 100644
 --- a/src/skippy/sampling.cpp
 +++ b/src/skippy/sampling.cpp
-@@ -20,6 +20,10 @@
+@@ -19,6 +19,10 @@
  #include <utility>
  #include <vector>
  
@@ -34,7 +36,7 @@ index 74eb3aa59..7cf74c2ba 100644
  using json = nlohmann::ordered_json;
  
  void skippy_record_tokens(
-@@ -166,6 +170,22 @@ static llama_token skippy_greedy_sample_context_with_eog_policy(
+@@ -159,6 +163,22 @@ static llama_token skippy_greedy_sample_context_with_eog_policy(
          return 0;
      }
  
@@ -58,4 +60,5 @@ index 74eb3aa59..7cf74c2ba 100644
      float best_logit = -std::numeric_limits<float>::infinity();
      for (int32_t token = 0; token < n_vocab; ++token) {
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
+

--- a/third_party/llama.cpp/patches/0028-skippy-propagate-ctx_other-for-nemotron-h-moe-MTP-dr.patch
+++ b/third_party/llama.cpp/patches/0028-skippy-propagate-ctx_other-for-nemotron-h-moe-MTP-dr.patch
@@ -1,7 +1,7 @@
-From f8555a4b26f363713ff8dc1808f1ede6e1de6592 Mon Sep 17 00:00:00 2001
+From 12e7a0a5d465bcd53abecc89bda3294240a5c14b Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 26 Aug 2026 22:47:11 +1000
-Subject: [PATCH 26/32] skippy: propagate ctx_other for nemotron-h-moe MTP
+Subject: [PATCH 28/51] skippy: propagate ctx_other for nemotron-h-moe MTP
  draft contexts
 
 Rediffed for the post-#1436/#1457 patch series: insertion point moved
@@ -12,10 +12,10 @@ restructured upstream).
  1 file changed, 10 insertions(+)
 
 diff --git a/src/llama-context.cpp b/src/llama-context.cpp
-index aa3d6230d..1d319e5fc 100644
+index 1fccc162d..b4ee4342e 100644
 --- a/src/llama-context.cpp
 +++ b/src/llama-context.cpp
-@@ -165,6 +165,16 @@ llama_context::llama_context(
+@@ -166,6 +166,16 @@ llama_context::llama_context(
          cparams.ctx_other = params.ctx_other;
      }
  
@@ -29,9 +29,9 @@ index aa3d6230d..1d319e5fc 100644
 +        cparams.ctx_other = params.ctx_other;
 +    }
 +
-     auto rope_scaling_type = params.rope_scaling_type;
-     if (rope_scaling_type == LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED) {
-         rope_scaling_type = hparams.rope_scaling_type_train;
+     if (cparams.rope_scaling_type == LLAMA_ROPE_SCALING_TYPE_UNSPECIFIED) {
+         cparams.rope_scaling_type = hparams.rope_scaling_type_train;
+     }
 -- 
 2.55.0
 

--- a/third_party/llama.cpp/patches/0029-skippy-stage-Qwen4Exp-hyper-connected-residuals.patch
+++ b/third_party/llama.cpp/patches/0029-skippy-stage-Qwen4Exp-hyper-connected-residuals.patch
@@ -1,8 +1,8 @@
-From 11075272839ac3c4d7fc650e97dcba4001b978a6 Mon Sep 17 00:00:00 2001
+From e8aa9d603c4459be5956b95cb9e6544760f7ea45 Mon Sep 17 00:00:00 2001
 From: Jimmy
  <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a02b36a8@meshllm.communities.buzz.xyz>
 Date: Sat, 29 Aug 2026 01:06:43 +1000
-Subject: [PATCH 27/32] skippy: stage Qwen4Exp hyper-connected residuals
+Subject: [PATCH 29/51] skippy: stage Qwen4Exp hyper-connected residuals
 
 Carry Qwen4Exp's hyper-connected residual through an explicit wide graph input, retain token sidebands for PLE history, and limit graph execution to the selected layer range.
 
@@ -24,7 +24,7 @@ Signed-off-by: Jimmy <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a0
  create mode 100644 tests/test-skippy-activation-layout.cpp
 
 diff --git a/src/llama-graph.cpp b/src/llama-graph.cpp
-index df0c3019b..33d933c3f 100644
+index d08104618..09a628b48 100644
 --- a/src/llama-graph.cpp
 +++ b/src/llama-graph.cpp
 @@ -28,6 +28,7 @@ static thread_local skippy_graph_filter g_skippy_graph_filter;
@@ -83,7 +83,7 @@ index df0c3019b..33d933c3f 100644
      const skippy_activation_tokens & stage_tokens = skippy_graph_get_activation_tokens();
      GGML_ASSERT(stage_tokens.tokens != nullptr);
 diff --git a/src/llama-graph.h b/src/llama-graph.h
-index 15fc4fa83..3a00c0e93 100644
+index 2d3b07930..32a215ddd 100644
 --- a/src/llama-graph.h
 +++ b/src/llama-graph.h
 @@ -72,6 +72,13 @@ struct skippy_activation_gemma3n_altup {
@@ -133,10 +133,10 @@ index 15fc4fa83..3a00c0e93 100644
  public:
      llm_graph_input_stage_tokens() = default;
 diff --git a/src/llama-model-loader.cpp b/src/llama-model-loader.cpp
-index 4e7bca8ea..4eac8bb40 100644
+index 5d0123c2b..6d8f302de 100644
 --- a/src/llama-model-loader.cpp
 +++ b/src/llama-model-loader.cpp
-@@ -1223,6 +1223,13 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1264,6 +1264,13 @@ struct ggml_tensor * llama_model_loader::create_tensor(
                     (tn.tensor == LLM_TENSOR_ALTUP_PROJ && g_skippy_filter.include_embeddings) ||
                     (tn.tensor == LLM_TENSOR_ALTUP_UNEMBD_PROJ && g_skippy_filter.include_output);
          }
@@ -151,10 +151,10 @@ index 4e7bca8ea..4eac8bb40 100644
              llm_kv.arch == LLM_ARCH_NEMOTRON_H_MOE &&
              hparams.n_layer_nextn > 0 &&
 diff --git a/src/models/qwen4exp.cpp b/src/models/qwen4exp.cpp
-index abf6a0502..0820ca16f 100644
+index 773204a5a..6cbbc480a 100644
 --- a/src/models/qwen4exp.cpp
 +++ b/src/models/qwen4exp.cpp
-@@ -294,9 +294,24 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -342,9 +342,24 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
      int sections[4];
      std::copy(std::begin(hparams.rope_sections), std::begin(hparams.rope_sections) + 4, sections);
  
@@ -182,7 +182,7 @@ index abf6a0502..0820ca16f 100644
  
      auto * inp = build_inp_mem_hybrid();
  
-@@ -311,7 +326,7 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -359,7 +374,7 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
      }
  
      ggml_tensor * inp_pos     = build_inp_pos();
@@ -191,7 +191,7 @@ index abf6a0502..0820ca16f 100644
  
      ggml_tensor * ple_emb = nullptr;
      if (hparams.ple_n_heads > 0) {
-@@ -320,13 +335,19 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -368,13 +383,19 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
          ggml_build_forward_expand(gf, ple_emb);
      }
  
@@ -217,7 +217,7 @@ index abf6a0502..0820ca16f 100644
          res->t_layer_inp[il] = res_hc;
  
          if (hparams.is_ple(il)) {
-@@ -349,7 +370,7 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -397,7 +418,7 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
              cur = build_layer_attn(inp->get_attn(), mctx_hyb, cur, inp_pos, sections, il);
          }
  
@@ -226,7 +226,7 @@ index abf6a0502..0820ca16f 100644
              // everything below is per token, so drop the rows that produce no output
              cur    = ggml_get_rows(ctx0, cur,    inp_out_ids);
              inject = ggml_get_rows(ctx0, inject, inp_out_ids);
-@@ -377,6 +398,13 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -425,6 +446,13 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
          cb(res_hc, "l_last", il);
      }
  
@@ -346,10 +346,10 @@ index 440db0aef..dd66056ad 100644
      skippy_glm_dsa_top_k_scope(
              const skippy_activation_desc * desc,
 diff --git a/src/skippy/execution-batch.cpp b/src/skippy/execution-batch.cpp
-index 2d771832a..eaab6d31f 100644
+index c6637b4b3..01a22dccf 100644
 --- a/src/skippy/execution-batch.cpp
 +++ b/src/skippy/execution-batch.cpp
-@@ -63,6 +63,14 @@ enum skippy_status skippy_iteration_batch_sampled(
+@@ -62,6 +62,14 @@ enum skippy_status skippy_iteration_batch_sampled(
      }
  
      const bool activation_input = skippy_is_filtered(first) && first->stage_model->config.layer_start > 0;
@@ -364,7 +364,7 @@ index 2d771832a..eaab6d31f 100644
      const bool request_logits = first->stage_model->config.include_output;
      const bool request_embeddings = skippy_emits_activation_frame(first);
      size_t total_token_count = 0;
-@@ -160,9 +168,13 @@ enum skippy_status skippy_iteration_batch_sampled(
+@@ -169,9 +177,13 @@ enum skippy_status skippy_iteration_batch_sampled(
      const int32_t n_tokens = static_cast<int32_t>(total_token_count);
      std::vector<llama_token> token_storage(total_token_count);
      std::vector<float> embd_storage;
@@ -378,7 +378,7 @@ index 2d771832a..eaab6d31f 100644
          if ((batch_input_flags & SKIPPY_ACTIVATION_FLAG_GLM_DSA_TOP_K) != 0) {
              glm_dsa_input_top_k_storage.resize(
                      total_token_count * static_cast<size_t>(batch_input_top_k) * batch_input_streams);
-@@ -187,7 +199,7 @@ enum skippy_status skippy_iteration_batch_sampled(
+@@ -196,7 +208,7 @@ enum skippy_status skippy_iteration_batch_sampled(
                  float * destination = embd_storage.data() + (offset + token_index) * static_cast<size_t>(n_embd_inp);
                  std::memcpy(
                          destination,
@@ -387,7 +387,7 @@ index 2d771832a..eaab6d31f 100644
                          static_cast<size_t>(n_embd) * sizeof(float));
                  if (n_embd_inp > n_embd) {
                      std::memset(
-@@ -196,6 +208,12 @@ enum skippy_status skippy_iteration_batch_sampled(
+@@ -205,6 +217,12 @@ enum skippy_status skippy_iteration_batch_sampled(
                              static_cast<size_t>(n_embd_inp - n_embd) * sizeof(float));
                  }
              }
@@ -400,7 +400,7 @@ index 2d771832a..eaab6d31f 100644
              if (!glm_dsa_input_top_k_storage.empty()) {
                  const size_t sideband_values = request.token_count * static_cast<size_t>(batch_input_top_k) * batch_input_streams;
                  const int32_t * source = reinterpret_cast<const int32_t *>(
-@@ -237,6 +255,11 @@ enum skippy_status skippy_iteration_batch_sampled(
+@@ -246,6 +264,11 @@ enum skippy_status skippy_iteration_batch_sampled(
      };
  
      skippy_activation_tokens_scope activation_tokens_scope(token_storage.data(), total_token_count);
@@ -412,7 +412,7 @@ index 2d771832a..eaab6d31f 100644
      const llama_pos batch_pos_start = pos_storage.empty() ? first->n_past : pos_storage[0];
      skippy_glm_dsa_top_k_scope glm_dsa_top_k_scope(
              glm_dsa_input_top_k_storage.empty() ? nullptr : glm_dsa_input_top_k_storage.data(),
-@@ -515,6 +538,15 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+@@ -530,6 +553,15 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
      };
  
      skippy_activation_tokens_scope activation_tokens_scope(token_ids, request_count);
@@ -429,7 +429,7 @@ index 2d771832a..eaab6d31f 100644
      skippy_glm_dsa_top_k_scope glm_dsa_top_k_scope(
              glm_dsa_input_top_k_storage.empty() ? nullptr : glm_dsa_input_top_k_storage.data(),
 diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
-index 7420978ae..376e9b09f 100644
+index 86fcc259a..47ddeeef1 100644
 --- a/tests/CMakeLists.txt
 +++ b/tests/CMakeLists.txt
 @@ -156,6 +156,8 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)

--- a/third_party/llama.cpp/patches/0030-skippy-validate-runtime-slices-by-realized-contract.patch
+++ b/third_party/llama.cpp/patches/0030-skippy-validate-runtime-slices-by-realized-contract.patch
@@ -1,8 +1,8 @@
-From d5548b9f410a0d0913f5c2e9b48a1ad1ed2a8dc8 Mon Sep 17 00:00:00 2001
+From 2c8fc559ce442344c96305da3cb313077c2d24ea Mon Sep 17 00:00:00 2001
 From: scama
  <a1860575018c4680d5669dd7bc3bd356b478bccb8d42e194df46304a5e25f49a@meshllm.communities.buzz.xyz>
 Date: Wed, 2 Sep 2026 19:15:16 +1000
-Subject: [PATCH] skippy: validate runtime slices by realized contract
+Subject: [PATCH 30/51] skippy: validate runtime slices by realized contract
 
 ---
  src/skippy/model_loading.cpp | 116 -----------------------------------
@@ -136,5 +136,5 @@ index 9ad6d4f3a..64ddaf1bb 100644
              llama_model_free(model);
              const char * message = "layer_end exceeds model layer count";
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
 

--- a/third_party/llama.cpp/patches/0031-skippy-scope-Qwen4Exp-PLE-tables-to-owning-stages.patch
+++ b/third_party/llama.cpp/patches/0031-skippy-scope-Qwen4Exp-PLE-tables-to-owning-stages.patch
@@ -1,8 +1,8 @@
-From 063eb2c7d128cc1428f3f7838f6584bc230f578a Mon Sep 17 00:00:00 2001
+From a00c77f68b2692e11d189765cb9d8c0428ff246b Mon Sep 17 00:00:00 2001
 From: Jimmy
  <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a02b36a8@meshllm.communities.buzz.xyz>
 Date: Sat, 29 Aug 2026 02:13:55 +1000
-Subject: [PATCH 29/32] skippy: scope Qwen4Exp PLE tables to owning stages
+Subject: [PATCH 31/51] skippy: scope Qwen4Exp PLE tables to owning stages
 
 Co-authored-by: michaelneale <14976+michaelneale@users.noreply.github.com>
 
@@ -14,7 +14,7 @@ Signed-off-by: michaelneale <14976+michaelneale@users.noreply.github.com>
  3 files changed, 75 insertions(+), 8 deletions(-)
 
 diff --git a/src/llama-model-loader.cpp b/src/llama-model-loader.cpp
-index 4eac8bb40..8ade72322 100644
+index 6d8f302de..a3339888a 100644
 --- a/src/llama-model-loader.cpp
 +++ b/src/llama-model-loader.cpp
 @@ -1116,6 +1116,19 @@ static bool weight_buft_supported(const llama_hparams & hparams, ggml_tensor * w
@@ -37,7 +37,7 @@ index 4eac8bb40..8ade72322 100644
  static ggml_backend_buffer_type_t select_weight_buft(const llama_hparams & hparams, ggml_tensor * tensor, ggml_op op, const buft_list_t * buft_list) {
      GGML_ASSERT(!buft_list->empty());
      for (const auto & cur : *buft_list) {
-@@ -1193,6 +1206,9 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1234,6 +1247,9 @@ struct ggml_tensor * llama_model_loader::create_tensor(
              return false;
          }
  
@@ -47,7 +47,7 @@ index 4eac8bb40..8ade72322 100644
          bool keep = true;
          switch (info.layer) {
              case LLM_TENSOR_LAYER_INPUT:
-@@ -1223,11 +1239,9 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1264,11 +1280,9 @@ struct ggml_tensor * llama_model_loader::create_tensor(
                     (tn.tensor == LLM_TENSOR_ALTUP_PROJ && g_skippy_filter.include_embeddings) ||
                     (tn.tensor == LLM_TENSOR_ALTUP_UNEMBD_PROJ && g_skippy_filter.include_output);
          }
@@ -62,10 +62,10 @@ index 4eac8bb40..8ade72322 100644
          }
          if (!keep &&
 diff --git a/src/models/qwen4exp.cpp b/src/models/qwen4exp.cpp
-index 0820ca16f..6a9769dfc 100644
+index 6cbbc480a..04690bc96 100644
 --- a/src/models/qwen4exp.cpp
 +++ b/src/models/qwen4exp.cpp
-@@ -124,8 +124,21 @@ void llama_model_qwen4exp::load_arch_tensors(llama_model_loader & ml) {
+@@ -166,8 +166,21 @@ void llama_model_qwen4exp::load_arch_tensors(llama_model_loader & ml) {
          output = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD, "weight"), { n_embd, n_vocab }, TENSOR_DUPLICATED);
      }
  
@@ -82,13 +82,13 @@ index 0820ca16f..6a9769dfc 100644
 +        }
 +    }
 +
-     // flat [ple_head_dim, n_rows] gather target; n_rows is padded, so read it back
+     // flat [ple_head_dim, n_rows] gather target
 -    if (hparams.ple_n_heads > 0) {
 +    if (hparams.ple_n_heads > 0 && stage_contains_ple) {
-         const std::string ple_name = tn(LLM_TENSOR_PER_LAYER_TOKEN_EMBD, "weight").str();
-         const auto & ple_w = ml.require_weight(ple_name.c_str());
-         const int64_t ple_rows = ple_w.tensor->ne[1];
-@@ -328,8 +341,17 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
+         // the head ranges are what the gather indexes, so they set the minimum row count
+         int64_t ple_rows = 0;
+         for (uint32_t h = 0; h < hparams.ple_n_heads; ++h) {
+@@ -376,8 +389,17 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
      ggml_tensor * inp_pos     = build_inp_pos();
      ggml_tensor * inp_out_ids = (!stage_filtered || stage_filter.include_output) ? build_inp_out_ids() : nullptr;
  

--- a/third_party/llama.cpp/patches/0032-skippy-cache-chat-templates-for-model-lifetime.patch
+++ b/third_party/llama.cpp/patches/0032-skippy-cache-chat-templates-for-model-lifetime.patch
@@ -1,17 +1,17 @@
-From e6977d94b17569db010f5cf34fc616934d259ba3 Mon Sep 17 00:00:00 2001
+From 6334933e5aa442ff622198043c9521c8035b8cca Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 29 Aug 2026 10:28:15 +1000
-Subject: [PATCH] skippy: cache chat templates for model lifetime
+Subject: [PATCH 32/51] skippy: cache chat templates for model lifetime
 
 ---
- common/stage-chat.cpp          | 44 +++++++++++++++++++++++++++++++++++++++++--
+ common/stage-chat.cpp          | 44 ++++++++++++++++++++++++++++++++--
  src/skippy/model_lifecycle.cpp |  3 +++
  src/skippy/runtime_types.h     |  3 +++
- src/skippy/tokenization.cpp    | 35 +++++++++++++++++++++++++++++++++++
+ src/skippy/tokenization.cpp    | 35 +++++++++++++++++++++++++++
  4 files changed, 83 insertions(+), 2 deletions(-)
 
 diff --git a/common/stage-chat.cpp b/common/stage-chat.cpp
-index 8aa563bef..8ca0974d3 100644
+index 8aa563bef..02492ad81 100644
 --- a/common/stage-chat.cpp
 +++ b/common/stage-chat.cpp
 @@ -12,6 +12,38 @@
@@ -101,7 +101,7 @@ index ff8024a5f..f83801c97 100644
  
  struct skippy_verify_checkpoint {
 diff --git a/src/skippy/tokenization.cpp b/src/skippy/tokenization.cpp
-index 89d69ff3a..778fbf0c8 100644
+index 89d69ff3a..386ad3f24 100644
 --- a/src/skippy/tokenization.cpp
 +++ b/src/skippy/tokenization.cpp
 @@ -6,9 +6,44 @@
@@ -150,4 +150,5 @@ index 89d69ff3a..778fbf0c8 100644
  
  enum skippy_status skippy_tokenize(
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
+

--- a/third_party/llama.cpp/patches/0033-skippy-verify-wide-Qwen4Exp-activation-frames-safely.patch
+++ b/third_party/llama.cpp/patches/0033-skippy-verify-wide-Qwen4Exp-activation-frames-safely.patch
@@ -1,8 +1,8 @@
-From e6427a2bdd6c05aae1a2bdcd4d28d4134add0ad2 Mon Sep 17 00:00:00 2001
+From db30f018f7df6e092d87294ed7158833d4c1f1b7 Mon Sep 17 00:00:00 2001
 From: Jimmy
  <1fe240cd1a8cf775f6f3060f115e5a303181f3abf28ad4cb0c2515f4a02b36a8@meshllm.communities.buzz.xyz>
 Date: Sat, 29 Aug 2026 02:05:03 +1000
-Subject: [PATCH 30/32] skippy: verify wide Qwen4Exp activation frames safely
+Subject: [PATCH 33/51] skippy: verify wide Qwen4Exp activation frames safely
 
 Co-authored-by: michaelneale <14976+michaelneale@users.noreply.github.com>
 

--- a/third_party/llama.cpp/patches/0034-skippy-fix-Qwen4Exp-activation-frame-staging.patch
+++ b/third_party/llama.cpp/patches/0034-skippy-fix-Qwen4Exp-activation-frame-staging.patch
@@ -1,8 +1,8 @@
-From a4653405a51b0b3a4fe08e7959dddacdb9c9373b Mon Sep 17 00:00:00 2001
+From 0a1934dff221eb0a29eabd8599253ead4cd24f97 Mon Sep 17 00:00:00 2001
 From: Scam
  <44c96d97d4bda5bbcbd62565b0b19bb2e895e1fad5d9e9116f267909f1dae78e@meshllm.communities.buzz.xyz>
 Date: Sat, 29 Aug 2026 08:35:38 +1000
-Subject: [PATCH 31/32] skippy: fix Qwen4Exp activation frame staging
+Subject: [PATCH 34/51] skippy: fix Qwen4Exp activation frame staging
 
 ---
  src/skippy/activation.cpp      |  5 ++++-
@@ -28,10 +28,10 @@ index 43cba21f3..a598963a7 100644
          }
      }
 diff --git a/src/skippy/execution-batch.cpp b/src/skippy/execution-batch.cpp
-index eaab6d31f..0124f2f6d 100644
+index 01a22dccf..451f5c816 100644
 --- a/src/skippy/execution-batch.cpp
 +++ b/src/skippy/execution-batch.cpp
-@@ -410,6 +410,14 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+@@ -425,6 +425,14 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
      const int32_t n_embd_inp = llama_model_n_embd_inp(first->stage_model->model);
      const int32_t n_pos_per_embd = first->stage_model->model->hparams.n_pos_per_embd();
      const bool activation_input = skippy_is_filtered(first) && first->stage_model->config.layer_start > 0;
@@ -46,7 +46,7 @@ index eaab6d31f..0124f2f6d 100644
      const bool request_logits = first->stage_model->config.include_output;
      const bool request_embeddings = skippy_emits_activation_frame(first);
  
-@@ -473,10 +481,14 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+@@ -488,10 +496,14 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
      }
  
      std::vector<float> embd_storage;
@@ -61,7 +61,7 @@ index eaab6d31f..0124f2f6d 100644
          if ((batch_input_flags & SKIPPY_ACTIVATION_FLAG_GLM_DSA_TOP_K) != 0) {
              glm_dsa_input_top_k_storage.resize(request_count*batch_input_top_k);
          }
-@@ -487,6 +499,15 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+@@ -502,6 +514,15 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
              if ((input_desc->flags & SKIPPY_ACTIVATION_FLAG_GEMMA3N_ALTUP) != 0) {
                  skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, "batched activation decode does not support Gemma3n AltUp sidebands yet");
                  return SKIPPY_STATUS_UNSUPPORTED;
@@ -77,7 +77,7 @@ index eaab6d31f..0124f2f6d 100644
              } else if (n_embd_inp == n_embd) {
                  std::memcpy(dst, input_payload, hidden_bytes_per_request);
              } else {
-@@ -538,12 +559,8 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+@@ -553,12 +574,8 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
      };
  
      skippy_activation_tokens_scope activation_tokens_scope(token_ids, request_count);

--- a/third_party/llama.cpp/patches/0035-skippy-clear-stale-sidecar-rows-before-single-row-MT.patch
+++ b/third_party/llama.cpp/patches/0035-skippy-clear-stale-sidecar-rows-before-single-row-MT.patch
@@ -1,7 +1,7 @@
-From db38b11f4ea264d96b782a65520561dec43e632c Mon Sep 17 00:00:00 2001
+From 9784a150839aa8a86a6181c48f94f41b32609042 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sun, 30 Aug 2026 02:46:33 +0000
-Subject: [PATCH] skippy: clear stale sidecar rows before single-row MTP
+Subject: [PATCH 35/51] skippy: clear stale sidecar rows before single-row MTP
  proposals
 
 The native MTP sidecar keeps its own KV cache. When a proposal is
@@ -51,5 +51,5 @@ index 22bc61858..00ad16493 100644
              mtp_depth_scope.select(depth);
              llama_batch batch = {
 -- 
-2.43.0
+2.55.0
 

--- a/third_party/llama.cpp/patches/0036-skippy-offload-greedy-sampling-to-model-backend.patch
+++ b/third_party/llama.cpp/patches/0036-skippy-offload-greedy-sampling-to-model-backend.patch
@@ -1,7 +1,7 @@
-From 1980d970f0d700b54ec774afa8c5b0025afc8c0c Mon Sep 17 00:00:00 2001
+From 4f07ea765dafd08b1d00e795c977eab5a79777af Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 29 Aug 2026 10:37:31 +1000
-Subject: [PATCH] skippy: offload greedy sampling to model backend
+Subject: [PATCH 36/51] skippy: offload greedy sampling to model backend
 
 ---
  src/skippy/runtime_types.h     |  1 +
@@ -24,7 +24,7 @@ index f83801c97..51f4f71cb 100644
      bool sampling_config_valid = false;
      std::string chat_sampling_metadata;
 diff --git a/src/skippy/sampling.cpp b/src/skippy/sampling.cpp
-index 5c3cae65c..6fb1e1f64 100644
+index 0538678f0..f2885f09b 100644
 --- a/src/skippy/sampling.cpp
 +++ b/src/skippy/sampling.cpp
 @@ -302,10 +302,14 @@ void skippy_clear_chat_sampling(skippy_session * session) {
@@ -59,7 +59,7 @@ index 5c3cae65c..6fb1e1f64 100644
          llama_sampler_chain_add(sampler, llama_sampler_init_greedy());
          return sampler;
      }
-@@ -487,9 +492,26 @@ static bool skippy_ensure_plain_sampling_chain(
+@@ -485,9 +490,26 @@ static bool skippy_ensure_plain_sampling_chain(
      session->sampling_config = *sampling;
      session->sampling_config_valid = true;
      session->sampling_accepted_token_count = 0;
@@ -86,7 +86,7 @@ index 5c3cae65c..6fb1e1f64 100644
  bool skippy_init_chat_grammar_sampler(
          skippy_session * session,
          const json & metadata,
-@@ -600,6 +622,9 @@ static void skippy_sync_chat_sampling_history(skippy_session * session) {
+@@ -598,6 +620,9 @@ static void skippy_sync_chat_sampling_history(skippy_session * session) {
  
  static llama_token skippy_chat_sample_token(skippy_session * session, int32_t logits_index) {
      skippy_sync_chat_sampling_history(session);
@@ -96,7 +96,7 @@ index 5c3cae65c..6fb1e1f64 100644
      llama_synchronize(session->ctx);
  
      const llama_vocab * vocab = llama_model_get_vocab(session->stage_model->model);
-@@ -645,6 +670,7 @@ llama_token skippy_sample_token_ith(
+@@ -643,6 +668,7 @@ llama_token skippy_sample_token_ith(
          return 0;
      }
      if (skippy_mtp_greedy_sampling_fastpath_enabled() &&
@@ -137,7 +137,7 @@ index 184ccdba0..ef1ff64ac 100644
              skippy_release_execution_lane(session->stage_model, session->seq_id);
          }
 diff --git a/src/skippy/tokenization.cpp b/src/skippy/tokenization.cpp
-index 778fbf0c8..fb0aa0c54 100644
+index 386ad3f24..5b885bf68 100644
 --- a/src/skippy/tokenization.cpp
 +++ b/src/skippy/tokenization.cpp
 @@ -13,6 +13,11 @@
@@ -153,4 +153,5 @@ index 778fbf0c8..fb0aa0c54 100644
          struct skippy_model * model,
          skippy_chat_templates_create_fn create,
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
+

--- a/third_party/llama.cpp/patches/0037-skippy-avoid-redundant-resident-prefix-barriers.patch
+++ b/third_party/llama.cpp/patches/0037-skippy-avoid-redundant-resident-prefix-barriers.patch
@@ -1,7 +1,7 @@
-From 2b0b559cf1e57d8c723750e28c406a556692e454 Mon Sep 17 00:00:00 2001
+From 407560835f27d23c5651b9c1b0f489a7567f0f64 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 29 Aug 2026 11:27:34 +1000
-Subject: [PATCH] skippy: avoid redundant resident prefix barriers
+Subject: [PATCH 37/51] skippy: avoid redundant resident prefix barriers
 
 ---
  src/skippy/state.cpp | 4 ----
@@ -44,5 +44,5 @@ index 7270d2ea2..3a8763869 100644
  }
  
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
 

--- a/third_party/llama.cpp/patches/0038-skippy-carry-full-source-shared-table-ownership.patch
+++ b/third_party/llama.cpp/patches/0038-skippy-carry-full-source-shared-table-ownership.patch
@@ -1,8 +1,8 @@
-From e452cbe8a43fa879e89d328b7c2e7c33707316da Mon Sep 17 00:00:00 2001
+From 7c2002433c487dd33e587ed8c949195475f7a8e5 Mon Sep 17 00:00:00 2001
 From: Scam
  <44c96d97d4bda5bbcbd62565b0b19bb2e895e1fad5d9e9116f267909f1dae78e@meshllm.communities.buzz.xyz>
 Date: Sat, 29 Aug 2026 08:36:03 +1000
-Subject: [PATCH 32/32] skippy: carry full-source shared-table ownership
+Subject: [PATCH 38/51] skippy: carry full-source shared-table ownership
 
 ---
  include/skippy/common.h        |  2 +-

--- a/third_party/llama.cpp/patches/0039-skippy-add-kv_offload-kv_unified-swa_full-op_offload.patch
+++ b/third_party/llama.cpp/patches/0039-skippy-add-kv_offload-kv_unified-swa_full-op_offload.patch
@@ -1,9 +1,9 @@
-From d7e50e616c8493982f09bf6591ff57264c9f64f2 Mon Sep 17 00:00:00 2001
+From 8f8a13129515635c90679dc94b2b7332103fafd6 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Thu, 27 Aug 2026 15:26:27 -0400
-Subject: [PATCH] skippy: add kv_offload, kv_unified, swa_full, op_offload,
- no_host_buffer, check_tensors, direct_io, main_gpu, and split_mode runtime
- config controls
+Subject: [PATCH 39/51] skippy: add kv_offload, kv_unified, swa_full,
+ op_offload, no_host_buffer, check_tensors, direct_io, main_gpu, and
+ split_mode runtime config controls
 
 ---
  CMakeLists.txt                                |  5 ++
@@ -34,7 +34,7 @@ index 586bf97f6..9de023d3d 100644
  set(LLAMA_VERSION_MAJOR 0)
  set(LLAMA_VERSION_MINOR 3)
 diff --git a/include/skippy/common.h b/include/skippy/common.h
-index e7f322abf..c9d92c28f 100644
+index af927f835..c9d92c28f 100644
 --- a/include/skippy/common.h
 +++ b/include/skippy/common.h
 @@ -34,7 +34,7 @@ extern "C" {
@@ -94,7 +94,7 @@ index bfb80e105..ba62f60cf 100644
  LLAMA_API enum skippy_status skippy_model_open(
          const char * path,
 diff --git a/src/CMakeLists.txt b/src/CMakeLists.txt
-index 7ee82c713..b59528d62 100644
+index 33fc32b19..894741717 100644
 --- a/src/CMakeLists.txt
 +++ b/src/CMakeLists.txt
 @@ -80,6 +80,17 @@ target_compile_features   (llama PRIVATE cxx_std_17) # don't bump
@@ -164,7 +164,7 @@ index 8bd88058a..0f7c83139 100644
 +        const skippy_runtime_config * config,
 +        llama_context_params & params);
 diff --git a/src/skippy/model_loading.cpp b/src/skippy/model_loading.cpp
-index 9ad6d4f3a..8ac133f2a 100644
+index 64ddaf1bb..33c54cf42 100644
 --- a/src/skippy/model_loading.cpp
 +++ b/src/skippy/model_loading.cpp
 @@ -452,6 +452,18 @@ static void skippy_enable_integrated_mtp_tensors(
@@ -186,7 +186,7 @@ index 9ad6d4f3a..8ac133f2a 100644
  extern "C" {
  
  static enum skippy_status skippy_finish_model_open(
-@@ -634,6 +646,12 @@ static enum skippy_status skippy_finish_model_open(
+@@ -518,6 +530,12 @@ static enum skippy_status skippy_finish_model_open(
      params.n_threads_batch = config != nullptr && config->n_threads_batch > 0 ? config->n_threads_batch : params.n_threads;
      params.n_seq_max = stage_model->lane_count;
      params.kv_unified = stage_model->lane_count > 1;
@@ -199,7 +199,7 @@ index 9ad6d4f3a..8ac133f2a 100644
      params.type_k = config != nullptr && config->cache_type_k > 0 ? static_cast<ggml_type>(config->cache_type_k) : GGML_TYPE_F16;
      params.type_v = config != nullptr && config->cache_type_v > 0 ? static_cast<ggml_type>(config->cache_type_v) : GGML_TYPE_F16;
      params.flash_attn_type = config != nullptr ? static_cast<llama_flash_attn_type>(config->flash_attn_type) : LLAMA_FLASH_ATTN_TYPE_AUTO;
-@@ -753,9 +771,6 @@ enum skippy_status skippy_model_open_impl(
+@@ -637,9 +655,6 @@ enum skippy_status skippy_model_open_impl(
      if (config != nullptr) {
          params.n_gpu_layers = config->n_gpu_layers;
          skippy_apply_model_load_memory_config(config, params);
@@ -209,7 +209,7 @@ index 9ad6d4f3a..8ac133f2a 100644
      }
      if (event_scope.is_enabled()) {
          params.progress_callback = skippy_model_open_progress_callback;
-@@ -840,9 +855,6 @@ enum skippy_status skippy_model_open_from_parts_impl(
+@@ -724,9 +739,6 @@ enum skippy_status skippy_model_open_from_parts_impl(
      if (config != nullptr) {
          params.n_gpu_layers = config->n_gpu_layers;
          skippy_apply_model_load_memory_config(config, params);
@@ -219,7 +219,7 @@ index 9ad6d4f3a..8ac133f2a 100644
      }
      if (event_scope.is_enabled()) {
          params.progress_callback = skippy_model_open_progress_callback;
-@@ -899,9 +911,6 @@ enum skippy_status skippy_model_attach_mtp_draft_model(
+@@ -783,9 +795,6 @@ enum skippy_status skippy_model_attach_mtp_draft_model(
      if (config != nullptr) {
          model_params.n_gpu_layers = config->n_gpu_layers;
          skippy_apply_model_load_memory_config(config, model_params);
@@ -229,7 +229,7 @@ index 9ad6d4f3a..8ac133f2a 100644
      }
  
      llama_backend_init();
-@@ -931,6 +940,12 @@ enum skippy_status skippy_model_attach_mtp_draft_model(
+@@ -815,6 +824,12 @@ enum skippy_status skippy_model_attach_mtp_draft_model(
      ctx_params.n_threads_batch = config != nullptr && config->n_threads_batch > 0 ? config->n_threads_batch : ctx_params.n_threads;
      ctx_params.n_seq_max = target_model->lane_count;
      ctx_params.kv_unified = target_model->lane_count > 1;
@@ -302,4 +302,5 @@ index 000000000..42fae794a
 +    return passed ? 0 : 1;
 +}
 -- 
-2.50.1 (Apple Git-155)
+2.55.0
+

--- a/third_party/llama.cpp/patches/0040-skippy-remove-serial-c1-synchronization-overhead.patch
+++ b/third_party/llama.cpp/patches/0040-skippy-remove-serial-c1-synchronization-overhead.patch
@@ -1,7 +1,7 @@
-From 92a192d0686c4ff6f7491adb271ae39310159fbb Mon Sep 17 00:00:00 2001
+From bfb1f21ea2c5aa9c7dafa31c8b25f234c40ff6ff Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 29 Aug 2026 12:53:48 +1000
-Subject: [PATCH] skippy: remove serial c1 synchronization overhead
+Subject: [PATCH 40/51] skippy: remove serial c1 synchronization overhead
 
 ---
  src/skippy/activation.cpp       |  2 +-
@@ -9,14 +9,14 @@ Subject: [PATCH] skippy: remove serial c1 synchronization overhead
  src/skippy/execution-single.cpp |  1 +
  src/skippy/runtime_support.h    |  3 ++
  src/skippy/runtime_types.h      |  7 ++++
- src/skippy/sampling.cpp         | 74 +++++++++++++++++++++++++++++----
+ src/skippy/sampling.cpp         | 73 +++++++++++++++++++++++++++++----
  src/skippy/sampling_internal.h  |  6 +++
  src/skippy/session.cpp          | 33 ++++++++++++---
  src/skippy/state.cpp            |  8 ++--
  9 files changed, 116 insertions(+), 19 deletions(-)
 
 diff --git a/src/skippy/activation.cpp b/src/skippy/activation.cpp
-index 2e85acf51..435515075 100644
+index a598963a7..58da7bc25 100644
 --- a/src/skippy/activation.cpp
 +++ b/src/skippy/activation.cpp
 @@ -378,6 +378,7 @@ enum skippy_status skippy_decode_batch(
@@ -27,16 +27,16 @@ index 2e85acf51..435515075 100644
  
      session->n_past += static_cast<int32_t>(token_count);
      return skippy_success(out_error);
-@@ -987,4 +988,3 @@ enum skippy_status skippy_restore_verify_prefix(
+@@ -1019,4 +1020,3 @@ enum skippy_status skippy_restore_verify_prefix(
      *out_restored = true;
      return SKIPPY_STATUS_OK;
  }
 -
 diff --git a/src/skippy/execution-batch.cpp b/src/skippy/execution-batch.cpp
-index c6637b4b3..0df661209 100644
+index 451f5c816..678a40692 100644
 --- a/src/skippy/execution-batch.cpp
 +++ b/src/skippy/execution-batch.cpp
-@@ -261,6 +261,7 @@ enum skippy_status skippy_iteration_batch_sampled(
+@@ -284,6 +284,7 @@ enum skippy_status skippy_iteration_batch_sampled(
          skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "llama_decode failed for scheduler iteration");
          return SKIPPY_STATUS_RUNTIME_ERROR;
      }
@@ -44,7 +44,7 @@ index c6637b4b3..0df661209 100644
  
      float * embeddings = request_embeddings ? llama_get_embeddings(first->ctx) : nullptr;
      if (request_embeddings && embeddings == nullptr) {
-@@ -545,6 +546,7 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+@@ -594,6 +595,7 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
          skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "llama_decode failed");
          return SKIPPY_STATUS_RUNTIME_ERROR;
      }
@@ -79,7 +79,7 @@ index 8146f5a65..2d35f7d5f 100644
  void skippy_mtp_clear_session_state(skippy_session * session);
  void skippy_clear_chat_sampling(skippy_session * session);
 diff --git a/src/skippy/runtime_types.h b/src/skippy/runtime_types.h
-index 51f4f71cb..2a3b87f40 100644
+index 51f4f71cb..dbe7ab2e4 100644
 --- a/src/skippy/runtime_types.h
 +++ b/src/skippy/runtime_types.h
 @@ -5,6 +5,7 @@
@@ -98,7 +98,7 @@ index 51f4f71cb..2a3b87f40 100644
      skippy_runtime_config config = {};
      skippy_glm_dsa_op_timing glm_dsa_timing = {};
      bool executable = true;
-@@ -115,6 +116,11 @@ struct skippy_session {
+@@ -116,6 +118,11 @@ struct skippy_session {
      int32_t preserve_prefix_tokens = 0;
      std::vector<llama_token> token_history;
      std::vector<skippy_token_signal> signal_history;
@@ -111,7 +111,7 @@ index 51f4f71cb..2a3b87f40 100644
      llama_sampler * grammar_sampler = nullptr;
      bool sampling_backend_enabled = false;
 diff --git a/src/skippy/sampling.cpp b/src/skippy/sampling.cpp
-index 6fb1e1f64..a2d695de7 100644
+index f2885f09b..8a798a734 100644
 --- a/src/skippy/sampling.cpp
 +++ b/src/skippy/sampling.cpp
 @@ -12,6 +12,7 @@
@@ -162,7 +162,7 @@ index 6fb1e1f64..a2d695de7 100644
      if (status == SKIPPY_STATUS_OK) {
          skippy_record_tokens(session, token_ids, token_count);
          status = skippy_mtp_sync_target_inputs(session, token_ids, nullptr, token_count, token_start, out_error);
-@@ -392,6 +406,41 @@ static bool skippy_sampling_configs_equal(
+@@ -392,6 +405,41 @@ static bool skippy_sampling_configs_equal(
      return true;
  }
  
@@ -204,7 +204,7 @@ index 6fb1e1f64..a2d695de7 100644
  llama_sampler * skippy_build_sampling_chain(
          skippy_session * session,
          const skippy_sampling_config * sampling) {
-@@ -623,9 +672,16 @@ static void skippy_sync_chat_sampling_history(skippy_session * session) {
+@@ -621,9 +669,16 @@ static void skippy_sync_chat_sampling_history(skippy_session * session) {
  static llama_token skippy_chat_sample_token(skippy_session * session, int32_t logits_index) {
      skippy_sync_chat_sampling_history(session);
      if (session->sampling_backend_enabled) {
@@ -368,4 +368,5 @@ index 3a8763869..a2292fef8 100644
      return skippy_success(out_error);
  }
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
+

--- a/third_party/llama.cpp/patches/0041-skippy-report-physical-KV-cache-occupancy.patch
+++ b/third_party/llama.cpp/patches/0041-skippy-report-physical-KV-cache-occupancy.patch
@@ -1,29 +1,15 @@
-From 6dc2063aa7a37ed1baca62481fdc2aeda12d4f61 Mon Sep 17 00:00:00 2001
+From 2fc467d876af0e8ed8e8d6c065a6ad383d7d0c6e Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sun, 30 Aug 2026 05:37:40 +1000
-Subject: [PATCH] skippy: report physical KV cache occupancy
+Subject: [PATCH 41/51] skippy: report physical KV cache occupancy
 
 ---
- include/skippy/common.h |  2 +-
- include/skippy/state.h  |  6 ++++++
- src/llama-kv-cache.cpp  |  8 ++++++++
- src/llama-kv-cache.h    |  1 +
- src/skippy/state.cpp    | 66 ++++++++++++++++++++++++++++++++++++++++++++++++++
- 5 files changed, 82 insertions(+), 1 deletion(-)
+ include/skippy/state.h |  6 ++++
+ src/llama-kv-cache.cpp |  8 +++++
+ src/llama-kv-cache.h   |  1 +
+ src/skippy/state.cpp   | 66 ++++++++++++++++++++++++++++++++++++++++++
+ 4 files changed, 81 insertions(+)
 
-diff --git a/include/skippy/common.h b/include/skippy/common.h
-index af927f835..c9d92c28f 100644
---- a/include/skippy/common.h
-+++ b/include/skippy/common.h
-@@ -34,7 +34,7 @@ extern "C" {
- 
- #define SKIPPY_ABI_VERSION_MAJOR 0
- #define SKIPPY_ABI_VERSION_MINOR 1
--#define SKIPPY_ABI_VERSION_PATCH 42
-+#define SKIPPY_ABI_VERSION_PATCH 43
- 
- #if defined(_MSC_VER)
- #define SKIPPY_DEPRECATED(message) __declspec(deprecated(message))
 diff --git a/include/skippy/state.h b/include/skippy/state.h
 index 1c77c5450..aa698c124 100644
 --- a/include/skippy/state.h
@@ -42,10 +28,10 @@ index 1c77c5450..aa698c124 100644
  LLAMA_API enum skippy_status skippy_session_drop_sequence(
          struct skippy_session * session,
 diff --git a/src/llama-kv-cache.cpp b/src/llama-kv-cache.cpp
-index 0a363e9c9..e0ddb4044 100644
+index 411049cd2..082207755 100644
 --- a/src/llama-kv-cache.cpp
 +++ b/src/llama-kv-cache.cpp
-@@ -1464,6 +1464,14 @@ const llama_kv_cells & llama_kv_cache::get_cells(llama_seq_id seq_id) const {
+@@ -1463,6 +1463,14 @@ const llama_kv_cells & llama_kv_cache::get_cells(llama_seq_id seq_id) const {
      return v_cells[seq_to_stream[seq_id]];
  }
  
@@ -73,10 +59,11 @@ index 39d313ae3..15fad3e20 100644
  
      bool get_has_shift() const;
 diff --git a/src/skippy/state.cpp b/src/skippy/state.cpp
-index a2292fef8..99b724ca0 100644
+index a2292fef8..620ee3578 100644
 --- a/src/skippy/state.cpp
 +++ b/src/skippy/state.cpp
-@@ -7,6 +7,9 @@
+@@ -6,7 +6,10 @@
+ 
  #include "llama-kv-cache.h"
  #include "llama-kv-cache-dsa.h"
 +#include "llama-kv-cache-dsa-iswa.h"
@@ -155,4 +142,5 @@ index a2292fef8..99b724ca0 100644
 +
  } // extern "C"
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
+

--- a/third_party/llama.cpp/patches/0042-skippy-wire-sampling-and-chat-request-defaults.patch
+++ b/third_party/llama.cpp/patches/0042-skippy-wire-sampling-and-chat-request-defaults.patch
@@ -1,7 +1,7 @@
-From ea0868d3218a03fd6c0a357cb330b84ca689e9c0 Mon Sep 17 00:00:00 2001
+From a330bedb692438677c6910c5f0c4238b262da951 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sun, 30 Aug 2026 18:26:07 +1000
-Subject: [PATCH] skippy: wire sampling and chat request defaults
+Subject: [PATCH 42/51] skippy: wire sampling and chat request defaults
 
 ---
  common/stage-chat.cpp         |  42 +++++-
@@ -12,10 +12,10 @@ Subject: [PATCH] skippy: wire sampling and chat request defaults
  5 files changed, 288 insertions(+), 60 deletions(-)
 
 diff --git a/common/stage-chat.cpp b/common/stage-chat.cpp
-index 02492ad81..aa06561d1 100644
+index 02492ad81..b3f2ef4c9 100644
 --- a/common/stage-chat.cpp
 +++ b/common/stage-chat.cpp
-@@ -131,7 +131,8 @@ static json skippy_common_grammar_triggers_to_json(const std::vector<common_gram
+@@ -147,7 +147,8 @@ static json skippy_common_grammar_triggers_to_json(const std::vector<common_gram
  static json skippy_common_chat_metadata_json(
          const common_chat_params & params,
          common_reasoning_format reasoning_format,
@@ -25,7 +25,7 @@ index 02492ad81..aa06561d1 100644
      return {
          {"chat_format", static_cast<int>(params.format)},
          {"reasoning_format", common_reasoning_format_name(reasoning_format)},
-@@ -143,6 +144,7 @@ static json skippy_common_chat_metadata_json(
+@@ -159,6 +160,7 @@ static json skippy_common_chat_metadata_json(
          {"grammar_triggers", skippy_common_grammar_triggers_to_json(params.grammar_triggers)},
          {"preserved_tokens", params.preserved_tokens},
          {"additional_stops", params.additional_stops},
@@ -33,7 +33,7 @@ index 02492ad81..aa06561d1 100644
      };
  }
  
-@@ -157,6 +159,11 @@ enum skippy_status skippy_apply_chat_template_json(
+@@ -173,6 +175,11 @@ enum skippy_status skippy_apply_chat_template_json(
          bool parallel_tool_calls,
          const char * reasoning_format_name,
          const char * chat_template_kwargs_json,
@@ -45,7 +45,7 @@ index 02492ad81..aa06561d1 100644
          char * output_text,
          size_t output_text_capacity,
          size_t * out_text_bytes,
-@@ -194,7 +201,7 @@ enum skippy_status skippy_apply_chat_template_json(
+@@ -210,7 +217,7 @@ enum skippy_status skippy_apply_chat_template_json(
          inputs.tools                 = common_chat_tools_parse_oaicompat(tools);
          inputs.tool_choice           = common_chat_tool_choice_parse_oaicompat(skippy_common_tool_choice_string(tool_choice_json));
          inputs.add_generation_prompt = add_assistant;
@@ -54,7 +54,7 @@ index 02492ad81..aa06561d1 100644
          inputs.parallel_tool_calls   = parallel_tool_calls;
          if (override_enable_thinking) {
              const char * value = enable_thinking ? "true" : "false";
-@@ -215,6 +222,9 @@ enum skippy_status skippy_apply_chat_template_json(
+@@ -231,6 +238,9 @@ enum skippy_status skippy_apply_chat_template_json(
          if (reasoning_format_name != nullptr && reasoning_format_name[0] != '\0') {
              inputs.reasoning_format = common_reasoning_format_from_name(reasoning_format_name);
          }
@@ -64,7 +64,7 @@ index 02492ad81..aa06561d1 100644
          json chat_template_kwargs = skippy_common_parse_json_or_null(chat_template_kwargs_json);
          if (!chat_template_kwargs.is_null()) {
              if (!chat_template_kwargs.is_object()) {
-@@ -244,20 +253,36 @@ enum skippy_status skippy_apply_chat_template_json(
+@@ -244,20 +254,36 @@ enum skippy_status skippy_apply_chat_template_json(
              inputs.chat_template_kwargs["reasoning_effort"] = "0";
          }
  
@@ -191,10 +191,10 @@ index ccf3d020c..80b91879d 100644
          size_t output_text_capacity,
          size_t * out_text_bytes,
 diff --git a/src/skippy/sampling.cpp b/src/skippy/sampling.cpp
-index ee480fc33..c12194bb4 100644
+index 8a798a734..2dd702878 100644
 --- a/src/skippy/sampling.cpp
 +++ b/src/skippy/sampling.cpp
-@@ -370,8 +370,10 @@ static bool skippy_sampling_is_greedy_equivalent(const skippy_sampling_config *
+@@ -369,8 +369,10 @@ static bool skippy_sampling_is_greedy_equivalent(const skippy_sampling_config *
          return true;
      }
      const float repeat_penalty = sampling->repeat_penalty == 0.0f ? 1.0f : sampling->repeat_penalty;
@@ -206,7 +206,7 @@ index ee480fc33..c12194bb4 100644
             sampling->presence_penalty == 0.0f &&
             sampling->frequency_penalty == 0.0f &&
             repeat_penalty == 1.0f &&
-@@ -392,10 +394,44 @@ static bool skippy_sampling_configs_equal(
+@@ -391,10 +393,44 @@ static bool skippy_sampling_configs_equal(
              lhs.frequency_penalty != rhs.frequency_penalty ||
              lhs.repeat_penalty != rhs.repeat_penalty ||
              lhs.logit_bias_count != rhs.logit_bias_count ||
@@ -252,7 +252,7 @@ index ee480fc33..c12194bb4 100644
      const uint32_t logit_bias_count = std::min<uint32_t>(lhs.logit_bias_count, SKIPPY_MAX_LOGIT_BIAS);
      for (uint32_t i = 0; i < logit_bias_count; ++i) {
          if (lhs.logit_bias[i].token != rhs.logit_bias[i].token ||
-@@ -441,6 +477,116 @@ bool skippy_reset_reusable_sampling(skippy_session * session) {
+@@ -440,6 +476,116 @@ bool skippy_reset_reusable_sampling(skippy_session * session) {
      return true;
  }
  
@@ -369,7 +369,7 @@ index ee480fc33..c12194bb4 100644
  llama_sampler * skippy_build_sampling_chain(
          skippy_session * session,
          const skippy_sampling_config * sampling) {
-@@ -455,65 +601,83 @@ llama_sampler * skippy_build_sampling_chain(
+@@ -454,65 +600,83 @@ llama_sampler * skippy_build_sampling_chain(
          return sampler;
      }
  
@@ -503,4 +503,5 @@ index ee480fc33..c12194bb4 100644
  }
  
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
+

--- a/third_party/llama.cpp/patches/0043-skippy-avoid-reinitializing-reused-backend-samplers.patch
+++ b/third_party/llama.cpp/patches/0043-skippy-avoid-reinitializing-reused-backend-samplers.patch
@@ -1,17 +1,17 @@
-From 521e12a2f6aaf1e68dad129adcc561d77ac76413 Mon Sep 17 00:00:00 2001
+From d0246c4ad134b74b2dfb85741dc2e2d920435b7c Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sun, 30 Aug 2026 06:38:46 +0000
-Subject: [PATCH] skippy: avoid reinitializing reused backend samplers
+Subject: [PATCH 43/51] skippy: avoid reinitializing reused backend samplers
 
 ---
  src/skippy/sampling.cpp | 6 +++++-
  1 file changed, 5 insertions(+), 1 deletion(-)
 
 diff --git a/src/skippy/sampling.cpp b/src/skippy/sampling.cpp
-index ee480fc33..03867b722 100644
+index 2dd702878..567388f6d 100644
 --- a/src/skippy/sampling.cpp
 +++ b/src/skippy/sampling.cpp
-@@ -546,7 +546,11 @@ static bool skippy_ensure_plain_sampling_chain(
+@@ -709,7 +709,11 @@ static bool skippy_ensure_plain_sampling_chain(
  void skippy_refresh_backend_sampling(
          skippy_session * session,
          const skippy_sampling_config * sampling) {
@@ -25,5 +25,5 @@ index ee480fc33..03867b722 100644
      }
      session->sampling_backend_enabled = false;
 -- 
-2.43.0
+2.55.0
 

--- a/third_party/llama.cpp/patches/0044-skippy-record-verify-batches-once-on-activation-inpu.patch
+++ b/third_party/llama.cpp/patches/0044-skippy-record-verify-batches-once-on-activation-inpu.patch
@@ -1,7 +1,8 @@
-From f7b4211b767bcf63a6dd4286629b5d7c18f17cc2 Mon Sep 17 00:00:00 2001
+From 35def568b251f2c1f697cfe8663f157da46e6f38 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 1 Sep 2026 20:04:15 +1000
-Subject: [PATCH] skippy: record verify batches once on activation-input stages
+Subject: [PATCH 44/51] skippy: record verify batches once on activation-input
+ stages
 
 Sampled verification exposes each input to the sampler exactly once and
 in causal order as its row is sampled. The token-batch path rewinds the
@@ -48,5 +49,5 @@ index 58da7bc25..beecb2204 100644
  }
  
 -- 
-2.50.1 (Apple Git-155)
+2.55.0
 

--- a/third_party/llama.cpp/patches/0045-skippy-carry-batch-placement-in-decode-batch-failure.patch
+++ b/third_party/llama.cpp/patches/0045-skippy-carry-batch-placement-in-decode-batch-failure.patch
@@ -1,7 +1,7 @@
-From 8ecf5c931cdad8709fa39fcb2018a12f3352ad2e Mon Sep 17 00:00:00 2001
+From a85716b9be2fb712f2374c37e296ffd41ac19a30 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 1 Sep 2026 21:29:55 +1000
-Subject: [PATCH] skippy: carry batch placement in decode-batch failures
+Subject: [PATCH 45/51] skippy: carry batch placement in decode-batch failures
 
 llama.cpp's own diagnostics go to its log callback, which stage hosts
 do not always surface, so a remote llama_decode failure previously
@@ -44,5 +44,5 @@ index beecb2204..d59562c9c 100644
      }
      skippy_mark_context_work_pending(session->stage_model);
 -- 
-2.50.1 (Apple Git-155)
+2.55.0
 

--- a/third_party/llama.cpp/patches/0046-skippy-let-sampled-verify-windows-coexist-with-backe.patch
+++ b/third_party/llama.cpp/patches/0046-skippy-let-sampled-verify-windows-coexist-with-backe.patch
@@ -1,7 +1,7 @@
-From cf4943f670d5f448e51bedfdaedb64208e7c6254 Mon Sep 17 00:00:00 2001
+From 66b7264dc5ecf5747717278c035cf29bad49ffff Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 1 Sep 2026 21:37:06 +1000
-Subject: [PATCH] skippy: let sampled verify windows coexist with backend
+Subject: [PATCH 46/51] skippy: let sampled verify windows coexist with backend
  sampling
 
 Backend (in-graph) sampling limited every decode on the context to one
@@ -34,10 +34,10 @@ Three coordinated changes:
  4 files changed, 32 insertions(+), 3 deletions(-)
 
 diff --git a/src/llama-context.cpp b/src/llama-context.cpp
-index 1d319e5fc..756d09a14 100644
+index b4ee4342e..186238c72 100644
 --- a/src/llama-context.cpp
 +++ b/src/llama-context.cpp
-@@ -1730,7 +1730,11 @@ int llama_context::decode(const llama_batch & batch_inp) {
+@@ -1733,7 +1733,11 @@ int llama_context::decode(const llama_batch & batch_inp) {
                  const llama_seq_id seq_id = batch_inp.seq_id ? batch_inp.seq_id[i][s] : 0;
  
                  seq_output_count[seq_id]++;
@@ -123,5 +123,5 @@ index 9ab6b0712..be29b2ff8 100644
      status = skippy_checkpoint_verify_window(
              session,
 -- 
-2.50.1 (Apple Git-155)
+2.55.0
 

--- a/third_party/llama.cpp/patches/0047-skippy-account-retained-tensors-during-staged-loads.patch
+++ b/third_party/llama.cpp/patches/0047-skippy-account-retained-tensors-during-staged-loads.patch
@@ -1,7 +1,7 @@
-From 955040775049a693f532142ea8e1291bc4f8c402 Mon Sep 17 00:00:00 2001
+From a3d464813bec7733fa99dfe0add779d329d73f29 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Sat, 29 Aug 2026 01:31:34 -0700
-Subject: [PATCH] skippy: account retained tensors during staged loads
+Subject: [PATCH 47/51] skippy: account retained tensors during staged loads
 
 ---
  src/CMakeLists.txt                            |  46 ++++
@@ -69,7 +69,7 @@ index 894741717..f25a38e24 100644
  
  if (BUILD_SHARED_LIBS)
 diff --git a/src/llama-model-loader.cpp b/src/llama-model-loader.cpp
-index 8ade72322..2d4993f3e 100644
+index a3339888a..bc2b1e782 100644
 --- a/src/llama-model-loader.cpp
 +++ b/src/llama-model-loader.cpp
 @@ -9,6 +9,7 @@
@@ -80,7 +80,7 @@ index 8ade72322..2d4993f3e 100644
  #include <cstdint>
  #include <cstring>
  #include <future>
-@@ -1270,7 +1271,6 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1311,7 +1312,6 @@ struct ggml_tensor * llama_model_loader::create_tensor(
                          nbytes);
  
                  if (requested_tensor_exists && first_filtered_request) {
@@ -88,7 +88,7 @@ index 8ade72322..2d4993f3e 100644
                      if (!(flags & TENSOR_DUPLICATED)) {
                          n_created++;
                      }
-@@ -1321,7 +1321,6 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1362,7 +1362,6 @@ struct ggml_tensor * llama_model_loader::create_tensor(
              const size_t nbytes = ggml_nbytes(t_meta);
              LLAMA_LOG_WARN("model has unused tensor %s (size = %zu bytes) -- ignoring\n", tn.str().c_str(), nbytes);
  
@@ -96,7 +96,7 @@ index 8ade72322..2d4993f3e 100644
              n_created++;
  
              return nullptr;
-@@ -1530,14 +1529,10 @@ struct ggml_tensor * llama_model_loader::create_tensor(
+@@ -1568,14 +1567,10 @@ struct ggml_tensor * llama_model_loader::create_tensor(
          }
      }
  
@@ -112,7 +112,7 @@ index 8ade72322..2d4993f3e 100644
          n_created++;
      }
  
-@@ -1595,9 +1590,28 @@ void llama_model_loader::init_mappings(bool prefetch, llama_mlocks * mlock_mmaps
+@@ -1633,9 +1628,28 @@ void llama_model_loader::init_mappings(bool prefetch, llama_mlocks * mlock_mmaps
          }
      }
  
@@ -144,15 +144,15 @@ index 8ade72322..2d4993f3e 100644
      }
  }
  
-@@ -1658,6 +1672,7 @@ bool llama_model_loader::load_all_data(
+@@ -1696,6 +1710,7 @@ bool llama_model_loader::load_all_data(
          return true;
      }
      GGML_ASSERT(size_data != 0 && "call init_mappings() first");
 +    const size_t size_done_before = size_done;
  
-     std::vector<no_init<uint8_t>> read_buf;
      std::vector<std::future<std::pair<ggml_tensor *, bool>>> validation_result;
-@@ -1768,7 +1783,10 @@ bool llama_model_loader::load_all_data(
+ 
+@@ -1823,7 +1838,10 @@ bool llama_model_loader::load_all_data(
          }
  
          if (progress_callback) {
@@ -164,7 +164,7 @@ index 8ade72322..2d4993f3e 100644
                  return false;
              }
          }
-@@ -1881,6 +1899,7 @@ bool llama_model_loader::load_all_data(
+@@ -1941,6 +1959,7 @@ bool llama_model_loader::load_all_data(
          }
  
          size_done += n_size;
@@ -172,7 +172,7 @@ index 8ade72322..2d4993f3e 100644
      }
  
      // free temporary resources used for async uploads
-@@ -1907,7 +1926,7 @@ bool llama_model_loader::load_all_data(
+@@ -1967,7 +1986,7 @@ bool llama_model_loader::load_all_data(
      }
  
      // check if this is the last call and do final cleanup
@@ -182,7 +182,7 @@ index 8ade72322..2d4993f3e 100644
          if (use_mmap) {
              for (uint32_t idx = 0; idx < mappings.size(); idx++) {
 diff --git a/tests/CMakeLists.txt b/tests/CMakeLists.txt
-index 376e9b09f..ed156f339 100644
+index 47ddeeef1..c8a131e40 100644
 --- a/tests/CMakeLists.txt
 +++ b/tests/CMakeLists.txt
 @@ -217,6 +217,22 @@ if (NOT WIN32 OR NOT BUILD_SHARED_LIBS)
@@ -475,5 +475,5 @@ index 000000000..c8ad5f1b2
 +    return EXIT_SUCCESS;
 +}
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
 

--- a/third_party/llama.cpp/patches/0048-skippy-expose-graph-activation-boundaries.patch
+++ b/third_party/llama.cpp/patches/0048-skippy-expose-graph-activation-boundaries.patch
@@ -1,7 +1,7 @@
-From 1b82b29f90184fa89722e085867927a3324788ce Mon Sep 17 00:00:00 2001
+From 463f8a3700f4ef410cb9020feedd9a4655317137 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Tue, 1 Sep 2026 21:32:42 +1000
-Subject: [PATCH] skippy: expose graph activation boundaries
+Subject: [PATCH 48/51] skippy: expose graph activation boundaries
 
 ---
  include/skippy/activation.h      | 16 ++++++
@@ -100,7 +100,7 @@ index ba62f60cf..f63a3418f 100644
  LLAMA_API enum skippy_status skippy_session_create(
          struct skippy_model * model,
 diff --git a/src/llama-context.cpp b/src/llama-context.cpp
-index 756d09a14..6526dd382 100644
+index 186238c72..c1b0fb822 100644
 --- a/src/llama-context.cpp
 +++ b/src/llama-context.cpp
 @@ -12,6 +12,7 @@
@@ -111,7 +111,7 @@ index 756d09a14..6526dd382 100644
  
  #include <cinttypes>
  #include <cmath>
-@@ -2448,6 +2449,32 @@ llm_graph_result * llama_context::get_gf_res_prev() const {
+@@ -2451,6 +2452,32 @@ llm_graph_result * llama_context::get_gf_res_prev() const {
      return static_cast<llm_graph_result *>(gf_res_prev.get());
  }
  
@@ -144,7 +144,7 @@ index 756d09a14..6526dd382 100644
  ggml_cgraph * llama_context::graph_reserve(
          uint32_t n_tokens, uint32_t n_seqs, uint32_t n_outputs, const llama_memory_context_i * mctx, bool split_only, size_t * sizes) {
      LLAMA_LOG_DEBUG("%s: reserving a graph for ubatch with n_tokens = %4u, n_seqs = %2u, n_outputs = %4u\n", __func__, n_tokens, n_seqs, n_outputs);
-@@ -2482,6 +2509,68 @@ ggml_cgraph * llama_context::graph_reserve(
+@@ -2485,6 +2512,68 @@ ggml_cgraph * llama_context::graph_reserve(
  
      auto * gf = model.build_graph(gparams);
  
@@ -247,7 +247,7 @@ index 20c121b24..9e883575f 100644
      ggml_backend_buffer_ptr buf_output;
  
 diff --git a/src/llama-graph.cpp b/src/llama-graph.cpp
-index 33d933c3f..64e9134f6 100644
+index 09a628b48..a0582fa5d 100644
 --- a/src/llama-graph.cpp
 +++ b/src/llama-graph.cpp
 @@ -1564,6 +1564,8 @@ void llm_graph_result::reset() {
@@ -260,7 +260,7 @@ index 33d933c3f..64e9134f6 100644
      t_layer_inp.resize(LLAMA_MAX_LAYERS + 1);
      std::fill(t_layer_inp.begin(), t_layer_inp.end(), nullptr);
 diff --git a/src/llama-graph.h b/src/llama-graph.h
-index 3a00c0e93..572d833ab 100644
+index 32a215ddd..5674bdcf1 100644
 --- a/src/llama-graph.h
 +++ b/src/llama-graph.h
 @@ -1061,6 +1061,12 @@ public:
@@ -306,10 +306,10 @@ index 8e712f757..800a69b1b 100644
          ggml_build_forward_expand(gf, cur);
          return;
 diff --git a/src/models/qwen4exp.cpp b/src/models/qwen4exp.cpp
-index 6a9769dfc..683f96c8e 100644
+index 04690bc96..51fee94c2 100644
 --- a/src/models/qwen4exp.cpp
 +++ b/src/models/qwen4exp.cpp
-@@ -319,6 +319,7 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -367,6 +367,7 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
          cb(inp_hc->values, "hc_stage_input", -1);
          ggml_set_input(inp_hc->values);
          inpL = inp_hc->values;
@@ -317,7 +317,7 @@ index 6a9769dfc..683f96c8e 100644
          res->add_input(std::move(inp_hc));
      } else {
          inpL = build_inp_embd(model.tok_embd);
-@@ -422,6 +423,7 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
+@@ -470,6 +471,7 @@ llama_model_qwen4exp::graph::graph(const llama_model & model, const llm_graph_pa
  
      if (stage_filtered && !stage_filter.include_output) {
          cb(res_hc, "stage_boundary", il_end - 1);
@@ -451,7 +451,7 @@ index 2828ffe38..4ccf2c4a2 100644
  
  } // extern "C"
 diff --git a/src/skippy/model_loading.cpp b/src/skippy/model_loading.cpp
-index 166f2f7b7..0202e5a1c 100644
+index 33c54cf42..04f26b31a 100644
 --- a/src/skippy/model_loading.cpp
 +++ b/src/skippy/model_loading.cpp
 @@ -51,6 +51,7 @@
@@ -462,7 +462,7 @@ index 166f2f7b7..0202e5a1c 100644
  #include "skippy/sampling_internal.h"
  #include "skippy/speculative_internal.h"
  #include "skippy/model_loading_internal.h"
-@@ -696,6 +697,58 @@ static enum skippy_status skippy_finish_model_open(
+@@ -579,6 +580,58 @@ static enum skippy_status skippy_finish_model_open(
          return SKIPPY_STATUS_RUNTIME_ERROR;
      }
  
@@ -537,5 +537,5 @@ index 5180bfa24..a82b64408 100644
      std::mutex lane_mutex;
      std::vector<bool> lane_in_use;
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
 

--- a/third_party/llama.cpp/patches/0049-fix-skippy-harden-C-API-defaults-and-sampling.patch
+++ b/third_party/llama.cpp/patches/0049-fix-skippy-harden-C-API-defaults-and-sampling.patch
@@ -1,8 +1,8 @@
-From 5958112ee6413a338f6b2d2922134385e4e84f38 Mon Sep 17 00:00:00 2001
+From 719c7eb9422a62606325ac0d8399116636865dae Mon Sep 17 00:00:00 2001
 From: scama
  <a1860575018c4680d5669dd7bc3bd356b478bccb8d42e194df46304a5e25f49a@meshllm.communities.buzz.xyz>
 Date: Wed, 2 Sep 2026 12:07:43 +1000
-Subject: [PATCH] fix(skippy): harden C API defaults and sampling
+Subject: [PATCH 49/51] fix(skippy): harden C API defaults and sampling
 
 ---
  include/skippy/common.h                       |  2 +-
@@ -41,7 +41,7 @@ index f63a3418f..c0425211a 100644
  #define SKIPPY_TRISTATE_AUTO  (-1)
  /** @brief Sentinel for `skippy_runtime_config` tri-state fields: force false. */
 diff --git a/src/skippy/model_loading.cpp b/src/skippy/model_loading.cpp
-index 0202e5a1c..673df1212 100644
+index 04f26b31a..9dd911adf 100644
 --- a/src/skippy/model_loading.cpp
 +++ b/src/skippy/model_loading.cpp
 @@ -467,6 +467,16 @@ static bool skippy_resolve_tristate(int32_t tristate, bool derived_default) {
@@ -169,5 +169,5 @@ index be29b2ff8..cce5baa4f 100644
          session->sampling_backend_enabled = false;
          // The detached chain has already been backend-initialized and
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
 

--- a/third_party/llama.cpp/patches/0050-fix-skippy-key-input-boundary-to-consumed-layers.patch
+++ b/third_party/llama.cpp/patches/0050-fix-skippy-key-input-boundary-to-consumed-layers.patch
@@ -1,8 +1,8 @@
-From ec025030af0709eb9ca95115f0b2f5acc237fcb2 Mon Sep 17 00:00:00 2001
+From fbbbb4e4aa4c69a6bc10ab2712c0e3b8a4739314 Mon Sep 17 00:00:00 2001
 From: scama
  <a1860575018c4680d5669dd7bc3bd356b478bccb8d42e194df46304a5e25f49a@meshllm.communities.buzz.xyz>
 Date: Wed, 2 Sep 2026 12:41:43 +1000
-Subject: [PATCH 50/50] fix(skippy): key input boundary to consumed layers
+Subject: [PATCH 50/51] fix(skippy): key input boundary to consumed layers
 
 ---
  include/skippy/common.h      | 2 +-
@@ -24,10 +24,10 @@ index a9165abcf..4729ae67b 100644
  #if defined(_MSC_VER)
  #define SKIPPY_DEPRECATED(message) __declspec(deprecated(message))
 diff --git a/src/llama-context.cpp b/src/llama-context.cpp
-index 6526dd382..accfa6808 100644
+index c1b0fb822..c5499774d 100644
 --- a/src/llama-context.cpp
 +++ b/src/llama-context.cpp
-@@ -2531,7 +2531,7 @@ ggml_cgraph * llama_context::graph_reserve(
+@@ -2534,7 +2534,7 @@ ggml_cgraph * llama_context::graph_reserve(
      };
  
      const skippy_graph_filter & stage_filter = skippy_graph_get_filter();
@@ -37,10 +37,10 @@ index 6526dd382..accfa6808 100644
          uint64_t elements_per_token = 0;
          uint64_t bytes_per_token = 0;
 diff --git a/src/skippy/model_loading.cpp b/src/skippy/model_loading.cpp
-index 673df1212..15ac94ac7 100644
+index 9dd911adf..b573780a4 100644
 --- a/src/skippy/model_loading.cpp
 +++ b/src/skippy/model_loading.cpp
-@@ -739,7 +739,7 @@ static enum skippy_status skippy_finish_model_open(
+@@ -622,7 +622,7 @@ static enum skippy_status skippy_finish_model_open(
          };
      }
  
@@ -50,5 +50,5 @@ index 673df1212..15ac94ac7 100644
          uint64_t elements_per_token = 0;
          uint64_t bytes_per_token = 0;
 -- 
-2.54.0 (Apple Git-157)
+2.55.0
 

--- a/third_party/llama.cpp/patches/0051-skippy-expose-the-native-session-sequence-ID.patch
+++ b/third_party/llama.cpp/patches/0051-skippy-expose-the-native-session-sequence-ID.patch
@@ -1,22 +1,23 @@
-From 4f7c1c95a7e1b9c3d2f6e8a0b4c6d8e0f2a4b6c8 Mon Sep 17 00:00:00 2001
+From ec0a3d0a983e999aea7f82512ecbec1e6ec61537 Mon Sep 17 00:00:00 2001
 From: Mesh-LLM CI <ci@mesh-llm.local>
 Date: Wed, 2 Sep 2026 10:00:00 +1000
-Subject: [PATCH] skippy: expose the native session sequence ID
+Subject: [PATCH 51/51] skippy: expose the native session sequence ID
 
 Multimodal mtmd evaluation writes llama.cpp KV cells directly. It must use
 the sequence claimed by the Skippy session, rather than the default sequence
 zero, so cleanup and subsequent requests operate on the same lane.
 ---
  include/skippy/common.h  | 2 +-
- include/skippy/runtime.h | 3 +++
+ include/skippy/runtime.h | 4 ++++
  src/skippy/session.cpp   | 5 +++++
- 3 files changed, 9 insertions(+), 1 deletion(-)
+ 3 files changed, 10 insertions(+), 1 deletion(-)
 
 diff --git a/include/skippy/common.h b/include/skippy/common.h
-index e0024ede2..425aea03a 100644
+index 4729ae67b..68a1dee71 100644
 --- a/include/skippy/common.h
 +++ b/include/skippy/common.h
-@@ -35,6 +35,6 @@ extern "C" {
+@@ -34,7 +34,7 @@ extern "C" {
+ 
  #define SKIPPY_ABI_VERSION_MAJOR 0
  #define SKIPPY_ABI_VERSION_MINOR 1
 -#define SKIPPY_ABI_VERSION_PATCH 47
@@ -25,10 +26,10 @@ index e0024ede2..425aea03a 100644
  #if defined(_MSC_VER)
  #define SKIPPY_DEPRECATED(message) __declspec(deprecated(message))
 diff --git a/include/skippy/runtime.h b/include/skippy/runtime.h
-index ba62f60cf..096fe75f0 100644
+index c0425211a..4c66e6772 100644
 --- a/include/skippy/runtime.h
 +++ b/include/skippy/runtime.h
-@@ -187,6 +187,10 @@ LLAMA_API int32_t skippy_session_position(
+@@ -205,6 +205,10 @@ LLAMA_API int32_t skippy_session_position(
  LLAMA_API int32_t skippy_session_batch_size(
          const struct skippy_session * session);
  
@@ -43,7 +44,7 @@ diff --git a/src/skippy/session.cpp b/src/skippy/session.cpp
 index aae665f53..09beb4f11 100644
 --- a/src/skippy/session.cpp
 +++ b/src/skippy/session.cpp
-@@ -184,6 +184,11 @@ int32_t skippy_session_position(
+@@ -183,6 +183,11 @@ int32_t skippy_session_position(
      return session != nullptr ? session->n_past : -1;
  }
  
@@ -55,6 +56,6 @@ index aae665f53..09beb4f11 100644
  int32_t skippy_session_batch_size(
          const struct skippy_session * session) {
      return session != nullptr && session->ctx != nullptr ? llama_n_batch(session->ctx) : 0;
- }
 -- 
-2.50.1 (Apple Git-155)
+2.55.0
+

--- a/third_party/llama.cpp/patches/0054-build-adapt-Skippy-additions-to-rebased-llama-APIs.patch
+++ b/third_party/llama.cpp/patches/0054-build-adapt-Skippy-additions-to-rebased-llama-APIs.patch
@@ -1,0 +1,48 @@
+From 669f2dfeb852bb87673c136f934116c38952d3d6 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Thu, 3 Sep 2026 09:10:41 -0400
+Subject: [PATCH 54/57] build: adapt Skippy additions to rebased llama APIs
+
+---
+ src/models/inkling.cpp                        | 4 ++--
+ tests/test-skippy-model-loader-accounting.cpp | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/models/inkling.cpp b/src/models/inkling.cpp
+index 619bc3e73..e442e398d 100644
+--- a/src/models/inkling.cpp
++++ b/src/models/inkling.cpp
+@@ -16,7 +16,7 @@ void llama_model_inkling::load_arch_hparams(llama_model_loader & ml) {
+     ml.get_key(LLM_KV_NEXTN_PREDICT_LAYERS, hparams.n_layer_nextn, false);
+     GGML_ASSERT(hparams.n_layer_nextn < hparams.n_layer_all);
+ 
+-    ml.get_key(LLM_KV_EXPERT_FEED_FORWARD_LENGTH, hparams.n_ff_exp);
++    ml.get_key_or_arr(LLM_KV_EXPERT_FEED_FORWARD_LENGTH, hparams.n_ff_exp_arr, hparams.n_layer_all);
+     ml.get_key(LLM_KV_EXPERT_SHARED_COUNT,        hparams.n_expert_shared);
+     ml.get_key(LLM_KV_EXPERT_WEIGHTS_SCALE,       hparams.expert_weights_scale);
+     ml.get_key(LLM_KV_EXPERT_GATING_FUNC,         hparams.expert_gating_func, false);
+@@ -67,7 +67,7 @@ void llama_model_inkling::load_arch_tensors(llama_model_loader & ml) {
+     const int64_t head_dim = hparams.n_embd_head_k();
+     const int64_t d_rel    = hparams.inkling_d_rel;
+     const int64_t K        = hparams.n_shortconv_l_cache;
+-    const int64_t n_ff_exp = hparams.n_ff_exp;
++    const int64_t n_ff_exp = hparams.n_ff_exp();
+     const int64_t n_shexp  = hparams.n_expert_shared;
+ 
+     tok_embd    = create_tensor(tn(LLM_TENSOR_TOKEN_EMBD,      "weight"), {n_embd, n_vocab}, mtp_only ? TENSOR_NOT_REQUIRED : 0);
+diff --git a/tests/test-skippy-model-loader-accounting.cpp b/tests/test-skippy-model-loader-accounting.cpp
+index c8ad5f1b2..7c1c43e05 100644
+--- a/tests/test-skippy-model-loader-accounting.cpp
++++ b/tests/test-skippy-model-loader-accounting.cpp
+@@ -125,7 +125,7 @@ static bool check_context_load_lifecycle(const char * model_path) {
+     ggml_context * accounting_ctx_raw = accounting_ctx.get();
+     ggml_context * synthetic_ctx_raw = synthetic_ctx.get();
+     const auto cpu_buft = ggml_backend_cpu_buffer_type();
+-    loader.ctx_map.emplace(cpu_buft, std::move(accounting_ctx));
++    loader.ctx_map.emplace(llama_model_loader::ctx_key { cpu_buft, false }, std::move(accounting_ctx));
+     loader.init_mappings(false);
+ 
+     const size_t weight_size = ggml_nbytes(weight);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0055-fix-skippy-validate-staged-decode-inputs.patch
+++ b/third_party/llama.cpp/patches/0055-fix-skippy-validate-staged-decode-inputs.patch
@@ -1,0 +1,413 @@
+From 46d030baaac891ca778268c5666e4b6d8ecf95c1 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Thu, 3 Sep 2026 09:10:41 -0400
+Subject: [PATCH 55/57] fix(skippy): validate staged decode inputs
+
+---
+ src/llama-context.cpp           |  6 +++
+ src/skippy/activation.cpp       | 10 ++++-
+ src/skippy/execution-batch.cpp  | 77 +++++++++++++++++++++++++++------
+ src/skippy/execution-single.cpp | 26 ++++++++---
+ src/skippy/sampling.cpp         | 64 +++++++++++++++------------
+ src/skippy/sampling_internal.h  |  2 +
+ src/skippy/verification.cpp     |  2 +
+ 7 files changed, 138 insertions(+), 49 deletions(-)
+
+diff --git a/src/llama-context.cpp b/src/llama-context.cpp
+index c5499774d..09d21f37e 100644
+--- a/src/llama-context.cpp
++++ b/src/llama-context.cpp
+@@ -1733,6 +1733,12 @@ int llama_context::decode(const llama_batch & batch_inp) {
+             for (int32_t s = 0; s < ns; ++s) {
+                 const llama_seq_id seq_id = batch_inp.seq_id ? batch_inp.seq_id[i][s] : 0;
+ 
++                if (seq_id < 0 || static_cast<uint32_t>(seq_id) >= n_seq_max) {
++                    LLAMA_LOG_ERROR("%s: invalid sequence ID %d (expected 0 <= seq_id < %u)\n",
++                            __func__, seq_id, n_seq_max);
++                    return -1;
++                }
++
+                 seq_output_count[seq_id]++;
+                 // Only sequences that actually have a backend sampler attached
+                 // are limited to one output row; a sampler on some other
+diff --git a/src/skippy/activation.cpp b/src/skippy/activation.cpp
+index 889278d71..1cb2b5e6e 100644
+--- a/src/skippy/activation.cpp
++++ b/src/skippy/activation.cpp
+@@ -801,7 +801,13 @@ enum skippy_status skippy_verify_activation_frame(
+         const size_t batch_embd_bytes = static_cast<size_t>(n_tokens)*n_embd*sizeof(float);
+         std::memcpy(batch.embd, input_payload, std::min(hidden_bytes, batch_embd_bytes));
+         if (qwen4exp_activation_input) {
+-            batch.token = const_cast<llama_token *>(token_ids);
++            batch.token = static_cast<llama_token *>(std::malloc(sizeof(llama_token)*static_cast<size_t>(n_tokens)));
++            if (batch.token == nullptr) {
++                llama_batch_free(batch);
++                skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, "failed to allocate activation verification token batch");
++                return SKIPPY_STATUS_RUNTIME_ERROR;
++            }
++            std::memcpy(batch.token, token_ids, sizeof(llama_token)*static_cast<size_t>(n_tokens));
+         }
+     }
+     batch.n_tokens = n_tokens;
+@@ -1030,6 +1036,8 @@ enum skippy_status skippy_restore_verify_prefix(
+                 session,
+                 checkpoint->token_ids.data(),
+                 accepted_count,
++                nullptr,
++                0,
+                 false,
+                 SKIPPY_GLM_DSA_PHASE_HINT_VERIFY,
+                 out_error);
+diff --git a/src/skippy/execution-batch.cpp b/src/skippy/execution-batch.cpp
+index 678a40692..6fc255e33 100644
+--- a/src/skippy/execution-batch.cpp
++++ b/src/skippy/execution-batch.cpp
+@@ -21,6 +21,35 @@
+ #include <string>
+ #include <vector>
+ 
++static enum skippy_status skippy_resolve_activation_width(
++        const skippy_model * stage_model,
++        bool qwen4exp_activation_input,
++        int32_t n_embd,
++        size_t & activation_width,
++        int32_t & qwen4exp_hc,
++        skippy_error ** out_error) {
++    activation_width = static_cast<size_t>(n_embd);
++    qwen4exp_hc = 0;
++    if (!qwen4exp_activation_input) {
++        return SKIPPY_STATUS_OK;
++    }
++
++    qwen4exp_hc = static_cast<int32_t>(stage_model->model->hparams.dsv4_hc_mult);
++    const int32_t n_embd_out = llama_model_n_embd_out(stage_model->model);
++    if (qwen4exp_hc <= 0 ||
++        static_cast<size_t>(n_embd) > std::numeric_limits<size_t>::max() / static_cast<size_t>(qwen4exp_hc)) {
++        skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, "Qwen4Exp activation width metadata is invalid");
++        return SKIPPY_STATUS_UNSUPPORTED;
++    }
++
++    activation_width = static_cast<size_t>(n_embd) * static_cast<size_t>(qwen4exp_hc);
++    if (n_embd_out <= 0 || activation_width != static_cast<size_t>(n_embd_out)) {
++        skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, "Qwen4Exp activation width metadata is inconsistent");
++        return SKIPPY_STATUS_UNSUPPORTED;
++    }
++    return SKIPPY_STATUS_OK;
++}
++
+ 
+ extern "C" {
+ enum skippy_status skippy_iteration_batch_sampled(
+@@ -64,12 +93,18 @@ enum skippy_status skippy_iteration_batch_sampled(
+     const bool activation_input = skippy_is_filtered(first) && first->stage_model->config.layer_start > 0;
+     const bool qwen4exp_activation_input =
+             activation_input && first->stage_model->model->arch == LLM_ARCH_QWEN4EXP;
+-    const int32_t qwen4exp_hc = qwen4exp_activation_input
+-        ? static_cast<int32_t>(first->stage_model->model->hparams.dsv4_hc_mult)
+-        : 0;
+-    const size_t activation_width = qwen4exp_activation_input
+-        ? static_cast<size_t>(n_embd) * static_cast<size_t>(qwen4exp_hc)
+-        : static_cast<size_t>(n_embd);
++    int32_t qwen4exp_hc = 0;
++    size_t activation_width = 0;
++    enum skippy_status width_status = skippy_resolve_activation_width(
++            first->stage_model,
++            qwen4exp_activation_input,
++            n_embd,
++            activation_width,
++            qwen4exp_hc,
++            out_error);
++    if (width_status != SKIPPY_STATUS_OK) {
++        return width_status;
++    }
+     const bool request_logits = first->stage_model->config.include_output;
+     const bool request_embeddings = skippy_emits_activation_frame(first);
+     size_t total_token_count = 0;
+@@ -87,6 +122,10 @@ enum skippy_status skippy_iteration_batch_sampled(
+             skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "all requests must belong to the same stage model");
+             return SKIPPY_STATUS_INVALID_ARGUMENT;
+         }
++        enum skippy_status usable_status = skippy_require_usable_session(session, out_error);
++        if (usable_status != SKIPPY_STATUS_OK) {
++            return usable_status;
++        }
+         for (size_t prior = 0; prior < request_index; ++prior) {
+             if (requests[prior].session == session) {
+                 skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "an iteration may contain each session only once");
+@@ -199,7 +238,7 @@ enum skippy_status skippy_iteration_batch_sampled(
+     for (size_t request_index = 0; request_index < request_count; ++request_index) {
+         const skippy_iteration_request & request = requests[request_index];
+         const size_t offset = request_offsets[request_index];
+-        const size_t hidden_bytes = skippy_activation_hidden_bytes(request.session, request.token_count);
++        const size_t hidden_bytes = request.token_count * activation_width * sizeof(float);
+         std::copy(request.token_ids, request.token_ids + request.token_count, token_storage.begin() + offset);
+ 
+         if (activation_input) {
+@@ -428,12 +467,18 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+     const bool activation_input = skippy_is_filtered(first) && first->stage_model->config.layer_start > 0;
+     const bool qwen4exp_activation_input =
+             activation_input && first->stage_model->model->arch == LLM_ARCH_QWEN4EXP;
+-    const int32_t qwen4exp_hc = qwen4exp_activation_input
+-        ? static_cast<int32_t>(first->stage_model->model->hparams.dsv4_hc_mult)
+-        : 0;
+-    const size_t activation_width = qwen4exp_activation_input
+-        ? static_cast<size_t>(n_embd) * static_cast<size_t>(qwen4exp_hc)
+-        : static_cast<size_t>(n_embd);
++    int32_t qwen4exp_hc = 0;
++    size_t activation_width = 0;
++    enum skippy_status width_status = skippy_resolve_activation_width(
++            first->stage_model,
++            qwen4exp_activation_input,
++            n_embd,
++            activation_width,
++            qwen4exp_hc,
++            out_error);
++    if (width_status != SKIPPY_STATUS_OK) {
++        return width_status;
++    }
+     const bool request_logits = first->stage_model->config.include_output;
+     const bool request_embeddings = skippy_emits_activation_frame(first);
+ 
+@@ -442,7 +487,7 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+         return SKIPPY_STATUS_INVALID_ARGUMENT;
+     }
+ 
+-    const size_t hidden_bytes_per_request = skippy_activation_hidden_bytes(first, 1);
++    const size_t hidden_bytes_per_request = activation_width * sizeof(float);
+     uint64_t batch_input_flags = 0;
+     uint32_t batch_input_top_k = 0;
+     uint64_t batch_output_flags = 0;
+@@ -452,6 +497,10 @@ enum skippy_status skippy_decode_step_frame_batch_sampled(
+             skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "all sessions must belong to the same stage model");
+             return SKIPPY_STATUS_INVALID_ARGUMENT;
+         }
++        enum skippy_status usable_status = skippy_require_usable_session(session, out_error);
++        if (usable_status != SKIPPY_STATUS_OK) {
++            return usable_status;
++        }
+         const skippy_activation_desc * input_desc = input_descs != nullptr ? input_descs[i] : nullptr;
+         const void * input_payload = input_payloads != nullptr ? input_payloads[i] : nullptr;
+         enum skippy_status status = skippy_validate_frame_input(session, input_desc, input_payload, 1, out_error);
+diff --git a/src/skippy/execution-single.cpp b/src/skippy/execution-single.cpp
+index 0ce65471f..7b4006f02 100644
+--- a/src/skippy/execution-single.cpp
++++ b/src/skippy/execution-single.cpp
+@@ -83,6 +83,8 @@ enum skippy_status skippy_prefill_chunk(
+             session,
+             token_ids,
+             token_count,
++            nullptr,
++            0,
+             false,
+             SKIPPY_GLM_DSA_PHASE_HINT_PREFILL,
+             out_error);
+@@ -112,6 +114,8 @@ enum skippy_status skippy_decode_step_sampled(
+             session,
+             &token_id,
+             1,
++            nullptr,
++            0,
+             true,
+             SKIPPY_GLM_DSA_PHASE_HINT_DECODE,
+             out_error);
+@@ -195,21 +199,27 @@ enum skippy_status skippy_decode_batch_sampled(
+         return SKIPPY_STATUS_UNSUPPORTED;
+     }
+ 
+-    const int32_t n_tokens = static_cast<int32_t>(request_count);
+-    llama_batch batch = llama_batch_init(n_tokens, 0, 1);
+-    batch.n_tokens = n_tokens;
+-    for (int32_t i = 0; i < n_tokens; ++i) {
++    for (size_t i = 0; i < request_count; ++i) {
+         skippy_session * session = sessions[i];
+         if (session == nullptr || session->ctx != first->ctx || session->stage_model != first->stage_model) {
+-            llama_batch_free(batch);
+             skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "all sessions must belong to the same stage model");
+             return SKIPPY_STATUS_INVALID_ARGUMENT;
+         }
++        enum skippy_status usable_status = skippy_require_usable_session(session, out_error);
++        if (usable_status != SKIPPY_STATUS_OK) {
++            return usable_status;
++        }
+         if (skippy_is_filtered(session) && session->stage_model->config.layer_start > 0) {
+-            llama_batch_free(batch);
+             skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, "batched token decode requires the first runtime slice or a full model");
+             return SKIPPY_STATUS_UNSUPPORTED;
+         }
++    }
++
++    const int32_t n_tokens = static_cast<int32_t>(request_count);
++    llama_batch batch = llama_batch_init(n_tokens, 0, 1);
++    batch.n_tokens = n_tokens;
++    for (int32_t i = 0; i < n_tokens; ++i) {
++        skippy_session * session = sessions[i];
+         batch.token[i] = token_ids[i];
+         batch.pos[i] = session->n_past;
+         batch.n_seq_id[i] = 1;
+@@ -357,6 +367,8 @@ static enum skippy_status skippy_prefill_chunk_frame_impl(
+                 session,
+                 token_ids,
+                 token_count,
++                positions,
++                position_count,
+                 request_logits,
+                 SKIPPY_GLM_DSA_PHASE_HINT_PREFILL,
+                 out_error);
+@@ -550,6 +562,8 @@ enum skippy_status skippy_decode_step_frame_sampled(
+                 session,
+                 &token_id,
+                 1,
++                nullptr,
++                0,
+                 true,
+                 SKIPPY_GLM_DSA_PHASE_HINT_DECODE,
+                 out_error);
+diff --git a/src/skippy/sampling.cpp b/src/skippy/sampling.cpp
+index 2b3a555da..364064609 100644
+--- a/src/skippy/sampling.cpp
++++ b/src/skippy/sampling.cpp
+@@ -41,6 +41,8 @@ enum skippy_status skippy_decode_tokens(
+         skippy_session * session,
+         const llama_token * token_ids,
+         size_t token_count,
++        const llama_pos * positions,
++        size_t position_count,
+         bool request_logits,
+         int32_t glm_dsa_phase_hint,
+         struct skippy_error ** out_error) {
+@@ -59,40 +61,38 @@ enum skippy_status skippy_decode_tokens(
+         return SKIPPY_STATUS_INVALID_ARGUMENT;
+     }
+ 
+-    const int32_t n_tokens = static_cast<int32_t>(token_count);
+-    if (n_tokens == 1) {
+-        llama_token token = token_ids[0];
+-        llama_pos pos = session->n_past;
+-        int32_t n_seq_id = 1;
+-        llama_seq_id seq_id = session->seq_id;
+-        llama_seq_id * seq_ids = &seq_id;
+-        int8_t logits = request_logits ? 1 : 0;
+-        llama_batch batch = {
+-            /*n_tokens =*/ 1,
+-            /*token    =*/ &token,
+-            /*embd     =*/ nullptr,
+-            /*pos      =*/ &pos,
+-            /*n_seq_id =*/ &n_seq_id,
+-            /*seq_id   =*/ &seq_ids,
+-            /*logits   =*/ &logits,
+-        };
+-        enum skippy_status status = skippy_decode_batch(session, batch, 1, glm_dsa_phase_hint, out_error);
+-        if (status == SKIPPY_STATUS_OK) {
+-            skippy_record_tokens(session, token_ids, token_count);
+-            status = skippy_mtp_sync_target_inputs(session, token_ids, nullptr, token_count, pos, out_error);
+-        }
+-        return status;
++    const int32_t n_pos_per_embd = session->stage_model->model->hparams.n_pos_per_embd();
++    if (n_pos_per_embd <= 0 ||
++        token_count > std::numeric_limits<size_t>::max() / static_cast<size_t>(n_pos_per_embd)) {
++        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "model position sideband width is invalid");
++        return SKIPPY_STATUS_INVALID_ARGUMENT;
++    }
++    const size_t expected_position_count = token_count * static_cast<size_t>(n_pos_per_embd);
++    if ((positions == nullptr && position_count != 0) ||
++        (positions != nullptr && position_count != expected_position_count)) {
++        skippy_set_error(out_error, SKIPPY_STATUS_INVALID_ARGUMENT, "position_count must equal token_count * n_pos_per_embd when positions are supplied");
++        return SKIPPY_STATUS_INVALID_ARGUMENT;
+     }
+ 
++    const int32_t n_tokens = static_cast<int32_t>(token_count);
+     const llama_pos token_start = session->n_past;
+-    session->prefill_positions.resize(token_count);
++    session->prefill_positions.resize(expected_position_count);
+     session->prefill_n_seq_ids.resize(token_count, 1);
+     session->prefill_seq_ids.resize(token_count, session->seq_id);
+     session->prefill_seq_id_ptrs.resize(token_count);
+     session->prefill_logits.resize(token_count, 0);
++    if (positions != nullptr) {
++        std::copy(positions, positions + position_count, session->prefill_positions.begin());
++    }
+     for (int32_t i = 0; i < n_tokens; ++i) {
+         const size_t index = static_cast<size_t>(i);
+-        session->prefill_positions[index] = session->n_past + i;
++        if (positions == nullptr) {
++            const llama_pos position = session->n_past + i;
++            for (int32_t dimension = 0; dimension < n_pos_per_embd; ++dimension) {
++                session->prefill_positions[static_cast<size_t>(dimension) * token_count + index] =
++                        dimension == 3 ? 0 : position;
++            }
++        }
+         session->prefill_n_seq_ids[index] = 1;
+         session->prefill_seq_ids[index] = session->seq_id;
+         session->prefill_seq_id_ptrs[index] = &session->prefill_seq_ids[index];
+@@ -111,7 +111,8 @@ enum skippy_status skippy_decode_tokens(
+     enum skippy_status status = skippy_decode_batch(session, batch, token_count, glm_dsa_phase_hint, out_error);
+     if (status == SKIPPY_STATUS_OK) {
+         skippy_record_tokens(session, token_ids, token_count);
+-        status = skippy_mtp_sync_target_inputs(session, token_ids, nullptr, token_count, token_start, out_error);
++        const llama_pos effective_token_start = positions != nullptr ? positions[0] : token_start;
++        status = skippy_mtp_sync_target_inputs(session, token_ids, nullptr, token_count, effective_token_start, out_error);
+     }
+     return status;
+ }
+@@ -374,6 +375,8 @@ static bool skippy_sampling_is_greedy_equivalent(const skippy_sampling_config *
+             (sampling->flags & SKIPPY_SAMPLING_FLAG_IGNORE_EOS) != 0;
+     return sampling->temperature <= 0.0f &&
+            !ignore_eos &&
++           sampling->sampler_count == 0 &&
++           sampling->mirostat_mode == 0 &&
+            sampling->presence_penalty == 0.0f &&
+            sampling->frequency_penalty == 0.0f &&
+            repeat_penalty == 1.0f &&
+@@ -383,8 +386,13 @@ static bool skippy_sampling_is_greedy_equivalent(const skippy_sampling_config *
+ static bool skippy_sampling_configs_equal(
+         const skippy_sampling_config & lhs,
+         const skippy_sampling_config & rhs) {
++    const uint32_t behavioral_flags = ~SKIPPY_SAMPLING_FLAG_IGNORE_EOS;
++    const bool lhs_ignore_eos = lhs.ignore_eos != 0 ||
++            (lhs.flags & SKIPPY_SAMPLING_FLAG_IGNORE_EOS) != 0;
++    const bool rhs_ignore_eos = rhs.ignore_eos != 0 ||
++            (rhs.flags & SKIPPY_SAMPLING_FLAG_IGNORE_EOS) != 0;
+     if (lhs.version != rhs.version ||
+-            lhs.flags != rhs.flags ||
++            (lhs.flags & behavioral_flags) != (rhs.flags & behavioral_flags) ||
+             lhs.seed != rhs.seed ||
+             lhs.top_k != rhs.top_k ||
+             lhs.penalty_last_n != rhs.penalty_last_n ||
+@@ -409,7 +417,7 @@ static bool skippy_sampling_configs_equal(
+             lhs.mirostat_entropy != rhs.mirostat_entropy ||
+             lhs.mirostat_learning_rate != rhs.mirostat_learning_rate ||
+             lhs.sampler_count != rhs.sampler_count ||
+-            lhs.ignore_eos != rhs.ignore_eos ||
++            lhs_ignore_eos != rhs_ignore_eos ||
+             lhs.dry_sequence_breaker_count != rhs.dry_sequence_breaker_count) {
+         return false;
+     }
+diff --git a/src/skippy/sampling_internal.h b/src/skippy/sampling_internal.h
+index 9f819704f..8a491c335 100644
+--- a/src/skippy/sampling_internal.h
++++ b/src/skippy/sampling_internal.h
+@@ -20,6 +20,8 @@ enum skippy_status skippy_decode_tokens(
+         skippy_session * session,
+         const llama_token * token_ids,
+         size_t token_count,
++        const llama_pos * positions,
++        size_t position_count,
+         bool request_logits,
+         int32_t glm_dsa_phase_hint,
+         skippy_error ** out_error);
+diff --git a/src/skippy/verification.cpp b/src/skippy/verification.cpp
+index cce5baa4f..8716da11d 100644
+--- a/src/skippy/verification.cpp
++++ b/src/skippy/verification.cpp
+@@ -187,6 +187,8 @@ enum skippy_status skippy_verify_tokens_frame_sampled(
+                         session,
+                         token_ids,
+                         token_count,
++                        nullptr,
++                        0,
+                         false,
+                         SKIPPY_GLM_DSA_PHASE_HINT_VERIFY,
+                         out_error);
+-- 
+2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0056-fix-skippy-harden-runtime-option-validation.patch
+++ b/third_party/llama.cpp/patches/0056-fix-skippy-harden-runtime-option-validation.patch
@@ -1,0 +1,111 @@
+From 7db7d479a74c9705f85f7b7d2a8c77ae8727665d Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Thu, 3 Sep 2026 09:10:41 -0400
+Subject: [PATCH 56/57] fix(skippy): harden runtime option validation
+
+---
+ src/skippy/environment.h     | 46 +++++++++++++++++++++++-------------
+ src/skippy/model_loading.cpp |  6 ++---
+ 2 files changed, 33 insertions(+), 19 deletions(-)
+
+diff --git a/src/skippy/environment.h b/src/skippy/environment.h
+index f22af9c5a..eb8763650 100644
+--- a/src/skippy/environment.h
++++ b/src/skippy/environment.h
+@@ -1,20 +1,35 @@
+ #pragma once
+ 
+ #include <algorithm>
++#include <cctype>
+ #include <cerrno>
+ #include <cstdint>
+ #include <cstdlib>
+ #include <cstring>
+ 
++inline bool skippy_env_value_equals(const char * value, const char * expected) {
++    while (*value != '\0' && *expected != '\0') {
++        const unsigned char lhs = static_cast<unsigned char>(*value);
++        const unsigned char rhs = static_cast<unsigned char>(*expected);
++        if (std::tolower(lhs) != std::tolower(rhs)) {
++            return false;
++        }
++        ++value;
++        ++expected;
++    }
++    return *value == '\0' && *expected == '\0';
++}
++
++inline bool skippy_env_value_is_false(const char * value) {
++    return skippy_env_value_equals(value, "0") ||
++           skippy_env_value_equals(value, "false") ||
++           skippy_env_value_equals(value, "off") ||
++           skippy_env_value_equals(value, "no");
++}
++
+ inline bool skippy_env_enabled(const char * name) {
+     const char * value = std::getenv(name);
+-    if (value == nullptr || value[0] == '\0') {
+-        return false;
+-    }
+-    return std::strcmp(value, "0") != 0 &&
+-           std::strcmp(value, "false") != 0 &&
+-           std::strcmp(value, "off") != 0 &&
+-           std::strcmp(value, "no") != 0;
++    return value != nullptr && value[0] != '\0' && !skippy_env_value_is_false(value);
+ }
+ 
+ inline bool skippy_env_disabled(const char * name) {
+@@ -22,13 +37,7 @@ inline bool skippy_env_disabled(const char * name) {
+     if (value == nullptr || value[0] == '\0') {
+         return false;
+     }
+-    return std::strcmp(value, "0") == 0 ||
+-           std::strcmp(value, "false") == 0 ||
+-           std::strcmp(value, "FALSE") == 0 ||
+-           std::strcmp(value, "off") == 0 ||
+-           std::strcmp(value, "OFF") == 0 ||
+-           std::strcmp(value, "no") == 0 ||
+-           std::strcmp(value, "NO") == 0;
++    return skippy_env_value_is_false(value);
+ }
+ 
+ inline uint32_t skippy_env_u32(const char * name, uint32_t fallback, uint32_t min_value, uint32_t max_value) {
+@@ -44,6 +53,11 @@ inline uint32_t skippy_env_u32(const char * name, uint32_t fallback, uint32_t mi
+         return fallback;
+     }
+ 
+-    return std::min<uint32_t>(max_value, std::max<uint32_t>(min_value, static_cast<uint32_t>(parsed)));
++    if (parsed < static_cast<unsigned long>(min_value)) {
++        return min_value;
++    }
++    if (parsed > static_cast<unsigned long>(max_value)) {
++        return max_value;
++    }
++    return static_cast<uint32_t>(parsed);
+ }
+-
+diff --git a/src/skippy/model_loading.cpp b/src/skippy/model_loading.cpp
+index b573780a4..ef2608438 100644
+--- a/src/skippy/model_loading.cpp
++++ b/src/skippy/model_loading.cpp
+@@ -592,14 +592,14 @@ static enum skippy_status skippy_finish_model_open(
+ 
+     const auto fail_boundary_load = [&](const char * message) {
+         if (event_scope != nullptr) {
+-            event_scope->emit_failure(SKIPPY_STATUS_RUNTIME_ERROR, message);
++            event_scope->emit_failure(SKIPPY_STATUS_UNSUPPORTED, message);
+         }
+         llama_free(stage_model->ctx);
+         stage_model->ctx = nullptr;
+         llama_model_free(model);
+         delete stage_model;
+-        skippy_set_error(out_error, SKIPPY_STATUS_RUNTIME_ERROR, message);
+-        return SKIPPY_STATUS_RUNTIME_ERROR;
++        skippy_set_error(out_error, SKIPPY_STATUS_UNSUPPORTED, message);
++        return SKIPPY_STATUS_UNSUPPORTED;
+     };
+ 
+     if (config != nullptr && config->filter_tensors_on_load && !config->include_output) {
+-- 
+2.50.1 (Apple Git-155)
+

--- a/third_party/llama.cpp/patches/0057-fix-skippy-preserve-effective-request-sampling-polic.patch
+++ b/third_party/llama.cpp/patches/0057-fix-skippy-preserve-effective-request-sampling-polic.patch
@@ -1,0 +1,63 @@
+From 7b1c40f9503f8a51bddb2dbd97646d63f639fe67 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Thu, 3 Sep 2026 09:10:41 -0400
+Subject: [PATCH 57/57] fix(skippy): preserve effective request sampling policy
+
+---
+ common/stage-chat.cpp | 33 +++++++++++++++------------------
+ 1 file changed, 15 insertions(+), 18 deletions(-)
+
+diff --git a/common/stage-chat.cpp b/common/stage-chat.cpp
+index 180c0a884..e5c5d8452 100644
+--- a/common/stage-chat.cpp
++++ b/common/stage-chat.cpp
+@@ -219,22 +219,6 @@ extern "C" SKIPPY_COMMON_API enum skippy_status skippy_apply_chat_template_json(
+         inputs.add_generation_prompt = add_assistant;
+         inputs.use_jinja             = use_jinja;
+         inputs.parallel_tool_calls   = parallel_tool_calls;
+-        if (override_enable_thinking) {
+-            const char * value = enable_thinking ? "true" : "false";
+-            inputs.enable_thinking = enable_thinking;
+-            inputs.chat_template_kwargs["enable_thinking"] = value;
+-            inputs.chat_template_kwargs["enableThinking"] = value;
+-            inputs.chat_template_kwargs["enable_reasoning"] = value;
+-            inputs.chat_template_kwargs["use_reasoning"] = value;
+-            inputs.chat_template_kwargs["reasoning_enabled"] = value;
+-            inputs.chat_template_kwargs["use_thinking"] = value;
+-            inputs.chat_template_kwargs["thinking_enabled"] = value;
+-            inputs.chat_template_kwargs["enable_think"] = value;
+-            inputs.chat_template_kwargs["think_enabled"] = value;
+-            if (!enable_thinking) {
+-                inputs.chat_template_kwargs["reasoning_effort"] = "0";
+-            }
+-        }
+         if (reasoning_format_name != nullptr && reasoning_format_name[0] != '\0') {
+             inputs.reasoning_format = common_reasoning_format_from_name(reasoning_format_name);
+         }
+@@ -250,8 +234,21 @@ extern "C" SKIPPY_COMMON_API enum skippy_status skippy_apply_chat_template_json(
+                 inputs.chat_template_kwargs[key] = value.dump();
+             }
+         }
+-        if (override_enable_thinking && !enable_thinking) {
+-            inputs.chat_template_kwargs["reasoning_effort"] = "0";
++        if (override_enable_thinking) {
++            const char * value = enable_thinking ? "true" : "false";
++            inputs.enable_thinking = enable_thinking;
++            inputs.chat_template_kwargs["enable_thinking"] = value;
++            inputs.chat_template_kwargs["enableThinking"] = value;
++            inputs.chat_template_kwargs["enable_reasoning"] = value;
++            inputs.chat_template_kwargs["use_reasoning"] = value;
++            inputs.chat_template_kwargs["reasoning_enabled"] = value;
++            inputs.chat_template_kwargs["use_thinking"] = value;
++            inputs.chat_template_kwargs["thinking_enabled"] = value;
++            inputs.chat_template_kwargs["enable_think"] = value;
++            inputs.chat_template_kwargs["think_enabled"] = value;
++            if (!enable_thinking) {
++                inputs.chat_template_kwargs["reasoning_effort"] = "0";
++            }
+         }
+ 
+         common_chat_templates_ptr custom_tmpls;
+-- 
+2.50.1 (Apple Git-155)
+


### PR DESCRIPTION
# Rebase llama.cpp patch queue onto upstream `0df974d777`

Automated canary repair (run 33732614416, patch-queue mode). The nightly
llama-upstream canary failed to apply our patch queue onto the new upstream
master: patch `0001-Add-staged-model-graph-and-family-support.patch` hit
`git am --3way` content conflicts in `src/llama-arch.cpp`,
`src/llama-context.cpp`, `src/llama-kv-cells.h`, and
`src/models/qwen3next.cpp`. The queue was rebuilt on a branch based on the
repair target per the `llama-patch-changes` runbook, and the regenerated
series applies clean end to end.

- Old pinned upstream: `cc83d7b482`
- Repair target upstream: `0df974d777` (96 upstream commits, 2026-08-29 → 09-03)
- Queue: 51 patches, none added or dropped; 2 subject-only renames
- Final patched tree: `16e120bbd` (was `f31fec8c7` at the old pin)

## Key upstream changes in the range

**Model loading / hparams**

- `#28159` — `hparams.n_layer_nextn` is now loaded once, centrally in
  `llama_model_base::load_hparams()` (with an `n_layer_nextn < n_layer_all`
  assert), and the per-arch `LLM_KV_NEXTN_PREDICT_LAYERS` loads were removed
  from ~20 model files (deepseek2, qwen3next, bailingmoe, cohere2moe,
  deepseek32/4, dots3note, exaone*, …). This is the change our patch 0001
  collided with.
- `#28173` (load arrays with `n_layer_all`), `#27483` (avoid RAM peaking at
  load), `#28121` (noscan `ssm_a` flags), `#27837` + `#27969`
  (`--tensor-read-lazy` renamed to `--lazy-mode` with `-lzm` shorthand).
- New model: NVIDIA Nemotron-3-Puzzle-75B-A9B (`#25444`); DeepSeek-V4 /
  DSpark vision fixes (`#28154`, `#28294`, `#28133`).

**KV cache / cells**

- `#28011`, `#28040`, `#27991` — reworked the per-sequence position index in
  `llama_kv_cells`: `seq_pos_inc`/`seq_pos_dec` now take the cell index, the
  index maps positions to cells, n-gram history lookup goes through the
  index, and non-contiguous cell restore is optimized. Patch 0001's
  position-continuity check built on the old index shape conflicted here.
- `#28038` (alloc-size guard), `#27967` (Hadamard `k_rot` copy guard during
  context shift), `#28030` (yarn autoscale of `n_ctx_train`).

**Context / graph**

- `#27310` — DFlash: the speculative encoder is fused into the KV-cache
  injection; `llama_context::decode()` gained a `dflash_embd` branch selecting
  `hparams.n_embd_inp_enc()`. Patch 0001 rewrites the `n_embd` computation
  this branch lives in.
- `#27941` + `#28123` + `#28023` — Qwen4Exp: seq_cp / block position keying /
  mtmd input / CUDA abort fixes, recurrent state rollback support, indexer
  head slicing, plus new arch tests. Directly touches the arch our staged
  Qwen4Exp patches (0029–0034) target.
- `#27930` — new `SWIGLU_CLAMP` ggml op; `#28174` — `preserve_reasoning`
  enabled by default in common/server; `#27301` — alloc dependencies in
  `graph_optimize`.

**Backends / platform**

- Metal: Metal 4.0 tensor API on M5+/A19+ (`#27461`), fa-vec tunings for
  M1–M5/A18/A19 chips, autoreleasepool leak fixes + CI check (`#27883`,
  `#27884`), top-k radix (`#28073`), quantized concat (`#28116`),
  low-memory query fix (`#27701`).
- CUDA: sparse-fa for DSV4/GLM (`#27970`), MoE fusion extended to
  speculative decoding and >1 token batches (`#27621`), fused MoE weighted
  expert reduction (`#25950`), XOR-swizzled FA smem tiles (`#25635`).
- ROCm 10.0 bump; SYCL / Hexagon / OpenCL / Vulkan / WebGPU fixes; RPC rdma
  fixes; cpp-httplib vendored at 0.54.0; server accepts `data:` URLs for
  video/audio (`#27700`).

## Patch-queue evolution

The series was regenerated from a rebuilt llama.cpp branch on top of
`0df974d777` (capability-owned commits reconstructed, final tree verified,
then `git format-patch`). Per-patch outcome:

- **0001 — staged model graph and family support** (the patch that broke the
  canary; 3 real resolutions):
  - `src/llama-context.cpp` — upstream `#27310` inserted the DFlash
    `dflash_embd ? hparams.n_embd_inp_enc()` arm into the `n_embd`
    expression this patch rewrites. Resolution keeps the new DFlash arm and
    still drops the `mtp_embd` special case, as before.
  - `src/llama-kv-cells.h` — the patch previously threaded a
    `seq_pos_index_mismatch[LLAMA_MAX_SEQ]` counter through
    `seq_pos_inc`/`seq_pos_dec`/`reset` (extending their signatures with the
    cell index) to make `seq_pos_is_cell_contiguous()` O(1). Upstream
    `#28011`/`#28040` changed those helpers to take the cell index and
    reworked the index, so the counter bookkeeping no longer applied.
    Resolution: the counter is gone entirely and
    `seq_pos_is_cell_contiguous()` is re-expressed as a single ordered scan
    over the `(pos → cell)` index entries verifying dense positions and
    `pos == cell` alignment. Same contract, validated directly against the
    new index shape.
  - `src/models/deepseek2.cpp`, `src/models/qwen3next.cpp` — the patch used
    to delete the per-arch `NextN/MTP` `NEXTN_PREDICT_LAYERS` loads and
    asserts (the same duplication upstream later removed itself in
    `#28159`). Those hunks became no-ops and were dropped; the staged family
    path now relies on upstream's central load plus the patch's own
    `deepseek2` load/assert (kept).
- **0012 — fixup: staged runtime wiring onto per-op Metal layout** — only
  `tests/test-llama-archs.cpp` changed (125 → 20 lines). Kept: the
  `glm_dsa_backend_config_supported()` skip guard and the WebGPU `FIXME`
  skip in `test_backends`. Dropped: the GLM-DSA index-share fixture variants
  (`glm_dsa_indexshare_fixture`), the `scoped_test_env` helpers, and the
  extended `get_model_and_ctx` signature (cb_eval / flash_attn) — upstream
  `#27941` rebuilt that fixture area and the old plumbing no longer applies.
  See risks below.
- **0041 — physical KV-cache occupancy** — no longer carries the mid-series
  `SKIPPY_ABI_VERSION_PATCH` bump; the bump chain is now spread across the
  ABI-owning patches (each increments by one, 35 → 48). End state unchanged.
- **0039, 0051 — renamed only** (subject now matches content:
  "add kv_offload, kv_unified, swa_full, op_offload…" and "expose the
  native session sequence ID"). No content change.
- **All other patches (0002–0007, 0010, 0011, 0013–0026, 0028–0038,
  0040, 0042–0050)** — rebase churn only: refreshed blob indices, hunk
  offsets, context lines where upstream edited nearby code (e.g. 0019's
  Metal hunks now sit against the `MTLLanguageVersion4_0_GGML` context from
  `#27461`; 0028's `ctx_other` hunks follow the constructor's
  `cparams.rope_scaling_type` refactor from `#28030`), plus the regenerated
  `[PATCH n/51]` subjects and git trailers. Patch intent is unchanged.

Net effect measured on the final trees (`f31fec8c7` vs `16e120bbd`): the
only files where the patched tree moves differently from pure upstream are
`src/llama-kv-cells.h`, `src/models/deepseek2.cpp`,
`src/models/qwen3next.cpp`, and `tests/test-llama-archs.cpp` — exactly the
four resolutions above. **`include/skippy/**`, `include/skippy.h`, and
`src/skippy/**` are byte-identical** between the old and new final trees.

## ABI impact

- None at the boundary: the final `SKIPPY_ABI_VERSION` is `0.1.48` before
  and after this repair; all public `include/skippy/*.h` headers and
  `src/skippy/**` implementation files are byte-identical to the old
  certified tree.
- The Rust mirror `crates/skippy-ffi` (`ABI_VERSION` 0/1/48) matches the
  patched tree. No crate in `crates/` is modified by this branch.
- The only distribution change is internal to the series: the ABI patch
  bump moved out of 0041 into the incremental chain carried by the
  ABI-owning patches (0003 → 0051), which is where the skill wants it.

## Risks for reviewers

1. **Possible dropped intent in 0012's test fixture work.** The GLM-DSA
   index-share fixture variants, scoped test-env helpers, and
   `get_model_and_ctx` extensions were removed because upstream's rewritten
   fixture no longer admits them. Upstream did *not* absorb the GLM-DSA
   variants (it added similar `indexer_types` fixtures only for DOTS3NOTE).
   Certification parity can't see this; if those fixtures guarded a staged
   GLM-DSA correctness case, it is no longer exercised by
   `test-llama-archs`. The skip guards that keep CI green remain. Reviewer
   judgment requested on whether the dropped fixtures need re-derivation on
   the new fixture shape.
2. **KV-cells contiguity check cost.** `seq_pos_is_cell_contiguous()` went
   from O(1) (counter) to an ordered scan over the sequence's position index
   on the staged graph-build path. Correct against the new index, but hot
   staged decode on long contexts pays O(positions) per check. If that shows
   up in staged TTFT profiles, a mismatch counter can be reintroduced on top
   of the new index shape in a follow-up.
3. **Duplicate `NEXTN_PREDICT_LAYERS` load for deepseek2.** Upstream now
   loads it centrally (`llama-model.cpp`) and our 0001 re-adds an arch-level
   load. Both write the same optional key to the same field, so behavior is
   unchanged, but the arch-level load in 0001 is now redundant and should be
   dropped in a later hygiene pass.
4. **Upstream behavior changes now riding along** (inherent to the pin
   bump, called out because staged paths inherit them): `preserve_reasoning`
   defaults on (`#28174`), DFlash decode selects `n_embd_inp_enc()` when
   embd batches are present (`#27310`), Qwen4Exp position-keying/seq_cp and
   recurrent-rollback fixes (`#27941`, `#28123`) interact with our staged
   Qwen4Exp patches, and Metal 4.0 tensor API activates on M5+/A19+
   (`#27461`) beneath our Metal pipeline-cache patch (0019).
5. **No lanes weakened.** This branch touches only the 51 patch files — no
   changes to `ci/llama-canary/*`, `scripts/skippy-family-battery.sh`, or
   any manifest; no lane is skipped or excluded.

## Validation

- `scripts/prepare-llama.sh 0df974d777` applies the full queue clean
  (recorded: upstream sha, patched sha `16e120bbd`, patch digest).
- Native build of the rebased queue completed on the family-certify runner
  (Release, Metal backend, arm64; build stamp matches the final patched
  sha).
- The wrapper re-runs the full family battery (`--skip-build`) after this
  description is drafted and posts the certified result as a PR comment;
  families most exposed to this range are `qwen3-next` (Qwen4Exp fixes),
  `nemotron` (MTP/hybrid changes), `deepseek2` (MLA/NextN load move), and
  the dense/spec lanes generally.
- Per the repair loop, a separate fresh-context review turn re-checks this
  certified repair for dropped intent/rebase leftovers after a green
  battery; any fixes land as their own `review(llama):` commit and merged
  main is re-certified by the next canary run before the pin advances.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Inkling text, image, and audio models.
  * Added staged model execution for processing large models in layer ranges.
  * Added model loading from multiple parts and tools for creating sliced or merged model packages.
  * Added session state export/import, KV-cache management, resident prefixes, and memory usage reporting.
  * Added activation-frame execution, batched requests, speculative decoding, MTP drafts, and n-gram drafting.
  * Expanded sampling options, chat templates, grammar, JSON schema, and token signal reporting.

* **Bug Fixes**
  * Improved input validation, error details, runtime option handling, and sampling reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->