### PR TITLE
fix(skippy): restore resident KV suffix locality

### DIFF
--- a/crates/skippy-server/src/frontend/backend.rs
+++ b/crates/skippy-server/src/frontend/backend.rs
@@ -1390,7 +1390,7 @@ impl StageOpenAiBackend {
 
         match dispatch(request).await {
             Ok(stream) => Ok(match guard {
-                Some(guard) => TerminalGuardedChatStream::new(stream, guard),
+                Some(guard) => TerminalGuardedChatStream::pinned(stream, guard),
                 None => stream,
             }),
             Err(error) => {

--- a/crates/skippy-server/src/frontend/local_generation/token_generation.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation.rs
@@ -335,14 +335,13 @@ fn deferred_suffix_prefill_enabled(
     payload: Option<StagePrefixCachePayload>,
     max_tokens: u32,
 ) -> bool {
+    // Resident KV suffixes must remain in the serialized cache operation. Releasing
+    // it between restore and suffix prefill lets another request interleave and
+    // destroys prefill phase locality on a shared accelerator.
     max_tokens > 0
         && matches!(
             payload,
-            Some(
-                StagePrefixCachePayload::ResidentKv
-                    | StagePrefixCachePayload::KvRecurrent
-                    | StagePrefixCachePayload::FullState
-            )
+            Some(StagePrefixCachePayload::KvRecurrent | StagePrefixCachePayload::FullState)
         )
 }
 
@@ -1663,11 +1662,16 @@ fn default_local_text_serving_selects_iteration_scheduler() {
 
 #[cfg(test)]
 #[test]
-fn deferred_suffix_prefill_requires_a_nonzero_generation_budget() {
-    assert!(deferred_suffix_prefill_enabled(
+fn resident_kv_suffix_prefill_stays_inside_the_cache_operation() {
+    assert!(!deferred_suffix_prefill_enabled(
         Some(StagePrefixCachePayload::ResidentKv),
         1,
     ));
+}
+
+#[cfg(test)]
+#[test]
+fn recurrent_suffix_prefill_requires_a_nonzero_generation_budget() {
     assert!(deferred_suffix_prefill_enabled(
         Some(StagePrefixCachePayload::KvRecurrent),
         1,
@@ -1677,7 +1681,7 @@ fn deferred_suffix_prefill_requires_a_nonzero_generation_budget() {
         1,
     ));
     assert!(!deferred_suffix_prefill_enabled(
-        Some(StagePrefixCachePayload::ResidentKv),
+        Some(StagePrefixCachePayload::KvRecurrent),
         0,
     ));
     assert!(!deferred_suffix_prefill_enabled(None, 1));


### PR DESCRIPTION
## Original problem

PR #1478 moved resident-KV prompt-suffix prefill outside the serialized cache restore operation. At concurrent admission, another request could interleave between prefix restore and suffix prefill, destroying prefill phase locality on a shared Metal accelerator.

The same current-main snapshot also called `TerminalGuardedChatStream::new` even though the merged API exposes `TerminalGuardedChatStream::pinned`, preventing skippy-server from compiling.

## Diagnostics

### C2 power-gated ABA

| Metric | Before (current) | After (serialized suffix) | Delta |
|---|---:|---:|---:|
| Workload window | 108.19 s | **97.37 s** | **-9.99%** |
| System output | 6.405 tok/s | **7.117 tok/s** | **+11.12%** |
| TTFT p50 | 17.32 s | **12.59 s** | **-27.31%** |
| Mean in flight | 1.894 | **1.989** | +5.02% |
| Correct requests | 8/8 | 8/8 | equal |

The bracketing current-code repeat completed in 108.54 s, making the full sequence **108.19 → 97.37 → 108.54 s** with 24/24 requests correct. The candidate beat the two controls by 9.99–10.30% in workload time and 11.1–11.5% in goodput; control spread was 0.32%.

### C8 controlled guardrail

Both arms used the same 131,072-token KV pool, 8 execution lanes, `n_batch=2048`, and `n_ubatch=128`.

| Metric | Before (current) | After (serialized suffix) | Delta |
|---|---:|---:|---:|
| Workload window | 113.57 s | **100.11 s** | **-11.85%** |
| System output | 6.102 tok/s | **6.922 tok/s** | **+13.44%** |
| TTFT p50 | 94.39 s | **87.18 s** | **-7.63%** |
| TTFT p95 | 108.16 s | **94.12 s** | **-12.98%** |
| Mean in flight | 7.79 | 7.83 | equal |
| Correct requests | 8/8 | 8/8 | equal |

GPU frequency remained pinned near 1380 MHz and neither arm entered a power-limit zone. Separate default-C8 capacity, lane-planning, and batch-width mismatches were exposed during the guardrail run; they are not part of this regression fix.

## Fix

- Keep resident-KV suffix prefill inside the same cache-aware serialized operation as prefix restore.
- Preserve the deferred suffix path for recurrent and full-state payloads.
- Add a unit-test contract that resident-KV suffix prefill cannot re-enter the deferred path.
- Use the existing pinned guarded-stream constructor so the current base compiles.

No protocol, configuration, or migration changes are required.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo test -p skippy-server --lib` (666 passed, 3 ignored)
- [x] `cargo check -p skippy-server`
- [x] `cargo clippy -p skippy-server --all-targets -- -D warnings`
- [x] `cargo check -p mesh-llm`
- [x] `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- [x] No UI changes; visual evidence does not apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved chat completion streaming when mesh integrations are active, providing more reliable terminal output behavior.
  - Corrected deferred processing during local text generation to ensure resident KV state is handled consistently.
  - Fixed recurrent-generation handling when no generation budget is available, improving stability and preventing unexpected processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
