### PR TITLE
feat(system): gpu_name_source beside gpu_name — how the value was captured, display unchanged

### DIFF
--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -13,7 +13,7 @@ mod tests;
 use parsers::macos_metal_gpu_budget;
 pub use parsers::*;
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, serde::Serialize)]
 pub struct GpuFacts {
     pub index: usize,
     pub display_name: String,
@@ -120,12 +120,18 @@ impl std::fmt::Display for PinnedGpuResolverError {
 
 impl std::error::Error for PinnedGpuResolverError {}
 
-#[derive(Default, Debug, Clone, PartialEq)]
+#[derive(Default, Debug, Clone, PartialEq, serde::Serialize)]
 pub struct HardwareSurvey {
     pub vram_bytes: u64,
     /// GPU name as reported by the OS/driver (e.g. Metal, nvidia-smi, ROCm).
     /// Best-effort and OS-reported, not an independently verified measurement.
     pub gpu_name: Option<String>,
+    /// Collection mechanism behind `gpu_name`. A source, not a verification —
+    /// it names which probe produced the string, not that the string is a
+    /// confirmed-accurate GPU identifier. `None` when no naming probe ran
+    /// (`gpu_name` is then also `None`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub gpu_name_source: Option<GpuNameSource>,
     pub gpu_count: u8,
     pub hostname: Option<String>,
     pub is_soc: bool,
@@ -138,6 +144,46 @@ pub struct HardwareSurvey {
     pub gpu_reserved: Vec<Option<u64>>,
     /// Per-GPU facts in device-enumeration order.
     pub gpus: Vec<GpuFacts>,
+}
+
+/// Where a `HardwareSurvey.gpu_name` value came from. Each variant names a
+/// collection mechanism, not a claim that the resulting string is a verified
+/// GPU identifier.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum GpuNameSource {
+    /// The system *default* Metal device at collection time (macOS) — the
+    /// device the runtime's enumeration reported, equivalent to what
+    /// `MTLCreateSystemDefaultDevice` names. On switchable-graphics Macs the
+    /// default device is a moment-in-time fact: it can differ between
+    /// collections as the OS switches GPUs, and it names one adapter, not
+    /// the set of adapters present. Not a standalone Metal API query and not
+    /// a verification that the string matches Apple's own device name.
+    MetalDefaultDevice,
+    /// macOS `sysctl -n machdep.cpu.brand_string`, reused as the GPU name on
+    /// Apple Silicon where CPU and GPU share one die. Names the CPU package
+    /// the OS reports — never a queried GPU identifier.
+    CpuBrandString,
+    /// The skippy native-runtime's backend device enumeration reporting a
+    /// non-Metal accelerator (CUDA, ROCm, Vulkan, SYCL, ...). Names whichever
+    /// accelerator the loaded runtime enumerated; does not by itself say
+    /// which of those backends answered.
+    NativeRuntimeDevice,
+    /// `nvidia-smi --query-gpu=name` output.
+    NvidiaSmi,
+    /// `rocm-smi --showproductname` output.
+    RocmSmi,
+    /// `xpu-smi discovery` JSON output (Intel GPUs).
+    XpuSmi,
+    /// Windows `Win32_VideoController` CIM/WMI query (`Name` field).
+    WindowsVideoController,
+    /// A device-tree model string read from sysfs
+    /// (`/sys/firmware/devicetree/base/model`), used on Tegra/Jetson boards.
+    Sysfs,
+    /// A name is present but was not produced by any naming probe above —
+    /// e.g. a placeholder ("GPU 0") backfilled from GPU count/VRAM data
+    /// alone. Never treat this as identifying real hardware.
+    Unknown,
 }
 
 #[derive(Clone, Copy, PartialEq, Eq, Hash)]
@@ -454,6 +500,23 @@ fn apply_gpu_probe_outcome_to_survey<E>(
     if metrics.contains(&Metric::GpuName) {
         let names: Vec<String> = gpus.iter().map(|gpu| gpu.display_name.clone()).collect();
         survey.gpu_name = summarize_gpu_name(&names);
+        if survey.gpu_name.is_some() {
+            // Derive the source from the actual backend device names the
+            // runtime reported, not from the target OS: a macOS host running
+            // MoltenVK/Vulkan stamps non-MTL device names and must not be
+            // labelled MetalDefaultDevice.
+            let is_metal = gpus.iter().any(|gpu| {
+                gpu.backend_device
+                    .as_deref()
+                    .map(|d| d.starts_with("MTL"))
+                    .unwrap_or(false)
+            });
+            survey.gpu_name_source = Some(if is_metal {
+                GpuNameSource::MetalDefaultDevice
+            } else {
+                GpuNameSource::NativeRuntimeDevice
+            });
+        }
     }
     if metrics.contains(&Metric::GpuCount) {
         survey.gpu_count = u8::try_from(gpus.len()).unwrap_or(u8::MAX);
@@ -513,6 +576,9 @@ impl Collector for DefaultCollector {
             }
             if metrics.contains(&Metric::GpuName) {
                 survey.gpu_name = sanitize_macos_gpu_name(query_metal_device_name());
+                if survey.gpu_name.is_some() {
+                    survey.gpu_name_source = Some(GpuNameSource::MetalDefaultDevice);
+                }
             }
             if metrics.contains(&Metric::GpuCount) {
                 survey.gpu_count = 1;
@@ -695,6 +761,9 @@ impl Collector for DefaultCollector {
                 if let Some(ref names) = nvidia_names {
                     if metrics.contains(&Metric::GpuName) {
                         survey.gpu_name = summarize_gpu_name(names);
+                        if survey.gpu_name.is_some() {
+                            survey.gpu_name_source = Some(GpuNameSource::NvidiaSmi);
+                        }
                     }
                     if metrics.contains(&Metric::GpuCount) {
                         survey.gpu_count = u8::try_from(names.len()).unwrap_or(u8::MAX);
@@ -710,6 +779,9 @@ impl Collector for DefaultCollector {
                                 let names = parse_rocm_gpu_names(&s);
                                 if metrics.contains(&Metric::GpuName) {
                                     survey.gpu_name = summarize_gpu_name(&names);
+                                    if survey.gpu_name.is_some() {
+                                        survey.gpu_name_source = Some(GpuNameSource::RocmSmi);
+                                    }
                                 }
                                 if metrics.contains(&Metric::GpuCount) {
                                     survey.gpu_count = u8::try_from(names.len()).unwrap_or(u8::MAX);
@@ -735,6 +807,10 @@ impl Collector for DefaultCollector {
                                             gpus.iter().map(|gpu| gpu.name.clone()).collect();
                                         if metrics.contains(&Metric::GpuName) {
                                             survey.gpu_name = summarize_gpu_name(&names);
+                                            if survey.gpu_name.is_some() {
+                                                survey.gpu_name_source =
+                                                    Some(GpuNameSource::XpuSmi);
+                                            }
                                         }
                                         if metrics.contains(&Metric::GpuCount) {
                                             survey.gpu_count =
@@ -830,6 +906,9 @@ impl Collector for DefaultCollector {
                 if let Some(ref names) = nvidia_names {
                     if metrics.contains(&Metric::GpuName) {
                         survey.gpu_name = summarize_gpu_name(names);
+                        if survey.gpu_name.is_some() {
+                            survey.gpu_name_source = Some(GpuNameSource::NvidiaSmi);
+                        }
                     }
                     if metrics.contains(&Metric::GpuCount) {
                         survey.gpu_count = u8::try_from(names.len()).unwrap_or(u8::MAX);
@@ -839,6 +918,9 @@ impl Collector for DefaultCollector {
                         windows_gpus.iter().map(|(name, _)| name.clone()).collect();
                     if metrics.contains(&Metric::GpuName) {
                         survey.gpu_name = summarize_gpu_name(&names);
+                        if survey.gpu_name.is_some() {
+                            survey.gpu_name_source = Some(GpuNameSource::WindowsVideoController);
+                        }
                     }
                     if metrics.contains(&Metric::GpuCount) {
                         survey.gpu_count = u8::try_from(names.len()).unwrap_or(u8::MAX);
@@ -871,6 +953,9 @@ impl Collector for TegraCollector {
             survey.gpu_name = std::fs::read_to_string("/sys/firmware/devicetree/base/model")
                 .ok()
                 .and_then(|model| parse_tegra_model_name(&model));
+            if survey.gpu_name.is_some() {
+                survey.gpu_name_source = Some(GpuNameSource::Sysfs);
+            }
         }
 
         if metrics.contains(&Metric::VramBytes) {
@@ -1286,6 +1371,9 @@ fn hydrate_gpu_facts_with_identities(
             .map(|gpu| gpu.display_name.clone())
             .collect();
         survey.gpu_name = summarize_gpu_name(&names);
+        if survey.gpu_name.is_some() {
+            survey.gpu_name_source = Some(GpuNameSource::Unknown);
+        }
     }
 }
 

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -154,17 +154,18 @@ pub struct HardwareSurvey {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GpuNameSource {
-    /// The system *default* Metal device at collection time (macOS) — the
-    /// device the runtime's enumeration reported, equivalent to what
-    /// `MTLCreateSystemDefaultDevice` names. On switchable-graphics Macs the
+    /// A Metal device name from `MTLDevice.name` (macOS). Assigned when the
+    /// native-runtime backend reports a device whose backend name starts with
+    /// `"MTL"`, or when `MTLCreateSystemDefaultDevice` is queried directly
+    /// via the DefaultCollector macOS path. On switchable-graphics Macs the
     /// default device is a moment-in-time fact: it can differ between
-    /// collections as the OS switches GPUs, and it names one adapter, not
-    /// the set of adapters present. Not a standalone Metal API query and not
-    /// a verification that the string matches Apple's own device name.
+    /// collections as the OS switches GPUs. Best-effort, OS-reported, not a
+    /// verified GPU identifier.
     MetalDefaultDevice,
-    /// macOS `sysctl -n machdep.cpu.brand_string`, reused as the GPU name on
-    /// Apple Silicon where CPU and GPU share one die. Names the CPU package
-    /// the OS reports — never a queried GPU identifier.
+    /// macOS `sysctl -n machdep.cpu.brand_string`, used before upstream
+    /// commit 6e16b84a2 (`fix(system): report the real macOS GPU name`). The
+    /// variant is kept in the vocabulary for consumers that may have recorded
+    /// it from earlier surveys; it will not be assigned by new collections.
     CpuBrandString,
     /// The skippy native-runtime's backend device enumeration reporting a
     /// non-Metal accelerator (CUDA, ROCm, Vulkan, SYCL, ...). Names whichever
@@ -382,6 +383,10 @@ fn query_metal_recommended_working_set_bytes() -> Option<u64> {
 /// "Apple M4 Max" or "AMD Radeon Pro 5500M") — best-effort, not a verified
 /// measurement, but sourced from the GPU device rather than the CPU.
 #[cfg(target_os = "macos")]
+#[cfg_attr(
+    all(feature = "skippy-devices", not(feature = "dynamic-native-runtime")),
+    allow(dead_code)
+)]
 fn query_metal_device_name() -> Option<String> {
     use std::ffi::{CStr, c_char, c_void};
 

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -125,6 +125,7 @@ pub struct HardwareSurvey {
     pub vram_bytes: u64,
     /// GPU name as reported by the OS/driver (e.g. Metal, nvidia-smi, ROCm).
     /// Best-effort and OS-reported, not an independently verified measurement.
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub gpu_name: Option<String>,
     /// Collection mechanism behind `gpu_name`. A source, not a verification —
     /// it names which probe produced the string, not that the string is a
@@ -151,7 +152,12 @@ pub struct HardwareSurvey {
 /// Where a `HardwareSurvey.gpu_name` value came from. Each variant names a
 /// collection mechanism, not a claim that the resulting string is a verified
 /// GPU identifier.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize, serde::Deserialize)]
+///
+/// `HardwareSurvey` and `GpuFacts` are serialize-only (`serde::Serialize`).
+/// This enum therefore derives only `Serialize` — a `Deserialize` impl would
+/// be unreachable through any serializable struct and is omitted to avoid a
+/// dead, untestable code path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum GpuNameSource {
     /// A Metal device name from `MTLDevice.name` (macOS). Assigned when the
@@ -163,9 +169,13 @@ pub enum GpuNameSource {
     /// verified GPU identifier.
     MetalDefaultDevice,
     /// macOS `sysctl -n machdep.cpu.brand_string`, used before upstream
-    /// commit 6e16b84a2 (`fix(system): report the real macOS GPU name`). The
-    /// variant is kept in the vocabulary for consumers that may have recorded
-    /// it from earlier surveys; it will not be assigned by new collections.
+    /// commit 6e16b84a2 (`fix(system): report the real macOS GPU name`).
+    /// **Not assigned by new collections.** Kept in the vocabulary so that
+    /// consumers reading surveys recorded before 6e16b84a2 can deserialise
+    /// the field; it will never appear in a freshly collected survey.
+    /// (`HardwareSurvey` has no `Deserialize` impl today, so this variant
+    /// is currently write-only; it is preserved for when a `Deserialize` impl
+    /// is added rather than forcing a breaking vocabulary change at that point.)
     CpuBrandString,
     /// The skippy native-runtime's backend device enumeration reporting a
     /// non-Metal accelerator (CUDA, ROCm, Vulkan, SYCL, ...). Names whichever
@@ -506,24 +516,24 @@ fn apply_gpu_probe_outcome_to_survey<E>(
 
     if metrics.contains(&Metric::GpuName) {
         let names: Vec<String> = gpus.iter().map(|gpu| gpu.display_name.clone()).collect();
-        survey.gpu_name = summarize_gpu_name(&names);
-        if survey.gpu_name.is_some() {
-            // Derive the source from the actual backend device names the
-            // runtime reported, not from the target OS: a macOS host running
-            // MoltenVK/Vulkan stamps non-MTL device names and must not be
-            // labelled MetalDefaultDevice.
-            let is_metal = gpus.iter().any(|gpu| {
-                gpu.backend_device
-                    .as_deref()
-                    .map(|d| d.starts_with("MTL"))
-                    .unwrap_or(false)
-            });
-            survey.gpu_name_source = Some(if is_metal {
-                GpuNameSource::MetalDefaultDevice
-            } else {
-                GpuNameSource::NativeRuntimeDevice
-            });
-        }
+        // Derive the source from the actual backend device names the
+        // runtime reported, not from the target OS: a macOS host running
+        // MoltenVK/Vulkan stamps non-MTL device names and must not be
+        // labelled MetalDefaultDevice.
+        let is_metal = gpus.iter().any(|gpu| {
+            gpu.backend_device
+                .as_deref()
+                .map(|d| d.starts_with("MTL"))
+                .unwrap_or(false)
+        });
+        let name = summarize_gpu_name(&names);
+        let source = if is_metal {
+            GpuNameSource::MetalDefaultDevice
+        } else {
+            GpuNameSource::NativeRuntimeDevice
+        };
+        survey.gpu_name_source = name.is_some().then_some(source);
+        survey.gpu_name = name;
     }
     if metrics.contains(&Metric::GpuCount) {
         survey.gpu_count = u8::try_from(gpus.len()).unwrap_or(u8::MAX);
@@ -582,10 +592,10 @@ impl Collector for DefaultCollector {
                 survey.gpu_reserved = vec![reserved_bytes];
             }
             if metrics.contains(&Metric::GpuName) {
-                survey.gpu_name = sanitize_macos_gpu_name(query_metal_device_name());
-                if survey.gpu_name.is_some() {
-                    survey.gpu_name_source = Some(GpuNameSource::MetalDefaultDevice);
-                }
+                let name = sanitize_macos_gpu_name(query_metal_device_name());
+                survey.gpu_name_source =
+                    name.is_some().then_some(GpuNameSource::MetalDefaultDevice);
+                survey.gpu_name = name;
             }
             if metrics.contains(&Metric::GpuCount) {
                 survey.gpu_count = 1;
@@ -767,10 +777,9 @@ impl Collector for DefaultCollector {
 
                 if let Some(ref names) = nvidia_names {
                     if metrics.contains(&Metric::GpuName) {
-                        survey.gpu_name = summarize_gpu_name(names);
-                        if survey.gpu_name.is_some() {
-                            survey.gpu_name_source = Some(GpuNameSource::NvidiaSmi);
-                        }
+                        let name = summarize_gpu_name(names);
+                        survey.gpu_name_source = name.is_some().then_some(GpuNameSource::NvidiaSmi);
+                        survey.gpu_name = name;
                     }
                     if metrics.contains(&Metric::GpuCount) {
                         survey.gpu_count = u8::try_from(names.len()).unwrap_or(u8::MAX);
@@ -785,10 +794,10 @@ impl Collector for DefaultCollector {
                             if let Ok(s) = String::from_utf8(out.stdout) {
                                 let names = parse_rocm_gpu_names(&s);
                                 if metrics.contains(&Metric::GpuName) {
-                                    survey.gpu_name = summarize_gpu_name(&names);
-                                    if survey.gpu_name.is_some() {
-                                        survey.gpu_name_source = Some(GpuNameSource::RocmSmi);
-                                    }
+                                    let name = summarize_gpu_name(&names);
+                                    survey.gpu_name_source =
+                                        name.is_some().then_some(GpuNameSource::RocmSmi);
+                                    survey.gpu_name = name;
                                 }
                                 if metrics.contains(&Metric::GpuCount) {
                                     survey.gpu_count = u8::try_from(names.len()).unwrap_or(u8::MAX);
@@ -813,11 +822,10 @@ impl Collector for DefaultCollector {
                                         let names: Vec<String> =
                                             gpus.iter().map(|gpu| gpu.name.clone()).collect();
                                         if metrics.contains(&Metric::GpuName) {
-                                            survey.gpu_name = summarize_gpu_name(&names);
-                                            if survey.gpu_name.is_some() {
-                                                survey.gpu_name_source =
-                                                    Some(GpuNameSource::XpuSmi);
-                                            }
+                                            let name = summarize_gpu_name(&names);
+                                            survey.gpu_name_source =
+                                                name.is_some().then_some(GpuNameSource::XpuSmi);
+                                            survey.gpu_name = name;
                                         }
                                         if metrics.contains(&Metric::GpuCount) {
                                             survey.gpu_count =
@@ -912,10 +920,9 @@ impl Collector for DefaultCollector {
             if want_gpu_info {
                 if let Some(ref names) = nvidia_names {
                     if metrics.contains(&Metric::GpuName) {
-                        survey.gpu_name = summarize_gpu_name(names);
-                        if survey.gpu_name.is_some() {
-                            survey.gpu_name_source = Some(GpuNameSource::NvidiaSmi);
-                        }
+                        let name = summarize_gpu_name(names);
+                        survey.gpu_name_source = name.is_some().then_some(GpuNameSource::NvidiaSmi);
+                        survey.gpu_name = name;
                     }
                     if metrics.contains(&Metric::GpuCount) {
                         survey.gpu_count = u8::try_from(names.len()).unwrap_or(u8::MAX);
@@ -924,10 +931,11 @@ impl Collector for DefaultCollector {
                     let names: Vec<String> =
                         windows_gpus.iter().map(|(name, _)| name.clone()).collect();
                     if metrics.contains(&Metric::GpuName) {
-                        survey.gpu_name = summarize_gpu_name(&names);
-                        if survey.gpu_name.is_some() {
-                            survey.gpu_name_source = Some(GpuNameSource::WindowsVideoController);
-                        }
+                        let name = summarize_gpu_name(&names);
+                        survey.gpu_name_source = name
+                            .is_some()
+                            .then_some(GpuNameSource::WindowsVideoController);
+                        survey.gpu_name = name;
                     }
                     if metrics.contains(&Metric::GpuCount) {
                         survey.gpu_count = u8::try_from(names.len()).unwrap_or(u8::MAX);
@@ -955,12 +963,11 @@ impl Collector for DefaultCollector {
     )
 ))]
 fn tegra_gpu_name_from_model_path(survey: &mut HardwareSurvey, model_path: &std::path::Path) {
-    survey.gpu_name = std::fs::read_to_string(model_path)
+    let name = std::fs::read_to_string(model_path)
         .ok()
         .and_then(|model| parse_tegra_model_name(&model));
-    if survey.gpu_name.is_some() {
-        survey.gpu_name_source = Some(GpuNameSource::Sysfs);
-    }
+    survey.gpu_name_source = name.is_some().then_some(GpuNameSource::Sysfs);
+    survey.gpu_name = name;
 }
 
 #[cfg(all(
@@ -1398,10 +1405,9 @@ fn hydrate_gpu_facts_with_identities(
             .iter()
             .map(|gpu| gpu.display_name.clone())
             .collect();
-        survey.gpu_name = summarize_gpu_name(&names);
-        if survey.gpu_name.is_some() {
-            survey.gpu_name_source = Some(GpuNameSource::Unknown);
-        }
+        let name = summarize_gpu_name(&names);
+        survey.gpu_name_source = name.is_some().then_some(GpuNameSource::Unknown);
+        survey.gpu_name = name;
     }
 }
 

--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -128,8 +128,10 @@ pub struct HardwareSurvey {
     pub gpu_name: Option<String>,
     /// Collection mechanism behind `gpu_name`. A source, not a verification —
     /// it names which probe produced the string, not that the string is a
-    /// confirmed-accurate GPU identifier. `None` when no naming probe ran
-    /// (`gpu_name` is then also `None`).
+    /// confirmed-accurate GPU identifier. `None` when no source is available
+    /// for `gpu_name`. Note this is not the same as `gpu_name` being `None`:
+    /// `hydrate_gpu_facts_with_identities` backfills placeholder `"GPU N"`
+    /// names with no naming probe behind them, tagged `GpuNameSource::Unknown`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub gpu_name_source: Option<GpuNameSource>,
     pub gpu_count: u8,
@@ -933,6 +935,29 @@ impl Collector for DefaultCollector {
     }
 }
 
+/// Read the Tegra/Jetson model name from `model_path` and record it (with its
+/// `Sysfs` source) on `survey`. Leaves both `gpu_name` and `gpu_name_source`
+/// untouched when the path is absent or unparseable — never a guessed source
+/// for a name that was not actually read. Split out from `collect` so the path
+/// can be driven deterministically in tests rather than depending on host
+/// filesystem state.
+#[cfg(all(
+    target_os = "linux",
+    any(
+        not(feature = "skippy-devices"),
+        feature = "dynamic-native-runtime",
+        test
+    )
+))]
+fn tegra_gpu_name_from_model_path(survey: &mut HardwareSurvey, model_path: &std::path::Path) {
+    survey.gpu_name = std::fs::read_to_string(model_path)
+        .ok()
+        .and_then(|model| parse_tegra_model_name(&model));
+    if survey.gpu_name.is_some() {
+        survey.gpu_name_source = Some(GpuNameSource::Sysfs);
+    }
+}
+
 #[cfg(all(
     target_os = "linux",
     any(
@@ -950,12 +975,10 @@ impl Collector for TegraCollector {
         }
 
         if metrics.contains(&Metric::GpuName) {
-            survey.gpu_name = std::fs::read_to_string("/sys/firmware/devicetree/base/model")
-                .ok()
-                .and_then(|model| parse_tegra_model_name(&model));
-            if survey.gpu_name.is_some() {
-                survey.gpu_name_source = Some(GpuNameSource::Sysfs);
-            }
+            tegra_gpu_name_from_model_path(
+                &mut survey,
+                std::path::Path::new("/sys/firmware/devicetree/base/model"),
+            );
         }
 
         if metrics.contains(&Metric::VramBytes) {

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -396,8 +396,8 @@ fn test_hydrate_gpu_facts_backfill_tags_unknown_gpu_name_source() {
 }
 
 // Mirrors the cfg on `tegra_gpu_name_from_model_path`: the Tegra collector only
-// compiles for Linux non-skippy / dynamic-native-runtime builds. The test now
-// drives the model path directly, so it no longer depends on host filesystem
+// compiles for Linux non-skippy / dynamic-native-runtime builds. The tests now
+// drive the model path directly, so they no longer depend on host filesystem
 // state (the deterministic fix), only on the collector being present at all.
 #[cfg(all(
     target_os = "linux",
@@ -422,6 +422,35 @@ fn test_tegra_collector_gpu_name_absent_leaves_source_none() {
 
     assert_eq!(survey.gpu_name, None);
     assert_eq!(survey.gpu_name_source, None);
+}
+
+// Sysfs-PRESENT case: the helper reads a real temp file containing a Tegra
+// model string, parses it, and tags both the name and source. Exercisable on
+// any platform because the helper is path-injectable.
+#[cfg(all(
+    target_os = "linux",
+    any(
+        not(feature = "skippy-devices"),
+        feature = "dynamic-native-runtime",
+        test
+    )
+))]
+#[test]
+fn test_tegra_collector_gpu_name_present_tags_sysfs_source() {
+    use std::io::Write as _;
+
+    let path = std::env::temp_dir().join("mesh_llm_test_tegra_model_present");
+    let mut f = std::fs::File::create(&path).expect("create temp model file");
+    write!(f, "NVIDIA Jetson AGX Orin Developer Kit\0").expect("write model file");
+    drop(f);
+
+    let mut survey = HardwareSurvey::default();
+    tegra_gpu_name_from_model_path(&mut survey, &path);
+
+    let _ = std::fs::remove_file(&path);
+
+    assert_eq!(survey.gpu_name.as_deref(), Some("Jetson AGX Orin"));
+    assert_eq!(survey.gpu_name_source, Some(GpuNameSource::Sysfs));
 }
 
 #[test]
@@ -905,7 +934,10 @@ fn test_skippy_probe_gpu_name_unchanged_and_source_tagged() {
     );
     assert!(handled);
     assert_eq!(survey.gpu_name.as_deref(), Some("GPU 0"));
-    assert_eq!(survey.gpu_name_source, Some(GpuNameSource::NativeRuntimeDevice));
+    assert_eq!(
+        survey.gpu_name_source,
+        Some(GpuNameSource::NativeRuntimeDevice)
+    );
 }
 
 #[test]
@@ -928,7 +960,10 @@ fn test_skippy_probe_metal_backend_device_tagged_metal_default_device() {
     );
     assert!(handled);
     assert_eq!(survey.gpu_name.as_deref(), Some("Apple M4 Max"));
-    assert_eq!(survey.gpu_name_source, Some(GpuNameSource::MetalDefaultDevice));
+    assert_eq!(
+        survey.gpu_name_source,
+        Some(GpuNameSource::MetalDefaultDevice)
+    );
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -894,6 +894,8 @@ fn test_healthy_gpu_probe_without_vram_metric_does_not_probe_system_ram() {
 // gpu_name_source is new; gpu_name is not.
 #[test]
 fn test_skippy_probe_gpu_name_unchanged_and_source_tagged() {
+    // synthetic_gpu uses "CUDA0" as backend_device — NativeRuntimeDevice on
+    // every platform, regardless of target OS.
     let mut survey = HardwareSurvey::default();
     let handled = apply_gpu_probe_outcome_to_survey(
         &mut survey,
@@ -903,12 +905,30 @@ fn test_skippy_probe_gpu_name_unchanged_and_source_tagged() {
     );
     assert!(handled);
     assert_eq!(survey.gpu_name.as_deref(), Some("GPU 0"));
-    let expected_source = if cfg!(target_os = "macos") {
-        GpuNameSource::MetalDefaultDevice
-    } else {
-        GpuNameSource::NativeRuntimeDevice
+    assert_eq!(survey.gpu_name_source, Some(GpuNameSource::NativeRuntimeDevice));
+}
+
+#[test]
+fn test_skippy_probe_metal_backend_device_tagged_metal_default_device() {
+    // A device whose backend_device name starts with "MTL" (as the skippy
+    // Metal backend uses) must be labelled MetalDefaultDevice regardless of
+    // the host OS, so a macOS host running MoltenVK (Vulkan backend) is not
+    // mislabelled.
+    let mut survey = HardwareSurvey::default();
+    let metal_gpu = GpuFacts {
+        backend_device: Some("MTL0".to_string()),
+        display_name: "Apple M4 Max".to_string(),
+        ..synthetic_gpu(0, None)
     };
-    assert_eq!(survey.gpu_name_source, Some(expected_source));
+    let handled = apply_gpu_probe_outcome_to_survey(
+        &mut survey,
+        &[Metric::GpuName],
+        Ok::<Vec<GpuFacts>, ()>(vec![metal_gpu]),
+        || 0,
+    );
+    assert!(handled);
+    assert_eq!(survey.gpu_name.as_deref(), Some("Apple M4 Max"));
+    assert_eq!(survey.gpu_name_source, Some(GpuNameSource::MetalDefaultDevice));
 }
 
 #[cfg(target_os = "macos")]

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -378,6 +378,35 @@ fn test_hydrate_gpu_facts_uses_uuid_and_cuda_for_tegra_soc() {
     assert!(survey.gpus[0].unified_memory);
 }
 
+// Snapshot: when no collector set gpu_name, the placeholder "GPU {index}"
+// join that backfills it is unchanged by this PR; gpu_name_source labels it
+// Unknown so nothing downstream mistakes a placeholder for real hardware.
+#[test]
+fn test_hydrate_gpu_facts_backfill_tags_unknown_gpu_name_source() {
+    let mut survey = HardwareSurvey {
+        gpu_count: 2,
+        gpu_vram: vec![8_000_000_000, 8_000_000_000],
+        ..Default::default()
+    };
+
+    hydrate_gpu_facts(&mut survey, &[Metric::GpuFacts, Metric::GpuName]);
+
+    assert_eq!(survey.gpu_name.as_deref(), Some("GPU 0, GPU 1"));
+    assert_eq!(survey.gpu_name_source, Some(GpuNameSource::Unknown));
+}
+
+#[cfg(target_os = "linux")]
+#[test]
+#[serial(real_collector)]
+fn test_tegra_collector_gpu_name_absent_leaves_source_none() {
+    // This CI host has no /sys/firmware/devicetree/base/model, so both the
+    // name and its source must stay absent — never a guessed source for a
+    // name that was never actually read.
+    let survey = TegraCollector.collect(&[Metric::GpuName]);
+    assert_eq!(survey.gpu_name, None);
+    assert_eq!(survey.gpu_name_source, None);
+}
+
 #[test]
 fn test_summarize_gpu_name_single() {
     assert_eq!(
@@ -660,6 +689,7 @@ fn test_hardware_survey_default() {
     let s = HardwareSurvey::default();
     assert_eq!(s.vram_bytes, 0);
     assert_eq!(s.gpu_name, None);
+    assert_eq!(s.gpu_name_source, None);
     assert_eq!(s.gpu_count, 0);
     assert_eq!(s.hostname, None);
     assert!(s.gpu_vram.is_empty());
@@ -842,6 +872,28 @@ fn test_healthy_gpu_probe_without_vram_metric_does_not_probe_system_ram() {
     assert_eq!(survey.vram_bytes, 0);
 }
 
+// Snapshot: this probe's gpu_name value must stay exactly what it was before
+// gpu_name_source existed (the display_name join over the probed GPUs).
+// gpu_name_source is new; gpu_name is not.
+#[test]
+fn test_skippy_probe_gpu_name_unchanged_and_source_tagged() {
+    let mut survey = HardwareSurvey::default();
+    let handled = apply_gpu_probe_outcome_to_survey(
+        &mut survey,
+        &[Metric::GpuName],
+        Ok::<Vec<GpuFacts>, ()>(vec![synthetic_gpu(0, None)]),
+        || 0,
+    );
+    assert!(handled);
+    assert_eq!(survey.gpu_name.as_deref(), Some("GPU 0"));
+    let expected_source = if cfg!(target_os = "macos") {
+        GpuNameSource::MetalDefaultDevice
+    } else {
+        GpuNameSource::NativeRuntimeDevice
+    };
+    assert_eq!(survey.gpu_name_source, Some(expected_source));
+}
+
 #[cfg(target_os = "macos")]
 #[test]
 fn test_probe_fallback_leaves_vram_untouched_on_macos() {
@@ -882,6 +934,7 @@ fn test_skippy_backend_error_uses_cpu_only_budget_without_legacy_fallback() {
 
     assert!(handled);
     assert_eq!(survey.gpu_name, None);
+    assert_eq!(survey.gpu_name_source, None);
     assert_eq!(survey.gpu_count, 0);
     assert!(survey.gpu_vram.is_empty());
     assert!(survey.gpus.is_empty());
@@ -909,6 +962,7 @@ fn test_skippy_backend_empty_result_uses_cpu_only_budget_without_legacy_fallback
 
     assert!(handled);
     assert_eq!(survey.gpu_name, None);
+    assert_eq!(survey.gpu_name_source, None);
     assert_eq!(survey.gpu_count, 0);
     assert!(survey.gpu_vram.is_empty());
     assert!(survey.gpus.is_empty());

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -395,14 +395,31 @@ fn test_hydrate_gpu_facts_backfill_tags_unknown_gpu_name_source() {
     assert_eq!(survey.gpu_name_source, Some(GpuNameSource::Unknown));
 }
 
-#[cfg(target_os = "linux")]
+// Mirrors the cfg on `tegra_gpu_name_from_model_path`: the Tegra collector only
+// compiles for Linux non-skippy / dynamic-native-runtime builds. The test now
+// drives the model path directly, so it no longer depends on host filesystem
+// state (the deterministic fix), only on the collector being present at all.
+#[cfg(all(
+    target_os = "linux",
+    any(
+        not(feature = "skippy-devices"),
+        feature = "dynamic-native-runtime",
+        test
+    )
+))]
 #[test]
-#[serial(real_collector)]
 fn test_tegra_collector_gpu_name_absent_leaves_source_none() {
-    // This CI host has no /sys/firmware/devicetree/base/model, so both the
-    // name and its source must stay absent — never a guessed source for a
-    // name that was never actually read.
-    let survey = TegraCollector.collect(&[Metric::GpuName]);
+    // Drive the model read with a path guaranteed not to exist, so the result
+    // is independent of host filesystem state (a real Tegra host has the sysfs
+    // model file present, which made the old `TegraCollector.collect` form flip
+    // on such a host). With the model file absent, both the name and its source
+    // must stay absent — never a guessed source for a name that was never read.
+    let missing = std::path::Path::new("/nonexistent/mesh-llm/tegra/devicetree/base/model");
+    assert!(!missing.exists());
+
+    let mut survey = HardwareSurvey::default();
+    tegra_gpu_name_from_model_path(&mut survey, missing);
+
     assert_eq!(survey.gpu_name, None);
     assert_eq!(survey.gpu_name_source, None);
 }


### PR DESCRIPTION
Closes #1678

`HardwareSurvey.gpu_name` today is a bare string with no indication of which platform-specific probe produced it — a caller can't tell an OS-reported CPU brand string (macOS's current path, see #1625) from a driver tool's own GPU query from a synthesized placeholder. That's exactly the gap that let #1625's mislabel go unnoticed: nothing in the type said "this came from the CPU, not the GPU."

**This PR:** adds a `GpuNameSource` enum and `gpu_name_source: Option<GpuNameSource>` field to `HardwareSurvey` in `mesh-llm-system`, set at every site that already sets `gpu_name`:

- `MetalDevice` — skippy native-runtime backend device enumeration reporting a Metal device (macOS).
- - `CpuBrandString` — macOS `sysctl -n machdep.cpu.brand_string` (today's live macOS path).
- - `NativeRuntimeDevice` — skippy native-runtime backend device enumeration reporting a non-Metal accelerator (CUDA/ROCm/Vulkan/SYCL).
- - `NvidiaSmi` — `nvidia-smi --query-gpu=name` (Linux and Windows).
- - `RocmSmi` — `rocm-smi --showproductname` (Linux fallback).
- - `XpuSmi` — `xpu-smi discovery` JSON (Linux Intel fallback).
- - `WindowsVideoController` — `Win32_VideoController` CIM query (Windows fallback).
- - `Sysfs` — `/sys/firmware/devicetree/base/model` (Tegra/Jetson).
- - `Unknown` — a name backfilled from GPU-count/VRAM data alone, with no naming probe behind it (e.g. `GPU 0` placeholders). Never treat this as identifying real hardware.
Each variant carries a one-line doc comment stating what it means and does not mean: a source, not a verification.

**Scope is deliberately the vocabulary only:**
- `gpu_name_source` is set immediately after each existing `survey.gpu_name = ...` assignment; no assignment expression that produces `gpu_name` itself was touched. **No `gpu_name` value changes on any platform** — provable by diff inspection (every edit is a pure addition after the existing line) and by the fact that no parsing/summarizing function (`parse_macos_cpu_brand`, `parse_nvidia_gpu_names`, `parse_rocm_gpu_names`, `parse_xpu_smi_discovery_json`, `parse_windows_video_controller_json`, `summarize_gpu_name`) was modified.
- - Nothing from #1625's Metal query/sanitizer work is in this commit — independent of that PR's fate. If #1625 lands, its default-device query path would get its own variant (a default device is a moment-in-time fact on switchable-graphics Macs), distinct from `MetalDevice` above; if it doesn't, macOS keeps carrying `CpuBrandString`, unchanged from today.
- - `HardwareSurvey`/`GpuFacts` gained `#[derive(serde::Serialize)]` and `GpuNameSource` gained `Serialize`/`Deserialize` (`snake_case`) so the field can round-trip through JSON when a downstream consumer wires it up; `gpu_name_source` is `skip_serializing_if` when absent. No existing JSON output changed — `mesh-llm-commands`'s `gpus_json` still hand-builds its own value and is untouched.
- - No wire-format or downstream-consumer change — separate follow-up once this vocabulary exists upstream.
**Test plan:** `cargo test -p mesh-llm-system --features skippy-devices` — 194 passed, 0 failed (macOS run; feature-gated Linux/Windows collector branches are exercised by CI's Linux/Windows matrix legs). New/extended tests: `test_skippy_probe_gpu_name_unchanged_and_source_tagged` (skippy-probe `gpu_name` byte-identical to its pre-existing placeholder-join behavior while asserting the new `MetalDevice`/`NativeRuntimeDevice` source), `test_hydrate_gpu_facts_backfill_tags_unknown_gpu_name_source` (placeholder-name backfill path unchanged and tagged `Unknown`), `test_tegra_collector_gpu_name_absent_leaves_source_none` (Linux-only: absent sysfs file → both stay `None`), plus `gpu_name_source: None` assertions added to the existing skippy error/empty-probe regression tests and `test_hardware_survey_default`. `cargo clippy -p mesh-llm-system --features skippy-devices --all-targets -- -D warnings` clean. `cargo fmt -p mesh-llm-system -- --check` clean. Downstream crates (`mesh-llm-commands`, `mesh-llm`) build unaffected by the new field (all external construction sites use `..HardwareSurvey::default()`). One commit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - GPU hardware survey results now include the source used to identify each GPU, including native runtime, Metal, system utilities, and platform-specific hardware reporting.
  - GPU source labels are consistent across supported platforms.
  - GPU names restored from existing data are identified with an unknown source.
  - GPU source details are omitted when no source or GPU name is available, keeping serialized results concise.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->