### PR TITLE
fix(split): don't build the native MTP graph on a split stage

### DIFF
--- a/crates/mesh-llm-host-runtime/src/runtime/local_split/loading.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local_split/loading.rs
@@ -627,6 +627,23 @@ pub(super) fn stage_source_prepare_timeout(
         .max(MIN_STAGE_SOURCE_PREPARE_TIMEOUT))
 }
 
+/// Whether a stage holds every tensor the native MTP draft graph reads.
+///
+/// The MTP block is the trailing `nextn` block, so it materializes only on the
+/// final stage (`downstream` is `None`). Its graph also reads the token
+/// embedding matrix, and `include_embeddings` is `layer_start == 0`
+/// (`mesh/stage_artifacts.rs`, `mesh/stage_transport.rs`, and the artifact
+/// selection below). When the `nextn` block carries no `embed_tokens` of its
+/// own, the arch graph falls back to `model.tok_embd`; on a stage that starts
+/// past layer 0 that tensor is absent and the fallback is unguarded, so the
+/// graph build dereferences null.
+///
+/// Both conditions therefore hold only when one stage owns the whole layer
+/// range. Any real multi-stage split must run with native MTP off.
+fn stage_can_build_native_mtp_graph(layer_start: u32, downstream_present: bool) -> bool {
+    layer_start == 0 && !downstream_present
+}
+
 pub(super) fn split_runtime_stage_load_request(
     spec: &SplitGenerationLoadSpec<'_>,
     settings: &SplitGenerationLoadSettings<'_>,
@@ -635,6 +652,7 @@ pub(super) fn split_runtime_stage_load_request(
     stage0_return_endpoint: &str,
 ) -> skippy::StageLoadRequest {
     let resolved_config = &settings.runtime_options.config;
+    let downstream_present = downstream.is_some();
     let upstream = if downstream.is_none() {
         split_runtime_stage_upstream(spec, stage0_return_endpoint)
     } else {
@@ -698,7 +716,8 @@ pub(super) fn split_runtime_stage_load_request(
             swa_full: resolved_config.swa_full,
             cache_idle_slots: resolved_config.cache_idle_slots,
         },
-        native_mtp_enabled: resolved_config.native_mtp_enabled,
+        native_mtp_enabled: resolved_config.native_mtp_enabled
+            && stage_can_build_native_mtp_graph(stage.layer_start, downstream_present),
         shutdown_generation: spec.generation.generation,
         coordinator_term: spec.generation.coordinator_term,
         coordinator_id: Some(spec.node.id()),
@@ -1219,6 +1238,23 @@ pub(super) fn split_stage_topology_instance(
                 },
             })
             .collect(),
+    }
+}
+
+#[cfg(test)]
+mod native_mtp_stage_tests {
+    use super::stage_can_build_native_mtp_graph;
+
+    #[test]
+    fn only_a_single_stage_owning_the_whole_range_can_build_the_mtp_graph() {
+        // Sole stage: holds the embeddings and the trailing nextn block.
+        assert!(stage_can_build_native_mtp_graph(0, false));
+        // Stage 0 of a split: has embeddings, but the nextn block is downstream.
+        assert!(!stage_can_build_native_mtp_graph(0, true));
+        // Final stage of a split: has the nextn block, but no embeddings.
+        assert!(!stage_can_build_native_mtp_graph(20, false));
+        // Middle stage: neither.
+        assert!(!stage_can_build_native_mtp_graph(20, true));
     }
 }
 

--- a/crates/mesh-llm-host-runtime/src/runtime/local_split/tests/content_attestation.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local_split/tests/content_attestation.rs
@@ -67,6 +67,11 @@ struct StrictMultimodalStageLoads {
     projector_path: PathBuf,
     stage0: skippy::StageLoadRequest,
     worker: skippy::StageLoadRequest,
+    /// Same two stages, rebuilt with the resolver's native-MTP answer forced
+    /// on, so a test can assert the stage-shape gate rather than whichever
+    /// default the fixture's resolved config happens to carry.
+    stage0_mtp_forced: skippy::StageLoadRequest,
+    worker_mtp_forced: skippy::StageLoadRequest,
 }
 
 fn strict_multimodal_config(model_path: &Path, projector_path: &Path) -> plugin::MeshConfig {
@@ -170,7 +175,7 @@ async fn strict_multimodal_stage_loads() -> StrictMultimodalStageLoads {
         &spec,
         &settings,
         &generation.stages[0],
-        Some(downstream),
+        Some(downstream.clone()),
         "127.0.0.1:41000",
     );
     let worker = split_runtime_stage_load_request(
@@ -181,10 +186,29 @@ async fn strict_multimodal_stage_loads() -> StrictMultimodalStageLoads {
         "127.0.0.1:41000",
     );
 
+    let mut mtp_settings = settings;
+    mtp_settings.runtime_options.config.native_mtp_enabled = true;
+    let stage0_mtp_forced = split_runtime_stage_load_request(
+        &spec,
+        &mtp_settings,
+        &generation.stages[0],
+        Some(downstream),
+        "127.0.0.1:41000",
+    );
+    let worker_mtp_forced = split_runtime_stage_load_request(
+        &spec,
+        &mtp_settings,
+        downstream_stage,
+        None,
+        "127.0.0.1:41000",
+    );
+
     StrictMultimodalStageLoads {
         projector_path,
         stage0,
         worker,
+        stage0_mtp_forced,
+        worker_mtp_forced,
     }
 }
 
@@ -201,6 +225,26 @@ async fn strict_multimodal_stage_builder_keeps_local_paths_off_downstream_loads(
     assert!(loads.worker.local_source_required);
     assert!(loads.worker.model_path.is_none());
     assert!(loads.worker.projector_path.is_none());
+}
+
+/// A multi-stage split must never ask a stage to build the native MTP draft
+/// graph. Stage 0 holds the token embeddings but not the trailing `nextn`
+/// block; the final stage holds the `nextn` block but starts past layer 0, so
+/// it has no `model.tok_embd`. The arch graph's embedding fallback is
+/// unguarded, so building it on such a stage dereferences null and the process
+/// dies with SIGSEGV during graph reserve, before serving.
+#[tokio::test]
+async fn multi_stage_split_disables_native_mtp_even_when_the_resolver_enables_it() {
+    let loads = strict_multimodal_stage_loads().await;
+
+    assert!(
+        !loads.stage0_mtp_forced.native_mtp_enabled,
+        "stage 0 of a split has no nextn block"
+    );
+    assert!(
+        !loads.worker_mtp_forced.native_mtp_enabled,
+        "a stage starting past layer 0 has no token embeddings"
+    );
 }
 
 #[test]


### PR DESCRIPTION
27B split serving SIGSEGVs on the final stage during model load.

`qwen35.cpp:541` falls back to `model.tok_embd` when the nextn block has no `embed_tokens`, with no null check. Stage artifacts only include the embeddings when `layer_start == 0`, so a stage starting past layer 0 passes NULL to `ggml_get_rows`, which faults reading `a->ne[2]` — matching the crash report address `0x20`.

Verified against the real GGUF header of `Qwen3.8-27B-UD-Q4_K_M`: `block_count=65`, `nextn_predict_layers=1`, nextn block ships `eh_proj/enorm/hnorm/shared_head_norm` and no `embed_tokens` — so the fallback is always taken. In a two-stage split no stage satisfies both conditions (stage 0 has embeddings but no nextn block; final stage has nextn but doesn't start at 0).

Fix gates native MTP on a stage owning the whole layer range. Single-node serving unchanged.

## Validation
- 2917 host-runtime lib tests pass; clippy `-D warnings` clean on `mesh-llm-host-runtime` and `mesh-llm`; `cargo fmt --all --check` clean.
- Regression test confirmed to FAIL without the fix (first version of it did not — it asserted nothing because the fixture resolver had MTP off; rewritten to force the resolver to `true`).
- On hardware: rebuilt and redeployed M5+M4, reran the exact command that crashed twice. M4 no longer crashes; no new crash report.

## Not proved
No end-to-end 27B split token yet — both post-fix attempts hit a separate peer stage-generation eligibility blocker. That is a distinct bug, still being chased. The crash fix stands on the load-survival evidence above.

Same unguarded fallback pattern exists in 9 other archs (deepseek2/4, glm4-moe, hy-v3, cohere2moe...) — untested here, not changed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of native MTP in staged model execution.
  - Native MTP is now used only when a single stage owns the complete layer range.
  - Multi-stage configurations consistently disable native MTP, including when it is globally enabled.
  - Prevents invalid graph construction for split-stage deployments.
  - Added coverage for both single-stage and multi-stage configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->