### PR TITLE
fix: use served model IDs in ready commands

### DIFF
--- a/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/run_auto.rs
@@ -1627,7 +1627,6 @@ pub(super) async fn run_auto(ctx: RunAutoContext) -> Result<()> {
     let primary_model_name = requested_model_names.first().cloned().unwrap_or_default();
     let startup_ready_reporter = StartupReadyReporter::new_with_failure_policy(
         &requested_model_names,
-        primary_model_name.clone(),
         api_ready_url,
         ready_console_url,
         ready_api_port,

--- a/crates/mesh-llm-host-runtime/src/runtime/serving_surface.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/serving_surface.rs
@@ -368,7 +368,6 @@ pub(crate) fn assert_passive_path_immediate_spawn_behavior() {
 pub(crate) fn assert_quitting_during_startup_cancels_without_late_ready_render() {
     let reporter = StartupReadyReporter::new(
         &["Qwen3-8B-Q4_K_M".to_string()],
-        "Qwen3-8B-Q4_K_M".to_string(),
         "http://127.0.0.1:9337".to_string(),
         Some("http://127.0.0.1:3131".to_string()),
         9337,
@@ -376,7 +375,9 @@ pub(crate) fn assert_quitting_during_startup_cancels_without_late_ready_render()
     );
     reporter.mark_shutdown_requested();
     assert!(
-        reporter.mark_ready_and_build_event(0).is_none(),
+        reporter
+            .mark_ready_and_build_event(0, "Qwen3-8B-Q4_K_M")
+            .is_none(),
         "startup shutdown should cancel any late RuntimeReady emission"
     );
 }
@@ -386,7 +387,6 @@ pub(crate) fn assert_startup_ready_reporter_waits_for_rust_owned_model_ready_edg
     let models = vec!["model-a".to_string(), "model-b".to_string()];
     let reporter = StartupReadyReporter::new(
         &models,
-        "model-a".to_string(),
         "http://127.0.0.1:9337".to_string(),
         Some("http://127.0.0.1:3131".to_string()),
         9337,
@@ -394,16 +394,16 @@ pub(crate) fn assert_startup_ready_reporter_waits_for_rust_owned_model_ready_edg
     );
 
     assert!(
-        reporter.mark_ready_and_build_event(0).is_none(),
+        reporter.mark_ready_and_build_event(0, "model-a").is_none(),
         "one model-ready edge must not replace the remaining Rust-owned readiness edges"
     );
     assert!(
-        reporter.mark_ready_and_build_event(0).is_none(),
+        reporter.mark_ready_and_build_event(0, "model-a").is_none(),
         "a repeated edge for one startup slot must not mark a different slot ready"
     );
     assert!(
         matches!(
-            reporter.mark_ready_and_build_event(1),
+            reporter.mark_ready_and_build_event(1, "model-b"),
             Some(OutputEvent::RuntimeReady { .. })
         ),
         "RuntimeReady should appear only after every startup model hits the Rust-owned ready path"
@@ -655,7 +655,6 @@ pub(super) async fn startup_ready_reporter_uses_bound_urls_for_runtime_ready() {
     let models = vec!["model-a".to_string()];
     let reporter = StartupReadyReporter::new(
         &models,
-        "model-a".to_string(),
         api_url.clone(),
         Some(console_url.clone()),
         api_port,
@@ -668,7 +667,7 @@ pub(super) async fn startup_ready_reporter_uses_bound_urls_for_runtime_ready() {
         api_port: reported_api_port,
         console_port: reported_console_port,
         ..
-    }) = reporter.mark_ready_and_build_event(0)
+    }) = reporter.mark_ready_and_build_event(0, "model-a")
     else {
         panic!("reporter should emit RuntimeReady when the model is ready");
     };
@@ -684,6 +683,56 @@ pub(super) async fn startup_ready_reporter_uses_bound_urls_for_runtime_ready() {
 #[test]
 pub(super) fn startup_ready_reporter_waits_for_rust_owned_model_ready_edges() {
     assert_startup_ready_reporter_waits_for_rust_owned_model_ready_edges();
+}
+
+#[test]
+fn startup_ready_commands_use_the_primary_served_model_in_either_load_order() {
+    let primary_id = "local-gguf/sha256-f90897d3a4d7e185";
+    for primary_first in [true, false] {
+        let models = vec![
+            "/models/primary.gguf".to_string(),
+            "other-model".to_string(),
+        ];
+        let reporter = StartupReadyReporter::new(
+            &models,
+            "http://127.0.0.1:9337".to_string(),
+            None,
+            9337,
+            None,
+        );
+        let (first, last) = if primary_first { (0, 1) } else { (1, 0) };
+        let served_models = [primary_id, "other-served-model"];
+        assert!(
+            reporter
+                .mark_ready_and_build_event(first, served_models[first])
+                .is_none()
+        );
+        let Some(OutputEvent::RuntimeReady {
+            pi_command,
+            goose_command,
+            ..
+        }) = reporter
+            .clone()
+            .mark_ready_and_build_event(last, served_models[last])
+        else {
+            panic!("both loaded models should make the runtime ready");
+        };
+        assert_eq!(
+            pi_command.unwrap(),
+            format!("mesh-llm pi --host 127.0.0.1:9337 --model '{primary_id}'")
+        );
+        assert_eq!(
+            goose_command.unwrap(),
+            format!(
+                "GOOSE_PROVIDER=openai OPENAI_HOST=http://127.0.0.1:9337 OPENAI_API_KEY=mesh GOOSE_MODEL={primary_id} goose session"
+            )
+        );
+        assert!(
+            reporter
+                .mark_ready_and_build_event(last, served_models[last])
+                .is_none()
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/mesh-llm-host-runtime/src/runtime/startup_handles.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/startup_handles.rs
@@ -762,12 +762,11 @@ pub(super) fn update_startup_target(
 
 #[derive(Clone)]
 pub(super) struct StartupReadyReporter {
-    pub(super) ready_by_model: Arc<Mutex<Vec<bool>>>,
+    pub(super) ready_by_model: Arc<Mutex<Vec<Option<String>>>>,
     pub(super) emitted: Arc<AtomicBool>,
     pub(super) shutdown_requested: Arc<AtomicBool>,
     startup_failure_policy: mesh_llm_config::StartupFailurePolicy,
     terminal_failures: Arc<Mutex<Vec<String>>>,
-    pub(super) primary_model: String,
     pub(super) api_url: String,
     pub(super) console_url: Option<String>,
     pub(super) api_port: u16,
@@ -784,7 +783,6 @@ impl StartupReadyReporter {
     )]
     pub(super) fn new(
         models: &[String],
-        primary_model: String,
         api_url: String,
         console_url: Option<String>,
         api_port: u16,
@@ -792,7 +790,6 @@ impl StartupReadyReporter {
     ) -> Self {
         Self::new_with_failure_policy(
             models,
-            primary_model,
             api_url,
             console_url,
             api_port,
@@ -803,21 +800,19 @@ impl StartupReadyReporter {
 
     pub(super) fn new_with_failure_policy(
         models: &[String],
-        primary_model: String,
         api_url: String,
         console_url: Option<String>,
         api_port: u16,
         console_port: Option<u16>,
         startup_failure_policy: mesh_llm_config::StartupFailurePolicy,
     ) -> Self {
-        let ready_by_model = vec![false; models.len()];
+        let ready_by_model = vec![None; models.len()];
         Self {
             ready_by_model: Arc::new(Mutex::new(ready_by_model)),
             emitted: Arc::new(AtomicBool::new(false)),
             shutdown_requested: Arc::new(AtomicBool::new(false)),
             startup_failure_policy,
             terminal_failures: Arc::new(Mutex::new(Vec::new())),
-            primary_model,
             api_url,
             console_url,
             api_port,
@@ -877,23 +872,22 @@ impl StartupReadyReporter {
         self.shutdown_requested.store(true, Ordering::SeqCst);
     }
 
-    pub(super) fn mark_ready_and_build_event(&self, readiness_index: usize) -> Option<OutputEvent> {
-        let models_count = {
+    pub(super) fn mark_ready_and_build_event(
+        &self,
+        readiness_index: usize,
+        loaded_model: &str,
+    ) -> Option<OutputEvent> {
+        let (models_count, primary_model) = {
             let mut ready_by_model = self
                 .ready_by_model
                 .lock()
                 .expect("startup readiness mutex poisoned");
-            if let Some(entry) = ready_by_model.get_mut(readiness_index) {
-                *entry = true;
+            *ready_by_model.get_mut(readiness_index)? = Some(loaded_model.to_string());
+            if ready_by_model.iter().any(Option::is_none) {
+                return None;
             }
-            if ready_by_model.iter().all(|ready| *ready) {
-                Some(ready_by_model.len())
-            } else {
-                None
-            }
+            (ready_by_model.len(), ready_by_model[0].as_ref()?.clone())
         };
-
-        let models_count = models_count?;
 
         if self.shutdown_requested.load(Ordering::SeqCst) {
             return None;
@@ -906,11 +900,11 @@ impl StartupReadyReporter {
         let pi_command = Some(format!(
             "mesh-llm pi --host 127.0.0.1:{} --model {}",
             self.api_port,
-            single_quote_shell_arg(&self.primary_model)
+            single_quote_shell_arg(&primary_model)
         ));
         let goose_command = Some(format!(
             "GOOSE_PROVIDER=openai OPENAI_HOST={} OPENAI_API_KEY=mesh GOOSE_MODEL={} goose session",
-            self.api_url, self.primary_model
+            self.api_url, primary_model
         ));
         Some(OutputEvent::RuntimeReady {
             api_url: self.api_url.clone(),
@@ -923,8 +917,8 @@ impl StartupReadyReporter {
         })
     }
 
-    fn mark_ready_and_maybe_emit(&self, readiness_index: usize) {
-        let Some(event) = self.mark_ready_and_build_event(readiness_index) else {
+    fn mark_ready_and_maybe_emit(&self, readiness_index: usize, loaded_model: &str) {
+        let Some(event) = self.mark_ready_and_build_event(readiness_index, loaded_model) else {
             return;
         };
         let _ = emit_event(event);
@@ -948,7 +942,6 @@ mod startup_failure_policy_tests {
     fn reporter(policy: StartupFailurePolicy) -> StartupReadyReporter {
         StartupReadyReporter::new_with_failure_policy(
             &["model-a".to_string()],
-            "model-a".to_string(),
             "http://127.0.0.1:1".to_string(),
             None,
             1,

--- a/crates/mesh-llm-host-runtime/src/runtime/startup_handles/startup_loop.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/startup_handles/startup_loop.rs
@@ -918,7 +918,7 @@ pub(in crate::runtime) async fn startup_publish_loaded_runtime(
         cs.update(true, true).await;
     }
     update_pi_models_json(loaded_name, ctx.api_port);
-    startup_ready_reporter.mark_ready_and_maybe_emit(ctx.readiness_index);
+    startup_ready_reporter.mark_ready_and_maybe_emit(ctx.readiness_index, loaded_name);
     let _ = emit_event(OutputEvent::ModelReady {
         model: loaded_name.to_string(),
         internal_port: Some(handle.port),


### PR DESCRIPTION
## Title

Use served model IDs in ready commands

## Original problem

After starting with `--gguf`, the ready output uses the file path as the Goose/Pi model ID. Pasting that command requests a model the node does not serve.

## Diagnostics

The regression supplies a file-path startup reference and a different canonical served ID. Before the fix, the Pi command still contains the path. The test checks both primary-first and secondary-first completion, including a cloned readiness reporter.

## Fix

Record each slot's loaded model ID on its existing readiness edge. Build the commands from the primary slot after every startup model is ready. The ID comes from the same publication path used to register the loaded runtime.

For `mesh-llm serve --gguf /path/to/model.gguf`, the regression verifies these commands when the resolved ID is `local-gguf/sha256-f90897d3a4d7e185`:

```sh
mesh-llm pi --host 127.0.0.1:9337 --model 'local-gguf/sha256-f90897d3a4d7e185'
GOOSE_PROVIDER=openai OPENAI_HOST=http://127.0.0.1:9337 OPENAI_API_KEY=mesh GOOSE_MODEL=local-gguf/sha256-f90897d3a4d7e185 goose session
```

Fixes #1594.

## Validation

- [x] Ran the relevant local checks, with the limitation below.
- [x] No visual UI change; exact command strings are asserted in the regression.

13 relevant host-runtime tests pass: nine serving-surface tests, three startup-failure-policy tests and the quitting-during-startup test. `cargo check` for `mesh-llm-host-runtime` and `mesh-llm`, and `cargo fmt --all --check`, pass.

The required strict Clippy command fails on Windows in unchanged dependencies: `audit.rs:469` (`needless_return`) and `materialized_cache.rs:94` (`dead_code`). I reproduced both with the same command on the clean base commit. No live GGUF inference or HTTP smoke was run.

## Post-Deploy Monitoring & Validation

During native release validation, compare the emitted model IDs with `/v1/models` and exercise the copied commands. Local validation covers readiness-event generation and shutdown suppression.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Runtime readiness notifications now consistently reference the correct primary served model, regardless of which model finishes loading first.
  * Startup status reporting now associates each readiness event with the model that became ready.
  * Launch commands generated after all required models are ready now use the intended served model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->