### PR TITLE
fix(main): repair iOS keyring build and CLI timeout

### DIFF
--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -249,7 +249,7 @@ jobs:
     needs: runner_policy
     if: ${{ inputs.cli_surface_changed }}
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4028,6 +4028,7 @@ dependencies = [
 name = "mesh-llm-identity"
 version = "0.76.0-rc9"
 dependencies = [
+ "apple-native-keyring-store",
  "argon2",
  "base64 0.23.1",
  "chacha20poly1305 0.11.0",

--- a/crates/mesh-llm-identity/Cargo.toml
+++ b/crates/mesh-llm-identity/Cargo.toml
@@ -29,5 +29,9 @@ sha2.workspace = true
 thiserror = "2"
 zeroize = { version = "1", features = ["derive"] }
 
+[target.'cfg(target_os = "ios")'.dependencies]
+# keyring v4's Apple backend requires protected-data support on iOS.
+apple-native-keyring-store = { version = "1", features = ["protected"] }
+
 [dev-dependencies]
 serial_test = "4"

--- a/scripts/tests/test_cli_inventory_contract.py
+++ b/scripts/tests/test_cli_inventory_contract.py
@@ -94,6 +94,8 @@ class CliInventoryContractTests(unittest.TestCase):
 
         self.assertIn("Verify generated CLI inventory is deterministic and current", quality)
         self.assertIn("just cli-inventory-check", quality)
+        cli_job = quality.split("  cli_docs_sync:", 1)[1].split("\n  #", 1)[0]
+        self.assertIn("timeout-minutes: 15", cli_job)
         self.assertNotIn("Require public website docs update", quality)
         self.assertIn("npm run test:cli-explorer", web)
         self.assertIn("npm run test:cli-explorer", pages)


### PR DESCRIPTION
## Summary
- enable `apple-native-keyring-store/protected` only for iOS builds of `mesh-llm-identity`
- raise `CLI inventory freshness` from 5 to 15 minutes and pin the budget in its contract test

These are the two minimal repairs for the current main failures. No routing or coverage is removed.

## Validation
- real `aarch64-apple-ios` cross-check passed
- `mesh-llm-identity` tests: 38 passed
- `mesh-llm-identity` Clippy with `-D warnings` passed
- actionlint passed
- changed CLI timeout contract assertion passed

Final proof is the first exhaustive main run after merge: ordinary PR CI does not execute these two main-only rows.

## Credits
- Michael Neale — diagnosis and product direction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved iOS compatibility for secure keyring support.

- **Chores**
  - Increased the documentation synchronization CI timeout from 5 to 15 minutes.

- **Tests**
  - Added validation to ensure the documentation synchronization job retains the updated timeout setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->