### PR TITLE
fix(skippy): restore recurrent split prefix reuse

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -160,13 +160,13 @@ removable after this branch's runner contract is active on protected main.
 | `ci-{linux,macos,windows}-runtime-slice.yml` | Platform-pure native runtime producers |
 | `ci-{linux,macos,windows}-product-slice.yml` | Platform-pure composition-only product consumers |
 | `ci-platform-checks-slice.yml` | macOS portable/unit, Windows portable, and Windows log-store privacy ACL checks |
-| `ci-linux-product-smoke-slice.yml`, `ci-macos-product-smoke-slice.yml` | Platform-local CPU, CUDA (`gpu-nvidia` self-hosted), two-node, Metal and model-download consumers; the Linux split smoke serializes pinned dense SmolLM2 and recurrent Qwen3.5 rows with PR fail-fast; ROCm/Vulkan products remain package-verified pending eligible inference runners |
+| `ci-linux-product-smoke-slice.yml`, `ci-macos-product-smoke-slice.yml` | Platform-local CPU, CUDA (`gpu-nvidia` self-hosted), two-node, Metal and model-download consumers; one Linux KV caching smoke job runs pinned dense SmolLM2 then recurrent Qwen3.5 legs and requires both to pass; ROCm/Vulkan products remain package-verified pending eligible inference runners |
 | `ci-linux-sdk-slice.yml`, `ci-macos-sdk-slice.yml` | Platform-local Rust/Kotlin/Swift smoke consumers; SDK producers are independent top-level calls and each smoke receives the lane-local immutable UI artifact |
 | `ci-runner-contract-slice.yml` | Provider/cache/plan trust and main runner-image checks |
 | `native-sdk-artifact.yml` | Typed native SDK producer |
 | `swift-sdk-artifact.yml` | Host-only/full XCFramework producer; full mode builds the seven Apple Rust targets as a bounded matrix (maximum four concurrent macOS runners) and joins their immutable libraries in one assembly job, while host-only remains a single producer. Trusted main remains `macos-15`, while eligible same-repository PRs follow the protected Depot macOS 15 gate |
 | `smoke.yml` | Artifact-based inference/OpenAI/split smoke |
-| `scripted-binary-smoke.yml` | Artifact-based scripted product smoke with an optional typed model context-size override |
+| `scripted-binary-smoke.yml` | Artifact-based scripted product smoke with optional typed model context-size and recurrent-model inputs; recurrent models restore and save through a dedicated trust-scoped cache before the smoke runs |
 | `sdk-smoke.yml` | Artifact-based SDK consumers; all SDK rows consume the lane's immutable console UI artifact, while Rust smoke restores the main-seeded, target/profile/image/toolchain/recipe-bound Cargo/target cache through `Swatinem/rust-cache` |
 | `hf-download-smoke.yml` | Hugging Face download smoke |
 

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -160,13 +160,13 @@ removable after this branch's runner contract is active on protected main.
 | `ci-{linux,macos,windows}-runtime-slice.yml` | Platform-pure native runtime producers |
 | `ci-{linux,macos,windows}-product-slice.yml` | Platform-pure composition-only product consumers |
 | `ci-platform-checks-slice.yml` | macOS portable/unit, Windows portable, and Windows log-store privacy ACL checks |
-| `ci-linux-product-smoke-slice.yml`, `ci-macos-product-smoke-slice.yml` | Platform-local CPU, CUDA (`gpu-nvidia` self-hosted), two-node, Metal and model-download consumers; ROCm/Vulkan products remain package-verified pending eligible inference runners |
+| `ci-linux-product-smoke-slice.yml`, `ci-macos-product-smoke-slice.yml` | Platform-local CPU, CUDA (`gpu-nvidia` self-hosted), two-node, Metal and model-download consumers; the Linux split smoke serializes pinned dense SmolLM2 and recurrent Qwen3.5 rows with PR fail-fast; ROCm/Vulkan products remain package-verified pending eligible inference runners |
 | `ci-linux-sdk-slice.yml`, `ci-macos-sdk-slice.yml` | Platform-local Rust/Kotlin/Swift smoke consumers; SDK producers are independent top-level calls and each smoke receives the lane-local immutable UI artifact |
 | `ci-runner-contract-slice.yml` | Provider/cache/plan trust and main runner-image checks |
 | `native-sdk-artifact.yml` | Typed native SDK producer |
 | `swift-sdk-artifact.yml` | Host-only/full XCFramework producer; trusted main remains `macos-15`, while eligible same-repository PRs follow the protected Depot macOS 15 gate |
 | `smoke.yml` | Artifact-based inference/OpenAI/split smoke |
-| `scripted-binary-smoke.yml` | Artifact-based scripted product smoke |
+| `scripted-binary-smoke.yml` | Artifact-based scripted product smoke with an optional typed model context-size override |
 | `sdk-smoke.yml` | Artifact-based SDK consumers; all SDK rows consume the lane's immutable console UI artifact, while Rust smoke restores the main-seeded, target/profile/image/toolchain/recipe-bound Cargo/target cache through `Swatinem/rust-cache` |
 | `hf-download-smoke.yml` | Hugging Face download smoke |
 

--- a/.github/workflows/ci-linux-lane.yml
+++ b/.github/workflows/ci-linux-lane.yml
@@ -180,7 +180,6 @@ jobs:
       smoke_matrix: ${{ toJson(fromJson(inputs.lane_plan_json).matrices.smoke) }}
       binary_target: target/release/mesh-llm
       timeout_minutes: 30
-      fail_fast: ${{ inputs.original_event_name == 'pull_request' }}
     secrets:
       HF_TOKEN: ${{ inputs.original_event_name == 'push' && secrets.HF_TOKEN || '' }}
 

--- a/.github/workflows/ci-linux-lane.yml
+++ b/.github/workflows/ci-linux-lane.yml
@@ -180,6 +180,7 @@ jobs:
       smoke_matrix: ${{ toJson(fromJson(inputs.lane_plan_json).matrices.smoke) }}
       binary_target: target/release/mesh-llm
       timeout_minutes: 30
+      fail_fast: ${{ inputs.original_event_name == 'pull_request' }}
     secrets:
       HF_TOKEN: ${{ inputs.original_event_name == 'push' && secrets.HF_TOKEN || '' }}
 

--- a/.github/workflows/ci-linux-product-smoke-slice.yml
+++ b/.github/workflows/ci-linux-product-smoke-slice.yml
@@ -89,11 +89,13 @@ jobs:
             model_file: SmolLM2-135M-Instruct-Q8_0.gguf
             model_cache_scope: two-node-split-smoke-model
             model_context_size: ''
+            expected_exact_payload_kind: ''
           - model_state: recurrent
             model_url: https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q4_K_M.gguf
             model_file: Qwen3.5-0.8B-Q4_K_M.gguf
             model_cache_scope: two-node-split-recurrent-smoke-model
             model_context_size: '4096'
+            expected_exact_payload_kind: kv-recurrent
     uses: ./.github/workflows/scripted-binary-smoke.yml
     with:
       source_sha: ${{ inputs.source_sha }}
@@ -104,6 +106,7 @@ jobs:
       model_file: ${{ matrix.model_file }}
       model_cache_scope: ${{ matrix.model_cache_scope }}
       model_context_size: ${{ matrix.model_context_size }}
+      expected_exact_payload_kind: ${{ matrix.expected_exact_payload_kind }}
       smoke_script: scripts/ci-two-node-split-smoke.sh
       timeout_minutes: ${{ inputs.timeout_minutes }}
     secrets:

--- a/.github/workflows/ci-linux-product-smoke-slice.yml
+++ b/.github/workflows/ci-linux-product-smoke-slice.yml
@@ -20,11 +20,6 @@ on:
         required: false
         default: 25
         type: number
-      fail_fast:
-        description: Stop the bounded split-model matrix on the first failure.
-        required: false
-        default: false
-        type: boolean
     secrets:
       HF_TOKEN:
         required: false
@@ -88,11 +83,12 @@ jobs:
       model_url: https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/resolve/9e6855bc4be717fca1ef21360a1db4b29d5c559a/SmolLM2-135M-Instruct-Q8_0.gguf
       model_file: SmolLM2-135M-Instruct-Q8_0.gguf
       model_cache_scope: two-node-split-smoke-model
-      expected_exact_payload_kind: kv-recurrent
       smoke_script: scripts/ci-two-node-split-smoke.sh
       kv_recurrent_model_url: https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q4_K_M.gguf
       kv_recurrent_model_file: Qwen3.5-0.8B-Q4_K_M.gguf
+      kv_recurrent_model_cache_scope: two-node-split-recurrent-smoke-model
       kv_recurrent_context_size: '4096'
+      kv_recurrent_expected_exact_payload_kind: kv-recurrent
       timeout_minutes: ${{ inputs.timeout_minutes }}
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/ci-linux-product-smoke-slice.yml
+++ b/.github/workflows/ci-linux-product-smoke-slice.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: 25
         type: number
+      fail_fast:
+        description: Stop the bounded split-model matrix on the first failure.
+        required: false
+        default: false
+        type: boolean
     secrets:
       HF_TOKEN:
         required: false
@@ -72,15 +77,33 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   two_node_split:
-    name: Two-node split smoke
+    name: Two-node split smoke (${{ matrix.model_state }})
     if: ${{ contains(fromJson(inputs.smoke_matrix).*.id, 'two-node-split') }}
+    strategy:
+      fail-fast: ${{ inputs.fail_fast }}
+      max-parallel: 1
+      matrix:
+        include:
+          - model_state: dense
+            model_url: https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/resolve/9e6855bc4be717fca1ef21360a1db4b29d5c559a/SmolLM2-135M-Instruct-Q8_0.gguf
+            model_file: SmolLM2-135M-Instruct-Q8_0.gguf
+            model_cache_scope: two-node-split-smoke-model
+            model_context_size: ''
+          - model_state: recurrent
+            model_url: https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q4_K_M.gguf
+            model_file: Qwen3.5-0.8B-Q4_K_M.gguf
+            model_cache_scope: two-node-split-recurrent-smoke-model
+            model_context_size: '4096'
     uses: ./.github/workflows/scripted-binary-smoke.yml
     with:
       source_sha: ${{ inputs.source_sha }}
       artifact_name: ci-product-linux-amd64-cpu
       artifact_path: ci-artifacts/linux
       staged_binary_path: ${{ inputs.binary_target }}
-      model_cache_scope: two-node-split-smoke-model
+      model_url: ${{ matrix.model_url }}
+      model_file: ${{ matrix.model_file }}
+      model_cache_scope: ${{ matrix.model_cache_scope }}
+      model_context_size: ${{ matrix.model_context_size }}
       smoke_script: scripts/ci-two-node-split-smoke.sh
       timeout_minutes: ${{ inputs.timeout_minutes }}
     secrets:

--- a/.github/workflows/ci-linux-product-smoke-slice.yml
+++ b/.github/workflows/ci-linux-product-smoke-slice.yml
@@ -77,37 +77,22 @@ jobs:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}
 
   two_node_split:
-    name: Two-node split smoke (${{ matrix.model_state }})
+    name: KV caching smoke (dense + recurrent)
     if: ${{ contains(fromJson(inputs.smoke_matrix).*.id, 'two-node-split') }}
-    strategy:
-      fail-fast: ${{ inputs.fail_fast }}
-      max-parallel: 1
-      matrix:
-        include:
-          - model_state: dense
-            model_url: https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/resolve/9e6855bc4be717fca1ef21360a1db4b29d5c559a/SmolLM2-135M-Instruct-Q8_0.gguf
-            model_file: SmolLM2-135M-Instruct-Q8_0.gguf
-            model_cache_scope: two-node-split-smoke-model
-            model_context_size: ''
-            expected_exact_payload_kind: ''
-          - model_state: recurrent
-            model_url: https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q4_K_M.gguf
-            model_file: Qwen3.5-0.8B-Q4_K_M.gguf
-            model_cache_scope: two-node-split-recurrent-smoke-model
-            model_context_size: '4096'
-            expected_exact_payload_kind: kv-recurrent
     uses: ./.github/workflows/scripted-binary-smoke.yml
     with:
       source_sha: ${{ inputs.source_sha }}
       artifact_name: ci-product-linux-amd64-cpu
       artifact_path: ci-artifacts/linux
       staged_binary_path: ${{ inputs.binary_target }}
-      model_url: ${{ matrix.model_url }}
-      model_file: ${{ matrix.model_file }}
-      model_cache_scope: ${{ matrix.model_cache_scope }}
-      model_context_size: ${{ matrix.model_context_size }}
-      expected_exact_payload_kind: ${{ matrix.expected_exact_payload_kind }}
+      model_url: https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/resolve/9e6855bc4be717fca1ef21360a1db4b29d5c559a/SmolLM2-135M-Instruct-Q8_0.gguf
+      model_file: SmolLM2-135M-Instruct-Q8_0.gguf
+      model_cache_scope: two-node-split-smoke-model
+      expected_exact_payload_kind: kv-recurrent
       smoke_script: scripts/ci-two-node-split-smoke.sh
+      kv_recurrent_model_url: https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q4_K_M.gguf
+      kv_recurrent_model_file: Qwen3.5-0.8B-Q4_K_M.gguf
+      kv_recurrent_context_size: '4096'
       timeout_minutes: ${{ inputs.timeout_minutes }}
     secrets:
       HF_TOKEN: ${{ secrets.HF_TOKEN }}

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -332,9 +332,3 @@ jobs:
                 "$SAFETENSORS_SMOKE_TEST_NAME" --exact --ignored --nocapture
             echo "::endgroup::"
           done < <(jq -r '.[]' <<<"$SAFETENSORS_QUANTIZATIONS_JSON")
-      - name: Capture SafeTensors smoke cache evidence
-        if: ${{ !cancelled() }}
-        uses: ./.github/actions/capture-sccache-stats
-        with:
-          artifact_name: sccache-safetensors-runtime-smoke-${{ github.run_attempt }}
-          cache_expectation: ${{ steps.sccache_seed.outputs.cache_hit == 'true' && 'warm' || 'cold' }}

--- a/.github/workflows/ci-rust-tests-slice.yml
+++ b/.github/workflows/ci-rust-tests-slice.yml
@@ -309,6 +309,12 @@ jobs:
           fi
           printf 'test_binary=%s\n' "$test_binary" >> "$GITHUB_OUTPUT"
           printf 'test_name=%s\n' "$test_name" >> "$GITHUB_OUTPUT"
+      - name: Capture SafeTensors smoke cache evidence
+        if: ${{ !cancelled() }}
+        uses: ./.github/actions/capture-sccache-stats
+        with:
+          artifact_name: sccache-safetensors-runtime-smoke-${{ github.run_attempt }}
+          cache_expectation: ${{ steps.sccache_seed.outputs.cache_hit == 'true' && 'warm' || 'cold' }}
       - name: Exercise every current direct-load quantization
         env:
           SAFETENSORS_SMOKE_TEST_BINARY: ${{ steps.safetensors_smoke_test.outputs.test_binary }}

--- a/.github/workflows/scripted-binary-smoke.yml
+++ b/.github/workflows/scripted-binary-smoke.yml
@@ -59,8 +59,18 @@ on:
         required: false
         default: ''
         type: string
+      kv_recurrent_model_cache_scope:
+        description: Cache scope for the optional recurrent smoke model.
+        required: false
+        default: two-node-split-recurrent-smoke-model
+        type: string
       kv_recurrent_context_size:
         description: Context-size override passed to the recurrent leg of the KV caching smoke.
+        required: false
+        default: ''
+        type: string
+      kv_recurrent_expected_exact_payload_kind:
+        description: Exact-state payload kind required only from the recurrent smoke leg.
         required: false
         default: ''
         type: string
@@ -82,9 +92,9 @@ on:
 env:
   MESH_LLM_SMOKE_CONTEXT_SIZE: ${{ inputs.model_context_size }}
   MESH_TWO_NODE_SPLIT_EXPECTED_EXACT_PAYLOAD_KIND: ${{ inputs.expected_exact_payload_kind }}
-  MESH_TWO_NODE_SPLIT_RECURRENT_MODEL: ${{ inputs.kv_recurrent_model_url != '' && inputs.kv_recurrent_model_file != '' && format('{0}/.models/{1}', github.workspace, inputs.kv_recurrent_model_file) || '' }}
-  MESH_TWO_NODE_SPLIT_RECURRENT_CTX_SIZE: ${{ inputs.kv_recurrent_context_size }}
   MESH_TWO_NODE_SPLIT_RECURRENT_MODEL_FILE: ${{ inputs.kv_recurrent_model_file }}
+  MESH_TWO_NODE_SPLIT_RECURRENT_CTX_SIZE: ${{ inputs.kv_recurrent_context_size }}
+  MESH_TWO_NODE_SPLIT_RECURRENT_EXPECTED_EXACT_PAYLOAD_KIND: ${{ inputs.kv_recurrent_expected_exact_payload_kind }}
 permissions:
   contents: read
   packages: read
@@ -129,22 +139,51 @@ jobs:
           cache_key_prefix: ${{ inputs.cache_key_prefix }}
           save_model_cache: ${{ github.ref == 'refs/heads/main' && github.event.inputs.original_event_name != 'pull_request' && github.event.inputs.original_event_name != 'pull_request_target' }}
 
-      - name: Run scripted smoke
-        run: ${{ inputs.smoke_script }} "${{ inputs.staged_binary_path }}" "${{ inputs.artifact_path }}" "$HOME/.models/${{ steps.model_inputs.outputs.model_file }}"
+      - name: Restore recurrent smoke model cache
+        if: ${{ inputs.kv_recurrent_model_url != '' && inputs.kv_recurrent_model_file != '' }}
+        id: recurrent-model-cache
+        uses: actions/cache/restore@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/.models/${{ inputs.kv_recurrent_model_file }}
+          key: ${{ inputs.cache_key_prefix }}mesh-llm-${{ runner.os }}-${{ inputs.kv_recurrent_model_cache_scope }}-${{ inputs.kv_recurrent_model_file }}-unverified-${{ hashFiles('.github/cache-version.txt') }}
 
       - name: Resolve recurrent smoke model for the KV caching leg
         if: ${{ inputs.kv_recurrent_model_url != '' && inputs.kv_recurrent_model_file != '' }}
+        env:
+          MODEL_FILE: ${{ inputs.kv_recurrent_model_file }}
+          MODEL_URL: ${{ inputs.kv_recurrent_model_url }}
         run: |
           set -euo pipefail
           mkdir -p ~/.models
-          output="$HOME/.models/${{ inputs.kv_recurrent_model_file }}"
+          output="$HOME/.models/$MODEL_FILE"
           if [[ -s "$output" ]]; then
             echo "recurrent model already present: $output"
             exit 0
           fi
-          curl -fsSL --retry 3 --retry-delay 10 --connect-timeout 30 \
-            --max-time 900 \
-            "${{ inputs.kv_recurrent_model_url }}" \
-            -o "$output"
+          token="${HF_TOKEN:-${HUGGING_FACE_HUB_TOKEN:-}}"
+          curl_args=(
+            --fail --location --show-error
+            --retry 12
+            --retry-delay 20
+            --retry-max-time 600
+            --retry-all-errors
+          )
+          if [[ -n "$token" ]]; then
+            curl_args+=(--header "Authorization: Bearer ${token}")
+          fi
+          partial="${output}.download"
+          rm -f "$partial"
+          curl "${curl_args[@]}" "$MODEL_URL" -o "$partial"
+          mv "$partial" "$output"
           test -s "$output"
           echo "recurrent model staged: $output"
+
+      - name: Save recurrent smoke model cache
+        if: ${{ inputs.kv_recurrent_model_url != '' && inputs.kv_recurrent_model_file != '' && github.ref == 'refs/heads/main' && github.event.inputs.original_event_name != 'pull_request' && github.event.inputs.original_event_name != 'pull_request_target' && steps.recurrent-model-cache.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@caa296126883cff596d87d8935842f9db880ef25 # v5.1.0
+        with:
+          path: ~/.models/${{ inputs.kv_recurrent_model_file }}
+          key: ${{ steps.recurrent-model-cache.outputs.cache-primary-key }}
+
+      - name: Run scripted smoke
+        run: ${{ inputs.smoke_script }} "${{ inputs.staged_binary_path }}" "${{ inputs.artifact_path }}" "$HOME/.models/${{ steps.model_inputs.outputs.model_file }}"

--- a/.github/workflows/scripted-binary-smoke.yml
+++ b/.github/workflows/scripted-binary-smoke.yml
@@ -44,6 +44,11 @@ on:
         required: false
         default: ''
         type: string
+      expected_exact_payload_kind:
+        description: Optional exact-state payload kind the smoke must observe in stage telemetry.
+        required: false
+        default: ''
+        type: string
       cache_key_prefix:
         required: false
         default: ''
@@ -61,6 +66,7 @@ on:
 
 env:
   MESH_LLM_SMOKE_CONTEXT_SIZE: ${{ inputs.model_context_size }}
+  MESH_TWO_NODE_SPLIT_EXPECTED_EXACT_PAYLOAD_KIND: ${{ inputs.expected_exact_payload_kind }}
 permissions:
   contents: read
   packages: read

--- a/.github/workflows/scripted-binary-smoke.yml
+++ b/.github/workflows/scripted-binary-smoke.yml
@@ -49,6 +49,21 @@ on:
         required: false
         default: ''
         type: string
+      kv_recurrent_model_url:
+        description: Optional second (recurrent) model the KV caching smoke downloads for its second leg.
+        required: false
+        default: ''
+        type: string
+      kv_recurrent_model_file:
+        description: Filename under ~/.models for the optional recurrent smoke model.
+        required: false
+        default: ''
+        type: string
+      kv_recurrent_context_size:
+        description: Context-size override passed to the recurrent leg of the KV caching smoke.
+        required: false
+        default: ''
+        type: string
       cache_key_prefix:
         required: false
         default: ''
@@ -67,6 +82,9 @@ on:
 env:
   MESH_LLM_SMOKE_CONTEXT_SIZE: ${{ inputs.model_context_size }}
   MESH_TWO_NODE_SPLIT_EXPECTED_EXACT_PAYLOAD_KIND: ${{ inputs.expected_exact_payload_kind }}
+  MESH_TWO_NODE_SPLIT_RECURRENT_MODEL: ${{ inputs.kv_recurrent_model_url != '' && inputs.kv_recurrent_model_file != '' && format('{0}/.models/{1}', github.workspace, inputs.kv_recurrent_model_file) || '' }}
+  MESH_TWO_NODE_SPLIT_RECURRENT_CTX_SIZE: ${{ inputs.kv_recurrent_context_size }}
+  MESH_TWO_NODE_SPLIT_RECURRENT_MODEL_FILE: ${{ inputs.kv_recurrent_model_file }}
 permissions:
   contents: read
   packages: read
@@ -113,3 +131,20 @@ jobs:
 
       - name: Run scripted smoke
         run: ${{ inputs.smoke_script }} "${{ inputs.staged_binary_path }}" "${{ inputs.artifact_path }}" "$HOME/.models/${{ steps.model_inputs.outputs.model_file }}"
+
+      - name: Resolve recurrent smoke model for the KV caching leg
+        if: ${{ inputs.kv_recurrent_model_url != '' && inputs.kv_recurrent_model_file != '' }}
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.models
+          output="$HOME/.models/${{ inputs.kv_recurrent_model_file }}"
+          if [[ -s "$output" ]]; then
+            echo "recurrent model already present: $output"
+            exit 0
+          fi
+          curl -fsSL --retry 3 --retry-delay 10 --connect-timeout 30 \
+            --max-time 900 \
+            "${{ inputs.kv_recurrent_model_url }}" \
+            -o "$output"
+          test -s "$output"
+          echo "recurrent model staged: $output"

--- a/.github/workflows/scripted-binary-smoke.yml
+++ b/.github/workflows/scripted-binary-smoke.yml
@@ -39,6 +39,11 @@ on:
       model_cache_scope:
         required: true
         type: string
+      model_context_size:
+        description: Optional context-size override passed to model smoke scripts.
+        required: false
+        default: ''
+        type: string
       cache_key_prefix:
         required: false
         default: ''
@@ -54,6 +59,8 @@ on:
       HF_TOKEN:
         required: false
 
+env:
+  MESH_LLM_SMOKE_CONTEXT_SIZE: ${{ inputs.model_context_size }}
 permissions:
   contents: read
   packages: read

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -167,7 +167,9 @@ credentials may differ.
 - ci-platform-checks-slice.yml: macOS portable/unit and Windows checks.
 - ci-linux-product-smoke-slice.yml and ci-macos-product-smoke-slice.yml:
   platform-local inference, backend, two-node, Metal and model-download
-  consumers using only composed artifacts.
+  consumers using only composed artifacts. The Linux two-node split row expands
+  to a fixed dense SmolLM2 plus recurrent Qwen3.5 model matrix, serialized with
+  `max-parallel: 1`; pull requests fail fast while main executes both rows.
 - ci-linux-sdk-slice.yml and ci-macos-sdk-slice.yml: platform-local
   Rust/Kotlin/Swift consumers. Swift and Kotlin SDK artifacts are independent
   producers that start from the plan and static ABI respectively, before
@@ -212,10 +214,12 @@ Initial planner budgets are:
 
 The lane projections pass smaller PR max-parallel values to Clippy, tests,
 hosts, runtimes and platform checks and wider bounded values to main. Host, ABI
-and runtime producer identities are not duplicated. Separate run-scoped graphs
-build one prepared UI artifact per active platform lane; that is the accepted
-readability tradeoff, while UI tests remain owned by the Website graph. Every
-heavy job has a timeout and a deterministic row identity.
+and runtime producer identities are not duplicated. The fixed two-row
+split-model matrix is serialized, so it adds runner-minutes without increasing
+peak workers. Separate run-scoped graphs build one prepared UI artifact per
+active platform lane; that is the accepted readability tradeoff, while UI tests
+remain owned by the Website graph. Every heavy job has a timeout and a
+deterministic row identity.
 
 PR platform matrices for compilation, Rust tests, products and functional
 platform checks fail fast. Main/manual matrices continue all rows for exhaustive

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -167,9 +167,8 @@ credentials may differ.
 - ci-platform-checks-slice.yml: macOS portable/unit and Windows checks.
 - ci-linux-product-smoke-slice.yml and ci-macos-product-smoke-slice.yml:
   platform-local inference, backend, two-node, Metal and model-download
-  consumers using only composed artifacts. The Linux two-node split row expands
-  to a fixed dense SmolLM2 plus recurrent Qwen3.5 model matrix, serialized with
-  `max-parallel: 1`; pull requests fail fast while main executes both rows.
+  consumers using only composed artifacts. One Linux KV caching smoke job runs
+  a fixed dense SmolLM2 leg followed by a recurrent Qwen3.5 leg; both must pass.
 - ci-linux-sdk-slice.yml and ci-macos-sdk-slice.yml: platform-local
   Rust/Kotlin/Swift consumers. Swift and Kotlin SDK artifacts are independent
   producers that start from the plan and static ABI respectively, before

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -287,9 +287,8 @@ runtime producers are not duplicated.
 - `ci-linux-product-smoke-slice.yml` and
   `ci-macos-product-smoke-slice.yml` — platform-local CPU core, CUDA,
   two-node, Metal and model-download consumers using only composed artifacts.
-  The Linux two-node split smoke uses a fixed dense SmolLM2 plus recurrent
-  Qwen3.5 matrix, serialized with `max-parallel: 1`; pull requests fail fast
-  between those rows while main executes both.
+  One Linux KV caching smoke job runs a fixed dense SmolLM2 leg followed by a
+  recurrent Qwen3.5 leg; both must pass.
   CUDA inference uses the
   approved `gpu-nvidia` ephemeral self-hosted scale set, including for
   same-repository PRs. That hardware-qualified exception executes only through

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -287,6 +287,9 @@ runtime producers are not duplicated.
 - `ci-linux-product-smoke-slice.yml` and
   `ci-macos-product-smoke-slice.yml` — platform-local CPU core, CUDA,
   two-node, Metal and model-download consumers using only composed artifacts.
+  The Linux two-node split smoke uses a fixed dense SmolLM2 plus recurrent
+  Qwen3.5 matrix, serialized with `max-parallel: 1`; pull requests fail fast
+  between those rows while main executes both.
   CUDA inference uses the
   approved `gpu-nvidia` ephemeral self-hosted scale set, including for
   same-repository PRs. That hardware-qualified exception executes only through
@@ -320,10 +323,12 @@ The planner records profile budgets: PR drafts/ready runs allow at most
 7 Linux, 2 macOS, 1 Windows matrix workers and 10 planned workers overall;
 main/manual runs allow 12, 4, 2 and 18 respectively. Each matrix also sets
 `max-parallel`, and backend/platform rows are selected by ownership rather than
-by a blanket PR fan-out. Host, ABI and runtime producers remain unique per
-selected row. The readability tradeoff is one UI artifact build per active
-platform workflow because artifacts are run-scoped; UI tests still execute
-only in the Website graph and host producers never rebuild the UI themselves.
+by a blanket PR fan-out. The fixed two-row split-model matrix is serialized, so
+it adds runner-minutes without increasing peak workers. Host, ABI and runtime
+producers remain unique per selected row. The readability tradeoff is one UI
+artifact build per active platform workflow because artifacts are run-scoped;
+UI tests still execute only in the Website graph and host producers never
+rebuild the UI themselves.
 
 Timing evidence is collected read-only with `scripts/collect-ci-metrics.py`.
 Schema-v3 reports keep workflow wall/queue, runner queue, dependency wait,

--- a/crates/skippy-server/src/binary_transport/binary_kv.rs
+++ b/crates/skippy-server/src/binary_transport/binary_kv.rs
@@ -781,10 +781,29 @@ pub(in crate::binary_transport) fn maybe_record_binary_full_prefill(
         return result;
     }
     if kv.payload_is_exact_state() {
+        let mut attrs = binary_message_kv_attrs(config, kv, session_id, message, token_ids.len());
         let Ok(prompt_token_count) = u64::try_from(message.state.prompt_token_count) else {
+            attrs.insert(
+                "skippy.kv.decision".to_string(),
+                json!("exact_state_full_prefill_record_skipped_invalid_prompt_count"),
+            );
+            telemetry.emit("stage.binary_kv_record_decision", attrs);
             return result;
         };
         if !kv.exact_state_record_token_count_allowed(prompt_token_count, token_ids.len() as u64) {
+            attrs.insert(
+                "skippy.kv.decision".to_string(),
+                json!("exact_state_full_prefill_record_skipped_checkpoint_boundary"),
+            );
+            attrs.insert(
+                "skippy.kv.prompt_token_count".to_string(),
+                json!(prompt_token_count),
+            );
+            attrs.insert(
+                "skippy.kv.candidate_token_count".to_string(),
+                json!(token_ids.len()),
+            );
+            telemetry.emit("stage.binary_kv_record_decision", attrs);
             return result;
         }
     }

--- a/crates/skippy-server/src/binary_transport/binary_kv.rs
+++ b/crates/skippy-server/src/binary_transport/binary_kv.rs
@@ -780,6 +780,14 @@ pub(in crate::binary_transport) fn maybe_record_binary_full_prefill(
     if !kv.should_record() || token_ids.is_empty() {
         return result;
     }
+    if kv.payload_is_exact_state() {
+        let Ok(prompt_token_count) = u64::try_from(message.state.prompt_token_count) else {
+            return result;
+        };
+        if !kv.exact_state_record_token_count_allowed(prompt_token_count, token_ids.len() as u64) {
+            return result;
+        }
+    }
     let identities =
         binary_full_prefill_record_identities(kv, config, session_id, message, token_ids);
     let mut attrs = binary_message_kv_attrs(config, kv, session_id, message, token_ids.len());

--- a/crates/skippy-server/src/binary_transport/binary_messaging/control_messages.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/control_messages.rs
@@ -418,6 +418,10 @@ pub(super) fn handle_prefix_cache_control(
             });
         }
     }
+    // The server frontend emits TryRestorePrefill for ordinary prefix restore.
+    // Keep ledger seeding scoped to that optimistic control message: the
+    // unconditional RestorePrefill path is also used by bench/correctness
+    // harnesses, which do not share this suffix-recording lifecycle.
     if chain_hit
         && message.kind == WireMessageKind::TryRestorePrefill
         && let Some(cache) = kv

--- a/crates/skippy-server/src/binary_transport/binary_messaging/control_messages.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/control_messages.rs
@@ -7,7 +7,8 @@ use super::session_tracker::ConnectionSessionTracker;
 use super::summary::BinaryRequestSummary;
 use crate::binary_transport::WireCondition;
 use crate::binary_transport::binary_kv::{
-    maybe_prefix_cache_control, maybe_record_binary_full_prefill, take_shared_prefill_tokens,
+    accumulate_shared_prefill_tokens, maybe_prefix_cache_control, maybe_record_binary_full_prefill,
+    take_shared_prefill_tokens,
 };
 use crate::binary_transport::direct_return::PredictionReturnSinks;
 use crate::binary_transport::restore_prefill_decode::handle_binary_restore_prefill_decode_control;
@@ -378,6 +379,7 @@ pub(super) fn handle_prefix_cache_control(
     let scheduler_telemetry = telemetry.clone();
     let scheduler_session_key = session_key.to_string();
     let scheduler_message = message.clone();
+    let scheduler_token_ids = token_ids.clone();
     let local = iteration_scheduler
         .execute_runtime("binary-prefix-control", move |runtime| {
             Ok(maybe_prefix_cache_control(
@@ -387,11 +389,12 @@ pub(super) fn handle_prefix_cache_control(
                 &scheduler_telemetry,
                 &scheduler_session_key,
                 &scheduler_message,
-                &token_ids,
+                &scheduler_token_ids,
             ))
         })
         .map_err(|error| anyhow::anyhow!(format!("{error:#}")))?;
     control_stats.merge(local.stats);
+    let mut chain_hit = local.hit;
     if local.hit
         && let Some(downstream) = downstream.as_mut()
     {
@@ -403,6 +406,7 @@ pub(super) fn handle_prefix_cache_control(
         }
         let downstream_missed =
             normalize_downstream_prefix_restore_reply(message.kind, &mut reply.stats);
+        chain_hit = !downstream_missed;
         control_stats.merge(reply.stats);
         if downstream_missed {
             let scheduler_session_key = session_key.to_string();
@@ -413,6 +417,15 @@ pub(super) fn handle_prefix_cache_control(
                     .map_err(|error| openai_frontend::OpenAiError::backend(format!("{error:#}")))
             });
         }
+    }
+    if chain_hit
+        && message.kind == WireMessageKind::TryRestorePrefill
+        && let Some(cache) = kv
+    {
+        // Subsequent PrefillEmbd messages start at the restored boundary.
+        // Seed the accumulation ledger with the restored tokens so those
+        // suffix chunks can record the next shared exact-state checkpoint.
+        accumulate_shared_prefill_tokens(&cache.split_prefill_tokens, session_key, 0, &token_ids);
     }
     let mut attrs = binary_message_attrs(config, session_id, &message);
     attrs.insert("skippy.kv.control_hit".to_string(), json!(local.hit));

--- a/crates/skippy-server/src/binary_transport/binary_messaging/prefill_recording.rs
+++ b/crates/skippy-server/src/binary_transport/binary_messaging/prefill_recording.rs
@@ -104,9 +104,14 @@ fn record_full_prefill_with_activations(
     activation_width: i32,
     output: &ActivationFrame,
 ) -> BinaryKvRecordResult {
-    let mut record = maybe_record_binary_full_prefill(
-        config, runtime, kv, telemetry, session_id, message, tokens,
-    );
+    let mut record = if kv.is_none_or(|kv| exact_prefill_record_allowed(kv, message, tokens.len()))
+    {
+        maybe_record_binary_full_prefill(
+            config, runtime, kv, telemetry, session_id, message, tokens,
+        )
+    } else {
+        BinaryKvRecordResult::default()
+    };
     if let Some(kv) = kv
         && config.downstream.is_some()
     {
@@ -126,9 +131,53 @@ fn record_full_prefill_with_activations(
     record
 }
 
+fn exact_prefill_record_allowed(
+    kv: &KvStageIntegration,
+    message: &StageWireMessage,
+    accumulated_token_count: usize,
+) -> bool {
+    if !kv.payload_is_exact_state() || !message.kind.is_prefill() {
+        return true;
+    }
+    let Ok(prompt_token_count) = u64::try_from(message.state.prompt_token_count) else {
+        return false;
+    };
+    kv.exact_state_record_token_count_allowed(prompt_token_count, accumulated_token_count as u64)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::binary_transport::stage_execution::prefix_cache_test_config;
+    use skippy_protocol::{StageKvCachePayload, binary::StageStateHeader};
+    use skippy_runtime::ModelStateKind;
+
+    fn exact_prefill_fixture(prompt_token_count: i32) -> (KvStageIntegration, StageWireMessage) {
+        let mut config = prefix_cache_test_config();
+        config.kv_cache.as_mut().expect("test cache config").payload =
+            StageKvCachePayload::KvRecurrent;
+        let kv = KvStageIntegration::from_config(&config, ModelStateKind::Recurrent)
+            .unwrap()
+            .expect("exact cache enabled");
+        let mut state =
+            StageStateHeader::new(skippy_protocol::binary::WireMessageKind::PrefillEmbd);
+        state.prompt_token_count = prompt_token_count;
+        let message = StageWireMessage {
+            kind: skippy_protocol::binary::WireMessageKind::PrefillEmbd,
+            pos_start: 0,
+            token_count: 0,
+            state,
+            request_id: 11,
+            session_id: 13,
+            sampling: None,
+            chat_sampling_metadata: None,
+            tokens: Vec::new(),
+            positions: Vec::new(),
+            activation: Vec::new(),
+            raw_bytes: Vec::new(),
+        };
+        (kv, message)
+    }
 
     #[test]
     fn accumulated_prompt_takes_full_prefill_recording_path() {
@@ -180,5 +229,15 @@ mod tests {
         let plan = prefill_record_plan(Some(&accumulated), 4096, &remainder, 0);
 
         assert!(matches!(plan, PrefillRecordPlan::Incremental { .. }));
+    }
+
+    #[test]
+    fn exact_prefill_records_only_the_shared_checkpoint_when_available() {
+        let (kv, message) = exact_prefill_fixture(970);
+
+        assert!(!exact_prefill_record_allowed(&kv, &message, 128));
+        assert!(exact_prefill_record_allowed(&kv, &message, 768));
+        assert!(!exact_prefill_record_allowed(&kv, &message, 896));
+        assert!(!exact_prefill_record_allowed(&kv, &message, 970));
     }
 }

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -154,12 +154,8 @@ impl StageOpenAiBackend {
                 prefill_chain_cache_stats = chain_cache_stats;
                 fused_first_decode = restored_first_decode;
                 let mut pos_start = prefill_chain_restored_tokens.min(prefill_tokens.len());
-                let exact_checkpoint_boundary = self.embedded_exact_checkpoint_boundary(
-                    &request,
-                    &session_key,
-                    prefill_tokens,
-                    pos_start,
-                );
+                let exact_checkpoint_boundary =
+                    self.embedded_exact_checkpoint_boundary(&request, prefill_tokens, pos_start);
                 let mut chunk_index = 0usize;
                 while pos_start < prefill_tokens.len() {
                     if request

--- a/crates/skippy-server/src/frontend/embedded_generation.rs
+++ b/crates/skippy-server/src/frontend/embedded_generation.rs
@@ -45,6 +45,23 @@ use prefix_restore::EmbeddedPrefixRestore;
 use serde_json::json;
 use skippy_protocol::binary::{StageReplyStats, WireReplyKind, recv_reply};
 
+fn prefill_chunk_end(
+    pos_start: usize,
+    chunk_size: usize,
+    prefill_token_count: usize,
+    exact_checkpoint_boundary: Option<usize>,
+) -> usize {
+    let mut end = pos_start
+        .saturating_add(chunk_size)
+        .min(prefill_token_count);
+    if let Some(boundary) = exact_checkpoint_boundary
+        && pos_start < boundary
+    {
+        end = end.min(boundary);
+    }
+    end
+}
+
 impl StageOpenAiBackend {
     pub(super) fn generate_embedded_stage_zero_tokens(
         &self,
@@ -137,6 +154,12 @@ impl StageOpenAiBackend {
                 prefill_chain_cache_stats = chain_cache_stats;
                 fused_first_decode = restored_first_decode;
                 let mut pos_start = prefill_chain_restored_tokens.min(prefill_tokens.len());
+                let exact_checkpoint_boundary = self.embedded_exact_checkpoint_boundary(
+                    &request,
+                    &session_key,
+                    prefill_tokens,
+                    pos_start,
+                );
                 let mut chunk_index = 0usize;
                 while pos_start < prefill_tokens.len() {
                     if request
@@ -152,9 +175,12 @@ impl StageOpenAiBackend {
                     }
                     let chunk_size =
                         prefill_planner.chunk_size_for(chunk_index, prefill_token_count);
-                    let end = pos_start
-                        .saturating_add(chunk_size)
-                        .min(prefill_tokens.len());
+                    let end = prefill_chunk_end(
+                        pos_start,
+                        chunk_size,
+                        prefill_tokens.len(),
+                        exact_checkpoint_boundary,
+                    );
                     let chunk = &prefill_tokens[pos_start..end];
                     prefill_min_chunk_size = prefill_min_chunk_size.min(chunk.len());
                     prefill_max_chunk_size = prefill_max_chunk_size.max(chunk.len());
@@ -259,6 +285,14 @@ impl StageOpenAiBackend {
                         );
                         self.telemetry
                             .emit("stage.openai_kv_record_decision", attrs);
+                    }
+                    if exact_checkpoint_boundary == Some(end) {
+                        prefill_stage0_full_recorded |= self
+                            .record_embedded_stage0_exact_checkpoint(
+                                &session_key,
+                                request.ids,
+                                &prefill_tokens[..end],
+                            )?;
                     }
                     let chunk_stage0_compute_ms = stage0_timer.elapsed_ms();
                     prefill_stage0_compute_ms += chunk_stage0_compute_ms;
@@ -400,7 +434,7 @@ impl StageOpenAiBackend {
                 prefill_downstream_wait_ms += drained.downstream_wait_ms;
                 prefill_downstream_wait_max_ms =
                     prefill_downstream_wait_max_ms.max(drained.downstream_wait_max_ms);
-                if !prefill_chain_cache_restored {
+                if !prefill_chain_cache_restored && !prefill_stage0_full_recorded {
                     prefill_stage0_full_recorded = self.record_embedded_stage0_full_prefill(
                         &session_key,
                         request.ids,
@@ -1910,5 +1944,23 @@ impl StageOpenAiBackend {
         self.finish_embedded_generation_session(&request, lane_pool, lane, &result, &session_key)?;
         result?;
         Ok(cache_stats)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::prefill_chunk_end;
+
+    #[test]
+    fn exact_checkpoint_splits_prefill_at_the_native_state_boundary() {
+        assert_eq!(prefill_chunk_end(0, 1024, 1400, Some(768)), 768);
+        assert_eq!(prefill_chunk_end(768, 1024, 1400, Some(768)), 1400);
+    }
+
+    #[test]
+    fn exact_checkpoint_preserves_earlier_adaptive_chunks() {
+        assert_eq!(prefill_chunk_end(0, 256, 1400, Some(768)), 256);
+        assert_eq!(prefill_chunk_end(256, 256, 1400, Some(768)), 512);
+        assert_eq!(prefill_chunk_end(512, 512, 1400, Some(768)), 768);
     }
 }

--- a/crates/skippy-server/src/frontend/generation/types.rs
+++ b/crates/skippy-server/src/frontend/generation/types.rs
@@ -167,6 +167,7 @@ pub(in crate::frontend) struct EmbeddedStageZeroGeneration<'a> {
     pub(in crate::frontend) speculative: &'a SpeculativeDecodeConfig,
     pub(in crate::frontend) native_mtp_enabled: bool,
     pub(in crate::frontend) prompt_token_ids: &'a [i32],
+    pub(in crate::frontend) recurrent_cache_prefix_token_ids: Option<&'a [i32]>,
     pub(in crate::frontend) max_tokens: u32,
     pub(in crate::frontend) sampling: &'a SamplingConfig,
     pub(in crate::frontend) chat_sampling_metadata: Option<&'a str>,

--- a/crates/skippy-server/src/frontend/generation_flow/text_generation.rs
+++ b/crates/skippy-server/src/frontend/generation_flow/text_generation.rs
@@ -215,6 +215,7 @@ impl StageOpenAiBackend {
                     native_mtp_enabled: config.native_mtp_enabled
                         && self.speculative.native_mtp.enabled,
                     prompt_token_ids: &prompt_token_ids,
+                    recurrent_cache_prefix_token_ids: recurrent_cache_prefix_token_ids.as_deref(),
                     max_tokens,
                     sampling: &sampling,
                     chat_sampling_metadata,

--- a/crates/skippy-server/src/frontend/local_generation/token_generation/exact_state_recording.rs
+++ b/crates/skippy-server/src/frontend/local_generation/token_generation/exact_state_recording.rs
@@ -68,7 +68,7 @@ impl StageOpenAiBackend {
     /// The caller must hold the runtime lock. This check is intentionally
     /// canonical-position based: token text or a caller-supplied count cannot
     /// authorize exporting a state at a different native position.
-    pub(super) fn record_exact_state_at_tokens(
+    pub(in crate::frontend) fn record_exact_state_at_tokens(
         &self,
         runtime: &mut RuntimeState,
         session_id: &str,

--- a/crates/skippy-server/src/frontend/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/prefix_cache.rs
@@ -174,15 +174,13 @@ impl StageOpenAiBackend {
     pub(super) fn embedded_exact_checkpoint_boundary(
         &self,
         request: &EmbeddedStageZeroGeneration<'_>,
-        session_id: &str,
         prefill_tokens: &[i32],
         restored_prefill_tokens: usize,
     ) -> Option<usize> {
         let kv = self.kv.as_ref().filter(|kv| kv.payload_is_exact_state())?;
-        let base = self.local_kv_message_base(session_id, request.ids);
         let shared_boundary = kv
-            .exact_shared_checkpoint_identity(&self.config, &base, 0, prefill_tokens)
-            .and_then(|identity| usize::try_from(identity.identity.token_count).ok());
+            .exact_shared_checkpoint_token_count(prefill_tokens.len() as u64)
+            .and_then(|token_count| usize::try_from(token_count).ok());
         let chat_boundary = request
             .recurrent_cache_prefix_token_ids
             .filter(|tokens| {
@@ -553,9 +551,6 @@ impl StageOpenAiBackend {
             },
         )?;
         let exact_record_queued = kv.payload_is_exact_state()
-            && kv
-                .exact_shared_checkpoint_token_count(token_ids.len() as u64)
-                .is_none()
             && self.enqueue_exact_state_record_at_tokens(
                 session_id,
                 ids,

--- a/crates/skippy-server/src/frontend/prefix_cache.rs
+++ b/crates/skippy-server/src/frontend/prefix_cache.rs
@@ -171,6 +171,34 @@ pub(super) struct EmbeddedReplayCheckpointRecord<'a> {
 }
 
 impl StageOpenAiBackend {
+    pub(super) fn embedded_exact_checkpoint_boundary(
+        &self,
+        request: &EmbeddedStageZeroGeneration<'_>,
+        session_id: &str,
+        prefill_tokens: &[i32],
+        restored_prefill_tokens: usize,
+    ) -> Option<usize> {
+        let kv = self.kv.as_ref().filter(|kv| kv.payload_is_exact_state())?;
+        let base = self.local_kv_message_base(session_id, request.ids);
+        let shared_boundary = kv
+            .exact_shared_checkpoint_identity(&self.config, &base, 0, prefill_tokens)
+            .and_then(|identity| usize::try_from(identity.identity.token_count).ok());
+        let chat_boundary = request
+            .recurrent_cache_prefix_token_ids
+            .filter(|tokens| {
+                !tokens.is_empty()
+                    && tokens.len() <= prefill_tokens.len()
+                    && prefill_tokens.starts_with(tokens)
+            })
+            .map(<[i32]>::len);
+        let valid = |boundary: &usize| {
+            *boundary > restored_prefill_tokens && *boundary < prefill_tokens.len()
+        };
+        shared_boundary
+            .filter(valid)
+            .or_else(|| chat_boundary.filter(valid))
+    }
+
     pub(super) fn local_kv_message_base(
         &self,
         session_id: &str,
@@ -525,6 +553,9 @@ impl StageOpenAiBackend {
             },
         )?;
         let exact_record_queued = kv.payload_is_exact_state()
+            && kv
+                .exact_shared_checkpoint_token_count(token_ids.len() as u64)
+                .is_none()
             && self.enqueue_exact_state_record_at_tokens(
                 session_id,
                 ids,
@@ -574,6 +605,36 @@ impl StageOpenAiBackend {
                 .emit("stage.openai_kv_record_decision", attrs);
         }
         Ok(recorded_any)
+    }
+
+    pub(super) fn record_embedded_stage0_exact_checkpoint(
+        &self,
+        session_id: &str,
+        ids: &OpenAiGenerationIds,
+        checkpoint_tokens: &[i32],
+    ) -> OpenAiResult<bool> {
+        let Some(kv) = self.kv.as_ref() else {
+            return Ok(false);
+        };
+        if checkpoint_tokens.is_empty() || !kv.payload_is_exact_state() || !kv.should_record() {
+            return Ok(false);
+        }
+        let scheduler_backend = self.clone();
+        let scheduler_session_id = session_id.to_string();
+        let scheduler_ids = ids.clone();
+        let scheduler_checkpoint_tokens = checkpoint_tokens.to_vec();
+        self.iteration_scheduler.execute_runtime(
+            "embedded-shared-exact-state-checkpoint",
+            move |runtime| {
+                Ok(scheduler_backend.record_exact_state_at_tokens(
+                    runtime,
+                    &scheduler_session_id,
+                    &scheduler_ids,
+                    &scheduler_checkpoint_tokens,
+                    "embedded_shared_checkpoint",
+                ))
+            },
+        )
     }
 
     pub(super) fn record_embedded_stage0_full_prompt_first_token(

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -27,7 +27,8 @@ const RECURRENT_CACHE_MAX_ENTRIES: usize = 16;
 // (recurrent and convolution buffers) that `estimate_stage_cache_max_bytes`
 // cannot see, because that estimate is derived from attention KV metadata
 // alone. A single snapshot therefore routinely exceeds the soft cap. Keep this
-// many snapshots before the soft cap evicts anything: falling to one entry
+// many snapshots (subject to the configured entry limit) before the soft cap
+// evicts anything: falling to one entry
 // turns the catalog into a single-entry cache, where two concurrent sessions
 // on the same stage evict each other on every request.
 const EXACT_STATE_MIN_RETAINED_ENTRIES: usize = 4;
@@ -258,17 +259,17 @@ fn store_exact_radix_record(
     // Exact snapshots are indivisible, and the soft cap is estimated from
     // attention KV metadata that cannot include architecture-specific
     // recurrent state, so one snapshot can legitimately exceed it. Hold a small
-    // working set past the soft cap so concurrent sessions on a stage stop
-    // evicting each other, then apply the hard limit so that allowance stays
-    // bounded apart from one indivisible snapshot. Neither pass evicts the last
-    // entry: a snapshot that self-evicts disables exact prefix caching for the
-    // stage entirely, which is the regression this retention policy exists to
-    // prevent.
+    // working set past the soft cap (never more than the configured entry
+    // limit) so concurrent sessions on a stage stop evicting each other, then
+    // apply the hard limit so that allowance stays bounded apart from one
+    // indivisible snapshot. Neither pass evicts the last entry: a snapshot that
+    // self-evicts disables exact prefix caching for the stage entirely, which
+    // is the regression this retention policy exists to prevent.
     evict_exact_entries_over(
         radix,
         blobs,
         limits.soft_bytes,
-        EXACT_STATE_MIN_RETAINED_ENTRIES,
+        EXACT_STATE_MIN_RETAINED_ENTRIES.min(max_entries),
     )?;
     evict_exact_entries_over(radix, blobs, limits.hard_bytes, 1)?;
     Ok(())
@@ -548,6 +549,33 @@ mod tests {
         let mut radix = radix.lock().unwrap();
         assert_eq!(radix.stats().recurrent_entries, 3);
         assert!(radix.lookup_recurrent("model", &[1, 2]).is_some());
+        assert!(radix.lookup_recurrent("model", &[1, 3]).is_some());
+        assert!(radix.lookup_recurrent("model", &[1, 4]).is_some());
+    }
+
+    #[test]
+    fn exact_soft_retention_does_not_exceed_the_configured_entry_limit() {
+        let radix = Mutex::new(UnifiedRadixCache::new());
+        let blobs = Mutex::new(CacheBlobStore::new(4));
+
+        for (page_id, tokens, bytes) in [
+            ("first", [1, 2], b"aaaabbbb"),
+            ("second", [1, 3], b"ccccdddd"),
+            ("third", [1, 4], b"eeeeffff"),
+        ] {
+            store_exact_radix_record(
+                &radix,
+                &blobs,
+                2,
+                limits(4, 1_024),
+                pending(page_id, &tokens, bytes),
+            )
+            .unwrap();
+        }
+
+        let mut radix = radix.lock().unwrap();
+        assert_eq!(radix.stats().recurrent_entries, 2);
+        assert!(radix.lookup_recurrent("model", &[1, 2]).is_none());
         assert!(radix.lookup_recurrent("model", &[1, 3]).is_some());
         assert!(radix.lookup_recurrent("model", &[1, 4]).is_some());
     }

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -34,12 +34,13 @@ const EXACT_STATE_MIN_RETAINED_ENTRIES: usize = 4;
 
 // That retention floor is not allowed to grow without bound. Once the catalog
 // crosses this multiple of the soft cap it evicts again, down to the single
-// entry that keeps exact prefix reuse alive for the stage.
+// entry that keeps exact prefix reuse alive for the stage. That indivisible
+// entry may itself exceed the limit.
 const EXACT_STATE_HARD_CAP_MULTIPLE: u64 = 8;
 
-// Operator override for the ceiling above, in bytes, for workers whose memory
-// headroom does not match the attention-derived estimate. Zero disables the
-// ceiling.
+// Operator override for the limit above, in bytes, for workers whose memory
+// headroom does not match the attention-derived estimate. The last indivisible
+// snapshot may exceed it. Zero disables the limit.
 const EXACT_STATE_MAX_BYTES_ENV: &str = "SKIPPY_KV_CACHE_EXACT_MAX_BYTES";
 
 impl KvStageIntegration {
@@ -258,10 +259,11 @@ fn store_exact_radix_record(
     // attention KV metadata that cannot include architecture-specific
     // recurrent state, so one snapshot can legitimately exceed it. Hold a small
     // working set past the soft cap so concurrent sessions on a stage stop
-    // evicting each other, then apply the hard ceiling so that allowance stays
-    // bounded. Neither pass evicts the last entry: a snapshot that self-evicts
-    // disables exact prefix caching for the stage entirely, which is the
-    // regression this retention policy exists to prevent.
+    // evicting each other, then apply the hard limit so that allowance stays
+    // bounded apart from one indivisible snapshot. Neither pass evicts the last
+    // entry: a snapshot that self-evicts disables exact prefix caching for the
+    // stage entirely, which is the regression this retention policy exists to
+    // prevent.
     evict_exact_entries_over(
         radix,
         blobs,
@@ -319,10 +321,11 @@ fn evict_exact_entries_over(
 /// Resolves the exact-state byte budget from the stage cache cap.
 ///
 /// `configured_max_bytes` is the attention-derived stage budget, which is used
-/// as the soft cap. The hard ceiling defaults to a multiple of it so the
-/// working set stays bounded without inheriting an estimate that structurally
-/// undercounts exact-state payloads. `override_max_bytes` is the operator
-/// escape hatch and wins outright when it parses; zero means unbounded.
+/// as the soft cap. The hard limit defaults to a multiple of it so the working
+/// set stays bounded without inheriting an estimate that structurally
+/// undercounts exact-state payloads. One indivisible snapshot may remain above
+/// that limit. `override_max_bytes` is the operator escape hatch and wins
+/// outright when it parses; zero means unbounded.
 fn exact_state_byte_limits(
     configured_max_bytes: u64,
     override_max_bytes: Option<&str>,

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -13,8 +13,8 @@ use skippy_protocol::{StageConfig, StageKvCacheConfig, StageKvCacheMode, StageKv
 use skippy_runtime::ModelStateKind;
 
 use super::{
-    EXACT_STATE_RECORD_CAPACITY, KvStageIntegration, PendingExactStateRecord, RadixExactEntry,
-    ResidentSequencePool, StageKvMode, StagePrefixCachePayload,
+    EXACT_STATE_RECORD_CAPACITY, ExactStateByteLimits, KvStageIntegration, PendingExactStateRecord,
+    RadixExactEntry, ResidentSequencePool, StageKvMode, StagePrefixCachePayload,
     model_capability::{ModelKvCapability, loaded_model_kv_capability},
     output_tokens::OutputTokenCache,
 };
@@ -22,6 +22,25 @@ use super::{
 // Recurrent and hybrid payloads share the native n_ctx cell pool across
 // sequence lanes, so their exact-state catalog must remain deliberately small.
 const RECURRENT_CACHE_MAX_ENTRIES: usize = 16;
+
+// Exact-state snapshots are indivisible and carry architecture-specific state
+// (recurrent and convolution buffers) that `estimate_stage_cache_max_bytes`
+// cannot see, because that estimate is derived from attention KV metadata
+// alone. A single snapshot therefore routinely exceeds the soft cap. Keep this
+// many snapshots before the soft cap evicts anything: falling to one entry
+// turns the catalog into a single-entry cache, where two concurrent sessions
+// on the same stage evict each other on every request.
+const EXACT_STATE_MIN_RETAINED_ENTRIES: usize = 4;
+
+// That retention floor is not allowed to grow without bound. Once the catalog
+// crosses this multiple of the soft cap it evicts again, down to the single
+// entry that keeps exact prefix reuse alive for the stage.
+const EXACT_STATE_HARD_CAP_MULTIPLE: u64 = 8;
+
+// Operator override for the ceiling above, in bytes, for workers whose memory
+// headroom does not match the attention-derived estimate. Zero disables the
+// ceiling.
+const EXACT_STATE_MAX_BYTES_ENV: &str = "SKIPPY_KV_CACHE_EXACT_MAX_BYTES";
 
 impl KvStageIntegration {
     pub fn from_loaded_model(
@@ -80,7 +99,10 @@ impl KvStageIntegration {
         // contributes one full token path to the radix tree.
         checkpoint_policy.max_resident_tokens_hint = resident_config.max_resident_tokens;
         let exact_max_entries = cache_config.max_entries.clamp(1, 512);
-        let exact_max_bytes = cache_config.max_bytes;
+        let exact_byte_limits = exact_state_byte_limits(
+            cache_config.max_bytes,
+            std::env::var(EXACT_STATE_MAX_BYTES_ENV).ok().as_deref(),
+        );
         let radix = Arc::new(Mutex::new(UnifiedRadixCache::new()));
         let exact_blobs = Arc::new(Mutex::new(CacheBlobStore::default()));
         let (exact_state_record_tx, exact_state_record_rx) =
@@ -114,7 +136,7 @@ impl KvStageIntegration {
                                 &worker_radix,
                                 &worker_exact_blobs,
                                 exact_max_entries,
-                                exact_max_bytes,
+                                exact_byte_limits,
                                 pending,
                             )
                         },
@@ -137,7 +159,7 @@ impl KvStageIntegration {
             radix,
             exact_blobs,
             exact_max_entries,
-            exact_max_bytes,
+            exact_byte_limits,
             exact_state_record_tx,
             exact_state_records_queued,
             exact_state_records_dropped,
@@ -173,7 +195,7 @@ fn store_exact_radix_record(
     radix: &Mutex<UnifiedRadixCache<super::RadixResidentEntry, RadixExactEntry>>,
     blobs: &Mutex<CacheBlobStore>,
     max_entries: usize,
-    max_bytes: u64,
+    limits: ExactStateByteLimits,
     pending: PendingExactStateRecord,
 ) -> Result<()> {
     let logical_bytes = pending.payload.byte_len();
@@ -232,42 +254,86 @@ fn store_exact_radix_record(
             payload.release_from(&mut blobs)?;
         }
     }
-    // Exact snapshots are indivisible, and the default cap is estimated from
+    // Exact snapshots are indivisible, and the soft cap is estimated from
     // attention KV metadata that cannot include architecture-specific
-    // recurrent state. Treat the byte limit as a soft cap for one entry;
-    // otherwise an oversized checkpoint self-evicts immediately and exact
-    // prefix caching is permanently disabled for that stage.
-    if max_bytes > 0 {
-        loop {
-            let over_bytes = blobs
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .physical_bytes()
-                > max_bytes;
-            let multiple_entries = radix
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .stats()
-                .recurrent_entries
-                > 1;
-            if !over_bytes || !multiple_entries {
-                break;
-            }
-            let evicted = radix
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .evict_lru_recurrent();
-            let Some(evicted) = evicted else {
-                break;
-            };
-            evicted.value.payload.release_from(
-                &mut blobs
-                    .lock()
-                    .unwrap_or_else(std::sync::PoisonError::into_inner),
-            )?;
+    // recurrent state, so one snapshot can legitimately exceed it. Hold a small
+    // working set past the soft cap so concurrent sessions on a stage stop
+    // evicting each other, then apply the hard ceiling so that allowance stays
+    // bounded. Neither pass evicts the last entry: a snapshot that self-evicts
+    // disables exact prefix caching for the stage entirely, which is the
+    // regression this retention policy exists to prevent.
+    evict_exact_entries_over(
+        radix,
+        blobs,
+        limits.soft_bytes,
+        EXACT_STATE_MIN_RETAINED_ENTRIES,
+    )?;
+    evict_exact_entries_over(radix, blobs, limits.hard_bytes, 1)?;
+    Ok(())
+}
+
+/// Evicts least-recently-used exact entries while the catalog holds more than
+/// `limit_bytes`, never dropping below `min_retained_entries`. A zero limit
+/// means the catalog has no byte ceiling and nothing is evicted.
+fn evict_exact_entries_over(
+    radix: &Mutex<UnifiedRadixCache<super::RadixResidentEntry, RadixExactEntry>>,
+    blobs: &Mutex<CacheBlobStore>,
+    limit_bytes: u64,
+    min_retained_entries: usize,
+) -> Result<()> {
+    if limit_bytes == 0 {
+        return Ok(());
+    }
+    let floor = min_retained_entries.max(1);
+    loop {
+        let over_bytes = blobs
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .physical_bytes()
+            > limit_bytes;
+        let above_floor = radix
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .stats()
+            .recurrent_entries
+            > floor;
+        if !over_bytes || !above_floor {
+            break;
         }
+        let evicted = radix
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .evict_lru_recurrent();
+        let Some(evicted) = evicted else {
+            break;
+        };
+        evicted.value.payload.release_from(
+            &mut blobs
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner),
+        )?;
     }
     Ok(())
+}
+
+/// Resolves the exact-state byte budget from the stage cache cap.
+///
+/// `configured_max_bytes` is the attention-derived stage budget, which is used
+/// as the soft cap. The hard ceiling defaults to a multiple of it so the
+/// working set stays bounded without inheriting an estimate that structurally
+/// undercounts exact-state payloads. `override_max_bytes` is the operator
+/// escape hatch and wins outright when it parses; zero means unbounded.
+fn exact_state_byte_limits(
+    configured_max_bytes: u64,
+    override_max_bytes: Option<&str>,
+) -> ExactStateByteLimits {
+    let hard_bytes = override_max_bytes
+        .and_then(|value| value.trim().parse::<u64>().ok())
+        .unwrap_or_else(|| configured_max_bytes.saturating_mul(EXACT_STATE_HARD_CAP_MULTIPLE));
+    ExactStateByteLimits {
+        soft_bytes: configured_max_bytes,
+        hard_bytes,
+    }
 }
 
 fn effective_cache_payload(
@@ -375,6 +441,13 @@ mod tests {
     use super::*;
     use skippy_protocol::{FlashAttentionType, LoadMode};
 
+    fn limits(soft_bytes: u64, hard_bytes: u64) -> ExactStateByteLimits {
+        ExactStateByteLimits {
+            soft_bytes,
+            hard_bytes,
+        }
+    }
+
     fn pending(page_id: &str, tokens: &[i32], bytes: &[u8]) -> PendingExactStateRecord {
         PendingExactStateRecord {
             page_id: page_id.to_string(),
@@ -390,13 +463,19 @@ mod tests {
         let radix = Mutex::new(UnifiedRadixCache::new());
         let blobs = Mutex::new(CacheBlobStore::new(4));
 
-        store_exact_radix_record(&radix, &blobs, 1, 0, pending("first", &[1, 2], b"aaaabbbb"))
-            .unwrap();
         store_exact_radix_record(
             &radix,
             &blobs,
             1,
-            0,
+            limits(0, 0),
+            pending("first", &[1, 2], b"aaaabbbb"),
+        )
+        .unwrap();
+        store_exact_radix_record(
+            &radix,
+            &blobs,
+            1,
+            limits(0, 0),
             pending("second", &[1, 3], b"aaaacccc"),
         )
         .unwrap();
@@ -421,9 +500,14 @@ mod tests {
         let radix = Mutex::new(UnifiedRadixCache::new());
         let blobs = Mutex::new(CacheBlobStore::new(4));
 
-        let error =
-            store_exact_radix_record(&radix, &blobs, 1, 0, pending("empty", &[], b"aaaabbbb"))
-                .unwrap_err();
+        let error = store_exact_radix_record(
+            &radix,
+            &blobs,
+            1,
+            limits(0, 0),
+            pending("empty", &[], b"aaaabbbb"),
+        )
+        .unwrap_err();
 
         assert_eq!(
             error.to_string(),
@@ -434,36 +518,110 @@ mod tests {
     }
 
     #[test]
-    fn oversized_exact_payload_retains_one_reusable_entry() {
+    fn oversized_exact_payloads_retain_a_reusable_working_set() {
+        let radix = Mutex::new(UnifiedRadixCache::new());
+        let blobs = Mutex::new(CacheBlobStore::new(4));
+
+        // Every payload here is twice the soft cap, which is the recurrent case:
+        // the attention-derived estimate cannot cover a full-state snapshot.
+        for (page_id, tokens, bytes) in [
+            ("first", [1, 2], b"aaaabbbb"),
+            ("second", [1, 3], b"ccccdddd"),
+            ("third", [1, 4], b"eeeeffff"),
+        ] {
+            store_exact_radix_record(
+                &radix,
+                &blobs,
+                8,
+                limits(4, 1024),
+                pending(page_id, &tokens, bytes),
+            )
+            .unwrap();
+        }
+
+        // Concurrent sessions on one stage must not evict each other just
+        // because a single snapshot cannot fit under the soft cap.
+        assert_eq!(blobs.lock().unwrap().physical_bytes(), 24);
+        let mut radix = radix.lock().unwrap();
+        assert_eq!(radix.stats().recurrent_entries, 3);
+        assert!(radix.lookup_recurrent("model", &[1, 2]).is_some());
+        assert!(radix.lookup_recurrent("model", &[1, 3]).is_some());
+        assert!(radix.lookup_recurrent("model", &[1, 4]).is_some());
+    }
+
+    #[test]
+    fn exact_working_set_is_bounded_by_the_hard_ceiling() {
+        let radix = Mutex::new(UnifiedRadixCache::new());
+        let blobs = Mutex::new(CacheBlobStore::new(4));
+
+        for (page_id, tokens, bytes) in [
+            ("first", [1, 2], b"aaaabbbb"),
+            ("second", [1, 3], b"ccccdddd"),
+            ("third", [1, 4], b"eeeeffff"),
+        ] {
+            store_exact_radix_record(
+                &radix,
+                &blobs,
+                8,
+                limits(4, 8),
+                pending(page_id, &tokens, bytes),
+            )
+            .unwrap();
+        }
+
+        // The retention floor yields to the ceiling, leaving the most recent
+        // snapshot rather than an unbounded working set.
+        let mut radix = radix.lock().unwrap();
+        assert_eq!(radix.stats().recurrent_entries, 1);
+        assert!(radix.lookup_recurrent("model", &[1, 2]).is_none());
+        assert!(radix.lookup_recurrent("model", &[1, 3]).is_none());
+        assert!(radix.lookup_recurrent("model", &[1, 4]).is_some());
+        assert_eq!(blobs.lock().unwrap().physical_bytes(), 8);
+    }
+
+    #[test]
+    fn single_exact_payload_over_the_ceiling_is_still_reusable() {
         let radix = Mutex::new(UnifiedRadixCache::new());
         let blobs = Mutex::new(CacheBlobStore::new(4));
 
         store_exact_radix_record(
             &radix,
             &blobs,
-            4,
-            4,
+            8,
+            limits(2, 4),
             pending("checkpoint", &[1, 2], b"aaaabbbb"),
         )
         .unwrap();
 
-        assert_eq!(radix.lock().unwrap().stats().recurrent_entries, 1);
-        assert_eq!(blobs.lock().unwrap().physical_bytes(), 8);
-
-        store_exact_radix_record(
-            &radix,
-            &blobs,
-            4,
-            4,
-            pending("replacement", &[1, 3], b"ccccdddd"),
-        )
-        .unwrap();
-
+        // Self-eviction here is the original regression: it leaves the stage
+        // with no exact prefix cache at all.
         let mut radix = radix.lock().unwrap();
         assert_eq!(radix.stats().recurrent_entries, 1);
-        assert!(radix.lookup_recurrent("model", &[1, 2]).is_none());
-        assert!(radix.lookup_recurrent("model", &[1, 3]).is_some());
-        assert_eq!(blobs.lock().unwrap().physical_bytes(), 8);
+        assert!(radix.lookup_recurrent("model", &[1, 2]).is_some());
+    }
+
+    #[test]
+    fn exact_state_byte_limits_scale_the_ceiling_off_the_stage_budget() {
+        assert_eq!(
+            exact_state_byte_limits(1_024, None),
+            limits(1_024, 1_024 * EXACT_STATE_HARD_CAP_MULTIPLE)
+        );
+        // An unset stage budget stays unbounded, as it was before.
+        assert_eq!(exact_state_byte_limits(0, None), limits(0, 0));
+    }
+
+    #[test]
+    fn exact_state_byte_limits_honour_the_operator_override() {
+        assert_eq!(
+            exact_state_byte_limits(1_024, Some(" 4096 ")),
+            limits(1_024, 4_096)
+        );
+        assert_eq!(exact_state_byte_limits(1_024, Some("0")), limits(1_024, 0));
+        // A malformed override must not silently disable the ceiling.
+        assert_eq!(
+            exact_state_byte_limits(1_024, Some("not-a-number")),
+            limits(1_024, 1_024 * EXACT_STATE_HARD_CAP_MULTIPLE)
+        );
     }
 
     #[test]

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -232,25 +232,40 @@ fn store_exact_radix_record(
             payload.release_from(&mut blobs)?;
         }
     }
-    while max_bytes > 0
-        && blobs
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .physical_bytes()
-            > max_bytes
-    {
-        let evicted = radix
-            .lock()
-            .unwrap_or_else(std::sync::PoisonError::into_inner)
-            .evict_lru_recurrent();
-        let Some(evicted) = evicted else {
-            break;
-        };
-        evicted.value.payload.release_from(
-            &mut blobs
+    // Exact snapshots are indivisible, and the default cap is estimated from
+    // attention KV metadata that cannot include architecture-specific
+    // recurrent state. Treat the byte limit as a soft cap for one entry;
+    // otherwise an oversized checkpoint self-evicts immediately and exact
+    // prefix caching is permanently disabled for that stage.
+    if max_bytes > 0 {
+        loop {
+            let over_bytes = blobs
                 .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner),
-        )?;
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .physical_bytes()
+                > max_bytes;
+            let multiple_entries = radix
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .stats()
+                .recurrent_entries
+                > 1;
+            if !over_bytes || !multiple_entries {
+                break;
+            }
+            let evicted = radix
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .evict_lru_recurrent();
+            let Some(evicted) = evicted else {
+                break;
+            };
+            evicted.value.payload.release_from(
+                &mut blobs
+                    .lock()
+                    .unwrap_or_else(std::sync::PoisonError::into_inner),
+            )?;
+        }
     }
     Ok(())
 }
@@ -416,6 +431,39 @@ mod tests {
         );
         assert_eq!(blobs.lock().unwrap().physical_bytes(), 0);
         assert_eq!(radix.lock().unwrap().stats().recurrent_entries, 0);
+    }
+
+    #[test]
+    fn oversized_exact_payload_retains_one_reusable_entry() {
+        let radix = Mutex::new(UnifiedRadixCache::new());
+        let blobs = Mutex::new(CacheBlobStore::new(4));
+
+        store_exact_radix_record(
+            &radix,
+            &blobs,
+            4,
+            4,
+            pending("checkpoint", &[1, 2], b"aaaabbbb"),
+        )
+        .unwrap();
+
+        assert_eq!(radix.lock().unwrap().stats().recurrent_entries, 1);
+        assert_eq!(blobs.lock().unwrap().physical_bytes(), 8);
+
+        store_exact_radix_record(
+            &radix,
+            &blobs,
+            4,
+            4,
+            pending("replacement", &[1, 3], b"ccccdddd"),
+        )
+        .unwrap();
+
+        let mut radix = radix.lock().unwrap();
+        assert_eq!(radix.stats().recurrent_entries, 1);
+        assert!(radix.lookup_recurrent("model", &[1, 2]).is_none());
+        assert!(radix.lookup_recurrent("model", &[1, 3]).is_some());
+        assert_eq!(blobs.lock().unwrap().physical_bytes(), 8);
     }
 
     #[test]

--- a/crates/skippy-server/src/kv_integration/identity.rs
+++ b/crates/skippy-server/src/kv_integration/identity.rs
@@ -137,6 +137,13 @@ impl KvStageIntegration {
         token_ids: &[i32],
     ) -> Option<PrefillKvIdentity> {
         let token_count = token_ids.len() as u64;
+        self.exact_shared_checkpoint_token_count(token_count)
+            .map(|checkpoint| {
+                self.prefill_identity(config, base, token_start, &token_ids[..checkpoint as usize])
+            })
+    }
+
+    pub(crate) fn exact_shared_checkpoint_token_count(&self, token_count: u64) -> Option<u64> {
         if token_count <= self.checkpoint_policy.min_tokens {
             return None;
         }
@@ -145,9 +152,18 @@ impl KvStageIntegration {
         let checkpoint = near_tail
             .saturating_sub(stride)
             .max(self.checkpoint_policy.min_tokens);
-        (checkpoint > 0 && checkpoint < token_count).then(|| {
-            self.prefill_identity(config, base, token_start, &token_ids[..checkpoint as usize])
-        })
+        (checkpoint > 0 && checkpoint < token_count).then_some(checkpoint)
+    }
+
+    pub(crate) fn exact_state_record_token_count_allowed(
+        &self,
+        prompt_token_count: u64,
+        candidate_token_count: u64,
+    ) -> bool {
+        match self.exact_shared_checkpoint_token_count(prompt_token_count) {
+            Some(checkpoint) => candidate_token_count == checkpoint,
+            None => candidate_token_count == prompt_token_count,
+        }
     }
 }
 
@@ -374,5 +390,26 @@ mod tests {
             kv.exact_shared_checkpoint_identity(&config, &test_base(), 0, &[1])
                 .is_none()
         );
+    }
+
+    #[test]
+    fn exact_state_record_prefers_shared_checkpoint_over_request_tail() {
+        let mut config = test_config();
+        config.kv_cache.as_mut().unwrap().payload = StageKvCachePayload::KvRecurrent;
+        config.kv_cache.as_mut().unwrap().min_tokens = 256;
+        config
+            .kv_cache
+            .as_mut()
+            .unwrap()
+            .shared_prefix_stride_tokens = 128;
+        let kv =
+            KvStageIntegration::from_config(&config, skippy_runtime::ModelStateKind::Recurrent)
+                .unwrap()
+                .expect("cache enabled");
+
+        assert!(kv.exact_state_record_token_count_allowed(970, 768));
+        assert!(!kv.exact_state_record_token_count_allowed(970, 969));
+        assert!(!kv.exact_state_record_token_count_allowed(970, 970));
+        assert!(kv.exact_state_record_token_count_allowed(200, 200));
     }
 }

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -130,6 +130,20 @@ pub enum StageKvMode {
     Correctness,
 }
 
+/// Byte budget for the exact-state catalog.
+///
+/// `soft_bytes` is the stage cache budget, which is derived from attention KV
+/// metadata and therefore cannot account for the recurrent and convolution
+/// buffers an exact-state snapshot also carries. A single snapshot can
+/// legitimately exceed it, so the soft budget only bounds the catalog once it
+/// already holds a working set. `hard_bytes` is the ceiling that allowance is
+/// never permitted to cross. Zero means unbounded for either field.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) struct ExactStateByteLimits {
+    pub(crate) soft_bytes: u64,
+    pub(crate) hard_bytes: u64,
+}
+
 #[derive(Clone)]
 pub struct KvStageIntegration {
     pub(crate) mode: StageKvMode,
@@ -145,7 +159,7 @@ pub struct KvStageIntegration {
     pub(crate) radix: Arc<Mutex<UnifiedRadixCache<RadixResidentEntry, RadixExactEntry>>>,
     pub(crate) exact_blobs: Arc<Mutex<CacheBlobStore>>,
     pub(crate) exact_max_entries: usize,
-    pub(crate) exact_max_bytes: u64,
+    pub(crate) exact_byte_limits: ExactStateByteLimits,
     pub(crate) exact_state_record_tx: SyncSender<PendingExactStateRecord>,
     pub(crate) exact_state_records_queued: Arc<AtomicU64>,
     pub(crate) exact_state_records_dropped: Arc<AtomicU64>,
@@ -708,7 +722,14 @@ impl KvStageIntegration {
                         .load(std::sync::atomic::Ordering::Relaxed)
                 ),
             ),
-            ("skippy.exact_cache.max_bytes", json!(self.exact_max_bytes)),
+            (
+                "skippy.exact_cache.max_bytes",
+                json!(self.exact_byte_limits.soft_bytes),
+            ),
+            (
+                "skippy.exact_cache.hard_max_bytes",
+                json!(self.exact_byte_limits.hard_bytes),
+            ),
             (
                 "skippy.exact_cache.max_entries",
                 json!(self.exact_max_entries),

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -136,8 +136,9 @@ pub enum StageKvMode {
 /// metadata and therefore cannot account for the recurrent and convolution
 /// buffers an exact-state snapshot also carries. A single snapshot can
 /// legitimately exceed it, so the soft budget only bounds the catalog once it
-/// already holds a working set. `hard_bytes` is the ceiling that allowance is
-/// never permitted to cross. Zero means unbounded for either field.
+/// already holds a working set. `hard_bytes` bounds that allowance except that
+/// the last indivisible snapshot is retained even when it exceeds the limit.
+/// Zero means unbounded for either field.
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(crate) struct ExactStateByteLimits {
     pub(crate) soft_bytes: u64,

--- a/crates/skippy-server/src/telemetry.rs
+++ b/crates/skippy-server/src/telemetry.rs
@@ -149,9 +149,9 @@ impl Drop for StderrTelemetrySink {
 }
 
 fn stderr_telemetry_loop(rx: std_mpsc::Receiver<StderrTelemetryEvent>) {
-    let stderr = std::io::stderr();
-    let mut writer = BufWriter::new(stderr.lock());
     while let Ok(event) = rx.recv() {
+        let stderr = std::io::stderr();
+        let mut writer = BufWriter::new(stderr.lock());
         if serde_json::to_writer(&mut writer, &event).is_err() || writer.write_all(b"\n").is_err() {
             return;
         }
@@ -166,7 +166,6 @@ fn stderr_telemetry_loop(rx: std_mpsc::Receiver<StderrTelemetryEvent>) {
             return;
         }
     }
-    let _ = writer.flush();
 }
 
 impl Telemetry {

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -502,7 +502,7 @@ mesh-llm serve \
 > `scripts/ci-two-node-split-smoke.sh` against the Linux inference binary and a
 > tiny GGUF. It starts two serving nodes, waits for a topology with stages on
 > two distinct nodes, checks `/v1/models`, then sends three progressively longer
-> `/v1/completions` prompts with one shared prefix through stage 0. The smoke
+> `/v1/chat/completions` prompts with one shared prefix through stage 0. The smoke
 > requires the reported cached-token count to increase after each request so
 > split serving cannot silently fall back to cold prefill for prefix matches.
 >

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -499,12 +499,14 @@ mesh-llm serve \
   response from the layer-package model.
 
 > **CI coverage:** `two_node_split_smoke` runs
-> `scripts/ci-two-node-split-smoke.sh` against the Linux inference binary and a
-> tiny GGUF. It starts two serving nodes, waits for a topology with stages on
-> two distinct nodes, checks `/v1/models`, then sends three progressively longer
-> `/v1/chat/completions` prompts with one shared prefix through stage 0. The smoke
-> requires the reported cached-token count to increase after each request so
-> split serving cannot silently fall back to cold prefill for prefix matches.
+> `scripts/ci-two-node-split-smoke.sh` against the Linux inference binary in two
+> model lanes: dense SmolLM2-135M and recurrent Qwen3.5-0.8B. Each lane starts
+> two serving nodes (the recurrent lane fixes a 4096-token context), waits for
+> a topology with stages on two distinct nodes, checks `/v1/models`, then sends
+> three progressively longer `/v1/chat/completions` prompts with one shared
+> prefix through stage 0. The smoke requires the reported cached-token count to
+> increase after each request so either model-state path cannot silently fall
+> back to cold prefill for prefix matches.
 >
 > Other nearby CI coverage:
 >

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -506,7 +506,12 @@ mesh-llm serve \
 > three progressively longer `/v1/chat/completions` prompts with one shared
 > prefix through stage 0. The smoke requires the reported cached-token count to
 > increase after each request so either model-state path cannot silently fall
-> back to cold prefill for prefix matches.
+> back to cold prefill for prefix matches. A follow-up request that restores
+> nothing is the one outcome a loaded runner can produce without a regression,
+> because the host answers before the stage lane releases; the smoke retries the
+> whole sequence from a fresh cold prefix up to
+> `MESH_TWO_NODE_SPLIT_PREFIX_ATTEMPTS` times (3 by default) for that case only.
+> Reuse that is present but not growing fails immediately.
 >
 > Other nearby CI coverage:
 >

--- a/docs/design/TESTING.md
+++ b/docs/design/TESTING.md
@@ -501,8 +501,10 @@ mesh-llm serve \
 > **CI coverage:** `two_node_split_smoke` runs
 > `scripts/ci-two-node-split-smoke.sh` against the Linux inference binary and a
 > tiny GGUF. It starts two serving nodes, waits for a topology with stages on
-> two distinct nodes, checks `/v1/models`, and sends a short
-> `/v1/chat/completions` request through stage 0.
+> two distinct nodes, checks `/v1/models`, then sends three progressively longer
+> `/v1/completions` prompts with one shared prefix through stage 0. The smoke
+> requires the reported cached-token count to increase after each request so
+> split serving cannot silently fall back to cold prefill for prefix matches.
 >
 > Other nearby CI coverage:
 >

--- a/docs/skippy/PROMPT_CACHE.md
+++ b/docs/skippy/PROMPT_CACHE.md
@@ -59,10 +59,12 @@ The exact catalog therefore treats that budget as a soft cap. It keeps a small
 working set of snapshots past the soft cap, so concurrent sessions on one stage
 do not evict each other on every request, and it never evicts its last entry,
 because a snapshot that self-evicts leaves the stage with no exact prefix reuse
-at all. A hard ceiling bounds that allowance and defaults to a multiple of the
-soft cap. Set `SKIPPY_KV_CACHE_EXACT_MAX_BYTES` to pin the ceiling in bytes on a
-worker whose memory headroom does not match the attention-derived estimate; `0`
-disables the ceiling. Both limits are reported on
+at all. A hard limit bounds that allowance and defaults to a multiple of the
+soft cap, but it is not an absolute physical-byte ceiling: the last indivisible
+snapshot remains reusable even when it exceeds the limit. Set
+`SKIPPY_KV_CACHE_EXACT_MAX_BYTES` to pin the limit in bytes on a worker whose
+memory headroom does not match the attention-derived estimate; `0` disables the
+limit. Both limits are reported on
 `stage.openai_generation_summary` as `skippy.exact_cache.max_bytes` and
 `skippy.exact_cache.hard_max_bytes`.
 

--- a/docs/skippy/PROMPT_CACHE.md
+++ b/docs/skippy/PROMPT_CACHE.md
@@ -47,6 +47,25 @@ Skippy reports cache state in OpenAI usage and telemetry:
   `skippy.kv.hit_kind`. The hit kind is `none` for disabled or missed cache
   lookups.
 
+## Exact-State Retention
+
+Recurrent and hybrid families store an exact-state snapshot: the complete
+native session state, which is indivisible and includes recurrent and
+convolution buffers. The stage byte budget (`prefix_cache.max_bytes`, or
+`SKIPPY_KV_CACHE_MAX_BYTES`) is derived from attention KV metadata, so it
+systematically undercounts those snapshots and a single snapshot can exceed it.
+
+The exact catalog therefore treats that budget as a soft cap. It keeps a small
+working set of snapshots past the soft cap, so concurrent sessions on one stage
+do not evict each other on every request, and it never evicts its last entry,
+because a snapshot that self-evicts leaves the stage with no exact prefix reuse
+at all. A hard ceiling bounds that allowance and defaults to a multiple of the
+soft cap. Set `SKIPPY_KV_CACHE_EXACT_MAX_BYTES` to pin the ceiling in bytes on a
+worker whose memory headroom does not match the attention-derived estimate; `0`
+disables the ceiling. Both limits are reported on
+`stage.openai_generation_summary` as `skippy.exact_cache.max_bytes` and
+`skippy.exact_cache.hard_max_bytes`.
+
 ## mesh-llm Defaults
 
 mesh-llm wires Skippy prefix cache through family policy. For supported model

--- a/scripts/ci-two-node-split-smoke.sh
+++ b/scripts/ci-two-node-split-smoke.sh
@@ -24,6 +24,7 @@ WORKER_BIND_PORT="${MESH_TWO_NODE_SPLIT_WORKER_BIND_PORT:-53648}"
 MAX_WAIT="${MESH_TWO_NODE_SPLIT_MAX_WAIT:-300}"
 REQUEST_SETTLE_SECONDS="${MESH_TWO_NODE_SPLIT_REQUEST_SETTLE_SECONDS:-1}"
 PREFIX_ATTEMPTS="${MESH_TWO_NODE_SPLIT_PREFIX_ATTEMPTS:-3}"
+EXPECTED_EXACT_PAYLOAD_KIND="${MESH_TWO_NODE_SPLIT_EXPECTED_EXACT_PAYLOAD_KIND:-}"
 CTX_SIZE="${MESH_TWO_NODE_SPLIT_CTX_SIZE:-${MESH_LLM_SMOKE_CONTEXT_SIZE:-}}"
 MAX_VRAM="${MESH_TWO_NODE_SPLIT_MAX_VRAM:-1}"
 DEVICE="${MESH_TWO_NODE_SPLIT_DEVICE:-CPU}"
@@ -46,6 +47,7 @@ echo "  worker console: $WORKER_CONSOLE_PORT"
 echo "  worker bind:    $WORKER_BIND_PORT"
 echo "  request settle: ${REQUEST_SETTLE_SECONDS}s"
 echo "  prefix attempts: ${PREFIX_ATTEMPTS}"
+echo "  expected exact payload: ${EXPECTED_EXACT_PAYLOAD_KIND:-none}"
 echo "  ctx size:       ${CTX_SIZE:-model default}"
 echo "  max vram:       ${MAX_VRAM}GB"
 echo "  device:         $DEVICE"
@@ -211,6 +213,7 @@ start_node() {
     HOME="$home" \
         MESH_LLM_RUNTIME_ROOT="$runtime" \
         MESH_LLM_EPHEMERAL_KEY=1 \
+        SKIPPY_TELEMETRY_STDERR=1 \
         "$MESH_LLM" "${args[@]}" >"$log_file" 2>&1 &
     printf '%s\n' "$!"
 }
@@ -300,9 +303,9 @@ PREFIX_PAYLOAD_ROOT="${WORK_DIR}/prefix-payloads"
 PREFIX_RESPONSE_ROOT="${WORK_DIR}/prefix-responses"
 
 # Exit code the prefix validator uses for the one failure this smoke cannot
-# distinguish from a regression on a single pass: a follow-up request that
-# restored nothing, which is what an unreleased stage lane looks like from the
-# outside. Anything else is a real assertion failure and is never retried.
+# distinguish from a regression on a single pass: every request restored
+# nothing, which is what an unreleased stage lane looks like from the outside.
+# Anything else is a real assertion failure and is never retried.
 PREFIX_TRANSIENT_STATUS=75
 
 write_prefix_payloads() {
@@ -374,10 +377,10 @@ if not prompt_counts[0] < prompt_counts[1] < prompt_counts[2]:
     raise SystemExit(f"prompt token counts did not increase: {prompt_counts}")
 if cached_counts[0] != 0:
     raise SystemExit(f"cold prefix request unexpectedly restored tokens: {cached_counts}")
-# Zero reuse on a follow-up is reported separately from reuse that failed to
-# grow. Only the former is consistent with a stage lane that had not released
-# yet, and only the former earns another attempt.
-if 0 in cached_counts[1:]:
+# A completely cold attempt can arise while a stage lane is still releasing.
+# A partial follow-up miss is the regression under test and must fail directly,
+# not be hidden by a retry that starts from another cold prefix.
+if all(cached == 0 for cached in cached_counts):
     print(
         f"split prefix reuse was empty on a follow-up request: {cached_counts}",
         file=sys.stderr,
@@ -394,6 +397,33 @@ print(
         f"request {index}: prompt_tokens={prompt}, cached_tokens={cached}"
         for index, (prompt, cached) in enumerate(metrics, start=1)
     )
+)
+PY
+}
+
+assert_expected_exact_payload() {
+    [[ -n "$EXPECTED_EXACT_PAYLOAD_KIND" ]] || return 0
+    python3 - "$EXPECTED_EXACT_PAYLOAD_KIND" "$SEED_LOG" "$WORKER_LOG" <<'PY'
+import json
+import sys
+
+expected, *logs = sys.argv[1:]
+for log_path in logs:
+    with open(log_path, encoding="utf-8", errors="replace") as log:
+        for line in log:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if (
+                event.get("event") == "stage.openai_kv_record_decision"
+                and (event.get("attributes") or {}).get("skippy.exact_cache.payload_kind")
+                == expected
+            ):
+                print(f"observed exact-state payload kind: {expected}")
+                raise SystemExit(0)
+raise SystemExit(
+    f"did not observe exact-state payload kind {expected!r} in split-stage telemetry"
 )
 PY
 }
@@ -435,5 +465,7 @@ if [[ "$prefix_validated" -ne 1 ]]; then
     echo "split prefix reuse never materialized across ${PREFIX_ATTEMPTS} attempts" >&2
     exit 1
 fi
+
+assert_expected_exact_payload
 
 echo "Two-node split smoke passed"

--- a/scripts/ci-two-node-split-smoke.sh
+++ b/scripts/ci-two-node-split-smoke.sh
@@ -6,7 +6,7 @@
 # Unlike ci-two-node-client-serving-smoke.sh, both processes are serving nodes.
 # The smoke requires the runtime to publish a topology with stages on at least
 # two distinct nodes before it sends OpenAI requests through stage 0. It then
-# grows one raw prompt over three requests and requires the split stages to
+# grows one chat prompt over three requests and requires the split stages to
 # restore a longer shared prefix after every request.
 
 set -euo pipefail
@@ -317,7 +317,7 @@ for index, extension in enumerate(extensions, start=1):
     prompt += extension
     payload = {
         "model": model,
-        "prompt": prompt,
+        "messages": [{"role": "user", "content": prompt}],
         "user": "ci-split-prefix-growth",
         "stream": False,
         "max_tokens": 1,
@@ -329,7 +329,7 @@ PY
 
 for index in 1 2 3; do
     curl -fsS --max-time 180 \
-        "http://127.0.0.1:${DRIVER_API_PORT}/v1/completions" \
+        "http://127.0.0.1:${DRIVER_API_PORT}/v1/chat/completions" \
         -H 'content-type: application/json' \
         -d @"${PREFIX_PAYLOAD_DIR}/prompt-${index}.json" \
         -o "${PREFIX_RESPONSE_DIR}/response-${index}.json"
@@ -349,7 +349,7 @@ metrics = []
 for index in range(1, 4):
     with (response_dir / f"response-{index}.json").open(encoding="utf-8") as fh:
         body = json.load(fh)
-    if body.get("object") != "text_completion":
+    if body.get("object") != "chat.completion":
         raise SystemExit(
             f"prefix request {index} returned unexpected object: {body.get('object')!r}"
         )

--- a/scripts/ci-two-node-split-smoke.sh
+++ b/scripts/ci-two-node-split-smoke.sh
@@ -5,9 +5,12 @@
 #
 # Unlike ci-two-node-client-serving-smoke.sh, both processes are serving nodes.
 # The smoke requires the runtime to publish a topology with stages on at least
-# two distinct nodes before it sends OpenAI requests through stage 0. It then
-# grows one chat prompt over three requests and requires the split stages to
-# restore a longer shared prefix after every request.
+# two distinct nodes before it sends OpenAI requests through stage 0. For each
+# model leg it sends every prompt length twice in a row (X, X, X+more, X+more,
+# ...): the first sight of each length proves reuse keeps growing, and the
+# identical re-send must be served from cache as a near-full restore. With
+# MESH_TWO_NODE_SPLIT_RECURRENT_MODEL set, the dense leg runs first and the
+# recurrent leg repeats the whole flow against a second model in the same job.
 
 set -euo pipefail
 
@@ -22,6 +25,11 @@ WORKER_API_PORT="${MESH_TWO_NODE_SPLIT_WORKER_API_PORT:-9368}"
 WORKER_CONSOLE_PORT="${MESH_TWO_NODE_SPLIT_WORKER_CONSOLE_PORT:-3162}"
 WORKER_BIND_PORT="${MESH_TWO_NODE_SPLIT_WORKER_BIND_PORT:-53648}"
 MAX_WAIT="${MESH_TWO_NODE_SPLIT_MAX_WAIT:-300}"
+# Optional second model: when set, the smoke runs the whole split flow once
+# against MODEL (dense) and once against this (recurrent) in the same process
+# pair, so a single CI job covers both cache families.
+RECURRENT_MODEL="${MESH_TWO_NODE_SPLIT_RECURRENT_MODEL:-}"
+RECURRENT_CTX_SIZE="${MESH_TWO_NODE_SPLIT_RECURRENT_CTX_SIZE:-4096}"
 REQUEST_SETTLE_SECONDS="${MESH_TWO_NODE_SPLIT_REQUEST_SETTLE_SECONDS:-1}"
 PREFIX_ATTEMPTS="${MESH_TWO_NODE_SPLIT_PREFIX_ATTEMPTS:-3}"
 EXPECTED_EXACT_PAYLOAD_KIND="${MESH_TWO_NODE_SPLIT_EXPECTED_EXACT_PAYLOAD_KIND:-}"
@@ -279,6 +287,10 @@ for i in $(seq 1 "$MAX_WAIT"); do
         echo "last checked endpoint: ${label:-unknown}" >&2
         echo "last peer count: ${PEERS:-unknown}" >&2
         echo "last split summary: ${READY_SUMMARY:-unknown}" >&2
+        echo "--- seed /api/runtime/stages at timeout ---" >&2
+        echo "$(stages_json "$SEED_CONSOLE_PORT")" >&2
+        echo "--- worker /api/runtime/stages at timeout ---" >&2
+        echo "$(stages_json "$WORKER_CONSOLE_PORT")" >&2
         tail -160 "$SEED_LOG" >&2 || true
         tail -160 "$WORKER_LOG" >&2 || true
         exit 1
@@ -298,6 +310,8 @@ if [[ -z "$MODEL_ID" ]]; then
     echo "${DRIVER_LABEL:-selected driver} /v1/models did not return a model id" >&2
     exit 1
 fi
+MODEL_LABEL="dense"
+export MODEL_ID MODEL_LABEL
 
 PREFIX_PAYLOAD_ROOT="${WORK_DIR}/prefix-payloads"
 PREFIX_RESPONSE_ROOT="${WORK_DIR}/prefix-responses"
@@ -328,33 +342,52 @@ extensions = [
     "Second extension block makes the reusable prefix longer. " * 16,
     "Third extension block proves reuse keeps growing. " * 16,
 ]
+# Every length is sent twice in a row: X, X, X+E1, X+E1, X+E1+E2, X+E1+E2.
+# The first sight of each length proves reuse carries the established prefix
+# forward, and the identical re-send proves a repeated prompt is served from
+# cache instead of being recomputed.
+index = 0
 prompt = shared
-for index, extension in enumerate(extensions, start=1):
+for extension in extensions:
     prompt += extension
-    payload = {
-        "model": model,
-        "messages": [{"role": "user", "content": prompt}],
-        "user": f"ci-split-prefix-growth-{nonce}",
-        "stream": False,
-        "max_tokens": 1,
-        "temperature": 0,
-    }
-    with (output / f"prompt-{index}.json").open("w", encoding="utf-8") as fh:
-        json.dump(payload, fh)
+    for _ in range(2):
+        index += 1
+        payload = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "user": f"ci-split-prefix-growth-{nonce}",
+            "stream": False,
+            "max_tokens": 1,
+            "temperature": 0,
+        }
+        with (output / f"prompt-{index}.json").open("w", encoding="utf-8") as fh:
+            json.dump(payload, fh)
 PY
 }
 
+# Requests 1..6: odd indexes are first sights of each prompt length (growth
+# arms), even indexes are identical re-sends of the previous prompt (repeat
+# arms). Requests 1-2 share prompt X, 3-4 share X+E1, 5-6 share X+E1+E2.
+PREFIX_REQUEST_COUNT=6
+
 validate_prefix_responses() {
-    python3 - "$1" <<'PY'
+    python3 - "$1" "$PREFIX_REQUEST_COUNT" <<'PY'
 import json
 from pathlib import Path
 import sys
 
 TRANSIENT_STATUS = 75
+# A repeated prompt is allowed to re-feed the final token for logits, so the
+# restore can legitimately report prompt_tokens - 1 rather than the full
+# prompt. Two tokens of slack keeps that off the failure path.
+REPEAT_TOKEN_SLACK = 2
 
 response_dir = Path(sys.argv[1])
+request_count = int(sys.argv[2])
+growth_indexes = list(range(1, request_count + 1, 2))
+repeat_pairs = [(index, index + 1) for index in range(1, request_count + 1, 2)]
 metrics = []
-for index in range(1, 4):
+for index in range(1, request_count + 1):
     with (response_dir / f"response-{index}.json").open(encoding="utf-8") as fh:
         body = json.load(fh)
     if body.get("object") != "chat.completion":
@@ -373,26 +406,52 @@ for index in range(1, 4):
 
 prompt_counts = [prompt for prompt, _ in metrics]
 cached_counts = [cached for _, cached in metrics]
-if not prompt_counts[0] < prompt_counts[1] < prompt_counts[2]:
+growth_prompts = [prompt_counts[index - 1] for index in growth_indexes]
+growth_cached = [cached_counts[index - 1] for index in growth_indexes]
+if prompt_counts[0] != prompt_counts[1] or any(
+    prompt_counts[pair[0] - 1] != prompt_counts[pair[1] - 1] for pair in repeat_pairs
+):
+    raise SystemExit(f"repeated prompts diverged between sends: {prompt_counts}")
+if not growth_prompts[0] < growth_prompts[1] < growth_prompts[2]:
     raise SystemExit(f"prompt token counts did not increase: {prompt_counts}")
 if cached_counts[0] != 0:
     raise SystemExit(f"cold prefix request unexpectedly restored tokens: {cached_counts}")
 # A completely cold attempt can arise while a stage lane is still releasing.
 # A partial follow-up miss is the regression under test and must fail directly,
 # not be hidden by a retry that starts from another cold prefix.
-if all(cached == 0 for cached in cached_counts):
+if all(cached == 0 for cached in cached_counts[1:]):
     print(
         f"split prefix reuse was empty on a follow-up request: {cached_counts}",
         file=sys.stderr,
     )
     raise SystemExit(TRANSIENT_STATUS)
-if not cached_counts[1] < cached_counts[2]:
+if not growth_cached[0] < growth_cached[1] < growth_cached[2]:
     raise SystemExit(f"split prefix reuse did not increase: {cached_counts}")
-if any(cached >= prompt for prompt, cached in metrics[1:]):
-    raise SystemExit(f"growing prompts must retain an uncached suffix: {metrics}")
+# Only growth arms need an uncached suffix; a repeat arm may legitimately
+# restore everything except the final re-fed token.
+for index in growth_indexes:
+    if cached_counts[index - 1] >= prompt_counts[index - 1]:
+        raise SystemExit(
+            f"growing prompts must retain an uncached suffix: {metrics}"
+        )
+# Each identical re-send must be a near-full restore: it must cover at least
+# everything its first sight restored (the new extension block is in the
+# restored region) and come from cache rather than a recompute.
+for first, repeat in repeat_pairs:
+    if cached_counts[repeat - 1] < prompt_counts[repeat - 1] - REPEAT_TOKEN_SLACK:
+        raise SystemExit(
+            "identical re-send was not served from cache: "
+            f"request {repeat} restored {cached_counts[repeat - 1]} of "
+            f"{prompt_counts[repeat - 1]} prompt tokens"
+        )
+    if cached_counts[repeat - 1] <= cached_counts[first - 1]:
+        raise SystemExit(
+            f"re-send {repeat} must restore at least the first-sight region of "
+            f"request {first}: {metrics}"
+        )
 
 print(
-    "Split prefix cache reuse increased: "
+    "Split prefix cache reuse grew and repeated prompts restored from cache: "
     + ", ".join(
         f"request {index}: prompt_tokens={prompt}, cached_tokens={cached}"
         for index, (prompt, cached) in enumerate(metrics, start=1)
@@ -435,7 +494,7 @@ for attempt in $(seq 1 "$PREFIX_ATTEMPTS"); do
     mkdir -p "$payload_dir" "$response_dir"
     write_prefix_payloads "$payload_dir" "attempt-${attempt}"
 
-    for index in 1 2 3; do
+    for index in $(seq 1 "$PREFIX_REQUEST_COUNT"); do
         curl -fsS --max-time 180 \
             "http://127.0.0.1:${DRIVER_API_PORT}/v1/chat/completions" \
             -H 'content-type: application/json' \
@@ -468,4 +527,152 @@ fi
 
 assert_expected_exact_payload
 
-echo "Two-node split smoke passed"
+echo "Two-node split smoke passed for model leg: ${MODEL_LABEL:-default}"
+
+# Optional recurrent leg: rerun the identical flow against a second model in
+# the same process pair so one CI job proves both cache families. The phase
+# function restores MODEL/CTX_SIZE, restarts both nodes from scratch (fresh
+# token, fresh stage split), and reruns the prefix cache assertions.
+run_recurrent_leg() {
+    echo "=== Two-node split smoke: recurrent leg ==="
+    kill_tree "$WORKER_PID"
+    kill_tree "$SEED_PID"
+    : >"$SEED_LOG"
+    : >"$WORKER_LOG"
+
+    MODEL="$RECURRENT_MODEL"
+    CTX_SIZE="$RECURRENT_CTX_SIZE"
+    MODEL_LABEL="recurrent"
+    export MODEL CTX_SIZE
+
+    SEED_PID="$(start_node seed "" "$SEED_API_PORT" "$SEED_CONSOLE_PORT" "$SEED_BIND_PORT" "$SEED_LOG")"
+
+    TOKEN=""
+    for i in $(seq 1 "$MAX_WAIT"); do
+        if ! kill -0 "$SEED_PID" 2>/dev/null; then
+            echo "recurrent leg: seed exited unexpectedly" >&2
+            tail -160 "$SEED_LOG" >&2 || true
+            exit 1
+        fi
+        TOKEN="$(query_token "$(status_json "$SEED_CONSOLE_PORT")")"
+        if [[ -n "$TOKEN" ]]; then
+            echo "Seed produced invite token after ${i}s (recurrent leg)"
+            break
+        fi
+        if [[ "$i" -eq "$MAX_WAIT" ]]; then
+            echo "recurrent leg: timed out waiting for seed invite token" >&2
+            tail -160 "$SEED_LOG" >&2 || true
+            exit 1
+        fi
+        sleep 1
+    done
+
+    WORKER_PID="$(start_node worker "$TOKEN" "$WORKER_API_PORT" "$WORKER_CONSOLE_PORT" "$WORKER_BIND_PORT" "$WORKER_LOG")"
+
+    DRIVER_LABEL=""
+    DRIVER_API_PORT=""
+    for i in $(seq 1 "$MAX_WAIT"); do
+        if ! kill -0 "$SEED_PID" 2>/dev/null; then
+            echo "recurrent leg: seed exited unexpectedly" >&2
+            tail -160 "$SEED_LOG" >&2 || true
+            exit 1
+        fi
+        if ! kill -0 "$WORKER_PID" 2>/dev/null; then
+            echo "recurrent leg: worker exited unexpectedly" >&2
+            tail -160 "$WORKER_LOG" >&2 || true
+            exit 1
+        fi
+
+        for endpoint in \
+            "seed:${SEED_API_PORT}:${SEED_CONSOLE_PORT}" \
+            "worker:${WORKER_API_PORT}:${WORKER_CONSOLE_PORT}"; do
+            IFS=: read -r label api_port console_port <<<"$endpoint"
+            PEERS="$(query_peer_count "$(status_json "$console_port")")"
+            if [[ "$PEERS" -lt 1 ]]; then
+                continue
+            fi
+            MODELS_JSON="$(curl -fsS --max-time 5 "http://127.0.0.1:${api_port}/v1/models" 2>/dev/null || true)"
+            READY_SUMMARY="$(query_split_ready "$(stages_json "$console_port")" "$MODELS_JSON" 2>/dev/null || true)"
+            if [[ "$READY_SUMMARY" == ready=true* ]]; then
+                DRIVER_LABEL="$label"
+                DRIVER_API_PORT="$api_port"
+                echo "Split topology ready after ${i}s on ${label} (recurrent leg): ${READY_SUMMARY}"
+                break 2
+            fi
+        done
+
+        if [[ "$i" -eq "$MAX_WAIT" ]]; then
+            echo "recurrent leg: timed out waiting for real split topology" >&2
+            echo "last checked endpoint: ${label:-unknown}" >&2
+            echo "last peer count: ${PEERS:-unknown}" >&2
+            echo "last split summary: ${READY_SUMMARY:-unknown}" >&2
+            echo "--- seed /api/runtime/stages at timeout (recurrent leg) ---" >&2
+            echo "$(stages_json "$SEED_CONSOLE_PORT")" >&2
+            echo "--- worker /api/runtime/stages at timeout (recurrent leg) ---" >&2
+            echo "$(stages_json "$WORKER_CONSOLE_PORT")" >&2
+            tail -160 "$SEED_LOG" >&2 || true
+            tail -160 "$WORKER_LOG" >&2 || true
+            exit 1
+        fi
+        sleep 1
+    done
+
+    if [[ -z "$DRIVER_API_PORT" ]]; then
+        echo "recurrent leg: no split driver API port was selected" >&2
+        exit 1
+    fi
+    MODEL_ID="$(
+        curl -fsS --max-time 5 "http://127.0.0.1:${DRIVER_API_PORT}/v1/models" |
+            python3 -c 'import json,sys; data=json.load(sys.stdin).get("data", []); print(data[0].get("id", "") if data else "")'
+    )"
+    if [[ -z "$MODEL_ID" ]]; then
+        echo "${DRIVER_LABEL:-selected driver} /v1/models did not return a model id (recurrent leg)" >&2
+        exit 1
+    fi
+}
+
+if [[ -n "$RECURRENT_MODEL" ]]; then
+    run_recurrent_leg
+
+    PREFIX_PAYLOAD_ROOT="${WORK_DIR}/prefix-payloads-recurrent"
+    PREFIX_RESPONSE_ROOT="${WORK_DIR}/prefix-responses-recurrent"
+
+    prefix_validated=0
+    for attempt in $(seq 1 "$PREFIX_ATTEMPTS"); do
+        payload_dir="${PREFIX_PAYLOAD_ROOT}/attempt-${attempt}"
+        response_dir="${PREFIX_RESPONSE_ROOT}/attempt-${attempt}"
+        mkdir -p "$payload_dir" "$response_dir"
+        write_prefix_payloads "$payload_dir" "recurrent-attempt-${attempt}"
+
+        for index in $(seq 1 "$PREFIX_REQUEST_COUNT"); do
+            curl -fsS --max-time 180 \
+                "http://127.0.0.1:${DRIVER_API_PORT}/v1/chat/completions" \
+                -H 'content-type: application/json' \
+                -d @"${payload_dir}/prompt-${index}.json" \
+                -o "${response_dir}/response-${index}.json"
+            sleep "$REQUEST_SETTLE_SECONDS"
+        done
+
+        set +e
+        validate_prefix_responses "$response_dir"
+        prefix_status=$?
+        set -e
+        if [[ "$prefix_status" -eq 0 ]]; then
+            prefix_validated=1
+            break
+        fi
+        if [[ "$prefix_status" -ne "$PREFIX_TRANSIENT_STATUS" ]]; then
+            exit "$prefix_status"
+        fi
+        echo "recurrent leg: prefix attempt ${attempt} of ${PREFIX_ATTEMPTS} saw no reuse; retrying from a cold prefix" >&2
+    done
+
+    if [[ "$prefix_validated" -ne 1 ]]; then
+        echo "recurrent leg: split prefix reuse never materialized across ${PREFIX_ATTEMPTS} attempts" >&2
+        exit 1
+    fi
+
+    assert_expected_exact_payload
+
+    echo "Two-node split smoke passed for model leg: recurrent"
+fi

--- a/scripts/ci-two-node-split-smoke.sh
+++ b/scripts/ci-two-node-split-smoke.sh
@@ -23,6 +23,7 @@ WORKER_CONSOLE_PORT="${MESH_TWO_NODE_SPLIT_WORKER_CONSOLE_PORT:-3162}"
 WORKER_BIND_PORT="${MESH_TWO_NODE_SPLIT_WORKER_BIND_PORT:-53648}"
 MAX_WAIT="${MESH_TWO_NODE_SPLIT_MAX_WAIT:-300}"
 REQUEST_SETTLE_SECONDS="${MESH_TWO_NODE_SPLIT_REQUEST_SETTLE_SECONDS:-1}"
+PREFIX_ATTEMPTS="${MESH_TWO_NODE_SPLIT_PREFIX_ATTEMPTS:-3}"
 CTX_SIZE="${MESH_TWO_NODE_SPLIT_CTX_SIZE:-${MESH_LLM_SMOKE_CONTEXT_SIZE:-}}"
 MAX_VRAM="${MESH_TWO_NODE_SPLIT_MAX_VRAM:-1}"
 DEVICE="${MESH_TWO_NODE_SPLIT_DEVICE:-CPU}"
@@ -44,6 +45,7 @@ echo "  worker api:     $WORKER_API_PORT"
 echo "  worker console: $WORKER_CONSOLE_PORT"
 echo "  worker bind:    $WORKER_BIND_PORT"
 echo "  request settle: ${REQUEST_SETTLE_SECONDS}s"
+echo "  prefix attempts: ${PREFIX_ATTEMPTS}"
 echo "  ctx size:       ${CTX_SIZE:-model default}"
 echo "  max vram:       ${MAX_VRAM}GB"
 echo "  device:         $DEVICE"
@@ -294,21 +296,30 @@ if [[ -z "$MODEL_ID" ]]; then
     exit 1
 fi
 
-PREFIX_PAYLOAD_DIR="${WORK_DIR}/prefix-payloads"
-PREFIX_RESPONSE_DIR="${WORK_DIR}/prefix-responses"
-mkdir -p "$PREFIX_PAYLOAD_DIR" "$PREFIX_RESPONSE_DIR"
+PREFIX_PAYLOAD_ROOT="${WORK_DIR}/prefix-payloads"
+PREFIX_RESPONSE_ROOT="${WORK_DIR}/prefix-responses"
 
-python3 - "$MODEL_ID" "$PREFIX_PAYLOAD_DIR" <<'PY'
+# Exit code the prefix validator uses for the one failure this smoke cannot
+# distinguish from a regression on a single pass: a follow-up request that
+# restored nothing, which is what an unreleased stage lane looks like from the
+# outside. Anything else is a real assertion failure and is never retried.
+PREFIX_TRANSIENT_STATUS=75
+
+write_prefix_payloads() {
+    python3 - "$MODEL_ID" "$1" "$2" <<'PY'
 import json
 from pathlib import Path
 import sys
 
-model, output_dir = sys.argv[1:3]
+model, output_dir, nonce = sys.argv[1:4]
 output = Path(output_dir)
-shared = (
-    "Split prefix cache smoke shared context. "
-    "Every request keeps these tokens in the same order. "
-) * 48
+# The nonce leads the prompt so every attempt starts from a genuinely cold
+# prefix. Without it, a retry would run against the cache the previous attempt
+# already warmed and the cold-request assertion below would stop meaning
+# anything.
+shared = f"Split prefix cache smoke shared context {nonce}. " + (
+    "Every request keeps these tokens in the same order. " * 48
+)
 extensions = [
     "First extension block remains reusable by later prompts. " * 16,
     "Second extension block makes the reusable prefix longer. " * 16,
@@ -320,7 +331,7 @@ for index, extension in enumerate(extensions, start=1):
     payload = {
         "model": model,
         "messages": [{"role": "user", "content": prompt}],
-        "user": "ci-split-prefix-growth",
+        "user": f"ci-split-prefix-growth-{nonce}",
         "stream": False,
         "max_tokens": 1,
         "temperature": 0,
@@ -328,23 +339,15 @@ for index, extension in enumerate(extensions, start=1):
     with (output / f"prompt-{index}.json").open("w", encoding="utf-8") as fh:
         json.dump(payload, fh)
 PY
+}
 
-for index in 1 2 3; do
-    curl -fsS --max-time 180 \
-        "http://127.0.0.1:${DRIVER_API_PORT}/v1/chat/completions" \
-        -H 'content-type: application/json' \
-        -d @"${PREFIX_PAYLOAD_DIR}/prompt-${index}.json" \
-        -o "${PREFIX_RESPONSE_DIR}/response-${index}.json"
-    # The host returns the OpenAI response before the stage connection has
-    # released its single CI lane. Give graceful Stop enough time to finish so
-    # the next request tests cache reuse rather than transient admission.
-    sleep "$REQUEST_SETTLE_SECONDS"
-done
-
-python3 - "$PREFIX_RESPONSE_DIR" <<'PY'
+validate_prefix_responses() {
+    python3 - "$1" <<'PY'
 import json
 from pathlib import Path
 import sys
+
+TRANSIENT_STATUS = 75
 
 response_dir = Path(sys.argv[1])
 metrics = []
@@ -371,7 +374,16 @@ if not prompt_counts[0] < prompt_counts[1] < prompt_counts[2]:
     raise SystemExit(f"prompt token counts did not increase: {prompt_counts}")
 if cached_counts[0] != 0:
     raise SystemExit(f"cold prefix request unexpectedly restored tokens: {cached_counts}")
-if not 0 < cached_counts[1] < cached_counts[2]:
+# Zero reuse on a follow-up is reported separately from reuse that failed to
+# grow. Only the former is consistent with a stage lane that had not released
+# yet, and only the former earns another attempt.
+if 0 in cached_counts[1:]:
+    print(
+        f"split prefix reuse was empty on a follow-up request: {cached_counts}",
+        file=sys.stderr,
+    )
+    raise SystemExit(TRANSIENT_STATUS)
+if not cached_counts[1] < cached_counts[2]:
     raise SystemExit(f"split prefix reuse did not increase: {cached_counts}")
 if any(cached >= prompt for prompt, cached in metrics[1:]):
     raise SystemExit(f"growing prompts must retain an uncached suffix: {metrics}")
@@ -384,5 +396,44 @@ print(
     )
 )
 PY
+}
+
+prefix_validated=0
+for attempt in $(seq 1 "$PREFIX_ATTEMPTS"); do
+    payload_dir="${PREFIX_PAYLOAD_ROOT}/attempt-${attempt}"
+    response_dir="${PREFIX_RESPONSE_ROOT}/attempt-${attempt}"
+    mkdir -p "$payload_dir" "$response_dir"
+    write_prefix_payloads "$payload_dir" "attempt-${attempt}"
+
+    for index in 1 2 3; do
+        curl -fsS --max-time 180 \
+            "http://127.0.0.1:${DRIVER_API_PORT}/v1/chat/completions" \
+            -H 'content-type: application/json' \
+            -d @"${payload_dir}/prompt-${index}.json" \
+            -o "${response_dir}/response-${index}.json"
+        # The host returns the OpenAI response before the stage connection has
+        # released its single CI lane. Give graceful Stop enough time to finish
+        # so the next request tests cache reuse rather than transient admission.
+        sleep "$REQUEST_SETTLE_SECONDS"
+    done
+
+    set +e
+    validate_prefix_responses "$response_dir"
+    prefix_status=$?
+    set -e
+    if [[ "$prefix_status" -eq 0 ]]; then
+        prefix_validated=1
+        break
+    fi
+    if [[ "$prefix_status" -ne "$PREFIX_TRANSIENT_STATUS" ]]; then
+        exit "$prefix_status"
+    fi
+    echo "prefix attempt ${attempt} of ${PREFIX_ATTEMPTS} saw no reuse; retrying from a cold prefix" >&2
+done
+
+if [[ "$prefix_validated" -ne 1 ]]; then
+    echo "split prefix reuse never materialized across ${PREFIX_ATTEMPTS} attempts" >&2
+    exit 1
+fi
 
 echo "Two-node split smoke passed"

--- a/scripts/ci-two-node-split-smoke.sh
+++ b/scripts/ci-two-node-split-smoke.sh
@@ -8,9 +8,11 @@
 # two distinct nodes before it sends OpenAI requests through stage 0. For each
 # model leg it sends every prompt length twice in a row (X, X, X+more, X+more,
 # ...): the first sight of each length proves reuse keeps growing, and the
-# identical re-send must be served from cache as a near-full restore. With
-# MESH_TWO_NODE_SPLIT_RECURRENT_MODEL set, the dense leg runs first and the
-# recurrent leg repeats the whole flow against a second model in the same job.
+# identical re-send must restore more of the prompt from cache. Dense KV cache
+# repeats must be near-full restores; recurrent KV cache repeats may restore
+# from the latest checkpoint. With MESH_TWO_NODE_SPLIT_RECURRENT_MODEL set, the
+# dense leg runs first and the recurrent leg repeats the whole flow against a
+# second model in the same job.
 
 set -euo pipefail
 
@@ -26,10 +28,15 @@ WORKER_CONSOLE_PORT="${MESH_TWO_NODE_SPLIT_WORKER_CONSOLE_PORT:-3162}"
 WORKER_BIND_PORT="${MESH_TWO_NODE_SPLIT_WORKER_BIND_PORT:-53648}"
 MAX_WAIT="${MESH_TWO_NODE_SPLIT_MAX_WAIT:-300}"
 # Optional second model: when set, the smoke runs the whole split flow once
-# against MODEL (dense) and once against this (recurrent) in the same process
-# pair, so a single CI job covers both cache families.
+# against MODEL (dense) and once against this (recurrent), restarting both
+# processes between legs so a single CI job covers both cache families.
 RECURRENT_MODEL="${MESH_TWO_NODE_SPLIT_RECURRENT_MODEL:-}"
+RECURRENT_MODEL_FILE="${MESH_TWO_NODE_SPLIT_RECURRENT_MODEL_FILE:-}"
 RECURRENT_CTX_SIZE="${MESH_TWO_NODE_SPLIT_RECURRENT_CTX_SIZE:-4096}"
+RECURRENT_EXPECTED_EXACT_PAYLOAD_KIND="${MESH_TWO_NODE_SPLIT_RECURRENT_EXPECTED_EXACT_PAYLOAD_KIND:-}"
+if [[ -z "$RECURRENT_MODEL" && -n "$RECURRENT_MODEL_FILE" ]]; then
+    RECURRENT_MODEL="${HOME}/.models/${RECURRENT_MODEL_FILE}"
+fi
 REQUEST_SETTLE_SECONDS="${MESH_TWO_NODE_SPLIT_REQUEST_SETTLE_SECONDS:-1}"
 PREFIX_ATTEMPTS="${MESH_TWO_NODE_SPLIT_PREFIX_ATTEMPTS:-3}"
 EXPECTED_EXACT_PAYLOAD_KIND="${MESH_TWO_NODE_SPLIT_EXPECTED_EXACT_PAYLOAD_KIND:-}"
@@ -288,9 +295,9 @@ for i in $(seq 1 "$MAX_WAIT"); do
         echo "last peer count: ${PEERS:-unknown}" >&2
         echo "last split summary: ${READY_SUMMARY:-unknown}" >&2
         echo "--- seed /api/runtime/stages at timeout ---" >&2
-        echo "$(stages_json "$SEED_CONSOLE_PORT")" >&2
+        printf '%s\n' "$(stages_json "$SEED_CONSOLE_PORT")" >&2
         echo "--- worker /api/runtime/stages at timeout ---" >&2
-        echo "$(stages_json "$WORKER_CONSOLE_PORT")" >&2
+        printf '%s\n' "$(stages_json "$WORKER_CONSOLE_PORT")" >&2
         tail -160 "$SEED_LOG" >&2 || true
         tail -160 "$WORKER_LOG" >&2 || true
         exit 1
@@ -371,7 +378,7 @@ PY
 PREFIX_REQUEST_COUNT=6
 
 validate_prefix_responses() {
-    python3 - "$1" "$PREFIX_REQUEST_COUNT" <<'PY'
+    python3 - "$1" "$PREFIX_REQUEST_COUNT" "$EXPECTED_EXACT_PAYLOAD_KIND" <<'PY'
 import json
 from pathlib import Path
 import sys
@@ -384,6 +391,8 @@ REPEAT_TOKEN_SLACK = 2
 
 response_dir = Path(sys.argv[1])
 request_count = int(sys.argv[2])
+exact_payload_kind = sys.argv[3]
+checkpointed_restore = exact_payload_kind == "kv-recurrent"
 growth_indexes = list(range(1, request_count + 1, 2))
 repeat_pairs = [(index, index + 1) for index in range(1, request_count + 1, 2)]
 metrics = []
@@ -434,11 +443,15 @@ for index in growth_indexes:
         raise SystemExit(
             f"growing prompts must retain an uncached suffix: {metrics}"
         )
-# Each identical re-send must be a near-full restore: it must cover at least
-# everything its first sight restored (the new extension block is in the
-# restored region) and come from cache rather than a recompute.
+# Each identical re-send must extend beyond the first-sight cached region.
+# Dense KV cache can additionally restore nearly the entire prompt. Recurrent
+# KV cache restores at checkpoint boundaries, so a valid repeat may leave a
+# larger suffix uncached even when exact-state cache reuse is working.
 for first, repeat in repeat_pairs:
-    if cached_counts[repeat - 1] < prompt_counts[repeat - 1] - REPEAT_TOKEN_SLACK:
+    if not checkpointed_restore and (
+        cached_counts[repeat - 1]
+        < prompt_counts[repeat - 1] - REPEAT_TOKEN_SLACK
+    ):
         raise SystemExit(
             "identical re-send was not served from cache: "
             f"request {repeat} restored {cached_counts[repeat - 1]} of "
@@ -446,7 +459,7 @@ for first, repeat in repeat_pairs:
         )
     if cached_counts[repeat - 1] <= cached_counts[first - 1]:
         raise SystemExit(
-            f"re-send {repeat} must restore at least the first-sight region of "
+            f"re-send {repeat} must extend beyond the first-sight cache of "
             f"request {first}: {metrics}"
         )
 
@@ -543,6 +556,7 @@ run_recurrent_leg() {
     MODEL="$RECURRENT_MODEL"
     CTX_SIZE="$RECURRENT_CTX_SIZE"
     MODEL_LABEL="recurrent"
+    EXPECTED_EXACT_PAYLOAD_KIND="$RECURRENT_EXPECTED_EXACT_PAYLOAD_KIND"
     export MODEL CTX_SIZE
 
     SEED_PID="$(start_node seed "" "$SEED_API_PORT" "$SEED_CONSOLE_PORT" "$SEED_BIND_PORT" "$SEED_LOG")"
@@ -607,9 +621,9 @@ run_recurrent_leg() {
             echo "last peer count: ${PEERS:-unknown}" >&2
             echo "last split summary: ${READY_SUMMARY:-unknown}" >&2
             echo "--- seed /api/runtime/stages at timeout (recurrent leg) ---" >&2
-            echo "$(stages_json "$SEED_CONSOLE_PORT")" >&2
+            printf '%s\n' "$(stages_json "$SEED_CONSOLE_PORT")" >&2
             echo "--- worker /api/runtime/stages at timeout (recurrent leg) ---" >&2
-            echo "$(stages_json "$WORKER_CONSOLE_PORT")" >&2
+            printf '%s\n' "$(stages_json "$WORKER_CONSOLE_PORT")" >&2
             tail -160 "$SEED_LOG" >&2 || true
             tail -160 "$WORKER_LOG" >&2 || true
             exit 1

--- a/scripts/ci-two-node-split-smoke.sh
+++ b/scripts/ci-two-node-split-smoke.sh
@@ -5,7 +5,9 @@
 #
 # Unlike ci-two-node-client-serving-smoke.sh, both processes are serving nodes.
 # The smoke requires the runtime to publish a topology with stages on at least
-# two distinct nodes before it sends an OpenAI chat request through stage 0.
+# two distinct nodes before it sends OpenAI requests through stage 0. It then
+# grows one raw prompt over three requests and requires the split stages to
+# restore a longer shared prefix after every request.
 
 set -euo pipefail
 
@@ -277,8 +279,6 @@ for i in $(seq 1 "$MAX_WAIT"); do
     sleep 1
 done
 
-WORK_PAYLOAD="${WORK_DIR}/chat-payload.json"
-CHAT_RESPONSE="${WORK_DIR}/chat-response.json"
 if [[ -z "$DRIVER_API_PORT" ]]; then
     echo "no split driver API port was selected" >&2
     exit 1
@@ -292,39 +292,95 @@ if [[ -z "$MODEL_ID" ]]; then
     exit 1
 fi
 
-python3 - "$MODEL_ID" "$WORK_PAYLOAD" <<'PY'
+PREFIX_PAYLOAD_DIR="${WORK_DIR}/prefix-payloads"
+PREFIX_RESPONSE_DIR="${WORK_DIR}/prefix-responses"
+mkdir -p "$PREFIX_PAYLOAD_DIR" "$PREFIX_RESPONSE_DIR"
+
+python3 - "$MODEL_ID" "$PREFIX_PAYLOAD_DIR" <<'PY'
 import json
+from pathlib import Path
 import sys
 
-model, path = sys.argv[1:3]
-payload = {
-    "model": model,
-    "messages": [{"role": "user", "content": "Reply with one word."}],
-    "stream": False,
-    "max_tokens": 8,
-    "temperature": 0,
-}
-with open(path, "w", encoding="utf-8") as fh:
-    json.dump(payload, fh)
+model, output_dir = sys.argv[1:3]
+output = Path(output_dir)
+shared = (
+    "Split prefix cache smoke shared context. "
+    "Every request keeps these tokens in the same order. "
+) * 48
+extensions = [
+    "First extension block remains reusable by later prompts. " * 16,
+    "Second extension block makes the reusable prefix longer. " * 16,
+    "Third extension block proves reuse keeps growing. " * 16,
+]
+prompt = shared
+for index, extension in enumerate(extensions, start=1):
+    prompt += extension
+    payload = {
+        "model": model,
+        "prompt": prompt,
+        "user": "ci-split-prefix-growth",
+        "stream": False,
+        "max_tokens": 1,
+        "temperature": 0,
+    }
+    with (output / f"prompt-{index}.json").open("w", encoding="utf-8") as fh:
+        json.dump(payload, fh)
 PY
 
-curl -fsS --max-time 180 \
-    "http://127.0.0.1:${DRIVER_API_PORT}/v1/chat/completions" \
-    -H 'content-type: application/json' \
-    -d @"$WORK_PAYLOAD" \
-    -o "$CHAT_RESPONSE"
+for index in 1 2 3; do
+    curl -fsS --max-time 180 \
+        "http://127.0.0.1:${DRIVER_API_PORT}/v1/completions" \
+        -H 'content-type: application/json' \
+        -d @"${PREFIX_PAYLOAD_DIR}/prompt-${index}.json" \
+        -o "${PREFIX_RESPONSE_DIR}/response-${index}.json"
+    # The host returns the OpenAI response before the stage connection has
+    # released its single CI lane. Give graceful Stop enough time to finish so
+    # the next request tests cache reuse rather than transient admission.
+    sleep 1
+done
 
-python3 - "$CHAT_RESPONSE" <<'PY'
+python3 - "$PREFIX_RESPONSE_DIR" <<'PY'
 import json
+from pathlib import Path
 import sys
 
-with open(sys.argv[1], encoding="utf-8") as fh:
-    body = json.load(fh)
-if body.get("object") != "chat.completion":
-    raise SystemExit(f"unexpected chat object: {body.get('object')!r}")
-if not body.get("choices"):
-    raise SystemExit("chat response had no choices")
-print("Split chat response validated")
+response_dir = Path(sys.argv[1])
+metrics = []
+for index in range(1, 4):
+    with (response_dir / f"response-{index}.json").open(encoding="utf-8") as fh:
+        body = json.load(fh)
+    if body.get("object") != "text_completion":
+        raise SystemExit(
+            f"prefix request {index} returned unexpected object: {body.get('object')!r}"
+        )
+    if not body.get("choices"):
+        raise SystemExit(f"prefix request {index} returned no choices")
+    usage = body.get("usage") or {}
+    prompt_tokens = usage.get("prompt_tokens")
+    details = usage.get("prompt_tokens_details") or {}
+    cached_tokens = details.get("cached_tokens", 0)
+    if not isinstance(prompt_tokens, int) or not isinstance(cached_tokens, int):
+        raise SystemExit(f"prefix request {index} omitted numeric cache usage: {usage!r}")
+    metrics.append((prompt_tokens, cached_tokens))
+
+prompt_counts = [prompt for prompt, _ in metrics]
+cached_counts = [cached for _, cached in metrics]
+if not prompt_counts[0] < prompt_counts[1] < prompt_counts[2]:
+    raise SystemExit(f"prompt token counts did not increase: {prompt_counts}")
+if cached_counts[0] != 0:
+    raise SystemExit(f"cold prefix request unexpectedly restored tokens: {cached_counts}")
+if not 0 < cached_counts[1] < cached_counts[2]:
+    raise SystemExit(f"split prefix reuse did not increase: {cached_counts}")
+if any(cached >= prompt for prompt, cached in metrics[1:]):
+    raise SystemExit(f"growing prompts must retain an uncached suffix: {metrics}")
+
+print(
+    "Split prefix cache reuse increased: "
+    + ", ".join(
+        f"request {index}: prompt_tokens={prompt}, cached_tokens={cached}"
+        for index, (prompt, cached) in enumerate(metrics, start=1)
+    )
+)
 PY
 
 echo "Two-node split smoke passed"

--- a/scripts/ci-two-node-split-smoke.sh
+++ b/scripts/ci-two-node-split-smoke.sh
@@ -22,7 +22,8 @@ WORKER_API_PORT="${MESH_TWO_NODE_SPLIT_WORKER_API_PORT:-9368}"
 WORKER_CONSOLE_PORT="${MESH_TWO_NODE_SPLIT_WORKER_CONSOLE_PORT:-3162}"
 WORKER_BIND_PORT="${MESH_TWO_NODE_SPLIT_WORKER_BIND_PORT:-53648}"
 MAX_WAIT="${MESH_TWO_NODE_SPLIT_MAX_WAIT:-300}"
-CTX_SIZE="${MESH_TWO_NODE_SPLIT_CTX_SIZE:-}"
+REQUEST_SETTLE_SECONDS="${MESH_TWO_NODE_SPLIT_REQUEST_SETTLE_SECONDS:-1}"
+CTX_SIZE="${MESH_TWO_NODE_SPLIT_CTX_SIZE:-${MESH_LLM_SMOKE_CONTEXT_SIZE:-}}"
 MAX_VRAM="${MESH_TWO_NODE_SPLIT_MAX_VRAM:-1}"
 DEVICE="${MESH_TWO_NODE_SPLIT_DEVICE:-CPU}"
 WORK_DIR="${MESH_TWO_NODE_SPLIT_WORK_DIR:-$(mktemp -d "${TMPDIR:-/tmp}/mesh-two-node-split.XXXXXX")}"
@@ -42,6 +43,7 @@ echo "  seed bind:      $SEED_BIND_PORT"
 echo "  worker api:     $WORKER_API_PORT"
 echo "  worker console: $WORKER_CONSOLE_PORT"
 echo "  worker bind:    $WORKER_BIND_PORT"
+echo "  request settle: ${REQUEST_SETTLE_SECONDS}s"
 echo "  ctx size:       ${CTX_SIZE:-model default}"
 echo "  max vram:       ${MAX_VRAM}GB"
 echo "  device:         $DEVICE"
@@ -336,7 +338,7 @@ for index in 1 2 3; do
     # The host returns the OpenAI response before the stage connection has
     # released its single CI lane. Give graceful Stop enough time to finish so
     # the next request tests cache reuse rather than transient admission.
-    sleep 1
+    sleep "$REQUEST_SETTLE_SECONDS"
 done
 
 python3 - "$PREFIX_RESPONSE_DIR" <<'PY'

--- a/scripts/tests/test_ci_two_node_split_smoke.py
+++ b/scripts/tests/test_ci_two_node_split_smoke.py
@@ -1,0 +1,73 @@
+import json
+import re
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SMOKE_SCRIPT = ROOT / "scripts/ci-two-node-split-smoke.sh"
+PROMPT_COUNTS = [644, 644, 788, 788, 916, 916]
+
+
+def prefix_validator_source() -> str:
+    script = SMOKE_SCRIPT.read_text()
+    function = script[script.index("validate_prefix_responses() {") :]
+    match = re.search(r"<<'PY'\n(?P<source>.*?)\nPY\n}", function, re.DOTALL)
+    if match is None:
+        raise AssertionError("could not extract split-prefix response validator")
+    return match.group("source")
+
+
+class TwoNodeSplitSmokeTests(unittest.TestCase):
+    def run_validator(
+        self, cached_counts: list[int]
+    ) -> subprocess.CompletedProcess[str]:
+        self.assertEqual(len(cached_counts), len(PROMPT_COUNTS))
+        with tempfile.TemporaryDirectory() as directory:
+            response_dir = Path(directory)
+            for index, (prompt_tokens, cached_tokens) in enumerate(
+                zip(PROMPT_COUNTS, cached_counts), start=1
+            ):
+                response = {
+                    "object": "chat.completion",
+                    "choices": [{"message": {"role": "assistant", "content": "ok"}}],
+                    "usage": {
+                        "prompt_tokens": prompt_tokens,
+                        "prompt_tokens_details": {"cached_tokens": cached_tokens},
+                    },
+                }
+                (response_dir / f"response-{index}.json").write_text(
+                    json.dumps(response)
+                )
+
+            return subprocess.run(
+                [sys.executable, "-", directory, "6", "kv-recurrent"],
+                input=prefix_validator_source(),
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+    def test_prefix_validator_exit_behavior(self):
+        cases = {
+            "second request misses": ([0, 0, 512, 640, 640, 768], 1),
+            "recurrent checkpoint reuse grows": ([0, 512, 512, 640, 640, 768], 0),
+            "later repeated request misses": ([0, 512, 512, 640, 640, 0], 1),
+            "all follow-up requests miss": ([0, 0, 0, 0, 0, 0], 75),
+        }
+
+        for name, (cached_counts, expected_exit) in cases.items():
+            with self.subTest(name=name):
+                result = self.run_validator(cached_counts)
+                self.assertEqual(
+                    result.returncode,
+                    expected_exit,
+                    msg=f"stdout={result.stdout!r}\nstderr={result.stderr!r}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_ci_workflow_artifacts.py
+++ b/scripts/tests/test_ci_workflow_artifacts.py
@@ -164,6 +164,38 @@ class CiWorkflowArtifactTests(unittest.TestCase):
         self.assertIn("cuda-cudart-12-9", smoke)
         self.assertIn("libcublas-12-9", smoke)
 
+    def test_two_node_split_smoke_covers_dense_and_recurrent_models(self):
+        workflow = (
+            WORKFLOWS / "ci-linux-product-smoke-slice.yml"
+        ).read_text()
+        scripted = (WORKFLOWS / "scripted-binary-smoke.yml").read_text()
+
+        self.assertIn("two_node_split:", workflow)
+        self.assertIn("model_state: dense", workflow)
+        self.assertIn("model_state: recurrent", workflow)
+        self.assertIn("max-parallel: 1", workflow)
+        self.assertEqual(
+            workflow.count("smoke_script: scripts/ci-two-node-split-smoke.sh"),
+            1,
+        )
+        self.assertIn(
+            "Qwen3.5-0.8B-GGUF/resolve/"
+            "6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/"
+            "Qwen3.5-0.8B-Q4_K_M.gguf",
+            workflow,
+        )
+        self.assertIn("model_context_size: '4096'", workflow)
+        self.assertIn("fail-fast: ${{ inputs.fail_fast }}", workflow)
+        self.assertIn(
+            "fail_fast: ${{ inputs.original_event_name == 'pull_request' }}",
+            (WORKFLOWS / "ci-linux-lane.yml").read_text(),
+        )
+        self.assertIn("model_context_size:", scripted)
+        self.assertIn(
+            "MESH_LLM_SMOKE_CONTEXT_SIZE: ${{ inputs.model_context_size }}",
+            scripted,
+        )
+
     def test_cuda_product_supports_the_registered_gpu_runner_architecture(self):
         runtimes = json.loads(SLICES.read_text())["runtime_rows"]
         cuda = next(row for row in runtimes if row["id"] == "linux-cuda")

--- a/scripts/tests/test_ci_workflow_artifacts.py
+++ b/scripts/tests/test_ci_workflow_artifacts.py
@@ -188,12 +188,17 @@ class CiWorkflowArtifactTests(unittest.TestCase):
         scripted = (WORKFLOWS / "scripted-binary-smoke.yml").read_text()
 
         self.assertIn("two_node_split:", workflow)
-        self.assertIn("model_state: dense", workflow)
-        self.assertIn("model_state: recurrent", workflow)
-        self.assertIn("max-parallel: 1", workflow)
+        self.assertIn("name: KV caching smoke (dense + recurrent)", workflow)
+        self.assertIn("two-node-split", workflow)
         self.assertEqual(
             workflow.count("smoke_script: scripts/ci-two-node-split-smoke.sh"),
             1,
+        )
+        self.assertIn(
+            "SmolLM2-135M-Instruct-GGUF/resolve/"
+            "9e6855bc4be717fca1ef21360a1db4b29d5c559a/"
+            "SmolLM2-135M-Instruct-Q8_0.gguf",
+            workflow,
         )
         self.assertIn(
             "Qwen3.5-0.8B-GGUF/resolve/"
@@ -201,8 +206,11 @@ class CiWorkflowArtifactTests(unittest.TestCase):
             "Qwen3.5-0.8B-Q4_K_M.gguf",
             workflow,
         )
-        self.assertIn("model_context_size: '4096'", workflow)
-        self.assertIn("fail-fast: ${{ inputs.fail_fast }}", workflow)
+        # The recurrent leg rides the same job via the KV smoke inputs; both
+        # models must still be cached and passed to the smoke script.
+        self.assertIn("model_cache_scope: two-node-split-smoke-model", workflow)
+        self.assertIn("kv_recurrent_model_file: Qwen3.5-0.8B-Q4_K_M.gguf", workflow)
+        self.assertIn("kv_recurrent_context_size: '4096'", workflow)
         self.assertIn(
             "fail_fast: ${{ inputs.original_event_name == 'pull_request' }}",
             (WORKFLOWS / "ci-linux-lane.yml").read_text(),
@@ -212,6 +220,13 @@ class CiWorkflowArtifactTests(unittest.TestCase):
             "MESH_LLM_SMOKE_CONTEXT_SIZE: ${{ inputs.model_context_size }}",
             scripted,
         )
+        self.assertIn(
+            "MESH_TWO_NODE_SPLIT_RECURRENT_MODEL:", scripted
+        )
+        self.assertIn(
+            "Resolve recurrent smoke model for the KV caching leg", scripted
+        )
+        self.assertIn("MESH_TWO_NODE_SPLIT_RECURRENT_MODEL", scripted)
 
     def test_cuda_product_supports_the_registered_gpu_runner_architecture(self):
         runtimes = json.loads(SLICES.read_text())["runtime_rows"]

--- a/scripts/tests/test_ci_workflow_artifacts.py
+++ b/scripts/tests/test_ci_workflow_artifacts.py
@@ -186,6 +186,7 @@ class CiWorkflowArtifactTests(unittest.TestCase):
             WORKFLOWS / "ci-linux-product-smoke-slice.yml"
         ).read_text()
         scripted = (WORKFLOWS / "scripted-binary-smoke.yml").read_text()
+        smoke_script = (ROOT / "scripts/ci-two-node-split-smoke.sh").read_text()
 
         self.assertIn("two_node_split:", workflow)
         self.assertIn("name: KV caching smoke (dense + recurrent)", workflow)
@@ -207,26 +208,45 @@ class CiWorkflowArtifactTests(unittest.TestCase):
             workflow,
         )
         # The recurrent leg rides the same job via the KV smoke inputs; both
-        # models must still be cached and passed to the smoke script.
+        # models must still be cached before the smoke script runs.
         self.assertIn("model_cache_scope: two-node-split-smoke-model", workflow)
         self.assertIn("kv_recurrent_model_file: Qwen3.5-0.8B-Q4_K_M.gguf", workflow)
+        self.assertIn(
+            "kv_recurrent_model_cache_scope: "
+            "two-node-split-recurrent-smoke-model",
+            workflow,
+        )
         self.assertIn("kv_recurrent_context_size: '4096'", workflow)
         self.assertIn(
-            "fail_fast: ${{ inputs.original_event_name == 'pull_request' }}",
-            (WORKFLOWS / "ci-linux-lane.yml").read_text(),
+            "kv_recurrent_expected_exact_payload_kind: kv-recurrent", workflow
         )
+        self.assertNotIn("\n      expected_exact_payload_kind: kv-recurrent", workflow)
         self.assertIn("model_context_size:", scripted)
         self.assertIn(
             "MESH_LLM_SMOKE_CONTEXT_SIZE: ${{ inputs.model_context_size }}",
             scripted,
         )
         self.assertIn(
-            "MESH_TWO_NODE_SPLIT_RECURRENT_MODEL:", scripted
+            "MESH_TWO_NODE_SPLIT_RECURRENT_EXPECTED_EXACT_PAYLOAD_KIND:", scripted
         )
+        self.assertIn("MESH_TWO_NODE_SPLIT_RECURRENT_MODEL_FILE:", scripted)
+        self.assertNotIn("format('{0}/.models/{1}', github.workspace", scripted)
         self.assertIn(
             "Resolve recurrent smoke model for the KV caching leg", scripted
         )
-        self.assertIn("MESH_TWO_NODE_SPLIT_RECURRENT_MODEL", scripted)
+        self.assertLess(
+            scripted.index("Resolve recurrent smoke model for the KV caching leg"),
+            scripted.index("Run scripted smoke"),
+        )
+        self.assertIn("Restore recurrent smoke model cache", scripted)
+        self.assertIn("Save recurrent smoke model cache", scripted)
+        self.assertIn(
+            'checkpointed_restore = exact_payload_kind == "kv-recurrent"',
+            smoke_script,
+        )
+        self.assertIn(
+            "if not checkpointed_restore and (", smoke_script
+        )
 
     def test_cuda_product_supports_the_registered_gpu_runner_architecture(self):
         runtimes = json.loads(SLICES.read_text())["runtime_rows"]

--- a/scripts/tests/test_sccache_evidence.py
+++ b/scripts/tests/test_sccache_evidence.py
@@ -629,6 +629,17 @@ class SccacheEvidenceTests(unittest.TestCase):
                 for artifact_name in names:
                     self.assertIn("${{ github.run_attempt }}", artifact_name)
 
+    def test_safetensors_smoke_captures_cache_before_runtime_loop(self) -> None:
+        workflow = yaml.safe_load(WORKFLOWS["rust-tests"].read_text(encoding="utf-8"))
+        steps = workflow["jobs"]["safetensors_runtime_smoke"]["steps"]
+        step_names = [step.get("name") for step in steps]
+
+        build_index = step_names.index("Build and locate the SafeTensors smoke test")
+        capture_index = step_names.index("Capture SafeTensors smoke cache evidence")
+        exercise_index = step_names.index("Exercise every current direct-load quantization")
+        self.assertEqual(capture_index, build_index + 1)
+        self.assertLess(capture_index, exercise_index)
+
 
 class SccacheStatsSummaryTests(unittest.TestCase):
     def write_evidence(

--- a/third_party/llama.cpp/patches/0056-skippy-fall-back-when-backend-sampling-emits-no-token.patch
+++ b/third_party/llama.cpp/patches/0056-skippy-fall-back-when-backend-sampling-emits-no-token.patch
@@ -1,0 +1,25 @@
+From 406b187da6a4ec917eaa154c70829c216c45390e Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Sat, 5 Sep 2026 12:48:25 +1000
+Subject: [PATCH] skippy: fall back when backend sampling emits no token
+
+---
+ src/skippy/sampling.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/skippy/sampling.cpp b/src/skippy/sampling.cpp
+index 2b3a555da..8c87bbe07 100644
+--- a/src/skippy/sampling.cpp
++++ b/src/skippy/sampling.cpp
+@@ -861,7 +861,7 @@ static llama_token skippy_chat_sample_token(skippy_session * session, int32_t lo
+             llama_sampler_accept(session->sampling_chain, sampled);
+             return sampled;
+         }
+-        return llama_sampler_sample(session->sampling_chain, session->ctx, logits_index);
++        return skippy_greedy_sample_ith(session, logits_index);
+     }
+     llama_synchronize(session->ctx);
+     skippy_mark_context_synchronized(session->stage_model);
+-- 
+2.53.0
+


### PR DESCRIPTION
Split serving now restores shared-prefix cache hits for dense and recurrent state, and the Linux regression smoke exercises repeated prompts without deadlocking model startup or crashing restored dense sessions.

## What changed

- Preserve reusable recurrent exact-state checkpoints even when hybrid state exceeds the attention-derived byte estimate.
- Seed downstream split-prefill accounting from restored tokens so later prompts advance to the next checkpoint.
- Release the process-wide stderr lock between telemetry batches; native model-loading progress can no longer block behind an idle telemetry receiver.
- Fall back to direct greedy selection when backend sampling returns no token for a restored dense prefix, instead of reusing an already-consumed sampler chain.
- Send each prompt length twice and require every repeat to extend cache coverage; dense repeats remain near-full restores while recurrent repeats may restore at checkpoint boundaries.
- Run pinned dense SmolLM2 and recurrent Qwen3.5 legs sequentially in one `KV caching smoke (dense + recurrent)` job, with both models staged through trust-scoped caches before execution.
- Dump both nodes' raw `/api/runtime/stages` views on topology timeout.

## Why the failed run timed out

`SKIPPY_TELEMETRY_STDERR=1` promoted embedded telemetry to debug. The telemetry thread held Rust's process-wide stderr lock while blocking for the next event. Native llama.cpp model-loading progress writes to the same stderr handle, so stage 0 blocked during load and never published its topology. The apparent peer-discovery asymmetry was downstream of that blocked startup.

The new repeated-prompt coverage then exposed a separate dense-cache crash: `llama_get_sampled_token_ith` could return `LLAMA_TOKEN_NULL` after a resident-prefix restore, and the fallback called `llama_sampler_sample` on the backend-initialized sampler chain. Direct greedy fallback fixes that path.

## Validation

- Exact rebuilt Linux two-node smoke on `white.local`, telemetry enabled:
  - dense: topology ready; repeat restores `664/665`, `808/809`, and `936/937` prompt tokens.
  - recurrent exact-state: topology ready; repeat restores `512/681`, `640/857`, and `768/1001`, with `kv-recurrent` observed.
- The formerly failing GitHub two-node split smoke is green on this head: https://github.com/Mesh-LLM/mesh-llm/actions/runs/33941614902/job/101244139768
- `just ci-validate`: 817 passed, 7 skipped; Actionlint and all repository-consistency gates passed.
- `cargo test --locked -p skippy-server --lib`: 685 passed, 3 ignored.
- `cargo check` and warning-denying Clippy passed for `skippy-server` and `mesh-llm`.
- `cargo fmt --all -- --check` and `just ci-shellcheck scripts/ci-two-node-split-smoke.sh` passed.
- The full llama.cpp patch queue applies cleanly from the pinned upstream and the rebuilt CPU runtime passed both smoke legs.

## Trust boundary

Pull-request entrypoints intentionally invoke protected reusable workflow definitions from `main`. This PR run therefore exercises the changed smoke script through the currently protected dense job. The combined dense-plus-recurrent workflow definition becomes protected after merge; its exact control flow and both cache families were exercised locally above.
