### PR TITLE
Reject explicit joins from nodes already in another active mesh

### DIFF
--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -423,6 +423,24 @@ impl Node {
                     context.remote.fmt_short()
                 )
             })?;
+        let is_explicit_join_target = self
+            .join_targets
+            .lock()
+            .await
+            .iter()
+            .any(|target| target.id == context.remote);
+        if is_explicit_join_target
+            && let Some(local_mesh_id) = self.mesh_id().await
+            && let Some(remote_mesh_id) = direct_announcement.mesh_id.as_deref()
+            && local_mesh_id != remote_mesh_id
+        {
+            anyhow::bail!(
+                "mesh ID conflict: local node belongs to mesh '{}' but peer {} belongs to mesh '{}'; stop the local mesh before joining another mesh",
+                local_mesh_id,
+                context.remote.fmt_short(),
+                remote_mesh_id
+            );
+        }
         if let Err(reason) = self
             .validate_direct_peer_requirements(
                 context.remote,

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/connections.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/connections.rs
@@ -487,6 +487,29 @@ async fn make_test_node_with_requirements(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explicit_join_rejects_conflicting_active_meshes() -> Result<()> {
+    let host = make_test_node(super::NodeRole::Worker).await?;
+    let joiner = make_test_node(super::NodeRole::Worker).await?;
+    host.set_mesh_id("host-mesh".to_string()).await;
+    joiner.set_mesh_id("joiner-mesh".to_string()).await;
+    host.start_accepting();
+    joiner.start_accepting();
+
+    let error = joiner
+        .join(&host.invite_token().await)
+        .await
+        .expect_err("an explicit join must not connect two active meshes");
+    let message = format!("{error:#}");
+    assert!(message.contains("mesh ID conflict"), "{message}");
+    assert!(message.contains("joiner-mesh"), "{message}");
+    assert!(message.contains("host-mesh"), "{message}");
+    assert!(message.contains("stop the local mesh"), "{message}");
+    assert!(joiner.peers().await.is_empty());
+
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn host_role_claim_transitions_regossip_to_connected_peer() -> Result<()> {
     let host = make_test_node(super::NodeRole::Worker).await?;
     let peer = make_test_node(super::NodeRole::Worker).await?;


### PR DESCRIPTION
An operator who asks an **already-running node with active mesh membership** to explicitly join a target in a different mesh now gets an immediate, actionable membership error instead of a later, misleading split protocol-generation exclusion.

This is a runtime-state guard. A fresh `mesh-llm ... --join <token>` process starts unattached and should adopt the target mesh; persisted `mesh-id` is not, by itself, evidence that the new node is actively attached. This PR does not claim to explain or fix the separately observed fresh-start/persisted-state incident.

Example:

```text
mesh ID conflict: local node belongs to mesh 'joiner-mesh' but peer <node-id> belongs to mesh 'host-mesh'; stop the local mesh before joining another mesh
```

## Behavior

- Fail closed when a configured explicit join target advertises an ID different from the node's current in-memory mesh ID.
- Preserve node identity and active mesh membership; a live node does not silently merge or switch meshes.
- Leave fresh, unattached startup joins and ordinary discovery/inbound gossip behavior unchanged.

## Protocol

No wire-format or protocol-generation change. This catches a conflicting live membership state before peer capability admission.

## Validation

At commit `8fee6e036c5bebc6bc48253a7b665946680ee492`:

- `cargo fmt --all --check`
- `cargo check -p mesh-llm-host-runtime`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- `cargo test -p mesh-llm-host-runtime --lib` — 2,941 passed, 0 failed, 9 ignored

The linker emitted pre-existing macOS object deployment-version warnings during the test link.

## Credits

Mic identified the confusing distinction between a fresh startup join and joining from an already-active node, and shaped the fail-closed behavior for the latter.
