### PR TITLE
fix: Prepare release UI from container-owned checkouts

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -471,7 +471,9 @@ fail-open policy.
 - `restore-release-ui` / `scripts/ui-distribution.py`: verify the shared release
   console's source SHA, version, complete file hashes and built JavaScript entry
   before platform-specific Rust compilation or SDK resource packaging. The
-  `prepared-release-ui-*` artifact retains for 90 days and is excluded from the
+  UI producer's version step trusts only `GITHUB_WORKSPACE` in the container's
+  active Git configuration before verifying the exact checkout SHA.
+  The `prepared-release-ui-*` artifact retains for 90 days and is excluded from the
   GitHub release asset glob. Swift release resource assembly skips pnpm and the
   console build when this artifact is supplied; ordinary PR/main behavior is
   unchanged.

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -102,6 +102,7 @@ jobs:
         run: |
           set -euo pipefail
           [[ "$UI_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
           test "$(git rev-parse HEAD)" = "$UI_SOURCE_SHA"
           scripts/release-version.sh "$RELEASE_TAG"
           echo "VITE_MESH_LLM_DEBUG_UI=false" >> "$GITHUB_ENV"

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -119,6 +119,9 @@ main.
 
 Release efficiency TODOs:
 
+- [x] Prepare release UI versions in container checkouts with different owners.
+  QA: execute the workflow step with Git's ownership check enabled, verify
+  workspace-only trust and source rejection, then shellcheck the extracted step.
 - [x] Build one version-bound console distribution and verify its complete file
   checksums before each host embeds it or an SDK packages it. QA: run the UI
   identity/tampering tests and release artifact graph tests.
@@ -146,7 +149,10 @@ the same script and rejects any tracked diff. Canary dispatches do not mutate
 Release calls the existing UI producer once with the immutable source SHA and
 release tag. It prepares that version, builds the TypeScript console in release
 mode, and records every output checksum in `.mesh-llm-ui-release.json`. The
-Linux amd64/arm64, macOS and Windows host producers restore and verify this same
+version step registers only `GITHUB_WORKSPACE` as a safe Git directory in the
+container's active home before checking the source SHA or running the version
+script; checkout's temporary home configuration does not reach these commands.
+The Linux amd64/arm64, macOS and Windows host producers restore and verify this same
 distribution before compiling their own target-specific Rust embedding crate
 and host. Swift resource assembly and the release-tag SDK resources consume the
 same bytes with `--skip-build`. Missing manifests, mismatched source/version,

--- a/scripts/tests/test_release_workflow_artifacts.py
+++ b/scripts/tests/test_release_workflow_artifacts.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
+import os
+import subprocess
+import tempfile
 import unittest
+
+import yaml
 
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -15,6 +20,83 @@ def job_block(workflow: str, job_name: str, next_job_name: str) -> str:
 
 
 class ReleaseWorkflowArtifactTests(unittest.TestCase):
+    def test_release_ui_version_preparation_handles_container_ownership(self) -> None:
+        workflow = yaml.safe_load(
+            (ROOT / ".github/workflows/ci-ui-artifact-slice.yml").read_text()
+        )
+        step = next(
+            step for step in workflow["jobs"]["ui_artifact"]["steps"]
+            if step.get("name") == "Prepare release UI version"
+        )
+        for source in ("matching", "mismatching", "malformed"):
+            with self.subTest(source=source), tempfile.TemporaryDirectory() as temp:
+                root = Path(temp).resolve()
+                repo = root / "container checkout"
+                repo.mkdir()
+                home = root / "home"
+                home.mkdir()
+                env = {
+                    key: value for key, value in os.environ.items()
+                    if not key.startswith("GIT_")
+                }
+                env.update(
+                    HOME=str(home), XDG_CONFIG_HOME=str(home),
+                    GIT_CONFIG_GLOBAL=str(home / ".gitconfig"),
+                    GIT_CONFIG_NOSYSTEM="1",
+                )
+
+                def git(*args: str) -> subprocess.CompletedProcess[str]:
+                    return subprocess.run(
+                        ["git", *args], cwd=repo, env=env,
+                        text=True, capture_output=True,
+                    )
+
+                self.assertEqual(git("init", "--quiet").returncode, 0)
+                commit = git(
+                    "-c", "user.name=Test", "-c", "user.email=test@example.invalid",
+                    "-c", "commit.gpgsign=false", "commit", "--allow-empty", "-m", "fixture",
+                )
+                self.assertEqual(commit.returncode, 0, commit.stderr)
+                sha = git("rev-parse", "HEAD").stdout.strip()
+                scripts = repo / "scripts"
+                scripts.mkdir()
+                version = scripts / "release-version.sh"
+                version.write_text(
+                    '#!/usr/bin/env bash\nset -euo pipefail\n'
+                    'git rev-parse HEAD > version-source\nprintf "%s\\n" "$1" > version-tag\n'
+                )
+                version.chmod(0o755)
+                env.update(
+                    GIT_TEST_ASSUME_DIFFERENT_OWNER="1",
+                    GITHUB_WORKSPACE=str(repo), GITHUB_ENV=str(root / "github-env"),
+                    UI_SOURCE_SHA=sha if source == "matching" else (
+                        "0" * 40 if source == "mismatching" else "invalid"
+                    ),
+                    RELEASE_TAG="v0.76.0-rc9",
+                )
+                untrusted = git("rev-parse", "HEAD")
+                self.assertNotEqual(untrusted.returncode, 0)
+                self.assertIn("dubious ownership", untrusted.stderr)
+                result = subprocess.run(
+                    ["bash", "-c", step["run"]], cwd=repo, env=env,
+                    text=True, capture_output=True,
+                )
+                if source != "matching":
+                    self.assertNotEqual(result.returncode, 0)
+                    self.assertFalse((repo / "version-tag").exists())
+                    self.assertFalse((root / "github-env").exists())
+                    continue
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual((repo / "version-source").read_text().strip(), sha)
+                self.assertEqual((repo / "version-tag").read_text().strip(), env["RELEASE_TAG"])
+                self.assertEqual(
+                    (root / "github-env").read_text(), "VITE_MESH_LLM_DEBUG_UI=false\n"
+                )
+                self.assertEqual(
+                    git("config", "--global", "--get-all", "safe.directory").stdout.splitlines(),
+                    [str(repo)],
+                )
+
     def test_release_ui_is_one_verified_producer_for_hosts_and_sdks(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         producer = job_block(workflow, "release_ui", "build")


### PR DESCRIPTION
Release UI preparation can now verify and version the checkout inside the build container. The non-publishing [release canary](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34189448604/job/101944423165) failed immediately after checkout because Git's safe-directory entry existed only in the checkout action's temporary home.

Register only `GITHUB_WORKSPACE` in the shell's active Git configuration before checking the immutable source SHA and invoking the version script. The source check, one-UI producer graph, and runner placement remain intact.

Validation:

- Execute the actual workflow shell step under Git's simulated ownership mismatch. The test reproduced the original failure and passes with the fix, including Git access from the version-script child process, workspace-only trust, and rejection of mismatched or malformed source SHAs.
- All 25 release-artifact workflow tests and shellcheck of the extracted step pass.
- [Hosted Quality](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34191016672/job/101949149697) passes all 833 script tests, workflow validation, and the CI, release, publish-chain, and console-print consistency checks.
- Local `just ci-validate` completed with the existing CLI-planner test's 60-second timeout and a Python 3.12/macOS filesystem-permission error in the Windows dependency test; seven PowerShell tests were skipped. The CLI timeout also reproduces on the unchanged #1684 checkout. Rerunning all 32 Windows dependency and release-workflow tests under Python 3.14 passes, as do the four local repository-consistency recipes.
- Remaining platform CI and a fresh non-publishing release canary are required before completing integration.

Current revision is rebased onto `afa36ab02` after #1672 added a workspace crate that the protected planner selected against the older checkout. The ownership repair is unchanged by the rebase; all 25 focused tests, actionlint, and shellcheck pass again. Fresh CI is running at `3798a4132`; the earlier results above describe the pre-rebase revision. CodeRabbit's review of that repair produced no actionable comments.

Follow-up to #1684.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved release UI version preparation for containerized checkouts with differing file ownership.
  - Added workspace validation before generating release versions, including rejection of mismatched or malformed source revisions.

- **Documentation**
  - Updated CI and release documentation with verification steps and workspace trust requirements.

- **Tests**
  - Added coverage for matching, mismatched, and malformed source revisions in container-ownership scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->