### PR TITLE
test(model-hf): make the read-only filesystem warning test portable

### DIFF
--- a/crates/model-hf/src/cache_paths.rs
+++ b/crates/model-hf/src/cache_paths.rs
@@ -342,16 +342,20 @@ mod tests {
 
     #[test]
     fn read_only_filesystem_warning_includes_os_error_and_recovery_path() {
+        // Raw OS error 30 is EROFS on POSIX but ERROR_READ_FAULT on Windows, so
+        // assert the contract (the OS error text is surfaced verbatim) rather
+        // than the POSIX wording.
+        let os_error = std::io::Error::from_raw_os_error(30).to_string();
         let warning = DownloadDirectoryFallback {
             kind: DownloadDirectoryKind::HuggingFaceXet,
             requested: PathBuf::from("/"),
             selected: PathBuf::from("/writable/data/huggingface/xet"),
-            error: std::io::Error::from_raw_os_error(30).to_string(),
+            error: os_error.clone(),
             raw_os_error: Some(30),
         };
 
         let message = warning.to_string();
-        assert!(message.contains("Read-only file system"));
+        assert!(message.contains(&os_error));
         assert!(message.contains("/writable/data/huggingface/xet"));
         assert!(message.contains("HF_XET_CACHE"));
         assert!(message.contains("MESH_LLM_DATA_DIR"));


### PR DESCRIPTION
`cache_paths::tests::read_only_filesystem_warning_includes_os_error_and_recovery_path` builds `io::Error::from_raw_os_error(30)` and asserts that the warning contains "Read-only file system". Raw OS error 30 is EROFS on POSIX, but on Windows it is ERROR_READ_FAULT ("The system cannot read from the specified device"), so the test fails on native Windows while the code under test is fine.

The test now asserts the actual contract: the warning surfaces the OS error text verbatim (`message.contains(&os_error)`), whatever the platform's wording for code 30 is. The recovery-path and env-var assertions are unchanged.

Found while reviewing #1628 on Windows (see the comment there). Unrelated to that PR: `cache_paths.rs` was untouched by it.

Verified on Windows 11 at `main` f945d5af3: `cargo test --locked -p model-hf --lib` 47 passed (was 46/47), `cargo clippy --no-deps -p model-hf --all-targets -- -D warnings` clean, `cargo fmt --check -p model-hf` clean, `repo-consistency no-console-print` clean. Not run on POSIX here; there the new assertion should be at least as strict as the old one, since the error string is "Read-only file system (os error 30)".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of read-only filesystem warnings by checking the operating system’s actual error text.
  * This makes test coverage more reliable across platforms with different wording for filesystem access errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->