### PR TITLE
fix: serialize materialized cache writes on Windows

### DIFF
--- a/crates/skippy-runtime/src/package/materialized_cache.rs
+++ b/crates/skippy-runtime/src/package/materialized_cache.rs
@@ -4,9 +4,6 @@ use std::{
     sync::atomic::{AtomicU64, Ordering},
 };
 
-#[cfg(unix)]
-use std::os::fd::AsRawFd;
-
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 
@@ -96,10 +93,7 @@ pub(super) struct MaterializedOutputLock {
 
 impl Drop for MaterializedOutputLock {
     fn drop(&mut self) {
-        #[cfg(unix)]
-        unsafe {
-            let _ = libc::flock(self.file.as_raw_fd(), libc::LOCK_UN);
-        }
+        let _ = self.file.unlock();
     }
 }
 
@@ -117,13 +111,8 @@ pub(super) fn lock_output(output: &Path) -> Result<MaterializedOutputLock> {
         .open(&lock_path)
         .with_context(|| format!("open materialized cache lock {}", lock_path.display()))?;
 
-    #[cfg(unix)]
-    unsafe {
-        if libc::flock(file.as_raw_fd(), libc::LOCK_EX) != 0 {
-            return Err(std::io::Error::last_os_error())
-                .with_context(|| format!("lock materialized cache {}", lock_path.display()));
-        }
-    }
+    file.lock()
+        .with_context(|| format!("lock materialized cache {}", lock_path.display()))?;
 
     Ok(MaterializedOutputLock { file })
 }
@@ -280,4 +269,63 @@ fn sanitize_suffix(value: &str) -> String {
             }
         })
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    #[test]
+    fn output_lock_excludes_other_processes_until_dropped() {
+        let dir = tempfile::tempdir().unwrap();
+        let output = dir.path().join("model.gguf");
+        let guard = lock_output(&output).unwrap();
+        assert_child_lock_state(&output, "locked");
+        drop(guard);
+        assert_child_lock_state(&output, "unlocked");
+        let guard = lock_output(&output).unwrap();
+        assert_child_lock_state(&output, "locked");
+        drop(guard);
+    }
+
+    fn assert_child_lock_state(output: &Path, expected: &str) {
+        let result = Command::new(std::env::current_exe().unwrap())
+            .args([
+                "--exact",
+                "package::materialized_cache::tests::probe_output_lock_in_child",
+                "--ignored",
+                "--nocapture",
+            ])
+            .env("SKIPPY_TEST_OUTPUT_LOCK_PATH", output)
+            .env("SKIPPY_TEST_OUTPUT_LOCK_STATE", expected)
+            .output()
+            .unwrap();
+        assert!(
+            result.status.success()
+                && String::from_utf8_lossy(&result.stdout).contains("1 passed;"),
+            "lock probe failed: {}\n{}",
+            String::from_utf8_lossy(&result.stdout),
+            String::from_utf8_lossy(&result.stderr)
+        );
+    }
+
+    #[test]
+    #[ignore = "subprocess helper for output_lock_excludes_other_processes_until_dropped"]
+    fn probe_output_lock_in_child() {
+        let output = PathBuf::from(std::env::var_os("SKIPPY_TEST_OUTPUT_LOCK_PATH").unwrap());
+        let file = fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .open(sibling_path(&output, "lock"))
+            .unwrap();
+        match std::env::var("SKIPPY_TEST_OUTPUT_LOCK_STATE")
+            .unwrap()
+            .as_str()
+        {
+            "locked" => assert!(matches!(file.try_lock(), Err(fs::TryLockError::WouldBlock))),
+            "unlocked" => file.try_lock().unwrap(),
+            state => panic!("unexpected lock state: {state}"),
+        }
+    }
 }


### PR DESCRIPTION
## Original problem

On Windows, two processes materializing the same model output could both pass `lock_output`: the lock file was opened, but the exclusive lock existed only under `cfg(unix)`.

Fixes #1682.

## Diagnostics

A Windows regression starts a second process and tries to acquire the same lock. On the original code that process succeeds while the first guard is alive. With this change it receives `WouldBlock`, can acquire the lock after guard drop, and is excluded again after reacquisition.

## Fix

Use the standard library's `File::lock` and `File::unlock` on the existing read/write handle. This retains the guard lifetime across output publication and cache-record writing, preserves Unix flock behavior, and adds Windows locking without a dependency or cache-format change.

## Validation

- [x] Ran the relevant local checks; limits are recorded below.
- UI evidence is not applicable to this filesystem change.
- Windows: 113 `skippy-runtime` library tests passed, with one ignored subprocess helper and three unchanged native-runtime tests filtered out. The helper's caller verifies that exactly one probe test actually ran.
- `cargo check --locked -p skippy-runtime --features dynamic-native-runtime`
- `cargo clippy --locked --no-deps -p skippy-runtime --all-targets --features dynamic-native-runtime -- -D warnings`
- `cargo check --locked -p mesh-llm`
- `cargo fmt --all --check` and `git diff --check`

The unfiltered baseline already failed these three tests because the native runtime library was not loaded: `cache_append_extends_the_committed_history`, `cache_drafts_from_committed_history_and_never_mutates_for_a_prefix`, and `invalid_selected_backend_device_fails_before_model_open`. The passing run uses `--skip` for those tests only.

Full-host `cargo clippy --locked -p mesh-llm --all-targets -- -D warnings` stops at the pre-existing `needless_return` in `crates/mesh-llm-events/src/audit.rs:469`; that file is identical to the base commit. Linux/macOS and live model inference were not run locally.

## Post-Deploy Monitoring & Validation

On the first Windows build containing this change, concurrent starts targeting one materialized output should serialize without publication/cache-record races. Check for new `lock materialized cache` errors. If locking regresses on a supported filesystem, revert this commit while investigating that filesystem's lock support.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File locking now works consistently across supported platforms.

* **Bug Fixes**
  * Improved materialized cache locking to prevent concurrent processes from accessing output simultaneously.
  * Locks are reliably released when no longer needed.
  * Lock behavior now remains effective across separate processes until the lock is explicitly released.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->