### PR TITLE
task: Share release UI assets and use CPU images for composition

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -150,7 +150,7 @@ it after the protected-main runner-contract update is active.
 | `ci-windows-lane.yml` | Windows host/runtime/product/platform graph with one platform-local UI producer |
 | `ci-quality-slice.yml` | Contracts, format, Clippy and generated CLI inventory freshness; additive protected authority sentinel |
 | `ci-web-slice.yml` | Console quality, console Playwright E2E, public website build, and CLI explorer browser validation |
-| `ci-ui-artifact-slice.yml` | Immutable console distribution producer |
+| `ci-ui-artifact-slice.yml` | Immutable console distribution producer; release callers prepare one source/version-bound UI with complete file checksums, shared by all hosts and SDK resources |
 | `static-abi-artifact.yml` | Typed static llama ABI producer with internal runner policy and an exact toolchain-epoch output |
 | `ci-rust-tests-slice.yml` | Typed deterministic Cargo test batches that verify the producer-owned static ABI toolchain epoch and a pinned, digest-verified Skippy correctness fixture; related PR changes additionally compile one asserted, fully qualified runtime test and smoke an immutable SmolLM2 SafeTensors checkpoint through the complete Mesh config/resolver/server/native path to sampled prefill and decode with every supported load-time quantization |
 | `ci-{linux,macos,windows}-host-slice.yml` | Platform-pure neutral host producers; no empty cross-platform jobs |
@@ -206,7 +206,8 @@ Reusable slices/workflows with a `container:` job, and what backs it:
 | `website-pages.yml` | `build` | `public web` |
 | `nightly-stability-run.yml` | `stability` | `public web` (bakes node/pnpm the CLI-smoke step needs) |
 | `nightly-kv-coverage.yml` | `ownership-state-machines` | `public cpu`, sha256:8d93de6b... |
-| `release.yml` (several CUDA/ROCm/Vulkan build/compose rows) | per-backend `public` digests | pre-existing, unrelated to this containerization work; each row pins its own backend digest via `ci/slices.yml` / job matrix, not a shared convention |
+| `release.yml` (CUDA/ROCm/Vulkan compiler rows) | per-backend `public` digests | Native compiler/toolkit images remain backend-specific; amd64 CUDA preserves its intentional ARC self-hosted placement |
+| `release.yml` (Linux CUDA/ROCm/Vulkan composition rows) | `public cpu`, sha256:8d93de6b... | Verify, compose, readiness-test and archive exact producer bytes without downloading a compiler toolkit |
 
 `public cpu` and `public web` are separate image builds (the latter adds
 `PLAYWRIGHT_BROWSERS_PATH=/opt/ms-playwright`,
@@ -459,6 +460,14 @@ changed paths require the documented CI-control or runner-infrastructure
 fail-open policy.
 
 ## Artifact and cache owners
+
+- `restore-release-ui` / `scripts/ui-distribution.py`: verify the shared release
+  console's source SHA, version, complete file hashes and built JavaScript entry
+  before platform-specific Rust compilation or SDK resource packaging. The
+  `prepared-release-ui-*` artifact retains for 90 days and is excluded from the
+  GitHub release asset glob. Swift release resource assembly skips pnpm and the
+  console build when this artifact is supplied; ordinary PR/main behavior is
+  unchanged.
 
 - `prepare-host-input` / `prepare-windows-host-input`: neutral host bytes,
   import report and checksum.

--- a/.github/actions/restore-release-ui/action.yml
+++ b/.github/actions/restore-release-ui/action.yml
@@ -1,0 +1,37 @@
+name: Restore verified release UI
+description: Restore a real UI distribution bound to one immutable release source and version.
+
+inputs:
+  artifact_name:
+    description: Run-scoped artifact produced by the shared UI builder.
+    required: true
+  source_sha:
+    description: Expected immutable source commit.
+    required: true
+  release_tag:
+    description: Expected release version tag.
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+      with:
+        name: ${{ inputs.artifact_name }}
+        path: crates/mesh-llm-ui/dist
+    - name: Verify release UI identity and contents
+      shell: bash
+      env:
+        UI_SOURCE_SHA: ${{ inputs.source_sha }}
+        UI_RELEASE_TAG: ${{ inputs.release_tag }}
+      run: |
+        set -euo pipefail
+        if command -v python3 >/dev/null 2>&1; then
+          python_bin=python3
+        else
+          python_bin=python
+        fi
+        "$python_bin" scripts/ui-distribution.py verify \
+          --dist crates/mesh-llm-ui/dist \
+          --source-sha "$UI_SOURCE_SHA" \
+          --release-tag "$UI_RELEASE_TAG"

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -27,6 +27,11 @@ on:
         required: false
         default: 1
         type: number
+      release_tag:
+        description: Optional release version to prepare and bind to the UI artifact.
+        required: false
+        default: ''
+        type: string
 
 permissions:
   contents: read
@@ -87,6 +92,19 @@ jobs:
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
+      - name: Prepare release UI version
+        if: ${{ inputs.release_tag != '' }}
+        working-directory: .
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          UI_SOURCE_SHA: ${{ inputs.source_sha }}
+        run: |
+          set -euo pipefail
+          [[ "$UI_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          test "$(git rev-parse HEAD)" = "$UI_SOURCE_SHA"
+          scripts/release-version.sh "$RELEASE_TAG"
+          echo "VITE_MESH_LLM_DEBUG_UI=false" >> "$GITHUB_ENV"
       # The container image bakes a warm pnpm store at
       # /home/runner/.local/share/pnpm/store (mesh-llm-runner-images
       # scripts/warm-dependencies.sh). Point pnpm at it directly instead of
@@ -107,6 +125,19 @@ jobs:
         run: pnpm run build
       - name: Verify console distribution
         run: test -s dist/index.html
+      - name: Bind release UI identity and checksums
+        if: ${{ inputs.release_tag != '' }}
+        working-directory: .
+        shell: bash
+        env:
+          UI_SOURCE_SHA: ${{ inputs.source_sha }}
+          UI_RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ui-distribution.py stamp \
+            --dist crates/mesh-llm-ui/dist \
+            --source-sha "$UI_SOURCE_SHA" \
+            --release-tag "$UI_RELEASE_TAG"
       - name: Upload immutable console distribution
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -214,9 +214,21 @@ jobs:
           depot_pr_enabled: 'false'
           manual_use_depot: ${{ inputs.use_depot == true }}
 
+  release_ui:
+    name: Prepare shared release console
+    needs: metadata
+    uses: ./.github/workflows/ci-ui-artifact-slice.yml
+    with:
+      source_sha: ${{ needs.metadata.outputs.source_sha }}
+      original_event_name: ${{ github.event_name }}
+      force_hosted: true
+      artifact_name: prepared-release-ui-${{ needs.metadata.outputs.tag }}-${{ needs.metadata.outputs.source_sha }}
+      release_tag: ${{ needs.metadata.outputs.tag }}
+      retention_days: 90
+
   build:
     name: Build immutable host ${{ matrix.name }}
-    needs: metadata
+    needs: [metadata, release_ui]
     # Host attestation consumes the signing key. Keep this producer on GitHub
     # until compilation and signing are split into separate jobs.
     runs-on: ${{ matrix.os }}
@@ -233,19 +245,13 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
+          ref: ${{ needs.metadata.outputs.source_sha }}
           persist-credentials: false
-
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 10.34.5
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.20.0
-          cache: pnpm
-          cache-dependency-path: |
-            .github/cache-version.txt
-            crates/mesh-llm-ui/pnpm-lock.yaml
+          package-manager-cache: false
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-20
 
@@ -275,6 +281,13 @@ jobs:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: scripts/release-version.sh "$RELEASE_TAG"
 
+      - name: Restore shared release UI
+        uses: ./.github/actions/restore-release-ui
+        with:
+          artifact_name: prepared-release-ui-${{ needs.metadata.outputs.tag }}-${{ needs.metadata.outputs.source_sha }}
+          source_sha: ${{ needs.metadata.outputs.source_sha }}
+          release_tag: ${{ needs.metadata.outputs.tag }}
+
       - name: Prepare release attestation keys
         env:
           MESH_RELEASE_ATTESTATION_SIGNING_KEY_FILE: ${{ runner.temp }}/mesh-release-attestation-private-key.json
@@ -289,6 +302,7 @@ jobs:
         uses: ./.github/actions/prepare-host-input
         with:
           profile: release
+          skip_ui: "true"
           output_dir: host-input
           attestation_signing_key_file: ${{ runner.temp }}/mesh-release-attestation-private-key.json
           attestation_public_key_file: ${{ runner.temp }}/mesh-release-attestation-public-key.json
@@ -805,11 +819,13 @@ jobs:
 
   build_swift_sdk_artifact:
     name: Build Swift SDK XCFramework
-    needs: metadata
+    needs: [metadata, release_ui]
     permissions:
       contents: read
     uses: ./.github/workflows/swift-sdk-artifact.yml
     with:
+      source_sha: ${{ needs.metadata.outputs.source_sha }}
+      ui_artifact_name: prepared-release-ui-${{ needs.metadata.outputs.tag }}-${{ needs.metadata.outputs.source_sha }}
       original_event_name: ${{ github.event_name }}
       force_hosted: false
       mode: full
@@ -825,7 +841,7 @@ jobs:
 
   build_linux_arm64:
     name: Build immutable host Linux ARM64
-    needs: metadata
+    needs: [metadata, release_ui]
     # Host attestation consumes the signing key. Keep this producer on GitHub
     # until compilation and signing are split into separate jobs.
     runs-on: ubuntu-24.04-arm
@@ -835,17 +851,12 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
+          ref: ${{ needs.metadata.outputs.source_sha }}
           persist-credentials: false
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 10.34.5
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.20.0
-          cache: pnpm
-          cache-dependency-path: |
-            .github/cache-version.txt
-            crates/mesh-llm-ui/pnpm-lock.yaml
+          package-manager-cache: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-20
       - uses: taiki-e/install-action@3d23c1bbdafe696dfccad2664945a04f47d03dc3 # just
       - name: Install dependencies
@@ -855,6 +866,13 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: scripts/release-version.sh "$RELEASE_TAG"
+      - name: Restore shared release UI
+        uses: ./.github/actions/restore-release-ui
+        with:
+          artifact_name: prepared-release-ui-${{ needs.metadata.outputs.tag }}-${{ needs.metadata.outputs.source_sha }}
+          source_sha: ${{ needs.metadata.outputs.source_sha }}
+          release_tag: ${{ needs.metadata.outputs.tag }}
+
       - name: Prepare release attestation keys
         env:
           MESH_RELEASE_ATTESTATION_SIGNING_KEY_FILE: ${{ runner.temp }}/mesh-release-attestation-private-key.json
@@ -869,6 +887,7 @@ jobs:
         uses: ./.github/actions/prepare-host-input
         with:
           profile: release
+          skip_ui: "true"
           output_dir: host-input
           attestation_signing_key_file: ${{ runner.temp }}/mesh-release-attestation-private-key.json
           attestation_public_key_file: ${{ runner.temp }}/mesh-release-attestation-public-key.json
@@ -984,11 +1003,9 @@ jobs:
       matrix:
         include:
           - cuda_version: '12.9.2'
-            runner_image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:c5b85ef527230f77cf9933ef40bcb44316f9bbcb8fd2ce0651b58acda5143dfd
           - cuda_version: '13.1.2'
-            runner_image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:6b87598605f5d8deeafecfb1a55027e0ca9e47f4fc6f230d030487c450c31aa6
     container:
-      image: ${{ matrix.runner_image }}
+      image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:8d93de6ba30173e825a16fdecf011f9c632edc6e1259df7289e491b0a05f829d
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1001,7 +1018,7 @@ jobs:
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
-        run: verify-runner-image public cuda
+        run: verify-runner-image public cpu
       - name: Download immutable host input
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1067,12 +1084,10 @@ jobs:
         include:
           - cuda_version: '12.9.2'
             cuda_major: '12'
-            runner_image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:c5b85ef527230f77cf9933ef40bcb44316f9bbcb8fd2ce0651b58acda5143dfd
           - cuda_version: '13.1.2'
             cuda_major: '13'
-            runner_image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:6b87598605f5d8deeafecfb1a55027e0ca9e47f4fc6f230d030487c450c31aa6
     container:
-      image: ${{ matrix.runner_image }}
+      image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:8d93de6ba30173e825a16fdecf011f9c632edc6e1259df7289e491b0a05f829d
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1085,7 +1100,7 @@ jobs:
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
-        run: verify-runner-image public cuda
+        run: verify-runner-image public cpu
       - name: Download immutable host input
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1147,7 +1162,7 @@ jobs:
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
     runs-on: ${{ needs.metadata.outputs.runner_4 }}
     container:
-      image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:0e13e5d2d2c121df265ff6c69be81e468989e09f81d6b7ff049b110cc0bb0d2b
+      image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:8d93de6ba30173e825a16fdecf011f9c632edc6e1259df7289e491b0a05f829d
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1158,7 +1173,7 @@ jobs:
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
-        run: verify-runner-image public rocm
+        run: verify-runner-image public cpu
       - name: Download immutable host input
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1218,7 +1233,7 @@ jobs:
     if: ${{ needs.metadata.outputs.skip_gpu_bundles != 'true' }}
     runs-on: ${{ needs.metadata.outputs.runner_4 }}
     container:
-      image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:ce55fed5c680cd3184b5d4770d9a77c43a702687690906e5753efd2cea27ed80
+      image: ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:8d93de6ba30173e825a16fdecf011f9c632edc6e1259df7289e491b0a05f829d
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
@@ -1229,7 +1244,7 @@ jobs:
       - name: Trust checkout directory
         run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Verify prebuilt backend environment
-        run: verify-runner-image public vulkan
+        run: verify-runner-image public cpu
       - name: Download immutable host input
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
@@ -1285,7 +1300,7 @@ jobs:
 
   windows_host_input:
     name: Build immutable host Windows x86_64
-    needs: metadata
+    needs: [metadata, release_ui]
     runs-on: windows-2022
     env:
       MESH_LLM_REQUIRE_SCCACHE: "1"
@@ -1293,17 +1308,12 @@ jobs:
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
+          ref: ${{ needs.metadata.outputs.source_sha }}
           persist-credentials: false
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        with:
-          version: 10.34.5
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.20.0
-          cache: pnpm
-          cache-dependency-path: |
-            .github/cache-version.txt
-            crates/mesh-llm-ui/pnpm-lock.yaml
+          package-manager-cache: false
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-20
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
         with:
@@ -1315,6 +1325,13 @@ jobs:
         env:
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
         run: scripts/release-version.sh "$RELEASE_TAG"
+      - name: Restore shared release UI
+        uses: ./.github/actions/restore-release-ui
+        with:
+          artifact_name: prepared-release-ui-${{ needs.metadata.outputs.tag }}-${{ needs.metadata.outputs.source_sha }}
+          source_sha: ${{ needs.metadata.outputs.source_sha }}
+          release_tag: ${{ needs.metadata.outputs.tag }}
+
       - name: Prepare release attestation keys
         shell: pwsh
         env:
@@ -1329,6 +1346,7 @@ jobs:
         uses: ./.github/actions/prepare-windows-host-input
         with:
           profile: release
+          skip_ui: "true"
           attestation_signing_key_file: ${{ runner.temp }}/mesh-release-attestation-private-key.json
           attestation_public_key_file: ${{ runner.temp }}/mesh-release-attestation-public-key.json
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -1657,6 +1675,7 @@ jobs:
     name: Publish GitHub release
     needs:
       - metadata
+      - release_ui
       - build
       - compose_cpu_products
       - inference_smoke_tests
@@ -1693,22 +1712,21 @@ jobs:
           persist-credentials: false
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
-        if: github.event_name == 'workflow_dispatch'
-        with:
-          version: 10.34.5
-
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         if: github.event_name == 'workflow_dispatch'
         with:
           node-version: 24.20.0
-          cache: pnpm
-          cache-dependency-path: |
-            .github/cache-version.txt
-            crates/mesh-llm-ui/pnpm-lock.yaml
+          package-manager-cache: false
 
       - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-20
         if: github.event_name == 'workflow_dispatch'
+
+      - name: Restore shared release UI
+        uses: ./.github/actions/restore-release-ui
+        with:
+          artifact_name: prepared-release-ui-${{ needs.metadata.outputs.tag }}-${{ needs.metadata.outputs.source_sha }}
+          source_sha: ${{ needs.metadata.outputs.source_sha }}
+          release_tag: ${{ needs.metadata.outputs.tag }}
 
       - name: Download release artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
@@ -1792,7 +1810,7 @@ jobs:
           fi
           install -m 0644 "$generated_binding" "$tracked_binding"
           cmp "$generated_binding" "$tracked_binding"
-          scripts/package-sdk-console-assets.sh --sdk all
+          scripts/package-sdk-console-assets.sh --sdk all --skip-build
           scripts/verify-sdk-console-assets.sh --sdk all
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/.github/workflows/swift-sdk-artifact.yml
+++ b/.github/workflows/swift-sdk-artifact.yml
@@ -31,6 +31,11 @@ on:
         required: false
         default: ''
         type: string
+      ui_artifact_name:
+        description: Optional verified release UI artifact shared with the host producers.
+        required: false
+        default: ''
+        type: string
       prepare_release_version:
         description: Prepare checked-out sources for release_tag before building.
         required: false
@@ -107,6 +112,8 @@ jobs:
           RELEASE_TAG: ${{ inputs.release_tag }}
           PREPARE_RELEASE_VERSION: ${{ inputs.prepare_release_version }}
           UPDATE_RELEASE_MANIFEST: ${{ inputs.update_release_manifest }}
+          UI_ARTIFACT_NAME: ${{ inputs.ui_artifact_name }}
+          UI_SOURCE_SHA: ${{ inputs.source_sha }}
           EVENT_NAME: ${{ github.event_name }}
         run: |
           set -euo pipefail
@@ -119,6 +126,11 @@ jobs:
           esac
           if [[ ! "$MAX_PARALLEL" =~ ^[1-4]$ ]]; then
             echo "max_parallel must be an integer from 1 through 4" >&2
+            exit 1
+          fi
+          if [[ -n "$UI_ARTIFACT_NAME" &&
+                ( -z "$RELEASE_TAG" || ! "$UI_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ) ]]; then
+            echo "a release UI artifact requires its immutable source SHA and release tag" >&2
             exit 1
           fi
           if [[ ( "$PREPARE_RELEASE_VERSION" == "true" ||
@@ -266,14 +278,15 @@ jobs:
           persist-credentials: false
 
       - uses: pnpm/action-setup@0977fd99725f1db4007ccb2928dbb4e90d06cc86 # v6.0.10
+        if: ${{ inputs.ui_artifact_name == '' }}
         with:
           version: 10.34.5
 
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 24.20.0
-          package-manager-cache: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
-          cache: ${{ needs.runner_policy.outputs.allow_native_github_cache == 'true' && 'pnpm' || '' }}
+          package-manager-cache: ${{ inputs.ui_artifact_name == '' && needs.runner_policy.outputs.allow_native_github_cache == 'true' }}
+          cache: ${{ inputs.ui_artifact_name == '' && needs.runner_policy.outputs.allow_native_github_cache == 'true' && 'pnpm' || '' }}
           cache-dependency-path: |
             .github/cache-version.txt
             crates/mesh-llm-ui/pnpm-lock.yaml
@@ -327,8 +340,23 @@ jobs:
         run: scripts/release-version.sh "$RELEASE_TAG"
 
       - name: Prepare Swift console resources
+        if: ${{ inputs.ui_artifact_name == '' }}
         run: |
           scripts/package-sdk-console-assets.sh --sdk swift
+          scripts/verify-sdk-console-assets.sh --sdk swift
+
+      - name: Restore shared release UI
+        if: ${{ inputs.ui_artifact_name != '' }}
+        uses: ./.github/actions/restore-release-ui
+        with:
+          artifact_name: ${{ inputs.ui_artifact_name }}
+          source_sha: ${{ inputs.source_sha }}
+          release_tag: ${{ inputs.release_tag }}
+
+      - name: Prepare Swift resources from verified release UI
+        if: ${{ inputs.ui_artifact_name != '' }}
+        run: |
+          scripts/package-sdk-console-assets.sh --sdk swift --skip-build
           scripts/verify-sdk-console-assets.sh --sdk swift
 
       - name: Verify tagged Swift console resources

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -125,6 +125,10 @@ Release efficiency TODOs:
   keeping compiler images and ARC CUDA placement unchanged. QA: compare the
   CUDA compiler job with the baseline and run `just check-release` and
   `just ci-validate`.
+- [x] Accept current catalog-wrapped runtime diagnostics in the shared SDK
+  smoke helper while preserving legacy list support. QA: exercise both JSON
+  forms, malformed reports, incompatible/ambiguous runtimes and ABI checks in
+  `test_ci_prepare_native_runtime`, then run shellcheck and `just ci-validate`.
 - [ ] Validate the shared UI and CPU-image composers in a non-publishing release
   canary. QA: verify all host/runtime hashes, no-driver readiness, SDK resources,
   and per-phase timings on Linux amd64/arm64, macOS, and Windows.

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -116,6 +116,19 @@ main.
 
 ### Release source and version ownership
 
+Release efficiency TODOs:
+
+- [x] Build one version-bound console distribution and verify its complete file
+  checksums before each host embeds it or an SDK packages it. QA: run the UI
+  identity/tampering tests and release artifact graph tests.
+- [x] Use the existing CPU image for composition-only Linux release jobs while
+  keeping compiler images and ARC CUDA placement unchanged. QA: compare the
+  CUDA compiler job with the baseline and run `just check-release` and
+  `just ci-validate`.
+- [ ] Validate the shared UI and CPU-image composers in a non-publishing release
+  canary. QA: verify all host/runtime hashes, no-driver readiness, SDK resources,
+  and per-phase timings on Linux amd64/arm64, macOS, and Windows.
+
 `scripts/release-version.sh` is the single owner of the tracked release-version
 surface. On a non-canary `release.yml` dispatch, the metadata job applies that
 script, creates a linear release-source commit when needed, and fast-forwards
@@ -124,6 +137,24 @@ preflight, dispatches that workflow, and waits for its result. A tag push must
 already be reachable from `main` and version-complete; the metadata job applies
 the same script and rejects any tracked diff. Canary dispatches do not mutate
 `main` or publish.
+
+Release calls the existing UI producer once with the immutable source SHA and
+release tag. It prepares that version, builds the TypeScript console in release
+mode, and records every output checksum in `.mesh-llm-ui-release.json`. The
+Linux amd64/arm64, macOS and Windows host producers restore and verify this same
+distribution before compiling their own target-specific Rust embedding crate
+and host. Swift resource assembly and the release-tag SDK resources consume the
+same bytes with `--skip-build`. Missing manifests, mismatched source/version,
+changed files and placeholder HTML fail before host compilation. UI artifacts
+use `prepared-release-ui-*`, outside the published `release-*` asset namespace.
+
+Linux CUDA, ROCm and Vulkan release composition jobs use the pinned `public
+cpu` image, retaining producer checksum/import checks, attestation verification,
+and no-driver readiness. Native compiler images, CUDA architecture lists and
+the intentional ARC self-hosted amd64 CUDA placement remain unchanged. The
+shared UI producer introduces one dependency before host and Swift production;
+the release canary must compare total execution and phase timings before
+claiming a wall-time improvement.
 
 The later publish job checks out the canonical source commit, adds only the
 generated SwiftPM/binding and SDK console resources needed by the immutable

--- a/scripts/ci-prepare-native-runtime.sh
+++ b/scripts/ci-prepare-native-runtime.sh
@@ -143,8 +143,17 @@ expected_skippy_abi = sys.argv[4]
 with open(sys.argv[3], encoding="utf-8") as fh:
     rows = json.load(fh)
 
+# Current hosts include catalog diagnostics around the runtime rows. Older
+# smoke products emit the same rows directly as a list.
+if isinstance(rows, dict):
+    rows = rows.get("runtimes")
 if not isinstance(rows, list):
-    raise SystemExit("native runtime compatibility output must be a JSON list")
+    raise SystemExit(
+        "native runtime compatibility output must be a JSON list or an object "
+        "with a runtimes list"
+    )
+if not all(isinstance(row, dict) for row in rows):
+    raise SystemExit("native runtime compatibility rows must be JSON objects")
 
 supported = [row for row in rows if row.get("supported") is True]
 preferred = [row for row in supported if row.get("backend") == requested_backend]

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -2930,11 +2930,11 @@ class CiArtifactActionTests(unittest.TestCase):
         # baked pnpm store instead (#1392); see the comment on
         # `eligible_consumers` above.
         self.assertIn(
-            f"cache: ${{{{ {native_cache_expression} && 'pnpm' || '' }}}}",
+            f"cache: ${{{{ inputs.ui_artifact_name == '' && {native_cache_expression} && 'pnpm' || '' }}}}",
             swift,
         )
         self.assertIn(
-            f"package-manager-cache: ${{{{ {native_cache_expression} }}}}",
+            f"package-manager-cache: ${{{{ inputs.ui_artifact_name == '' && {native_cache_expression} }}}}",
             swift,
         )
         self.assertIn(

--- a/scripts/tests/test_ci_prepare_native_runtime.py
+++ b/scripts/tests/test_ci_prepare_native_runtime.py
@@ -112,6 +112,8 @@ class CiPrepareNativeRuntimeTests(unittest.TestCase):
         runtime_id: str,
         backend: str,
         supported: bool,
+        *,
+        include_catalogs: bool = False,
     ) -> Path:
         binary = product / "mesh-llm"
         binary.parent.mkdir(parents=True, exist_ok=True)
@@ -128,8 +130,22 @@ class CiPrepareNativeRuntimeTests(unittest.TestCase):
                 "url": None,
             }
         ]
+        report = (
+            {
+                "catalogs": {
+                    "manifest_artifacts": 0,
+                    "bundle_dirs": [str(product / "native-runtimes")],
+                    "bundle_artifacts": len(rows),
+                    "bundle_duplicates_of_catalog": 0,
+                    "bundle_duplicates_of_bundles": 0,
+                },
+                "runtimes": rows,
+            }
+            if include_catalogs
+            else rows
+        )
         rows_path = product / "runtime-rows.json"
-        rows_path.write_text(json.dumps(rows), encoding="utf-8")
+        rows_path.write_text(json.dumps(report), encoding="utf-8")
         binary.write_text(
             """#!/usr/bin/env bash
 set -euo pipefail
@@ -183,6 +199,102 @@ cat "$(dirname "$0")/runtime-rows.json"
             self.assertEqual(Path(result.stdout.strip()), runtime.resolve())
             self.assertIn("verified native runtime artifact", result.stderr)
             self.assertIn("Reusing compatible native runtime", result.stderr)
+            self.assertFalse(out.exists())
+
+    def test_reuses_runtime_from_catalog_wrapped_report(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            product = Path(directory) / "product"
+            runtime = self.write_runtime(product / "native-runtimes")
+            binary = self.write_fake_binary(
+                product, runtime.name, "cpu", True, include_catalogs=True
+            )
+            out = Path(directory) / "fallback"
+
+            result = self.run_script(out, binary)
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertEqual(Path(result.stdout.strip()), runtime.resolve())
+            self.assertIn("verified native runtime artifact", result.stderr)
+            self.assertFalse(out.exists())
+
+    def test_catalog_wrapped_report_preserves_runtime_rejection(self) -> None:
+        for supported, abi, error in (
+            (False, None, "expected exactly one compatible"),
+            (True, "99.99.99", "has Skippy ABI 99.99.99"),
+        ):
+            with self.subTest(supported=supported, abi=abi):
+                with tempfile.TemporaryDirectory() as directory:
+                    product = Path(directory) / "product"
+                    runtime = self.write_runtime(
+                        product / "native-runtimes", skippy_abi=abi
+                    )
+                    binary = self.write_fake_binary(
+                        product, runtime.name, "cpu", supported, include_catalogs=True
+                    )
+                    out = Path(directory) / "fallback"
+
+                    result = self.run_script(
+                        out,
+                        binary,
+                        extra_env={"MESH_SDK_NATIVE_RUNTIME_BUILD_FALLBACK": "1"},
+                    )
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn(error, result.stderr)
+                    self.assertFalse(out.exists())
+
+    def test_rejects_malformed_runtime_reports_without_building(self) -> None:
+        for report in (
+            None,
+            {},
+            {"runtimes": None},
+            {"runtimes": {}},
+            [None],
+            {"runtimes": [None]},
+        ):
+            with self.subTest(report=report):
+                with tempfile.TemporaryDirectory() as directory:
+                    product = Path(directory) / "product"
+                    runtime = self.write_runtime(product / "native-runtimes")
+                    binary = self.write_fake_binary(product, runtime.name, "cpu", True)
+                    (product / "runtime-rows.json").write_text(
+                        json.dumps(report), encoding="utf-8"
+                    )
+                    out = Path(directory) / "fallback"
+
+                    result = self.run_script(
+                        out,
+                        binary,
+                        extra_env={"MESH_SDK_NATIVE_RUNTIME_BUILD_FALLBACK": "1"},
+                    )
+
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertIn("native runtime compatibility", result.stderr)
+                    self.assertNotIn("Traceback", result.stderr)
+                    self.assertFalse(out.exists())
+
+    def test_rejects_ambiguous_catalog_wrapped_report_without_building(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            product = Path(directory) / "product"
+            runtime = self.write_runtime(product / "native-runtimes")
+            binary = self.write_fake_binary(
+                product, runtime.name, "cpu", True, include_catalogs=True
+            )
+            report_path = product / "runtime-rows.json"
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            report["runtimes"].append({**report["runtimes"][0], "id": "another-runtime"})
+            report_path.write_text(json.dumps(report), encoding="utf-8")
+            out = Path(directory) / "fallback"
+
+            result = self.run_script(
+                out,
+                binary,
+                extra_env={"MESH_SDK_NATIVE_RUNTIME_BUILD_FALLBACK": "1"},
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("expected exactly one compatible", result.stderr)
+            self.assertIn("another-runtime:cpu", result.stderr)
             self.assertFalse(out.exists())
 
     def test_reuses_sole_compatible_product_backend_before_cpu_fallback(self) -> None:

--- a/scripts/tests/test_release_workflow_artifacts.py
+++ b/scripts/tests/test_release_workflow_artifacts.py
@@ -15,6 +15,62 @@ def job_block(workflow: str, job_name: str, next_job_name: str) -> str:
 
 
 class ReleaseWorkflowArtifactTests(unittest.TestCase):
+    def test_release_ui_is_one_verified_producer_for_hosts_and_sdks(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        producer = job_block(workflow, "release_ui", "build")
+        self.assertIn("uses: ./.github/workflows/ci-ui-artifact-slice.yml", producer)
+        self.assertIn("source_sha: ${{ needs.metadata.outputs.source_sha }}", producer)
+        self.assertIn("release_tag: ${{ needs.metadata.outputs.tag }}", producer)
+        artifact = "prepared-release-ui-${{ needs.metadata.outputs.tag }}-${{ needs.metadata.outputs.source_sha }}"
+        self.assertIn(f"artifact_name: {artifact}", producer)
+        ui_workflow = (ROOT / ".github/workflows/ci-ui-artifact-slice.yml").read_text()
+        self.assertIn('echo "VITE_MESH_LLM_DEBUG_UI=false" >> "$GITHUB_ENV"', ui_workflow)
+        self.assertLess(ui_workflow.index("Prepare release UI version"), ui_workflow.index("Install UI dependencies"))
+        self.assertIn("python3 scripts/ui-distribution.py stamp", ui_workflow)
+        restore = (ROOT / ".github/actions/restore-release-ui/action.yml").read_text()
+        self.assertIn('"$python_bin" scripts/ui-distribution.py verify', restore)
+        for name, next_name in (("build", "compose_cpu_products"),
+                                ("build_linux_arm64", "compose_linux_arm64_cpu"),
+                                ("windows_host_input", "compose_windows_gpu")):
+            host = job_block(workflow, name, next_name)
+            with self.subTest(host=name):
+                self.assertIn("needs: [metadata, release_ui]", host)
+                self.assertIn(f"artifact_name: {artifact}", host)
+                self.assertIn('skip_ui: "true"', host)
+                self.assertNotIn("pnpm/action-setup", host)
+                self.assertLess(host.index("restore-release-ui"), host.index("Build and attest"))
+        swift = job_block(workflow, "build_swift_sdk_artifact", "build_linux_arm64")
+        self.assertIn("needs: [metadata, release_ui]", swift)
+        self.assertIn(f"ui_artifact_name: {artifact}", swift)
+        swift_workflow = (ROOT / ".github/workflows/swift-sdk-artifact.yml").read_text()
+        self.assertIn("if: ${{ inputs.ui_artifact_name == '' }}", swift_workflow)
+        self.assertIn("scripts/package-sdk-console-assets.sh --sdk swift --skip-build", swift_workflow)
+        publish = job_block(workflow, "publish", "dispatch_packaging_release")
+        self.assertIn("      - release_ui", publish)
+        self.assertIn("--sdk all --skip-build", publish)
+        self.assertNotIn("pnpm/action-setup", publish)
+        self.assertFalse(artifact.startswith("release-"), "UI must not match published release-* assets")
+
+    def test_linux_release_composers_use_cpu_tools_and_keep_readiness(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        cpu = "ghcr.io/mesh-llm/mesh-llm-cuda-runner@sha256:8d93de6ba30173e825a16fdecf011f9c632edc6e1259df7289e491b0a05f829d"
+        for name, next_name in (("compose_linux_aarch64_cuda", "compose_linux_cuda"),
+                                ("compose_linux_cuda", "compose_linux_rocm"),
+                                ("compose_linux_rocm", "compose_linux_vulkan"),
+                                ("compose_linux_vulkan", "windows_host_input")):
+            compose = job_block(workflow, name, next_name)
+            with self.subTest(composer=name):
+                self.assertIn(f"image: {cpu}", compose)
+                self.assertIn("verify-runner-image public cpu", compose)
+                self.assertIn('readiness_smoke: "true"', compose)
+                self.assertIn("MESH_RELEASE_HOST_PRESTAMPED", compose)
+                self.assertNotIn("prepare-native-runtime-input", compose)
+        cuda = job_block(workflow, "build_native_runtime_linux_x86_64_cuda", "build_native_runtime_linux_x86_64_rocm")
+        self.assertIn("vars.USE_SELF_HOSTED == 'true'", cuda)
+        self.assertIn('"amd64","gpu-nvidia"', cuda)
+        self.assertIn("image: ${{ matrix.runner_image }}", cuda)
+        self.assertIn("verify-runner-image public cuda", cuda)
+
     def test_release_entrypoint_rejects_untrusted_refs(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         metadata = job_block(workflow, "metadata", "build")

--- a/scripts/tests/test_ui_distribution.py
+++ b/scripts/tests/test_ui_distribution.py
@@ -1,0 +1,119 @@
+import importlib.util
+import json
+import os
+from pathlib import Path
+import shlex
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SPEC = importlib.util.spec_from_file_location("ui_distribution", ROOT / "scripts/ui-distribution.py")
+UI = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(UI)
+SOURCE = "a" * 40
+TAG = "v0.74.0-rc.1"
+
+
+class UiDistributionTests(unittest.TestCase):
+    def setUp(self):
+        self.temp = tempfile.TemporaryDirectory()
+        self.addCleanup(self.temp.cleanup)
+        self.dist = Path(self.temp.name)
+        (self.dist / "assets").mkdir()
+        (self.dist / "assets/app.js").write_text("console.log('release');")
+        (self.dist / "index.html").write_text('<script type="module" src="/assets/app.js"></script>')
+
+    def test_stamp_and_verify_exact_release(self):
+        UI.stamp(self.dist, SOURCE, TAG)
+        UI.verify(self.dist, SOURCE, TAG)
+        manifest = json.loads((self.dist / UI.MANIFEST).read_text())
+        self.assertEqual(set(manifest["files"]), {"index.html", "assets/app.js"})
+
+    def test_wrong_source_and_version_are_rejected(self):
+        UI.stamp(self.dist, SOURCE, TAG)
+        for source, tag in (("b" * 40, TAG), (SOURCE, "v0.74.0")):
+            with self.subTest(source=source, tag=tag), self.assertRaisesRegex(ValueError, "identity"):
+                UI.verify(self.dist, source, tag)
+
+    def test_changed_and_extra_files_are_rejected(self):
+        UI.stamp(self.dist, SOURCE, TAG)
+        (self.dist / "assets/app.js").write_text("changed")
+        with self.assertRaisesRegex(ValueError, "checksums"):
+            UI.verify(self.dist, SOURCE, TAG)
+        UI.stamp(self.dist, SOURCE, TAG)
+        (self.dist / "assets/unexpected.js").write_text("extra")
+        with self.assertRaisesRegex(ValueError, "checksums"):
+            UI.verify(self.dist, SOURCE, TAG)
+
+    def test_missing_module_and_windows_placeholder_are_rejected(self):
+        (self.dist / "assets/app.js").unlink()
+        with self.assertRaisesRegex(ValueError, "JavaScript"):
+            UI.stamp(self.dist, SOURCE, TAG)
+        (self.dist / "index.html").write_text("<html></html>")
+        with self.assertRaisesRegex(ValueError, "JavaScript"):
+            UI.stamp(self.dist, SOURCE, TAG)
+
+    def test_missing_manifest_and_entry_are_rejected(self):
+        with self.assertRaisesRegex(ValueError, "release manifest"):
+            UI.verify(self.dist, SOURCE, TAG)
+        (self.dist / "index.html").unlink()
+        with self.assertRaisesRegex(ValueError, "index.html"):
+            UI.stamp(self.dist, SOURCE, TAG)
+
+    def test_symlinks_are_rejected(self):
+        (self.dist / "assets/link.js").symlink_to(self.dist / "assets/app.js")
+        with self.assertRaisesRegex(ValueError, "symbolic"):
+            UI.stamp(self.dist, SOURCE, TAG)
+
+    def test_identity_shape_is_checked(self):
+        for source, tag in (("main", TAG), (SOURCE, "main")):
+            with self.subTest(source=source, tag=tag), self.assertRaises(ValueError):
+                UI.stamp(self.dist, source, tag)
+
+    def test_restore_action_verifies_with_python3_or_python(self):
+        action = yaml.safe_load((ROOT / ".github/actions/restore-release-ui/action.yml").read_text())
+        verify_script = action["runs"]["steps"][1]["run"]
+        bash = shutil.which("bash")
+        self.assertIsNotNone(bash)
+        UI.stamp(self.dist, SOURCE, TAG)
+        for interpreters, selected in ((("python3", "python"), "python3"), (("python",), "python")):
+            with self.subTest(interpreters=interpreters), tempfile.TemporaryDirectory() as temporary:
+                workspace = Path(temporary)
+                binaries = workspace / "bin"
+                binaries.mkdir()
+                marker = workspace / "interpreter"
+                for interpreter in interpreters:
+                    executable = binaries / interpreter
+                    executable.write_text(
+                        f"#!/bin/sh\nprintf '%s\\n' {interpreter} > \"$UI_PYTHON_MARKER\"\n"
+                        f"exec {shlex.quote(sys.executable)} \"$@\"\n"
+                    )
+                    executable.chmod(0o755)
+                (workspace / "scripts").mkdir()
+                shutil.copyfile(ROOT / "scripts/ui-distribution.py", workspace / "scripts/ui-distribution.py")
+                dist = workspace / "crates/mesh-llm-ui/dist"
+                shutil.copytree(self.dist, dist)
+                env = {
+                    **os.environ,
+                    "PATH": str(binaries),
+                    "UI_SOURCE_SHA": SOURCE,
+                    "UI_RELEASE_TAG": TAG,
+                    "UI_PYTHON_MARKER": str(marker),
+                }
+                result = subprocess.run([bash, "-c", verify_script], cwd=workspace, env=env, capture_output=True, text=True)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(marker.read_text().strip(), selected)
+                (dist / "assets/app.js").write_text("tampered")
+                result = subprocess.run([bash, "-c", verify_script], cwd=workspace, env=env, capture_output=True, text=True)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("checksums", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/ui-distribution.py
+++ b/scripts/ui-distribution.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Bind a prepared release UI to its source revision and verify its exact bytes."""
+
+import argparse
+import hashlib
+from html.parser import HTMLParser
+import json
+from pathlib import Path
+import re
+
+
+MANIFEST = ".mesh-llm-ui-release.json"
+
+
+class ModuleScripts(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.sources = []
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if tag == "script" and attrs.get("type") == "module":
+            self.sources.append(attrs.get("src", ""))
+
+
+def describe(root: Path, source_sha: str, release_tag: str) -> dict:
+    if not re.fullmatch(r"[0-9a-f]{40}", source_sha):
+        raise ValueError("source SHA must be 40 lowercase hexadecimal characters")
+    if not re.fullmatch(r"v[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?", release_tag):
+        raise ValueError("release tag must be a versioned v-prefixed tag")
+    if not root.is_dir() or root.is_symlink():
+        raise ValueError("UI distribution must be a real directory")
+    files = {}
+    for path in sorted(root.rglob("*")):
+        if path.is_symlink():
+            raise ValueError("UI distribution must not contain symbolic links")
+        if path.is_file() and path.relative_to(root).as_posix() != MANIFEST:
+            files[path.relative_to(root).as_posix()] = hashlib.sha256(path.read_bytes()).hexdigest()
+    entry = root / "index.html"
+    if "index.html" not in files:
+        raise ValueError("UI distribution is missing index.html")
+    parser = ModuleScripts()
+    parser.feed(entry.read_text(encoding="utf-8"))
+    if not any(
+        src.removeprefix("/") in files and src.endswith(".js")
+        for src in parser.sources
+    ):
+        raise ValueError("UI index must reference a built local JavaScript module")
+    return {"schema": 1, "source_sha": source_sha, "release_tag": release_tag, "files": files}
+
+
+def stamp(root: Path, source_sha: str, release_tag: str) -> None:
+    manifest = describe(root, source_sha, release_tag)
+    (root / MANIFEST).write_text(json.dumps(manifest, sort_keys=True, indent=2) + "\n", encoding="utf-8")
+
+
+def verify(root: Path, source_sha: str, release_tag: str) -> None:
+    expected = describe(root, source_sha, release_tag)
+    manifest = root / MANIFEST
+    if not manifest.is_file() or manifest.is_symlink():
+        raise ValueError("UI distribution is missing its release manifest")
+    if json.loads(manifest.read_text(encoding="utf-8")) != expected:
+        raise ValueError("UI release identity or file checksums do not match")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("operation", choices=("stamp", "verify"))
+    parser.add_argument("--dist", type=Path, required=True)
+    parser.add_argument("--source-sha", required=True)
+    parser.add_argument("--release-tag", required=True)
+    args = parser.parse_args()
+    try:
+        {"stamp": stamp, "verify": verify}[args.operation](args.dist, args.source_sha, args.release_tag)
+    except (ValueError, OSError) as error:
+        parser.exit(1, f"{error}\n")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Original problem

Release host producers repeated the TypeScript UI build, while CUDA/ROCm/Vulkan composition jobs downloaded compiler images despite consuming already-built host and runtime artifacts.

## Diagnostics

I traced the host/runtime/product graph and verified that the existing CPU image supports both AMD64 and ARM64. The AMD64 CUDA compiler job remains byte-for-byte identical to the baseline, including its intentional ARC placement.

## Fix

Build one version/source-bound UI artifact with a complete checksum manifest, then verify and reuse it in every host producer, Swift resources, and release SDK resources. Native Rust embedding remains per architecture. Missing, changed, or placeholder UI inputs fail before compilation.

Six Linux composition rows use the existing pinned CPU image and retain dependency, attestation, and readiness checks. Compiler images, CUDA architecture lists, and runner-provider settings are unchanged.

The shared SDK smoke helper also accepts the current `{catalogs, runtimes}` diagnostic response and legacy lists. This fixes the schema mismatch introduced by the latest runtime-diagnostics change on `main`; malformed rows, incompatible runtimes, ABI mismatches, and ambiguous selections remain errors.

## Validation

- [x] All five required GitHub CI lanes passed at `fdef9cfc9`: [Linux](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34179498483), [macOS](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34179498413), [Windows](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34179498345), [Quality](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34179498314), and [Website](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34179498319). Both Rust and Kotlin SDK smoke tests pass with the current runtime JSON response.
- [x] `just ci-validate` passed: 825 Python tests passed and seven PowerShell behavior tests were skipped because the local host lacks `pwsh`. Crate-list, release-target, no-console-print, and publish-crates consistency gates passed. The final local gate used Homebrew Python 3.14/PyYAML.
- [x] Changed embedded Bash passed `just ci-shellcheck`. A real release-mode UI build passed manifest verification, with executable tests for Python selection and tampering rejection.
- [x] The published v0.75.1 ARM64 CUDA 13 product passed the unchanged composition script in the exact CPU image, with networking disabled, no GPU device, no `nvcc`, dependency verification, client readiness, graceful shutdown, and matching host/runtime hashes. This supplemental check did not repeat release signature verification because the temporary inputs lacked the release verifier/key; production checks are unchanged.
- [x] UI appearance is unchanged, so screenshots are not applicable.

The multi-platform release canary and end-to-end timing comparison remain pending. The existing trusted release workflow only accepts manual dispatch from `main`, so this PR does not bypass that boundary or claim a measured wall-time improvement.

Companion packaging, deterministic image assembly, publication handoff, and timing history: https://github.com/Mesh-LLM/mesh-packaging/pull/26.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Release builds now use one verified, version-bound console UI distribution across supported platforms and SDK packages.
  - UI assets are validated with source, version, and file checksums before packaging.
  - Swift SDK releases can reuse verified UI assets without rebuilding them locally.

- **Reliability**
  - Linux composition workflows use consistent tooling while retaining readiness checks.
  - Runtime discovery now supports catalog-wrapped reports and rejects malformed or ambiguous results safely.

- **Documentation**
  - Release ownership, verification, and workflow expectations are now documented.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->