### PR TITLE
fix(skippy): coordinate lanes with bounded KV admission

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
@@ -38,12 +38,12 @@ use skippy_protocol::{FlashAttentionType, LoadMode, StageConfig, StageDevice, St
 use skippy_runtime::{ModelInfo, MtpSource};
 use skippy_server::serving_hooks::{ModelServingHooks, SharedModelServingHooksFactory};
 use skippy_server::{
-    DEFAULT_EMBEDDED_MAX_TOKENS, EmbeddedOpenAiArgs, EmbeddedRuntimeOptions, EmbeddedRuntimeStatus,
-    EmbeddedServerHandle, EmbeddedState, OpenAiGuardrailsConfig, OpenAiGuardrailsStatus,
-    OpenAiGuardrailsTarget, SkippyRuntimeHandle, binary_transport::PredictionReturnHub,
-    binary_transport::PredictionReturnListener, binary_transport::WireCondition,
-    embedded_openai_backend, runtime_state::RuntimeState, telemetry::Telemetry,
-    telemetry::TelemetryLevel,
+    DEFAULT_EMBEDDED_MAX_TOKENS, DEFAULT_GENERATION_ADMISSION_TIMEOUT_SECS, EmbeddedOpenAiArgs,
+    EmbeddedRuntimeOptions, EmbeddedRuntimeStatus, EmbeddedServerHandle, EmbeddedState,
+    OpenAiGuardrailsConfig, OpenAiGuardrailsStatus, OpenAiGuardrailsTarget, SkippyRuntimeHandle,
+    binary_transport::PredictionReturnHub, binary_transport::PredictionReturnListener,
+    binary_transport::WireCondition, embedded_openai_backend, runtime_state::RuntimeState,
+    telemetry::Telemetry, telemetry::TelemetryLevel,
 };
 
 pub use certification::{
@@ -552,7 +552,7 @@ fn embedded_openai_args_from(
             .generation_concurrency
             .saturating_mul(8)
             .clamp(16, 256),
-        generation_admission_timeout_secs: 60,
+        generation_admission_timeout_secs: DEFAULT_GENERATION_ADMISSION_TIMEOUT_SECS,
         prefill_chunk_size: embedded_args.prefill_chunk_size,
         prefill_chunk_policy: embedded_args.prefill_chunk_policy,
         prefill_chunk_schedule: embedded_args.prefill_chunk_schedule,

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/translation.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/translation.rs
@@ -12,8 +12,8 @@ use skippy_protocol::{
 };
 use skippy_runtime::MtpSource;
 use skippy_server::{
-    EmbeddedOpenAiArgs, EmbeddedOpenAiRequestDefaults, EmbeddedRuntimeOptions,
-    NativeMtpProposalConfig, SpeculativeDecodeConfig, telemetry::Telemetry,
+    DEFAULT_GENERATION_ADMISSION_TIMEOUT_SECS, EmbeddedOpenAiArgs, EmbeddedOpenAiRequestDefaults,
+    EmbeddedRuntimeOptions, NativeMtpProposalConfig, SpeculativeDecodeConfig, telemetry::Telemetry,
 };
 
 use super::super::{
@@ -655,7 +655,7 @@ impl ResolvedEmbeddedOpenAiArgs {
             continuous_batching: self.continuous_batching,
             adaptive_generation_min_concurrency: None,
             generation_queue_capacity: self.generation_concurrency.saturating_mul(8).clamp(16, 256),
-            generation_admission_timeout_secs: 60,
+            generation_admission_timeout_secs: DEFAULT_GENERATION_ADMISSION_TIMEOUT_SECS,
             prefill_chunk_size: self.prefill_chunk_size,
             prefill_chunk_policy: self.prefill_chunk_policy,
             prefill_chunk_schedule: self.prefill_chunk_schedule,

--- a/crates/skippy-server/README.md
+++ b/crates/skippy-server/README.md
@@ -156,8 +156,10 @@ deadline handling.
   at once and defaults to the config's KV-derived `lane_count`.
   `--generation-queue-capacity` independently bounds additional waiting
   requests (default `clamp(8 * lanes, 16, 256)`), while
-  `--generation-admission-timeout-secs` bounds predicted and actual queue wait
-  (default 60 seconds). KV restore and prefill-record work runs on a separate
+  `--generation-admission-timeout-secs` can bound predicted and actual queue
+  wait; the default `0` waits until client cancellation so capacity pressure
+  drains through the bounded queue instead of rejecting accepted work. KV
+  restore and prefill-record work runs on a separate
   prompt-scaled deadline: admission timeout plus about one minute per 4,000
   prompt tokens, clamped to at least 60 seconds and at most 30 minutes. A
   legitimate prompt-sized prefill is therefore not killed by the queue-wait

--- a/crates/skippy-server/src/binary_transport/options.rs
+++ b/crates/skippy-server/src/binary_transport/options.rs
@@ -65,9 +65,6 @@ impl BinaryStageOptions {
         if args.openai_generation_concurrency == Some(0) {
             bail!("--openai-generation-concurrency must be greater than zero");
         }
-        if args.openai_generation_admission_timeout_secs == 0 {
-            bail!("--openai-generation-admission-timeout-secs must be greater than zero");
-        }
         if args.openai_prefill_chunk_size == 0 {
             bail!("--openai-prefill-chunk-size must be greater than zero");
         }
@@ -307,7 +304,7 @@ mod tests {
         assert!(options.native_mtp_enabled);
         assert_eq!(openai.generation_concurrency, 1);
         assert_eq!(openai.generation_queue_capacity, 16);
-        assert_eq!(openai.generation_admission_timeout_secs, 60);
+        assert_eq!(openai.generation_admission_timeout_secs, 0);
         assert_eq!(openai.speculative, expected);
     }
 

--- a/crates/skippy-server/src/cli.rs
+++ b/crates/skippy-server/src/cli.rs
@@ -1,5 +1,6 @@
 use std::{net::SocketAddr, path::PathBuf};
 
+use crate::frontend::DEFAULT_GENERATION_ADMISSION_TIMEOUT_SECS;
 use crate::telemetry::TelemetryLevel;
 use clap::{Parser, Subcommand, ValueEnum};
 
@@ -110,8 +111,8 @@ pub struct ServeBinaryArgs {
     pub openai_generation_queue_capacity: Option<usize>,
     #[arg(
         long,
-        default_value_t = 60,
-        help = "Maximum seconds an OpenAI generation request may wait for admission."
+        default_value_t = DEFAULT_GENERATION_ADMISSION_TIMEOUT_SECS,
+        help = "Maximum seconds an OpenAI generation request may wait for admission; 0 waits until cancellation."
     )]
     pub openai_generation_admission_timeout_secs: u64,
     #[arg(long, default_value_t = 256)]
@@ -207,8 +208,8 @@ pub struct ServeOpenAiArgs {
     pub generation_queue_capacity: Option<usize>,
     #[arg(
         long,
-        default_value_t = 60,
-        help = "Maximum seconds a generation request may wait for admission."
+        default_value_t = DEFAULT_GENERATION_ADMISSION_TIMEOUT_SECS,
+        help = "Maximum seconds a generation request may wait for admission; 0 waits until cancellation."
     )]
     pub generation_admission_timeout_secs: u64,
     #[arg(
@@ -282,7 +283,7 @@ mod tests {
         assert!(!args.openai_adaptive_generation_concurrency);
         assert_eq!(args.openai_adaptive_generation_min_concurrency, None);
         assert_eq!(args.openai_generation_queue_capacity, None);
-        assert_eq!(args.openai_generation_admission_timeout_secs, 60);
+        assert_eq!(args.openai_generation_admission_timeout_secs, 0);
 
         let cli = Cli::try_parse_from(["skippy-server", "serve-openai", "--config", "stage.json"])
             .unwrap();
@@ -299,7 +300,7 @@ mod tests {
         assert!(!args.adaptive_generation_concurrency);
         assert_eq!(args.adaptive_generation_min_concurrency, None);
         assert_eq!(args.generation_queue_capacity, None);
-        assert_eq!(args.generation_admission_timeout_secs, 60);
+        assert_eq!(args.generation_admission_timeout_secs, 0);
         assert_eq!(args.openai_guardrails, OpenAiGuardrailsCliMode::Metrics);
     }
 

--- a/crates/skippy-server/src/frontend.rs
+++ b/crates/skippy-server/src/frontend.rs
@@ -33,11 +33,12 @@ use self::{
 pub use self::admission::DECODE_BATCH_HEADROOM_TOKENS;
 use self::generation::*;
 pub use self::generation::{
-    CONTEXT_BUDGET_MAX_TOKENS, DEFAULT_EMBEDDED_MAX_TOKENS, EmbeddedOpenAiArgs,
-    EmbeddedOpenAiBackend, EmbeddedOpenAiRequestDefaults, EmbeddedOpenAiRouter,
-    EmbeddedReasoningBudget, EmbeddedReasoningEnabled, EmbeddedReasoningFormat,
-    embedded_openai_backend, embedded_openai_router, serve_embedded_openai,
-    serve_embedded_openai_with_shutdown, serve_openai,
+    CONTEXT_BUDGET_MAX_TOKENS, DEFAULT_EMBEDDED_MAX_TOKENS,
+    DEFAULT_GENERATION_ADMISSION_TIMEOUT_SECS, EmbeddedOpenAiArgs, EmbeddedOpenAiBackend,
+    EmbeddedOpenAiRequestDefaults, EmbeddedOpenAiRouter, EmbeddedReasoningBudget,
+    EmbeddedReasoningEnabled, EmbeddedReasoningFormat, embedded_openai_backend,
+    embedded_openai_router, serve_embedded_openai, serve_embedded_openai_with_shutdown,
+    serve_openai,
 };
 pub(crate) use self::generation::{
     default_generation_queue_capacity, resolve_adaptive_generation_min_concurrency,

--- a/crates/skippy-server/src/frontend/admission.rs
+++ b/crates/skippy-server/src/frontend/admission.rs
@@ -1,12 +1,20 @@
+#[cfg(test)]
 use crate::frontend::generation::GENERATION_RETRY_AFTER_SECS;
+#[cfg(test)]
 use axum::http::StatusCode;
 use openai_frontend::OpenAiError;
+#[cfg(test)]
 use openai_frontend::OpenAiErrorKind;
 use openai_frontend::OpenAiResult;
 use std::sync::Arc;
-use std::sync::Condvar;
 use std::sync::Mutex;
+use tokio::sync::Notify;
+
+#[cfg(test)]
+use std::sync::Condvar;
+#[cfg(test)]
 use std::time::Duration;
+#[cfg(test)]
 use std::time::Instant;
 
 /// Decode headroom this server actually reserves per in-flight request.
@@ -25,7 +33,9 @@ pub const DECODE_BATCH_HEADROOM_TOKENS: usize = 512;
 pub(super) struct GenerationTokenBudget {
     capacity_tokens: usize,
     state: Mutex<GenerationTokenBudgetState>,
+    #[cfg(test)]
     released: Condvar,
+    released_async: Notify,
 }
 
 #[derive(Debug, Default)]
@@ -51,8 +61,48 @@ impl GenerationTokenBudget {
         Self {
             capacity_tokens: ctx_size.max(1),
             state: Mutex::new(GenerationTokenBudgetState::default()),
+            #[cfg(test)]
             released: Condvar::new(),
+            released_async: Notify::new(),
         }
+    }
+
+    pub(super) fn try_reserve(
+        self: &Arc<Self>,
+        request: GenerationTokenBudgetRequest,
+    ) -> OpenAiResult<Option<GenerationTokenReservation>> {
+        let tokens = request.reservation_tokens();
+        self.ensure_request_fits(tokens)?;
+        let mut state = self
+            .state
+            .lock()
+            .map_err(|_| OpenAiError::backend("generation token budget lock poisoned"))?;
+        if state.active_tokens.saturating_add(tokens) > self.capacity_tokens {
+            return Ok(None);
+        }
+        state.active_tokens = state.active_tokens.saturating_add(tokens);
+        Ok(Some(GenerationTokenReservation {
+            budget: self.clone(),
+            tokens,
+            active_tokens_after_reservation: state.active_tokens,
+        }))
+    }
+
+    pub(super) fn can_reserve_now(
+        &self,
+        request: GenerationTokenBudgetRequest,
+    ) -> OpenAiResult<bool> {
+        let tokens = request.reservation_tokens();
+        self.ensure_request_fits(tokens)?;
+        let state = self
+            .state
+            .lock()
+            .map_err(|_| OpenAiError::backend("generation token budget lock poisoned"))?;
+        Ok(state.active_tokens.saturating_add(tokens) <= self.capacity_tokens)
+    }
+
+    pub(super) fn release_notification(&self) -> &Notify {
+        &self.released_async
     }
 
     #[cfg(test)]
@@ -64,13 +114,15 @@ impl GenerationTokenBudget {
         self.reserve_cancellable(request, admission_timeout, None)
     }
 
-    pub(super) fn reserve_cancellable(
+    #[cfg(test)]
+    fn reserve_cancellable(
         self: &Arc<Self>,
         request: GenerationTokenBudgetRequest,
         admission_timeout: Duration,
         cancellation: Option<&openai_frontend::CancellationToken>,
     ) -> OpenAiResult<GenerationTokenReservation> {
-        let tokens = request.reservation_tokens(self.capacity_tokens);
+        let tokens = request.reservation_tokens();
+        self.ensure_request_fits(tokens)?;
         let deadline = Instant::now() + admission_timeout;
         let mut state = self
             .state
@@ -124,8 +176,18 @@ impl GenerationTokenBudget {
         self.capacity_tokens
     }
 
+    fn ensure_request_fits(&self, requested_tokens: usize) -> OpenAiResult<()> {
+        if requested_tokens <= self.capacity_tokens {
+            return Ok(());
+        }
+        Err(OpenAiError::context_length_exceeded(format!(
+            "request requires {requested_tokens} KV tokens but the runtime pool holds {}",
+            self.capacity_tokens
+        )))
+    }
+
     #[cfg(test)]
-    fn active_tokens(&self) -> usize {
+    pub(super) fn active_tokens(&self) -> usize {
         self.state
             .lock()
             .expect("generation token budget lock")
@@ -141,12 +203,10 @@ impl GenerationTokenBudgetRequest {
         }
     }
 
-    fn reservation_tokens(self, capacity_tokens: usize) -> usize {
+    pub(super) fn reservation_tokens(self) -> usize {
         let max_tokens = usize::try_from(self.max_tokens).unwrap_or(usize::MAX);
         let decode_headroom = max_tokens.min(DECODE_BATCH_HEADROOM_TOKENS);
-        self.prompt_tokens
-            .saturating_add(decode_headroom)
-            .min(capacity_tokens.max(1))
+        self.prompt_tokens.saturating_add(decode_headroom)
     }
 }
 
@@ -167,11 +227,14 @@ impl Drop for GenerationTokenReservation {
         }
         if let Ok(mut state) = self.budget.state.lock() {
             state.active_tokens = state.active_tokens.saturating_sub(self.tokens);
+            #[cfg(test)]
             self.budget.released.notify_one();
+            self.budget.released_async.notify_waiters();
         }
     }
 }
 
+#[cfg(test)]
 fn generation_token_budget_timeout_error(
     timeout: Duration,
     requested_tokens: usize,

--- a/crates/skippy-server/src/frontend/backend.rs
+++ b/crates/skippy-server/src/frontend/backend.rs
@@ -1,3 +1,6 @@
+use crate::frontend::admission::GenerationTokenBudget;
+use crate::frontend::admission::GenerationTokenBudgetRequest;
+use crate::frontend::admission::GenerationTokenReservation;
 use crate::frontend::generation::ChatOutputStreamParser;
 use crate::frontend::generation::GeneratedText;
 use crate::frontend::generation::GenerationActiveWorkReservation;
@@ -327,19 +330,27 @@ impl GenerationSessionPermit {
 
     async fn acquire_until(
         mut self,
-        deadline: Instant,
+        deadline: Option<Instant>,
         admission_timeout: Duration,
         cancellation: &openai_frontend::CancellationToken,
     ) -> OpenAiResult<Self> {
-        let acquire = tokio::time::timeout_at(
-            tokio::time::Instant::from_std(deadline),
-            self.entry.semaphore.clone().acquire_owned(),
-        );
-        let permit = tokio::select! {
-            result = acquire => result
-                .map_err(|_| generation_queue_timeout_error(admission_timeout))?
-                .map_err(|_| OpenAiError::backend("generation session lock closed"))?,
-            () = cancellation.cancelled() => return Err(request_cancelled_error()),
+        let permit = if let Some(deadline) = deadline {
+            let acquire = tokio::time::timeout_at(
+                tokio::time::Instant::from_std(deadline),
+                self.entry.semaphore.clone().acquire_owned(),
+            );
+            tokio::select! {
+                result = acquire => result
+                    .map_err(|_| generation_queue_timeout_error(admission_timeout))?
+                    .map_err(|_| OpenAiError::backend("generation session lock closed"))?,
+                () = cancellation.cancelled() => return Err(request_cancelled_error()),
+            }
+        } else {
+            tokio::select! {
+                result = self.entry.semaphore.clone().acquire_owned() => result
+                    .map_err(|_| OpenAiError::backend("generation session lock closed"))?,
+                () = cancellation.cancelled() => return Err(request_cancelled_error()),
+            }
         };
         if cancellation.is_cancelled() {
             return Err(request_cancelled_error());
@@ -376,6 +387,7 @@ struct GenerationAdmissionController {
     generation_queue_limit: usize,
     generation_service_estimator: Arc<GenerationServiceEstimator>,
     generation_session_locks: Arc<Mutex<BTreeMap<String, Arc<GenerationSessionLockEntry>>>>,
+    generation_token_budget: Arc<GenerationTokenBudget>,
 }
 
 impl GenerationAdmissionController {
@@ -386,6 +398,7 @@ impl GenerationAdmissionController {
             generation_queue_limit: backend.generation_queue_limit,
             generation_service_estimator: backend.generation_service_estimator.clone(),
             generation_session_locks: backend.generation_session_locks.clone(),
+            generation_token_budget: backend.generation_token_budget.clone(),
         }
     }
 
@@ -431,14 +444,22 @@ impl GenerationAdmissionController {
         work: GenerationAdmissionWork,
         scheduling: GenerationAdmissionScheduling,
     ) -> OpenAiResult<(GenerationAdmissionPermit, Option<GenerationSessionPermit>)> {
-        let deadline = Instant::now()
-            .checked_add(admission_timeout)
-            .ok_or_else(|| OpenAiError::backend("generation admission deadline overflow"))?;
+        let deadline = if admission_timeout.is_zero() {
+            None
+        } else {
+            Some(
+                Instant::now()
+                    .checked_add(admission_timeout)
+                    .ok_or_else(|| {
+                        OpenAiError::backend("generation admission deadline overflow")
+                    })?,
+            )
+        };
         let session_permit = self
             .acquire_session_until(ids, deadline, admission_timeout, cancellation)
             .await?;
 
-        if Instant::now() >= deadline {
+        if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
             return Err(generation_queue_timeout_error(admission_timeout));
         }
         let generation_permit = self
@@ -459,7 +480,7 @@ impl GenerationAdmissionController {
     async fn acquire_session_until(
         &self,
         ids: &OpenAiGenerationIds,
-        deadline: Instant,
+        deadline: Option<Instant>,
         admission_timeout: Duration,
         cancellation: &openai_frontend::CancellationToken,
     ) -> OpenAiResult<Option<GenerationSessionPermit>> {
@@ -482,7 +503,7 @@ impl GenerationAdmissionController {
 
     async fn acquire_generation_permit_until(
         &self,
-        deadline: Instant,
+        deadline: Option<Instant>,
         admission_timeout: Duration,
         cancellation: &openai_frontend::CancellationToken,
         work: GenerationAdmissionWork,
@@ -493,13 +514,19 @@ impl GenerationAdmissionController {
         }
         let claim = self.generation_limit.admission_queue().claim_or_enqueue(
             self.generation_limit.semaphore(),
+            self.generation_token_budget.clone(),
+            GenerationTokenBudgetRequest::new(
+                usize::try_from(work.prompt_tokens).unwrap_or(usize::MAX),
+                u32::try_from(work.decode_tokens).unwrap_or(u32::MAX),
+            ),
             scheduling,
             self.generation_queue_depth.clone(),
             self.generation_queue_limit,
         )?;
         match claim {
-            GenerationAdmissionClaim::Acquired(permit) => Ok(GenerationAdmissionPermit {
-                _lane: self.generation_limit.wrap_permit(permit),
+            GenerationAdmissionClaim::Acquired(resources) => Ok(GenerationAdmissionPermit {
+                _lane: self.generation_limit.wrap_permit(resources.lane),
+                token_budget: resources.token_budget,
                 _active_work: self.generation_service_estimator.start_active(work),
                 predicted_wait_ms: Some(0.0),
                 demand_epoch: self.generation_limit.demand_epoch(),
@@ -519,7 +546,7 @@ impl GenerationAdmissionController {
                     .map_err(|predicted_wait_ms| {
                         generation_predicted_wait_error(predicted_wait_ms, admission_timeout)
                     })?;
-                let lane = lease
+                let resources = lease
                     .acquire(
                         self.generation_limit.semaphore(),
                         admission_timeout,
@@ -528,7 +555,8 @@ impl GenerationAdmissionController {
                     )
                     .await?;
                 Ok(GenerationAdmissionPermit {
-                    _lane: self.generation_limit.wrap_permit(lane),
+                    _lane: self.generation_limit.wrap_permit(resources.lane),
+                    token_budget: resources.token_budget,
                     _active_work: queued_work.promote(),
                     predicted_wait_ms,
                     demand_epoch: self.generation_limit.demand_epoch(),
@@ -543,6 +571,7 @@ impl GenerationAdmissionController {
 }
 
 pub(in crate::frontend) struct GenerationAdmissionPermit {
+    token_budget: GenerationTokenReservation,
     _lane: GenerationConcurrencyPermit,
     _active_work: GenerationActiveWorkReservation,
     predicted_wait_ms: Option<f64>,
@@ -554,6 +583,13 @@ pub(in crate::frontend) struct GenerationAdmissionPermit {
 }
 
 impl GenerationAdmissionPermit {
+    fn token_budget_stats(&self) -> (usize, usize) {
+        (
+            self.token_budget.tokens(),
+            self.token_budget.active_tokens_after_reservation(),
+        )
+    }
+
     fn demand_observation(&self) -> GenerationDemandObservation {
         GenerationDemandObservation {
             demand_epoch: self.demand_epoch,
@@ -1457,6 +1493,7 @@ impl StageOpenAiBackend {
         );
         self.emit_openai_phase("stage.openai_generation_admit", admit_timer, admit_attrs);
         let demand = permit.demand_observation();
+        let token_budget_stats = permit.token_budget_stats();
         let backend = self.clone();
         let hook_runtime = Some(tokio::runtime::Handle::current());
         let worker_context = context.clone();
@@ -1467,6 +1504,7 @@ impl StageOpenAiBackend {
                     prompt,
                     max_tokens,
                     prepared_text,
+                    token_budget_stats,
                     stop.as_ref(),
                     sampling,
                     hook_request,
@@ -1550,6 +1588,7 @@ impl StageOpenAiBackend {
         );
         self.emit_openai_phase("stage.openai_generation_admit", admit_timer, admit_attrs);
         let demand = permit.demand_observation();
+        let token_budget_stats = permit.token_budget_stats();
         let backend = self.clone();
         let chat_parse_metadata = prompt.chat_parse_metadata.clone();
         let (tx, rx) = mpsc::channel(16);
@@ -1593,6 +1632,7 @@ impl StageOpenAiBackend {
                 prompt,
                 max_tokens,
                 prepared_text,
+                token_budget_stats,
                 stop.as_ref(),
                 sampling,
                 hook_request,

--- a/crates/skippy-server/src/frontend/backend/tests.rs
+++ b/crates/skippy-server/src/frontend/backend/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::frontend::EmbeddedOpenAiRequestDefaults;
 use crate::frontend::SpeculativeDecodeConfig;
 use crate::frontend::admission::GenerationTokenBudget;
+use crate::frontend::generation::ADMISSION_STARVATION_BOUND_TURNS;
 use crate::frontend::generation::OpenAiBackendMode;
 use crate::frontend::iteration_scheduler::IterationScheduler;
 use crate::runtime_state::RuntimeState;
@@ -242,6 +243,103 @@ async fn capacity_waiters_drain_serially_after_each_kv_release() {
         assert_eq!(controller.generation_token_budget.active_tokens(), 10);
         drop(admitted);
     }
+    assert_eq!(controller.generation_queue_depth.load(Ordering::Acquire), 0);
+    assert_eq!(controller.generation_limit.available_permits(), 2);
+    assert_eq!(controller.generation_token_budget.active_tokens(), 0);
+}
+
+#[tokio::test]
+async fn full_pool_waiter_is_admitted_after_bounded_half_pool_bypasses() {
+    let controller = admission_controller_with_budget(2, 4, 10);
+    let half_pool_work = GenerationAdmissionWork::new(5, 0);
+    let full_pool_work = GenerationAdmissionWork::new(10, 0);
+    let active = controller
+        .acquire_work(
+            &trusted_ids("active-half-pool"),
+            &openai_frontend::CancellationToken::new(),
+            Duration::ZERO,
+            half_pool_work,
+        )
+        .await
+        .expect("initial half-pool admission");
+
+    let full_pool_controller = controller.clone();
+    let full_pool_waiter = tokio::spawn(async move {
+        full_pool_controller
+            .acquire_work(
+                &trusted_ids("full-pool-waiter"),
+                &openai_frontend::CancellationToken::new(),
+                Duration::ZERO,
+                full_pool_work,
+            )
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while controller.generation_queue_depth.load(Ordering::Acquire) != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("full-pool request entered the queue");
+
+    // Keep one half-pool reservation active and repeatedly fill/release the
+    // other half. The full-pool request cannot fit during these admissions.
+    for wave in 0..ADMISSION_STARVATION_BOUND_TURNS {
+        let bypass = tokio::time::timeout(
+            Duration::from_secs(1),
+            controller.acquire_work(
+                &trusted_ids(&format!("half-pool-bypass-{wave}")),
+                &openai_frontend::CancellationToken::new(),
+                Duration::ZERO,
+                half_pool_work,
+            ),
+        )
+        .await
+        .expect("fitting half-pool request completed before the timeout")
+        .expect("fitting half-pool request admitted before the bound");
+        assert_eq!(controller.generation_token_budget.active_tokens(), 10);
+        drop(bypass);
+    }
+
+    // The next fitting arrival reaches the bound and must remain queued while
+    // the controller drains capacity toward the older full-pool request.
+    let bypass_controller = controller.clone();
+    let blocked_bypass = tokio::spawn(async move {
+        bypass_controller
+            .acquire_work(
+                &trusted_ids("half-pool-after-bound"),
+                &openai_frontend::CancellationToken::new(),
+                Duration::ZERO,
+                half_pool_work,
+            )
+            .await
+    });
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while controller.generation_queue_depth.load(Ordering::Acquire) != 2 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("post-bound half-pool request remained queued");
+    assert!(!full_pool_waiter.is_finished());
+    assert!(!blocked_bypass.is_finished());
+
+    drop(active);
+    let admitted_full_pool = tokio::time::timeout(Duration::from_secs(1), full_pool_waiter)
+        .await
+        .expect("full-pool waiter admitted after capacity drained")
+        .expect("full-pool waiter task completed")
+        .expect("full-pool admission succeeded");
+    assert_eq!(controller.generation_token_budget.active_tokens(), 10);
+    assert!(!blocked_bypass.is_finished());
+
+    drop(admitted_full_pool);
+    let admitted_bypass = tokio::time::timeout(Duration::from_secs(1), blocked_bypass)
+        .await
+        .expect("younger half-pool waiter admitted after the senior completed")
+        .expect("half-pool waiter task completed")
+        .expect("half-pool admission succeeded");
+    drop(admitted_bypass);
     assert_eq!(controller.generation_queue_depth.load(Ordering::Acquire), 0);
     assert_eq!(controller.generation_limit.available_permits(), 2);
     assert_eq!(controller.generation_token_budget.active_tokens(), 0);

--- a/crates/skippy-server/src/frontend/backend/tests.rs
+++ b/crates/skippy-server/src/frontend/backend/tests.rs
@@ -50,6 +50,14 @@ fn admission_controller(
     generation_concurrency: usize,
     generation_queue_limit: usize,
 ) -> GenerationAdmissionController {
+    admission_controller_with_budget(generation_concurrency, generation_queue_limit, 4_096)
+}
+
+fn admission_controller_with_budget(
+    generation_concurrency: usize,
+    generation_queue_limit: usize,
+    token_capacity: usize,
+) -> GenerationAdmissionController {
     GenerationAdmissionController {
         generation_limit: Arc::new(GenerationConcurrencyController::fixed(
             generation_concurrency,
@@ -60,6 +68,7 @@ fn admission_controller(
             generation_concurrency,
         )),
         generation_session_locks: Arc::new(Mutex::new(BTreeMap::new())),
+        generation_token_budget: Arc::new(GenerationTokenBudget::new(token_capacity)),
     }
 }
 
@@ -120,7 +129,10 @@ async fn queued_admission_balances_shared_prefix_families_across_lane_wave() {
     .expect("all prompts become scheduler-visible");
 
     drop(active);
-    let (first_label, first) = rx.recv().await.expect("first queued admission");
+    let (first_label, first) = tokio::time::timeout(Duration::from_millis(250), rx.recv())
+        .await
+        .expect("first queued admission was promoted")
+        .expect("first queued admission");
     drop(first);
     let (second_label, second) = rx.recv().await.expect("second queued admission");
     assert_ne!(
@@ -133,6 +145,187 @@ async fn queued_admission_balances_shared_prefix_families_across_lane_wave() {
     drop(third);
     let (_, fourth) = rx.recv().await.expect("fourth queued admission");
     drop(fourth);
+}
+
+#[tokio::test]
+async fn capacity_waiter_holds_neither_a_lane_nor_kv_until_atomic_promotion() {
+    let controller = admission_controller_with_budget(2, 2, 10);
+    let active = controller
+        .acquire_work(
+            &trusted_ids("active"),
+            &openai_frontend::CancellationToken::new(),
+            Duration::ZERO,
+            GenerationAdmissionWork::new(7, 0),
+        )
+        .await
+        .expect("first capacity reservation");
+    let waiting_controller = controller.clone();
+    let waiter = tokio::spawn(async move {
+        waiting_controller
+            .acquire_work(
+                &trusted_ids("waiting"),
+                &openai_frontend::CancellationToken::new(),
+                Duration::ZERO,
+                GenerationAdmissionWork::new(7, 0),
+            )
+            .await
+    });
+
+    tokio::time::timeout(Duration::from_millis(100), async {
+        while controller.generation_queue_depth.load(Ordering::Acquire) != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("capacity waiter entered the queue");
+    assert_eq!(controller.generation_limit.available_permits(), 1);
+    assert_eq!(controller.generation_token_budget.active_tokens(), 7);
+
+    drop(active);
+    let promoted = tokio::time::timeout(Duration::from_millis(100), waiter)
+        .await
+        .expect("capacity waiter promoted")
+        .expect("capacity waiter task completed")
+        .expect("capacity waiter admission");
+    assert_eq!(controller.generation_limit.available_permits(), 1);
+    assert_eq!(controller.generation_token_budget.active_tokens(), 7);
+    drop(promoted);
+    assert_eq!(controller.generation_limit.available_permits(), 2);
+    assert_eq!(controller.generation_token_budget.active_tokens(), 0);
+}
+
+#[tokio::test]
+async fn capacity_waiters_drain_serially_after_each_kv_release() {
+    let controller = admission_controller_with_budget(2, 4, 10);
+    let active = controller
+        .acquire_work(
+            &trusted_ids("active"),
+            &openai_frontend::CancellationToken::new(),
+            Duration::ZERO,
+            GenerationAdmissionWork::new(10, 0),
+        )
+        .await
+        .expect("active capacity reservation");
+    let (tx, mut rx) = tokio::sync::mpsc::channel(4);
+    for index in 0..4 {
+        let controller = controller.clone();
+        let tx = tx.clone();
+        tokio::spawn(async move {
+            let cancellation = openai_frontend::CancellationToken::new();
+            let admitted = controller
+                .acquire_work(
+                    &trusted_ids(&format!("waiting-{index}")),
+                    &cancellation,
+                    Duration::ZERO,
+                    GenerationAdmissionWork::new(10, 0),
+                )
+                .await
+                .expect("queued capacity admission");
+            tx.send(admitted).await.unwrap();
+        });
+    }
+    drop(tx);
+    tokio::time::timeout(Duration::from_secs(1), async {
+        while controller.generation_queue_depth.load(Ordering::Acquire) != 4 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("all capacity waiters entered the queue");
+
+    drop(active);
+    for _ in 0..4 {
+        let admitted = tokio::time::timeout(Duration::from_secs(1), rx.recv())
+            .await
+            .expect("next capacity waiter promoted")
+            .expect("queued capacity admission");
+        assert_eq!(controller.generation_token_budget.active_tokens(), 10);
+        drop(admitted);
+    }
+    assert_eq!(controller.generation_queue_depth.load(Ordering::Acquire), 0);
+    assert_eq!(controller.generation_limit.available_permits(), 2);
+    assert_eq!(controller.generation_token_budget.active_tokens(), 0);
+}
+
+#[tokio::test]
+async fn request_larger_than_the_kv_pool_fails_without_queueing_or_taking_a_lane() {
+    let controller = admission_controller_with_budget(2, 2, 128);
+    let error = result_error(
+        controller
+            .acquire_work(
+                &trusted_ids("too-large"),
+                &openai_frontend::CancellationToken::new(),
+                Duration::ZERO,
+                GenerationAdmissionWork::new(129, 0),
+            )
+            .await,
+    );
+
+    assert_eq!(error.status(), axum::http::StatusCode::BAD_REQUEST);
+    assert_eq!(
+        error.body().error.code.as_deref(),
+        Some("context_length_exceeded")
+    );
+    assert!(
+        error
+            .body()
+            .error
+            .message
+            .contains("runtime pool holds 128")
+    );
+    assert_eq!(controller.generation_queue_depth.load(Ordering::Acquire), 0);
+    assert_eq!(controller.generation_limit.available_permits(), 2);
+    assert_eq!(controller.generation_token_budget.active_tokens(), 0);
+}
+
+#[tokio::test]
+async fn cancelling_a_capacity_waiter_leaks_neither_lane_nor_kv_reservation() {
+    let controller = admission_controller_with_budget(2, 2, 128);
+    let active = controller
+        .acquire_work(
+            &trusted_ids("active"),
+            &openai_frontend::CancellationToken::new(),
+            Duration::ZERO,
+            GenerationAdmissionWork::new(100, 0),
+        )
+        .await
+        .expect("first capacity reservation");
+    let cancellation = openai_frontend::CancellationToken::new();
+    let waiter_cancellation = cancellation.clone();
+    let waiting_controller = controller.clone();
+    let waiter = tokio::spawn(async move {
+        waiting_controller
+            .acquire_work(
+                &trusted_ids("waiting"),
+                &waiter_cancellation,
+                Duration::ZERO,
+                GenerationAdmissionWork::new(64, 0),
+            )
+            .await
+    });
+    tokio::time::timeout(Duration::from_millis(100), async {
+        while controller.generation_queue_depth.load(Ordering::Acquire) != 1 {
+            tokio::task::yield_now().await;
+        }
+    })
+    .await
+    .expect("capacity waiter entered the queue");
+
+    cancellation.cancel();
+    let error = result_error(
+        tokio::time::timeout(Duration::from_millis(100), waiter)
+            .await
+            .expect("cancelled capacity waiter returned")
+            .expect("capacity waiter task completed"),
+    );
+    assert!(error.body().error.message.contains("request cancelled"));
+    assert_eq!(controller.generation_queue_depth.load(Ordering::Acquire), 0);
+    assert_eq!(controller.generation_limit.available_permits(), 1);
+    assert_eq!(controller.generation_token_budget.active_tokens(), 100);
+
+    drop(active);
+    assert_eq!(controller.generation_limit.available_permits(), 2);
+    assert_eq!(controller.generation_token_budget.active_tokens(), 0);
 }
 
 #[tokio::test]

--- a/crates/skippy-server/src/frontend/generation.rs
+++ b/crates/skippy-server/src/frontend/generation.rs
@@ -23,8 +23,8 @@ pub use server::{
 };
 
 pub(in crate::frontend) use cache_hints::{
-    ChainPrefixRestore, GENERATION_RETRY_AFTER_SECS, GENERATION_TOKEN_BUDGET_TIMEOUT,
-    GenerationCacheStats, MAX_EXACT_REPLAY_TOKENS, OpenAiCacheHints, OpenAiGenerationIds,
+    ChainPrefixRestore, GENERATION_RETRY_AFTER_SECS, GenerationCacheStats, MAX_EXACT_REPLAY_TOKENS,
+    OpenAiCacheHints, OpenAiGenerationIds,
 };
 pub(in crate::frontend) use concurrency::*;
 pub(in crate::frontend) use draft_runner::*;
@@ -41,11 +41,19 @@ pub(crate) fn default_generation_queue_capacity(generation_concurrency: usize) -
     generation_concurrency.saturating_mul(8).clamp(16, 256)
 }
 
+/// Zero keeps accepted generation work queued until client cancellation.
+pub const DEFAULT_GENERATION_ADMISSION_TIMEOUT_SECS: u64 = 0;
+
 pub(crate) use server::resolve_adaptive_generation_min_concurrency;
 
 #[cfg(test)]
 mod admission_defaults_tests {
-    use super::default_generation_queue_capacity;
+    use super::{DEFAULT_GENERATION_ADMISSION_TIMEOUT_SECS, default_generation_queue_capacity};
+
+    #[test]
+    fn accepted_generation_waits_for_capacity_by_default() {
+        assert_eq!(DEFAULT_GENERATION_ADMISSION_TIMEOUT_SECS, 0);
+    }
 
     #[test]
     fn queue_capacity_tracks_lane_waves_with_bounds() {

--- a/crates/skippy-server/src/frontend/generation/cache_hints.rs
+++ b/crates/skippy-server/src/frontend/generation/cache_hints.rs
@@ -7,7 +7,6 @@ use skippy_protocol::binary::StageReplyStats;
 use std::sync::OnceLock;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering;
-use std::time::Duration;
 use std::time::Instant;
 use uuid::Uuid;
 
@@ -33,7 +32,6 @@ pub const CONTEXT_BUDGET_MAX_TOKENS: u32 = u32::MAX;
 /// request is silently clamped to whatever remaining budget exists
 /// rather than rejected — see `GenerationTokenLimit::resolve`.
 pub const DEFAULT_EMBEDDED_MAX_TOKENS: u32 = 4096;
-pub(in crate::frontend) const GENERATION_TOKEN_BUDGET_TIMEOUT: Duration = Duration::from_secs(10);
 pub(in crate::frontend) const GENERATION_RETRY_AFTER_SECS: u64 = 1;
 pub(in crate::frontend) const MAX_EXACT_REPLAY_TOKENS: usize = 8;
 

--- a/crates/skippy-server/src/frontend/generation/concurrency.rs
+++ b/crates/skippy-server/src/frontend/generation/concurrency.rs
@@ -158,8 +158,12 @@ impl Drop for GenerationConcurrencyPermit {
         if retirement.pending > 0 {
             retirement.pending -= 1;
             permit.forget();
+            drop(retirement);
+            self.admission_queue.notify_lane_available();
+            return;
         }
         drop(retirement);
+        drop(permit);
         self.admission_queue.notify_lane_available();
     }
 }

--- a/crates/skippy-server/src/frontend/generation/queue.rs
+++ b/crates/skippy-server/src/frontend/generation/queue.rs
@@ -1,3 +1,6 @@
+use crate::frontend::admission::GenerationTokenBudget;
+use crate::frontend::admission::GenerationTokenBudgetRequest;
+use crate::frontend::admission::GenerationTokenReservation;
 use crate::frontend::generation::CONTEXT_BUDGET_MAX_TOKENS;
 use crate::frontend::generation::GENERATION_RETRY_AFTER_SECS;
 use crate::frontend::generation::PhaseTimer;
@@ -66,6 +69,7 @@ impl Default for GenerationAdmissionScheduling {
 #[derive(Clone)]
 struct GenerationAdmissionWaiter {
     scheduling: GenerationAdmissionScheduling,
+    token_budget_request: GenerationTokenBudgetRequest,
     enqueued_turn: u64,
     order: u64,
 }
@@ -101,22 +105,27 @@ impl GenerationAdmissionQueue {
     pub(in crate::frontend) fn claim_or_enqueue(
         self: &Arc<Self>,
         generation_limit: Arc<Semaphore>,
+        token_budget: Arc<GenerationTokenBudget>,
+        token_budget_request: GenerationTokenBudgetRequest,
         scheduling: GenerationAdmissionScheduling,
         generation_queue_depth: Arc<AtomicUsize>,
         generation_queue_limit: usize,
     ) -> OpenAiResult<GenerationAdmissionClaim> {
+        // Validate an impossible request before queue capacity or current load
+        // can disguise it as transient overload.
+        let _ = token_budget.can_reserve_now(token_budget_request)?;
         let mut state = self
             .state
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
-        if state.waiters.is_empty() {
-            match generation_limit.try_acquire_owned() {
-                Ok(permit) => return Ok(GenerationAdmissionClaim::Acquired(permit)),
-                Err(tokio::sync::TryAcquireError::Closed) => {
-                    return Err(generation_lanes_busy_error());
-                }
-                Err(tokio::sync::TryAcquireError::NoPermits) => {}
-            }
+        if state.waiters.is_empty()
+            && let Some(resources) = try_acquire_generation_resources(
+                generation_limit.clone(),
+                &token_budget,
+                token_budget_request,
+            )?
+        {
+            return Ok(GenerationAdmissionClaim::Acquired(resources));
         }
         let reservation = reserve_generation_queue(generation_queue_depth, generation_queue_limit)
             .ok_or_else(generation_queue_full_error)?;
@@ -131,6 +140,7 @@ impl GenerationAdmissionQueue {
             id,
             GenerationAdmissionWaiter {
                 scheduling,
+                token_budget_request,
                 enqueued_turn: turn,
                 order: id,
             },
@@ -140,6 +150,8 @@ impl GenerationAdmissionQueue {
         Ok(GenerationAdmissionClaim::Queued(
             GenerationAdmissionQueueLease {
                 queue: Arc::clone(self),
+                token_budget,
+                token_budget_request,
                 id,
                 reservation: Some(reservation),
             },
@@ -150,7 +162,7 @@ impl GenerationAdmissionQueue {
         self.changed.notify_waiters();
     }
 
-    fn selected_waiter(&self) -> Option<u64> {
+    fn selected_waiter(&self, token_budget: &GenerationTokenBudget) -> OpenAiResult<Option<u64>> {
         // Notify wakes the whole waiting set. Serialize and memoize one
         // election per available lane so N waiters do not each refresh and
         // sort the same N affinities.
@@ -167,7 +179,7 @@ impl GenerationAdmissionQueue {
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             if let Some(selected_id) = state.selected_id {
-                return Some(selected_id);
+                return Ok(Some(selected_id));
             }
             (
                 state.turn,
@@ -178,12 +190,18 @@ impl GenerationAdmissionQueue {
                     .collect::<Vec<_>>(),
             )
         };
-        let affinities = waiters
+        let mut eligible_waiters = Vec::with_capacity(waiters.len());
+        for (id, waiter) in waiters {
+            if token_budget.can_reserve_now(waiter.token_budget_request)? {
+                eligible_waiters.push((id, waiter));
+            }
+        }
+        let affinities = eligible_waiters
             .iter()
             .map(|(_, waiter)| (waiter.scheduling.refresh_affinity)())
             .collect::<Vec<_>>();
         let selected_id = order_cache_aware_candidates(
-            waiters
+            eligible_waiters
                 .iter()
                 .map(|(_, waiter)| waiter)
                 .zip(affinities.iter())
@@ -201,7 +219,7 @@ impl GenerationAdmissionQueue {
             true,
         )
         .first()
-        .and_then(|index| waiters.get(*index).map(|(id, _)| id))
+        .and_then(|index| eligible_waiters.get(*index).map(|(id, _)| id))
         .copied();
         let mut state = self
             .state
@@ -212,7 +230,7 @@ impl GenerationAdmissionQueue {
         {
             state.selected_id = selected_id;
         }
-        state.selected_id
+        Ok(state.selected_id)
     }
 
     fn remove(&self, id: u64) -> bool {
@@ -248,12 +266,19 @@ impl GenerationAdmissionQueue {
 }
 
 pub(in crate::frontend) enum GenerationAdmissionClaim {
-    Acquired(OwnedSemaphorePermit),
+    Acquired(GenerationAdmissionResources),
     Queued(GenerationAdmissionQueueLease),
+}
+
+pub(in crate::frontend) struct GenerationAdmissionResources {
+    pub(in crate::frontend) lane: OwnedSemaphorePermit,
+    pub(in crate::frontend) token_budget: GenerationTokenReservation,
 }
 
 pub(in crate::frontend) struct GenerationAdmissionQueueLease {
     queue: Arc<GenerationAdmissionQueue>,
+    token_budget: Arc<GenerationTokenBudget>,
+    token_budget_request: GenerationTokenBudgetRequest,
     id: u64,
     reservation: Option<GenerationQueueReservation>,
 }
@@ -263,40 +288,77 @@ impl GenerationAdmissionQueueLease {
         mut self,
         generation_limit: Arc<Semaphore>,
         admission_timeout: Duration,
-        deadline: Instant,
+        deadline: Option<Instant>,
         cancellation: &CancellationToken,
-    ) -> OpenAiResult<OwnedSemaphorePermit> {
+    ) -> OpenAiResult<GenerationAdmissionResources> {
         loop {
             if cancellation.is_cancelled() {
                 return Err(OpenAiError::cancelled("request cancelled"));
             }
+            if deadline.is_some_and(|deadline| Instant::now() >= deadline) {
+                return Err(generation_queue_timeout_error(admission_timeout));
+            }
             let notified = self.queue.changed.notified();
             tokio::pin!(notified);
             notified.as_mut().enable();
-            if self.queue.selected_waiter() == Some(self.id) {
-                match generation_limit.clone().try_acquire_owned() {
-                    Ok(permit) => {
-                        self.queue.complete_selection(self.id);
-                        self.reservation.take();
-                        self.queue.changed.notify_waiters();
-                        return Ok(permit);
-                    }
-                    Err(tokio::sync::TryAcquireError::Closed) => {
-                        return Err(generation_lanes_busy_error());
-                    }
-                    Err(tokio::sync::TryAcquireError::NoPermits) => {}
-                }
+            let token_released = self.token_budget.release_notification().notified();
+            tokio::pin!(token_released);
+            token_released.as_mut().enable();
+            if self.queue.selected_waiter(&self.token_budget)? == Some(self.id)
+                && let Some(resources) = try_acquire_generation_resources(
+                    generation_limit.clone(),
+                    &self.token_budget,
+                    self.token_budget_request,
+                )?
+            {
+                self.queue.complete_selection(self.id);
+                self.reservation.take();
+                self.queue.changed.notify_waiters();
+                return Ok(resources);
             }
-            let timeout = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline));
-            tokio::select! {
-                () = &mut notified => {}
-                () = timeout => return Err(generation_queue_timeout_error(admission_timeout)),
-                () = cancellation.cancelled() => {
-                    return Err(OpenAiError::cancelled("request cancelled"));
+            if let Some(deadline) = deadline {
+                let timeout = tokio::time::sleep_until(tokio::time::Instant::from_std(deadline));
+                tokio::select! {
+                    () = &mut notified => {}
+                    () = &mut token_released => {}
+                    () = timeout => return Err(generation_queue_timeout_error(admission_timeout)),
+                    () = cancellation.cancelled() => {
+                        return Err(OpenAiError::cancelled("request cancelled"));
+                    }
+                }
+            } else {
+                tokio::select! {
+                    () = &mut notified => {}
+                    () = &mut token_released => {}
+                    () = cancellation.cancelled() => {
+                        return Err(OpenAiError::cancelled("request cancelled"));
+                    }
                 }
             }
         }
     }
+}
+
+fn try_acquire_generation_resources(
+    generation_limit: Arc<Semaphore>,
+    token_budget: &Arc<GenerationTokenBudget>,
+    token_budget_request: GenerationTokenBudgetRequest,
+) -> OpenAiResult<Option<GenerationAdmissionResources>> {
+    let lane = match generation_limit.try_acquire_owned() {
+        Ok(lane) => lane,
+        Err(tokio::sync::TryAcquireError::NoPermits) => return Ok(None),
+        Err(tokio::sync::TryAcquireError::Closed) => {
+            return Err(generation_lanes_busy_error());
+        }
+    };
+    let Some(token_budget) = token_budget.try_reserve(token_budget_request)? else {
+        // This is the raw semaphore permit rather than the controller wrapper,
+        // so releasing an unsuccessful partial claim does not wake the same
+        // waiter into a hot loop. A real KV release provides the wakeup.
+        drop(lane);
+        return Ok(None);
+    };
+    Ok(Some(GenerationAdmissionResources { lane, token_budget }))
 }
 
 impl Drop for GenerationAdmissionQueueLease {
@@ -367,8 +429,9 @@ impl GenerationServiceEstimator {
                 queued: false,
             });
         };
-        if let Some(wait_ms) =
-            predicted_wait_ms_for_state(&state, self.concurrency.load(Ordering::Acquire))
+        if !admission_timeout.is_zero()
+            && let Some(wait_ms) =
+                predicted_wait_ms_for_state(&state, self.concurrency.load(Ordering::Acquire))
             && wait_ms > admission_timeout.as_secs_f64() * 1_000.0
         {
             return Err(wait_ms);

--- a/crates/skippy-server/src/frontend/generation/queue.rs
+++ b/crates/skippy-server/src/frontend/generation/queue.rs
@@ -36,6 +36,22 @@ const SERVICE_RATE_EWMA_ALPHA: f64 = 0.25;
 const SERVICE_RATE_WINDOW: usize = 64;
 const ADMISSION_CACHE_AGING_COST_PER_TURN: u64 = 4_096;
 
+/// How many admissions the oldest waiter may be bypassed before the queue stops
+/// admitting anyone else and reserves the pool for it.
+///
+/// `selected_waiter` normally ranks only waiters that fit the *currently* free
+/// KV budget, so a request larger than the free budget is never a candidate. A
+/// continuous stream of smaller requests that each fit can therefore bypass a
+/// large waiter forever — unbounded when the admission timeout is zero and there
+/// is no deadline to break the wait. Once the oldest waiter has been passed over
+/// this many turns (each turn is one completed admission) and still cannot fit,
+/// admission is held so active reservations drain toward it. Every queued
+/// request fits an empty pool (`claim_or_enqueue` rejects impossible requests up
+/// front), so draining always makes progress. The bound trades a little
+/// throughput and cache locality for a hard ceiling on bypasses before drain
+/// reservation begins.
+pub(in crate::frontend) const ADMISSION_STARVATION_BOUND_TURNS: u64 = 32;
+
 pub(in crate::frontend) type GenerationCacheAffinityRefresh =
     Arc<dyn Fn() -> CacheAffinity + Send + Sync>;
 
@@ -190,6 +206,31 @@ impl GenerationAdmissionQueue {
                     .collect::<Vec<_>>(),
             )
         };
+        // Anti-starvation head-of-line reservation. The oldest waiter (smallest
+        // enqueued turn, then smallest order) is the one at risk: once it has
+        // been bypassed ADMISSION_STARVATION_BOUND_TURNS times, reserve the pool
+        // for it instead of letting a steady stream of smaller, currently-fitting
+        // requests keep passing it. If it now fits, hand it the lane directly so a
+        // higher cache-value newcomer cannot re-occupy the drained pool ahead of
+        // it; otherwise select nobody so active reservations keep draining.
+        if let Some((senior_id, senior)) = waiters
+            .iter()
+            .min_by_key(|(_, waiter)| (waiter.enqueued_turn, waiter.order))
+            && turn.saturating_sub(senior.enqueued_turn) >= ADMISSION_STARVATION_BOUND_TURNS
+        {
+            let senior_id = *senior_id;
+            if !token_budget.can_reserve_now(senior.token_budget_request)? {
+                return Ok(None);
+            }
+            let mut state = self
+                .state
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner);
+            if state.selected_id.is_none() && state.waiters.contains_key(&senior_id) {
+                state.selected_id = Some(senior_id);
+            }
+            return Ok(state.selected_id);
+        }
         let mut eligible_waiters = Vec::with_capacity(waiters.len());
         for (id, waiter) in waiters {
             if token_budget.can_reserve_now(waiter.token_budget_request)? {

--- a/crates/skippy-server/src/frontend/generation/server.rs
+++ b/crates/skippy-server/src/frontend/generation/server.rs
@@ -81,9 +81,6 @@ pub async fn serve_openai(args: ServeOpenAiArgs) -> Result<()> {
     if args.generation_concurrency == Some(0) {
         bail!("--generation-concurrency must be greater than zero");
     }
-    if args.generation_admission_timeout_secs == 0 {
-        bail!("--generation-admission-timeout-secs must be greater than zero");
-    }
     let generation_concurrency = args
         .generation_concurrency
         .unwrap_or_else(|| usize::try_from(config.lane_count).unwrap_or(usize::MAX));
@@ -409,9 +406,6 @@ fn embedded_openai_backend_with_scheduler(
     }
     if args.generation_concurrency == 0 {
         bail!("--openai-generation-concurrency must be greater than zero");
-    }
-    if args.generation_admission_timeout_secs == 0 {
-        bail!("--openai-generation-admission-timeout-secs must be greater than zero");
     }
     ensure_generation_concurrency_fits_lanes(
         args.generation_concurrency,

--- a/crates/skippy-server/src/frontend/generation_flow.rs
+++ b/crates/skippy-server/src/frontend/generation_flow.rs
@@ -1042,8 +1042,20 @@ impl StageOpenAiBackend {
 
 #[cfg(test)]
 mod tests {
-    use super::LocalSessionCleanupGuard;
+    use super::{LocalSessionCleanupGuard, text_generation::resident_capacity_target_tokens};
     use std::cell::Cell;
+
+    #[test]
+    fn resident_capacity_target_excludes_outer_decode_headroom() {
+        let prompt_tokens = 31_101;
+        let outer_reserved_tokens = prompt_tokens + 512;
+
+        assert_eq!(resident_capacity_target_tokens(prompt_tokens), 31_101);
+        assert_ne!(
+            resident_capacity_target_tokens(prompt_tokens),
+            u64::try_from(outer_reserved_tokens).unwrap()
+        );
+    }
 
     #[test]
     fn post_admission_multimodal_failure_releases_session() {

--- a/crates/skippy-server/src/frontend/generation_flow/text_generation.rs
+++ b/crates/skippy-server/src/frontend/generation_flow/text_generation.rs
@@ -1,14 +1,16 @@
-use crate::frontend::admission::GenerationTokenBudgetRequest;
 use crate::frontend::generation::{
-    EmbeddedStageZeroGeneration, GENERATION_TOKEN_BUDGET_TIMEOUT, GeneratedText,
-    GenerationTokenLimit, LocalGeneration, OpenAiBackendMode, OpenAiGenerationIds, PhaseTimer,
-    PreparedGenerationPrompt, PreparedTextPrompt, StageOpenAiBackend, TextGenerationCollector,
-    emulation_generation_active,
+    EmbeddedStageZeroGeneration, GeneratedText, GenerationTokenLimit, LocalGeneration,
+    OpenAiBackendMode, OpenAiGenerationIds, PhaseTimer, PreparedGenerationPrompt,
+    PreparedTextPrompt, StageOpenAiBackend, TextGenerationCollector, emulation_generation_active,
 };
 use crate::frontend::util::{generation_stop_values, openai_backend_error};
 use openai_frontend::{ChatCompletionRequest, OpenAiError, OpenAiResult};
 use serde_json::json;
 use skippy_runtime::SamplingConfig;
+
+pub(super) fn resident_capacity_target_tokens(prompt_token_count: usize) -> u64 {
+    u64::try_from(prompt_token_count).unwrap_or(u64::MAX)
+}
 
 impl StageOpenAiBackend {
     pub(in crate::frontend) fn prepare_text_prompt(
@@ -45,6 +47,7 @@ impl StageOpenAiBackend {
         prompt: PreparedGenerationPrompt,
         max_tokens: GenerationTokenLimit,
         prepared_text: Option<PreparedTextPrompt>,
+        token_budget_stats: (usize, usize),
         stop: Option<&openai_frontend::StopSequence>,
         sampling: SamplingConfig,
         hook_request: Option<ChatCompletionRequest>,
@@ -117,15 +120,11 @@ impl StageOpenAiBackend {
         if cancellation.is_some_and(openai_frontend::CancellationToken::is_cancelled) {
             return Err(OpenAiError::backend("request cancelled"));
         }
-        let token_admit_timer = PhaseTimer::start();
-        let token_budget_reservation = self.generation_token_budget.reserve_cancellable(
-            GenerationTokenBudgetRequest::new(prompt_token_ids.len(), max_tokens),
-            GENERATION_TOKEN_BUDGET_TIMEOUT,
-            cancellation,
-        )?;
         if cancellation.is_some_and(openai_frontend::CancellationToken::is_cancelled) {
             return Err(OpenAiError::backend("request cancelled"));
         }
+        let token_admit_timer = PhaseTimer::start();
+        let (reserved_tokens, active_reserved_tokens) = token_budget_stats;
         let mut token_admit_attrs = self.openai_attrs(&ids);
         token_admit_attrs.insert(
             "llama_stage.prompt_token_count".to_string(),
@@ -134,11 +133,11 @@ impl StageOpenAiBackend {
         token_admit_attrs.insert("llama_stage.max_tokens".to_string(), json!(max_tokens));
         token_admit_attrs.insert(
             "llama_stage.kv_reserved_tokens".to_string(),
-            json!(token_budget_reservation.tokens()),
+            json!(reserved_tokens),
         );
         token_admit_attrs.insert(
             "llama_stage.kv_active_reserved_tokens".to_string(),
-            json!(token_budget_reservation.active_tokens_after_reservation()),
+            json!(active_reserved_tokens),
         );
         token_admit_attrs.insert(
             "llama_stage.kv_capacity_tokens".to_string(),
@@ -153,7 +152,11 @@ impl StageOpenAiBackend {
             Some(kv) => kv
                 .reserve_resident_capacity(
                     &ids.session_label,
-                    u64::try_from(token_budget_reservation.tokens()).unwrap_or(u64::MAX),
+                    // The resident allocator adds its own n_batch-sized free
+                    // watermark for decode. Passing the outer reservation
+                    // (prompt + decode headroom) would charge that headroom a
+                    // second time and reject prompts that fit the shared pool.
+                    resident_capacity_target_tokens(prompt_token_ids.len()),
                 )
                 .map_err(openai_backend_error)?,
             None => None,

--- a/crates/skippy-server/src/frontend/iteration_scheduler.rs
+++ b/crates/skippy-server/src/frontend/iteration_scheduler.rs
@@ -108,6 +108,7 @@ pub(crate) struct CacheAwareRuntimeRequest<'a> {
 
 struct IterationSchedulerShared {
     commands: std_mpsc::SyncSender<SchedulerCommand>,
+    max_direct_iteration_tokens: usize,
     owner_count: AtomicUsize,
     worker: Mutex<Option<JoinHandle<()>>>,
 }
@@ -360,6 +361,7 @@ struct SchedulerWorker {
     commands: std_mpsc::Receiver<SchedulerCommand>,
     kv_capacity_tokens: usize,
     max_direct_batch_size: usize,
+    max_direct_iteration_tokens: usize,
     max_commands_per_turn: usize,
     iteration_interval: Duration,
     active_runtime_sessions: usize,
@@ -407,6 +409,7 @@ impl IterationScheduler {
         let max_consecutive_prefill_iterations =
             scheduler_config.max_consecutive_prefill_iterations;
         let mixed_prefill_decode = scheduler_config.mixed_prefill_decode;
+        let max_direct_iteration_tokens = scheduler_config.max_tokens_per_iteration;
         let cache_runtime_queue = CacheRuntimeQueue::new(
             scheduler_config.cache_aging_cost_per_iteration,
             scheduler_config.group_waiting_prefixes,
@@ -459,6 +462,7 @@ impl IterationScheduler {
                     commands: receiver,
                     kv_capacity_tokens,
                     max_direct_batch_size: scheduler_lane_count.max(1),
+                    max_direct_iteration_tokens,
                     max_commands_per_turn: command_queue_capacity.min(MAX_COMMANDS_PER_TURN),
                     iteration_interval,
                     active_runtime_sessions: 0,
@@ -476,6 +480,7 @@ impl IterationScheduler {
         Ok(Self {
             shared: Arc::new(IterationSchedulerShared {
                 commands,
+                max_direct_iteration_tokens,
                 owner_count: AtomicUsize::new(1),
                 worker: Mutex::new(Some(worker)),
             }),
@@ -693,7 +698,11 @@ impl IterationScheduler {
         deadline: Option<Instant>,
         cancellation: Option<&openai_frontend::CancellationToken>,
     ) -> OpenAiResult<SchedulerIterationOutcome> {
-        validate_direct_iteration(token_ids, positions)?;
+        validate_direct_iteration(
+            token_ids,
+            positions,
+            self.shared.max_direct_iteration_tokens,
+        )?;
         ensure_direct_iteration_active(deadline, cancellation)?;
         self.enqueue_command(SchedulerCommand::ExecuteIteration(DirectIteration {
             session_id: session_id.to_string(),
@@ -1300,7 +1309,7 @@ impl SchedulerWorker {
         let batch = take_direct_iteration_batch(
             &mut self.direct_iterations,
             self.max_direct_batch_size,
-            MAX_NATIVE_ITERATION_TOKENS,
+            self.max_direct_iteration_tokens,
         );
         debug_assert!(!batch.is_empty(), "validated direct queue must yield work");
 

--- a/crates/skippy-server/src/frontend/iteration_scheduler/direct_batch.rs
+++ b/crates/skippy-server/src/frontend/iteration_scheduler/direct_batch.rs
@@ -81,15 +81,20 @@ pub(super) fn take_direct_iteration_batch(
     batch
 }
 
-pub(super) fn validate_direct_iteration(token_ids: &[i32], positions: &[i32]) -> OpenAiResult<()> {
+pub(super) fn validate_direct_iteration(
+    token_ids: &[i32],
+    positions: &[i32],
+    max_iteration_tokens: usize,
+) -> OpenAiResult<()> {
     if token_ids.is_empty() {
         return Err(OpenAiError::invalid_request(
             "scheduler iteration requires at least one token",
         ));
     }
-    if token_ids.len() > MAX_NATIVE_ITERATION_TOKENS {
+    let token_limit = max_iteration_tokens.min(MAX_NATIVE_ITERATION_TOKENS);
+    if token_ids.len() > token_limit {
         return Err(OpenAiError::invalid_request(format!(
-            "scheduler iteration exceeds the {MAX_NATIVE_ITERATION_TOKENS}-token limit"
+            "scheduler iteration exceeds the {token_limit}-token configured iteration limit"
         )));
     }
     if !positions.is_empty() && !positions.len().is_multiple_of(token_ids.len()) {

--- a/crates/skippy-server/src/frontend/iteration_scheduler/tests.rs
+++ b/crates/skippy-server/src/frontend/iteration_scheduler/tests.rs
@@ -32,6 +32,7 @@ fn expired_direct_iteration_behind_blocked_worker_never_reaches_native_runtime()
             commands: receiver,
             kv_capacity_tokens: 64,
             max_direct_batch_size: 1,
+            max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
             max_commands_per_turn: 8,
             iteration_interval: Duration::ZERO,
             active_runtime_sessions: 0,
@@ -87,6 +88,7 @@ fn direct_iteration_rechecks_deadline_after_worker_reply() {
     let scheduler = IterationScheduler {
         shared: Arc::new(IterationSchedulerShared {
             commands,
+            max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
             owner_count: AtomicUsize::new(1),
             worker: Mutex::new(None),
         }),
@@ -200,6 +202,7 @@ fn server_scheduler_worker_batches_and_completes_default_generations() {
         commands: receiver,
         kv_capacity_tokens: 64,
         max_direct_batch_size: 2,
+        max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
         max_commands_per_turn: 8,
         iteration_interval: Duration::ZERO,
         active_runtime_sessions: 0,
@@ -281,11 +284,15 @@ fn server_scheduler_worker_batches_and_completes_default_generations() {
 
 #[test]
 fn feature_driver_iterations_enforce_the_native_batch_shape() {
-    assert!(validate_direct_iteration(&[1], &[]).is_ok());
-    assert!(validate_direct_iteration(&[1, 2], &[0, 1]).is_ok());
-    assert!(validate_direct_iteration(&[], &[]).is_err());
-    assert!(validate_direct_iteration(&[1, 2], &[0, 1, 2]).is_err());
-    assert!(validate_direct_iteration(&vec![1; MAX_NATIVE_ITERATION_TOKENS + 1], &[]).is_err());
+    assert!(validate_direct_iteration(&[1], &[], 512).is_ok());
+    assert!(validate_direct_iteration(&[1, 2], &[0, 1], 512).is_ok());
+    assert!(validate_direct_iteration(&[], &[], 512).is_err());
+    assert!(validate_direct_iteration(&[1, 2], &[0, 1, 2], 512).is_err());
+    assert!(validate_direct_iteration(&vec![1; 513], &[], 512).is_err());
+    assert!(
+        validate_direct_iteration(&vec![1; MAX_NATIVE_ITERATION_TOKENS + 1], &[], usize::MAX)
+            .is_err()
+    );
 }
 
 #[test]
@@ -310,6 +317,25 @@ fn direct_iteration_batch_defers_duplicate_sessions() {
 }
 
 #[test]
+fn direct_prefill_wave_never_exceeds_configured_native_batch_tokens() {
+    let mut queue = (0..8)
+        .map(|index| direct_iteration(&format!("session-{index}"), 128))
+        .collect::<VecDeque<_>>();
+
+    let batch = take_direct_iteration_batch(&mut queue, 8, 512);
+
+    assert_eq!(batch.len(), 4);
+    assert_eq!(
+        batch
+            .iter()
+            .map(|request| request.token_ids.len())
+            .sum::<usize>(),
+        512
+    );
+    assert_eq!(queue.len(), 4);
+}
+
+#[test]
 fn token_control_is_applied_without_blocking_the_scheduler_iteration() {
     let runtime = Arc::new(Mutex::new(RuntimeState::new_modelless_for_test(1)));
     let (_commands, receiver) = std_mpsc::channel();
@@ -322,6 +348,7 @@ fn token_control_is_applied_without_blocking_the_scheduler_iteration() {
         commands: receiver,
         kv_capacity_tokens: 64,
         max_direct_batch_size: 1,
+        max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
         max_commands_per_turn: 8,
         iteration_interval: Duration::ZERO,
         active_runtime_sessions: 0,
@@ -378,6 +405,7 @@ fn resumed_request_cancellation_leaves_runtime_for_caller_cleanup() {
         commands: receiver,
         kv_capacity_tokens: 64,
         max_direct_batch_size: 1,
+        max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
         max_commands_per_turn: 8,
         iteration_interval: Duration::ZERO,
         active_runtime_sessions: 0,
@@ -432,6 +460,7 @@ fn feature_runtime_operations_execute_on_the_scheduler_worker() {
             commands: receiver,
             kv_capacity_tokens: 64,
             max_direct_batch_size: 3,
+            max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
             max_commands_per_turn: 8,
             iteration_interval: Duration::ZERO,
             active_runtime_sessions: 0,
@@ -446,6 +475,7 @@ fn feature_runtime_operations_execute_on_the_scheduler_worker() {
     let scheduler = IterationScheduler {
         shared: Arc::new(IterationSchedulerShared {
             commands,
+            max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
             owner_count: AtomicUsize::new(1),
             worker: Mutex::new(Some(worker)),
         }),
@@ -474,6 +504,7 @@ fn detached_runtime_operation_returns_before_work_completes() {
             commands: receiver,
             kv_capacity_tokens: 64,
             max_direct_batch_size: 3,
+            max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
             max_commands_per_turn: 8,
             iteration_interval: Duration::ZERO,
             active_runtime_sessions: 0,
@@ -488,6 +519,7 @@ fn detached_runtime_operation_returns_before_work_completes() {
     let scheduler = IterationScheduler {
         shared: Arc::new(IterationSchedulerShared {
             commands,
+            max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
             owner_count: AtomicUsize::new(1),
             worker: Mutex::new(Some(worker)),
         }),
@@ -613,6 +645,7 @@ fn full_direct_wave_suppresses_cache_runtime_while_direct_queue_is_temporarily_e
         commands: receiver,
         kv_capacity_tokens: 64,
         max_direct_batch_size: 1,
+        max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
         max_commands_per_turn: 8,
         iteration_interval: Duration::ZERO,
         active_runtime_sessions: 1,
@@ -657,6 +690,7 @@ fn resident_kv_does_not_engage_direct_wave_gate() {
         commands: receiver,
         kv_capacity_tokens: 64,
         max_direct_batch_size: 1,
+        max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
         max_commands_per_turn: 8,
         iteration_interval: Duration::ZERO,
         active_runtime_sessions: 1,
@@ -715,6 +749,7 @@ fn bounded_command_queue_fails_closed_with_overload() {
     let scheduler = IterationScheduler {
         shared: Arc::new(IterationSchedulerShared {
             commands,
+            max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
             owner_count: AtomicUsize::new(1),
             worker: Mutex::new(None),
         }),
@@ -747,6 +782,7 @@ fn worker_panic_is_contained_and_fails_active_requests() {
             commands: receiver,
             kv_capacity_tokens: 64,
             max_direct_batch_size: 1,
+            max_direct_iteration_tokens: MAX_NATIVE_ITERATION_TOKENS,
             max_commands_per_turn: 8,
             iteration_interval: Duration::ZERO,
             active_runtime_sessions: 0,

--- a/crates/skippy-server/src/frontend/tests/generation.rs
+++ b/crates/skippy-server/src/frontend/tests/generation.rs
@@ -167,10 +167,13 @@ fn queued_arrival_cannot_be_overtaken_when_a_lane_opens() {
     let queue = Arc::new(GenerationAdmissionQueue::new());
     let generation_limit = Arc::new(Semaphore::new(0));
     let generation_queue_depth = Arc::new(AtomicUsize::new(0));
+    let token_budget = Arc::new(GenerationTokenBudget::new(128));
 
     let first = queue
         .claim_or_enqueue(
             generation_limit.clone(),
+            token_budget.clone(),
+            GenerationTokenBudgetRequest::new(1, 1),
             GenerationAdmissionScheduling::default(),
             generation_queue_depth.clone(),
             2,
@@ -182,6 +185,8 @@ fn queued_arrival_cannot_be_overtaken_when_a_lane_opens() {
     let second = queue
         .claim_or_enqueue(
             generation_limit.clone(),
+            token_budget,
+            GenerationTokenBudgetRequest::new(1, 1),
             GenerationAdmissionScheduling::default(),
             generation_queue_depth.clone(),
             2,

--- a/crates/skippy-server/src/frontend/tests/mod.rs
+++ b/crates/skippy-server/src/frontend/tests/mod.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub(super) use super::{
-    admission::GenerationTokenBudget,
+    admission::{GenerationTokenBudget, GenerationTokenBudgetRequest},
     iteration_scheduler::IterationScheduler,
     prefill::{
         EmbeddedPrefillDrain, PrefillChunkObservation, PrefillChunkPolicy, PrefillChunkPolicyArgs,

--- a/crates/skippy-server/src/frontend/tests/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/tests/prefix_cache.rs
@@ -90,6 +90,32 @@ fn resident_capacity_unknown_fails_closed() {
 }
 
 #[test]
+fn resident_capacity_keeps_decode_watermark_separate_from_prompt_reservation() {
+    let config = prefix_cache_test_config();
+    let kv = KvStageIntegration::from_config(&config, skippy_runtime::ModelStateKind::Dense)
+        .unwrap()
+        .expect("resident prefix cache enabled");
+    let mut runtime = crate::runtime_state::RuntimeState::new_modelless_with_capacity_for_test(
+        config.lane_count,
+        31_613,
+    );
+    let _reservation = kv
+        .reserve_resident_capacity("queued", 31_101)
+        .unwrap()
+        .expect("resident reservation");
+
+    let decision = kv
+        .admit_resident_capacity(&mut runtime, "active", 0, 512, 512, None)
+        .unwrap();
+
+    assert!(decision.admitted);
+    assert_eq!(decision.active_tokens, 0);
+    assert_eq!(decision.inflight_outstanding_tokens, 31_101);
+    assert_eq!(decision.projected_free_tokens, 512);
+    assert_eq!(decision.admission_deficit_tokens, 0);
+}
+
+#[test]
 fn resident_capacity_admission_evicts_for_the_aggregate_active_four_wave() {
     let config = StageConfig {
         ctx_size: 131_072,

--- a/crates/skippy-server/src/lib.rs
+++ b/crates/skippy-server/src/lib.rs
@@ -49,14 +49,14 @@ pub use embedded::{
 };
 pub use frontend::{
     CONTEXT_BUDGET_MAX_TOKENS, DECODE_BATCH_HEADROOM_TOKENS, DEFAULT_EMBEDDED_MAX_TOKENS,
-    EmbeddedOpenAiArgs, EmbeddedOpenAiBackend, EmbeddedOpenAiRequestDefaults,
-    EmbeddedReasoningBudget, EmbeddedReasoningEnabled, EmbeddedReasoningFormat, LinearProposal,
-    LinearProposalDiscardReason, LinearProposalDisposition, LinearProposalIngress,
-    LinearProposalQuery, LinearProposalReceipt, LinearProposalSourceOutcome,
-    LinearProposalSourceResponse, LinearProposalSourceTelemetry, NativeMtpProposalConfig,
-    NgramExtensionConfig, NgramProposalConfig, NgramProposerKind, OpaqueProposalDecisionId,
-    OpenAiGuardrailsConfig, OpenAiGuardrailsStatus, OpenAiGuardrailsTarget,
-    SpeculativeDecodeConfig, VerifyWindowConfig, embedded_openai_backend,
+    DEFAULT_GENERATION_ADMISSION_TIMEOUT_SECS, EmbeddedOpenAiArgs, EmbeddedOpenAiBackend,
+    EmbeddedOpenAiRequestDefaults, EmbeddedReasoningBudget, EmbeddedReasoningEnabled,
+    EmbeddedReasoningFormat, LinearProposal, LinearProposalDiscardReason,
+    LinearProposalDisposition, LinearProposalIngress, LinearProposalQuery, LinearProposalReceipt,
+    LinearProposalSourceOutcome, LinearProposalSourceResponse, LinearProposalSourceTelemetry,
+    NativeMtpProposalConfig, NgramExtensionConfig, NgramProposalConfig, NgramProposerKind,
+    OpaqueProposalDecisionId, OpenAiGuardrailsConfig, OpenAiGuardrailsStatus,
+    OpenAiGuardrailsTarget, SpeculativeDecodeConfig, VerifyWindowConfig, embedded_openai_backend,
 };
 pub use skippy_protocol::StageConfig;
 pub use tokenizer::{MAX_TOKENIZE_TOKENS, TokenizerCapability, TokenizerCapabilityError};

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -4359,11 +4359,11 @@
   ],
   "crates/skippy-server/src/frontend/generation/server.rs": [
     {
-      "line": 196,
+      "line": 193,
       "macro_name": "println!"
     },
     {
-      "line": 343,
+      "line": 340,
       "macro_name": "println!"
     }
   ],


### PR DESCRIPTION
## Summary

Built directly on the merged #1636 tree.

Make the generation scheduler promote work only when it can atomically claim both an execution lane and the request's shared-KV reservation. This keeps `n_ctx` as a bounded physical pool while allowing excess API concurrency to drain through queued waves.

The change also makes the configured per-iteration token budget authoritative for direct prefill batches and removes timeout-based rejection as the default capacity path.

## What changed

- queue each request with its actual prompt + bounded decode-headroom demand
- atomically acquire a raw lane and KV reservation; a waiter holds neither resource while blocked on the other
- reject a request that can never fit the full pool immediately with `context_length_exceeded`
- keep accepted work queued until cancellation by default (`generation_admission_timeout_secs=0`), while retaining explicit positive timeouts and the bounded queue
- wake capacity waiters on either lane or KV release and release both resources on cancellation/error
- cap direct native prefill waves with `max_tokens_per_iteration` (`n_batch`) instead of the old hard-coded 2,048-token ceiling
- pass prompt demand—not prompt plus already-reserved decode headroom—to the resident-KV allocator, which maintains its own decode watermark

## Before / after: exact default C8 replay

Both arms used the same pinned Qwen3-30B-A3B model, fixed 8-request cohort, 4 warmups, Metal runtime ABI 0.1.49, default 32,768-token shared KV pool, auto concurrency, and default batch settings. No scheduler capacity overrides were supplied.

The candidate binary was built and measured at post-#1636 head `20803e35b`. Current head `cb1a67040` adds two review follow-ups outside that measured workload path: positive-timeout waiters now recheck the deadline before resource acquisition, and direct iterations larger than configured `n_batch` fail before enqueue. Both focused tests, Clippy, and the full 673-test library suite pass after those changes.

| Exact default C8 | #1636 runtime baseline (`790b67a42`) | This change | Result |
|---|---:|---:|---|
| Correct requests | 3 / 8 | **8 / 8** | **all 5 lost requests recovered** |
| Failed requests | 5 | **0** | **-5** |
| Expected prompt tokens completed | 28,946 / 74,380 | **74,380 / 74,380** | **complete** |
| Expected output tokens completed | 316 / 693 | **693 / 693** | **complete** |
| Post-lane KV wait timeouts | 3 | **0** | **eliminated** |
| Predicted/lane admission timeouts | 2 | **0** | **eliminated** |
| Native batch assertions | 0 | **0** | clean |
| Mean requests in flight | 2.91 | **5.31** | queued waves remain productive |
| Concurrency utilization | 36.42% | **66.34%** | +29.92 pp |

The baseline's 70.61 s window and 61.71/62.37 s TTFT p50/p95 cover only its three successful requests, so they are not comparable performance measurements. The complete candidate workload took 191.81 s, with TTFT p50/p95 94.43/187.98 s across all eight requests; the last requests intentionally wait for KV-safe waves.

## Before / after: native prefill budget

| 8 ready prefill chunks × 128 tokens, `n_batch=512` | Before | After |
|---|---:|---:|
| Scheduler ceiling used for direct batch | 2,048 tokens | **512 tokens** |
| Chunks eligible for one native call | 8 (1,024 tokens) | **4 (512 tokens)** |
| `sum(scheduled_tokens) <= n_batch` | No | **Yes** |

Covered by `direct_prefill_batch_respects_configured_iteration_token_budget`.

## Validation

- `cargo fmt --all -- --check`
- full `skippy-server` library suite: **673 passed, 0 failed, 3 ignored**
- `cargo check -p skippy-server --all-targets`
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- `cargo check -p mesh-llm-host-runtime --all-targets`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `cargo check -p mesh-llm --all-targets`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- exact default C8 agentic replay: **8/8 correct**, 74,380 prompt + 693 output tokens, zero failures

Regression coverage includes atomic resource promotion, serial KV-wave draining, impossible-request rejection, cancellation cleanup, the default no-timeout policy, configured native batch budgeting, and resident decode-watermark separation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Generation requests now wait for available capacity by default instead of timing out after 60 seconds.
  - Admission control accounts for execution capacity and token budgets, improving queue fairness under load.
  - Requests exceeding the configured token capacity are rejected early with a clear context-length error.
  - Direct iteration batches now respect the configured maximum token limit.

- **Bug Fixes**
  - Improved cancellation and resource-release handling prevents capacity reservations from being retained unnecessarily.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->