### PR TITLE
ci: run SafeTensors runtime smoke on affected PRs

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -151,7 +151,7 @@ removable after this branch's runner contract is active on protected main.
 | `ci-web-slice.yml` | Console quality, console Playwright E2E, public website build, and CLI explorer browser validation |
 | `ci-ui-artifact-slice.yml` | Immutable console distribution producer |
 | `static-abi-artifact.yml` | Typed static llama ABI producer with internal runner policy and an exact toolchain-epoch output |
-| `ci-rust-tests-slice.yml` | Typed deterministic Cargo test batches that verify the producer-owned static ABI toolchain epoch and a pinned, digest-verified Skippy correctness fixture |
+| `ci-rust-tests-slice.yml` | Typed deterministic Cargo test batches that verify the producer-owned static ABI toolchain epoch and a pinned, digest-verified Skippy correctness fixture; related PR changes additionally smoke immutable SmolLM2, Qwen2 and Qwen3 SafeTensors checkpoints through the complete Mesh config/resolver/server/native path to sampled prefill and decode, with Qwen2 quantized during load |
 | `ci-{linux,macos,windows}-host-slice.yml` | Platform-pure neutral host producers; no empty cross-platform jobs |
 | `ci-{linux,macos,windows}-runtime-slice.yml` | Platform-pure native runtime producers |
 | `ci-{linux,macos,windows}-product-slice.yml` | Platform-pure composition-only product consumers |

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -151,7 +151,7 @@ removable after this branch's runner contract is active on protected main.
 | `ci-web-slice.yml` | Console quality, console Playwright E2E, public website build, and CLI explorer browser validation |
 | `ci-ui-artifact-slice.yml` | Immutable console distribution producer |
 | `static-abi-artifact.yml` | Typed static llama ABI producer with internal runner policy and an exact toolchain-epoch output |
-| `ci-rust-tests-slice.yml` | Typed deterministic Cargo test batches that verify the producer-owned static ABI toolchain epoch and a pinned, digest-verified Skippy correctness fixture; related PR changes additionally smoke immutable SmolLM2, Qwen2 and Qwen3 SafeTensors checkpoints through the complete Mesh config/resolver/server/native path to sampled prefill and decode, with Qwen2 quantized during load |
+| `ci-rust-tests-slice.yml` | Typed deterministic Cargo test batches that verify the producer-owned static ABI toolchain epoch and a pinned, digest-verified Skippy correctness fixture; related PR changes additionally smoke an immutable SmolLM2 SafeTensors checkpoint through the complete Mesh config/resolver/server/native path to sampled prefill and decode with every supported load-time quantization |
 | `ci-{linux,macos,windows}-host-slice.yml` | Platform-pure neutral host producers; no empty cross-platform jobs |
 | `ci-{linux,macos,windows}-runtime-slice.yml` | Platform-pure native runtime producers |
 | `ci-{linux,macos,windows}-product-slice.yml` | Platform-pure composition-only product consumers |

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -215,10 +215,8 @@ jobs:
       MESH_LLM_REQUIRE_SCCACHE: "1"
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
-      SAFETENSORS_FIXTURES: |
-        smollm2\tHuggingFaceTB/SmolLM2-135M-Instruct\t12fd25f77366fa6b3b4b768ec3050bf629380bac\tpreserve
-        qwen2\tQwen/Qwen2.5-0.5B-Instruct\t7ae557604adf67be50417f59c2c2f167def9a775\tQ4_K_M
-        qwen3\tQwen/Qwen3-0.6B\tc1899de289a04d12100db370d81485cdf75e47ca\tpreserve
+      SAFETENSORS_REPOSITORY: HuggingFaceTB/SmolLM2-135M-Instruct
+      SAFETENSORS_REVISION: 12fd25f77366fa6b3b4b768ec3050bf629380bac
       SAFETENSORS_QUANTIZATIONS: >-
         preserve F32 F16 BF16 Q1_0 Q2_0 Q4_0 Q4_1 Q5_0 Q5_1
         IQ2_XXS IQ2_XS IQ2_S IQ2_M IQ1_S IQ1_M TQ1_0 TQ2_0
@@ -255,24 +253,14 @@ jobs:
           path: ${{ runner.temp }}/static-abi-input
       - name: Restore immutable static ABI input
         run: scripts/restore-static-abi-input.sh "$RUNNER_TEMP/static-abi-input" "$LLAMA_STAGE_BUILD_DIR" x86_64-unknown-linux-gnu cpu
-      - name: Load pinned SafeTensors families
+      - name: Download pinned SafeTensors checkpoint
         run: |
           set -euo pipefail
-          while IFS=$'\t' read -r family repository revision quantization; do
-            [[ -z "$family" ]] && continue
-            fixture_dir="$RUNNER_TEMP/safetensors-$family"
-            echo "::group::$family ($repository@$revision, $quantization)"
-            hf download "$repository" \
-              config.json tokenizer.json tokenizer_config.json model.safetensors \
-              --revision "$revision" \
-              --local-dir "$fixture_dir"
-            SKIPPY_SAFETENSORS_SMOKE_DIR="$fixture_dir" \
-              SKIPPY_SAFETENSORS_SMOKE_QUANTIZATION="$quantization" \
-              cargo test --locked -p mesh-llm-host-runtime --no-default-features \
-                safetensors_checkpoint_reaches_mesh_host_runtime -- \
-                --ignored --nocapture
-            echo "::endgroup::"
-          done <<< "$SAFETENSORS_FIXTURES"
+          fixture_dir="$RUNNER_TEMP/safetensors-smollm2"
+          hf download "$SAFETENSORS_REPOSITORY" \
+            config.json tokenizer.json tokenizer_config.json model.safetensors \
+            --revision "$SAFETENSORS_REVISION" \
+            --local-dir "$fixture_dir"
       - name: Exercise every current direct-load quantization
         run: |
           set -euo pipefail

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -197,3 +197,99 @@ jobs:
           artifact_name: sccache-ci-rust-tests-${{ matrix.batch.id }}-${{ github.run_attempt }}
           cache_expectation: ${{ steps.sccache_seed.outputs.cache_hit == 'true' && 'warm' || 'cold' }}
           minimum_hit_rate: "0.20"
+
+  safetensors_runtime_smoke:
+    name: SafeTensors runtime smoke
+    needs: runner_policy
+    if: ${{ inputs.original_event_name == 'pull_request' && (contains(inputs.rust_tests_matrix, 'skippy-model') || contains(inputs.rust_tests_matrix, 'skippy-runtime') || contains(inputs.rust_tests_matrix, 'skippy-quantize') || contains(inputs.rust_tests_matrix, 'skippy-ffi') || contains(inputs.rust_tests_matrix, 'skippy-server') || contains(inputs.rust_tests_matrix, 'skippy-protocol') || contains(inputs.rust_tests_matrix, 'skippy-cache') || contains(inputs.rust_tests_matrix, 'mesh-llm-config') || contains(inputs.rust_tests_matrix, 'mesh-llm-host-runtime') || contains(inputs.rust_tests_matrix, 'mesh-llm-cli')) }}
+    runs-on: ${{ needs.runner_policy.outputs.runner }}
+    timeout-minutes: 60
+    container:
+      image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:8d93de6ba30173e825a16fdecf011f9c632edc6e1259df7289e491b0a05f829d
+    defaults:
+      run:
+        shell: bash
+    env:
+      LLAMA_STAGE_BACKEND: cpu
+      LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-static
+      MESH_LLM_REQUIRE_SCCACHE: "1"
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
+      RUSTC_WRAPPER: sccache
+      SAFETENSORS_FIXTURES: |
+        smollm2\tHuggingFaceTB/SmolLM2-135M-Instruct\t12fd25f77366fa6b3b4b768ec3050bf629380bac\tpreserve
+        qwen2\tQwen/Qwen2.5-0.5B-Instruct\t7ae557604adf67be50417f59c2c2f167def9a775\tQ4_K_M
+        qwen3\tQwen/Qwen3-0.6B\tc1899de289a04d12100db370d81485cdf75e47ca\tpreserve
+      SAFETENSORS_QUANTIZATIONS: >-
+        preserve F32 F16 BF16 Q1_0 Q2_0 Q4_0 Q4_1 Q5_0 Q5_1
+        IQ2_XXS IQ2_XS IQ2_S IQ2_M IQ1_S IQ1_M TQ1_0 TQ2_0
+        Q2_K Q2_K_S IQ3_XS IQ3_XXS IQ3_S IQ3_M
+        Q3_K_S Q3_K_M Q3_K_L IQ4_NL IQ4_XS Q4_K_S Q4_K_M
+        Q5_K_S Q5_K_M Q6_K Q8_0 MXFP4_MOE
+    steps:
+      - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
+        with:
+          original_event_name: ${{ inputs.original_event_name }}
+          depot_selected: ${{ startsWith(needs.runner_policy.outputs.runner, 'depot-') }}
+          allow_native_github_cache: ${{ needs.runner_policy.outputs.allow_native_github_cache }}
+          allow_depot_remote_cache: ${{ needs.runner_policy.outputs.allow_depot_remote_cache }}
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          ref: ${{ inputs.source_sha || github.sha }}
+          persist-credentials: false
+      - name: Verify prebuilt test environment
+        run: verify-runner-image public cpu
+      - name: Resolve static ABI toolchain epoch
+        uses: ./.github/actions/resolve-native-toolchain-epoch
+        with:
+          pinned_epoch: ${{ inputs.static_abi_toolchain_epoch }}
+      - uses: ./.github/actions/configure-sccache-gha
+        with:
+          allow_depot_remote_cache: ${{ needs.runner_policy.outputs.allow_depot_remote_cache }}
+          allow_native_github_cache: ${{ needs.runner_policy.outputs.allow_native_github_cache }}
+      - name: Prepare patched llama.cpp
+        run: scripts/prepare-llama.sh pinned
+      - name: Download immutable static ABI input
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: ${{ inputs.static_abi_artifact_name }}
+          path: ${{ runner.temp }}/static-abi-input
+      - name: Restore immutable static ABI input
+        run: scripts/restore-static-abi-input.sh "$RUNNER_TEMP/static-abi-input" "$LLAMA_STAGE_BUILD_DIR" x86_64-unknown-linux-gnu cpu
+      - name: Load pinned SafeTensors families
+        run: |
+          set -euo pipefail
+          while IFS=$'\t' read -r family repository revision quantization; do
+            [[ -z "$family" ]] && continue
+            fixture_dir="$RUNNER_TEMP/safetensors-$family"
+            echo "::group::$family ($repository@$revision, $quantization)"
+            hf download "$repository" \
+              config.json tokenizer.json tokenizer_config.json model.safetensors \
+              --revision "$revision" \
+              --local-dir "$fixture_dir"
+            SKIPPY_SAFETENSORS_SMOKE_DIR="$fixture_dir" \
+              SKIPPY_SAFETENSORS_SMOKE_QUANTIZATION="$quantization" \
+              cargo test --locked -p mesh-llm-host-runtime --no-default-features \
+                safetensors_checkpoint_reaches_mesh_host_runtime -- \
+                --ignored --nocapture
+            echo "::endgroup::"
+          done <<< "$SAFETENSORS_FIXTURES"
+      - name: Exercise every current direct-load quantization
+        run: |
+          set -euo pipefail
+          fixture_dir="$RUNNER_TEMP/safetensors-smollm2"
+          for quantization in $SAFETENSORS_QUANTIZATIONS; do
+            echo "::group::$quantization"
+            SKIPPY_SAFETENSORS_SMOKE_DIR="$fixture_dir" \
+              SKIPPY_SAFETENSORS_SMOKE_QUANTIZATION="$quantization" \
+              SKIPPY_SAFETENSORS_SMOKE_IMATRIX=synthetic \
+              cargo test --locked -p mesh-llm-host-runtime --no-default-features \
+                safetensors_checkpoint_reaches_mesh_host_runtime -- \
+                --ignored --nocapture
+            echo "::endgroup::"
+          done
+      - name: Capture SafeTensors smoke cache evidence
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/capture-sccache-stats
+        with:
+          artifact_name: sccache-safetensors-runtime-smoke-${{ github.run_attempt }}
+          cache_expectation: opportunistic

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -263,10 +263,9 @@ runtime producers are not duplicated.
   toolchain epoch. Batches that exercise Skippy correctness tests restore an
   exact revision- and SHA-256-pinned model cache, verify the file before use,
   and leave publication to one trusted-main batch. Related Skippy crate changes
-  on pull requests also run immutable SmolLM2, Qwen2 and Qwen3 revisions through
-  the complete Mesh config/resolver/server/native SafeTensors path through
-  tokenizer, sampled prefill, and decode, including one load-time quantization
-  arm.
+  on pull requests also run an immutable SmolLM2 revision through the complete
+  Mesh config/resolver/server/native SafeTensors path through tokenizer, sampled
+  prefill, and decode with every supported load-time quantization.
 - `ci-{linux,macos,windows}-host-slice.yml` — one platform-pure neutral host
   producer consuming that lane's immutable UI distribution.
 - `ci-{linux,macos,windows}-runtime-slice.yml` — platform-pure native runtime

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -262,7 +262,11 @@ runtime producers are not duplicated.
   test batches consuming the static ABI artifact and its producer-owned
   toolchain epoch. Batches that exercise Skippy correctness tests restore an
   exact revision- and SHA-256-pinned model cache, verify the file before use,
-  and leave publication to one trusted-main batch.
+  and leave publication to one trusted-main batch. Related Skippy crate changes
+  on pull requests also run immutable SmolLM2, Qwen2 and Qwen3 revisions through
+  the complete Mesh config/resolver/server/native SafeTensors path through
+  tokenizer, sampled prefill, and decode, including one load-time quantization
+  arm.
 - `ci-{linux,macos,windows}-host-slice.yml` — one platform-pure neutral host
   producer consuming that lane's immutable UI distribution.
 - `ci-{linux,macos,windows}-runtime-slice.yml` — platform-pure native runtime

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -2742,7 +2742,11 @@ class CiArtifactActionTests(unittest.TestCase):
             "ci-ui-artifact-slice.yml": {"runner_policy", "ui_artifact"},
             "ci-linux-host-slice.yml": {"runner_policy", "linux_host"},
             "ci-linux-runtime-slice.yml": {"runner_policy", "linux_runtime"},
-            "ci-rust-tests-slice.yml": {"runner_policy", "rust_tests"},
+            "ci-rust-tests-slice.yml": {
+                "runner_policy",
+                "rust_tests",
+                "safetensors_runtime_smoke",
+            },
             "ci-macos-host-slice.yml": {"runner_policy", "macos_host"},
             "ci-platform-checks-slice.yml": {"runner_policy", "platform_checks"},
             "ci-windows-host-slice.yml": {"runner_policy", "windows_host"},

--- a/scripts/tests/test_depot_canary_workflow.py
+++ b/scripts/tests/test_depot_canary_workflow.py
@@ -445,7 +445,7 @@ class DepotCanaryWorkflowTests(unittest.TestCase):
                     self.assertIn("depot_selected:", block)
                     self.assertIn("startsWith(", block)
                     self.assertIn("needs.runner_policy.outputs.", block)
-        self.assertEqual(audit_calls, 23)
+        self.assertEqual(audit_calls, 24)
 
     def test_endpoint_and_docker_auth_probes_fail_closed(self) -> None:
         action = (

--- a/scripts/tests/test_sccache_evidence.py
+++ b/scripts/tests/test_sccache_evidence.py
@@ -95,6 +95,7 @@ class SccacheEvidenceTests(unittest.TestCase):
             ("ci-linux-runtime-slice.yml", "linux_runtime"): policy,
             ("ci-quality-slice.yml", "rust_clippy"): policy,
             ("ci-rust-tests-slice.yml", "rust_tests"): policy,
+            ("ci-rust-tests-slice.yml", "safetensors_runtime_smoke"): policy,
             ("ci-windows-host-slice.yml", "windows_host"): policy,
             ("ci-windows-runtime-slice.yml", "windows_runtime"): policy,
             ("cache-warm-sccache.yml", "warm"): "false",


### PR DESCRIPTION
## Summary

- add the protected `SafeTensors runtime smoke` job to the Rust-test slice
- run one immutable SmolLM2 checkpoint through the full Mesh resolver/server/native path for affected PRs
- exercise all 36 current direct-load quantization recipes on that fixture and update runner/cache policy fixtures plus CI documentation

This is the protected-workflow prerequisite for #1619. Once merged, #1619 can rebase and its exact head will execute this job through the default-branch Linux lane.

## Validation

- `just ci-validate` (750 passed, 7 skipped)
- focused runner/cache policy tests (80 passed)
- `actionlint` and `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added automated SafeTensors runtime smoke testing for an immutable SmolLM2 checkpoint.
  - Validates model loading, tokenization, prefill, decoding, and all supported load-time quantization paths.

- **Documentation**
  - Updated CI documentation and inventory details to reflect SmolLM2-focused validation and quantization coverage.

- **Tests**
  - Extended CI policy and workflow validation to include the runtime smoke test job and its caching requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->