### PR TITLE
fix(ci): allow CLI inventory cold install to finish

### DIFF
--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -249,7 +249,7 @@ jobs:
     needs: runner_policy
     if: ${{ inputs.cli_surface_changed }}
     runs-on: ${{ needs.runner_policy.outputs.runner_4 }}
-    timeout-minutes: 5
+    timeout-minutes: 15
     steps:
       - uses: Mesh-LLM/mesh-llm/.github/actions/audit-depot-pr-isolation@ed07043b84d720aab30e75ed2f038f7042576f16
         with:

--- a/scripts/tests/test_cli_inventory_contract.py
+++ b/scripts/tests/test_cli_inventory_contract.py
@@ -94,6 +94,8 @@ class CliInventoryContractTests(unittest.TestCase):
 
         self.assertIn("Verify generated CLI inventory is deterministic and current", quality)
         self.assertIn("just cli-inventory-check", quality)
+        cli_job = quality.split("  cli_docs_sync:", 1)[1].split("\n  #", 1)[0]
+        self.assertIn("timeout-minutes: 15", cli_job)
         self.assertNotIn("Require public website docs update", quality)
         self.assertIn("npm run test:cli-explorer", web)
         self.assertIn("npm run test:cli-explorer", pages)


### PR DESCRIPTION
## Summary
- raise `CLI inventory freshness` from a 5-minute to a 15-minute job timeout
- pin that budget in the existing CLI inventory contract test

Main's cold `npm ci` reached 4m53s after setup and was deterministically killed by the five-minute job timeout. This changes no commands, retry policy, runner routing, or gate semantics.

## Validation
Verified at `6d5ca0de04331629f9e67843d229c737feb9c505`:
- `actionlint .github/workflows/ci-quality-slice.yml`
- targeted CLI inventory workflow contract test
- Python syntax compile
- `git diff --check`

The full local contract file also reaches an unrelated existing `affected-crates.sh` portability failure under macOS Bash; the directly changed assertion passes. Final runtime proof is the first Main Quality run after merge because PRs execute the protected workflow definition from main.

## Credits
- Michael Neale — diagnosis and product direction


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Increased the CLI documentation synchronization workflow timeout to 15 minutes.
  - Added validation to ensure the workflow retains the expected timeout configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->