### PR TITLE
fix: Link CUDA package tools on driverless builders

### DIFF
--- a/ci/ci.md
+++ b/ci/ci.md
@@ -119,6 +119,9 @@ main.
 
 Release efficiency TODOs:
 
+- [x] Link the CUDA package tool with the selected build-time driver library.
+  QA: reproduce the unresolved driver symbols, verify the dynamic build-script
+  output and ELF link without a runtime stub search path, and run CI validation.
 - [x] Prepare release UI versions in container checkouts with different owners.
   QA: execute the workflow step with Git's ownership check enabled, verify
   workspace-only trust and source rejection, then shellcheck the extracted step.

--- a/crates/skippy-ffi/build.rs
+++ b/crates/skippy-ffi/build.rs
@@ -24,20 +24,6 @@ fn main() {
         return;
     }
 
-    let link_mode =
-        std::env::var("LLAMA_STAGE_LINK_MODE").or_else(|_| std::env::var("SKIPPY_LLAMA_LINK_MODE"));
-    if link_mode.as_deref() == Ok("dynamic") {
-        if let Ok(lib_dir) =
-            std::env::var("LLAMA_STAGE_LIB_DIR").or_else(|_| std::env::var("SKIPPY_LLAMA_LIB_DIR"))
-        {
-            println!("cargo:rustc-link-search=native={lib_dir}");
-        }
-        println!("cargo:rustc-link-lib=dylib=mtmd");
-        println!("cargo:rustc-link-lib=dylib=llama-common");
-        println!("cargo:rustc-link-lib=dylib=llama");
-        return;
-    }
-
     let workspace_root = std::path::PathBuf::from(
         std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR is set"),
     )
@@ -61,6 +47,27 @@ fn main() {
             }
         })
         .unwrap_or_else(|_| default_build_dir(&workspace_root, &backend));
+    let link_mode =
+        std::env::var("LLAMA_STAGE_LINK_MODE").or_else(|_| std::env::var("SKIPPY_LLAMA_LINK_MODE"));
+    if link_mode.as_deref() == Ok("dynamic") {
+        if let Ok(lib_dir) =
+            std::env::var("LLAMA_STAGE_LIB_DIR").or_else(|_| std::env::var("SKIPPY_LLAMA_LIB_DIR"))
+        {
+            println!("cargo:rustc-link-search=native={lib_dir}");
+        }
+        println!("cargo:rustc-link-lib=dylib=mtmd");
+        println!("cargo:rustc-link-lib=dylib=llama-common");
+        println!("cargo:rustc-link-lib=dylib=llama");
+        if target.contains("linux") && backend == "cuda" {
+            // Driverless builders use the toolkit's link-time driver stub.
+            // Resolve the same library CMake selected without embedding its
+            // directory in RPATH or copying it into the runtime package.
+            let cmake_cache = build_dir.join("CMakeCache.txt");
+            println!("cargo:rerun-if-changed={}", cmake_cache.display());
+            link_linux_lib_from_cache(&cmake_cache, "CUDA_cuda_driver_LIBRARY", "cuda");
+        }
+        return;
+    }
     ensure_static_native_ready(&workspace_root, &build_dir, &target, &backend);
 
     let search_dirs = [

--- a/scripts/tests/test_skippy_dynamic_link.py
+++ b/scripts/tests/test_skippy_dynamic_link.py
@@ -105,6 +105,7 @@ class SkippyDynamicLinkTests(unittest.TestCase):
     def test_driverless_elf_link_resolves_indirect_driver_without_bundling_stub(self) -> None:
         self.assertIsNotNone(shutil.which("cc"))
         self.assertIsNotNone(shutil.which("readelf"))
+        self.assertIsNotNone(shutil.which("ld.bfd"))
         lines, stubs = self.run_build_script("aarch64-unknown-linux-gnu", "cuda")
         root = stubs.parent.parent
         staged = root / "staged libraries"
@@ -136,7 +137,10 @@ class SkippyDynamicLinkTests(unittest.TestCase):
             elif line.startswith("cargo:rustc-link-lib="):
                 args.extend(["-l", line.split("=", 1)[1]])
         self.assertEqual(args[-2:], ["-l", "dylib=cuda"])
-        command = ["rustc", "--edition=2024", str(source), "-o", str(root / "probe")]
+        # Reproduce the ARM64 release's GNU linker. Other Rust targets may
+        # default to LLD, which accepts this unresolved indirect dependency.
+        command = ["rustc", "--edition=2024", "-C", "link-arg=-fuse-ld=bfd",
+                   str(source), "-o", str(root / "probe")]
         broken = subprocess.run(command + args[:-2], cwd=root, capture_output=True, text=True)
         self.assertNotEqual(broken.returncode, 0)
         self.assertIn("cuGetErrorString", broken.stderr)

--- a/scripts/tests/test_skippy_dynamic_link.py
+++ b/scripts/tests/test_skippy_dynamic_link.py
@@ -20,11 +20,15 @@ class SkippyDynamicLinkTests(unittest.TestCase):
         cls.binary = Path(cls.directory.name) / (
             "build-script.exe" if os.name == "nt" else "build-script"
         )
-        subprocess.run(
-            ["just", "with-lld", "rustc", "--edition=2024",
+        # Compile a standalone test fixture with the host linker. The contracts
+        # job has Rust and cc but does not install LLD.
+        result = subprocess.run(
+            ["rustc", "--edition=2024",
              str(ROOT / "crates/skippy-ffi/build.rs"), "-o", str(cls.binary)],
-            cwd=ROOT, check=True, capture_output=True, text=True,
+            cwd=ROOT, capture_output=True, text=True,
         )
+        if result.returncode:
+            raise RuntimeError(f"build-script fixture compilation failed:\n{result.stderr}")
 
     def run_build_script(self, target: str, backend: str, *, runtime_loader: bool = False,
                          legacy: bool = False) -> tuple[list[str], Path]:

--- a/scripts/tests/test_skippy_dynamic_link.py
+++ b/scripts/tests/test_skippy_dynamic_link.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class SkippyDynamicLinkTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.directory = tempfile.TemporaryDirectory()
+        cls.addClassCleanup(cls.directory.cleanup)
+        cls.binary = Path(cls.directory.name) / (
+            "build-script.exe" if os.name == "nt" else "build-script"
+        )
+        subprocess.run(
+            ["just", "with-lld", "rustc", "--edition=2024",
+             str(ROOT / "crates/skippy-ffi/build.rs"), "-o", str(cls.binary)],
+            cwd=ROOT, check=True, capture_output=True, text=True,
+        )
+
+    def run_build_script(self, target: str, backend: str, *, runtime_loader: bool = False,
+                         legacy: bool = False) -> tuple[list[str], Path]:
+        fixture = tempfile.TemporaryDirectory()
+        self.addCleanup(fixture.cleanup)
+        root = Path(fixture.name).resolve()
+        build = root / "native build"
+        build.mkdir()
+        stubs = root / "selected toolkit" / "stubs"
+        stubs.mkdir(parents=True)
+        driver = stubs / "libcuda.so"
+        driver.touch()
+        (build / "CMakeCache.txt").write_text(
+            f"CUDA_cuda_driver_LIBRARY:FILEPATH={driver}\n"
+        )
+        env = {
+            key: value for key, value in os.environ.items()
+            if not key.startswith(("LLAMA_STAGE_", "SKIPPY_LLAMA_", "CARGO_FEATURE_"))
+        }
+        prefix = "SKIPPY_LLAMA" if legacy else "LLAMA_STAGE"
+        env.update({
+            "CARGO_MANIFEST_DIR": str(ROOT / "crates/skippy-ffi"),
+            "TARGET": target,
+            f"{prefix}_LINK_MODE": "dynamic",
+            f"{prefix}_BUILD_DIR": str(build),
+            f"{prefix}_LIB_DIR": str(root / "staged libraries"),
+            f"{prefix}_BACKEND": backend,
+        })
+        if runtime_loader:
+            env["CARGO_FEATURE_DYNAMIC_RUNTIME"] = "1"
+        result = subprocess.run(
+            [str(self.binary)], cwd=root, env=env, check=True,
+            capture_output=True, text=True,
+        )
+        return result.stdout.splitlines(), stubs
+
+    def test_linux_cuda_links_selected_driver_without_runtime_search_path(self) -> None:
+        for target in ("aarch64-unknown-linux-gnu", "x86_64-unknown-linux-gnu"):
+            with self.subTest(target=target):
+                lines, stubs = self.run_build_script(target, "cuda")
+                self.assertIn(f"cargo:rustc-link-search=native={stubs}", lines)
+                self.assertIn("cargo:rustc-link-lib=dylib=cuda", lines)
+                self.assertIn("cargo:rustc-link-lib=dylib=llama", lines)
+                self.assertIn(
+                    f"cargo:rerun-if-changed={stubs.parent.parent / 'native build/CMakeCache.txt'}",
+                    lines,
+                )
+                self.assertFalse(any("rpath" in line or "rustc-link-arg" in line for line in lines))
+
+    def test_legacy_cuda_selectors_resolve_the_same_driver(self) -> None:
+        lines, stubs = self.run_build_script("aarch64-unknown-linux-gnu", "cuda", legacy=True)
+        self.assertIn(f"cargo:rustc-link-search=native={stubs}", lines)
+        self.assertIn("cargo:rustc-link-lib=dylib=cuda", lines)
+
+    def test_other_dynamic_targets_do_not_acquire_cuda_dependency(self) -> None:
+        for target, backend in (
+            ("aarch64-unknown-linux-gnu", "cpu"),
+            ("x86_64-unknown-linux-gnu", "rocm"),
+            ("x86_64-unknown-linux-gnu", "vulkan"),
+            ("aarch64-apple-darwin", "metal"),
+            ("x86_64-pc-windows-msvc", "cuda"),
+        ):
+            with self.subTest(target=target, backend=backend):
+                lines, stubs = self.run_build_script(target, backend)
+                self.assertNotIn("cargo:rustc-link-lib=dylib=cuda", lines)
+                self.assertNotIn(f"cargo:rustc-link-search=native={stubs}", lines)
+                self.assertIn("cargo:rustc-link-lib=dylib=llama", lines)
+
+    def test_runtime_loader_remains_free_of_native_link_dependencies(self) -> None:
+        lines, _ = self.run_build_script("aarch64-unknown-linux-gnu", "cuda", runtime_loader=True)
+        self.assertFalse(any(line.startswith("cargo:rustc-link-") for line in lines))
+
+    @unittest.skipUnless(sys.platform == "linux", "requires the ELF linker")
+    def test_driverless_elf_link_resolves_indirect_driver_without_bundling_stub(self) -> None:
+        self.assertIsNotNone(shutil.which("cc"))
+        self.assertIsNotNone(shutil.which("readelf"))
+        lines, stubs = self.run_build_script("aarch64-unknown-linux-gnu", "cuda")
+        root = stubs.parent.parent
+        staged = root / "staged libraries"
+        staged.mkdir()
+
+        def run(*args: str) -> subprocess.CompletedProcess[str]:
+            return subprocess.run(args, cwd=root, check=True, capture_output=True, text=True)
+
+        driver = root / "driver.c"
+        driver.write_text("int cuGetErrorString(void) { return 0; }\n")
+        run("cc", "-shared", "-fPIC", str(driver), "-Wl,-soname,libcuda.so.1",
+            "-o", str(stubs / "libcuda.so"))
+        runtime = root / "runtime.c"
+        runtime.write_text("extern int cuGetErrorString(void);\n"
+                           "int llama_entry(void) { return cuGetErrorString(); }\n")
+        run("cc", "-shared", "-fPIC", str(runtime), "-L", str(stubs), "-lcuda",
+            "-Wl,-soname,libllama.so", "-o", str(staged / "libllama.so"))
+        empty = root / "empty.c"
+        empty.write_text("void unused(void) {}\n")
+        for name in ("mtmd", "llama-common"):
+            run("cc", "-shared", "-fPIC", str(empty), "-o", str(staged / f"lib{name}.so"))
+        source = root / "probe.rs"
+        source.write_text('unsafe extern "C" { fn llama_entry() -> i32; }\n'
+                          'fn main() { std::process::exit(unsafe { llama_entry() }); }\n')
+        args = []
+        for line in lines:
+            if line.startswith("cargo:rustc-link-search="):
+                args.extend(["-L", line.split("=", 1)[1]])
+            elif line.startswith("cargo:rustc-link-lib="):
+                args.extend(["-l", line.split("=", 1)[1]])
+        self.assertEqual(args[-2:], ["-l", "dylib=cuda"])
+        command = ["rustc", "--edition=2024", str(source), "-o", str(root / "probe")]
+        broken = subprocess.run(command + args[:-2], cwd=root, capture_output=True, text=True)
+        self.assertNotEqual(broken.returncode, 0)
+        self.assertIn("cuGetErrorString", broken.stderr)
+        run(*(command + args))
+        dynamic = run("readelf", "-d", str(root / "probe")).stdout
+        runtime_dynamic = run("readelf", "-d", str(staged / "libllama.so")).stdout
+        self.assertIn("[libcuda.so.1]", runtime_dynamic)
+        self.assertNotIn(str(stubs), dynamic)
+        self.assertNotIn("RPATH", dynamic)
+        self.assertNotIn("RUNPATH", dynamic)
+        self.assertFalse((staged / "libcuda.so").exists())
+        self.assertFalse((staged / "libcuda.so.1").exists())


### PR DESCRIPTION
CUDA native runtime packages can build their bundled model-package tool on builders without an NVIDIA driver. The release canary failed for both [ARM64 CUDA 12](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34199626634/job/101975326035) and [ARM64 CUDA 13](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34199626634/job/101975325994) while linking `skippy-model-package`: the staged CUDA library requires `libcuda.so.1`, but the Rust dynamic-link path omitted the driver library.

Use the existing CMake-cache library resolver to add the selected CUDA driver library for Linux CUDA dynamic links. This uses a toolkit stub only at link time. It adds no runtime stub search path and copies no stub into the package. Runtime-loaded hosts still return before any native link directives; other backends and platforms keep their existing link behavior.

Validation at `7bccea80231516ddce3b3a7b70bcd77d436a0126`, rebased onto main `a6487dd64de7d0df4a2d72145d18ab33be0f0a9c`:

- Executable build-script regression reproduces missing driver directives before the fix and covers both Linux architectures, legacy selectors, other backends/platforms, and the runtime-loaded host.
- All five tests pass in the pinned ARM64 Linux CPU image. The ELF test creates a minimal indirect driver dependency, proves linking fails without the driver argument, and proves the corrected emitted arguments link successfully without embedding or packaging the stub. This is link validation, not GPU execution or a rebuilt CUDA runtime.
- The rebase preserves the aggregate repair patch. All 24 focused package/link tests pass with the expected Linux-only skip on macOS. Rust formatting, locked `cargo check`, and all-targets warning-denying Clippy for `skippy-ffi` and `mesh-llm` were refreshed and pass using the official stable Rust toolchain.
- `just ci-validate` passes: 945 tests, eight platform skips, actionlint, and all four consistency checks. The ELF test skipped on macOS is covered by the Linux container run.
- The standalone build-script fixture uses the host linker and preserves compiler diagnostics. A container run with LLD removed reproduced the initial harness failure; all five tests pass after removing that unnecessary test dependency.
- The ELF negative control explicitly selects GNU ld, matching the ARM64 release failure. LLD permits the unresolved indirect dependency in this fixture; forcing that default reproduced the second test failure. The explicit GNU-linker test passes with either an LLD default or no installed LLD.

The complete CUDA package build and release integration remain to be verified after this repair. The separate AMD64 CUDA 12 failure on runner `white` occurs before checkout because Docker is absent; this change does not resolve that infrastructure problem or change CUDA placement.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved dynamic CUDA linking on Linux by selecting the configured driver library during builds.
  * Prevented unnecessary runtime stub-library search paths while preserving runtime-loader behavior.
  * Ensured non-CUDA targets do not acquire unintended CUDA dependencies.
* **Tests**
  * Added coverage for CUDA driver selection, legacy configurations, indirect driver dependencies, linker failures, and runtime dependency behavior.
* **Documentation**
  * Documented the release-efficiency validation steps for the updated CUDA linking behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
