### PR TITLE
fix(ci): fall back to any brew LLVM with Clang LibTooling in llama canary guard

### DIFF
--- a/.github/workflows/llama-upstream-canary.yml
+++ b/.github/workflows/llama-upstream-canary.yml
@@ -77,9 +77,20 @@ jobs:
             echo "HF_CACHE is not exported on this runner" >&2
             missing=1
           fi
+          # Match scripts/check-skippy-generated-family-patch.sh: prefer the
+          # pinned llvm@22, but accept any Homebrew LLVM that provides Clang
+          # LibTooling (bin/clang + ClangConfig.cmake) so a runner image whose
+          # pinned keg was rotated out does not fail the whole canary.
           llvm_prefix="$(brew --prefix llvm@22 2>/dev/null || true)"
-          if [[ ! -x "$llvm_prefix/bin/clang" || ! -f "$llvm_prefix/lib/cmake/clang/ClangConfig.cmake" ]]; then
-            echo "pinned llvm@22 with Clang LibTooling is not installed on the family-certify image" >&2
+          llvm_ok() {
+            [[ -n "$1" && -x "$1/bin/clang" && -f "$1/lib/cmake/clang/ClangConfig.cmake" ]]
+          }
+          if ! llvm_ok "$llvm_prefix"; then
+            echo "pinned llvm@22 missing or incomplete on the family-certify image; falling back to $(brew --prefix llvm 2>/dev/null || echo 'brew llvm')" >&2
+            llvm_prefix="$(brew --prefix llvm 2>/dev/null || true)"
+          fi
+          if ! llvm_ok "$llvm_prefix"; then
+            echo "no Homebrew LLVM with Clang LibTooling is installed on the family-certify image" >&2
             missing=1
           else
             echo "SKIPPY_REWRITER_LLVM_PREFIX=$llvm_prefix" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Problem

The daily `llama-upstream-canary` run on main has failed since the llvm@22 preflight guard landed — e.g. https://github.com/Mesh-LLM/mesh-llm/actions/runs/34203985444/job/101989066614 fails with

```
pinned llvm@22 with Clang LibTooling is not installed on the family-certify image
bake the missing tools into the family-certify runner image; this job installs nothing
```

The family-certify runner image no longer carries the pinned `llvm@22` keg, and the guard treated that as fatal for the whole job.

## Fix

`scripts/check-skippy-generated-family-patch.sh` already accepts any Homebrew LLVM that provides Clang LibTooling (`bin/clang` + `lib/cmake/clang/ClangConfig.cmake`), falling back from `llvm@22` to plain `brew llvm`. This PR makes the workflow preflight guard use the same policy: prefer the pinned `llvm@22`, fall back to any valid brew LLVM, and only fail when no LibTooling-capable LLVM exists at all.

This unblocks the canary immediately; restoring the pinned llvm@22 to the runner image is still preferable and tracked separately.

## Validation

- bash syntax check of the modified preflight block
- YAML parse check of the workflow
- GitHub reports the fix branch contains current main (592de242b)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Toolchain validation now supports compatible Homebrew LLVM installations when the preferred LLVM package is unavailable or incomplete.
  - Clearer reporting indicates when a fallback installation is being used.
  - Validation still fails when no suitable LLVM installation is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->