### PR TITLE
docs(contributing): how to run crate test gates on a bare Windows checkout

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,6 +162,39 @@ not report, lock, or clean a second artifact tree.
 
 On native Windows, `just check-release` runs the host-safe Rust/doc invariant subset and skips the Bash-only `install.sh` / `package-release.sh` parity checks. Run it on macOS or Linux when you need full shell parity coverage.
 
+### Testing crates on native Windows
+
+A bare Windows checkout cannot build the test targets of crates that pull in
+`skippy-ffi`'s static link mode — `mesh-llm-system` does, through
+`mesh-llm-runtime-install`, which depends on `skippy-ffi` with
+`default-features = false` — because `skippy-ffi/build.rs` then requires
+prepared llama.cpp ABI archives
+(`automatic native preparation is not supported for Windows from build.rs yet`).
+`just test-all` needs the same native preparation, through its Bash pipeline.
+
+For crate suites that do not exercise the native runtime, enable
+`dynamic-native-runtime`: feature unification turns on `skippy-ffi`'s
+`dynamic-runtime`, whose build script returns early. The `mesh-llm-system`
+gates then run on a machine without a prepared native build:
+
+```powershell
+cargo test --locked -p mesh-llm-system --lib --features dynamic-native-runtime
+cargo clippy --no-deps -p mesh-llm-system --all-targets --features dynamic-native-runtime -- -D warnings
+cargo fmt --check -p mesh-llm-system
+cargo run -p xtask -- repo-consistency no-console-print
+```
+
+`--no-deps` keeps Clippy scoped to the package you are changing. Some
+`cfg`-gated code is dead only on Windows and currently fails `-D warnings`
+there (`download_optional_url` in `autoupdate/release_fetch.rs`, two
+`SignalOutcome` variants in `backend.rs`, the lock file field in
+`skippy-runtime`'s `materialized_cache.rs`), so compare your run against the
+same command on `main` before attributing an error to your change. Running the
+native-runtime suites still needs a prepared build (`LLAMA_STAGE_BUILD_DIR`
+or `SKIPPY_LLAMA_BUILD_DIR` pointing at one), which this section does not cover.
+The Rust MSVC toolchain needs the Visual Studio Build Tools with the
+"Desktop development with C++" workload installed.
+
 ## CI / GitHub Actions
 
 For the current PR and main topology, read [`ci/ci.md`](ci/ci.md), the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -168,7 +168,7 @@ A bare Windows checkout cannot build the test targets of crates that pull in
 `skippy-ffi`'s static link mode — `mesh-llm-system` does, through
 `mesh-llm-runtime-install`, which depends on `skippy-ffi` with
 `default-features = false` — because `skippy-ffi/build.rs` then requires
-prepared llama.cpp ABI archives
+the llama.cpp ABI archives to be prepared
 (`automatic native preparation is not supported for Windows from build.rs yet`).
 `just test-all` needs the same native preparation, through its Bash pipeline.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -165,9 +165,9 @@ On native Windows, `just check-release` runs the host-safe Rust/doc invariant su
 ### Testing crates on native Windows
 
 A bare Windows checkout cannot build the test targets of crates that pull in
-`skippy-ffi`'s static link mode — `mesh-llm-system` does, through
+`skippy-ffi`'s static link mode (`mesh-llm-system` does, through
 `mesh-llm-runtime-install`, which depends on `skippy-ffi` with
-`default-features = false` — because `skippy-ffi/build.rs` then requires
+`default-features = false`), because `skippy-ffi/build.rs` then requires
 the llama.cpp ABI archives to be prepared
 (`automatic native preparation is not supported for Windows from build.rs yet`).
 `just test-all` needs the same native preparation, through its Bash pipeline.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,12 +184,10 @@ cargo fmt --check -p mesh-llm-system
 cargo run -p xtask -- repo-consistency no-console-print
 ```
 
-`--no-deps` keeps Clippy scoped to the package you are changing. Some
-`cfg`-gated code is dead only on Windows and currently fails `-D warnings`
-there (`download_optional_url` in `autoupdate/release_fetch.rs`, two
-`SignalOutcome` variants in `backend.rs`, the lock file field in
-`skippy-runtime`'s `materialized_cache.rs`), so compare your run against the
-same command on `main` before attributing an error to your change. Running the
+`--no-deps` keeps Clippy scoped to the package you are changing. `cfg`-gated
+code can be dead on one platform only, so if a platform-specific warning
+appears that your diff does not touch, compare the run against the same
+command on `main` before attributing it to your change. Running the
 native-runtime suites still needs a prepared build (`LLAMA_STAGE_BUILD_DIR`
 or `SKIPPY_LLAMA_BUILD_DIR` pointing at one), which this section does not cover.
 The Rust MSVC toolchain needs the Visual Studio Build Tools with the


### PR DESCRIPTION
Companion to the install-side Windows notes from #1535, for the developer side.

A Windows checkout without prepared llama.cpp archives cannot build the test targets of crates that pull in `skippy-ffi`'s static link mode — `mesh-llm-system` does, through `mesh-llm-runtime-install` (`default-features = false`) — because `skippy-ffi/build.rs` refuses to prepare the native ABI on Windows. `just test-all` needs the same preparation.

This adds a short "Testing crates on native Windows" subsection to CONTRIBUTING.md: the `--features dynamic-native-runtime` workaround (feature unification enables `skippy-ffi`'s `dynamic-runtime`, whose build script returns early), the exact gate commands that run on a bare Windows machine, `--no-deps` Clippy scoping plus the three Windows-only dead-code sites that currently fail `-D warnings` on `main` (so contributors compare against `main` before blaming their diff), the env vars for a prepared native build, and the MSVC prerequisite.

Verified on Windows 11 at `main` f945d5af3: the bare `cargo test -p mesh-llm-system --lib` failure, every command in the snippet, and the three dead-code sites (`cargo clippy --no-deps ... -D warnings`). Docs only; no code change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Windows testing guidance to explain that conditionally compiled code may be reported as dead on one platform.
  * Added a recommendation to compare platform-specific warnings with the same command on the main branch when the warning appears unrelated to the current changes.
  * Clarified how to assess warnings that occur only in platform-specific builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->