### PR TITLE
Catch CI coverage gaps before changes reach main

### DIFF
--- a/.agents/skills/manage-ci/SKILL.md
+++ b/.agents/skills/manage-ci/SKILL.md
@@ -350,6 +350,18 @@ checked-in expiry are the maintainer-controlled approval boundary.
   additional coverage, not a replacement.
 - Restore smoke inputs through the shared restore action and reusable smoke
   workflows. Every CI invocation of `mesh-llm` includes `--log-format json`.
+- New release-only preparation paths must execute without publication in PR/main
+  validation using the same implementation and container as release. CI-definition
+  changes need candidate-definition evidence; green protected-main execution alone
+  is not evidence that edited workflow YAML ran. Record any bootstrap gap before
+  requesting merge.
+- Hardware CUDA smoke must select a CUDA backend device explicitly and require
+  positive layer-offload and CUDA model-buffer evidence from each serving
+  process after successful inference. Device enumeration, library loading, or
+  a CPU-forced completion alone do not qualify GPU execution. CPU rows retain
+  explicit CPU selection.
+- CLI JSON consumed by scripts must be exercised with the actual composed host
+  in product smoke, not only with mocked JSON or Cargo dependency coverage.
 - Release and packaging wrap the same producers with signing, attestation,
   publication, and retention. They do not fork the underlying build commands.
 

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -685,6 +685,17 @@ state, not proof that a restriction is absent.
 
 ### PR/main recurrence coverage
 
+During typed-suite qualification, the existing Linux catalog IDs keep their
+original executable owners: `core` calls `smoke.yml`, `two-node-client` calls
+the passive-client serving script, and `two-node-split` calls the dense plus
+Qwen3.5 recurrent script through `scripted-binary-smoke.yml`. Their original
+artifact identities, cache scopes and exact recurrent-payload gate are retained.
+The new `product-integration-*` and `qwen-recurrent-gate` selectors remain dormant
+until a deliberate catalog migration; they are not aliases for these old IDs.
+Planner-fixture-to-workflow tests require every selected Linux smoke ID to have
+its exact job selector, executable consumer and matching product producer. This
+restores selected CPU work without expanding the catalog or qualifying GPUs.
+
 Explicit ownership routes script-only changes: release UI preparation and the
 version updater select the UI producer; product smoke and the native-runtime
 reader select product smoke; the shared native-runtime reader also selects all

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -682,3 +682,50 @@ gh api orgs/Mesh-LLM/actions/runner-groups
 
 Organization runner-group responses of `403` are unverified administrative
 state, not proof that a restriction is absent.
+
+### PR/main recurrence coverage
+
+Explicit ownership routes script-only changes: release UI preparation and the
+version updater select the UI producer; product smoke and the native-runtime
+reader select product smoke; the shared native-runtime reader also selects all
+three SDK consumers. Six single-path planner fixtures protect these edges,
+including CUDA hardware selection for both smoke scripts and the offload verifier.
+The ownership catalog delta must land as a separate maintainer-controlled
+catalog-only change before the implementation is rebased; protected PR catalog
+comparison must not be bypassed. Until then this combined working diff cannot
+pass its protected Plan gate.
+
+Product inference smoke invokes `ci-prepare-native-runtime.sh` against the real
+composed binary before starting inference, with build fallback disabled. This
+exercises the SDK CLI-JSON consumer even when full SDK rows are not selected;
+mocked report tests alone do not establish producer/consumer compatibility.
+
+Every console UI producer invokes `ci-prepare-release-ui.sh` in the same pinned
+web container. Release prepares the requested immutable source/version; ordinary
+PR/main producers rehearse that same release preparation in a disposable clone,
+without altering their source, UI mode, or publishing anything. Git trust is
+process-scoped to the exact checkout, including child version-script commands.
+Candidate workflow YAML still requires explicit execution evidence before merge:
+the protected default-branch PR executor does not execute edited YAML.
+
+GPU smoke checks existing utilities and dynamically loads the CUDA 12 runtime
+libraries rather than installing system packages with sudo. Missing tools or
+libraries fail the runner contract before inference. This does not itself prove
+ephemeral placement: administrators must keep persistent runner labels disjoint
+from the CI pool and enforce protected workflow restrictions on its runner group.
+
+The CUDA smoke row sets `MESH_CI_DEVICE=CUDA0` for normal, headless,
+compatibility and constrained-stack probes; other rows retain the CPU default.
+Each serving process must complete inference and then pass
+`ci-verify-smoke-offload.py` against its own isolated runtime-root/PID native
+log: positive GPU-offloaded layers plus a nonzero CUDA0 model buffer. Missing
+logs, zero offload and CPU-only/device-enumeration output fail closed. Selected
+summary lines are printed as JSON evidence before scoped cleanup removes the
+runtime directory. This does not prove runner isolation or performance, and
+local fixture tests are not live GPU qualification.
+
+Product-integration callers retain explicit `MTL0`, `Vulkan0` and `ROCm0`
+selection; this CUDA-specific verifier does not claim offload qualification for
+those backends. Compatibility smoke honors `MESH_COMPAT_DEVICE` first, falling
+back to `MESH_CI_DEVICE` and then CPU, so both the new product suite and legacy
+core CUDA workflow select their intended device.

--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -708,8 +708,12 @@ process-scoped to the exact checkout, including child version-script commands.
 Candidate workflow YAML still requires explicit execution evidence before merge:
 the protected default-branch PR executor does not execute edited YAML.
 
-GPU smoke checks existing utilities and dynamically loads the CUDA 12 runtime
-libraries rather than installing system packages with sudo. Missing tools or
+Both legacy `smoke.yml` and typed `product-integration-smoke.yml` CUDA setup
+check existing curl/jq/lsof utilities and dynamically load all three CUDA 12
+runtime libraries rather than installing system packages with sudo. Both retain
+GPU name, compute capability and driver provenance via `nvidia-smi`. Executed
+workflow-block tests cover missing utilities, each missing library and failed
+device provenance; these isolated probes do not qualify an actual runner image. Missing tools or
 libraries fail the runner contract before inference. This does not itself prove
 ephemeral placement: administrators must keep persistent runner labels disjoint
 from the CI pool and enforce protected workflow restrictions on its runner group.

--- a/.github/workflows/ci-linux-product-smoke-slice.yml
+++ b/.github/workflows/ci-linux-product-smoke-slice.yml
@@ -29,6 +29,59 @@ permissions:
   packages: read
 
 jobs:
+  # Keep catalogued CPU consumers executable until the typed-suite catalog
+  # migration is qualified and bootstrapped. New IDs below are not aliases.
+  core:
+    name: Core inference smoke
+    if: ${{ contains(fromJson(inputs.smoke_matrix).*.id, 'core') }}
+    uses: ./.github/workflows/smoke.yml
+    with:
+      source_sha: ${{ inputs.source_sha }}
+      artifact_name: ci-product-linux-amd64-cpu
+      artifact_path: ci-artifacts/linux
+      mesh_binary_target: ${{ inputs.binary_target }}
+      cache_key_prefix: ""
+      timeout_minutes: ${{ inputs.timeout_minutes }}
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  two_node_client:
+    name: Two-node client smoke
+    if: ${{ contains(fromJson(inputs.smoke_matrix).*.id, 'two-node-client') }}
+    uses: ./.github/workflows/scripted-binary-smoke.yml
+    with:
+      source_sha: ${{ inputs.source_sha }}
+      artifact_name: ci-product-linux-amd64-cpu
+      artifact_path: ci-artifacts/linux
+      staged_binary_path: ${{ inputs.binary_target }}
+      model_cache_scope: two-node-smoke-model
+      smoke_script: scripts/ci-two-node-client-serving-smoke.sh
+      timeout_minutes: ${{ inputs.timeout_minutes }}
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+  two_node_split:
+    name: KV caching smoke (dense + recurrent)
+    if: ${{ contains(fromJson(inputs.smoke_matrix).*.id, 'two-node-split') }}
+    uses: ./.github/workflows/scripted-binary-smoke.yml
+    with:
+      source_sha: ${{ inputs.source_sha }}
+      artifact_name: ci-product-linux-amd64-cpu
+      artifact_path: ci-artifacts/linux
+      staged_binary_path: ${{ inputs.binary_target }}
+      model_url: https://huggingface.co/unsloth/SmolLM2-135M-Instruct-GGUF/resolve/9e6855bc4be717fca1ef21360a1db4b29d5c559a/SmolLM2-135M-Instruct-Q8_0.gguf
+      model_file: SmolLM2-135M-Instruct-Q8_0.gguf
+      model_cache_scope: two-node-split-smoke-model
+      smoke_script: scripts/ci-two-node-split-smoke.sh
+      kv_recurrent_model_url: https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/6ab461498e2023f6e3c1baea90a8f0fe38ab64d0/Qwen3.5-0.8B-Q4_K_M.gguf
+      kv_recurrent_model_file: Qwen3.5-0.8B-Q4_K_M.gguf
+      kv_recurrent_model_cache_scope: two-node-split-recurrent-smoke-model
+      kv_recurrent_context_size: '4096'
+      kv_recurrent_expected_exact_payload_kind: kv-recurrent
+      timeout_minutes: ${{ inputs.timeout_minutes }}
+    secrets:
+      HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
   product_integration_cpu:
     name: CPU product integration suite
     if: ${{ contains(fromJson(inputs.smoke_matrix).*.id, 'product-integration-cpu') }}

--- a/.github/workflows/ci-ui-artifact-slice.yml
+++ b/.github/workflows/ci-ui-artifact-slice.yml
@@ -92,19 +92,13 @@ jobs:
         with:
           ref: ${{ inputs.source_sha || github.sha }}
           persist-credentials: false
-      - name: Prepare release UI version
-        if: ${{ inputs.release_tag != '' }}
+      - name: Prepare release UI version (or rehearse without publication)
         working-directory: .
         shell: bash
         env:
           RELEASE_TAG: ${{ inputs.release_tag }}
-          UI_SOURCE_SHA: ${{ inputs.source_sha }}
-        run: |
-          set -euo pipefail
-          [[ "$UI_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]
-          test "$(git rev-parse HEAD)" = "$UI_SOURCE_SHA"
-          scripts/release-version.sh "$RELEASE_TAG"
-          echo "VITE_MESH_LLM_DEBUG_UI=false" >> "$GITHUB_ENV"
+          UI_SOURCE_SHA: ${{ inputs.source_sha || github.sha }}
+        run: scripts/ci-prepare-release-ui.sh "$UI_SOURCE_SHA" "$RELEASE_TAG"
       # The container image bakes a warm pnpm store at
       # /home/runner/.local/share/pnpm/store (mesh-llm-runner-images
       # scripts/warm-dependencies.sh). Point pnpm at it directly instead of

--- a/.github/workflows/product-integration-smoke.yml
+++ b/.github/workflows/product-integration-smoke.yml
@@ -90,11 +90,19 @@ jobs:
         if: inputs.platform == 'linux' && inputs.backend == 'cpu'
         run: verify-runner-image public cpu
 
-      - name: Install CUDA runtime libraries and record device provenance
+      - name: Verify prebuilt CUDA utilities and libraries and record device provenance
         if: inputs.platform == 'linux' && inputs.backend == 'cuda'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends cuda-cudart-12-9 libcublas-12-9 curl jq lsof
+          set -euo pipefail
+          for tool in curl jq lsof; do
+            command -v "$tool" || { echo "GPU runner image is missing $tool" >&2; exit 1; }
+          done
+          python3 - <<'PYTHON'
+          import ctypes
+          for library in ("libcudart.so.12", "libcublas.so.12", "libcublasLt.so.12"):
+              ctypes.CDLL(library)
+              print(f"GPU runner library load passed: {library}")
+          PYTHON
           nvidia-smi --query-gpu=name,compute_cap,driver_version --format=csv,noheader
 
       - name: Record Vulkan device provenance

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -76,6 +76,8 @@ jobs:
       # `~/.cache/pip` and onto this ephemeral runner's `/tmp` instead.
       # Harmless (the runner is single-use), just not container-only.
       PIP_CACHE_DIR: /tmp/pip-cache
+      # Shared by normal, headless, compatibility and constrained-stack smokes.
+      MESH_CI_DEVICE: ${{ inputs.runner == 'gpu-nvidia' && 'CUDA0' || 'CPU' }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -120,11 +122,13 @@ jobs:
         if: inputs.runner != 'gpu-nvidia'
         run: verify-runner-image public cpu
 
-      - name: Install smoke runtime utilities (self-hosted)
+      - name: Verify prebuilt GPU smoke utilities
         if: inputs.runner == 'gpu-nvidia'
         run: |
-          sudo apt-get update
-          sudo apt-get install -y curl jq lsof
+          set -euo pipefail
+          for tool in curl jq lsof; do
+            command -v "$tool" || { echo "GPU runner image is missing $tool" >&2; exit 1; }
+          done
 
       - name: Install smoke dependencies
         # The venv baked into the image is pinned to the image's own mesh-llm
@@ -154,12 +158,16 @@ jobs:
           HUGGING_FACE_HUB_TOKEN: ""
         run: npm install --global openai@7.5.0
 
-      - name: Install CUDA smoke runtime libraries
+      - name: Verify prebuilt CUDA smoke runtime libraries
         if: inputs.runner == 'gpu-nvidia'
         run: |
-          sudo apt-get install -y --no-install-recommends \
-            cuda-cudart-12-9 \
-            libcublas-12-9
+          set -euo pipefail
+          python3 - <<'PYTHON'
+          import ctypes
+          for library in ("libcudart.so.12", "libcublas.so.12", "libcublasLt.so.12"):
+              ctypes.CDLL(library)
+              print(f"GPU runner library load passed: {library}")
+          PYTHON
           nvidia-smi --query-gpu=name,compute_cap,driver_version \
             --format=csv,noheader
 

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -345,7 +345,7 @@ runtime producers are not duplicated.
   logs on success or failure. The existing Qwen3.5 recurrent job remains
   required until Granite passes that live contract. The typed runner supports
   CPU, CUDA, Metal, Vulkan, and ROCm,
-  but only CPU is selected during the first qualification stage; the existing
+  but the checked catalog still selects the retained legacy CPU consumers; the existing
   CUDA inference and Metal model-load signals remain required until their typed
   product rows pass live qualification in that order. CUDA and Metal request
   their explicit accelerator device and reject unsupported typed selections.
@@ -723,6 +723,17 @@ for scope-specific checks, and run the canonical `just test-all` target when
 full repository validation is required.
 
 ### PR/main recurrence coverage
+
+During typed-suite qualification, the existing Linux catalog IDs keep their
+original executable owners: `core` calls `smoke.yml`, `two-node-client` calls
+the passive-client serving script, and `two-node-split` calls the dense plus
+Qwen3.5 recurrent script through `scripted-binary-smoke.yml`. Their original
+artifact identities, cache scopes and exact recurrent-payload gate are retained.
+The new `product-integration-*` and `qwen-recurrent-gate` selectors remain dormant
+until a deliberate catalog migration; they are not aliases for these old IDs.
+Planner-fixture-to-workflow tests require every selected Linux smoke ID to have
+its exact job selector, executable consumer and matching product producer. This
+restores selected CPU work without expanding the catalog or qualifying GPUs.
 
 Explicit ownership routes script-only changes: release UI preparation and the
 version updater select the UI producer; product smoke and the native-runtime

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -355,14 +355,16 @@ runtime producers are not duplicated.
   protected default-branch reusable workflows, receives no repository secrets or
   credential-bearing caches, and is restricted to the repository's GPU runner
   group. Its PR runtime is compiled for both sm86 and sm120 because the scale
-  set currently contains RTX 3080 and RTX 5090 workers. The smoke installs the
-  pinned CUDA 12.9 user-space runtime libraries required by the host-linked
-  product before inference. Vulkan uses the same approved `gpu-nvidia` host
-  with the explicit `Vulkan0` device. ROCm uses `ROCm0` and its reusable job is
-  skipped unless `MESH_ROCM_INFERENCE_RUNNER_ENABLED` is exactly `true`; the
-  corresponding repository-scoped `gpu-amd` runner could not be verified from
-  the current GitHub token. Accelerator product-integration rows remain absent
-  from the checked plan until their live qualification is accepted.
+  set currently contains RTX 3080 and RTX 5090 workers. The core CUDA smoke
+  verifies preinstalled CUDA 12 user-space libraries before inference; it never
+  repairs a mismatched worker with sudo. The separate product-integration CUDA
+  workflow still installs its CUDA dependencies. Vulkan product integration uses
+  the same approved `gpu-nvidia` host with the explicit `Vulkan0` device. ROCm
+  uses `ROCm0` and its reusable job is skipped unless
+  `MESH_ROCM_INFERENCE_RUNNER_ENABLED` is exactly `true`; the corresponding
+  repository-scoped `gpu-amd` runner could not be verified from the current
+  GitHub token. Accelerator product-integration rows remain absent from the
+  checked plan until their live qualification is accepted.
 - `ci-linux-sdk-slice.yml` and `ci-macos-sdk-slice.yml` — platform-local
   Rust, Kotlin and Swift consumers. Each smoke downloads the matching
   platform lane's immutable UI artifact before packaging SDK resources;
@@ -719,3 +721,50 @@ complete
 [manage-ci validation contract](../.agents/skills/manage-ci/SKILL.md#validation-contract)
 for scope-specific checks, and run the canonical `just test-all` target when
 full repository validation is required.
+
+### PR/main recurrence coverage
+
+Explicit ownership routes script-only changes: release UI preparation and the
+version updater select the UI producer; product smoke and the native-runtime
+reader select product smoke; the shared native-runtime reader also selects all
+three SDK consumers. Six single-path planner fixtures protect these edges,
+including CUDA hardware selection for both smoke scripts and the offload verifier.
+The ownership catalog delta must land as a separate maintainer-controlled
+catalog-only change before the implementation is rebased; protected PR catalog
+comparison must not be bypassed. Until then this combined working diff cannot
+pass its protected Plan gate.
+
+Product inference smoke invokes `ci-prepare-native-runtime.sh` against the real
+composed binary before starting inference, with build fallback disabled. This
+exercises the SDK CLI-JSON consumer even when full SDK rows are not selected;
+mocked report tests alone do not establish producer/consumer compatibility.
+
+Every console UI producer invokes `ci-prepare-release-ui.sh` in the same pinned
+web container. Release prepares the requested immutable source/version; ordinary
+PR/main producers rehearse that same release preparation in a disposable clone,
+without altering their source, UI mode, or publishing anything. Git trust is
+process-scoped to the exact checkout, including child version-script commands.
+Candidate workflow YAML still requires explicit execution evidence before merge:
+the protected default-branch PR executor does not execute edited YAML.
+
+GPU smoke checks existing utilities and dynamically loads the CUDA 12 runtime
+libraries rather than installing system packages with sudo. Missing tools or
+libraries fail the runner contract before inference. This does not itself prove
+ephemeral placement: administrators must keep persistent runner labels disjoint
+from the CI pool and enforce protected workflow restrictions on its runner group.
+
+The CUDA smoke row sets `MESH_CI_DEVICE=CUDA0` for normal, headless,
+compatibility and constrained-stack probes; other rows retain the CPU default.
+Each serving process must complete inference and then pass
+`ci-verify-smoke-offload.py` against its own isolated runtime-root/PID native
+log: positive GPU-offloaded layers plus a nonzero CUDA0 model buffer. Missing
+logs, zero offload and CPU-only/device-enumeration output fail closed. Selected
+summary lines are printed as JSON evidence before scoped cleanup removes the
+runtime directory. This does not prove runner isolation or performance, and
+local fixture tests are not live GPU qualification.
+
+Product-integration callers retain explicit `MTL0`, `Vulkan0` and `ROCm0`
+selection; this CUDA-specific verifier does not claim offload qualification for
+those backends. Compatibility smoke honors `MESH_COMPAT_DEVICE` first, falling
+back to `MESH_CI_DEVICE` and then CPU, so both the new product suite and legacy
+core CUDA workflow select their intended device.

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -355,10 +355,10 @@ runtime producers are not duplicated.
   protected default-branch reusable workflows, receives no repository secrets or
   credential-bearing caches, and is restricted to the repository's GPU runner
   group. Its PR runtime is compiled for both sm86 and sm120 because the scale
-  set currently contains RTX 3080 and RTX 5090 workers. The core CUDA smoke
-  verifies preinstalled CUDA 12 user-space libraries before inference; it never
-  repairs a mismatched worker with sudo. The separate product-integration CUDA
-  workflow still installs its CUDA dependencies. Vulkan product integration uses
+  set currently contains RTX 3080 and RTX 5090 workers. Both core and typed
+  product-integration CUDA smoke verify preinstalled utilities and CUDA 12
+  user-space libraries before recording device provenance and starting inference;
+  neither repairs a mismatched worker with sudo. Vulkan product integration uses
   the same approved `gpu-nvidia` host with the explicit `Vulkan0` device. ROCm
   uses `ROCm0` and its reusable job is skipped unless
   `MESH_ROCM_INFERENCE_RUNNER_ENABLED` is exactly `true`; the corresponding
@@ -747,8 +747,12 @@ process-scoped to the exact checkout, including child version-script commands.
 Candidate workflow YAML still requires explicit execution evidence before merge:
 the protected default-branch PR executor does not execute edited YAML.
 
-GPU smoke checks existing utilities and dynamically loads the CUDA 12 runtime
-libraries rather than installing system packages with sudo. Missing tools or
+Both legacy `smoke.yml` and typed `product-integration-smoke.yml` CUDA setup
+check existing curl/jq/lsof utilities and dynamically load all three CUDA 12
+runtime libraries rather than installing system packages with sudo. Both retain
+GPU name, compute capability and driver provenance via `nvidia-smi`. Executed
+workflow-block tests cover missing utilities, each missing library and failed
+device provenance; these isolated probes do not qualify an actual runner image. Missing tools or
 libraries fail the runner contract before inference. This does not itself prove
 ephemeral placement: administrators must keep persistent runner labels disjoint
 from the CI pool and enforce protected workflow restrictions on its runner group.

--- a/ci/ownership.yml
+++ b/ci/ownership.yml
@@ -125,6 +125,8 @@
       "domain": "ui",
       "patterns": [
         "crates/mesh-llm-ui/**",
+        "scripts/ci-prepare-release-ui.sh",
+        "scripts/release-version.sh",
         "pnpm-lock.yaml",
         "package.json"
       ]
@@ -135,6 +137,9 @@
         "scripts/build-*.sh",
         "scripts/build-*.ps1",
         "scripts/ci-*-smoke.sh",
+        "scripts/ci-smoke-test.sh",
+        "scripts/ci-verify-smoke-offload.py",
+        "scripts/ci-prepare-native-runtime.sh",
         "scripts/ci-*-smoke.py",
         "scripts/ci-*-smoke.cjs",
         "scripts/compose-product*",
@@ -196,6 +201,7 @@
         "crates/mesh-llm-sdk/**",
         "crates/mesh-llm-api-client/**",
         "crates/mesh-llm-api-server/**",
+        "scripts/ci-prepare-native-runtime.sh",
         "scripts/ci-rust-sdk-smoke.sh",
         "sdk/**"
       ]
@@ -204,6 +210,7 @@
       "domain": "sdk-kotlin",
       "patterns": [
         "sdk/kotlin/**",
+        "scripts/ci-prepare-native-runtime.sh",
         "scripts/ci-kotlin-sdk-smoke.sh"
       ]
     },
@@ -212,6 +219,7 @@
       "patterns": [
         "sdk/swift/**",
         "Package.swift",
+        "scripts/ci-prepare-native-runtime.sh",
         "scripts/ci-swift-sdk-smoke.sh"
       ]
     },
@@ -237,6 +245,9 @@
       "domain": "backend-cuda",
       "patterns": [
         "scripts/detect-cuda-arch.sh",
+        "scripts/ci-smoke-test.sh",
+        "scripts/ci-compat-smoke.sh",
+        "scripts/ci-verify-smoke-offload.py",
         "scripts/build-linux.sh",
         "scripts/build-windows.ps1"
       ]

--- a/scripts/ci-compat-smoke.sh
+++ b/scripts/ci-compat-smoke.sh
@@ -5,10 +5,16 @@
 
 set -euo pipefail
 
+# Bounded hardware selection; CUDA can never silently opt out of offload checks.
+SMOKE_DEVICE="${MESH_COMPAT_DEVICE:-${MESH_CI_DEVICE:-CPU}}"
+case "$SMOKE_DEVICE" in
+    CPU|CUDA0|Vulkan0|ROCm0|MTL0) ;;
+    *) echo "Unsupported MESH_CI_DEVICE: $SMOKE_DEVICE (expected CPU, CUDA0, Vulkan0, ROCm0 or MTL0)" >&2; exit 1 ;;
+esac
+
 MESH_LLM="${1:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>}"
 BIN_DIR="${2:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>}"
 MODEL="${3:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path>}"
-DEVICE="${MESH_COMPAT_DEVICE:-CPU}"
 API_PORT="${MESH_COMPAT_API_PORT:-9348}"
 CONSOLE_PORT="${MESH_COMPAT_CONSOLE_PORT:-3142}"
 MAX_WAIT="${MESH_COMPAT_MAX_WAIT:-180}"
@@ -18,6 +24,7 @@ ATTESTATION_EXPECTED_STATUS="${MESH_RELEASE_ATTESTATION_EXPECTED_STATUS:-valid}"
 SMOKE_STATE_DIR="$(mktemp -d /tmp/mesh-llm-compat-state.XXXXXX)"
 SMOKE_CONFIG_PATH="$SMOKE_STATE_DIR/config.toml"
 SMOKE_RUNTIME_ROOT="$SMOKE_STATE_DIR/runtime"
+trap 'rm -rf -- "$SMOKE_STATE_DIR"' EXIT
 
 inspect_release_attestation() {
     if [[ -z "$ATTESTATION_PUBLIC_KEY_FILE" ]]; then
@@ -42,7 +49,7 @@ echo "  bin-dir:   $BIN_DIR (compatibility placeholder)"
 echo "  model:     $MODEL"
 echo "  api port:  $API_PORT"
 echo "  console:   $CONSOLE_PORT"
-echo "  device:    $DEVICE"
+echo "  device:    $SMOKE_DEVICE"
 
 if [[ ! -x "$MESH_LLM" ]]; then
     echo "Missing executable mesh-llm binary: $MESH_LLM" >&2
@@ -69,7 +76,7 @@ env MESH_LLM_CONFIG="$SMOKE_CONFIG_PATH" MESH_LLM_RUNTIME_ROOT="$SMOKE_RUNTIME_R
     serve \
     --model "$MODEL" \
     --no-draft \
-    --device "$DEVICE" \
+    --device "$SMOKE_DEVICE" \
     --ctx-size "${MESH_COMPAT_CTX_SIZE:-256}" \
     --port "$API_PORT" \
     --console "$CONSOLE_PORT" \
@@ -133,5 +140,8 @@ python3 scripts/ci-openai-python-smoke.py --base-url "$BASE_URL"
 python3 scripts/ci-litellm-smoke.py --base-url "$BASE_URL" --model "$MODEL_ID"
 python3 scripts/ci-langchain-openai-smoke.py --base-url "$BASE_URL" --model "$MODEL_ID"
 NODE_PATH="${NODE_PATH:-$(npm root -g 2>/dev/null || true)}" node scripts/ci-openai-node-smoke.cjs --base-url "$BASE_URL"
+
+python3 scripts/ci-verify-smoke-offload.py --device "$SMOKE_DEVICE" \
+    --native-log "$SMOKE_RUNTIME_ROOT/$MESH_PID/logs/skippy-native.log"
 
 echo "OpenAI compatibility smoke passed"

--- a/scripts/ci-prepare-release-ui.sh
+++ b/scripts/ci-prepare-release-ui.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# The same release preparation runs in every UI producer's pinned container.
+# Ordinary CI rehearses in a disposable clone; its product source is untouched.
+set -euo pipefail
+source_sha="${1:?expected immutable source SHA}"
+release_tag="${2:-}"
+[[ "$source_sha" =~ ^[0-9a-f]{40}$ ]] || { echo "invalid UI source SHA" >&2; exit 1; }
+root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Checkout's temporary HOME does not survive into subsequent container steps.
+# Scope Git trust to this checkout, never a wildcard or a persistent runner HOME.
+export GIT_CONFIG_COUNT=1
+export GIT_CONFIG_KEY_0=safe.directory
+export GIT_CONFIG_VALUE_0="$root"
+test "$(git -C "$root" rev-parse HEAD)" = "$source_sha"
+
+if [[ -z "$release_tag" ]]; then
+    rehearsal="$(mktemp -d "${RUNNER_TEMP:-/tmp}/mesh-release-ui.XXXXXX")"
+    trap 'rm -rf -- "$rehearsal"' EXIT
+    git clone --quiet --shared --no-checkout "$root" "$rehearsal/source"
+    git -c safe.directory="$rehearsal/source" -C "$rehearsal/source" checkout --quiet --detach "$source_sha"
+    # Invoke the exact release branch, with no publishing token or remote writes.
+    GITHUB_ENV="$rehearsal/github-env" \
+        "$rehearsal/source/scripts/ci-prepare-release-ui.sh" "$source_sha" v99.99.99-ci-rehearsal
+    exit 0
+fi
+
+cd "$root"
+scripts/release-version.sh "$release_tag"
+echo "VITE_MESH_LLM_DEBUG_UI=false" >> "${GITHUB_ENV:?expected GitHub environment file}"

--- a/scripts/ci-smoke-test.sh
+++ b/scripts/ci-smoke-test.sh
@@ -9,11 +9,17 @@
 
 set -euo pipefail
 
+# Bounded hardware selection; CUDA can never silently opt out of offload checks.
+SMOKE_DEVICE="${MESH_CI_DEVICE:-CPU}"
+case "$SMOKE_DEVICE" in
+    CPU|CUDA0|Vulkan0|ROCm0|MTL0) ;;
+    *) echo "Unsupported MESH_CI_DEVICE: $SMOKE_DEVICE (expected CPU, CUDA0, Vulkan0, ROCm0 or MTL0)" >&2; exit 1 ;;
+esac
+
 MESH_LLM="${1:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> [mmproj-path]}"
 BIN_DIR="${2:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> [mmproj-path]}"
 MODEL="${3:?Usage: $0 <mesh-llm-binary> <bin-dir> <model-path> [mmproj-path]}"
 MMPROJ="${4:-}"
-DEVICE="${MESH_CI_DEVICE:-CPU}"
 API_PORT="${MESH_CI_API_PORT:-9337}"
 CONSOLE_PORT="${MESH_CI_CONSOLE_PORT:-3131}"
 MAX_WAIT="${MESH_CI_MAX_WAIT:-180}"
@@ -23,6 +29,7 @@ ATTESTATION_EXPECTED_STATUS="${MESH_RELEASE_ATTESTATION_EXPECTED_STATUS:-valid}"
 SMOKE_STATE_DIR="$(mktemp -d /tmp/mesh-llm-smoke-state.XXXXXX)"
 SMOKE_CONFIG_PATH="$SMOKE_STATE_DIR/config.toml"
 SMOKE_RUNTIME_ROOT="$SMOKE_STATE_DIR/runtime"
+trap 'rm -rf -- "$SMOKE_STATE_DIR"' EXIT
 
 inspect_release_attestation() {
     if [[ -z "$ATTESTATION_PUBLIC_KEY_FILE" ]]; then
@@ -57,7 +64,7 @@ fi
 echo "  api port:  $API_PORT"
 echo "  console:   $CONSOLE_PORT"
 echo "  os:        $(uname -s)"
-echo "  device:    $DEVICE"
+echo "  device:    $SMOKE_DEVICE"
 
 if [[ ! -x "$MESH_LLM" ]]; then
     echo "Missing executable mesh-llm binary: $MESH_LLM" >&2
@@ -77,12 +84,18 @@ if [[ ! -d "$RUNTIME_BUNDLE" ]]; then
 fi
 export MESH_LLM_NATIVE_RUNTIME_BUNDLE_DIR="$RUNTIME_BUNDLE"
 
+# Exercise the SDK's CLI-JSON consumer with the actual composed host, even when
+# semantic routing did not select a full SDK build. Mock JSON fixtures cannot
+# catch a producer changing its output shape independently of this consumer.
+MESH_SDK_NATIVE_RUNTIME_BUILD_FALLBACK=0 scripts/ci-prepare-native-runtime.sh \
+    "$SMOKE_STATE_DIR/sdk-runtime" cpu --reuse-from-binary "$MESH_LLM"
+
 ARGS=(
     --log-format json
     serve
     --model "$MODEL"
     --no-draft
-    --device "$DEVICE"
+    --device "$SMOKE_DEVICE"
     --ctx-size "${MESH_CI_CTX_SIZE:-256}"
     --port "$API_PORT"
     --console "$CONSOLE_PORT"
@@ -222,6 +235,9 @@ AUTO_PAYLOAD="$(
 AUTO_RESPONSE="$(curl -fsS --max-time 60 "${BASE_URL}/chat/completions" -H 'content-type: application/json' -d "$AUTO_PAYLOAD")"
 printf '%s' "$AUTO_RESPONSE" | jq -e '(.choices[0].message.content | length > 0)' >/dev/null
 
+python3 scripts/ci-verify-smoke-offload.py --device "$SMOKE_DEVICE" \
+    --native-log "$SMOKE_RUNTIME_ROOT/$MESH_PID/logs/skippy-native.log"
+
 echo "Testing headless mode subcase..."
 HEADLESS_API_PORT="${MESH_CI_HEADLESS_API_PORT:-9338}"
 HEADLESS_CONSOLE_PORT="${MESH_CI_HEADLESS_CONSOLE_PORT:-3132}"
@@ -231,7 +247,7 @@ HEADLESS_ARGS=(
     serve
     --model "$MODEL"
     --no-draft
-    --device "$DEVICE"
+    --device "$SMOKE_DEVICE"
     --ctx-size "${MESH_CI_CTX_SIZE:-256}"
     --port "$HEADLESS_API_PORT"
     --console "$HEADLESS_CONSOLE_PORT"
@@ -261,8 +277,8 @@ for i in $(seq 1 "$MAX_WAIT"); do
         exit 1
     fi
 
-    if curl -sf "http://127.0.0.1:${HEADLESS_API_PORT}/v1/models" >/dev/null 2>&1 &&
-       curl -sf "http://127.0.0.1:${HEADLESS_CONSOLE_PORT}/api/status" >/dev/null 2>&1; then
+    if curl -sf "http://127.0.0.1:${HEADLESS_API_PORT}/v1/models" | jq -e '.data | length > 0' >/dev/null 2>&1 &&
+       curl -sf "http://127.0.0.1:${HEADLESS_CONSOLE_PORT}/api/status" | jq -e '.llama_ready == true' >/dev/null 2>&1; then
         echo "Headless mode ready after ${i}s"
         break
     fi
@@ -285,5 +301,15 @@ if [[ -n "$ATTESTATION_PUBLIC_KEY_FILE" && "$HEADLESS_ATTESTATION_STATUS" != "$A
     echo "Unexpected headless runtime release-attestation status: expected $ATTESTATION_EXPECTED_STATUS, got ${HEADLESS_ATTESTATION_STATUS:-<empty>}" >&2
     exit 1
 fi
+
+# HTTP readiness alone can precede model loading. Exercise this process too,
+# rather than borrowing the first process's successful completion/offload log.
+echo "Testing headless chat completion..."
+HEADLESS_RESPONSE="$(curl -fsS --max-time 60 \
+    "http://127.0.0.1:${HEADLESS_API_PORT}/v1/chat/completions" \
+    -H 'content-type: application/json' -d "$AUTO_PAYLOAD")"
+printf '%s' "$HEADLESS_RESPONSE" | jq -e '(.choices[0].message.content | length > 0)' >/dev/null
+python3 scripts/ci-verify-smoke-offload.py --device "$SMOKE_DEVICE" \
+    --native-log "$SMOKE_RUNTIME_ROOT/$HEADLESS_PID/logs/skippy-native.log"
 
 echo "Skippy smoke passed"

--- a/scripts/ci-verify-smoke-offload.py
+++ b/scripts/ci-verify-smoke-offload.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Require native model-offload evidence after the caller's inference probes.
+
+Read the exact process's raw native log, not filtered JSON (which can discard
+load_tensors summaries), and never search another PID or a previous smoke run.
+This is a functional offload check, not a kernel-utilization benchmark.
+"""
+import argparse
+import json
+from pathlib import Path
+import re
+import sys
+
+
+# llama-model.cpp logs these INFO lines after buffer allocation. CPU_Host CUDA
+# staging buffers and device discovery are deliberately not GPU weight evidence.
+OFFLOAD = re.compile(r"^(?:llm_)?load_tensors: offloaded (\d+)/(\d+) layers to GPU$")
+CUDA_BUFFER = re.compile(
+    r"^(?:llm_)?load_tensors:\s+CUDA0 model buffer size =\s+([0-9]+(?:\.[0-9]+)?) MiB$"
+)
+
+
+def verify_cuda_offload(lines):
+    """Fail closed on absent, zero, malformed or contradictory load evidence."""
+    counts = []
+    buffers = []
+    evidence = []
+    for raw in lines:
+        line = raw.strip()
+        match = OFFLOAD.fullmatch(line)
+        if match:
+            loaded, total = map(int, match.groups())
+            if not 0 < loaded <= total:
+                raise ValueError("zero or invalid GPU layer-offload count")
+            counts.append((loaded, total))
+            evidence.append(line)
+        match = CUDA_BUFFER.fullmatch(line)
+        if match:
+            size = float(match[1])
+            if size <= 0:
+                raise ValueError("zero CUDA0 model buffer")
+            buffers.append(size)
+            evidence.append(line)
+    if not counts or not buffers:
+        raise ValueError("missing positive GPU layer-offload and CUDA0 model-buffer evidence")
+    return evidence
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--device", required=True, choices=("CPU", "CUDA0", "Vulkan0", "ROCm0", "MTL0"))
+    parser.add_argument("--native-log", required=True, type=Path)
+    args = parser.parse_args()
+    if args.device != "CUDA0":
+        print(f"{args.device} smoke: CUDA offload qualification not requested")
+        return 0
+    try:
+        with args.native_log.open(encoding="utf-8") as log:
+            evidence = verify_cuda_offload(log)
+    except (OSError, UnicodeError, ValueError) as error:
+        print(f"CUDA smoke offload failed ({args.native_log}): {error}", file=sys.stderr)
+        return 1
+    print(json.dumps({"check": "cuda_model_offload", "device": args.device,
+                      "native_log": str(args.native_log), "evidence": evidence}))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tests/fixtures/ci-plan/compat-smoke-script.json
+++ b/scripts/tests/fixtures/ci-plan/compat-smoke-script.json
@@ -1,0 +1,23 @@
+{
+  "profile": "pr-ready",
+  "event_name": "pull_request",
+  "source_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "changed_files": [
+    "scripts/ci-compat-smoke.sh"
+  ],
+  "affected_crates": [
+    "mesh-llm-host-runtime",
+    "mesh-llm"
+  ],
+  "workspace_packages": [
+    {
+      "name": "mesh-llm-host-runtime",
+      "path": "crates/mesh-llm-host-runtime"
+    },
+    {
+      "name": "mesh-llm",
+      "path": "crates/mesh-llm"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/ci-plan/native-runtime-consumer-script.json
+++ b/scripts/tests/fixtures/ci-plan/native-runtime-consumer-script.json
@@ -1,0 +1,23 @@
+{
+  "profile": "pr-ready",
+  "event_name": "pull_request",
+  "source_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "changed_files": [
+    "scripts/ci-prepare-native-runtime.sh"
+  ],
+  "affected_crates": [
+    "mesh-llm-host-runtime",
+    "mesh-llm"
+  ],
+  "workspace_packages": [
+    {
+      "name": "mesh-llm-host-runtime",
+      "path": "crates/mesh-llm-host-runtime"
+    },
+    {
+      "name": "mesh-llm",
+      "path": "crates/mesh-llm"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/ci-plan/product-smoke-script.json
+++ b/scripts/tests/fixtures/ci-plan/product-smoke-script.json
@@ -1,0 +1,23 @@
+{
+  "profile": "pr-ready",
+  "event_name": "pull_request",
+  "source_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "changed_files": [
+    "scripts/ci-smoke-test.sh"
+  ],
+  "affected_crates": [
+    "mesh-llm-host-runtime",
+    "mesh-llm"
+  ],
+  "workspace_packages": [
+    {
+      "name": "mesh-llm-host-runtime",
+      "path": "crates/mesh-llm-host-runtime"
+    },
+    {
+      "name": "mesh-llm",
+      "path": "crates/mesh-llm"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/ci-plan/release-ui-script.json
+++ b/scripts/tests/fixtures/ci-plan/release-ui-script.json
@@ -1,0 +1,23 @@
+{
+  "profile": "pr-ready",
+  "event_name": "pull_request",
+  "source_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "changed_files": [
+    "scripts/ci-prepare-release-ui.sh"
+  ],
+  "affected_crates": [
+    "mesh-llm-host-runtime",
+    "mesh-llm"
+  ],
+  "workspace_packages": [
+    {
+      "name": "mesh-llm-host-runtime",
+      "path": "crates/mesh-llm-host-runtime"
+    },
+    {
+      "name": "mesh-llm",
+      "path": "crates/mesh-llm"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/ci-plan/release-version-script.json
+++ b/scripts/tests/fixtures/ci-plan/release-version-script.json
@@ -1,0 +1,23 @@
+{
+  "profile": "pr-ready",
+  "event_name": "pull_request",
+  "source_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "changed_files": [
+    "scripts/release-version.sh"
+  ],
+  "affected_crates": [
+    "mesh-llm-host-runtime",
+    "mesh-llm"
+  ],
+  "workspace_packages": [
+    {
+      "name": "mesh-llm-host-runtime",
+      "path": "crates/mesh-llm-host-runtime"
+    },
+    {
+      "name": "mesh-llm",
+      "path": "crates/mesh-llm"
+    }
+  ]
+}

--- a/scripts/tests/fixtures/ci-plan/smoke-offload-script.json
+++ b/scripts/tests/fixtures/ci-plan/smoke-offload-script.json
@@ -1,0 +1,23 @@
+{
+  "profile": "pr-ready",
+  "event_name": "pull_request",
+  "source_sha": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "changed_files": [
+    "scripts/ci-verify-smoke-offload.py"
+  ],
+  "affected_crates": [
+    "mesh-llm-host-runtime",
+    "mesh-llm"
+  ],
+  "workspace_packages": [
+    {
+      "name": "mesh-llm-host-runtime",
+      "path": "crates/mesh-llm-host-runtime"
+    },
+    {
+      "name": "mesh-llm",
+      "path": "crates/mesh-llm"
+    }
+  ]
+}

--- a/scripts/tests/test_ci_cuda_setup.py
+++ b/scripts/tests/test_ci_cuda_setup.py
@@ -1,0 +1,67 @@
+"""Execute both CUDA workflow preflights with isolated tool/library probes."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+LIBRARIES = ("libcudart.so.12", "libcublas.so.12", "libcublasLt.so.12")
+
+
+class CudaSetupTests(unittest.TestCase):
+    def test_both_cuda_preflights_fail_closed_without_installing(self):
+        for workflow, job, condition in (
+            ("smoke.yml", "smoke_tests", "inputs.runner == 'gpu-nvidia'"),
+            ("product-integration-smoke.yml", "product_integration",
+             "inputs.platform == 'linux' && inputs.backend == 'cuda'"),
+        ):
+            with self.subTest(workflow=workflow):
+                data = yaml.safe_load((ROOT / ".github/workflows" / workflow).read_text())
+                steps = [step for step in data["jobs"][job]["steps"]
+                         if step.get("if") == condition and "run" in step]
+                script = "\n".join(step["run"] for step in steps)
+                self.assertNotIn("sudo", script)
+                self.assertNotIn("apt-get", script)
+                for missing in (None, "curl", "jq", "lsof", *LIBRARIES, "nvidia-smi"):
+                    with self.subTest(missing=missing), tempfile.TemporaryDirectory() as directory:
+                        root = Path(directory)
+                        calls = root / "calls"
+                        tools = root / "bin"
+                        tools.mkdir()
+                        for tool in ("curl", "jq", "lsof", "nvidia-smi"):
+                            if tool == missing and tool != "nvidia-smi":
+                                continue
+                            path = tools / tool
+                            path.write_text('#!/bin/sh\nprintf "%s\\n" "' + tool +
+                                            ' $*" >> "$CALLS"\n' +
+                                            ('exit 1\n' if tool == missing else 'exit 0\n'))
+                            path.chmod(0o755)
+                        (tools / "python3").symlink_to(sys.executable)
+                        (root / "ctypes.py").write_text(
+                            'import os\n'
+                            'def CDLL(library):\n'
+                            '    with open(os.environ["CALLS"], "a") as calls:\n'
+                            '        calls.write(library + "\\n")\n'
+                            '    if library == os.environ.get("MISSING"):\n'
+                            '        raise OSError("missing library")\n')
+                        result = subprocess.run(
+                            [shutil.which("bash"), "-c", script], cwd=root,
+                            env={**os.environ, "PATH": str(tools), "PYTHONPATH": str(root),
+                                 "CALLS": str(calls), "MISSING": missing or ""},
+                            capture_output=True, text=True, timeout=10)
+                        recorded = calls.read_text().splitlines() if calls.exists() else []
+                        if missing is None:
+                            self.assertEqual(result.returncode, 0, result.stderr)
+                            self.assertEqual(recorded, [*LIBRARIES,
+                                "nvidia-smi --query-gpu=name,compute_cap,driver_version --format=csv,noheader"])
+                        else:
+                            self.assertNotEqual(result.returncode, 0, result.stdout)
+                            if missing in ("curl", "jq", "lsof"):
+                                self.assertEqual(recorded, [])
+                            elif missing in LIBRARIES:
+                                self.assertEqual(recorded, list(LIBRARIES[:LIBRARIES.index(missing) + 1]))

--- a/scripts/tests/test_ci_product_integration_smoke.py
+++ b/scripts/tests/test_ci_product_integration_smoke.py
@@ -88,8 +88,14 @@ esac
             )
             path.chmod(path.stat().st_mode | stat.S_IXUSR)
             return
+        # Execute the actual consumer's device selection/guard before the
+        # harmless phase stub, so typed-call environment drift cannot hide
+        # behind the suite manifest's independently recorded device.
+        consumer = (ROOT / "scripts" / path.name).read_text()
+        device_setup = consumer[:consumer.index("MESH_LLM=")]
         path.write_text(
-            """#!/usr/bin/env bash
+            device_setup + '\n[[ "$SMOKE_DEVICE" == "$STUB_EXPECTED_DEVICE" ]]\n' +
+            """
 set -euo pipefail
 phase="${MESH_PRODUCT_INTEGRATION_PHASE:?missing phase}"
 for log_path in "${MESH_CI_LOG:-}" "${MESH_CI_HEADLESS_LOG:-}" "${MESH_COMPAT_LOG:-}"; do
@@ -155,6 +161,13 @@ fi
                 "PATH": "/usr/bin:/bin",
                 "MESH_PRODUCT_INTEGRATION_PHASE_ROOT": str(phase_root),
                 "STUB_SPLIT_EVIDENCE_MODE": split_evidence_mode,
+                "STUB_EXPECTED_DEVICE": {"cpu": "CPU", "cuda": "CUDA0", "metal": "MTL0",
+                                         "vulkan": "Vulkan0", "rocm": "ROCm0"}.get(backend, "invalid"),
+                # A typed compatibility call must override the generic CPU
+                # fallback via MESH_COMPAT_DEVICE; the standalone caller must
+                # override this common default via MESH_CI_DEVICE.
+                "MESH_CI_DEVICE": "CPU",
+                "MESH_COMPAT_DEVICE": "CPU",
             }
             if failure_phase is not None:
                 env["STUB_FAIL_PHASE"] = failure_phase

--- a/scripts/tests/test_ci_product_integration_smoke.py
+++ b/scripts/tests/test_ci_product_integration_smoke.py
@@ -93,8 +93,9 @@ esac
         # behind the suite manifest's independently recorded device.
         consumer = (ROOT / "scripts" / path.name).read_text()
         device_setup = consumer[:consumer.index("MESH_LLM=")]
+        # Fail explicitly: errexit can be disabled by the shell invocation.
         path.write_text(
-            device_setup + '\n[[ "$SMOKE_DEVICE" == "$STUB_EXPECTED_DEVICE" ]]\n' +
+            device_setup + '\n[[ "$SMOKE_DEVICE" == "$STUB_EXPECTED_DEVICE" ]] || exit 97\n' +
             """
 set -euo pipefail
 phase="${MESH_PRODUCT_INTEGRATION_PHASE:?missing phase}"
@@ -123,6 +124,7 @@ fi
         recurrent_artifact_id: str = RECURRENT_ARTIFACT_ID,
         recurrent_sha256: str | None = None,
         split_evidence_mode: str = "valid",
+        script_mutation: tuple[str, str, str] | None = None,
     ) -> tuple[subprocess.CompletedProcess[str], dict | None]:
         with tempfile.TemporaryDirectory() as directory:
             root = Path(directory)
@@ -139,6 +141,13 @@ fi
                 "ci-two-node-split-smoke.sh",
             ):
                 self.write_stub(scripts / name)
+
+            if script_mutation is not None:
+                name, original, replacement = script_mutation
+                script = scripts / name
+                source = script.read_text()
+                self.assertIn(original, source, f"mutation target missing in {name}")
+                script.write_text(source.replace(original, replacement, 1))
 
             binary = root / "mesh-llm"
             binary.touch(mode=0o755)
@@ -283,6 +292,50 @@ fi
                 self.assertEqual(result.returncode, 0, result.stderr)
                 assert manifest is not None
                 self.assertEqual(manifest["provenance"]["device"], expected_device)
+
+    def test_device_drift_mutations_fail_the_owning_phase(self) -> None:
+        # Mutate only disposable scripts, retaining the real caller and device
+        # guards. Exact status/phase assertions exclude unrelated shell failures.
+        cases = (
+            (
+                "standalone caller override",
+                (PRODUCT_SCRIPT.name, 'MESH_CI_DEVICE="$DEVICE"', 'MESH_CI_DEVICE="CPU"'),
+                "dense-standalone",
+            ),
+            (
+                "compatibility caller override",
+                (PRODUCT_SCRIPT.name, 'MESH_COMPAT_DEVICE="$DEVICE"', 'MESH_COMPAT_DEVICE="CPU"'),
+                "dense-openai-sdk",
+            ),
+            (
+                "compatibility selector precedence",
+                (
+                    "ci-compat-smoke.sh",
+                    'SMOKE_DEVICE="${MESH_COMPAT_DEVICE:-${MESH_CI_DEVICE:-CPU}}"',
+                    'SMOKE_DEVICE="${MESH_CI_DEVICE:-CPU}"',
+                ),
+                "dense-openai-sdk",
+            ),
+        )
+        for platform, backend in (
+            ("linux", "cuda"), ("linux", "vulkan"),
+            ("linux", "rocm"), ("macos", "metal"),
+        ):
+            for name, mutation, failure_phase in cases:
+                with self.subTest(backend=backend, mutation=name):
+                    result, manifest = self.run_suite(
+                        platform=platform, backend=backend, script_mutation=mutation,
+                    )
+                    self.assertEqual(result.returncode, 97, result.stderr)
+                    self.assertIsNotNone(manifest)
+                    assert manifest is not None
+                    self.assertEqual(manifest["suite_status"], "failed")
+                    self.assertEqual(manifest["reconciliation"]["status"], "failed")
+                    self.assertEqual(
+                        manifest["reconciliation"]["failure_phase"], failure_phase,
+                    )
+                    self.assertEqual(manifest["phases"][-1]["phase"], failure_phase)
+                    self.assertEqual(manifest["phases"][-1]["exit_code"], 97)
 
     def test_failed_phase_is_recorded_and_reconciliation_fails_closed(self) -> None:
         result, manifest = self.run_suite("dense-openai-sdk")

--- a/scripts/tests/test_ci_recurrence.py
+++ b/scripts/tests/test_ci_recurrence.py
@@ -1,0 +1,164 @@
+"""Execution-level regressions for the PR-green/main-red preparation boundaries."""
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class CiRecurrenceTests(unittest.TestCase):
+    def test_ui_candidate_step_executes_checkout_trust_before_version_preparation(self):
+        workflow = yaml.safe_load((ROOT / ".github/workflows/ci-ui-artifact-slice.yml").read_text())
+        steps = workflow["jobs"]["ui_artifact"]["steps"]
+        step = next(item for item in steps if "ci-prepare-release-ui.sh" in item.get("run", ""))
+        self.assertNotIn("if", step, "ordinary PR/main must exercise release preparation")
+        # Git's own ownership-test mode reproduces the container ownership error
+        # without root/chown. Only the expensive version rewrite is a test double.
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            scripts = root / "scripts"
+            scripts.mkdir()
+            shutil.copy2(ROOT / "scripts/ci-prepare-release-ui.sh", scripts)
+            version = scripts / "release-version.sh"
+            version.write_text('#!/usr/bin/env bash\nset -euo pipefail\ngit ls-files > prepared-files\nprintf "%s" "$1" > prepared-version\n')
+            version.chmod(0o755)
+            env = {**os.environ, "GIT_CONFIG_GLOBAL": str(root / "empty-config"),
+                   "GIT_CONFIG_NOSYSTEM": "1", "GITHUB_ENV": str(root / "github-env"),
+                   "RUNNER_TEMP": directory}
+            def git(*args):
+                return subprocess.check_output(["git", *args], cwd=root, env=env, text=True).strip()
+            git("init", "--quiet")
+            git("add", "scripts")
+            git("-c", "user.name=Fixture", "-c", "user.email=fixture@example.invalid",
+                "-c", "commit.gpgsign=false", "commit", "--quiet", "-m", "fixture")
+            sha = git("rev-parse", "HEAD")
+            env.update(UI_SOURCE_SHA=sha, RELEASE_TAG="v99.99.99-ci-rehearsal",
+                       GIT_TEST_ASSUME_DIFFERENT_OWNER="1")
+            rejected = subprocess.run(["git", "rev-parse", "HEAD"], cwd=root, env=env, capture_output=True)
+            self.assertNotEqual(rejected.returncode, 0, "ownership reproduction must fail first")
+            result = subprocess.run(["bash", "-e", "-c", step["run"]], cwd=root, env=env,
+                                    capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertIn("scripts/release-version.sh", (root / "prepared-files").read_text())
+            self.assertEqual((root / "prepared-version").read_text(), env["RELEASE_TAG"])
+            (root / "prepared-files").unlink()
+            (root / "prepared-version").unlink()
+            (root / "github-env").unlink()
+            env["RELEASE_TAG"] = ""
+            result = subprocess.run(["bash", "-e", "-c", step["run"]], cwd=root, env=env,
+                                    capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            self.assertFalse((root / "prepared-version").exists())
+            self.assertFalse((root / "github-env").exists(), "rehearsal must not change the real UI mode")
+            self.assertEqual(list(root.glob("mesh-release-ui.*")), [])
+
+    def test_product_smoke_exercises_sdk_reader_before_serving(self):
+        script = (ROOT / "scripts/ci-smoke-test.sh").read_text()
+        self.assertIn("MESH_SDK_NATIVE_RUNTIME_BUILD_FALLBACK=0 scripts/ci-prepare-native-runtime.sh", script)
+        self.assertLess(script.index("scripts/ci-prepare-native-runtime.sh"), script.index("MESH_PID=$!"))
+        self.assertIn('--reuse-from-binary "$MESH_LLM"', script)
+
+    def test_gpu_setup_checks_existing_libraries_instead_of_sudo(self):
+        workflow = yaml.safe_load((ROOT / ".github/workflows/smoke.yml").read_text())
+        steps = workflow["jobs"]["smoke_tests"]["steps"]
+        runs = "\n".join(step.get("run", "") for step in steps)
+        self.assertNotIn("sudo", runs)
+        for library in ("libcudart.so.12", "libcublas.so.12", "libcublasLt.so.12"):
+            self.assertIn(library, runs)
+        self.assertIn("ctypes.CDLL(library)", runs)
+
+
+class CudaSmokeContractTests(unittest.TestCase):
+    def test_cuda_row_selects_device_for_all_smoke_steps(self):
+        workflow = yaml.safe_load((ROOT / ".github/workflows/smoke.yml").read_text())
+        job = workflow["jobs"]["smoke_tests"]
+        self.assertEqual(job["env"].get("MESH_CI_DEVICE"),
+                         "${{ inputs.runner == 'gpu-nvidia' && 'CUDA0' || 'CPU' }}")
+        for step in job["steps"]:
+            if "ci-smoke-test.sh" in step.get("run", "") or "ci-compat-smoke.sh" in step.get("run", ""):
+                self.assertNotIn("MESH_CI_DEVICE", step.get("env", {}))
+
+    def test_every_serve_checks_its_own_native_offload_log(self):
+        for filename, pids in (("ci-smoke-test.sh", ("MESH_PID", "HEADLESS_PID")),
+                               ("ci-compat-smoke.sh", ("MESH_PID",))):
+            with self.subTest(filename=filename):
+                script = (ROOT / "scripts" / filename).read_text()
+                self.assertNotIn("--device CPU", script)
+                self.assertEqual(script.count('    --device "$SMOKE_DEVICE"'), len(pids))
+                for pid in pids:
+                    self.assertIn(f'"$SMOKE_RUNTIME_ROOT/${pid}/logs/skippy-native.log"', script)
+                self.assertEqual(script.count("scripts/ci-verify-smoke-offload.py"), len(pids))
+
+
+    def test_headless_completion_succeeds_before_its_offload_check(self):
+        script = (ROOT / "scripts/ci-smoke-test.sh").read_text()
+        # Execute the real final headless block, including set -e behavior,
+        # curl flags and jq's nonempty-content gate. Only HTTP and the offload
+        # subprocess are doubles; no model/server or GPU is started here.
+        block = script[script.index('HEADLESS_ATTESTATION_STATUS='):]
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            commands = root / "bin"
+            commands.mkdir()
+            trace = root / "trace"
+            curl = commands / "curl"
+            curl.write_text('''#!/usr/bin/env bash
+set -eu
+case "$*" in
+    *'/api/status'*) printf '%s' '{"release_attestation":{"status":"missing"}}' ;;
+    *'/v1/chat/completions'*)
+        printf 'chat:%s\\n' "$*" >> "$TRACE"
+        printf '%s' "$CHAT_RESPONSE"
+        exit "$CHAT_EXIT"
+        ;;
+    *) exit 90 ;;
+esac
+''')
+            python = commands / "python3"
+            python.write_text('''#!/usr/bin/env bash
+set -eu
+if [[ "$1" == scripts/ci-verify-smoke-offload.py ]]; then
+    printf 'offload:%s\\n' "$*" >> "$TRACE"
+else
+    exec "$REAL_PYTHON" "$@"
+fi
+''')
+            curl.chmod(0o755)
+            python.chmod(0o755)
+            env = {**os.environ, "PATH": f"{commands}:{os.environ['PATH']}",
+                   "TRACE": str(trace), "REAL_PYTHON": sys.executable,
+                   "HEADLESS_CONSOLE_PORT": "3132", "HEADLESS_API_PORT": "9338",
+                   "ATTESTATION_PUBLIC_KEY_FILE": "", "SMOKE_DEVICE": "CUDA0",
+                   "SMOKE_RUNTIME_ROOT": str(root / "runtime"), "HEADLESS_PID": "12345",
+                   "AUTO_PAYLOAD": '{"model":"auto"}'}
+            for response, status, succeeds in (
+                ('{"choices":[{"message":{"content":"hello"}}]}', "0", True),
+                ('{"choices":[{"message":{"content":""}}]}', "0", False),
+                ('{"choices":[]}', "0", False),
+                ('not json', "0", False),
+                ('{"choices":[{"message":{"content":"hello"}}]}', "22", False),
+            ):
+                with self.subTest(response=response, status=status):
+                    trace.write_text("")
+                    result = subprocess.run(["bash", "-euo", "pipefail", "-c", block],
+                                            cwd=root, env={**env, "CHAT_RESPONSE": response,
+                                                          "CHAT_EXIT": status},
+                                            capture_output=True, text=True)
+                    events = trace.read_text().splitlines()
+                    self.assertTrue(events and events[0].startswith("chat:"), events)
+                    self.assertIn("-fsS --max-time 60", events[0])
+                    self.assertIn("http://127.0.0.1:9338/v1/chat/completions", events[0])
+                    if succeeds:
+                        self.assertEqual(result.returncode, 0, result.stderr)
+                        self.assertEqual(len(events), 2, events)
+                        self.assertEqual(events[1], "offload:scripts/ci-verify-smoke-offload.py "
+                                         f"--device CUDA0 --native-log {root}/runtime/12345/logs/skippy-native.log")
+                    else:
+                        self.assertNotEqual(result.returncode, 0, result.stdout)
+                        self.assertEqual(len(events), 1, "offload must not run after failed inference")

--- a/scripts/tests/test_ci_smoke_offload.py
+++ b/scripts/tests/test_ci_smoke_offload.py
@@ -1,0 +1,94 @@
+"""Execute the offload gate with native-log fixtures, without starting a GPU job."""
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+ROOT = Path(__file__).resolve().parents[2]
+SCRIPT = ROOT / "scripts/ci-verify-smoke-offload.py"
+LAYERS = "load_tensors: offloaded 25/25 layers to GPU\n"
+BUFFER = "load_tensors:        CUDA0 model buffer size =   256.50 MiB\n"
+
+
+class SmokeOffloadTests(unittest.TestCase):
+    def run_gate(self, log, device="CUDA0"):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory) / "skippy-native.log"
+            if log is not None:
+                path.write_text(log)
+            return subprocess.run([sys.executable, str(SCRIPT), "--device", device,
+                                   "--native-log", str(path)], text=True, capture_output=True)
+
+    def test_accepts_positive_offload_and_cuda_weights(self):
+        result = self.run_gate(LAYERS + BUFFER)
+        self.assertEqual(result.returncode, 0, result.stderr)
+        evidence = json.loads(result.stdout)
+        self.assertEqual(evidence["device"], "CUDA0")
+        self.assertEqual(evidence["evidence"], [LAYERS.strip(), BUFFER.strip()])
+
+    def test_rejects_cpu_fallback_and_non_evidence(self):
+        for log in (None, "", LAYERS, BUFFER,
+                    "ggml_cuda_init: found 1 CUDA devices\n",
+                    "load_tensors: CPU_Mapped model buffer size = 256.50 MiB\n",
+                    LAYERS.replace("25/25", "0/25") + BUFFER,
+                    LAYERS.replace("25/25", "26/25") + BUFFER,
+                    LAYERS + BUFFER.replace("256.50", "0.00"),
+                    LAYERS + BUFFER.replace("CUDA0", "CUDA_Host"),
+                    LAYERS + BUFFER.replace("CUDA0", "CUDA1"),
+                    LAYERS + BUFFER.replace("model buffer", "compute buffer"),
+                    "load_tensors: offloading 25 repeating layers to GPU\n" + BUFFER,
+                    LAYERS + BUFFER + LAYERS.replace("25/25", "0/25")):
+            with self.subTest(log=log):
+                self.assertNotEqual(self.run_gate(log).returncode, 0)
+
+    def test_cpu_row_does_not_require_cuda_log(self):
+        result = self.run_gate(None, "CPU")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("not requested", result.stdout)
+
+    def test_unknown_device_cannot_disable_the_gate(self):
+        for device in ("auto", "cuda", "", "CUDA1"):
+            with self.subTest(device=device):
+                self.assertNotEqual(self.run_gate(LAYERS + BUFFER, device).returncode, 0)
+
+    def test_smoke_scripts_reject_unknown_device_before_launch(self):
+        for script in ("ci-smoke-test.sh", "ci-compat-smoke.sh"):
+            with self.subTest(script=script):
+                result = subprocess.run(["bash", str(ROOT / "scripts" / script)],
+                                        env={**os.environ, "MESH_CI_DEVICE": "auto"},
+                                        capture_output=True, text=True)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("Unsupported MESH_CI_DEVICE", result.stderr)
+
+
+    def test_other_product_backends_are_preserved_without_cuda_claim(self):
+        for device in ("Vulkan0", "ROCm0", "MTL0"):
+            with self.subTest(device=device):
+                result = self.run_gate(None, device)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertIn(f"{device} smoke: CUDA offload qualification not requested", result.stdout)
+
+    def test_compat_device_override_and_common_fallback(self):
+        script = (ROOT / "scripts/ci-compat-smoke.sh").read_text()
+        setup = script[:script.index('MESH_LLM=')]
+        for common, compat, expected in (("CUDA0", None, "CUDA0"),
+                                          (None, "CUDA0", "CUDA0"),
+                                          (None, "MTL0", "MTL0"),
+                                          (None, "Vulkan0", "Vulkan0"),
+                                          (None, "ROCm0", "ROCm0"),
+                                          ("CPU", "CUDA0", "CUDA0"),
+                                          (None, None, "CPU")):
+            with self.subTest(common=common, compat=compat):
+                env = {key: value for key, value in os.environ.items()
+                       if key not in ("MESH_CI_DEVICE", "MESH_COMPAT_DEVICE")}
+                if common is not None:
+                    env["MESH_CI_DEVICE"] = common
+                if compat is not None:
+                    env["MESH_COMPAT_DEVICE"] = compat
+                result = subprocess.run(["bash", "-c", setup + '\nprintf "%s" "$SMOKE_DEVICE"'],
+                                        env=env, capture_output=True, text=True)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertEqual(result.stdout, expected)

--- a/scripts/tests/test_ci_smoke_offload.py
+++ b/scripts/tests/test_ci_smoke_offload.py
@@ -56,12 +56,33 @@ class SmokeOffloadTests(unittest.TestCase):
 
     def test_smoke_scripts_reject_unknown_device_before_launch(self):
         for script in ("ci-smoke-test.sh", "ci-compat-smoke.sh"):
-            with self.subTest(script=script):
-                result = subprocess.run(["bash", str(ROOT / "scripts" / script)],
-                                        env={**os.environ, "MESH_CI_DEVICE": "auto"},
-                                        capture_output=True, text=True)
+            with self.subTest(script=script), tempfile.TemporaryDirectory() as directory:
+                root = Path(directory)
+                launched = root / "launched"
+                binary = root / "mesh-llm"
+                binary.write_text('#!/bin/sh\nprintf "launch\\n" >> "$LAUNCH_PROBE"\nexit 1\n')
+                binary.chmod(0o755)
+                model = root / "model.gguf"
+                model.touch()
+                (root / "native-runtimes").mkdir()
+                # Isolate the SDK preflight too: a misplaced guard must be able
+                # to reach the launch probe, never a real runtime or endpoint.
+                (root / "scripts").mkdir()
+                helper = root / "scripts/ci-prepare-native-runtime.sh"
+                helper.write_text('#!/bin/sh\nexit 0\n')
+                helper.chmod(0o755)
+                env = {key: value for key, value in os.environ.items()
+                       if not key.startswith(("MESH_", "BASH_ENV"))}
+                result = subprocess.run(
+                    ["bash", str(ROOT / "scripts" / script), str(binary), str(root), str(model)],
+                    cwd=root, env={**env, "MESH_CI_DEVICE": "auto",
+                                   "LAUNCH_PROBE": str(launched),
+                                   "MESH_CI_LOG": str(root / "smoke.log"),
+                                   "MESH_COMPAT_LOG": str(root / "compat.log")},
+                    capture_output=True, text=True, timeout=10)
                 self.assertNotEqual(result.returncode, 0)
                 self.assertIn("Unsupported MESH_CI_DEVICE", result.stderr)
+                self.assertFalse(launched.exists(), "invalid device launched mesh-llm")
 
 
     def test_other_product_backends_are_preserved_without_cuda_claim(self):

--- a/scripts/tests/test_ci_workflow_artifacts.py
+++ b/scripts/tests/test_ci_workflow_artifacts.py
@@ -174,8 +174,9 @@ class CiWorkflowArtifactTests(unittest.TestCase):
             product_smoke,
         )
         self.assertIn("inputs.platform == 'linux' && inputs.backend == 'cuda'", product_smoke)
-        self.assertIn("cuda-cudart-12-9", product_smoke)
-        self.assertIn("libcublas-12-9", product_smoke)
+        for library in ("libcudart.so.12", "libcublas.so.12", "libcublasLt.so.12"):
+            self.assertIn(library, product_smoke)
+        self.assertNotIn("sudo apt-get", product_smoke)
 
     def test_product_integration_supports_accelerator_backends(self):
         product_smoke = (WORKFLOWS / "product-integration-smoke.yml").read_text()

--- a/scripts/tests/test_plan_ci.py
+++ b/scripts/tests/test_plan_ci.py
@@ -28,6 +28,30 @@ def fixture(name: str) -> dict[str, object]:
 
 
 class PlanCiTests(unittest.TestCase):
+    def test_script_only_changes_reach_their_executable_consumers(self) -> None:
+        cases = (
+            ("release-ui-script.json", {"ui-artifact"}, set()),
+            ("release-version-script.json", {"ui-artifact"}, set()),
+            ("native-runtime-consumer-script.json", {"product-smoke", "sdk"}, {"rust", "kotlin", "swift"}),
+            ("product-smoke-script.json", {"product-smoke"}, set()),
+        )
+        for fixture_name, required, sdk_languages in cases:
+            with self.subTest(fixture=fixture_name):
+                payload = fixture(fixture_name)
+                self.assertEqual(len(payload["changed_files"]), 1)
+                plan = PLANNER.build_plan(payload, root=ROOT)
+                self.assertTrue(required <= set(plan["required_slices"]), plan["required_slices"])
+                self.assertTrue(plan["matrices"]["hosts"], "UI must feed a real host producer")
+                if "product-smoke" in required:
+                    self.assertIn("core", {row["id"] for row in plan["matrices"]["smoke"]})
+                self.assertTrue(sdk_languages <= {row["language"] for row in plan["matrices"]["sdk"]})
+
+    def test_cuda_smoke_scripts_select_hardware_consumer(self) -> None:
+        for name in ("product-smoke-script.json", "compat-smoke-script.json", "smoke-offload-script.json"):
+            with self.subTest(fixture=name):
+                plan = PLANNER.build_plan(fixture(name), root=ROOT)
+                self.assertTrue({"core", "core-cuda"} <= {row["id"] for row in plan["matrices"]["smoke"]})
+
     def test_manifest_root_is_independent_from_workspace_root(self) -> None:
         with (
             tempfile.TemporaryDirectory() as workspace_directory,

--- a/scripts/tests/test_plan_ci.py
+++ b/scripts/tests/test_plan_ci.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 import tempfile
 import unittest
+
+import yaml
 from unittest import mock
 
 
@@ -51,6 +53,50 @@ class PlanCiTests(unittest.TestCase):
             with self.subTest(fixture=name):
                 plan = PLANNER.build_plan(fixture(name), root=ROOT)
                 self.assertTrue({"core", "core-cuda"} <= {row["id"] for row in plan["matrices"]["smoke"]})
+
+    def test_planned_linux_smoke_rows_have_executable_job_owners(self) -> None:
+        workflow = yaml.safe_load(
+            (ROOT / ".github/workflows/ci-linux-product-smoke-slice.yml").read_text()
+        )
+        owners = {
+            "core": ("core", "smoke.yml", None),
+            "core-cuda": ("core_cuda", "smoke.yml", None),
+            "two-node-client": ("two_node_client", "scripted-binary-smoke.yml",
+                                "scripts/ci-two-node-client-serving-smoke.sh"),
+            "two-node-split": ("two_node_split", "scripted-binary-smoke.yml",
+                               "scripts/ci-two-node-split-smoke.sh"),
+            "model-download": ("model_download", "hf-download-smoke.yml", None),
+        }
+        # Exercise all checked planner fixtures, including docs-only, main,
+        # runtime and the six single-script recurrence regressions.
+        for path in sorted(FIXTURE_ROOT.glob("*.json")):
+            with self.subTest(fixture=path.name):
+                payload = fixture(path.name)
+                # Empty fixture closures should stay empty, not query the
+                # surrounding checkout and escape the synthetic workspace.
+                with mock.patch.object(PLANNER, "_affected_crates", return_value=payload.get("affected_crates", [])):
+                    plan = PLANNER.build_plan(payload, root=ROOT)
+                for row in plan["matrices"]["smoke"]:
+                    if row["id"] == "metal-model-load":
+                        continue
+                    job_id, callee, script = owners[row["id"]]
+                    self.assertIn(job_id, workflow["jobs"], row)
+                    job = workflow["jobs"][job_id]
+                    # Exact sole selector proves singleton selection executes
+                    # its consumer and an empty/unselected plan skips it.
+                    self.assertEqual(job["if"], "${{ contains(fromJson(inputs.smoke_matrix).*.id, '" + row["id"] + "') }}")
+                    self.assertEqual(job["uses"], "./.github/workflows/" + callee)
+                    if script:
+                        self.assertEqual(job["with"]["smoke_script"], script)
+                    if row["id"] != "model-download":
+                        backend = "cuda" if row["id"] == "core-cuda" else "cpu"
+                        self.assertEqual(job["with"]["artifact_name"], f"ci-product-linux-amd64-{backend}")
+                        self.assertTrue(any(product["platform"] == "linux" and
+                                            product["backend"] == backend
+                                            for product in plan["matrices"]["runtime_products"]))
+                    if row["id"] == "two-node-split":
+                        self.assertEqual(job["with"]["kv_recurrent_expected_exact_payload_kind"], "kv-recurrent")
+                        self.assertEqual(job["with"]["kv_recurrent_model_file"], "Qwen3.5-0.8B-Q4_K_M.gguf")
 
     def test_manifest_root_is_independent_from_workspace_root(self) -> None:
         with (

--- a/scripts/tests/test_release_workflow_artifacts.py
+++ b/scripts/tests/test_release_workflow_artifacts.py
@@ -24,7 +24,9 @@ class ReleaseWorkflowArtifactTests(unittest.TestCase):
         artifact = "prepared-release-ui-${{ needs.metadata.outputs.tag }}-${{ needs.metadata.outputs.source_sha }}"
         self.assertIn(f"artifact_name: {artifact}", producer)
         ui_workflow = (ROOT / ".github/workflows/ci-ui-artifact-slice.yml").read_text()
-        self.assertIn('echo "VITE_MESH_LLM_DEBUG_UI=false" >> "$GITHUB_ENV"', ui_workflow)
+        preparation = (ROOT / "scripts/ci-prepare-release-ui.sh").read_text()
+        self.assertIn('echo "VITE_MESH_LLM_DEBUG_UI=false"', preparation)
+        self.assertIn('scripts/ci-prepare-release-ui.sh "$UI_SOURCE_SHA" "$RELEASE_TAG"', ui_workflow)
         self.assertLess(ui_workflow.index("Prepare release UI version"), ui_workflow.index("Install UI dependencies"))
         self.assertIn("python3 scripts/ui-distribution.py stamp", ui_workflow)
         restore = (ROOT / ".github/actions/restore-release-ui/action.yml").read_text()


### PR DESCRIPTION
## Summary
This is a general PR/main CI coverage repair, not a release-only change. PRs should select fewer tests for efficiency, but must select the executable consumers affected by a change.

Catch known PR-green/main-red regressions without making every PR exhaustive:

- Route script-only changes to their real UI, product, SDK and CUDA consumers, with six single-path planner fixtures.
- Exercise the SDK native-runtime JSON reader against the actual composed host with fallback builds disabled.
- Rehearse release UI version preparation in a disposable clone in the same pinned web image; keep ordinary UI mode unchanged and scope Git trust to exact process-local directories.
- Replace CUDA sudo package installation with preinstalled utility/library validation.
- Select CUDA0 explicitly in CUDA smoke and require positive GPU layer offload plus a nonzero CUDA0 model buffer after inference, independently for each PID. CPU rows remain CPU. A complete CUDA job should emit five records (normal/headless, compatibility, constrained normal/headless).

## Landing sequence — do not merge as-is
1. Land/reconcile the narrow UI Git-ownership repair #1687 first, preserving its exact/malformed/mismatched SHA, differently-owned checkout, child Git and unchanged-global-config regressions.
2. Maintainer lands catalog-only commit `9e7bf7169a43c43a60ebf250f3d4baef6e3fbe54`.
3. Rebase this implementation on that catalog. Protected PR planning requires byte-identical catalogs; this combined PR is expected to fail Plan until then. Do not bypass that gate. Review and execute the CPU transition repair below without enabling unqualified accelerator rows.
4. Obtain candidate-definition/live evidence below before implementation merge.

## Rebase on #1672
Rebased onto main `afa36ab02`, preserving its product-integration tests and explicit Metal/Vulkan/ROCm device selection. Compatibility smoke honors `MESH_COMPAT_DEVICE` before the shared core-smoke selector. CUDA verification remains CUDA-specific; other backend runs do not claim CUDA qualification. Follow-up `cdbe5e16f` ports preinstalled utility/library checks to the typed CUDA workflow too, retaining GPU/driver provenance. Both preflight blocks are executed with isolated tool/library doubles covering failure paths. Typed callers now exercise the actual standalone/compatibility device guards, not only independently generated manifest values.

## Validation
- CPU routing follow-up: full `just ci-validate` **956 tests, 7 skips**, actionlint and all consistency gates passed. Only a test comment was corrected afterwards; its regression and Python compilation were rerun. The three restored job mappings compare identical to pre-#1672, and Cargo output was cleaned (121.2 MiB).
- Review follow-up working tree (committed unchanged as `cdbe5e16f`): full `just ci-validate` **955 tests, 7 skips**, actionlint and all repository consistency gates passed. Embedded CUDA Bash shellcheck and all four changed Python modules compiled. Cargo output cleaned (121.2 MiB).
- After conflict resolution: full `just ci-validate` **954 tests, 7 skips**, actionlint and all repository consistency gates passed on the rebase working state. Changed-script shellcheck and Python compilation passed; Cargo output cleaned. Two added tests cover preserved non-CUDA backends and compatibility device precedence. Commit metadata normalization afterwards did not change the validated tree.
- Full `just ci-validate`: **845 tests, 7 skips**, actionlint, whitespace and all repository consistency gates passed on the precommit patch based on `9bb7b1eed68ea5d637fa37b457e619a33333f55a`.
- Changed-script shellcheck and Python compilation passed. Cargo output cleaned.
- Thinker independently reviewed implementation and ran the earlier 844-test suite plus actionlint/shellcheck/compilation/whitespace (not the Cargo consistency gates).
- Follow-up headless execution test independently verified: real Bash/jq, HTTP/offload subprocess doubles; successful nonempty completion must precede exact-PID offload. Removing the completion block in memory produces five failing subcases.
- No live GPU/container qualification claimed. Unit fixtures are not integration evidence.

## Outstanding acceptance gates
- **CPU transition repair implemented in `299b525e9`, awaiting review/candidate execution:** restored the exact original `core`, `two_node_client`, and `two_node_split` job contracts for the existing catalog IDs, including dense + Qwen recurrent validation. New typed-suite IDs remain dormant pending deliberate catalog migration. Nine planner fixtures now check job selectors, executable consumers and matching producers; no accelerator rows or catalog bypass added.
- Authorized candidate UI definition in the pinned image with **real** `release-version.sh`; the local Git-ownership test substitutes that expensive script.
- Authorized composed-product CUDA execution yielding five PID-specific offload records, and real composed-host SDK-reader execution.
- Runner-owner/admin resolution of white/ARC overlapping labels and protected-workflow runner-group restrictions. Removing sudo does not establish ephemeral placement. No runner administration changed here.
- PR reusable workflows execute protected `@main` definitions, so a green PR does not execute edited YAML. In particular old YAML does not set CUDA0 and would leave these scripts on CPU. Candidate-definition evidence is required.

## Diagnosis references
- Main CUDA sudo setup failure: https://github.com/Mesh-LLM/mesh-llm/actions/runs/34188660837/job/101946500112
- Release UI preparation failure: https://github.com/Mesh-LLM/mesh-llm/actions/runs/34189448604/job/101944423165
- CLI JSON producer/SDK reader boundary: #1675 / #1684.

## Review
Nick (ndizazzo) identified the typed-device/compatibility and CUDA setup integration gaps in his changes-requested review; the device fixes and setup port are implemented for re-review, not deemed approved. Thinker independently reproduced the inherited CPU routing blocker and verified pinned device behavior at `896841e65`; his finding drove the separate `299b525e9` transition repair.
Thinker reviewed the working implementation and independently confirmed closure of the headless regression gap. Requesting maintainer review of the published commits and the catalog-first bootstrap sequence.

Originating Buzz channel: `a7d0b8ef-9b25-432d-ae19-bacd410c81eb`, thread `bbc68483f722d0f37f5c58b59c98aa820e1d3ab6a52caa4ab890fac717f4232d`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Release workflows now rehearse UI preparation during pull requests and main-branch validation before publication.
  - Smoke tests support explicit CPU, CUDA, Vulkan, ROCm, and Metal device selection.
  - CUDA validation confirms successful inference uses GPU-offloaded layers and CUDA model buffers.
  - Product smoke tests exercise the composed host and native runtime.
  - Added Linux smoke coverage for core, two-node client, and split KV-caching scenarios.

- **Bug Fixes**
  - Improved cleanup and validation of smoke-test execution and device selection.

- **Tests**
  - Expanded coverage for release preparation, product smoke tests, device selection, and CUDA execution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


