### PR TITLE
fix(ci): catch SDK runtime JSON breaks before main

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -487,6 +487,11 @@ fail-open policy.
   a reliable import-library path for the tool.
 - `prepare-static-abi-input`: portable static ABI archive.
 - `compose-product-input`: exact host/runtime verification and composition.
+  Linux CPU readiness also feeds the composed host's real `runtime list
+  --available --json` output through `ci-prepare-native-runtime.sh`, the shared
+  SDK reader, with fallback building disabled. This covers CLI JSON changes
+  even when full SDK rows are unselected; accelerator compatibility is not
+  required on driverless composition workers.
 - `ci/model-artifacts/registry.json`: canonical immutable model identities,
   integrity, family capability tags, and allowed suite/cadence membership.
   `scripts/generate-test-model-manifests.py` owns the family battery and

--- a/.omo/specs/pr-ci-optimization.md
+++ b/.omo/specs/pr-ci-optimization.md
@@ -195,7 +195,11 @@ the planner, not represented as permanent skipped jobs.
 Host actions emit executable, checksum and import-policy evidence. The native
 runtime action emits a manifested archive. compose-product-input verifies exact
 producer bytes and performs no compilation, relinking, restamping or
-substitution. Smoke and SDK consumers download those artifacts only.
+substitution. Smoke and SDK consumers download those artifacts only. Linux CPU
+composition readiness additionally executes the shared SDK runtime reader on
+the real host's available-runtime JSON with fallback building disabled, even
+when full SDK rows are not selected. The #1675 path regression protects its
+existing host/runtime/product reachability without changing the catalogs.
 
 Selected PR and main product rows both use release-profile hosts. Native
 runtime compilation does not depend on host production, so each platform lane

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -469,6 +469,16 @@ Smoke and SDK consumers download those artifacts and never rebuild a missing
 producer. PR and smoke artifacts retain for one day; caches are acceleration,
 not correctness contracts.
 
+Linux CPU composition readiness runs the composed host's `runtime list
+--available --json` through the shared SDK runtime reader
+(`ci-prepare-native-runtime.sh`) with fallback building disabled. This protects
+that CLI/consumer boundary without selecting full SDK suites for every runtime
+change or requiring accelerator drivers on composition workers.
+`test_ci_sdk_json_consumer.py` checks the original #1675 changed paths select
+this product and its producers, and that invalid CLI JSON blocks publication.
+The protected workflow checks out candidate source before invoking the existing
+composition action; no catalog or workflow-definition change is needed.
+
 Non-Windows native runtime artifacts include the checksum-bound
 `skippy-model-package` tool under `tools/`. Split-serving smoke consumers use
 that producer-owned tool to convert registry-pinned GGUF fixtures into verified

--- a/scripts/ci-compose-product-input.sh
+++ b/scripts/ci-compose-product-input.sh
@@ -270,6 +270,15 @@ if [[ "$INPUT_READINESS_SMOKE" == "true" ]]; then
         "$output_dir/$INPUT_BINARY_NAME" --log-format json --version
     MESH_LLM_NATIVE_RUNTIME_BUNDLE_DIR="$output_dir/native-runtimes" \
         "$output_dir/$INPUT_BINARY_NAME" --log-format json runtime list
+    # Exercise the shared SDK reader even when full SDK suites are unselected.
+    # CPU needs no accelerator/driver; reuse only the just-composed producer bytes.
+    if [[ "$INPUT_BACKEND" == "cpu" && "$(uname -s)" == "Linux" ]]; then
+        echo "Checking CLI runtime JSON with the shared SDK runtime reader"
+        MESH_SDK_NATIVE_RUNTIME_BUILD_FALLBACK=0 \
+            scripts/ci-prepare-native-runtime.sh \
+                "$output_dir/sdk-runtime-fallback" cpu \
+                --reuse-from-binary "$output_dir/$INPUT_BINARY_NAME"
+    fi
     scripts/ci-client-readiness-smoke.sh \
         "$output_dir/$INPUT_BINARY_NAME" \
         "$output_dir/native-runtimes"

--- a/scripts/tests/fixtures/ci-plan/runtime-catalog-pr-1675.json
+++ b/scripts/tests/fixtures/ci-plan/runtime-catalog-pr-1675.json
@@ -1,0 +1,50 @@
+{
+  "profile": "pr-ready",
+  "event_name": "pull_request",
+  "source_sha": "14ec8d0ab5ed80edae2f9eb43f1d9a310d9cb7fe",
+  "base_sha": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+  "changed_files": [
+    "crates/mesh-llm-commands/src/runtime_native.rs",
+    "crates/mesh-llm-commands/src/runtime_native/formatters.rs",
+    "crates/mesh-llm-commands/src/runtime_native/setup_helpers.rs",
+    "crates/mesh-llm-host-runtime/src/system/native_runtime.rs",
+    "crates/mesh-llm-native-runtime/src/resolver.rs",
+    "crates/mesh-llm-runtime-install/src/install.rs",
+    "crates/mesh-llm-runtime-install/src/lib.rs",
+    "crates/mesh-llm-runtime-install/src/manifest.rs",
+    "crates/mesh-llm-runtime-install/src/types.rs",
+    "scripts/check-env-mutation-contract.py",
+    "scripts/tests/test_env_mutation_contract.py",
+    "tools/xtask/data/console_print_allowlist.json",
+    "website/src/docs/pages/CLI.md"
+  ],
+  "affected_crates": [
+    "mesh-llm",
+    "mesh-llm-commands",
+    "mesh-llm-host-runtime",
+    "mesh-llm-native-runtime",
+    "mesh-llm-runtime-install"
+  ],
+  "workspace_packages": [
+    {
+      "name": "mesh-llm",
+      "path": "crates/mesh-llm"
+    },
+    {
+      "name": "mesh-llm-commands",
+      "path": "crates/mesh-llm-commands"
+    },
+    {
+      "name": "mesh-llm-host-runtime",
+      "path": "crates/mesh-llm-host-runtime"
+    },
+    {
+      "name": "mesh-llm-native-runtime",
+      "path": "crates/mesh-llm-native-runtime"
+    },
+    {
+      "name": "mesh-llm-runtime-install",
+      "path": "crates/mesh-llm-runtime-install"
+    }
+  ]
+}

--- a/scripts/tests/test_ci_sdk_json_consumer.py
+++ b/scripts/tests/test_ci_sdk_json_consumer.py
@@ -1,0 +1,174 @@
+"""The #1675 CLI JSON boundary must run even without full SDK selection."""
+
+import hashlib
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import tempfile
+import unittest
+
+from scripts.tests import test_ci_artifact_actions as artifacts
+from scripts.tests import test_ci_prepare_native_runtime as runtime_tests
+from scripts.tests import test_plan_ci as planner_tests
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+class SdkJsonConsumerTests(unittest.TestCase):
+    def test_original_cli_change_selects_the_consumer_and_producers(self) -> None:
+        # Exact changed paths at #1675 head 14ec8d0, not this CI repair's
+        # control-plane paths (which would mask the miss by selecting everything).
+        payload = planner_tests.fixture("runtime-catalog-pr-1675.json")
+        for paths in (
+            payload["changed_files"],
+            ["crates/mesh-llm-commands/src/runtime_native/formatters.rs"],
+        ):
+            with self.subTest(paths=paths):
+                plan = planner_tests.PLANNER.build_plan(
+                    {**payload, "changed_files": paths}, root=ROOT
+                )
+                self.assertNotIn("ci-control", plan["domains"])
+                self.assertEqual(plan["matrices"]["sdk"], [])
+                self.assertIn("ui-artifact", plan["required_slices"])
+                self.assertIn("runtime-product", plan["required_slices"])
+                self.assertEqual(
+                    [row["id"] for row in plan["matrices"]["runtime_products"]],
+                    ["linux-cpu"],
+                )
+                self.assertEqual(
+                    [row["id"] for row in plan["matrices"]["hosts"]],
+                    ["linux-amd64-host"],
+                )
+
+        lane = (ROOT / ".github/workflows/ci-linux-lane.yml").read_text()
+        product = lane.split("  runtime_product:\n", 1)[1].split(
+            "  kotlin_sdk_input:\n", 1
+        )[0]
+        self.assertIn("needs: [hosts, native_runtimes]", product)
+        self.assertIn("uses: ./.github/workflows/ci-linux-product-slice.yml", product)
+        workflow = (ROOT / ".github/workflows/ci-linux-product-slice.yml").read_text()
+        self.assertIn("ref: ${{ inputs.source_sha || github.sha }}", workflow)
+        self.assertIn("uses: ./.github/actions/compose-product-input", workflow)
+        self.assertNotIn("readiness_smoke:", workflow)
+        action = (ROOT / ".github/actions/compose-product-input/action.yml").read_text()
+        readiness = action.split("  readiness_smoke:\n", 1)[1].split(
+            "  attestation_public_key_file:\n", 1
+        )[0]
+        self.assertIn('default: "true"', readiness)
+        self.assertIn("scripts/ci-compose-product-input.sh", action)
+
+    def run_composer(self, workspace: Path, report_kind: str) -> subprocess.CompletedProcess:
+        scripts = workspace / "scripts"
+        scripts.mkdir()
+        for name in (
+            "ci-compose-product-input.sh",
+            "ci-prepare-native-runtime.sh",
+            "compose-product-bundle.py",
+            "verify-native-runtime-package.sh",
+            "verify-checksum-sidecar.py",
+            "safe-extract-tar.py",
+        ):
+            shutil.copy2(ROOT / "scripts" / name, scripts / name)
+        abi = workspace / "crates/skippy-ffi/src/lib.rs"
+        abi.parent.mkdir(parents=True)
+        shutil.copy2(ROOT / "crates/skippy-ffi/src/lib.rs", abi)
+        # Only readiness/network startup is stubbed; execute the real composer,
+        # SDK reader and package verification against checksum-bound fixture bytes.
+        (scripts / "ci-client-readiness-smoke.sh").write_text(
+            '#!/bin/sh\ntouch "$GITHUB_WORKSPACE/readiness-ran"\n'
+        )
+        (scripts / "ci-client-readiness-smoke.sh").chmod(0o755)
+        (scripts / "package-native-runtime.sh").write_text(
+            '#!/bin/sh\ntouch "$GITHUB_WORKSPACE/fallback-ran"\nexit 99\n'
+        )
+        (scripts / "package-native-runtime.sh").chmod(0o755)
+        # Exercise the Linux-only gate on development hosts too, without changing
+        # the immutable package fixture into an actual loadable Linux runtime.
+        tools = workspace / "bin"
+        tools.mkdir()
+        (tools / "uname").write_text("#!/bin/sh\nprintf 'Linux\\n'\n")
+        (tools / "uname").chmod(0o755)
+        host_input, runtime_input = artifacts.CiArtifactActionTests().write_fake_product_inputs(
+            workspace
+        )
+        manifest_path = next(runtime_input.glob("*/manifest.json"))
+        manifest = json.loads(manifest_path.read_text())
+        manifest["runtime"]["skippy_abi"] = runtime_tests.current_skippy_abi()
+        manifest_path.write_text(json.dumps(manifest))
+        rows = [{"id": manifest["runtime"]["id"], "backend": "cpu", "supported": True}]
+        reports = {
+            "catalog": {"catalogs": {}, "runtimes": rows},
+            "legacy": rows,
+            "malformed": {"runtimes": {}},
+            "unsupported": {"runtimes": [{**rows[0], "supported": False}]},
+        }
+        host = host_input / "mesh-llm"
+        host.write_text(
+            '#!/usr/bin/env bash\nset -euo pipefail\n'
+            'if [[ "$*" == *"runtime list --available"* ]]; then\n'
+            '  [[ "$*" == *"--log-format json"* && "$*" == *"--json"* ]]\n'
+            '  [[ "$MESH_SDK_NATIVE_RUNTIME_BUILD_FALLBACK" == "0" ]]\n'
+            '  [[ -z "${MESH_LLM_CONFIG:-}" && -z "${MESH_LLM_NATIVE_RUNTIME_BUNDLE_DIR:-}" ]]\n'
+            '  touch "$GITHUB_WORKSPACE/sdk-reader-ran"\n'
+            f"  printf '%s\\n' '{json.dumps(reports[report_kind])}'\n"
+            'else\n  printf "mesh-llm 1.2.3\\n"\nfi\n'
+        )
+        digest = hashlib.sha256(host.read_bytes()).hexdigest()
+        (host_input / "mesh-llm.sha256").write_text(f"{digest}  mesh-llm\n")
+        return subprocess.run(
+            [str(scripts / "ci-compose-product-input.sh")],
+            cwd=workspace,
+            env={
+                **os.environ,
+                "PATH": f"{tools}:{os.environ['PATH']}",
+                "GITHUB_WORKSPACE": str(workspace),
+                "GITHUB_OUTPUT": str(workspace / "github-output"),
+                "INPUT_HOST_INPUT_DIR": str(host_input),
+                "INPUT_RUNTIME_INPUT_DIR": str(runtime_input),
+                "INPUT_OUTPUT_DIR": str(workspace / "product-input"),
+                "INPUT_BACKEND": "cpu",
+                "INPUT_VERSION": "1.2.3",
+                "INPUT_BINARY_NAME": "mesh-llm",
+                "INPUT_READINESS_SMOKE": "true",
+                "INPUT_ATTESTATION_PUBLIC_KEY_FILE": "",
+                "INPUT_ATTESTATION_VERIFIER": "",
+                "MESH_SDK_NATIVE_RUNTIME_BUILD_FALLBACK": "1",
+                "MESH_LLM_CONFIG": str(workspace / "ambient-config"),
+            },
+            capture_output=True, text=True, check=False,
+        )
+
+    def test_composition_runs_the_sdk_reader_before_publishing(self) -> None:
+        for report in ("catalog", "legacy"):
+            with self.subTest(report=report), tempfile.TemporaryDirectory() as directory:
+                workspace = Path(directory)
+                result = self.run_composer(workspace, report)
+                self.assertEqual(result.returncode, 0, result.stderr)
+                self.assertTrue((workspace / "sdk-reader-ran").exists())
+                self.assertTrue((workspace / "readiness-ran").exists())
+                self.assertTrue((workspace / "product-input.tar.gz").exists())
+                self.assertFalse((workspace / "fallback-ran").exists())
+                self.assertIn("Reusing compatible native runtime", result.stderr)
+
+    def test_bad_cli_json_blocks_product_publication_without_building(self) -> None:
+        for report, error in (
+            ("malformed", "native runtime compatibility output must be"),
+            ("unsupported", "expected exactly one compatible adjacent native runtime"),
+        ):
+            with self.subTest(report=report), tempfile.TemporaryDirectory() as directory:
+                workspace = Path(directory)
+                result = self.run_composer(workspace, report)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn(error, result.stderr)
+                self.assertTrue((workspace / "sdk-reader-ran").exists())
+                self.assertFalse((workspace / "readiness-ran").exists())
+                self.assertFalse((workspace / "product-input.tar.gz").exists())
+                self.assertFalse((workspace / "github-output").exists())
+                self.assertFalse((workspace / "fallback-ran").exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Catch CLI runtime-JSON changes in PR CI before they break the SDK runtime reader on main, without running every SDK suite on every PR.

- Run the existing shared SDK runtime reader against the actual composed Linux CPU host during its already-selected readiness check. Runtime fallback building is explicitly disabled; an incompatible report fails before product archival/publication.
- Preserve #1675's exact changed paths (and its formatter alone) as routing regressions: they select the Linux CPU product and producers even though full SDK suites remain unselected.
- Test catalog-wrapped and legacy reports through the real composer/reader/package verifier, plus malformed and unsupported reports that must block publication. The test host and network-readiness probe are stubs; this is not evidence of real-host GitHub execution.

Nine production lines; all other changes are tests/fixture and required CI documentation. No catalog, workflow YAML, runner, CUDA, release preparation, or recurrent-routing changes. The existing protected workflow checks out candidate source before invoking the local composer, so this path does not need a catalog bootstrap or candidate-workflow dispatch.

This is the narrow replacement for closed #1691. #1684's reader compatibility fix and #1687's release UI fix are preserved.

## Validation

On the final content based on `d6f09e098` (before the metadata-only commit):

- `just ci-validate`: passed, 943 tests / 7 skips plus actionlint, whitespace and all four xtask consistency gates.
- `just ci-shellcheck scripts/ci-compose-product-input.sh`: passed.
- `bash -n scripts/ci-compose-product-input.sh`: passed.
- `python3 -m py_compile scripts/tests/test_ci_sdk_json_consumer.py`: passed.
- Negative control substituting the unchanged main composer **only in temporary test copies**: four subcases failed as expected.
- Jimmy independently reviewed the six-file diff read-only and reported no blocking correctness/scope findings; he did not repeat the tests.
- Owned Cargo build output cleaned. Both protected catalogs remain byte-identical to main.

### GitHub execution evidence

Verified on exact head `d524f46bdb65578bac154317475ccb65e6179ed1`:

- All five Plan jobs passed.
- [Linux CPU composition job 102009345529](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34206764156/job/102009345529) **executed and succeeded**, not skipped. Its log records protected workflow `d6f09e098`, candidate checkout `d524f46bd`, `Checking CLI runtime JSON with the shared SDK runtime reader`, verified/reused adjacent CPU runtime, client readiness, and successful product upload.
- All five PR workflows and their stable `PR / Quality`, `PR / Website`, `PR / Linux`, `PR / macOS`, and `PR / Windows` checks succeeded. [Linux run 34206764156](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34206764156) finished at 09:39 UTC; Rust SDK smoke, Kotlin SDK smoke, CUDA inference smoke, and model-download smoke all executed and passed.
- Expected selective skips remain, including the product-integration suites and Qwen3.5 recurrent migration gate. This patch does not claim that those unselected checks executed.
- Final review check: GitHub has no inline review threads; CodeRabbit reported no actionable comments (its docstring-coverage advisory remains). Copilot failed on billing configuration and is not review evidence. Jimmy's independent read-only review is recorded above.
- At the 09:59 UTC handoff, current main was `592de242b871c0c35743683f91d4f829257972fc`, one commit ahead of this PR's base (`#1683`, family-battery catalogs/test changes). Its changed files do not overlap this six-file patch or alter the selected composer/reader/workflow path. GitHub reports this PR `MERGEABLE` / `BEHIND`; no rebase or rerun was performed, so the results above attest to the exact PR head, not a new combined revision.
- Separately, all five Main workflows at `592de242b` succeeded, including [Main Linux](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34209960871). Existing configuration/plan skips remain; this is not proof that every possible main/release check ran, and it does not include this unmerged repair.
- No merge, dispatch, rerun, runner/configuration change, or new source commit was performed. The pushed worktree is clean; Cargo build output was already cleaned. Keep the worktree until the PR merges or closes.

Origin: Buzz `mesh-releases`, channel `a7d0b8ef-9b25-432d-ae19-bacd410c81eb`, thread `bbc68483f722d0f37f5c58b59c98aa820e1d3ab6a52caa4ab890fac717f4232d`.

