### PR TITLE
fix(system): report the real macOS GPU name (not the CPU brand string)

### DIFF
--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -303,6 +303,54 @@ fn query_metal_recommended_working_set_bytes() -> Option<u64> {
     }
 }
 
+/// Queries the real GPU identifier via `MTLDevice.name` (e.g. "Apple M4 Max"
+/// or "AMD Radeon Pro 5500M") — never the CPU brand string.
+#[cfg(target_os = "macos")]
+fn query_metal_device_name() -> Option<String> {
+    use std::ffi::{CStr, c_char, c_void};
+
+    // `objc_msgSend` is declared to return `usize` here (matching the other
+    // FFI declaration of the same linked symbol above) and the pointer
+    // results below are recovered with `as *mut/*const _` casts, to avoid a
+    // `clashing_extern_declarations` warning from two conflicting return
+    // types for one symbol.
+    #[link(name = "objc")]
+    unsafe extern "C" {
+        fn sel_registerName(name: *const c_char) -> *mut c_void;
+        fn objc_msgSend(receiver: *mut c_void, selector: *mut c_void, ...) -> usize;
+    }
+
+    unsafe {
+        let metal =
+            libloading::Library::new("/System/Library/Frameworks/Metal.framework/Versions/A/Metal")
+                .ok()?;
+        let create_device = metal
+            .get::<unsafe extern "C" fn() -> *mut c_void>(b"MTLCreateSystemDefaultDevice")
+            .ok()?;
+        let device = create_device();
+        if device.is_null() {
+            return None;
+        }
+        let name_sel = sel_registerName(c"name".as_ptr());
+        if name_sel.is_null() {
+            return None;
+        }
+        let name_obj = objc_msgSend(device, name_sel) as *mut c_void;
+        if name_obj.is_null() {
+            return None;
+        }
+        let utf8_sel = sel_registerName(c"UTF8String".as_ptr());
+        if utf8_sel.is_null() {
+            return None;
+        }
+        let utf8_ptr = objc_msgSend(name_obj, utf8_sel) as *const c_char;
+        if utf8_ptr.is_null() {
+            return None;
+        }
+        Some(CStr::from_ptr(utf8_ptr).to_string_lossy().into_owned())
+    }
+}
+
 #[cfg(feature = "skippy-devices")]
 fn apply_skippy_backend_devices_to_survey(survey: &mut HardwareSurvey, metrics: &[Metric]) -> bool {
     let wants_gpu_data = metrics.contains(&Metric::GpuName)
@@ -434,17 +482,8 @@ impl Collector for DefaultCollector {
                 survey.gpu_vram = vec![vram_bytes];
                 survey.gpu_reserved = vec![reserved_bytes];
             }
-            let macos_gpu_name = if metrics.contains(&Metric::GpuName) {
-                std::process::Command::new("sysctl")
-                    .args(["-n", "machdep.cpu.brand_string"])
-                    .output()
-                    .ok()
-                    .and_then(|out| String::from_utf8(out.stdout).ok())
-            } else {
-                None
-            };
-            if let Some(gpu_name) = macos_gpu_name {
-                survey.gpu_name = parse_macos_cpu_brand(&gpu_name);
+            if metrics.contains(&Metric::GpuName) {
+                survey.gpu_name = sanitize_macos_gpu_name(query_metal_device_name());
             }
             if metrics.contains(&Metric::GpuCount) {
                 survey.gpu_count = 1;

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -272,6 +272,27 @@ fn read_windows_video_controllers() -> Vec<(String, u64)> {
     parse_windows_video_controller_json(&output)
 }
 
+/// Owns an Objective-C object retained via the "create rule" (e.g.
+/// `MTLCreateSystemDefaultDevice`, `NS_RETURNS_RETAINED`) and releases it on
+/// drop, so every return path -- including early `?`/null-check returns --
+/// balances the retain instead of leaking the object.
+#[cfg(target_os = "macos")]
+struct RetainedObjcObject(*mut std::ffi::c_void);
+
+#[cfg(target_os = "macos")]
+impl Drop for RetainedObjcObject {
+    fn drop(&mut self) {
+        if self.0.is_null() {
+            return;
+        }
+        #[link(name = "objc")]
+        unsafe extern "C" {
+            fn objc_release(obj: *mut std::ffi::c_void);
+        }
+        unsafe { objc_release(self.0) };
+    }
+}
+
 #[cfg(target_os = "macos")]
 fn query_metal_recommended_working_set_bytes() -> Option<u64> {
     use std::ffi::{c_char, c_void};
@@ -293,6 +314,7 @@ fn query_metal_recommended_working_set_bytes() -> Option<u64> {
         if device.is_null() {
             return None;
         }
+        let _device = RetainedObjcObject(device);
         let selector = c"recommendedMaxWorkingSetSize";
         let selector = sel_registerName(selector.as_ptr());
         if selector.is_null() {
@@ -331,6 +353,7 @@ fn query_metal_device_name() -> Option<String> {
         if device.is_null() {
             return None;
         }
+        let _device = RetainedObjcObject(device);
         let name_sel = sel_registerName(c"name".as_ptr());
         if name_sel.is_null() {
             return None;

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -123,6 +123,8 @@ impl std::error::Error for PinnedGpuResolverError {}
 #[derive(Default, Debug, Clone, PartialEq)]
 pub struct HardwareSurvey {
     pub vram_bytes: u64,
+    /// GPU name as reported by the OS/driver (e.g. Metal, nvidia-smi, ROCm).
+    /// Best-effort and OS-reported, not an independently verified measurement.
     pub gpu_name: Option<String>,
     pub gpu_count: u8,
     pub hostname: Option<String>,
@@ -281,6 +283,7 @@ struct RetainedObjcObject(*mut std::ffi::c_void);
 
 #[cfg(target_os = "macos")]
 impl Drop for RetainedObjcObject {
+    /// Releases the retained object, balancing the "create rule" retain.
     fn drop(&mut self) {
         if self.0.is_null() {
             return;
@@ -293,6 +296,8 @@ impl Drop for RetainedObjcObject {
     }
 }
 
+/// Queries the Metal-recommended working-set size in bytes for the default
+/// device — best-effort, OS-reported, not a verified measurement.
 #[cfg(target_os = "macos")]
 fn query_metal_recommended_working_set_bytes() -> Option<u64> {
     use std::ffi::{c_char, c_void};
@@ -325,8 +330,9 @@ fn query_metal_recommended_working_set_bytes() -> Option<u64> {
     }
 }
 
-/// Queries the real GPU identifier via `MTLDevice.name` (e.g. "Apple M4 Max"
-/// or "AMD Radeon Pro 5500M") — never the CPU brand string.
+/// Queries the GPU name as reported by the OS via `MTLDevice.name` (e.g.
+/// "Apple M4 Max" or "AMD Radeon Pro 5500M") — best-effort, not a verified
+/// measurement, but sourced from the GPU device rather than the CPU.
 #[cfg(target_os = "macos")]
 fn query_metal_device_name() -> Option<String> {
     use std::ffi::{CStr, c_char, c_void};

--- a/crates/mesh-llm-system/src/hardware/parsers.rs
+++ b/crates/mesh-llm-system/src/hardware/parsers.rs
@@ -37,15 +37,23 @@ pub fn parse_nvidia_gpu_memory_and_reserved(output: &str) -> Vec<(u64, Option<u6
         .collect()
 }
 
-/// Parse `sysctl -n machdep.cpu.brand_string` output → CPU brand string.
+/// Sanitizes a macOS Metal `MTLDevice.name` query result into `gpu_name`.
+/// Rejects anything shaped like a CPU brand string (`sysctl
+/// machdep.cpu.brand_string` output always embeds " CPU @ " and a GHz clock
+/// speed on Intel Macs) so a regression that re-wires CPU output into this
+/// path degrades to labeled-absent instead of silently mislabeling the CPU
+/// as the GPU.
 #[cfg(any(target_os = "macos", test))]
-pub fn parse_macos_cpu_brand(output: &str) -> Option<String> {
-    let s = output.trim();
-    if s.is_empty() {
-        None
-    } else {
-        Some(s.to_string())
+pub fn sanitize_macos_gpu_name(name: Option<String>) -> Option<String> {
+    let trimmed = name?.trim().to_string();
+    if trimmed.is_empty() {
+        return None;
     }
+    let lower = trimmed.to_ascii_lowercase();
+    if lower.contains("cpu") || lower.contains("ghz") {
+        return None;
+    }
+    Some(trimmed)
 }
 
 #[cfg(any(target_os = "macos", test))]

--- a/crates/mesh-llm-system/src/hardware/parsers.rs
+++ b/crates/mesh-llm-system/src/hardware/parsers.rs
@@ -38,11 +38,12 @@ pub fn parse_nvidia_gpu_memory_and_reserved(output: &str) -> Vec<(u64, Option<u6
 }
 
 /// Sanitizes a macOS Metal `MTLDevice.name` query result into `gpu_name`.
-/// Rejects anything shaped like a CPU brand string (`sysctl
-/// machdep.cpu.brand_string` output always embeds " CPU @ " and a GHz clock
-/// speed on Intel Macs) so a regression that re-wires CPU output into this
-/// path degrades to labeled-absent instead of silently mislabeling the CPU
-/// as the GPU.
+/// This is what the OS reported, not a verified measurement, so the only
+/// correction applied is rejecting anything shaped like a CPU brand string
+/// (`sysctl machdep.cpu.brand_string` output always embeds " CPU @ " and a
+/// GHz clock speed on Intel Macs) so a regression that re-wires CPU output
+/// into this path degrades to labeled-absent instead of silently
+/// mislabeling the CPU as the GPU.
 #[cfg(any(target_os = "macos", test))]
 pub fn sanitize_macos_gpu_name(name: Option<String>) -> Option<String> {
     let trimmed = name?.trim().to_string();

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -114,6 +114,8 @@ fn test_parse_nvidia_gpu_memory_and_reserved() {
     );
 }
 
+/// `sanitize_macos_gpu_name` passes through real GPU names untouched (modulo
+/// trimming), for both Apple Silicon and AMD/Intel discrete/integrated parts.
 #[test]
 fn test_sanitize_macos_gpu_name_accepts_real_gpu_names() {
     assert_eq!(
@@ -130,12 +132,16 @@ fn test_sanitize_macos_gpu_name_accepts_real_gpu_names() {
     );
 }
 
+/// Empty or missing input degrades to labeled-absent (`None`), not an empty
+/// string masquerading as a GPU name.
 #[test]
 fn test_sanitize_macos_gpu_name_empty_is_labeled_absent() {
     assert_eq!(sanitize_macos_gpu_name(Some(String::new())), None);
     assert_eq!(sanitize_macos_gpu_name(None), None);
 }
 
+/// Guards against the regression this fix removed: a CPU brand string routed
+/// into the GPU-name path must degrade to `None`, never surface mislabeled.
 #[test]
 fn test_sanitize_macos_gpu_name_flags_cpu_brand_string_mislabel() {
     // The exact `sysctl -n machdep.cpu.brand_string` shape this fix removed —

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -115,16 +115,35 @@ fn test_parse_nvidia_gpu_memory_and_reserved() {
 }
 
 #[test]
-fn test_parse_macos_cpu_brand() {
+fn test_sanitize_macos_gpu_name_accepts_real_gpu_names() {
     assert_eq!(
-        parse_macos_cpu_brand("Apple M4 Max\n"),
+        sanitize_macos_gpu_name(Some("Apple M4 Max\n".to_string())),
         Some("Apple M4 Max".to_string())
+    );
+    assert_eq!(
+        sanitize_macos_gpu_name(Some("AMD Radeon Pro 5500M".to_string())),
+        Some("AMD Radeon Pro 5500M".to_string())
+    );
+    assert_eq!(
+        sanitize_macos_gpu_name(Some("Intel(R) UHD Graphics 630".to_string())),
+        Some("Intel(R) UHD Graphics 630".to_string())
     );
 }
 
 #[test]
-fn test_parse_macos_cpu_brand_empty() {
-    assert_eq!(parse_macos_cpu_brand(""), None);
+fn test_sanitize_macos_gpu_name_empty_is_labeled_absent() {
+    assert_eq!(sanitize_macos_gpu_name(Some(String::new())), None);
+    assert_eq!(sanitize_macos_gpu_name(None), None);
+}
+
+#[test]
+fn test_sanitize_macos_gpu_name_flags_cpu_brand_string_mislabel() {
+    // The exact `sysctl -n machdep.cpu.brand_string` shape this fix removed —
+    // must never surface as a GPU name again.
+    assert_eq!(
+        sanitize_macos_gpu_name(Some("Intel(R) Core(TM) i9-9880H CPU @ 2.30GHz".to_string())),
+        None
+    );
 }
 
 #[test]


### PR DESCRIPTION
On macOS, `gpu_name` currently returns `sysctl -n machdep.cpu.brand_string` — the **CPU** brand string mislabeled as the GPU name (verified live on `main`). This reads the real GPU identifier instead, or reports it as absent rather than substituting the CPU string.

3 files (+88/-22): the fix in `crates/mesh-llm-system/src/hardware/{mod,parsers}.rs` plus tests. A mutant test flips if the brand-string fallback is reintroduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * macOS GPU names are now detected directly from Metal for more accurate hardware identification.
  * CPU brand strings are no longer displayed as GPU names.
  * Empty or unavailable GPU names are handled cleanly.
  * Hardware names use best-effort, OS-reported values.

* **Tests**
  * Added coverage for Apple, AMD, and Intel GPU names, including invalid, CPU-derived, and missing-name scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->