### PR TITLE
fix: retain device placement in native log summaries

### DIFF
--- a/crates/skippy-runtime/src/logging.rs
+++ b/crates/skippy-runtime/src/logging.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 use std::ffi::{CStr, c_char, c_int, c_void};
 use std::fs::{File, OpenOptions};
 use std::io::{LineWriter, Write};
@@ -185,6 +185,8 @@ struct NativeLogAggregator {
     metadata_progress: ProgressTracker,
     tensor_progress: ProgressTracker,
     layer_assign_progress: ProgressTracker,
+    layer_devices: BTreeMap<usize, String>,
+    layer_devices_emitted: bool,
     kv_cache_progress: ProgressTracker,
     metadata_in_dump: bool,
     metadata_summary_emitted: bool,
@@ -239,6 +241,8 @@ impl NativeLogAggregator {
         self.metadata_progress.reset();
         self.tensor_progress.reset();
         self.layer_assign_progress.reset();
+        self.layer_devices.clear();
+        self.layer_devices_emitted = false;
         self.kv_cache_progress.reset();
         self.metadata_in_dump = false;
         self.metadata_summary_emitted = false;
@@ -257,11 +261,15 @@ impl NativeLogAggregator {
         let mut events = Vec::new();
         let metadata_kv = parse_metadata_kv_line(s);
         let tensor_summary = parse_tensor_type_summary(s);
+        let layer_assignment = parse_layer_assignment(s);
         if metadata_kv.is_none() {
             events.extend(self.flush_metadata_summary());
         }
         if tensor_summary.is_none() {
             events.extend(self.flush_tensor_group_summary());
+        }
+        if layer_assignment.is_none() {
+            events.extend(self.flush_layer_device_summary());
         }
 
         if let Some((metadata_rows, tensor_rows)) = parse_loaded_metadata_counts(s) {
@@ -321,24 +329,8 @@ impl NativeLogAggregator {
             return events;
         }
 
-        if let Some(layer_index) = parse_layer_assign_index(s) {
-            if self.layer_assign_progress.total.is_none()
-                && let Some(total) = self
-                    .metadata_highlights
-                    .block_count
-                    .as_deref()
-                    .and_then(|s| s.parse::<usize>().ok())
-            {
-                self.layer_assign_progress.set_total(total);
-            }
-            let new_completed = layer_index + 1;
-            if new_completed > self.layer_assign_progress.completed {
-                let delta = new_completed - self.layer_assign_progress.completed;
-                events.extend(
-                    self.layer_assign_progress
-                        .advance(delta, "model", "layers", "layers"),
-                );
-            }
+        if let Some((layer_index, device)) = layer_assignment {
+            events.extend(self.record_layer_assignment(layer_index, device));
             return events;
         }
 
@@ -351,6 +343,45 @@ impl NativeLogAggregator {
         }
 
         events
+    }
+
+    fn record_layer_assignment(&mut self, layer_index: usize, device: &str) -> Vec<NativeLogEvent> {
+        if self.layer_devices.get(&layer_index).map(String::as_str) != Some(device) {
+            self.layer_devices.insert(layer_index, device.to_string());
+            self.layer_devices_emitted = false;
+        }
+        if self.layer_assign_progress.total.is_none()
+            && let Some(total) = self
+                .metadata_highlights
+                .block_count
+                .as_deref()
+                .and_then(|s| s.parse::<usize>().ok())
+        {
+            self.layer_assign_progress.set_total(total);
+        }
+        let new_completed = layer_index.saturating_add(1);
+        let delta = new_completed.saturating_sub(self.layer_assign_progress.completed);
+        self.layer_assign_progress
+            .advance(delta, "model", "layers", "layers")
+    }
+
+    fn flush_layer_device_summary(&mut self) -> Vec<NativeLogEvent> {
+        if self.layer_devices.is_empty() || self.layer_devices_emitted {
+            return Vec::new();
+        }
+        self.layer_devices_emitted = true;
+        let mut counts = BTreeMap::new();
+        for device in self.layer_devices.values() {
+            *counts.entry(device.as_str()).or_insert(0_u64) += 1;
+        }
+        vec![NativeLogEvent {
+            message: "Model layers by device".to_string(),
+            category: "model",
+            params: counts
+                .into_iter()
+                .map(|(device, count)| (device.to_string(), Value::from(count)))
+                .collect(),
+        }]
     }
 
     fn flush_metadata_summary(&mut self) -> Vec<NativeLogEvent> {
@@ -475,7 +506,7 @@ fn summarize_native_log_line(line: &str) -> Option<NativeLogEvent> {
     if line.contains("VRAM")
         || line.contains("vram")
         || line.contains("mem_alloc")
-        || line.contains("_Mapped model buffer size")
+        || line.contains("model buffer size")
         || (line.contains("GPU") && line.contains("memory"))
         || line.contains("compute buffer size")
         || line.contains("scratch buffer")
@@ -569,17 +600,12 @@ fn parse_tensor_type_summary(line: &str) -> Option<(&str, usize)> {
     Some((tensor_type.trim(), count))
 }
 
-fn parse_layer_assign_index(line: &str) -> Option<usize> {
-    if !line.starts_with("load_tensors: layer") || !line.contains("assigned to device") {
-        return None;
-    }
-    let (_, remainder) = line.split_once("load_tensors: layer")?;
-    let digits = remainder
-        .trim_start()
-        .chars()
-        .take_while(|ch| ch.is_ascii_digit())
-        .collect::<String>();
-    (!digits.is_empty()).then(|| digits.parse().ok()).flatten()
+fn parse_layer_assignment(line: &str) -> Option<(usize, &str)> {
+    let remainder = line.strip_prefix("load_tensors: layer")?;
+    let (index, device) = remainder.split_once("assigned to device")?;
+    let index = index.trim().parse().ok()?;
+    let device = device.split(',').next()?.trim();
+    (!device.is_empty()).then_some((index, device))
 }
 
 fn parse_kv_cache_layers_total(line: &str) -> Option<usize> {
@@ -1062,6 +1088,96 @@ mod tests {
     }
 
     #[test]
+    fn aggregator_preserves_model_buffers_for_all_devices() {
+        let mut aggregator = NativeLogAggregator::default();
+        for device in ["CUDA0", "CUDA1", "Metal", "ROCm0", "Vulkan0", "CPU_Mapped"] {
+            let line = format!("load_tensors: {device} model buffer size = 4321.00 MiB");
+            let events = aggregator.process_line(&line);
+            assert_eq!(events.len(), 1, "missing buffer for {device}");
+            assert_eq!(events[0].message, line);
+            assert_eq!(events[0].category, "memory");
+        }
+    }
+
+    #[test]
+    fn aggregator_summarizes_unique_layer_assignments_including_output_layer() {
+        let mut aggregator = NativeLogAggregator::default();
+        aggregator.process_line("llama_model_loader: - kv 0: qwen35.block_count u32 = 4");
+        for (layer, device) in [
+            (0, "CUDA0"),
+            (1, "CPU"),
+            (2, "CUDA0"),
+            (2, "CUDA0"),
+            (3, "CUDA1"),
+            (4, "CPU"),
+        ] {
+            let events = aggregator.process_line(&format!(
+                "load_tensors: layer {layer} assigned to device {device}, is_swa = 0"
+            ));
+            assert!(
+                events
+                    .iter()
+                    .all(|event| event.message != "Model layers by device")
+            );
+        }
+
+        assert_eq!(
+            aggregator.process_line("load_tensors: finished"),
+            vec![NativeLogEvent {
+                message: "Model layers by device".to_string(),
+                category: "model",
+                params: vec![
+                    ("CPU".to_string(), Value::from(2_u64)),
+                    ("CUDA0".to_string(), Value::from(2_u64)),
+                    ("CUDA1".to_string(), Value::from(1_u64)),
+                ],
+            }]
+        );
+        assert!(aggregator.process_line("load_tensors: finished").is_empty());
+    }
+
+    #[test]
+    fn aggregator_emits_only_changed_layer_device_counts() {
+        let mut aggregator = NativeLogAggregator::default();
+        aggregator.process_line("load_tensors: layer 0 assigned to device CUDA0");
+        assert_eq!(aggregator.process_line("load_tensors: finished").len(), 1);
+        aggregator.process_line("load_tensors: layer 0 assigned to device CUDA0");
+        assert!(aggregator.process_line("load_tensors: finished").is_empty());
+
+        aggregator.process_line("load_tensors: layer 0 assigned to device CPU");
+        assert_eq!(
+            aggregator.process_line("load_tensors: finished"),
+            vec![NativeLogEvent {
+                message: "Model layers by device".to_string(),
+                category: "model",
+                params: vec![("CPU".to_string(), Value::from(1_u64))],
+            }]
+        );
+    }
+
+    #[test]
+    fn aggregator_resets_layer_devices_for_each_model() {
+        let mut aggregator = NativeLogAggregator::default();
+        aggregator.process_line("load_tensors: layer 0 assigned to device CUDA0");
+        let next_model = aggregator.process_line(
+            "llama_model_loader: loaded meta data with 1 key-value pairs and 1 tensors from next.gguf (version GGUF V3)",
+        );
+        assert!(next_model.iter().any(|event| {
+            event.message == "Model layers by device"
+                && event.params == vec![("CUDA0".to_string(), Value::from(1_u64))]
+        }));
+        aggregator.process_line("load_tensors: layer 0 assigned to device Metal");
+        assert_eq!(
+            aggregator.process_line("load_tensors: finished"),
+            vec![NativeLogEvent {
+                message: "Model layers by device".to_string(),
+                category: "model",
+                params: vec![("Metal".to_string(), Value::from(1_u64))],
+            }]
+        );
+    }
+
+    #[test]
     fn aggregator_tags_cpu_offload_evidence_without_capacity_facts() {
         let mut aggregator = NativeLogAggregator::default();
         let model_buffer =
@@ -1225,25 +1341,33 @@ mod tests {
     }
 
     #[test]
-    fn parse_layer_assign_index_extracts_layer_number() {
+    fn parse_layer_assignment_extracts_layer_and_device() {
         assert_eq!(
-            parse_layer_assign_index("load_tensors: layer   0 assigned to device CUDA0"),
-            Some(0)
+            parse_layer_assignment("load_tensors: layer   0 assigned to device CUDA0"),
+            Some((0, "CUDA0"))
         );
         assert_eq!(
-            parse_layer_assign_index("load_tensors: layer  63 assigned to device CUDA0"),
-            Some(63)
+            parse_layer_assignment("load_tensors: layer  63 assigned to device CUDA0, is_swa = 0"),
+            Some((63, "CUDA0"))
         );
         assert_eq!(
-            parse_layer_assign_index("load_tensors: layer   5 assigned to device CPU"),
-            Some(5)
+            parse_layer_assignment("load_tensors: layer   5 assigned to device CPU, is_swa = 1"),
+            Some((5, "CPU"))
         );
         assert_eq!(
-            parse_layer_assign_index("llm_load_tensors: offloaded 64/65 layers"),
+            parse_layer_assignment("llm_load_tensors: offloaded 64/65 layers"),
             None
         );
         assert_eq!(
-            parse_layer_assign_index("load_tensors: layer   0 computation graph"),
+            parse_layer_assignment("load_tensors: layer   0 computation graph"),
+            None
+        );
+        assert_eq!(
+            parse_layer_assignment("load_tensors: layer x assigned to device CUDA0"),
+            None
+        );
+        assert_eq!(
+            parse_layer_assignment("load_tensors: layer 0 assigned to device , is_swa = 0"),
             None
         );
     }


### PR DESCRIPTION
## Original problem

Native log summaries omit GPU model-buffer sizes and discard device names while counting layer-assignment progress. This leaves a multi-GPU load's placement unavailable in the summarized diagnostics.

Fixes #1304.

## Diagnostics

Regression inputs reproduce both losses through `NativeLogAggregator::process_line`. The parser also covers the `, is_swa = ...` suffix used by the pinned llama.cpp source.

## Fix

Retain model-buffer lines for all devices and emit a compact, sorted count after an assignment block. Existing percentage progress remains. Repeated layer rows do not inflate the count, changed assignments replace their old device, and each new model resets the state.

For example, the summary message `Model layers by device` carries `CPU=2, CUDA0=2, CUDA1=1`; a line such as `load_tensors: CUDA0 model buffer size = 4321.00 MiB` is retained in the memory category.

The verbosity environment-variable cleanup discussed later in the issue is outside this change.

## Validation

- [x] Ran relevant local checks; limits are recorded below.
- Three initial regressions fail against the original production implementation.
- 116 `skippy-runtime` library tests pass on Windows, including the new aggregation tests. Three previously confirmed failures requiring a loaded native runtime are excluded: `cache_append_extends_the_committed_history`, `cache_drafts_from_committed_history_and_never_mutates_for_a_prefix`, and `invalid_selected_backend_device_fails_before_model_open`.
- Required checks for `skippy-runtime` (with `dynamic-native-runtime`) and `mesh-llm`, and `cargo fmt --all --check`, pass.
- Strict Clippy was run for both targets. It stops in unchanged Windows code: the unread lock-file field in `materialized_cache.rs:94`, and needless returns in `audit.rs:469` and `mesh-llm-plugin/src/io.rs:205`. All three files match the base.
- No GPU inference, packaged-runtime or multi-node smoke test was run.

## Post-Deploy Monitoring & Validation

On a multi-device load, check the memory-category model-buffer lines and the device-count summary against the raw native log. The summary is emitted on the next non-assignment line; a stream truncated before that point will not contain its final count.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native logs now summarize how model layers are distributed across devices.
  * Device-specific layer counts are reported when layer assignment completes.
  * Layer assignment data resets correctly for each model load.

* **Bug Fixes**
  * Improved recognition of model buffer size log entries.
  * Device assignment summaries now avoid repeating unchanged information.
  * Device-specific buffer information is preserved during log aggregation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->