### PR TITLE
fix(ci): exercise iOS-sensitive changes on PRs

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -164,7 +164,7 @@ removable after this branch's runner contract is active on protected main.
 | `ci-linux-sdk-slice.yml`, `ci-macos-sdk-slice.yml` | Platform-local Rust/Kotlin/Swift smoke consumers; SDK producers are independent top-level calls and each smoke receives the lane-local immutable UI artifact |
 | `ci-runner-contract-slice.yml` | Provider/cache/plan trust and main runner-image checks |
 | `native-sdk-artifact.yml` | Typed native SDK producer |
-| `swift-sdk-artifact.yml` | Host-only/full XCFramework producer; trusted main remains `macos-15`, while eligible same-repository PRs follow the protected Depot macOS 15 gate |
+| `swift-sdk-artifact.yml` | Host-only/full XCFramework producer; main/manual and dependency-, Swift-, FFI-, or identity-sensitive ready PRs use the iOS-inclusive full mode; trusted main remains `macos-15`, while eligible same-repository PRs follow the protected Depot macOS 15 gate |
 | `smoke.yml` | Artifact-based inference/OpenAI/split smoke |
 | `scripted-binary-smoke.yml` | Artifact-based scripted product smoke |
 | `sdk-smoke.yml` | Artifact-based SDK consumers; all SDK rows consume the lane's immutable console UI artifact, while Rust smoke restores the main-seeded, target/profile/image/toolchain/recipe-bound Cargo/target cache through `Swatinem/rust-cache` |

--- a/.github/actions/plan-ci/action.yml
+++ b/.github/actions/plan-ci/action.yml
@@ -109,6 +109,9 @@ outputs:
   cli_surface_changed:
     description: Planner-owned CLI surface change signal
     value: ${{ steps.plan.outputs.cli_surface_changed }}
+  swift_full_required:
+    description: Planner-owned iOS-inclusive Swift SDK change signal
+    value: ${{ steps.plan.outputs.swift_full_required }}
   docs_only:
     description: Planner-owned docs-only signal
     value: ${{ steps.plan.outputs.docs_only }}
@@ -263,7 +266,7 @@ runs:
           echo "linux_runtime_products_matrix=$(jq -c '[.matrices.runtime_products[] | select(.platform == "linux")]' ci-plan.json)"
           echo "macos_runtime_products_matrix=$(jq -c '[.matrices.runtime_products[] | select(.platform == "macos")]' ci-plan.json)"
           echo "windows_runtime_products_matrix=$(jq -c '[.matrices.runtime_products[] | select(.platform == "windows")]' ci-plan.json)"
-          for signal in rust_changed ui_changed website_changed website_docs_changed cli_surface_changed docs_only backend_changed runner_contract_required; do
+          for signal in rust_changed ui_changed website_changed website_docs_changed cli_surface_changed swift_full_required docs_only backend_changed runner_contract_required; do
             echo "${signal}=$(jq -r --arg signal "$signal" '.signals[$signal]' ci-plan.json)"
           done
           echo "linux_max_parallel=$(jq -r '.budgets.linux_max_parallel' ci-plan.json)"

--- a/.github/workflows/ci-macos-lane.yml
+++ b/.github/workflows/ci-macos-lane.yml
@@ -138,7 +138,7 @@ jobs:
       source_sha: ${{ inputs.source_sha }}
       original_event_name: ${{ inputs.original_event_name }}
       force_hosted: ${{ fromJson(inputs.lane_plan_json).signals.runner_contract_required }}
-      mode: ${{ (fromJson(inputs.lane_plan_json).profile == 'main' || fromJson(inputs.lane_plan_json).profile == 'manual-full') && 'full' || 'host-only' }}
+      mode: ${{ fromJson(inputs.lane_plan_json).signals.swift_full_required && 'full' || 'host-only' }}
       artifact_name: ci-sdk-swift
       retention_days: 1
       timeout_minutes: 90
@@ -154,7 +154,7 @@ jobs:
       sdk_matrix: ${{ toJson(fromJson(inputs.lane_plan_json).matrices.sdk) }}
       binary_target: target/release/mesh-llm
       ui_artifact_name: ci-ui-dist-macos-${{ github.run_id }}
-      swift_mode: ${{ (fromJson(inputs.lane_plan_json).profile == 'main' || fromJson(inputs.lane_plan_json).profile == 'manual-full') && 'full' || 'host-only' }}
+      swift_mode: ${{ fromJson(inputs.lane_plan_json).signals.swift_full_required && 'full' || 'host-only' }}
     secrets:
       HF_TOKEN: ${{ inputs.original_event_name == 'push' && secrets.HF_TOKEN || '' }}
 

--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -249,7 +249,7 @@ jobs:
     needs: runner_policy
     if: ${{ inputs.cli_surface_changed }}
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3932,6 +3932,7 @@ name = "mesh-llm-host-runtime"
 version = "0.76.0-rc9"
 dependencies = [
  "anyhow",
+ "apple-native-keyring-store",
  "argon2",
  "async-trait",
  "axum",
@@ -4028,6 +4029,7 @@ dependencies = [
 name = "mesh-llm-identity"
 version = "0.76.0-rc9"
 dependencies = [
+ "apple-native-keyring-store",
  "argon2",
  "base64 0.23.1",
  "chacha20poly1305 0.11.0",

--- a/ci/ci-plan.schema.json
+++ b/ci/ci-plan.schema.json
@@ -71,6 +71,7 @@
         "website_changed",
         "website_docs_changed",
         "cli_surface_changed",
+        "swift_full_required",
         "docs_only",
         "backend_changed",
         "runner_contract_required"
@@ -81,6 +82,7 @@
         "website_changed": {"type": "boolean"},
         "website_docs_changed": {"type": "boolean"},
         "cli_surface_changed": {"type": "boolean"},
+        "swift_full_required": {"type": "boolean"},
         "docs_only": {"type": "boolean"},
         "backend_changed": {"type": "boolean"},
         "runner_contract_required": {"type": "boolean"}

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -302,6 +302,9 @@ runtime producers are not duplicated.
   Rust's smoke also uses the exact main-seeded Cargo/target cache. Swift
   production starts from the plan and Kotlin production from the shared
   static ABI; only smoke consumers wait for the matching product lane.
+  Ready PRs use the full iOS-inclusive Swift producer when Cargo dependency
+  inputs, Swift package/build inputs, mesh FFI, or identity inputs change;
+  other selected PR rows may retain the host-only producer.
 - `ci-runner-contract-slice.yml` — plan/provider/PR cache-boundary checks and
   trusted-main runner-image contracts.
 

--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -113,6 +113,12 @@ hf_hub = { package = "mesh-llm-hf-hub", version = "1.0.2", default-features = fa
 tabwriter = "1"
 tempfile = "3"
 
+[target.'cfg(target_os = "ios")'.dependencies]
+# keyring v4's default Apple backend enables only the macOS keychain. Its
+# transitive Apple store rejects iOS unless protected data is enabled; this
+# direct edge unifies that feature for iOS SDK builds.
+apple-native-keyring-store = { version = "1", features = ["protected"] }
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61", features = [
     "Win32_Foundation",

--- a/crates/mesh-llm-identity/Cargo.toml
+++ b/crates/mesh-llm-identity/Cargo.toml
@@ -29,5 +29,11 @@ sha2.workspace = true
 thiserror = "2"
 zeroize = { version = "1", features = ["derive"] }
 
+[target.'cfg(target_os = "ios")'.dependencies]
+# keyring v4's default Apple backend enables only the macOS keychain. Its
+# transitive Apple store rejects iOS unless protected data is enabled; this
+# direct edge unifies that feature for iOS SDK builds.
+apple-native-keyring-store = { version = "1", features = ["protected"] }
+
 [dev-dependencies]
 serial_test = "4"

--- a/scripts/plan-ci.py
+++ b/scripts/plan-ci.py
@@ -606,6 +606,14 @@ def _signal_value(
         )
     if name == "cli_surface_changed":
         return "cli" in domains
+    if name == "swift_full_required":
+        return any(
+            path in {"Cargo.toml", "Cargo.lock", "Package.swift"}
+            or path.startswith("sdk/swift/")
+            or path.startswith("crates/mesh-llm-ffi/")
+            or path.startswith("crates/mesh-llm-identity/")
+            for path in changed_files
+        )
     if name == "docs_only":
         return _documentation_only(domains)
     if name == "backend_changed":
@@ -781,6 +789,7 @@ def _validate_plan(plan: dict[str, Any], slices: dict[str, Any], packages: list[
         "website_changed",
         "website_docs_changed",
         "cli_surface_changed",
+        "swift_full_required",
         "docs_only",
         "backend_changed",
         "runner_contract_required",
@@ -827,6 +836,16 @@ def build_plan(
         raw=input_data.get("affected_crates"),
     )
     domains = _matched_domains(ownership, changed_files, direct_crates)
+    if _signal_value(changed_files, domains, profile, "swift_full_required"):
+        # Dependency and shared FFI/identity changes can affect the iOS build
+        # even though their primary ownership is Rust. Add the existing Swift
+        # domain so normal slice dependency closure selects its producer.
+        domain_order = _string_list(ownership["domains"], "ownership.domains")
+        domains = [
+            domain
+            for domain in domain_order
+            if domain in set(domains) | {"sdk-swift"}
+        ]
     documentation_only = _documentation_only(domains)
     required_slices, reasons, force_all_rows = _select_slices(
         slices,
@@ -862,6 +881,7 @@ def build_plan(
         "website_changed",
         "website_docs_changed",
         "cli_surface_changed",
+        "swift_full_required",
         "docs_only",
         "backend_changed",
         "runner_contract_required",

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -1664,6 +1664,10 @@ class CiArtifactActionTests(unittest.TestCase):
         ).read_text(encoding="utf-8")
         routing = self.read_compute_changes()
 
+        macos_lane = (
+            ROOT / ".github" / "workflows" / "ci-macos-lane.yml"
+        ).read_text(encoding="utf-8")
+        self.assertEqual(macos_lane.count("signals.swift_full_required && 'full' || 'host-only'"), 2)
         self.assertIn("type: string", producer)
         self.assertIn("host-only|full", producer)
         self.assertIn(

--- a/scripts/tests/test_cli_inventory_contract.py
+++ b/scripts/tests/test_cli_inventory_contract.py
@@ -94,6 +94,8 @@ class CliInventoryContractTests(unittest.TestCase):
 
         self.assertIn("Verify generated CLI inventory is deterministic and current", quality)
         self.assertIn("just cli-inventory-check", quality)
+        cli_job = quality.split("  cli_docs_sync:", 1)[1].split("\n  #", 1)[0]
+        self.assertIn("timeout-minutes: 15", cli_job)
         self.assertNotIn("Require public website docs update", quality)
         self.assertIn("npm run test:cli-explorer", web)
         self.assertIn("npm run test:cli-explorer", pages)

--- a/scripts/tests/test_plan_ci.py
+++ b/scripts/tests/test_plan_ci.py
@@ -211,6 +211,7 @@ class PlanCiTests(unittest.TestCase):
                 "website_changed": False,
                 "website_docs_changed": False,
                 "cli_surface_changed": False,
+                "swift_full_required": False,
                 "docs_only": True,
                 "backend_changed": False,
                 "runner_contract_required": False,
@@ -287,6 +288,20 @@ class PlanCiTests(unittest.TestCase):
         self.assertNotIn("web", plan["required_slices"])
         self.assertTrue(plan["signals"]["cli_surface_changed"])
         self.assertFalse(plan["signals"]["website_docs_changed"])
+
+    def test_dependency_lockfile_change_requires_full_swift_input(self) -> None:
+        payload = fixture("runtime.json")
+        payload["changed_files"] = ["Cargo.lock"]
+
+        plan = PLANNER.build_plan(payload, root=ROOT)
+
+        self.assertTrue(plan["signals"]["swift_full_required"])
+        self.assertIn("swift", [row["id"] for row in plan["matrices"]["sdk"]])
+
+    def test_unrelated_runtime_change_keeps_host_only_swift_input(self) -> None:
+        plan = PLANNER.build_plan(fixture("runtime.json"), root=ROOT)
+
+        self.assertFalse(plan["signals"]["swift_full_required"])
 
     def test_backend_change_adds_only_the_owned_backend_rows(self) -> None:
         payload = fixture("runtime.json")


### PR DESCRIPTION
## Summary

- enable `apple-native-keyring-store/protected` for iOS consumers after the keyring v4 upgrade
- make dependency, Swift, FFI, and identity changes select the full iOS-inclusive Swift SDK producer on PRs
- raise CLI inventory's cold-install timeout from 5 to 15 minutes
- add planner and workflow contract coverage and update CI topology docs

## Why #1622 passed

#1622's Swift row was selected, but every PR was hard-coded to `host-only`; only main/manual built iOS. Its modified reusable workflow definition was also protected by PR entrypoints calling `@main`, so the new five-minute CLI timeout was not exercised before merge.

## Validation

- `actionlint -config-file .github/actionlint.yaml`
- focused planner/workflow contract tests (4/4 passed)
- `cargo tree -p mesh-llm-host-runtime --target aarch64-apple-ios -e features -i apple-native-keyring-store` confirms `protected`
- `cargo check --locked -p mesh-llm-identity --features host-io --target aarch64-apple-ios`
- `just ci-validate` reached 753 tests but was not clean in this local shell: PyYAML is absent, and unrelated tests invoke Apple Bash 3 / stale affected-crate output. `actionlint` and `git diff --check` passed before that test phase.

## Rollout note

PR macOS should exercise the full Swift/iOS producer for this dependency-sensitive change. The changed timeout itself is protected workflow YAML and therefore still requires the first post-merge Main Quality run as live rollout evidence.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **CI/CD**
  * Swift builds now automatically use the full iOS-inclusive configuration when relevant Cargo, Swift, FFI, or identity changes are detected.
  * Unrelated changes continue to use the host-only Swift configuration.
  * CLI documentation synchronization jobs may run for up to 15 minutes.

* **Platform Support**
  * Improved protected keyring support for iOS builds.

* **Documentation**
  * Updated CI documentation to explain Swift build selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->