### PR TITLE
fix(skippy): restore builds and SafeTensors inference

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -155,7 +155,7 @@ removable after this branch's runner contract is active on protected main.
 | `ci-web-slice.yml` | Console quality, console Playwright E2E, public website build, and CLI explorer browser validation |
 | `ci-ui-artifact-slice.yml` | Immutable console distribution producer |
 | `static-abi-artifact.yml` | Typed static llama ABI producer with internal runner policy and an exact toolchain-epoch output |
-| `ci-rust-tests-slice.yml` | Typed deterministic Cargo test batches that verify the producer-owned static ABI toolchain epoch and a pinned, digest-verified Skippy correctness fixture; related PR changes additionally smoke an immutable SmolLM2 SafeTensors checkpoint through the complete Mesh config/resolver/server/native path to sampled prefill and decode with every supported load-time quantization |
+| `ci-rust-tests-slice.yml` | Typed deterministic Cargo test batches that verify the producer-owned static ABI toolchain epoch and a pinned, digest-verified Skippy correctness fixture; related PR changes additionally compile one asserted, fully qualified runtime test and smoke an immutable SmolLM2 SafeTensors checkpoint through the complete Mesh config/resolver/server/native path to sampled prefill and decode with every supported load-time quantization |
 | `ci-{linux,macos,windows}-host-slice.yml` | Platform-pure neutral host producers; no empty cross-platform jobs |
 | `ci-{linux,macos,windows}-runtime-slice.yml` | Platform-pure native runtime producers |
 | `ci-{linux,macos,windows}-product-slice.yml` | Platform-pure composition-only product consumers |

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -212,6 +212,7 @@ jobs:
     env:
       LLAMA_STAGE_BACKEND: cpu
       LLAMA_STAGE_BUILD_DIR: .deps/llama.cpp/build-stage-abi-static
+      MESH_LLM_SKIP_UI: "1"
       MESH_LLM_REQUIRE_SCCACHE: "1"
       RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
       RUSTC_WRAPPER: sccache
@@ -240,6 +241,11 @@ jobs:
         uses: ./.github/actions/resolve-native-toolchain-epoch
         with:
           pinned_epoch: ${{ inputs.static_abi_toolchain_epoch }}
+      - id: sccache_seed
+        uses: ./.github/actions/restore-sccache-seed
+        with:
+          allow_trusted_seed: ${{ needs.runner_policy.outputs.allow_trusted_sccache_seed }}
+          cache_key: mesh-llm-sccache-seed-linux-x86_64-img-8d93de6b-epoch-8d93de6b-v2-${{ hashFiles('Cargo.lock', '.github/cache-version.txt', 'Justfile', 'just/**') }}
       - uses: ./.github/actions/configure-sccache-gha
         with:
           allow_depot_remote_cache: ${{ needs.runner_policy.outputs.allow_depot_remote_cache }}
@@ -253,6 +259,8 @@ jobs:
           path: ${{ runner.temp }}/static-abi-input
       - name: Restore immutable static ABI input
         run: scripts/restore-static-abi-input.sh "$RUNNER_TEMP/static-abi-input" "$LLAMA_STAGE_BUILD_DIR" x86_64-unknown-linux-gnu cpu
+      - name: Prepare UI placeholder
+        run: mkdir -p crates/mesh-llm-ui/dist && printf '<html></html>' > crates/mesh-llm-ui/dist/index.html
       - name: Download pinned SafeTensors checkpoint
         run: |
           set -euo pipefail
@@ -261,7 +269,37 @@ jobs:
             config.json tokenizer.json tokenizer_config.json model.safetensors \
             --revision "$SAFETENSORS_REVISION" \
             --local-dir "$fixture_dir"
+      - name: Build and locate the SafeTensors smoke test
+        id: safetensors_smoke_test
+        run: |
+          set -euo pipefail
+          test_name="inference::skippy::resolver::tests::safetensors_checkpoint_reaches_mesh_host_runtime"
+          test_binary="$(
+            cargo test --locked -p mesh-llm-host-runtime --no-default-features \
+              --lib --no-run --message-format=json |
+              jq -r 'select(
+                .reason == "compiler-artifact" and
+                .target.name == "mesh_llm_host_runtime" and
+                .profile.test == true and
+                .executable != null
+              ) | .executable' |
+              tail -n 1
+          )"
+          if [[ -z "$test_binary" || ! -x "$test_binary" ]]; then
+            echo "Unable to locate the mesh-llm-host-runtime library test binary" >&2
+            exit 1
+          fi
+          test_listing="$("$test_binary" --list --ignored --format terse)"
+          if ! grep -Fqx "$test_name: test" <<<"$test_listing"; then
+            echo "Required ignored smoke test is absent: $test_name" >&2
+            exit 1
+          fi
+          printf 'test_binary=%s\n' "$test_binary" >> "$GITHUB_OUTPUT"
+          printf 'test_name=%s\n' "$test_name" >> "$GITHUB_OUTPUT"
       - name: Exercise every current direct-load quantization
+        env:
+          SAFETENSORS_SMOKE_TEST_BINARY: ${{ steps.safetensors_smoke_test.outputs.test_binary }}
+          SAFETENSORS_SMOKE_TEST_NAME: ${{ steps.safetensors_smoke_test.outputs.test_name }}
         run: |
           set -euo pipefail
           fixture_dir="$RUNNER_TEMP/safetensors-smollm2"
@@ -270,9 +308,8 @@ jobs:
             SKIPPY_SAFETENSORS_SMOKE_DIR="$fixture_dir" \
               SKIPPY_SAFETENSORS_SMOKE_QUANTIZATION="$quantization" \
               SKIPPY_SAFETENSORS_SMOKE_IMATRIX=synthetic \
-              cargo test --locked -p mesh-llm-host-runtime --no-default-features \
-                safetensors_checkpoint_reaches_mesh_host_runtime -- \
-                --ignored --nocapture
+              "$SAFETENSORS_SMOKE_TEST_BINARY" \
+                "$SAFETENSORS_SMOKE_TEST_NAME" --exact --ignored --nocapture
             echo "::endgroup::"
           done
       - name: Capture SafeTensors smoke cache evidence
@@ -280,4 +317,4 @@ jobs:
         uses: ./.github/actions/capture-sccache-stats
         with:
           artifact_name: sccache-safetensors-runtime-smoke-${{ github.run_attempt }}
-          cache_expectation: opportunistic
+          cache_expectation: ${{ steps.sccache_seed.outputs.cache_hit == 'true' && 'warm' || 'cold' }}

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -269,9 +269,11 @@ runtime producers are not duplicated.
   toolchain epoch. Batches that exercise Skippy correctness tests restore an
   exact revision- and SHA-256-pinned model cache, verify the file before use,
   and leave publication to one trusted-main batch. Related Skippy crate changes
-  on pull requests also run an immutable SmolLM2 revision through the complete
-  Mesh config/resolver/server/native SafeTensors path through tokenizer, sampled
-  prefill, and decode with every supported load-time quantization.
+  on pull requests also compile one fully qualified runtime test, fail if that
+  test is absent, then run its binary against an immutable SmolLM2 revision
+  through the complete Mesh config/resolver/server/native SafeTensors path
+  through tokenizer, sampled prefill, and decode with every supported load-time
+  quantization.
 - `ci-{linux,macos,windows}-host-slice.yml` — one platform-pure neutral host
   producer consuming that lane's immutable UI distribution.
 - `ci-{linux,macos,windows}-runtime-slice.yml` — platform-pure native runtime

--- a/crates/mesh-llm-ui/build.rs
+++ b/crates/mesh-llm-ui/build.rs
@@ -2,7 +2,10 @@ use std::fs;
 use std::path::Path;
 
 fn main() {
-    println!("cargo:rerun-if-changed=dist");
+    // Keep Cargo's default package change detection. Watching `dist`
+    // explicitly makes a missing directory look changed on every invocation,
+    // so test loops rebuild this crate and every dependent crate indefinitely.
+    // The default still notices when `dist` appears or its contents change.
     configure_console_dist();
 }
 

--- a/crates/skippy-model/src/float_convert.rs
+++ b/crates/skippy-model/src/float_convert.rs
@@ -54,16 +54,11 @@ pub(crate) fn target_dtype_for_tensor(
     output_type: Option<ConvertOutputType>,
     shape: &[u64],
 ) -> Result<FloatDType> {
-    if shape.len() <= 1
-        && (matches!(source_dtype, FloatDType::F16 | FloatDType::Bf16)
-            || matches!(
-                output_type,
-                Some(ConvertOutputType::F16 | ConvertOutputType::Bf16)
-            ))
-    {
+    let target_dtype = target_dtype_for(source_dtype, output_type)?;
+    if shape.len() <= 1 && matches!(target_dtype, FloatDType::F16 | FloatDType::Bf16) {
         return Ok(FloatDType::F32);
     }
-    target_dtype_for(source_dtype, output_type)
+    Ok(target_dtype)
 }
 
 pub(crate) fn convert_float_chunk<W: Write>(
@@ -227,6 +222,9 @@ mod tests {
         assert_eq!(
             target_dtype_for_tensor(FloatDType::Bf16, None, &[8, 8]).unwrap(),
             FloatDType::Bf16
+        );
+        assert!(
+            target_dtype_for_tensor(FloatDType::Bf16, Some(ConvertOutputType::Auto), &[8]).is_err()
         );
     }
 }

--- a/crates/skippy-model/src/float_convert.rs
+++ b/crates/skippy-model/src/float_convert.rs
@@ -55,10 +55,11 @@ pub(crate) fn target_dtype_for_tensor(
     shape: &[u64],
 ) -> Result<FloatDType> {
     if shape.len() <= 1
-        && matches!(
-            output_type,
-            Some(ConvertOutputType::F16 | ConvertOutputType::Bf16)
-        )
+        && (matches!(source_dtype, FloatDType::F16 | FloatDType::Bf16)
+            || matches!(
+                output_type,
+                Some(ConvertOutputType::F16 | ConvertOutputType::Bf16)
+            ))
     {
         return Ok(FloatDType::F32);
     }
@@ -201,7 +202,15 @@ mod tests {
     }
 
     #[test]
-    fn target_dtype_keeps_rank_one_tensors_f32_for_float16_outputs() {
+    fn target_dtype_keeps_rank_one_half_precision_tensors_f32() {
+        assert_eq!(
+            target_dtype_for_tensor(FloatDType::Bf16, None, &[8]).unwrap(),
+            FloatDType::F32
+        );
+        assert_eq!(
+            target_dtype_for_tensor(FloatDType::F16, None, &[8]).unwrap(),
+            FloatDType::F32
+        );
         assert_eq!(
             target_dtype_for_tensor(FloatDType::Bf16, Some(ConvertOutputType::Bf16), &[8]).unwrap(),
             FloatDType::F32
@@ -213,6 +222,10 @@ mod tests {
         assert_eq!(
             target_dtype_for_tensor(FloatDType::Bf16, Some(ConvertOutputType::Bf16), &[8, 8])
                 .unwrap(),
+            FloatDType::Bf16
+        );
+        assert_eq!(
+            target_dtype_for_tensor(FloatDType::Bf16, None, &[8, 8]).unwrap(),
             FloatDType::Bf16
         );
     }

--- a/crates/skippy-model/src/gguf_writer.rs
+++ b/crates/skippy-model/src/gguf_writer.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 
 use crate::ConvertOutputType;
 use crate::float_convert::{
-    FloatDType, convert_float_chunk, read_float_element, target_dtype_for, target_dtype_for_tensor,
+    FloatDType, convert_float_chunk, read_float_element, target_dtype_for_tensor,
     write_float_element,
 };
 pub use crate::gguf_metadata::GgufKv;
@@ -1067,10 +1067,14 @@ impl ExpertGroup {
         let source_dtype = FloatDType::from_safetensor(tensor.dtype()).with_context(|| {
             format!("unsupported dtype {} for {}", tensor.dtype(), tensor.name())
         })?;
-        // Individual expert shards are merged into a rank-2-or-higher GGUF
-        // tensor below, so they must retain matrix precision even when a tiny
-        // fixture represents each expert with a rank-one source shape.
-        let target_dtype = target_dtype_for(source_dtype, output_type)?;
+        // The expert dimension is appended when the group becomes a GGUF
+        // tensor. Choose precision from that merged shape so rank-one source
+        // shards retain matrix precision while scalar shards become F32
+        // rank-one runtime operands.
+        let mut merged_shape = Vec::with_capacity(tensor.shape().len() + 1);
+        merged_shape.push(1);
+        merged_shape.extend_from_slice(tensor.shape());
+        let target_dtype = target_dtype_for_tensor(source_dtype, output_type, &merged_shape)?;
         let element_count = tensor_element_count(tensor)?;
         Ok(Self {
             key,

--- a/crates/skippy-model/src/gguf_writer.rs
+++ b/crates/skippy-model/src/gguf_writer.rs
@@ -11,7 +11,7 @@ use serde_json::Value;
 
 use crate::ConvertOutputType;
 use crate::float_convert::{
-    FloatDType, convert_float_chunk, read_float_element, target_dtype_for_tensor,
+    FloatDType, convert_float_chunk, read_float_element, target_dtype_for, target_dtype_for_tensor,
     write_float_element,
 };
 pub use crate::gguf_metadata::GgufKv;
@@ -1067,7 +1067,10 @@ impl ExpertGroup {
         let source_dtype = FloatDType::from_safetensor(tensor.dtype()).with_context(|| {
             format!("unsupported dtype {} for {}", tensor.dtype(), tensor.name())
         })?;
-        let target_dtype = target_dtype_for_tensor(source_dtype, output_type, tensor.shape())?;
+        // Individual expert shards are merged into a rank-2-or-higher GGUF
+        // tensor below, so they must retain matrix precision even when a tiny
+        // fixture represents each expert with a rank-one source shape.
+        let target_dtype = target_dtype_for(source_dtype, output_type)?;
         let element_count = tensor_element_count(tensor)?;
         Ok(Self {
             key,

--- a/crates/skippy-model/src/gguf_writer_tests/conversion.rs
+++ b/crates/skippy-model/src/gguf_writer_tests/conversion.rs
@@ -6,7 +6,7 @@ fn writes_raw_gguf_from_safetensors_with_streamed_payloads() {
     write_safetensor(
         &root.join("model.safetensors"),
         &[
-            ("b.weight", "BF16", &[2], &[9, 8, 7, 6]),
+            ("b.weight", "BF16", &[1, 2], &[9, 8, 7, 6]),
             ("a.weight", "F32", &[1], &[1, 2, 3, 4]),
         ],
     );

--- a/crates/skippy-model/src/gguf_writer_tests/layout.rs
+++ b/crates/skippy-model/src/gguf_writer_tests/layout.rs
@@ -49,6 +49,57 @@ fn streams_expert_tensors_as_merged_gguf_tensor() {
 }
 
 #[test]
+fn promotes_half_precision_scalar_expert_groups_to_f32() {
+    let root = unique_temp_dir();
+    fs::create_dir_all(&root).unwrap();
+    write_safetensor(
+        &root.join("model.safetensors"),
+        &[
+            (
+                "model.layers.1.mlp.experts.1.gate_proj.weight",
+                "BF16",
+                &[],
+                &[0x00, 0x40],
+            ),
+            (
+                "model.layers.1.mlp.experts.0.gate_proj.weight",
+                "BF16",
+                &[],
+                &[0x80, 0x3f],
+            ),
+        ],
+    );
+    let output = root.join("scalar-experts.gguf");
+
+    write_raw_safetensors_gguf(
+        &root,
+        &output,
+        RawGgufWriteOptions {
+            buffer_size: 3,
+            metadata: None,
+            tensor_name_map: TensorNameMap::HfToGguf,
+            split: None,
+            output_type: None,
+            tensor_selection: TensorSelection::All,
+        },
+    )
+    .unwrap();
+
+    let bytes = fs::read(&output).unwrap();
+    let parsed = parse_test_gguf(&bytes);
+    let merged_experts = parsed.tensor("blk.1.ffn_gate_exps.weight");
+    assert_eq!(merged_experts.dims, vec![2]);
+    assert_eq!(merged_experts.ggml_type, GGML_TYPE_F32);
+    assert_f32_tensor(
+        &bytes,
+        &parsed,
+        "blk.1.ffn_gate_exps.weight",
+        &[1.0, 2.0],
+    );
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn writes_only_selected_split_with_split_metadata() {
     let root = unique_temp_dir();
     fs::create_dir_all(&root).unwrap();

--- a/crates/skippy-model/src/gguf_writer_tests/validation.rs
+++ b/crates/skippy-model/src/gguf_writer_tests/validation.rs
@@ -90,6 +90,34 @@ fn direct_checkpoint_preserves_mixed_float_precisions() {
 }
 
 #[test]
+fn direct_checkpoint_promotes_half_precision_rank_one_tensors_to_f32() {
+    let root = unique_temp_dir();
+    fs::create_dir_all(&root).unwrap();
+    write_qwen_config_and_tokenizer(&root);
+    let bf16_bits = [0x3f80_u16, 0x4000_u16];
+    let bf16_bytes = bf16_bits
+        .iter()
+        .flat_map(|value| value.to_le_bytes())
+        .collect::<Vec<_>>();
+    write_safetensor(
+        &root.join("model.safetensors"),
+        &[("model.norm.weight", "BF16", &[2], &bf16_bytes)],
+    );
+
+    let checkpoint = DirectCheckpoint::open(&root, 4).unwrap();
+    let parsed = parse_test_gguf(checkpoint.metadata_gguf());
+    let output_norm = parsed.tensor("output_norm.weight");
+    let mut decoded = [0.0_f32; 2];
+    checkpoint
+        .read_tensor_f32("output_norm.weight", &mut decoded)
+        .unwrap();
+
+    assert_eq!(output_norm.ggml_type, GGML_TYPE_F32);
+    assert_eq!(decoded, [1.0, 2.0]);
+    fs::remove_dir_all(root).unwrap();
+}
+
+#[test]
 fn validates_qwen_dense_native_conversion_fixture() {
     let root = unique_temp_dir();
     fs::create_dir_all(&root).unwrap();

--- a/crates/skippy-server/src/frontend/backend.rs
+++ b/crates/skippy-server/src/frontend/backend.rs
@@ -1390,7 +1390,7 @@ impl StageOpenAiBackend {
 
         match dispatch(request).await {
             Ok(stream) => Ok(match guard {
-                Some(guard) => TerminalGuardedChatStream::new(stream, guard),
+                Some(guard) => TerminalGuardedChatStream::pinned(stream, guard),
                 None => stream,
             }),
             Err(error) => {

--- a/scripts/tests/test_build_ui.py
+++ b/scripts/tests/test_build_ui.py
@@ -67,6 +67,12 @@ class SemverRangeTests(unittest.TestCase):
 
 
 class BuildUiScriptTests(unittest.TestCase):
+    def test_rust_build_script_does_not_watch_a_missing_dist_directory(self) -> None:
+        build_script = (UI_DIR / "build.rs").read_text(encoding="utf-8")
+
+        self.assertNotIn('cargo:rerun-if-changed=dist', build_script)
+        self.assertIn("Cargo's default package change detection", build_script)
+
     def test_ui_pnpm_workspace_names_root_package(self) -> None:
         workspace = ROOT / "crates" / "mesh-llm-ui" / "pnpm-workspace.yaml"
 

--- a/scripts/tests/test_ci_workflow_artifacts.py
+++ b/scripts/tests/test_ci_workflow_artifacts.py
@@ -111,6 +111,25 @@ class CiWorkflowArtifactTests(unittest.TestCase):
             consumer,
         )
 
+    def test_safetensors_runtime_smoke_is_fail_closed_and_compiles_once(self):
+        workflow = (WORKFLOWS / "ci-rust-tests-slice.yml").read_text()
+        smoke = workflow[workflow.index("  safetensors_runtime_smoke:"):]
+        test_name = (
+            "inference::skippy::resolver::tests::"
+            "safetensors_checkpoint_reaches_mesh_host_runtime"
+        )
+
+        self.assertIn('MESH_LLM_SKIP_UI: "1"', smoke)
+        self.assertIn("uses: ./.github/actions/restore-sccache-seed", smoke)
+        self.assertEqual(smoke.count("cargo test --locked"), 1)
+        self.assertIn("--lib --no-run --message-format=json", smoke)
+        self.assertIn(f'test_name="{test_name}"', smoke)
+        self.assertIn('grep -Fqx "$test_name: test"', smoke)
+        self.assertIn(
+            '"$SAFETENSORS_SMOKE_TEST_NAME" --exact --ignored --nocapture',
+            smoke,
+        )
+
     def test_runtime_image_verification_preserves_backend_argument(self):
         workflow = (WORKFLOWS / "ci-linux-runtime-slice.yml").read_text()
 

--- a/scripts/tests/test_sccache_evidence.py
+++ b/scripts/tests/test_sccache_evidence.py
@@ -522,6 +522,9 @@ class SccacheEvidenceTests(unittest.TestCase):
             WORKFLOWS["host"],
             WORKFLOWS["runtime"],
         )
+        expected_restore_counts = {
+            "ci-rust-tests-slice.yml": 2,
+        }
         for path in consumers:
             with self.subTest(workflow=path.name):
                 workflow = yaml.safe_load(path.read_text(encoding="utf-8"))
@@ -531,9 +534,13 @@ class SccacheEvidenceTests(unittest.TestCase):
                     for step in job.get("steps", [])
                     if step.get("uses") == "./.github/actions/restore-sccache-seed"
                 ]
-                self.assertEqual(len(keys), 1)
-                self.assertIsNotNone(SEED_KEY_PATTERN.fullmatch(keys[0]))
-                self.assertEqual(keys[0], expected_key)
+                self.assertEqual(
+                    len(keys),
+                    expected_restore_counts.get(path.name, 1),
+                )
+                for key in keys:
+                    self.assertIsNotNone(SEED_KEY_PATTERN.fullmatch(key))
+                    self.assertEqual(key, expected_key)
         warmer = SEED_WARMER.read_text(encoding="utf-8")
         self.assertIn("run: just ci-sccache-seed-build", warmer)
         self.assertNotIn(


### PR DESCRIPTION
`main` currently has two independent breakages from recently merged changes. This PR repairs both so it can act as the release unblock.

## Fixes

### Restore workspace compilation

#1437 renamed `TerminalGuardedChatStream::new` to `::pinned` in `openai-frontend` but left the `skippy-server` call site behind. Use the constructor that now exists and already returns the boxed `ChatCompletionStream` required by the match arm.

### Restore direct SafeTensors inference

#1619 began preserving source BF16/F16 types during direct SafeTensors loading. That also preserved rank-one normalization weights as BF16, but llama.cpp's CPU elementwise path requires those vector operands to be F32 and aborted with:

```
binary_op: unsupported types: dst: f32, src0: f32, src1: bf16
```

Promote half-precision rank-one tensors to F32 while continuing to preserve checkpoint precision for rank-two-or-higher matrix tensors. Expert source shards are handled separately because they are merged into matrix tensors before llama.cpp sees them.

The conversion is exact for BF16/F16 values and does not alter model semantics.

## Regression coverage

- Assert direct checkpoints expose BF16 normalization vectors as GGML F32 with unchanged values.
- Retain coverage that BF16 matrices remain BF16 under `preserve`.
- Retain the rank-one expert fixture by applying matrix precision after expert merging.

## Local verification

- `cargo fmt --all --check`
- `cargo check -p skippy-model`
- `cargo clippy -p skippy-model --all-targets -- -D warnings`
- `cargo test -p skippy-model --lib` — 75 passed
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- Pinned SmolLM2 SafeTensors runtime smoke with `checkpoint_quantization=preserve` and the staged static runtime — model conversion, 310 MiB tensor load, llama context creation, and inference passed

The earlier constructor-only commit was also verified with `cargo check --workspace --all-targets`, clippy, and the full 665-test `skippy-server` suite.

CI is rerunning on the combined head.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when handling terminal-guarded chat response streams.
  * Corrected conversion of rank-one half-precision tensors to 32-bit floating point where required.
  * Preserved appropriate precision for higher-rank tensors and expert model data.
  * Improved automatic output-type selection and expert tensor layout conversions.
  * Prevented unnecessary UI-related rebuilds when distribution files are missing.

* **Tests**
  * Strengthened runtime validation for model loading, quantization, and streamed inference.
  * Added coverage for half-precision tensor conversion, expert layouts, and fail-closed CI checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->