### PR TITLE
chore: silence the Windows-only dead-code lints in mesh-llm-system

### DIFF
--- a/crates/mesh-llm-system/src/autoupdate/release_fetch.rs
+++ b/crates/mesh-llm-system/src/autoupdate/release_fetch.rs
@@ -422,6 +422,8 @@ async fn install_native_runtime_after_update(
 ) {
 }
 
+// Only the non-Windows `install_native_runtime_after_update` calls this.
+#[cfg(not(windows))]
 async fn download_optional_url(url: &str, path: &Path, expected_sha256: &str) -> Result<bool> {
     let response = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(60))

--- a/crates/mesh-llm-system/src/backend.rs
+++ b/crates/mesh-llm-system/src/backend.rs
@@ -172,7 +172,10 @@ enum ProcessSignal {
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]
 enum SignalOutcome {
     Sent,
+    // Only the non-Windows pid/name verification path constructs these.
+    #[cfg_attr(windows, allow(dead_code))]
     AlreadyDead,
+    #[cfg_attr(windows, allow(dead_code))]
     Skipped,
     Failed,
 }


### PR DESCRIPTION
Windows counterpart of the macOS pass in #1591. On a bare Windows checkout, `cargo clippy -p mesh-llm-system --all-targets --features dynamic-native-runtime -- -D warnings` fails on two cfg-gated sites that are dead only on Windows:

- `download_optional_url` in `autoupdate/release_fetch.rs`: its sole caller, `install_native_runtime_after_update`, is `#[cfg(not(windows))]`; the function is now gated the same way.
- `SignalOutcome::{AlreadyDead, Skipped}` in `backend.rs`: constructed only inside the `#[cfg(not(windows))]` pid/name verification block, still matched on Windows; `allow(dead_code)` on those two variants under `cfg(windows)`.

No behavior change on any platform; each attribute is a no-op outside Windows. Each site carries a one-line comment saying why it is dead there.

The third Windows-only site, `MaterializedOutputLock.file` in `skippy-runtime/src/package/materialized_cache.rs`, was in this PR until the review: #1685 replaces the unix-only `flock` with `File::lock`/`unlock`, which reads the field on every platform, so #1685 carries that file and the `allow` was dropped here. Until #1685 lands, `cargo clippy -p skippy-runtime -- -D warnings` still fails on Windows on that one field.

Verified on Windows 11 at the rebased head (on `main` 03267ccf0): `cargo clippy --no-deps -p mesh-llm-system --all-targets --features dynamic-native-runtime -- -D warnings` clean (it failed on the two sites before); earlier at `main` f945d5af3, `cargo test --locked -p mesh-llm-system --lib --features dynamic-native-runtime` 186 passed; `cargo fmt --check` and `repo-consistency no-console-print` clean. Not run on Linux or macOS here. Note that the Windows CI lane does not run for this PR: `ci/ownership.yml` maps only the Windows scripts and the `mesh-llm-nodejs` / `skippy-ffi` crates to `platform-windows`.

The Windows locking gap in `MaterializedOutputLock` noted in the first version of this description is now #1682, fixed by #1685.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added platform-specific annotations and documentation for internal update and process-handling code.
  * No user-facing behavior changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
