### PR TITLE
feat(runtime): explain native runtime catalog selection and rejection

### DIFF
--- a/crates/mesh-llm-commands/src/runtime_native.rs
+++ b/crates/mesh-llm-commands/src/runtime_native.rs
@@ -75,23 +75,17 @@ pub async fn run_native_runtime_list(
                 ..Default::default()
             })
             .await?;
-        if !json_output {
-            eprintln!("🔎 Catalogs consulted");
-            for line in sources.describe() {
-                eprintln!("   {line}");
-            }
-        }
         let profile = host_runtime_profile();
         let cache = native_runtime_cache(cache_dir)?;
         let mut resolver =
             NativeRuntimeResolver::new(mesh_version, profile.clone(), manifest.clone(), cache)
-                .with_bundle_dirs(sources.bundle_dirs);
+                .with_bundle_dirs(sources.bundle_dirs.clone());
         if let Some(skippy_abi_version) = configured.skippy_abi_version {
             resolver = resolver.with_skippy_abi_version(skippy_abi_version);
         }
         let evaluated = resolver.evaluate(&selection)?;
         let rows = available_runtime_rows(&manifest, &evaluated);
-        return formatter.render_available(&rows);
+        return formatter.render_available(&rows, &sources);
     }
 
     let installed = discover_local_native_runtimes(bundle_dirs, &cache)?;

--- a/crates/mesh-llm-commands/src/runtime_native.rs
+++ b/crates/mesh-llm-commands/src/runtime_native.rs
@@ -10,7 +10,7 @@ use mesh_llm_runtime_install::{
     CURRENT_MESH_VERSION, NativeRuntimeBundleInstallPolicy, NativeRuntimeDownloadProgressCallback,
     NativeRuntimeInstallOptions, NativeRuntimeManifestOptions, discover_local_native_runtimes,
     discover_native_runtime_bundle_dirs, host_runtime_profile, install_native_runtime,
-    load_release_manifest, native_runtime_cache,
+    load_release_manifest_with_sources, native_runtime_cache,
 };
 use mesh_llm_tui::terminal_progress::{
     ratio_complete_u64, render_inline_gauge_with_reserved_width,
@@ -64,21 +64,28 @@ pub async fn run_native_runtime_list(
     if available {
         let discovered_bundle_dirs = discover_native_runtime_bundle_dirs(bundle_dirs)?;
         print_configured_selector(configured, json_output);
-        if !json_output && manifest_path.is_none() && discovered_bundle_dirs.is_empty() {
+        if !json_output && manifest_path.is_none() {
             eprintln!("🔎 Loading native runtime release manifest");
         }
-        let manifest = load_release_manifest(NativeRuntimeManifestOptions {
-            mesh_version: mesh_version.to_string(),
-            manifest_path: manifest_path.map(Path::to_path_buf),
-            bundle_dirs: discovered_bundle_dirs.clone(),
-            ..Default::default()
-        })
-        .await?;
+        let (manifest, sources) =
+            load_release_manifest_with_sources(NativeRuntimeManifestOptions {
+                mesh_version: mesh_version.to_string(),
+                manifest_path: manifest_path.map(Path::to_path_buf),
+                bundle_dirs: discovered_bundle_dirs.clone(),
+                ..Default::default()
+            })
+            .await?;
+        if !json_output {
+            eprintln!("🔎 Catalogs consulted");
+            for line in sources.describe() {
+                eprintln!("   {line}");
+            }
+        }
         let profile = host_runtime_profile();
         let cache = native_runtime_cache(cache_dir)?;
         let mut resolver =
             NativeRuntimeResolver::new(mesh_version, profile.clone(), manifest.clone(), cache)
-                .with_bundle_dirs(discovered_bundle_dirs);
+                .with_bundle_dirs(sources.bundle_dirs);
         if let Some(skippy_abi_version) = configured.skippy_abi_version {
             resolver = resolver.with_skippy_abi_version(skippy_abi_version);
         }
@@ -143,7 +150,7 @@ pub async fn run_native_runtime_install(
     json_output: bool,
 ) -> Result<()> {
     let resolved_selection = resolve_runtime_selection(requested_runtime, configured)?;
-    if !json_output && manifest_path.is_none() && bundle_dirs.is_empty() {
+    if !json_output && manifest_path.is_none() {
         eprintln!("🔎 Loading native runtime release manifest");
     }
     if !json_output {

--- a/crates/mesh-llm-commands/src/runtime_native/formatters.rs
+++ b/crates/mesh-llm-commands/src/runtime_native/formatters.rs
@@ -93,7 +93,17 @@ impl RuntimeNativeFormatter for HumanFormatter {
 
     fn render_install_error(&self, error: &Error) -> Result<()> {
         eprintln!("❌ Native runtime install failed");
-        eprintln!("   Reason: {error}");
+        // Resolution failures carry a multi-line explanation (catalogs
+        // consulted, rejected candidates); keep every line aligned.
+        let mut lines = error.to_string();
+        lines.truncate(lines.trim_end().len());
+        let mut lines = lines.lines();
+        if let Some(first) = lines.next() {
+            eprintln!("   Reason: {first}");
+        }
+        for line in lines {
+            eprintln!("           {line}");
+        }
         eprintln!("   Try: mesh-llm runtime list --available");
         Ok(())
     }
@@ -153,6 +163,7 @@ impl RuntimeNativeFormatter for JsonFormatter {
             "status": install_status_label(outcome.status.clone()),
             "runtime": outcome.runtime,
             "resolution": outcome.resolution,
+            "catalogs": outcome.sources,
         }))
     }
 
@@ -268,6 +279,9 @@ fn print_install_human(outcome: &NativeRuntimeInstallOutcome) {
             eprintln!("   path: {}", outcome.runtime.path.display());
         }
     }
+    for line in outcome.sources.describe() {
+        eprintln!("   catalog: {line}");
+    }
 }
 
 fn print_doctor_human(report: &NativeRuntimeDoctorReport) {
@@ -335,76 +349,7 @@ fn print_doctor_human(report: &NativeRuntimeDoctorReport) {
 }
 
 fn format_rejection(reason: &CandidateRejection) -> String {
-    match reason {
-        CandidateRejection::MeshVersionMismatch { expected, actual } => {
-            format!("MeshLLM version mismatch: expected {expected}, found {actual}")
-        }
-        CandidateRejection::SkippyAbiMismatch { expected, actual } => {
-            format!("Skippy ABI mismatch: expected {expected}, found {actual}")
-        }
-        CandidateRejection::OsMismatch { expected, actual } => {
-            format!("OS mismatch: expected {expected}, artifact is for {actual}")
-        }
-        CandidateRejection::ArchMismatch { expected, actual } => {
-            format!("CPU architecture mismatch: expected {expected}, artifact is for {actual}")
-        }
-        CandidateRejection::TargetTripleMismatch { expected, actual } => {
-            format!("target triple mismatch: expected {expected}, host is {actual}")
-        }
-        CandidateRejection::BackendNotSupported { backend } => {
-            format!("backend {backend} is not supported on this host")
-        }
-        CandidateRejection::CudaProfileMissing => {
-            "CUDA runtime requires CUDA, but no CUDA profile was detected".to_string()
-        }
-        CandidateRejection::CudaToolkitMajorMismatch {
-            required,
-            installed,
-        } => {
-            let installed = installed
-                .iter()
-                .map(|major| major.to_string())
-                .collect::<Vec<_>>()
-                .join(", ");
-            format!(
-                "CUDA toolkit mismatch: runtime requires CUDA {required}, host has CUDA {installed} installed"
-            )
-        }
-        CandidateRejection::CudaToolkitMajorAboveDriver {
-            required,
-            driver_max,
-        } => {
-            format!(
-                "CUDA driver too old: runtime requires CUDA {required}, driver supports up to CUDA {driver_max}"
-            )
-        }
-        CandidateRejection::CudaToolkitNotDetected { required } => {
-            format!(
-                "no CUDA toolkit detected: runtime requires CUDA {required} libraries \
-                 (libcudart, libcublas, libcublasLt) on the loader path; \
-                 set MESH_LLM_CUDA_TOOLKIT_MAJORS if the toolkit is installed elsewhere"
-            )
-        }
-        CandidateRejection::CudaGpuArchUnsupported { supported } => {
-            format!(
-                "CUDA GPU architecture unsupported: runtime supports {}",
-                supported.join(", ")
-            )
-        }
-        CandidateRejection::RocmProfileMissing => {
-            "ROCm runtime requires ROCm, but no ROCm profile was detected".to_string()
-        }
-        CandidateRejection::RocmGpuArchUnsupported { supported } => {
-            format!(
-                "ROCm GPU architecture unsupported: runtime supports {}",
-                supported.join(", ")
-            )
-        }
-        CandidateRejection::VulkanProfileMissing => {
-            "Vulkan runtime requires Vulkan, but no Vulkan profile was detected".to_string()
-        }
-        CandidateRejection::SelectionMismatch { selection } => {
-            format!("selection mismatch: requested {selection}")
-        }
-    }
+    // The wording lives on `CandidateRejection` itself so the install
+    // diagnostics and this listing describe a rejection the same way.
+    reason.to_string()
 }

--- a/crates/mesh-llm-commands/src/runtime_native/formatters.rs
+++ b/crates/mesh-llm-commands/src/runtime_native/formatters.rs
@@ -4,6 +4,7 @@ use mesh_llm_native_runtime::{
 };
 use mesh_llm_runtime_install::{
     NativeRuntimeCatalogSources, NativeRuntimeInstallOutcome, NativeRuntimeInstallStatus,
+    NativeRuntimeResolutionError,
 };
 use serde::Serialize;
 use serde_json::json;
@@ -110,16 +111,18 @@ impl RuntimeNativeFormatter for HumanFormatter {
 
     fn render_install_error(&self, error: &Error) -> Result<()> {
         eprintln!("❌ Native runtime install failed");
-        // Resolution failures carry a multi-line explanation (catalogs
-        // consulted, rejected candidates); keep every line aligned.
-        let mut lines = error.to_string();
-        lines.truncate(lines.trim_end().len());
-        let mut lines = lines.lines();
-        if let Some(first) = lines.next() {
-            eprintln!("   Reason: {first}");
+        eprintln!("   Reason: {error}");
+        // A resolution failure carries its explanation (catalogs consulted,
+        // rejected candidates) as structure; the causes underneath, such as
+        // the resolver's own verdict or a manifest that failed to parse, stay
+        // one per line.
+        if let Some(resolution) = error.downcast_ref::<NativeRuntimeResolutionError>() {
+            for line in resolution.explanation_lines() {
+                eprintln!("   {line}");
+            }
         }
-        for line in lines {
-            eprintln!("           {line}");
+        for cause in error.chain().skip(1) {
+            eprintln!("   cause: {cause}");
         }
         eprintln!("   Try: mesh-llm runtime list --available");
         Ok(())
@@ -192,12 +195,16 @@ impl RuntimeNativeFormatter for JsonFormatter {
     }
 
     fn render_install_error(&self, error: &Error) -> Result<()> {
+        // `resolution` is the structured explanation of a failed selection
+        // (catalogs, plausible candidates and their rejection reasons); it is
+        // null for every other failure, and `context` keeps the cause chain.
         print_json(&json!({
             "status": "error",
             "error": {
                 "type": "native_runtime_install_failed",
                 "message": error.to_string(),
                 "context": error.chain().skip(1).map(ToString::to_string).collect::<Vec<_>>(),
+                "resolution": error.downcast_ref::<NativeRuntimeResolutionError>(),
             },
         }))
     }

--- a/crates/mesh-llm-commands/src/runtime_native/formatters.rs
+++ b/crates/mesh-llm-commands/src/runtime_native/formatters.rs
@@ -2,7 +2,9 @@ use anyhow::{Error, Result};
 use mesh_llm_native_runtime::{
     CachePrunePlan, CandidateRejection, HostRuntimeProfile, InstalledNativeRuntime,
 };
-use mesh_llm_runtime_install::{NativeRuntimeInstallOutcome, NativeRuntimeInstallStatus};
+use mesh_llm_runtime_install::{
+    NativeRuntimeCatalogSources, NativeRuntimeInstallOutcome, NativeRuntimeInstallStatus,
+};
 use serde::Serialize;
 use serde_json::json;
 use std::path::{Path, PathBuf};
@@ -42,7 +44,14 @@ pub(crate) struct NativeRuntimeDoctorReport {
 }
 
 pub(crate) trait RuntimeNativeFormatter {
-    fn render_available(&self, rows: &[AvailableRuntimeRow]) -> Result<()>;
+    /// Renders the available runtimes together with the catalogs that were
+    /// consulted to list them, so both output modes explain where the rows
+    /// came from.
+    fn render_available(
+        &self,
+        rows: &[AvailableRuntimeRow],
+        sources: &NativeRuntimeCatalogSources,
+    ) -> Result<()>;
     fn render_installed(
         &self,
         installed: &[InstalledNativeRuntime],
@@ -72,7 +81,15 @@ pub(crate) fn runtime_native_formatter(json_output: bool) -> Box<dyn RuntimeNati
 }
 
 impl RuntimeNativeFormatter for HumanFormatter {
-    fn render_available(&self, rows: &[AvailableRuntimeRow]) -> Result<()> {
+    fn render_available(
+        &self,
+        rows: &[AvailableRuntimeRow],
+        sources: &NativeRuntimeCatalogSources,
+    ) -> Result<()> {
+        eprintln!("🔎 Catalogs consulted");
+        for line in sources.describe() {
+            eprintln!("   {line}");
+        }
         print_available_human(rows);
         Ok(())
     }
@@ -146,8 +163,15 @@ impl RuntimeNativeFormatter for HumanFormatter {
 }
 
 impl RuntimeNativeFormatter for JsonFormatter {
-    fn render_available(&self, rows: &[AvailableRuntimeRow]) -> Result<()> {
-        print_json(rows)
+    fn render_available(
+        &self,
+        rows: &[AvailableRuntimeRow],
+        sources: &NativeRuntimeCatalogSources,
+    ) -> Result<()> {
+        print_json(&json!({
+            "catalogs": sources,
+            "runtimes": rows,
+        }))
     }
 
     fn render_installed(

--- a/crates/mesh-llm-commands/src/runtime_native/setup_helpers.rs
+++ b/crates/mesh-llm-commands/src/runtime_native/setup_helpers.rs
@@ -338,6 +338,7 @@ mod tests {
                 },
                 evaluated: Vec::new(),
             },
+            sources: Default::default(),
         }
     }
 }

--- a/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
@@ -915,6 +915,7 @@ mod dynamic {
                                         .runtime,
                                     evaluated: Vec::new(),
                                 },
+                                sources: Default::default(),
                             })
                         }
                     }

--- a/crates/mesh-llm-native-runtime/src/resolver.rs
+++ b/crates/mesh-llm-native-runtime/src/resolver.rs
@@ -37,6 +37,102 @@ pub enum CandidateRejection {
     SelectionMismatch { selection: String },
 }
 
+impl std::fmt::Display for CandidateRejection {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MeshVersionMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "MeshLLM version mismatch: expected {expected}, found {actual}"
+                )
+            }
+            Self::SkippyAbiMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "Skippy ABI mismatch: expected {expected}, found {actual}"
+                )
+            }
+            Self::OsMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "OS mismatch: expected {expected}, artifact is for {actual}"
+                )
+            }
+            Self::ArchMismatch { expected, actual } => write!(
+                f,
+                "CPU architecture mismatch: expected {expected}, artifact is for {actual}"
+            ),
+            Self::TargetTripleMismatch { expected, actual } => {
+                write!(
+                    f,
+                    "target triple mismatch: expected {expected}, host is {actual}"
+                )
+            }
+            Self::BackendNotSupported { backend } => {
+                write!(f, "backend {backend} is not supported on this host")
+            }
+            Self::CudaProfileMissing => {
+                write!(
+                    f,
+                    "CUDA runtime requires CUDA, but no CUDA profile was detected"
+                )
+            }
+            Self::CudaToolkitMajorMismatch {
+                required,
+                installed,
+            } => {
+                let installed = installed
+                    .iter()
+                    .map(|major| major.to_string())
+                    .collect::<Vec<_>>()
+                    .join(", ");
+                write!(
+                    f,
+                    "CUDA toolkit mismatch: runtime requires CUDA {required}, host has CUDA {installed} installed"
+                )
+            }
+            Self::CudaToolkitMajorAboveDriver {
+                required,
+                driver_max,
+            } => write!(
+                f,
+                "CUDA driver too old: runtime requires CUDA {required}, driver supports up to CUDA {driver_max}"
+            ),
+            Self::CudaToolkitNotDetected { required } => write!(
+                f,
+                "no CUDA toolkit detected: runtime requires CUDA {required} libraries \
+                 (libcudart, libcublas, libcublasLt) on the loader path; \
+                 set MESH_LLM_CUDA_TOOLKIT_MAJORS if the toolkit is installed elsewhere"
+            ),
+            Self::CudaGpuArchUnsupported { supported } => write!(
+                f,
+                "CUDA GPU architecture unsupported: runtime supports {}",
+                supported.join(", ")
+            ),
+            Self::RocmProfileMissing => {
+                write!(
+                    f,
+                    "ROCm runtime requires ROCm, but no ROCm profile was detected"
+                )
+            }
+            Self::RocmGpuArchUnsupported { supported } => write!(
+                f,
+                "ROCm GPU architecture unsupported: runtime supports {}",
+                supported.join(", ")
+            ),
+            Self::VulkanProfileMissing => {
+                write!(
+                    f,
+                    "Vulkan runtime requires Vulkan, but no Vulkan profile was detected"
+                )
+            }
+            Self::SelectionMismatch { selection } => {
+                write!(f, "selection mismatch: requested {selection}")
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
 pub struct CandidateEvaluation {
     pub artifact: NativeRuntimeArtifact,

--- a/crates/mesh-llm-runtime-install/src/install.rs
+++ b/crates/mesh-llm-runtime-install/src/install.rs
@@ -1,13 +1,16 @@
 //! Native runtime resolution, download, and installation.
 
 use crate::cache::{host_runtime_profile, native_runtime_cache};
-use crate::manifest::{load_release_manifest_with_bundle_dirs, normalize_sha256};
+use crate::manifest::{
+    NativeRuntimeCatalogSources, load_release_manifest_with_sources, normalize_sha256,
+};
 use crate::types::*;
 use anyhow::{Context, Result, bail};
 use futures_util::StreamExt;
 use mesh_llm_native_runtime::{
-    InstalledNativeRuntime, NativeRuntimeArtifact, NativeRuntimeCache, NativeRuntimeManifest,
-    NativeRuntimeResolver, NativeRuntimeSource,
+    CandidateEvaluation, CandidateRejection, InstalledNativeRuntime, NativeRuntimeArtifact,
+    NativeRuntimeCache, NativeRuntimeManifest, NativeRuntimeResolver, NativeRuntimeSource,
+    RuntimeSelection,
 };
 use sha2::Digest;
 use std::fs;
@@ -21,36 +24,109 @@ use tokio::io::AsyncWriteExt;
 pub async fn install_native_runtime(
     options: NativeRuntimeInstallOptions,
 ) -> Result<NativeRuntimeInstallOutcome> {
-    let (manifest, bundle_dirs) =
-        load_release_manifest_with_bundle_dirs(NativeRuntimeManifestOptions {
-            mesh_version: options.mesh_version.clone(),
-            manifest_path: options.manifest_path.clone(),
-            manifest_url: options.manifest_url.clone(),
-            bundle_dirs: options.bundle_dirs.clone(),
-            // Offline installs (`allow_download: false`) must not reach out
-            // for the default catalog either; bundles and the cache are the
-            // only sources then. Explicit manifest URLs are still honoured.
-            allow_default_manifest_url: options.allow_download,
-        })
-        .await?;
+    let (manifest, sources) = load_release_manifest_with_sources(NativeRuntimeManifestOptions {
+        mesh_version: options.mesh_version.clone(),
+        manifest_path: options.manifest_path.clone(),
+        manifest_url: options.manifest_url.clone(),
+        bundle_dirs: options.bundle_dirs.clone(),
+        // Offline installs (`allow_download: false`) must not reach out
+        // for the default catalog either; bundles and the cache are the
+        // only sources then. Explicit manifest URLs are still honoured.
+        allow_default_manifest_url: options.allow_download,
+    })
+    .await?;
     if manifest.artifacts.is_empty() {
-        bail!("no native runtime manifest entries found");
+        bail!(
+            "no native runtime manifest entries found\n{}",
+            describe_catalogs(&sources)
+        );
     }
     let skippy_abi_version = options
         .skippy_abi_version
         .clone()
         .unwrap_or_else(|| manifest.skippy_abi.clone());
     let cache = native_runtime_cache(options.cache_dir.as_deref())?;
-    let resolution = NativeRuntimeResolver::new(
+    let resolver = NativeRuntimeResolver::new(
         &options.mesh_version,
         host_runtime_profile(),
         manifest,
         cache.clone(),
     )
     .with_skippy_abi_version(skippy_abi_version)
-    .with_bundle_dirs(bundle_dirs)
-    .resolve(&options.selection)?;
-    install_resolved_runtime(&cache, resolution, &options).await
+    .with_bundle_dirs(sources.bundle_dirs.clone());
+    let resolution = match resolver.resolve(&options.selection) {
+        Ok(resolution) => resolution,
+        Err(err) => {
+            let evaluated = resolver.evaluate(&options.selection).unwrap_or_default();
+            bail!(
+                "{err}\n{}",
+                describe_resolution_failure(&sources, &options.selection, &evaluated)
+            );
+        }
+    };
+    let mut outcome = install_resolved_runtime(&cache, resolution, &options).await?;
+    outcome.sources = sources;
+    Ok(outcome)
+}
+
+fn describe_catalogs(sources: &NativeRuntimeCatalogSources) -> String {
+    sources
+        .describe()
+        .into_iter()
+        .map(|line| format!("catalog: {line}"))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+/// Explains a failed selection: which catalogs were consulted, and why each
+/// candidate that matched the requested selection was rejected. Candidates
+/// that never matched the selection (another backend, another id) are
+/// summarised as a count so the explanation stays focused on what the user
+/// asked for.
+pub(crate) fn describe_resolution_failure(
+    sources: &NativeRuntimeCatalogSources,
+    selection: &RuntimeSelection,
+    evaluated: &[CandidateEvaluation],
+) -> String {
+    let mut lines = vec![describe_catalogs(sources)];
+    let (matching, others): (Vec<_>, Vec<_>) = evaluated.iter().partition(|candidate| {
+        !candidate
+            .rejection_reasons
+            .iter()
+            .any(|reason| matches!(reason, CandidateRejection::SelectionMismatch { .. }))
+    });
+    if matching.is_empty() {
+        lines.push(format!(
+            "no catalog entry matches the requested selection ({} other candidates were not considered)",
+            others.len()
+        ));
+    } else {
+        for candidate in matching {
+            let reasons = if candidate.rejection_reasons.is_empty() {
+                "compatible".to_string()
+            } else {
+                candidate
+                    .rejection_reasons
+                    .iter()
+                    .map(ToString::to_string)
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            };
+            lines.push(format!("candidate {}: {reasons}", candidate.artifact.id));
+        }
+        if !others.is_empty() {
+            lines.push(format!(
+                "{} other candidates did not match the requested selection",
+                others.len()
+            ));
+        }
+    }
+    if let RuntimeSelection::Backend { kind, .. } = selection {
+        lines.push(format!(
+            "the {kind} runtime was requested explicitly; it was not replaced by another backend"
+        ));
+    }
+    lines.join("\n")
 }
 
 pub(crate) async fn install_resolved_runtime(
@@ -67,6 +143,7 @@ pub(crate) async fn install_resolved_runtime(
                     status: NativeRuntimeInstallStatus::Installed,
                     runtime,
                     resolution,
+                    sources: crate::manifest::NativeRuntimeCatalogSources::default(),
                 });
             }
             in_place_bundle_outcome(&path, resolution)
@@ -78,6 +155,7 @@ pub(crate) async fn install_resolved_runtime(
                 status: NativeRuntimeInstallStatus::Installed,
                 runtime,
                 resolution,
+                sources: crate::manifest::NativeRuntimeCatalogSources::default(),
             })
         }
         NativeRuntimeSource::Download { url: _ } => {
@@ -148,6 +226,7 @@ pub(crate) fn in_place_bundle_outcome(
         status: NativeRuntimeInstallStatus::AlreadyInstalled,
         runtime,
         resolution,
+        sources: crate::manifest::NativeRuntimeCatalogSources::default(),
     })
 }
 
@@ -165,6 +244,7 @@ pub(crate) fn installed_outcome(
         status: NativeRuntimeInstallStatus::AlreadyInstalled,
         runtime,
         resolution,
+        sources: crate::manifest::NativeRuntimeCatalogSources::default(),
     })
 }
 

--- a/crates/mesh-llm-runtime-install/src/install.rs
+++ b/crates/mesh-llm-runtime-install/src/install.rs
@@ -36,10 +36,11 @@ pub async fn install_native_runtime(
     })
     .await?;
     if manifest.artifacts.is_empty() {
-        bail!(
-            "no native runtime manifest entries found\n{}",
-            describe_catalogs(&sources)
-        );
+        return Err(NativeRuntimeResolutionError::empty_catalog(
+            sources,
+            options.selection.clone(),
+        )
+        .into());
     }
     let skippy_abi_version = options
         .skippy_abi_version
@@ -57,11 +58,25 @@ pub async fn install_native_runtime(
     let resolution = match resolver.resolve(&options.selection) {
         Ok(resolution) => resolution,
         Err(err) => {
-            let evaluated = resolver.evaluate(&options.selection).unwrap_or_default();
-            bail!(
-                "{err}\n{}",
-                describe_resolution_failure(&sources, &options.selection, &evaluated)
-            );
+            // The explanation becomes the outermost context of the resolver's
+            // own error: one line on top, the resolver's verdict and the
+            // deeper causes (an unreadable cache, a manifest that failed to
+            // parse) preserved underneath for the chain readers.
+            let explanation = match resolver.evaluate(&options.selection) {
+                Ok(evaluated) => NativeRuntimeResolutionError::rejected(
+                    sources,
+                    options.selection.clone(),
+                    &evaluated,
+                ),
+                // `evaluate` fails for the same reason `resolve` did when the
+                // candidates could not be enumerated at all; that is not a
+                // selection problem and must not read like one.
+                Err(_) => NativeRuntimeResolutionError::enumeration_failed(
+                    sources,
+                    options.selection.clone(),
+                ),
+            };
+            return Err(err.context(explanation));
         }
     };
     let mut outcome = install_resolved_runtime(&cache, resolution, &options).await?;
@@ -69,64 +84,179 @@ pub async fn install_native_runtime(
     Ok(outcome)
 }
 
-fn describe_catalogs(sources: &NativeRuntimeCatalogSources) -> String {
-    sources
-        .describe()
-        .into_iter()
-        .map(|line| format!("catalog: {line}"))
-        .collect::<Vec<_>>()
-        .join("\n")
+/// Why native runtime resolution failed, kept structured so `--json`
+/// consumers can read the catalogs and the candidates instead of parsing
+/// prose. It travels as the outermost context of the install error: its
+/// `Display` is a single line, the resolver's own verdict and the deeper
+/// causes stay underneath in the error chain, and
+/// `anyhow::Error::downcast_ref` recovers the structure.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub struct NativeRuntimeResolutionError {
+    /// One-line verdict; also what this error displays as.
+    pub summary: String,
+    /// What the caller asked for.
+    pub selection: RuntimeSelection,
+    /// Which catalogs were consulted.
+    pub catalogs: NativeRuntimeCatalogSources,
+    /// Candidates that were plausible for this host and selection, with why
+    /// each one was rejected. Empty when the candidates could not be
+    /// enumerated at all.
+    pub candidates: Vec<RejectedCandidate>,
+    /// Candidates set aside before explaining anything: built for another
+    /// platform, or not matching an explicit selection.
+    pub set_aside: usize,
+    /// `true` when the candidates could not be enumerated (unreadable bundle
+    /// manifest, unreadable cache). The cause is in the error chain and the
+    /// catalog is not at fault.
+    pub enumeration_failed: bool,
 }
 
-/// Explains a failed selection: which catalogs were consulted, and why each
-/// candidate that matched the requested selection was rejected. Candidates
-/// that never matched the selection (another backend, another id) are
-/// summarised as a count so the explanation stays focused on what the user
-/// asked for.
-pub(crate) fn describe_resolution_failure(
-    sources: &NativeRuntimeCatalogSources,
-    selection: &RuntimeSelection,
-    evaluated: &[CandidateEvaluation],
-) -> String {
-    let mut lines = vec![describe_catalogs(sources)];
-    let (matching, others): (Vec<_>, Vec<_>) = evaluated.iter().partition(|candidate| {
-        !candidate
-            .rejection_reasons
+/// A plausible candidate and the reasons it was rejected.
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize)]
+pub struct RejectedCandidate {
+    pub id: String,
+    pub reasons: Vec<CandidateRejection>,
+}
+
+impl NativeRuntimeResolutionError {
+    /// The merged catalog listed nothing at all.
+    pub(crate) fn empty_catalog(
+        catalogs: NativeRuntimeCatalogSources,
+        selection: RuntimeSelection,
+    ) -> Self {
+        Self {
+            summary: "no native runtime manifest entries found".to_string(),
+            selection,
+            catalogs,
+            candidates: Vec::new(),
+            set_aside: 0,
+            enumeration_failed: false,
+        }
+    }
+
+    /// Every candidate was evaluated and none could be selected.
+    pub(crate) fn rejected(
+        catalogs: NativeRuntimeCatalogSources,
+        selection: RuntimeSelection,
+        evaluated: &[CandidateEvaluation],
+    ) -> Self {
+        let (plausible, set_aside): (Vec<_>, Vec<_>) = evaluated
             .iter()
-            .any(|reason| matches!(reason, CandidateRejection::SelectionMismatch { .. }))
-    });
-    if matching.is_empty() {
-        lines.push(format!(
-            "no catalog entry matches the requested selection ({} other candidates were not considered)",
-            others.len()
-        ));
-    } else {
-        for candidate in matching {
-            let reasons = if candidate.rejection_reasons.is_empty() {
+            .partition(|candidate| candidate_is_plausible(candidate));
+        let candidates = plausible
+            .into_iter()
+            .map(|candidate| RejectedCandidate {
+                id: candidate.artifact.id.clone(),
+                reasons: candidate.rejection_reasons.clone(),
+            })
+            .collect::<Vec<_>>();
+        let summary = if candidates.is_empty() {
+            format!(
+                "no native runtime candidate applies to this host and selection ({} set aside)",
+                set_aside.len()
+            )
+        } else {
+            format!(
+                "no compatible native runtime: {} candidate(s) rejected, {} set aside",
+                candidates.len(),
+                set_aside.len()
+            )
+        };
+        Self {
+            summary,
+            selection,
+            catalogs,
+            candidates,
+            set_aside: set_aside.len(),
+            enumeration_failed: false,
+        }
+    }
+
+    /// The candidates could not be enumerated, so nothing was evaluated.
+    pub(crate) fn enumeration_failed(
+        catalogs: NativeRuntimeCatalogSources,
+        selection: RuntimeSelection,
+    ) -> Self {
+        Self {
+            summary: "native runtime candidates could not be enumerated".to_string(),
+            selection,
+            catalogs,
+            candidates: Vec::new(),
+            set_aside: 0,
+            enumeration_failed: true,
+        }
+    }
+
+    /// Lines for a human reader: the catalogs consulted, then the plausible
+    /// candidates with their rejection reasons, then what was set aside.
+    pub fn explanation_lines(&self) -> Vec<String> {
+        let mut lines = self
+            .catalogs
+            .describe()
+            .into_iter()
+            .map(|line| format!("catalog: {line}"))
+            .collect::<Vec<_>>();
+        if self.enumeration_failed {
+            lines.push(
+                "the candidates could not be enumerated; the cause is reported below, the catalog is not at fault"
+                    .to_string(),
+            );
+            return lines;
+        }
+        for candidate in &self.candidates {
+            let reasons = if candidate.reasons.is_empty() {
                 "compatible".to_string()
             } else {
                 candidate
-                    .rejection_reasons
+                    .reasons
                     .iter()
                     .map(ToString::to_string)
                     .collect::<Vec<_>>()
                     .join("; ")
             };
-            lines.push(format!("candidate {}: {reasons}", candidate.artifact.id));
+            lines.push(format!("candidate {}: {reasons}", candidate.id));
         }
-        if !others.is_empty() {
+        if self.candidates.is_empty() && self.set_aside > 0 {
+            lines.push(
+                "no catalog entry applies to this host and the requested selection".to_string(),
+            );
+        }
+        if self.set_aside > 0 {
             lines.push(format!(
-                "{} other candidates did not match the requested selection",
-                others.len()
+                "{} other candidates were set aside: built for another platform, or not matching the requested selection",
+                self.set_aside
             ));
         }
+        if let RuntimeSelection::Backend { kind, .. } = &self.selection {
+            lines.push(format!(
+                "the {kind} runtime was requested explicitly; it was not replaced by another backend"
+            ));
+        }
+        lines
     }
-    if let RuntimeSelection::Backend { kind, .. } = selection {
-        lines.push(format!(
-            "the {kind} runtime was requested explicitly; it was not replaced by another backend"
-        ));
+}
+
+impl std::fmt::Display for NativeRuntimeResolutionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.summary)
     }
-    lines.join("\n")
+}
+
+impl std::error::Error for NativeRuntimeResolutionError {}
+
+/// A candidate is worth explaining when it is built for this host and
+/// matches the requested selection; anything else is only counted, so a
+/// plain `runtime install` does not list every other platform's artifact.
+fn candidate_is_plausible(candidate: &CandidateEvaluation) -> bool {
+    !candidate.rejection_reasons.iter().any(|reason| {
+        matches!(
+            reason,
+            CandidateRejection::SelectionMismatch { .. }
+                | CandidateRejection::OsMismatch { .. }
+                | CandidateRejection::ArchMismatch { .. }
+                | CandidateRejection::TargetTripleMismatch { .. }
+        )
+    })
 }
 
 pub(crate) async fn install_resolved_runtime(

--- a/crates/mesh-llm-runtime-install/src/lib.rs
+++ b/crates/mesh-llm-runtime-install/src/lib.rs
@@ -24,7 +24,7 @@ pub use cache::{
 pub use install::install_native_runtime;
 pub use manifest::{
     NativeRuntimeCatalogSources, default_manifest_url, default_release_manifest_url,
-    load_release_manifest,
+    load_release_manifest, load_release_manifest_with_sources,
 };
 pub use types::{
     CURRENT_MESH_VERSION, NATIVE_RUNTIME_CACHE_DIR_ENV, NATIVE_RUNTIME_MANIFEST_URL_ENV,
@@ -38,13 +38,13 @@ pub use types::{
 pub(crate) use cache::resolve_cache_root;
 #[cfg(test)]
 pub(crate) use install::{
-    bundle_path_matches_explicit_root, emit_download_progress, install_resolved_runtime,
-    verify_download_policy_before_fetch,
+    bundle_path_matches_explicit_root, describe_resolution_failure, emit_download_progress,
+    install_resolved_runtime, verify_download_policy_before_fetch,
 };
 #[cfg(test)]
 pub(crate) use manifest::{
-    load_release_manifest_with_sources, manifest_url, release_manifest_checksum_url,
-    url_without_query, verify_release_manifest_checksum,
+    manifest_url, release_manifest_checksum_url, url_without_query,
+    verify_release_manifest_checksum,
 };
 
 #[cfg(test)]
@@ -1019,6 +1019,129 @@ mod tests {
             matches!(resolution.source, NativeRuntimeSource::Bundle { ref path } if path == &bundle.canonicalize().unwrap()),
             "the bundled copy must win over the download: {:?}",
             resolution.source
+        );
+    }
+
+    #[test]
+    fn catalog_sources_describe_every_consulted_source() {
+        let sources = NativeRuntimeCatalogSources {
+            manifest_url: Some("https://example.invalid/native-runtimes.json".to_string()),
+            manifest_artifacts: 12,
+            bundle_dirs: vec![PathBuf::from("C:/app/native-runtimes/cpu")],
+            bundle_artifacts: 1,
+            ..Default::default()
+        };
+        let lines = sources.describe();
+        assert_eq!(lines.len(), 2);
+        assert!(
+            lines[0].contains(
+                "release catalog https://example.invalid/native-runtimes.json (12 artifacts)"
+            ),
+            "{lines:?}"
+        );
+        assert!(
+            lines[1].contains("bundle directories (1 runtimes, 1 not already in the catalog)"),
+            "{lines:?}"
+        );
+
+        let offline = NativeRuntimeCatalogSources {
+            manifest_url: Some("https://example.invalid/native-runtimes.json".to_string()),
+            remote_error: Some("connection refused".to_string()),
+            bundle_dirs: vec![PathBuf::from("C:/app/native-runtimes/cpu")],
+            bundle_artifacts: 1,
+            ..Default::default()
+        };
+        let lines = offline.describe();
+        assert!(
+            lines[0].contains("unavailable, using bundles only: connection refused"),
+            "{lines:?}"
+        );
+
+        let no_network = NativeRuntimeCatalogSources::default();
+        let lines = no_network.describe();
+        assert!(
+            lines[0].contains("no release catalog consulted"),
+            "{lines:?}"
+        );
+        assert!(
+            lines[1].contains("no native runtime bundle directories"),
+            "{lines:?}"
+        );
+    }
+
+    #[test]
+    fn explicit_gpu_selection_failure_names_the_catalogs_and_the_rejected_candidates() {
+        let _guard = MANIFEST_ENV_LOCK.lock().unwrap();
+        unsafe {
+            std::env::remove_var(NATIVE_RUNTIME_MANIFEST_URL_ENV);
+        }
+        let temp = tempfile::tempdir().unwrap();
+        let bundle = temp.path().join("native-runtimes/cpu");
+        write_bundle(&bundle, &windows_cpu_bundle_artifact());
+        // The only cuda candidate needs CUDA 12 on a host whose driver stops
+        // at CUDA 11, so an explicit cuda request must fail loudly instead of
+        // resolving against the bundled cpu runtime.
+        let manifest_path =
+            release_manifest_file(temp.path(), vec![windows_cuda_release_artifact()]);
+        let (manifest, sources) = block_on_load(NativeRuntimeManifestOptions {
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            manifest_path: Some(manifest_path),
+            bundle_dirs: vec![bundle],
+            allow_default_manifest_url: true,
+            ..Default::default()
+        })
+        .unwrap();
+        let profile = HostRuntimeProfile {
+            os: "windows".to_string(),
+            arch: "x86_64".to_string(),
+            target_triple: Some("x86_64-pc-windows-msvc".to_string()),
+            available_flavors: std::collections::BTreeSet::from([
+                NativeRuntimeBackendKind::Cpu,
+                NativeRuntimeBackendKind::Cuda,
+            ]),
+            gpus: Vec::new(),
+            cuda: Some(HostCudaProfile {
+                toolkit_majors: std::collections::BTreeSet::new(),
+                driver_max_major: Some(11),
+                driver_version: None,
+                gpu_arches: std::collections::BTreeSet::from(["89".to_string()]),
+            }),
+            rocm: None,
+            vulkan: None,
+        };
+        let cache = native_runtime_cache(Some(&temp.path().join("cache"))).unwrap();
+        let selection = RuntimeSelection::Backend {
+            kind: NativeRuntimeBackendKind::Cuda,
+            cuda_toolkit_major: None,
+        };
+        let resolver = NativeRuntimeResolver::new(CURRENT_MESH_VERSION, profile, manifest, cache)
+            .with_skippy_abi_version(current_skippy_abi_version())
+            .with_bundle_dirs(sources.bundle_dirs.clone());
+        assert!(resolver.resolve(&selection).is_err());
+        let evaluated = resolver.evaluate(&selection).unwrap();
+
+        let explanation = describe_resolution_failure(&sources, &selection, &evaluated);
+
+        assert!(
+            explanation.contains("catalog: manifest file"),
+            "{explanation}"
+        );
+        assert!(
+            explanation
+                .contains("catalog: bundle directories (1 runtimes, 1 not already in the catalog)"),
+            "{explanation}"
+        );
+        assert!(
+            explanation.contains("candidate meshllm-native-runtime-windows-x86_64-cuda12: CUDA driver too old: runtime requires CUDA 12, driver supports up to CUDA 11"),
+            "{explanation}"
+        );
+        assert!(
+            explanation.contains("1 other candidates did not match the requested selection"),
+            "{explanation}"
+        );
+        assert!(
+            explanation.contains("the cuda runtime was requested explicitly"),
+            "{explanation}"
         );
     }
 }

--- a/crates/mesh-llm-runtime-install/src/lib.rs
+++ b/crates/mesh-llm-runtime-install/src/lib.rs
@@ -422,6 +422,22 @@ mod tests {
     }
 
     #[test]
+    fn manifest_diagnostic_urls_redact_fragments() {
+        // A fragment can carry a token just like a query; catalog reports
+        // must not echo either.
+        assert_eq!(
+            url_without_query(
+                "https://example.invalid/native-runtimes.json?token=secret#access=abc"
+            ),
+            "https://example.invalid/native-runtimes.json"
+        );
+        assert_eq!(
+            url_without_query("https://example.invalid/native-runtimes.json#access=abc"),
+            "https://example.invalid/native-runtimes.json"
+        );
+    }
+
+    #[test]
     fn manifest_diagnostic_urls_redact_userinfo() {
         let redacted =
             url_without_query("https://user:secret@example.invalid/native-runtimes.json?token=abc");

--- a/crates/mesh-llm-runtime-install/src/lib.rs
+++ b/crates/mesh-llm-runtime-install/src/lib.rs
@@ -21,7 +21,7 @@ pub use cache::{
     current_skippy_abi_version, default_native_runtime_cache, host_runtime_profile,
     native_runtime_cache, native_runtime_versions_match_current_sdk,
 };
-pub use install::install_native_runtime;
+pub use install::{NativeRuntimeResolutionError, RejectedCandidate, install_native_runtime};
 pub use manifest::{
     NativeRuntimeCatalogSources, default_manifest_url, default_release_manifest_url,
     load_release_manifest, load_release_manifest_with_sources,
@@ -38,12 +38,12 @@ pub use types::{
 pub(crate) use cache::resolve_cache_root;
 #[cfg(test)]
 pub(crate) use install::{
-    bundle_path_matches_explicit_root, describe_resolution_failure, emit_download_progress,
-    install_resolved_runtime, verify_download_policy_before_fetch,
+    bundle_path_matches_explicit_root, emit_download_progress, install_resolved_runtime,
+    verify_download_policy_before_fetch,
 };
 #[cfg(test)]
 pub(crate) use manifest::{
-    manifest_url, release_manifest_checksum_url, url_without_query,
+    manifest_url, normalize_sha256, release_manifest_checksum_url, url_without_query,
     verify_release_manifest_checksum,
 };
 
@@ -1012,6 +1012,9 @@ mod tests {
             .filter(|artifact| artifact.id == "meshllm-native-runtime-windows-x86_64-cpu")
             .count();
         assert_eq!(cpu_entries, 1, "{:?}", manifest.artifacts);
+        assert_eq!(sources.bundle_artifacts, 0);
+        assert_eq!(sources.bundle_duplicates_of_catalog, 1);
+        assert_eq!(sources.bundle_duplicates_of_bundles, 0);
 
         let profile = HostRuntimeProfile {
             os: "windows".to_string(),
@@ -1056,7 +1059,28 @@ mod tests {
             "{lines:?}"
         );
         assert!(
-            lines[1].contains("bundle directories (1 runtimes, 1 not already in the catalog)"),
+            lines[1].contains("bundle directories (1 runtimes: 1 added to the catalog)"),
+            "{lines:?}"
+        );
+
+        let shared = NativeRuntimeCatalogSources {
+            manifest_url: Some("https://example.invalid/native-runtimes.json".to_string()),
+            manifest_artifacts: 12,
+            bundle_dirs: vec![
+                PathBuf::from("C:/app/native-runtimes/cpu"),
+                PathBuf::from("C:/extra/cpu"),
+                PathBuf::from("C:/extra/cuda12"),
+            ],
+            bundle_artifacts: 1,
+            bundle_duplicates_of_catalog: 1,
+            bundle_duplicates_of_bundles: 1,
+            ..Default::default()
+        };
+        let lines = shared.describe();
+        assert!(
+            lines[1].contains(
+                "bundle directories (3 runtimes: 1 added to the catalog, 1 already listed by the release catalog, 1 duplicates of another bundle directory)"
+            ),
             "{lines:?}"
         );
 
@@ -1133,18 +1157,27 @@ mod tests {
         let resolver = NativeRuntimeResolver::new(CURRENT_MESH_VERSION, profile, manifest, cache)
             .with_skippy_abi_version(current_skippy_abi_version())
             .with_bundle_dirs(sources.bundle_dirs.clone());
-        assert!(resolver.resolve(&selection).is_err());
+        let resolver_error = resolver.resolve(&selection).unwrap_err();
         let evaluated = resolver.evaluate(&selection).unwrap();
 
-        let explanation = describe_resolution_failure(&sources, &selection, &evaluated);
+        let failure =
+            NativeRuntimeResolutionError::rejected(sources, selection.clone(), &evaluated);
+        let explanation = failure.explanation_lines().join("\n");
 
+        assert_eq!(
+            failure.summary,
+            "no compatible native runtime: 1 candidate(s) rejected, 1 set aside"
+        );
+        assert_eq!(failure.candidates.len(), 1);
+        assert_eq!(failure.set_aside, 1);
+        assert!(!failure.enumeration_failed);
         assert!(
             explanation.contains("catalog: manifest file"),
             "{explanation}"
         );
         assert!(
             explanation
-                .contains("catalog: bundle directories (1 runtimes, 1 not already in the catalog)"),
+                .contains("catalog: bundle directories (1 runtimes: 1 added to the catalog)"),
             "{explanation}"
         );
         assert!(
@@ -1152,12 +1185,203 @@ mod tests {
             "{explanation}"
         );
         assert!(
-            explanation.contains("1 other candidates did not match the requested selection"),
+            explanation.contains("1 other candidates were set aside"),
             "{explanation}"
         );
         assert!(
             explanation.contains("the cuda runtime was requested explicitly"),
             "{explanation}"
+        );
+
+        // As the outermost context of the resolver's error: one line on top,
+        // the resolver's verdict underneath, and the structure recoverable.
+        let wrapped = resolver_error.context(failure.clone());
+        assert!(!wrapped.to_string().contains('\n'), "{wrapped}");
+        assert_eq!(wrapped.to_string(), failure.summary);
+        let causes = wrapped
+            .chain()
+            .skip(1)
+            .map(ToString::to_string)
+            .collect::<Vec<_>>();
+        assert!(
+            causes[0].contains("no compatible native runtime found for Skippy ABI"),
+            "{causes:?}"
+        );
+        let recovered = wrapped
+            .downcast_ref::<NativeRuntimeResolutionError>()
+            .expect("the structured explanation is recoverable from the anyhow error");
+        assert_eq!(recovered, &failure);
+        let json = serde_json::to_value(recovered).unwrap();
+        assert_eq!(json["set_aside"], 1);
+        assert_eq!(
+            json["candidates"][0]["id"],
+            "meshllm-native-runtime-windows-x86_64-cuda12"
+        );
+    }
+
+    #[test]
+    fn recommended_selection_sets_aside_other_platforms_instead_of_listing_them() {
+        let temp = tempfile::tempdir().unwrap();
+        let mut linux_cuda = windows_cuda_release_artifact();
+        linux_cuda.id = "meshllm-native-runtime-linux-x86_64-cuda12".to_string();
+        linux_cuda.platform = NativeRuntimePlatform {
+            os: "linux".to_string(),
+            arch: "x86_64".to_string(),
+            target: Some("x86_64-unknown-linux-gnu".to_string()),
+        };
+        let manifest_path = release_manifest_file(
+            temp.path(),
+            vec![windows_cuda_release_artifact(), linux_cuda],
+        );
+        let (manifest, sources) = block_on_load(NativeRuntimeManifestOptions {
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            manifest_path: Some(manifest_path),
+            bundle_dirs: Vec::new(),
+            allow_default_manifest_url: false,
+            ..Default::default()
+        })
+        .unwrap();
+        // A Windows host whose driver stops at CUDA 11: the Windows cuda12
+        // runtime is the only plausible candidate, the Linux one is noise.
+        let profile = HostRuntimeProfile {
+            os: "windows".to_string(),
+            arch: "x86_64".to_string(),
+            target_triple: Some("x86_64-pc-windows-msvc".to_string()),
+            available_flavors: std::collections::BTreeSet::from([
+                NativeRuntimeBackendKind::Cpu,
+                NativeRuntimeBackendKind::Cuda,
+            ]),
+            gpus: Vec::new(),
+            cuda: Some(HostCudaProfile {
+                toolkit_majors: std::collections::BTreeSet::new(),
+                driver_max_major: Some(11),
+                driver_version: None,
+                gpu_arches: std::collections::BTreeSet::from(["89".to_string()]),
+            }),
+            rocm: None,
+            vulkan: None,
+        };
+        let cache = native_runtime_cache(Some(&temp.path().join("cache"))).unwrap();
+        let resolver = NativeRuntimeResolver::new(CURRENT_MESH_VERSION, profile, manifest, cache)
+            .with_skippy_abi_version(current_skippy_abi_version());
+        assert!(resolver.resolve(&RuntimeSelection::Recommended).is_err());
+        let evaluated = resolver.evaluate(&RuntimeSelection::Recommended).unwrap();
+
+        let failure = NativeRuntimeResolutionError::rejected(
+            sources,
+            RuntimeSelection::Recommended,
+            &evaluated,
+        );
+
+        assert_eq!(failure.candidates.len(), 1, "{failure:?}");
+        assert_eq!(
+            failure.candidates[0].id,
+            "meshllm-native-runtime-windows-x86_64-cuda12"
+        );
+        assert_eq!(failure.set_aside, 1);
+        let explanation = failure.explanation_lines().join("\n");
+        assert!(!explanation.contains("linux"), "{explanation}");
+        assert!(
+            explanation.contains("1 other candidates were set aside"),
+            "{explanation}"
+        );
+        assert!(
+            !explanation.contains("requested explicitly"),
+            "{explanation}"
+        );
+    }
+
+    #[test]
+    fn enumeration_failure_is_not_reported_as_a_catalog_mismatch() {
+        let failure = NativeRuntimeResolutionError::enumeration_failed(
+            NativeRuntimeCatalogSources::default(),
+            RuntimeSelection::Recommended,
+        );
+        let lines = failure.explanation_lines();
+        assert!(
+            lines
+                .iter()
+                .any(|line| line.contains("could not be enumerated")),
+            "{lines:?}"
+        );
+        assert!(
+            !lines.iter().any(|line| line.contains("set aside")),
+            "{lines:?}"
+        );
+
+        let wrapped =
+            anyhow::anyhow!("native runtime cache root is not readable").context(failure.clone());
+        assert_eq!(
+            wrapped.to_string(),
+            "native runtime candidates could not be enumerated"
+        );
+        assert!(
+            wrapped
+                .chain()
+                .skip(1)
+                .any(|cause| cause.to_string().contains("cache root is not readable")),
+            "the original cause must survive underneath the explanation"
+        );
+        let recovered = wrapped
+            .downcast_ref::<NativeRuntimeResolutionError>()
+            .unwrap();
+        assert!(recovered.enumeration_failed);
+        assert!(recovered.candidates.is_empty());
+    }
+
+    #[test]
+    fn release_manifest_checksum_url_drops_fragments() {
+        assert_eq!(
+            release_manifest_checksum_url("https://host/native-runtimes.json#tok"),
+            "https://host/native-runtimes.json.sha256"
+        );
+        assert_eq!(
+            release_manifest_checksum_url("https://host/native-runtimes.json?token=1#tok"),
+            "https://host/native-runtimes.json.sha256?token=1"
+        );
+    }
+
+    #[test]
+    fn invalid_sha256_error_does_not_echo_the_value() {
+        let err =
+            normalize_sha256("{\"mesh_version\": \"0.76.0\", \"artifacts\": []}").unwrap_err();
+        let message = err.to_string();
+        assert!(!message.contains("mesh_version"), "{message}");
+        assert!(
+            message.contains("expected 64 hexadecimal characters"),
+            "{message}"
+        );
+    }
+
+    #[test]
+    fn a_runtime_reached_through_two_bundle_directories_is_counted_as_a_bundle_duplicate() {
+        let temp = tempfile::tempdir().unwrap();
+        let first = temp.path().join("native-runtimes/cpu");
+        let second = temp.path().join("extra/cpu");
+        write_bundle(&first, &windows_cpu_bundle_artifact());
+        write_bundle(&second, &windows_cpu_bundle_artifact());
+        let manifest_path =
+            release_manifest_file(temp.path(), vec![windows_cuda_release_artifact()]);
+
+        let (manifest, sources) = block_on_load(NativeRuntimeManifestOptions {
+            mesh_version: CURRENT_MESH_VERSION.to_string(),
+            manifest_path: Some(manifest_path),
+            bundle_dirs: vec![first, second],
+            allow_default_manifest_url: false,
+            ..Default::default()
+        })
+        .unwrap();
+
+        assert_eq!(manifest.artifacts.len(), 2, "{:?}", manifest.artifacts);
+        assert_eq!(sources.bundle_artifacts, 1);
+        assert_eq!(sources.bundle_duplicates_of_catalog, 0);
+        assert_eq!(sources.bundle_duplicates_of_bundles, 1);
+        let lines = sources.describe();
+        assert!(
+            lines[1].contains(
+                "bundle directories (2 runtimes: 1 added to the catalog, 1 duplicates of another bundle directory)"
+            ),
+            "{lines:?}"
         );
     }
 }

--- a/crates/mesh-llm-runtime-install/src/manifest.rs
+++ b/crates/mesh-llm-runtime-install/src/manifest.rs
@@ -46,19 +46,75 @@ pub async fn load_release_manifest(
 
 /// Which catalogs a merged manifest load consulted, so callers can explain a
 /// selection (or a rejection) in terms of where the candidates came from.
-#[derive(Clone, Debug, Default, Eq, PartialEq)]
+#[derive(Clone, Debug, Default, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
 pub struct NativeRuntimeCatalogSources {
     /// Explicit `--manifest` file that was read.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub manifest_path: Option<PathBuf>,
     /// Remote manifest URL that was consulted (explicit, environment, or the
-    /// default release URL).
+    /// default release URL), with any query string removed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub manifest_url: Option<String>,
+    /// Artifacts contributed by the manifest file or URL.
+    #[serde(default)]
+    pub manifest_artifacts: usize,
     /// Why the remote manifest could not be used, when bundled artifacts
     /// carried the load instead. `None` when the fetch succeeded or was not
     /// attempted.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     pub remote_error: Option<String>,
     /// Bundle directories whose artifacts were merged in.
+    #[serde(default)]
     pub bundle_dirs: Vec<PathBuf>,
+    /// Artifacts contributed by the bundle directories (after deduplication
+    /// against the manifest).
+    #[serde(default)]
+    pub bundle_artifacts: usize,
+}
+
+impl NativeRuntimeCatalogSources {
+    /// Human-readable lines stating which catalogs were consulted, suitable
+    /// for CLI output and for explaining a failed selection.
+    pub fn describe(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        if let Some(path) = &self.manifest_path {
+            lines.push(format!(
+                "manifest file {} ({} artifacts)",
+                path.display(),
+                self.manifest_artifacts
+            ));
+        } else if let Some(url) = &self.manifest_url {
+            match &self.remote_error {
+                Some(error) => lines.push(format!(
+                    "release catalog {url} unavailable, using bundles only: {error}"
+                )),
+                None => lines.push(format!(
+                    "release catalog {url} ({} artifacts)",
+                    self.manifest_artifacts
+                )),
+            }
+        } else {
+            lines.push("no release catalog consulted (downloads disabled)".to_string());
+        }
+        if self.bundle_dirs.is_empty() {
+            lines.push("no native runtime bundle directories".to_string());
+        } else {
+            let dirs = self
+                .bundle_dirs
+                .iter()
+                .map(|dir| dir.display().to_string())
+                .collect::<Vec<_>>()
+                .join(", ");
+            // Every bundle directory carries exactly one runtime manifest;
+            // say how many of them were not already listed by the catalog.
+            lines.push(format!(
+                "bundle directories ({} runtimes, {} not already in the catalog): {dirs}",
+                self.bundle_dirs.len(),
+                self.bundle_artifacts
+            ));
+        }
+        lines
+    }
 }
 
 /// Like `load_release_manifest_with_sources`, returning only the bundle
@@ -89,7 +145,7 @@ pub(crate) async fn load_release_manifest_with_bundle_dirs(
 /// Candidates with the same identity coming from several sources are
 /// deduplicated downstream by the resolver, which also prefers a bundled copy
 /// over a download for the same artifact.
-pub(crate) async fn load_release_manifest_with_sources(
+pub async fn load_release_manifest_with_sources(
     mut options: NativeRuntimeManifestOptions,
 ) -> Result<(NativeRuntimeReleaseManifest, NativeRuntimeCatalogSources)> {
     options.bundle_dirs = discover_native_runtime_bundle_dirs(&options.bundle_dirs)?;
@@ -123,7 +179,8 @@ pub(crate) async fn load_release_manifest_with_sources(
             Err(err) => return Err(err),
         }
     }
-    append_bundle_artifacts(
+    sources.manifest_artifacts = artifacts.len();
+    sources.bundle_artifacts = append_bundle_artifacts(
         &mut artifacts,
         &mut mesh_version,
         &mut skippy_abi,
@@ -276,7 +333,8 @@ pub(crate) fn append_bundle_artifacts(
     skippy_abi: &mut String,
     bundle_dirs: &[PathBuf],
     manifest_loaded: bool,
-) -> Result<()> {
+) -> Result<usize> {
+    let mut appended = 0;
     for dir in bundle_dirs {
         let manifest = NativeRuntimeManifest::read_from_dir(dir)
             .with_context(|| format!("read bundled native runtime {}", dir.display()))?;
@@ -296,9 +354,10 @@ pub(crate) fn append_bundle_artifacts(
             .any(|existing| same_artifact_identity(existing, &manifest.runtime));
         if !duplicate {
             artifacts.push(manifest.runtime);
+            appended += 1;
         }
     }
-    Ok(())
+    Ok(appended)
 }
 
 /// Two catalog entries describe the same runtime when their id and release

--- a/crates/mesh-llm-runtime-install/src/manifest.rs
+++ b/crates/mesh-llm-runtime-install/src/manifest.rs
@@ -66,10 +66,18 @@ pub struct NativeRuntimeCatalogSources {
     /// Bundle directories whose artifacts were merged in.
     #[serde(default)]
     pub bundle_dirs: Vec<PathBuf>,
-    /// Artifacts contributed by the bundle directories (after deduplication
-    /// against the manifest).
+    /// Artifacts the bundle directories added to the catalog.
     #[serde(default)]
     pub bundle_artifacts: usize,
+    /// Bundled runtimes that the release catalog already listed (kept once,
+    /// served from the bundle).
+    #[serde(default)]
+    pub bundle_duplicates_of_catalog: usize,
+    /// Bundled runtimes that another bundle directory had already
+    /// contributed, for example the same runtime reached through an explicit
+    /// `--bundle-dir` and through the executable-adjacent directory.
+    #[serde(default)]
+    pub bundle_duplicates_of_bundles: usize,
 }
 
 impl NativeRuntimeCatalogSources {
@@ -106,12 +114,26 @@ impl NativeRuntimeCatalogSources {
                 .collect::<Vec<_>>()
                 .join(", ");
             // Every bundle directory carries exactly one runtime manifest;
-            // say how many of them were not already listed by the catalog.
-            lines.push(format!(
-                "bundle directories ({} runtimes, {} not already in the catalog): {dirs}",
+            // say how many of them the catalog gained, and where the others
+            // had already been listed.
+            let mut counts = format!(
+                "{} runtimes: {} added to the catalog",
                 self.bundle_dirs.len(),
                 self.bundle_artifacts
-            ));
+            );
+            if self.bundle_duplicates_of_catalog > 0 {
+                counts.push_str(&format!(
+                    ", {} already listed by the release catalog",
+                    self.bundle_duplicates_of_catalog
+                ));
+            }
+            if self.bundle_duplicates_of_bundles > 0 {
+                counts.push_str(&format!(
+                    ", {} duplicates of another bundle directory",
+                    self.bundle_duplicates_of_bundles
+                ));
+            }
+            lines.push(format!("bundle directories ({counts}): {dirs}"));
         }
         lines
     }
@@ -180,13 +202,16 @@ pub async fn load_release_manifest_with_sources(
         }
     }
     sources.manifest_artifacts = artifacts.len();
-    sources.bundle_artifacts = append_bundle_artifacts(
+    let merged = append_bundle_artifacts(
         &mut artifacts,
         &mut mesh_version,
         &mut skippy_abi,
         &options.bundle_dirs,
         manifest_loaded,
     )?;
+    sources.bundle_artifacts = merged.added;
+    sources.bundle_duplicates_of_catalog = merged.duplicates_of_catalog;
+    sources.bundle_duplicates_of_bundles = merged.duplicates_of_bundles;
     Ok((
         NativeRuntimeReleaseManifest {
             mesh_version,
@@ -261,7 +286,12 @@ pub(crate) fn verify_release_manifest_checksum(
     Ok(())
 }
 
+/// Derives the checksum URL from the manifest URL: `.sha256` goes on the
+/// path, the query string is kept, and a fragment is dropped since it never
+/// reaches the server (kept, it would end up inside the path and the server
+/// would answer with the manifest body instead of a checksum).
 pub(crate) fn release_manifest_checksum_url(url: &str) -> String {
+    let url = url.split_once('#').map_or(url, |(base, _)| base);
     match url.split_once('?') {
         Some((base, query)) => format!("{base}.sha256?{query}"),
         None => format!("{url}.sha256"),
@@ -337,8 +367,11 @@ pub(crate) fn append_bundle_artifacts(
     skippy_abi: &mut String,
     bundle_dirs: &[PathBuf],
     manifest_loaded: bool,
-) -> Result<usize> {
-    let mut appended = 0;
+) -> Result<BundleMergeCounts> {
+    // Entries below this index came from the release manifest; the ones
+    // appended afterwards came from earlier bundle directories.
+    let catalog_len = artifacts.len();
+    let mut counts = BundleMergeCounts::default();
     for dir in bundle_dirs {
         let manifest = NativeRuntimeManifest::read_from_dir(dir)
             .with_context(|| format!("read bundled native runtime {}", dir.display()))?;
@@ -350,18 +383,34 @@ pub(crate) fn append_bundle_artifacts(
             }
             *skippy_abi = manifest.runtime.skippy_abi.clone();
         }
-        // The same runtime can be both bundled and published. Keep one entry
-        // so listings stay unambiguous; the resolver still prefers the bundle
-        // directory as the source for that identity.
-        let duplicate = artifacts
+        // The same runtime can be both bundled and published, or reached
+        // through two bundle directories. Keep one entry so listings stay
+        // unambiguous; the resolver still prefers a bundle directory as the
+        // source for that identity.
+        match artifacts
             .iter()
-            .any(|existing| same_artifact_identity(existing, &manifest.runtime));
-        if !duplicate {
-            artifacts.push(manifest.runtime);
-            appended += 1;
+            .position(|existing| same_artifact_identity(existing, &manifest.runtime))
+        {
+            Some(index) if index < catalog_len => counts.duplicates_of_catalog += 1,
+            Some(_) => counts.duplicates_of_bundles += 1,
+            None => {
+                artifacts.push(manifest.runtime);
+                counts.added += 1;
+            }
         }
     }
-    Ok(appended)
+    Ok(counts)
+}
+
+/// What merging the bundle directories into the catalog produced.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct BundleMergeCounts {
+    /// Runtimes the bundles added to the catalog.
+    pub(crate) added: usize,
+    /// Bundled runtimes the release catalog already listed.
+    pub(crate) duplicates_of_catalog: usize,
+    /// Bundled runtimes an earlier bundle directory had already contributed.
+    pub(crate) duplicates_of_bundles: usize,
 }
 
 /// Two catalog entries describe the same runtime when their id and release
@@ -382,6 +431,11 @@ pub(crate) fn normalize_sha256(value: &str) -> Result<String> {
     if digest.len() == 64 && digest.chars().all(|ch| ch.is_ascii_hexdigit()) {
         Ok(digest)
     } else {
-        bail!("native runtime manifest contains invalid sha256: {value}");
+        // Do not echo the value: when a checksum fetch answers with the wrong
+        // body (a manifest, an error page) it would be copied into the error.
+        bail!(
+            "invalid sha256 digest: expected 64 hexadecimal characters, got {} characters",
+            digest.len()
+        );
     }
 }

--- a/crates/mesh-llm-runtime-install/src/manifest.rs
+++ b/crates/mesh-llm-runtime-install/src/manifest.rs
@@ -268,12 +268,16 @@ pub(crate) fn release_manifest_checksum_url(url: &str) -> String {
     }
 }
 
-/// Strips the query string and redacts any userinfo (`user:pass@`) from a
-/// URL before it is surfaced in error context or progress events. Mirrors
-/// `redact_url_userinfo` in `mesh-llm-host-runtime::logging::policy`; kept
-/// local because this crate does not otherwise depend on host-runtime.
+/// Strips the query string and the fragment, and redacts any userinfo
+/// (`user:pass@`) from a URL before it is surfaced in error context,
+/// progress events or catalog reports. Mirrors `redact_url_userinfo` in
+/// `mesh-llm-host-runtime::logging::policy`; kept local because this crate
+/// does not otherwise depend on host-runtime.
 pub(crate) fn url_without_query(url: &str) -> String {
-    let without_query = url.split_once('?').map_or(url, |(base, _)| base);
+    let without_fragment = url.split_once('#').map_or(url, |(base, _)| base);
+    let without_query = without_fragment
+        .split_once('?')
+        .map_or(without_fragment, |(base, _)| base);
     redact_url_userinfo(without_query)
 }
 

--- a/crates/mesh-llm-runtime-install/src/types.rs
+++ b/crates/mesh-llm-runtime-install/src/types.rs
@@ -72,6 +72,9 @@ pub struct NativeRuntimeInstallOutcome {
     pub status: NativeRuntimeInstallStatus,
     pub runtime: InstalledNativeRuntime,
     pub resolution: mesh_llm_native_runtime::NativeRuntimeResolution,
+    /// Which catalogs were consulted to reach this resolution.
+    #[serde(default)]
+    pub sources: crate::manifest::NativeRuntimeCatalogSources,
 }
 
 impl Default for NativeRuntimeManifestOptions {

--- a/scripts/check-env-mutation-contract.py
+++ b/scripts/check-env-mutation-contract.py
@@ -69,7 +69,7 @@ KNOWN_UNAUDITED_MUTATION_COUNTS = {
     "crates/mesh-llm-host-runtime/src/runtime/tests/auto_join.rs": 1,
     "crates/mesh-llm-host-runtime/src/runtime/tests/mod.rs": 2,
     "crates/mesh-llm-host-runtime/src/runtime/tests/startup_models.rs": 2,
-    "crates/mesh-llm-runtime-install/src/lib.rs": 15,
+    "crates/mesh-llm-runtime-install/src/lib.rs": 16,
     "crates/mesh-llm/src/commands/plugin_cli.rs": 3,
     "crates/model-hf/src/cache_paths.rs": 2,
 }

--- a/scripts/tests/test_env_mutation_contract.py
+++ b/scripts/tests/test_env_mutation_contract.py
@@ -28,7 +28,7 @@ class EnvironmentMutationContractTests(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, result.stderr)
         self.assertIn("35 Rust files", result.stdout)
-        self.assertIn("200 mutation sites", result.stdout)
+        self.assertIn("201 mutation sites", result.stdout)
         self.assertIn("18 contract-audited files", result.stdout)
 
     def test_unregistered_mutation_file_is_rejected_by_repository_discovery(self) -> None:

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -1121,43 +1121,51 @@
       "macro_name": "eprintln!"
     },
     {
-      "line": 147,
+      "line": 79,
       "macro_name": "eprintln!"
     },
     {
-      "line": 150,
+      "line": 81,
       "macro_name": "eprintln!"
     },
     {
-      "line": 191,
+      "line": 154,
       "macro_name": "eprintln!"
     },
     {
-      "line": 192,
+      "line": 157,
       "macro_name": "eprintln!"
     },
     {
-      "line": 194,
+      "line": 198,
       "macro_name": "eprintln!"
     },
     {
-      "line": 197,
+      "line": 199,
       "macro_name": "eprintln!"
     },
     {
-      "line": 225,
+      "line": 201,
       "macro_name": "eprintln!"
     },
     {
-      "line": 261,
+      "line": 204,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 232,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 268,
       "macro_name": "eprint!"
     },
     {
-      "line": 265,
+      "line": 272,
       "macro_name": "eprint!"
     },
     {
-      "line": 273,
+      "line": 280,
       "macro_name": "eprintln!"
     }
   ],
@@ -1167,47 +1175,43 @@
       "macro_name": "eprintln!"
     },
     {
-      "line": 96,
+      "line": 102,
       "macro_name": "eprintln!"
     },
     {
-      "line": 97,
+      "line": 105,
       "macro_name": "eprintln!"
     },
     {
-      "line": 108,
+      "line": 107,
       "macro_name": "eprintln!"
     },
     {
-      "line": 110,
+      "line": 118,
       "macro_name": "eprintln!"
     },
     {
-      "line": 119,
+      "line": 120,
       "macro_name": "eprintln!"
     },
     {
-      "line": 121,
+      "line": 129,
       "macro_name": "eprintln!"
     },
     {
-      "line": 126,
+      "line": 131,
       "macro_name": "eprintln!"
     },
     {
-      "line": 193,
+      "line": 136,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 204,
       "macro_name": "println!"
     },
     {
-      "line": 206,
-      "macro_name": "println!"
-    },
-    {
-      "line": 207,
-      "macro_name": "println!"
-    },
-    {
-      "line": 210,
+      "line": 217,
       "macro_name": "println!"
     },
     {
@@ -1215,19 +1219,15 @@
       "macro_name": "println!"
     },
     {
-      "line": 223,
+      "line": 221,
       "macro_name": "println!"
     },
     {
-      "line": 228,
+      "line": 229,
       "macro_name": "println!"
     },
     {
-      "line": 231,
-      "macro_name": "println!"
-    },
-    {
-      "line": 238,
+      "line": 234,
       "macro_name": "println!"
     },
     {
@@ -1239,83 +1239,79 @@
       "macro_name": "println!"
     },
     {
-      "line": 243,
-      "macro_name": "println!"
-    },
-    {
-      "line": 245,
-      "macro_name": "println!"
-    },
-    {
       "line": 249,
       "macro_name": "println!"
     },
     {
+      "line": 250,
+      "macro_name": "println!"
+    },
+    {
+      "line": 253,
+      "macro_name": "println!"
+    },
+    {
+      "line": 254,
+      "macro_name": "println!"
+    },
+    {
       "line": 256,
-      "macro_name": "eprintln!"
+      "macro_name": "println!"
     },
     {
       "line": 260,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 261,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 262,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 265,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 266,
-      "macro_name": "eprintln!"
+      "macro_name": "println!"
     },
     {
       "line": 267,
       "macro_name": "eprintln!"
     },
     {
-      "line": 268,
+      "line": 271,
       "macro_name": "eprintln!"
     },
     {
-      "line": 274,
-      "macro_name": "println!"
+      "line": 272,
+      "macro_name": "eprintln!"
     },
     {
-      "line": 275,
-      "macro_name": "println!"
+      "line": 273,
+      "macro_name": "eprintln!"
     },
     {
       "line": 276,
-      "macro_name": "println!"
+      "macro_name": "eprintln!"
     },
     {
       "line": 277,
-      "macro_name": "println!"
+      "macro_name": "eprintln!"
     },
     {
       "line": 278,
-      "macro_name": "println!"
+      "macro_name": "eprintln!"
     },
     {
       "line": 279,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 283,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 288,
       "macro_name": "println!"
     },
     {
-      "line": 284,
-      "macro_name": "println!"
-    },
-    {
-      "line": 287,
+      "line": 289,
       "macro_name": "println!"
     },
     {
       "line": 290,
+      "macro_name": "println!"
+    },
+    {
+      "line": 291,
       "macro_name": "println!"
     },
     {
@@ -1324,6 +1320,10 @@
     },
     {
       "line": 293,
+      "macro_name": "println!"
+    },
+    {
+      "line": 298,
       "macro_name": "println!"
     },
     {
@@ -1339,23 +1339,19 @@
       "macro_name": "println!"
     },
     {
-      "line": 309,
+      "line": 307,
       "macro_name": "println!"
     },
     {
-      "line": 313,
+      "line": 315,
       "macro_name": "println!"
     },
     {
-      "line": 316,
+      "line": 318,
       "macro_name": "println!"
     },
     {
-      "line": 317,
-      "macro_name": "println!"
-    },
-    {
-      "line": 322,
+      "line": 320,
       "macro_name": "println!"
     },
     {
@@ -1363,11 +1359,7 @@
       "macro_name": "println!"
     },
     {
-      "line": 325,
-      "macro_name": "println!"
-    },
-    {
-      "line": 329,
+      "line": 327,
       "macro_name": "println!"
     },
     {
@@ -1375,7 +1367,31 @@
       "macro_name": "println!"
     },
     {
-      "line": 332,
+      "line": 331,
+      "macro_name": "println!"
+    },
+    {
+      "line": 336,
+      "macro_name": "println!"
+    },
+    {
+      "line": 337,
+      "macro_name": "println!"
+    },
+    {
+      "line": 339,
+      "macro_name": "println!"
+    },
+    {
+      "line": 343,
+      "macro_name": "println!"
+    },
+    {
+      "line": 344,
+      "macro_name": "println!"
+    },
+    {
+      "line": 346,
       "macro_name": "println!"
     }
   ],

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -1121,19 +1121,23 @@
       "macro_name": "eprintln!"
     },
     {
-      "line": 79,
+      "line": 148,
       "macro_name": "eprintln!"
     },
     {
-      "line": 81,
+      "line": 151,
       "macro_name": "eprintln!"
     },
     {
-      "line": 154,
+      "line": 192,
       "macro_name": "eprintln!"
     },
     {
-      "line": 157,
+      "line": 193,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 195,
       "macro_name": "eprintln!"
     },
     {
@@ -1141,97 +1145,73 @@
       "macro_name": "eprintln!"
     },
     {
-      "line": 199,
+      "line": 226,
       "macro_name": "eprintln!"
     },
     {
-      "line": 201,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 204,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 232,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 268,
+      "line": 262,
       "macro_name": "eprint!"
     },
     {
-      "line": 272,
+      "line": 266,
       "macro_name": "eprint!"
     },
     {
-      "line": 280,
+      "line": 274,
       "macro_name": "eprintln!"
     }
   ],
   "crates/mesh-llm-commands/src/runtime_native/formatters.rs": [
     {
-      "line": 95,
+      "line": 89,
       "macro_name": "eprintln!"
     },
     {
-      "line": 102,
+      "line": 91,
       "macro_name": "eprintln!"
     },
     {
-      "line": 105,
+      "line": 112,
       "macro_name": "eprintln!"
     },
     {
-      "line": 107,
+      "line": 119,
       "macro_name": "eprintln!"
     },
     {
-      "line": 118,
+      "line": 122,
       "macro_name": "eprintln!"
     },
     {
-      "line": 120,
+      "line": 124,
       "macro_name": "eprintln!"
     },
     {
-      "line": 129,
+      "line": 135,
       "macro_name": "eprintln!"
     },
     {
-      "line": 131,
+      "line": 137,
       "macro_name": "eprintln!"
     },
     {
-      "line": 136,
+      "line": 146,
       "macro_name": "eprintln!"
     },
     {
-      "line": 204,
+      "line": 148,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 153,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 228,
       "macro_name": "println!"
     },
     {
-      "line": 217,
-      "macro_name": "println!"
-    },
-    {
-      "line": 218,
-      "macro_name": "println!"
-    },
-    {
-      "line": 221,
-      "macro_name": "println!"
-    },
-    {
-      "line": 229,
-      "macro_name": "println!"
-    },
-    {
-      "line": 234,
-      "macro_name": "println!"
-    },
-    {
-      "line": 239,
+      "line": 241,
       "macro_name": "println!"
     },
     {
@@ -1239,11 +1219,7 @@
       "macro_name": "println!"
     },
     {
-      "line": 249,
-      "macro_name": "println!"
-    },
-    {
-      "line": 250,
+      "line": 245,
       "macro_name": "println!"
     },
     {
@@ -1251,95 +1227,87 @@
       "macro_name": "println!"
     },
     {
-      "line": 254,
+      "line": 258,
       "macro_name": "println!"
     },
     {
-      "line": 256,
+      "line": 263,
       "macro_name": "println!"
     },
     {
-      "line": 260,
+      "line": 266,
       "macro_name": "println!"
-    },
-    {
-      "line": 267,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 271,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 272,
-      "macro_name": "eprintln!"
     },
     {
       "line": 273,
-      "macro_name": "eprintln!"
+      "macro_name": "println!"
     },
     {
-      "line": 276,
-      "macro_name": "eprintln!"
+      "line": 274,
+      "macro_name": "println!"
     },
     {
       "line": 277,
-      "macro_name": "eprintln!"
+      "macro_name": "println!"
     },
     {
       "line": 278,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 279,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 283,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 288,
       "macro_name": "println!"
     },
     {
-      "line": 289,
+      "line": 280,
       "macro_name": "println!"
     },
     {
-      "line": 290,
+      "line": 284,
       "macro_name": "println!"
     },
     {
       "line": 291,
-      "macro_name": "println!"
+      "macro_name": "eprintln!"
     },
     {
-      "line": 292,
-      "macro_name": "println!"
+      "line": 295,
+      "macro_name": "eprintln!"
     },
     {
-      "line": 293,
-      "macro_name": "println!"
+      "line": 296,
+      "macro_name": "eprintln!"
     },
     {
-      "line": 298,
-      "macro_name": "println!"
+      "line": 297,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 300,
+      "macro_name": "eprintln!"
     },
     {
       "line": 301,
-      "macro_name": "println!"
+      "macro_name": "eprintln!"
     },
     {
-      "line": 304,
-      "macro_name": "println!"
+      "line": 302,
+      "macro_name": "eprintln!"
     },
     {
-      "line": 306,
-      "macro_name": "println!"
+      "line": 303,
+      "macro_name": "eprintln!"
     },
     {
       "line": 307,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 312,
+      "macro_name": "println!"
+    },
+    {
+      "line": 313,
+      "macro_name": "println!"
+    },
+    {
+      "line": 314,
       "macro_name": "println!"
     },
     {
@@ -1347,19 +1315,23 @@
       "macro_name": "println!"
     },
     {
-      "line": 318,
+      "line": 316,
       "macro_name": "println!"
     },
     {
-      "line": 320,
+      "line": 317,
       "macro_name": "println!"
     },
     {
-      "line": 323,
+      "line": 322,
       "macro_name": "println!"
     },
     {
-      "line": 327,
+      "line": 325,
+      "macro_name": "println!"
+    },
+    {
+      "line": 328,
       "macro_name": "println!"
     },
     {
@@ -1371,19 +1343,11 @@
       "macro_name": "println!"
     },
     {
-      "line": 336,
-      "macro_name": "println!"
-    },
-    {
-      "line": 337,
-      "macro_name": "println!"
-    },
-    {
       "line": 339,
       "macro_name": "println!"
     },
     {
-      "line": 343,
+      "line": 342,
       "macro_name": "println!"
     },
     {
@@ -1391,7 +1355,43 @@
       "macro_name": "println!"
     },
     {
-      "line": 346,
+      "line": 347,
+      "macro_name": "println!"
+    },
+    {
+      "line": 351,
+      "macro_name": "println!"
+    },
+    {
+      "line": 354,
+      "macro_name": "println!"
+    },
+    {
+      "line": 355,
+      "macro_name": "println!"
+    },
+    {
+      "line": 360,
+      "macro_name": "println!"
+    },
+    {
+      "line": 361,
+      "macro_name": "println!"
+    },
+    {
+      "line": 363,
+      "macro_name": "println!"
+    },
+    {
+      "line": 367,
+      "macro_name": "println!"
+    },
+    {
+      "line": 368,
+      "macro_name": "println!"
+    },
+    {
+      "line": 370,
       "macro_name": "println!"
     }
   ],

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -1163,79 +1163,79 @@
   ],
   "crates/mesh-llm-commands/src/runtime_native/formatters.rs": [
     {
-      "line": 89,
+      "line": 90,
       "macro_name": "eprintln!"
     },
     {
-      "line": 91,
+      "line": 92,
       "macro_name": "eprintln!"
     },
     {
-      "line": 112,
+      "line": 113,
       "macro_name": "eprintln!"
     },
     {
-      "line": 119,
+      "line": 114,
       "macro_name": "eprintln!"
     },
     {
-      "line": 122,
+      "line": 121,
       "macro_name": "eprintln!"
     },
     {
-      "line": 124,
+      "line": 125,
       "macro_name": "eprintln!"
     },
     {
-      "line": 135,
+      "line": 127,
       "macro_name": "eprintln!"
     },
     {
-      "line": 137,
+      "line": 138,
       "macro_name": "eprintln!"
     },
     {
-      "line": 146,
+      "line": 140,
       "macro_name": "eprintln!"
     },
     {
-      "line": 148,
+      "line": 149,
       "macro_name": "eprintln!"
     },
     {
-      "line": 153,
+      "line": 151,
       "macro_name": "eprintln!"
     },
     {
-      "line": 228,
+      "line": 156,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 235,
       "macro_name": "println!"
     },
     {
-      "line": 241,
+      "line": 248,
       "macro_name": "println!"
     },
     {
-      "line": 242,
+      "line": 249,
       "macro_name": "println!"
     },
     {
-      "line": 245,
+      "line": 252,
       "macro_name": "println!"
     },
     {
-      "line": 253,
+      "line": 260,
       "macro_name": "println!"
     },
     {
-      "line": 258,
+      "line": 265,
       "macro_name": "println!"
     },
     {
-      "line": 263,
-      "macro_name": "println!"
-    },
-    {
-      "line": 266,
+      "line": 270,
       "macro_name": "println!"
     },
     {
@@ -1243,19 +1243,11 @@
       "macro_name": "println!"
     },
     {
-      "line": 274,
-      "macro_name": "println!"
-    },
-    {
-      "line": 277,
-      "macro_name": "println!"
-    },
-    {
-      "line": 278,
-      "macro_name": "println!"
-    },
-    {
       "line": 280,
+      "macro_name": "println!"
+    },
+    {
+      "line": 281,
       "macro_name": "println!"
     },
     {
@@ -1263,27 +1255,19 @@
       "macro_name": "println!"
     },
     {
+      "line": 285,
+      "macro_name": "println!"
+    },
+    {
+      "line": 287,
+      "macro_name": "println!"
+    },
+    {
       "line": 291,
-      "macro_name": "eprintln!"
+      "macro_name": "println!"
     },
     {
-      "line": 295,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 296,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 297,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 300,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 301,
+      "line": 298,
       "macro_name": "eprintln!"
     },
     {
@@ -1295,31 +1279,39 @@
       "macro_name": "eprintln!"
     },
     {
+      "line": 304,
+      "macro_name": "eprintln!"
+    },
+    {
       "line": 307,
       "macro_name": "eprintln!"
     },
     {
-      "line": 312,
-      "macro_name": "println!"
+      "line": 308,
+      "macro_name": "eprintln!"
     },
     {
-      "line": 313,
-      "macro_name": "println!"
+      "line": 309,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 310,
+      "macro_name": "eprintln!"
     },
     {
       "line": 314,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 319,
       "macro_name": "println!"
     },
     {
-      "line": 315,
+      "line": 320,
       "macro_name": "println!"
     },
     {
-      "line": 316,
-      "macro_name": "println!"
-    },
-    {
-      "line": 317,
+      "line": 321,
       "macro_name": "println!"
     },
     {
@@ -1327,35 +1319,39 @@
       "macro_name": "println!"
     },
     {
-      "line": 325,
+      "line": 323,
       "macro_name": "println!"
     },
     {
-      "line": 328,
+      "line": 324,
       "macro_name": "println!"
     },
     {
-      "line": 330,
+      "line": 329,
       "macro_name": "println!"
     },
     {
-      "line": 331,
+      "line": 332,
       "macro_name": "println!"
     },
     {
-      "line": 339,
+      "line": 335,
       "macro_name": "println!"
     },
     {
-      "line": 342,
+      "line": 337,
       "macro_name": "println!"
     },
     {
-      "line": 344,
+      "line": 338,
       "macro_name": "println!"
     },
     {
-      "line": 347,
+      "line": 346,
+      "macro_name": "println!"
+    },
+    {
+      "line": 349,
       "macro_name": "println!"
     },
     {
@@ -1367,11 +1363,7 @@
       "macro_name": "println!"
     },
     {
-      "line": 355,
-      "macro_name": "println!"
-    },
-    {
-      "line": 360,
+      "line": 358,
       "macro_name": "println!"
     },
     {
@@ -1379,7 +1371,7 @@
       "macro_name": "println!"
     },
     {
-      "line": 363,
+      "line": 362,
       "macro_name": "println!"
     },
     {
@@ -1392,6 +1384,18 @@
     },
     {
       "line": 370,
+      "macro_name": "println!"
+    },
+    {
+      "line": 374,
+      "macro_name": "println!"
+    },
+    {
+      "line": 375,
+      "macro_name": "println!"
+    },
+    {
+      "line": 377,
       "macro_name": "println!"
     }
   ],

--- a/website/src/docs/pages/CLI.md
+++ b/website/src/docs/pages/CLI.md
@@ -593,6 +593,18 @@ the default local-discovery behavior.
 Use `--json` for machine-readable output. Runtime selection is constrained by
 the running Mesh version, platform, backend, and Skippy ABI.
 
+With `--available`, the JSON output is an object rather than a bare array:
+`catalogs` says what was consulted (the manifest file or URL and how many
+artifacts it listed, the bundle directories and how many runtimes they added,
+and the remote error when the release catalog was unreachable and the bundles
+carried the load), and `runtimes` holds the rows. `runtime install --json`
+reports the same `catalogs` object on success. When no runtime can be
+selected, its `error` object carries a `resolution` field with the catalogs,
+the candidates that were plausible for this host and their rejection reasons,
+the number of candidates set aside, and whether the candidates could not be
+enumerated at all; `resolution` is `null` for other failures, and `context`
+keeps the cause chain in every case.
+
 #### `runtime scan-refresh`
 
 Use this to ask exactly one remote, owner-attested node to rescan its managed


### PR DESCRIPTION
Second part of #1612, on top of #1623. Native runtime resolution now says which catalogs it consulted and why a candidate was rejected.

## What changes

- `NativeRuntimeCatalogSources` counts the artifacts each source contributed and renders itself. It is public through `load_release_manifest_with_sources` and travels on `NativeRuntimeInstallOutcome`: the human output prints the catalog lines, the JSON output gains a `catalogs` object.
- An explicit selection that cannot be satisfied fails with the catalogs consulted, every candidate that matched the selection with its rejection reasons, a count of the candidates that never matched, and a reminder that the requested backend was not replaced by another one.
- `runtime list --available` prints the catalogs it consulted, and the progress messages no longer assume that a bundle means no catalog. In JSON mode the listing becomes an object with `catalogs` and `runtimes` instead of a bare array (the only in-repo consumer, `scripts/rc-release-smoke.sh`, stores that output as an audit artifact without parsing it).
- Diagnostic URLs drop their fragment as well as their query and userinfo before they reach a report.
- `CandidateRejection` implements `Display`, so the CLI listing and the install diagnostics use the same wording.
- The console print allowlist is regenerated for the new diagnostic lines, and the env-mutation census is frozen at its new count (one more `NATIVE_RUNTIME_MANIFEST_URL_ENV` test site under the existing `MANIFEST_ENV_LOCK` guard), including the repository total the contract test asserts.

## Verification

On the Windows bench: `cargo test -p mesh-llm-runtime-install --features skippy-ffi/dynamic-runtime` (41 passed), `cargo test -p mesh-llm-native-runtime` (33 passed), `cargo check -p mesh-llm --tests`, fmt and clippy clean on the touched crates, `repo-consistency no-console-print`, `check-env-mutation-contract.py` together with its unit tests (201 sites).

Refs #1612, #1511.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Runtime installation and availability results now identify the catalogs consulted, including online, offline, and bundled sources.
  - JSON output includes catalog details and structured runtime resolution information.
  - Human-readable output displays catalog descriptions and clearer installation errors with compatibility explanations.

- **Bug Fixes**
  - Native runtime manifest loading progress now appears consistently when needed.
  - Catalog URLs and checksum errors provide safer, sanitized diagnostics.

- **Documentation**
  - CLI documentation now describes the updated JSON output and resolution error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
