### PR TITLE
fix(skippy): default BUILTIN_UBATCH to 512 to clear the CUDA SSM SSD gate

### DIFF
--- a/crates/mesh-llm-commands/src/gpus/tune/apply_write_tests.rs
+++ b/crates/mesh-llm-commands/src/gpus/tune/apply_write_tests.rs
@@ -72,7 +72,7 @@ fn gpu_tune_apply_preserves_comments_and_writes_nested_fields() {
             .lines()
             .any(|line| line.trim() == "flash_attention = \"enabled\"")
     );
-    assert!(!prefix.lines().any(|line| line.trim() == "ubatch = 128"));
+    assert!(!prefix.lines().any(|line| line.trim() == "ubatch = 512"));
     assert!(
         model_fit_section
             .lines()
@@ -91,7 +91,7 @@ fn gpu_tune_apply_preserves_comments_and_writes_nested_fields() {
     assert!(
         model_fit_section
             .lines()
-            .any(|line| line.trim() == "ubatch = 128")
+            .any(|line| line.trim() == "ubatch = 512")
     );
     assert!(
         !model_fit_section
@@ -246,5 +246,5 @@ fn gpu_tune_replace_existing_writes_nested_recommendations_over_legacy_manual_fi
     assert_eq!(model_fit.cache_type_v.as_deref(), Some("q8_0"));
     assert_eq!(model_fit.ctx_size, Some(65_536));
     assert_eq!(model_fit.batch, Some(512));
-    assert_eq!(model_fit.ubatch, Some(128));
+    assert_eq!(model_fit.ubatch, Some(512));
 }

--- a/crates/mesh-llm-commands/src/gpus/tune/planning.rs
+++ b/crates/mesh-llm-commands/src/gpus/tune/planning.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 const BUILTIN_BATCH: u32 = 512;
-const BUILTIN_UBATCH: u32 = 128;
+const BUILTIN_UBATCH: u32 = 512;
 const BUILTIN_SAFETY_MARGIN_GB: f64 = 2.0;
 const LARGE_MODEL_MIN_BYTES: u64 = 50 * 1024 * 1024 * 1024;
 const MIN_AUTO_CONTEXT_LENGTH: u32 = 512;

--- a/crates/mesh-llm-commands/src/gpus/tune/recommendation_defaults_tests.rs
+++ b/crates/mesh-llm-commands/src/gpus/tune/recommendation_defaults_tests.rs
@@ -21,7 +21,7 @@ fn gpu_tune_recommends_stable_defaults() {
     assert_applied_flash_attention(&plan, TuneFlashAttentionValue::Enabled);
     assert_applied_context(&plan, 131_072);
     assert_applied_batch(&plan, 512);
-    assert_applied_ubatch(&plan, 128);
+    assert_applied_ubatch(&plan, 512);
     assert_applied_gpu_layers(&plan, TuneGpuLayersValue::All);
     assert_applied_fit_target(&plan, 22 * 1024);
 }

--- a/crates/mesh-llm-commands/src/gpus/tune/recommendation_defaults_tests.rs
+++ b/crates/mesh-llm-commands/src/gpus/tune/recommendation_defaults_tests.rs
@@ -1,6 +1,6 @@
 use mesh_llm_config::{
     FlashAttentionType, HardwareConfig, IntegerOrString, MeshConfig, ModelConfigDefaults,
-    ModelConfigEntry, ModelFitConfig,
+    ModelConfigEntry, ModelFitConfig, ThroughputConfig,
 };
 
 use super::*;
@@ -24,6 +24,35 @@ fn gpu_tune_recommends_stable_defaults() {
     assert_applied_ubatch(&plan, 512);
     assert_applied_gpu_layers(&plan, TuneGpuLayersValue::All);
     assert_applied_fit_target(&plan, 22 * 1024);
+}
+
+#[test]
+fn gpu_tune_does_not_shadow_throughput_profile_ubatch() {
+    let config = MeshConfig {
+        defaults: Some(ModelConfigDefaults {
+            throughput: Some(ThroughputConfig {
+                tuning_profile: Some("throughput".to_string()),
+                ..ThroughputConfig::default()
+            }),
+            ..ModelConfigDefaults::default()
+        }),
+        models: vec![ModelConfigEntry {
+            model: "hf://mesh/example.gguf".to_string(),
+            ..ModelConfigEntry::default()
+        }],
+        ..MeshConfig::default()
+    };
+    let plan = build_tune_plan(TuneRecommendationInput {
+        apply_mode: TuneApplyMode::ApplyMissing,
+        config: &config,
+        target: &recommendation_target(true),
+        metadata: &sample_metadata(8 * gib(), 32, 131_072, 0),
+        hardware: &gpu_hardware(24 * gib()),
+        survey: &survey_with_gpu(24 * gib(), 64 * gib()),
+    });
+
+    assert_applied_batch(&plan, 512);
+    assert_preserved(&plan, TuneField::Ubatch, "throughput tuning profile");
 }
 
 #[test]

--- a/crates/mesh-llm-commands/src/gpus/tune/recommendation_writes.rs
+++ b/crates/mesh-llm-commands/src/gpus/tune/recommendation_writes.rs
@@ -132,6 +132,16 @@ pub(crate) fn push_batch_statuses(
             existing_ubatch_source(model_entry, defaults),
         ),
     ] {
+        if field == TuneField::Ubatch
+            && source.is_none()
+            && effective_tuning_profile(model_entry, defaults).is_some()
+        {
+            plan.field_statuses.push(TuneFieldStatus::Preserved {
+                field,
+                reason: "the effective throughput tuning profile remains authoritative".to_string(),
+            });
+            continue;
+        }
         if let Some(source) = source
             && apply_mode != TuneApplyMode::ReplaceExisting
         {
@@ -156,6 +166,16 @@ pub(crate) fn push_batch_statuses(
             edit,
         });
     }
+}
+
+fn effective_tuning_profile<'a>(
+    model_entry: Option<&'a ModelConfigEntry>,
+    defaults: Option<&'a ModelConfigDefaults>,
+) -> Option<&'a str> {
+    model_entry
+        .and_then(|entry| entry.throughput.as_ref())
+        .and_then(|throughput| throughput.tuning_profile.as_deref())
+        .or_else(|| defaults?.throughput.as_ref()?.tuning_profile.as_deref())
 }
 
 pub(crate) fn push_gpu_layers_status(

--- a/crates/mesh-llm-config/src/model/built_in_schema/presentation.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema/presentation.rs
@@ -493,7 +493,7 @@ fn runtime_defaults_presentation(rendered: &str) -> Option<SettingPresentation> 
         .hint("range")),
         "defaults.model_fit.ubatch" => Some(sp(
             "Micro-batch size",
-            "Set the default decode micro-batch size.",
+            "Set the default micro-batch (physical prefill chunk) size. Values at or below 128 keep the CUDA SSM sequential-scan fallback; larger values enable the SSD chunked kernel for recurrent models.",
             MEMORY_CATEGORY,
             50,
         )

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/tests.rs
@@ -384,7 +384,7 @@ tuning_profile = "throughput"
     assert_eq!(resolved.model_fit.kv_offload, "true");
     assert_eq!(resolved.throughput.tuning_profile, "throughput");
     assert_eq!(resolved.model_fit.batch, 1024);
-    assert_eq!(resolved.model_fit.ubatch, 256);
+    assert_eq!(resolved.model_fit.ubatch, 1024);
     assert_eq!(resolved.throughput.parallel, 2);
     assert_eq!(resolved.throughput.continuous_batching, "true");
     assert_eq!(resolved.hardware.fit_target_mib, Some(10_752));

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/types.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/resolver/types.rs
@@ -8,7 +8,13 @@ use crate::plugin::{MeshConfig, ReasoningBudget, ReasoningEnabled, RequestDefaul
 
 pub(super) const BUILTIN_CTX_SIZE: u32 = 4096;
 pub(super) const BUILTIN_BATCH: u32 = 512;
-pub(super) const BUILTIN_UBATCH: u32 = 128;
+/// Matches llama.cpp's own default (`LLAMA_SERVER_DEFAULT_N_UBATCH = 512`) and clears
+/// the CUDA SSM SSD kernel gate (`n_tok > SSM_SSD_MIN_TOKENS`, 128, strict), which the
+/// previous 128 default missed by exactly one token — forcing every recurrent (mamba)
+/// prefill onto the sequential scan fallback. Measured on granite-4.0-h-1b: TTFT p50
+/// 0.670 → 0.415 s (C1) and 6.38 → 3.97 s (C8); decode 22.2 → 39.4 tok/s at C8.
+/// See WHITE_UBATCH_512_FALSIFICATION_2026_09_08 in the 2026-09-08 competitive bench.
+pub(super) const BUILTIN_UBATCH: u32 = 512;
 pub(super) const BUILTIN_PARALLEL: usize = 32;
 pub(super) const BUILTIN_PREFILL_CHUNK_SIZE: usize = 64;
 pub(super) const BUILTIN_PREFILL_ADAPTIVE_START: usize = 64;

--- a/crates/mesh-llm-host-runtime/src/runtime/context_planning.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/context_planning.rs
@@ -99,6 +99,59 @@ impl RuntimeResourcePlanningProfile {
 pub(super) struct RuntimeResourcePlan {
     pub(super) context_length: u32,
     pub(super) slots: usize,
+    /// Structured breakdown of the inputs and intermediate results the planner
+    /// used, emitted once per model start so every later memory-planning change
+    /// is measurable in production logs. `None` only for plans built outside
+    /// [`plan_runtime_resources`].
+    pub(super) breakdown: Option<RuntimeResourcePlanBreakdown>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) enum RuntimeResourcePlanSource {
+    ExplicitOverride,
+    StaticEstimate,
+    MeasuredFootprint,
+}
+
+impl RuntimeResourcePlanSource {
+    pub(super) const fn as_str(self) -> &'static str {
+        match self {
+            Self::ExplicitOverride => "explicit_override",
+            Self::StaticEstimate => "static_estimate",
+            Self::MeasuredFootprint => "measured_footprint",
+        }
+    }
+}
+
+/// The accounting selected at plan time. Static plans carry metadata-derived
+/// estimates; measured plans carry the prior compatible load's native KV rate
+/// and lane-scaled compute charge.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct RuntimeResourcePlanBreakdown {
+    pub(super) vram_bytes: u64,
+    pub(super) model_bytes: u64,
+    /// KV budget selected by the active planner. Static planning applies the
+    /// 85% utilization tax; measured planning applies its utilization target
+    /// and then subtracts the lane-scaled measured compute charge.
+    pub(super) kv_budget_bytes: u64,
+    /// Planned KV allocation: context_length x kv_bytes_per_token.
+    pub(super) planned_kv_bytes: u64,
+    /// Per-token KV cost used by the plan (layer-fraction scaled).
+    pub(super) kv_bytes_per_token: u64,
+    /// Compute charge held outside `kv_budget_bytes` by the selected planner.
+    pub(super) compute_charge_bytes: u64,
+    pub(super) planning_source: RuntimeResourcePlanSource,
+    /// `Some(false)` means a valid measured footprint proved that even the
+    /// minimum context cannot fit. Static and explicit plans use `None`.
+    pub(super) measured_fit: Option<bool>,
+    pub(super) slots: usize,
+    pub(super) context_length: u32,
+    /// True when slots came from the flat auto default rather than an
+    /// explicit override.
+    pub(super) slots_auto: bool,
+    /// True when the context length came from planning rather than an
+    /// explicit override.
+    pub(super) context_auto: bool,
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -117,6 +170,29 @@ pub(super) struct RuntimeResourcePlanInput<'a> {
     /// `None` means the whole model is local (fraction = 1.0).
     pub(super) local_layer_fraction: Option<f64>,
     pub(super) planning_profile: RuntimeResourcePlanningProfile,
+    /// Measured native buffer footprint from a prior context init of the same
+    /// shape on this node (compute + KV buffer sizes and the context length
+    /// they were measured at). When present, the planner charges these
+    /// measured sizes instead of the 85% KV tax (budget-driven sizing); when
+    /// absent it falls back to the static tax ladder.
+    pub(super) measured_buffers: Option<MeasuredBufferFootprint>,
+}
+
+/// Measured native buffer sizes from one context init, the ground truth the
+/// budget-driven planner charges in place of the KV-scaled tax.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct MeasuredBufferFootprint {
+    /// Compute-graph buffer(s) at context init, bytes.
+    pub(super) compute_bytes: u64,
+    /// KV buffer at `context_length`, bytes.
+    pub(super) kv_bytes: u64,
+    /// The context length the KV buffer was measured at.
+    pub(super) context_length: u32,
+    /// Lane count the buffers were measured at. Compute buffers scale
+    /// ~linearly with lanes (measured 399/783/1551 MiB at 2/4/8 lanes on the
+    /// 5080 for granite), so a plan resolving a different lane count scales
+    /// the compute charge by the lane ratio.
+    pub(super) lane_count: u32,
 }
 
 /// Plan context length and parallel slots.
@@ -128,16 +204,80 @@ pub(super) struct RuntimeResourcePlanInput<'a> {
 /// override via CLI flags), and an explicit `--ctx-size` override bypasses this
 /// entirely.
 pub(super) fn plan_runtime_resources(input: RuntimeResourcePlanInput<'_>) -> RuntimeResourcePlan {
-    let context_length = input
-        .ctx_size_override
-        .unwrap_or_else(|| planned_context_length(&input));
+    let context_auto = input.ctx_size_override.is_none();
+    let slots_auto = input.parallel_override.is_none();
     let slots = input
         .parallel_override
         .unwrap_or_else(planned_parallel_slots);
+    let estimated_kv_bytes_per_token = input
+        .metadata
+        .and_then(|metadata| {
+            input
+                .kv_cache_quant
+                .kv_cache_bytes_per_token(metadata)
+                .map(|bytes| scale_by_layer_fraction(bytes, &input))
+        })
+        .unwrap_or(0);
+    let estimated_kv_budget = usable_kv_cache_budget(input.vram_bytes, input.model_bytes);
+    let estimated_compute_charge = input
+        .vram_bytes
+        .saturating_sub(input.model_bytes)
+        .saturating_sub(estimated_kv_budget);
+
+    let (
+        context_length,
+        kv_budget_bytes,
+        kv_bytes_per_token,
+        compute_charge_bytes,
+        planning_source,
+        measured_fit,
+    ) = if let Some(context_length) = input.ctx_size_override {
+        (
+            context_length,
+            estimated_kv_budget,
+            estimated_kv_bytes_per_token,
+            estimated_compute_charge,
+            RuntimeResourcePlanSource::ExplicitOverride,
+            None,
+        )
+    } else if let Some(measured) = measured_context_plan(&input, slots) {
+        (
+            measured.context_length,
+            measured.kv_budget_bytes,
+            measured.kv_bytes_per_token,
+            measured.compute_charge_bytes,
+            RuntimeResourcePlanSource::MeasuredFootprint,
+            Some(measured.fits),
+        )
+    } else {
+        (
+            planned_context_length(&input),
+            estimated_kv_budget,
+            estimated_kv_bytes_per_token,
+            estimated_compute_charge,
+            RuntimeResourcePlanSource::StaticEstimate,
+            None,
+        )
+    };
+    let planned_kv_bytes = kv_bytes_per_token.saturating_mul(u64::from(context_length));
 
     RuntimeResourcePlan {
         context_length,
         slots,
+        breakdown: Some(RuntimeResourcePlanBreakdown {
+            vram_bytes: input.vram_bytes,
+            model_bytes: input.model_bytes,
+            kv_budget_bytes,
+            planned_kv_bytes,
+            kv_bytes_per_token,
+            compute_charge_bytes,
+            planning_source,
+            measured_fit,
+            slots,
+            context_length,
+            slots_auto,
+            context_auto,
+        }),
     }
 }
 
@@ -248,6 +388,58 @@ fn usable_kv_cache_budget(vram_bytes: u64, model_bytes: u64) -> u64 {
     budget.min(u128::from(u64::MAX)) as u64
 }
 
+/// Measured-vs-charged reconciliation, produced once the native context
+/// exists (after model open) and the `sched_reserve` buffer lines have been
+/// parsed.
+///
+/// `charged_compute_reserve_bytes` is the compute charge the selected planner
+/// actually held outside its KV budget. `measured_*` are what llama.cpp
+/// allocated, and the residual is what a re-plan with actual free memory would
+/// see.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(super) struct MemoryPlanReconciliation {
+    /// Compute charge held outside the KV budget by the selected planner.
+    pub(super) charged_compute_reserve_bytes: u64,
+    /// Measured compute buffer(s) at context init, if any were observed.
+    pub(super) measured_compute_bytes: Option<u64>,
+    /// Measured KV buffer(s) at context init, if any were observed.
+    pub(super) measured_kv_bytes: Option<u64>,
+    /// `vram - model - measured_compute - measured_kv` when both
+    /// measurements exist; the headroom a re-plan starts from.
+    pub(super) residual_free_bytes: Option<u64>,
+}
+
+pub(super) fn reconcile_memory_plan_with_measurements(
+    breakdown: &RuntimeResourcePlanBreakdown,
+    measured: Option<skippy_runtime::MeasuredNativeBuffers>,
+) -> MemoryPlanReconciliation {
+    let charged_compute_reserve_bytes = breakdown.compute_charge_bytes;
+    let host_memory_observed = measured.is_some_and(|measurement| measurement.host_memory_observed);
+    let mib_to_bytes = |mib: Option<f64>| mib.map(|mib| (mib * 1024.0 * 1024.0).round() as u64);
+    let measured_compute_bytes = mib_to_bytes(measured.and_then(|m| m.compute_mib));
+    let measured_kv_bytes = mib_to_bytes(measured.and_then(|m| m.kv_mib));
+    let residual_free_bytes = match (
+        host_memory_observed,
+        measured_compute_bytes,
+        measured_kv_bytes,
+    ) {
+        (false, Some(compute), Some(kv)) => Some(
+            breakdown
+                .vram_bytes
+                .saturating_sub(breakdown.model_bytes)
+                .saturating_sub(compute)
+                .saturating_sub(kv),
+        ),
+        _ => None,
+    };
+    MemoryPlanReconciliation {
+        charged_compute_reserve_bytes,
+        measured_compute_bytes,
+        measured_kv_bytes,
+        residual_free_bytes,
+    }
+}
+
 fn fallback_context_length(input: &RuntimeResourcePlanInput<'_>) -> u32 {
     let free_bytes = input.vram_bytes.saturating_sub(input.model_bytes);
     if free_bytes >= FALLBACK_CONTEXT_64K_FREE_BYTES {
@@ -271,6 +463,91 @@ fn snap_context_length_down(value: u32) -> u32 {
         .copied()
         .find(|step| *step <= value)
         .unwrap_or(value)
+}
+
+/// Fraction of usable memory the budget-driven planner targets (Step 2).
+///
+/// vLLM reserves ~8% of free memory after weights (`gpu_memory_utilization`
+/// 0.92), SGLang ~10% (`mem-fraction-static` 0.9). Ours is deliberately a
+/// little more conservative: mesh nodes can co-host other stages, and Metal
+/// unified-memory nodes share the pool with the OS (where an over-commit
+/// page-out stalls decode rather than failing loudly like a CUDA OOM).
+const DEFAULT_UTILIZATION_TARGET_NUMERATOR: u64 = 88;
+const DEFAULT_UTILIZATION_TARGET_DENOMINATOR: u64 = 100;
+
+/// Budget-driven context planning (Step 2) over the measured footprint from a
+/// prior context init.
+///
+/// Model: `budget = (vram - model) × utilization - measured_compute`, then
+/// solve for the deepest context whose *scaled* KV cost fits the budget. KV
+/// scales linearly with context (unified pool of `n_ctx` cells), so the
+/// measured KV bytes at `measured_ctx` give `kv_bytes_per_token_measured =
+/// kv_bytes / measured_ctx`, and the deepest affordable context is
+/// `budget / kv_bytes_per_token_measured`.
+///
+/// Returns `None` only when the measurement is structurally unusable (zero
+/// context, KV, or lanes), letting the static tax ladder answer instead. A
+/// valid measurement that cannot fit the minimum context returns an explicit
+/// `fits = false` plan so the caller fails closed. Compute buffers do not scale
+/// linearly with context (ubatch/graph shape dominates), so the measured value
+/// is charged as-is apart from the measured-to-requested lane ratio.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+struct MeasuredContextPlan {
+    context_length: u32,
+    kv_budget_bytes: u64,
+    kv_bytes_per_token: u64,
+    compute_charge_bytes: u64,
+    fits: bool,
+}
+
+fn measured_context_plan(
+    input: &RuntimeResourcePlanInput<'_>,
+    resolved_lanes: usize,
+) -> Option<MeasuredContextPlan> {
+    let measured = input.measured_buffers?;
+    if measured.context_length == 0 || measured.kv_bytes == 0 || measured.lane_count == 0 {
+        return None;
+    }
+    let metadata = input.metadata?;
+    let native_context = metadata.context_length;
+    if native_context == 0 {
+        return None;
+    }
+    let native_context = native_context.min(MAX_AUTO_CONTEXT_LENGTH);
+
+    let post_weight = input.vram_bytes.saturating_sub(input.model_bytes);
+    let utilised = u128::from(post_weight) * u128::from(DEFAULT_UTILIZATION_TARGET_NUMERATOR)
+        / u128::from(DEFAULT_UTILIZATION_TARGET_DENOMINATOR);
+    // Scale the measured compute charge by the lane ratio when the plan's
+    // resolved lane count differs from the one the footprint was measured at:
+    // compute buffers scale ~linearly with lanes (CUDA_Host + device graphs),
+    // while the unified KV pool is lane-invariant. Linear-through-origin
+    // slightly overestimates when scaling up (~2-3% at 4→8 on measured data),
+    // which is the conservative direction; scaling down is symmetric.
+    let lane_ratio_num = u128::from(resolved_lanes.max(1) as u64);
+    let lane_ratio_den = u128::from(measured.lane_count);
+    let compute_charge = u128::from(measured.compute_bytes) * lane_ratio_num / lane_ratio_den;
+    let budget = utilised.saturating_sub(compute_charge);
+    let measured_context = u128::from(measured.context_length);
+    let kv_per_token = u128::from(measured.kv_bytes).div_ceil(measured_context);
+    if kv_per_token == 0 {
+        return None;
+    }
+    let max_affordable = (budget / kv_per_token).min(u128::from(u32::MAX)) as u32;
+    let minimum = MIN_AUTO_CONTEXT_LENGTH.min(native_context);
+    let fits = max_affordable >= minimum;
+    let context_length = if fits {
+        snap_context_length_down(max_affordable.min(native_context)).max(minimum)
+    } else {
+        minimum
+    };
+    Some(MeasuredContextPlan {
+        context_length,
+        kv_budget_bytes: budget.min(u128::from(u64::MAX)) as u64,
+        kv_bytes_per_token: kv_per_token.min(u128::from(u64::MAX)) as u64,
+        compute_charge_bytes: compute_charge.min(u128::from(u64::MAX)) as u64,
+        fits,
+    })
 }
 
 #[cfg(test)]
@@ -301,6 +578,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
             planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: None,
         });
 
         assert_eq!(plan.context_length, 16_384);
@@ -319,6 +597,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
             planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: None,
         });
 
         assert_eq!(
@@ -343,6 +622,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::F16,
             local_layer_fraction: None,
             planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: None,
         });
         let q8_plan = plan_runtime_resources(RuntimeResourcePlanInput {
             ctx_size_override: None,
@@ -353,6 +633,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
             planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: None,
         });
 
         assert!(
@@ -374,6 +655,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
             planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: None,
         });
 
         assert_eq!(plan.context_length, 16_384);
@@ -397,6 +679,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
             planning_profile: profile,
+            measured_buffers: None,
         };
         let dedicated_plan =
             plan_runtime_resources(input(RuntimeResourcePlanningProfile::DedicatedLocal));
@@ -424,6 +707,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
             planning_profile: RuntimeResourcePlanningProfile::SharedMesh,
+            measured_buffers: None,
         });
 
         assert_eq!(
@@ -456,6 +740,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
             planning_profile: RuntimeResourcePlanningProfile::SharedMesh,
+            measured_buffers: None,
         });
 
         assert_eq!(
@@ -482,6 +767,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
             planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: None,
         });
 
         assert_eq!(plan.context_length, 32_768);
@@ -514,6 +800,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
             planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: None,
         });
 
         assert_eq!(plan.context_length, 32_768);
@@ -538,6 +825,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
             planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: None,
         });
 
         assert_eq!(plan.slots, 8);
@@ -569,6 +857,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: None,
             planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: None,
         });
 
         // With split awareness: local model ~174 GB, local KV fraction 0.66
@@ -581,6 +870,7 @@ mod tests {
             kv_cache_quant: GgufKvCacheQuant::Q8_0,
             local_layer_fraction: Some(local_fraction),
             planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: None,
         });
 
         assert!(
@@ -615,6 +905,7 @@ mod tests {
                 kv_cache_quant: quant,
                 local_layer_fraction: None,
                 planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+                measured_buffers: None,
             })
         };
         let q8_plan = plan_with(GgufKvCacheQuant::Q8_0);
@@ -626,5 +917,259 @@ mod tests {
             "lane count must not depend on KV quant under unified KV: q4={}, q8={}",
             q4_plan.slots, q8_plan.slots
         );
+    }
+
+    #[test]
+    fn budget_driven_context_uses_measured_kv_and_compute() {
+        // Roomy node: 16 GiB VRAM, 3 GiB weights. Here the measured KV
+        // per-token cost (2 GiB / 16_384 = 131_072 B) is twice the q8
+        // estimate (~69_632 B) the ladder assumes, so the budget-driven plan
+        // correctly lands at 65_536 while the estimate-based ladder would
+        // clamp at native 131_072. Measured reality cuts both ways: when the
+        // real KV cost is higher than estimated, the correct plan is
+        // shallower, not deeper. (Conversely, charging measured compute under
+        // an 88% utilization target only buys depth over the 85% tax when
+        // compute is under ~3% of free memory — the estimate is what binds
+        // on roomy nodes, not the tax.)
+        let metadata = gqa_metadata(131_072);
+        let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 3 * 1024 * 1024 * 1024,
+            vram_bytes: 16 * 1024 * 1024 * 1024,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::Q8_0,
+            local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: Some(MeasuredBufferFootprint {
+                compute_bytes: 512 * 1024 * 1024,
+                kv_bytes: 2 * 1024 * 1024 * 1024,
+                context_length: 16_384,
+                lane_count: 4,
+            }),
+        });
+        assert_eq!(plan.context_length, 65_536);
+        let measured_breakdown = plan.breakdown.expect("measured planner breakdown");
+        assert_eq!(
+            measured_breakdown.planning_source,
+            RuntimeResourcePlanSource::MeasuredFootprint
+        );
+        assert_eq!(measured_breakdown.kv_bytes_per_token, 131_072);
+        assert_eq!(measured_breakdown.compute_charge_bytes, 512 * 1024 * 1024);
+        assert_eq!(measured_breakdown.measured_fit, Some(true));
+        assert_eq!(measured_breakdown.planned_kv_bytes, 65_536 * 131_072);
+
+        // Tight node where the ladder's estimate binds: 5 GiB free, the q8
+        // estimate (65,536 B/tok for these dims) caps the ladder at 65_536,
+        // while a measured KV cost half the estimate (32,768 B/tok measured
+        // at 16_384) lets the budget-driven plan reach the full native
+        // window.
+        let tight = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 1024 * 1024 * 1024,
+            vram_bytes: 6 * 1024 * 1024 * 1024,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::Q8_0,
+            local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: Some(MeasuredBufferFootprint {
+                compute_bytes: 128 * 1024 * 1024,
+                kv_bytes: 512 * 1024 * 1024,
+                context_length: 16_384,
+                lane_count: 4,
+            }),
+        });
+        assert_eq!(tight.context_length, 131_072);
+
+        let tight_ladder = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 1024 * 1024 * 1024,
+            vram_bytes: 6 * 1024 * 1024 * 1024,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::Q8_0,
+            local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: None,
+        });
+        assert_eq!(tight_ladder.context_length, 65_536);
+    }
+
+    #[test]
+    fn budget_driven_context_degrades_to_ladder_when_measurement_is_unusable() {
+        let metadata = gqa_metadata(131_072);
+        let base = RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 5_000_000_000,
+            vram_bytes: 24_000_000_000,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::Q8_0,
+            local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: None,
+        };
+
+        // Zero-context, zero-KV, or zero-lane measurements cannot drive the
+        // budget model; the plan must equal the static-ladder answer.
+        let ladder = plan_runtime_resources(base).context_length;
+        for unusable in [
+            MeasuredBufferFootprint {
+                compute_bytes: 512 * 1024 * 1024,
+                kv_bytes: 0,
+                context_length: 16_384,
+                lane_count: 4,
+            },
+            MeasuredBufferFootprint {
+                compute_bytes: 512 * 1024 * 1024,
+                kv_bytes: 2 * 1024 * 1024 * 1024,
+                context_length: 0,
+                lane_count: 4,
+            },
+            MeasuredBufferFootprint {
+                compute_bytes: 512 * 1024 * 1024,
+                kv_bytes: 2 * 1024 * 1024 * 1024,
+                context_length: 16_384,
+                lane_count: 0,
+            },
+        ] {
+            let degraded = plan_runtime_resources(RuntimeResourcePlanInput {
+                measured_buffers: Some(unusable),
+                ..base
+            });
+            assert_eq!(degraded.context_length, ladder);
+        }
+    }
+
+    #[test]
+    fn budget_driven_context_reports_exhausted_measurement_without_fallback() {
+        let metadata = gqa_metadata(131_072);
+        let plan = plan_runtime_resources(RuntimeResourcePlanInput {
+            ctx_size_override: None,
+            parallel_override: None,
+            model_bytes: 5 * 1024 * 1024 * 1024,
+            vram_bytes: 6 * 1024 * 1024 * 1024,
+            metadata: Some(&metadata),
+            kv_cache_quant: GgufKvCacheQuant::Q8_0,
+            local_layer_fraction: None,
+            planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+            measured_buffers: Some(MeasuredBufferFootprint {
+                compute_bytes: 1024 * 1024 * 1024,
+                kv_bytes: 2 * 1024 * 1024 * 1024,
+                context_length: 16_384,
+                lane_count: 4,
+            }),
+        });
+        let breakdown = plan.breakdown.expect("planner breakdown");
+        assert_eq!(
+            breakdown.planning_source,
+            RuntimeResourcePlanSource::MeasuredFootprint
+        );
+        assert_eq!(breakdown.measured_fit, Some(false));
+        assert_eq!(plan.context_length, MIN_AUTO_CONTEXT_LENGTH);
+        assert!(breakdown.planned_kv_bytes > breakdown.kv_budget_bytes);
+    }
+
+    #[test]
+    fn budget_driven_compute_charge_scales_with_lane_count() {
+        // Compute buffers scale ~linearly with lanes (measured 399/783/1551
+        // MiB at 2/4/8 on the 5080). A footprint measured at 4 lanes must be
+        // charged at 2x when the plan resolves 8 lanes, and at 0.5x when it
+        // resolves 2 — and the context depth must follow the charge.
+        let metadata = gqa_metadata(131_072);
+        let footprint = MeasuredBufferFootprint {
+            compute_bytes: 512 * 1024 * 1024,
+            kv_bytes: 2 * 1024 * 1024 * 1024,
+            context_length: 16_384,
+            lane_count: 4,
+        };
+        let plan_at = |parallel_override: Option<usize>| {
+            plan_runtime_resources(RuntimeResourcePlanInput {
+                ctx_size_override: None,
+                parallel_override,
+                model_bytes: 3 * 1024 * 1024 * 1024,
+                vram_bytes: 16 * 1024 * 1024 * 1024,
+                metadata: Some(&metadata),
+                kv_cache_quant: GgufKvCacheQuant::Q8_0,
+                local_layer_fraction: None,
+                planning_profile: RuntimeResourcePlanningProfile::DedicatedLocal,
+                measured_buffers: Some(footprint),
+            })
+            .context_length
+        };
+
+        let at2 = plan_at(Some(2));
+        let at4 = plan_at(Some(4));
+        let at8 = plan_at(Some(8));
+        // Scaling the charge DOWN (fewer lanes than measured) frees budget and
+        // can only deepen (or hold) the plan; scaling UP can only shallow it.
+        assert!(at2 >= at4);
+        assert!(at8 <= at4);
+        // At the measured lane count the charge is exactly the measured value,
+        // so this matches the roomy-node case of
+        // budget_driven_context_uses_measured_kv_and_compute.
+        assert_eq!(at4, 65_536);
+    }
+
+    #[test]
+    fn reconciliation_exposes_overcharge_and_residual() {
+        let breakdown = RuntimeResourcePlanBreakdown {
+            vram_bytes: 16 * 1024 * 1024 * 1024,
+            model_bytes: 3 * 1024 * 1024 * 1024,
+            kv_budget_bytes: (13 * 1024 * 1024 * 1024) * 85 / 100,
+            planned_kv_bytes: 2 * 1024 * 1024 * 1024,
+            kv_bytes_per_token: 131_072,
+            compute_charge_bytes: (13 * 1024 * 1024 * 1024) - (13 * 1024 * 1024 * 1024) * 85 / 100,
+            planning_source: RuntimeResourcePlanSource::StaticEstimate,
+            measured_fit: None,
+            slots: 4,
+            context_length: 16_384,
+            slots_auto: true,
+            context_auto: true,
+        };
+
+        // Without measurements the reconciliation still reports the charged
+        // proxy so the log line carries the plan side of the story. The proxy
+        // is what the 85% budget floor leaves behind, so derive it the same
+        // way rather than as a separate 15% floor (85+15 != 100 in integer
+        // math).
+        let post_weight_bytes = 13 * 1024 * 1024 * 1024;
+        let unmeasured = reconcile_memory_plan_with_measurements(&breakdown, None);
+        assert_eq!(
+            unmeasured.charged_compute_reserve_bytes,
+            post_weight_bytes - post_weight_bytes * 85 / 100
+        );
+        assert_eq!(unmeasured.measured_compute_bytes, None);
+        assert_eq!(unmeasured.residual_free_bytes, None);
+
+        // With measurements: compute 0.5 GiB, KV 2.0 GiB over a 16 GiB node
+        // holding 3 GiB of weights leaves 10.5 GiB residual — far above the
+        // ~2 GiB proxy tax the planner charged.
+        let measured = skippy_runtime::MeasuredNativeBuffers {
+            compute_mib: Some(512.0),
+            kv_mib: Some(2048.0),
+            host_memory_observed: false,
+        };
+        let reconciled = reconcile_memory_plan_with_measurements(&breakdown, Some(measured));
+        assert_eq!(reconciled.measured_compute_bytes, Some(512 * 1024 * 1024));
+        assert_eq!(reconciled.measured_kv_bytes, Some(2048 * 1024 * 1024));
+        assert_eq!(
+            reconciled.residual_free_bytes,
+            Some(10 * 1024 * 1024 * 1024 + 512 * 1024 * 1024)
+        );
+        assert_eq!(
+            reconciled.charged_compute_reserve_bytes,
+            unmeasured.charged_compute_reserve_bytes
+        );
+
+        let host_offloaded = reconcile_memory_plan_with_measurements(
+            &breakdown,
+            Some(skippy_runtime::MeasuredNativeBuffers {
+                host_memory_observed: true,
+                ..measured
+            }),
+        );
+        assert_eq!(host_offloaded.residual_free_bytes, None);
     }
 }

--- a/crates/mesh-llm-host-runtime/src/runtime/local.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local.rs
@@ -3,6 +3,10 @@ use super::context_planning::{
     RuntimeResourcePlan, RuntimeResourcePlanInput, RuntimeResourcePlanningProfile,
     plan_runtime_resources,
 };
+use super::local_memory_plan::{
+    MemoryPlanMeasurementKey, MemoryPlanStartPath, emit_measured_memory_reconciliation,
+    emit_memory_plan_resolved, measured_buffers_footprint,
+};
 use super::split_planning::format_gb;
 use crate::api;
 use crate::inference::{election, skippy};
@@ -700,6 +704,17 @@ pub(super) async fn start_local_openai_model(
         effective_cache_type_v,
     )
     .unwrap_or(models::gguf::GgufKvCacheQuant::Q8_0);
+    let measurement_key = MemoryPlanMeasurementKey::new(format!(
+        "model={runtime_model_name:?};path={:?};bytes={local_model_bytes};capacity={my_vram};config={:?};config_model={:?};device={:?};pinned_gpu={:?};cache_k={effective_cache_type_k:?};cache_v={effective_cache_type_v:?};batch={:?};ubatch={:?};flash={:?}",
+        spec.model_path,
+        spec.mesh_config,
+        spec.config_model_id,
+        spec.device_override,
+        spec.pinned_gpu,
+        spec.n_batch_override,
+        spec.n_ubatch_override,
+        spec.flash_attention_override,
+    ));
 
     let plan = plan_runtime_resources(RuntimeResourcePlanInput {
         ctx_size_override: spec.ctx_size_override,
@@ -710,12 +725,35 @@ pub(super) async fn start_local_openai_model(
         kv_cache_quant,
         local_layer_fraction,
         planning_profile: spec.planning_profile,
+        measured_buffers: measured_buffers_footprint(&measurement_key),
     });
+    anyhow::ensure!(
+        !plan
+            .breakdown
+            .as_ref()
+            .is_some_and(|breakdown| breakdown.measured_fit == Some(false)),
+        "measured native buffers leave no capacity for the minimum context under the current model configuration"
+    );
 
     if let Some(package) = package {
-        start_local_package_v2_model(spec, model_name, package, plan, compact_meta.as_ref()).await
+        start_local_package_v2_model(
+            spec,
+            model_name,
+            package,
+            plan,
+            measurement_key,
+            compact_meta.as_ref(),
+        )
+        .await
     } else {
-        start_local_skippy_model(spec, model_name, plan, compact_meta.as_ref()).await
+        start_local_skippy_model(
+            spec,
+            model_name,
+            plan,
+            measurement_key,
+            compact_meta.as_ref(),
+        )
+        .await
     }
 }
 
@@ -723,6 +761,7 @@ async fn start_local_skippy_model(
     spec: LocalOpenAiModelStartSpec<'_>,
     model_name: String,
     plan: RuntimeResourcePlan,
+    measurement_key: MemoryPlanMeasurementKey,
     compact_meta: Option<&models::gguf::GgufCompactMeta>,
 ) -> Result<(
     String,
@@ -730,6 +769,11 @@ async fn start_local_skippy_model(
     tokio::sync::oneshot::Receiver<()>,
 )> {
     let context_length = plan.context_length;
+    emit_memory_plan_resolved(
+        &model_name,
+        plan.breakdown.as_ref(),
+        MemoryPlanStartPath::Direct,
+    );
     let fallback_projector_path = mmproj_path_for_model(&model_name).filter(|path| path.exists());
     let mut resolved = resolve_local_openai_skippy_config(
         &spec,
@@ -790,6 +834,7 @@ async fn start_local_skippy_model(
     })
     .await
     .context("join load skippy direct GGUF task")??;
+    emit_measured_memory_reconciliation(&model_name, &measurement_key, &plan);
     let _ = emit_event(OutputEvent::ModelLoaded {
         model: model_name.clone(),
         bytes: None,
@@ -820,6 +865,7 @@ async fn start_local_package_v2_model(
     model_name: String,
     package: skippy::SkippyPackageIdentity,
     plan: RuntimeResourcePlan,
+    measurement_key: MemoryPlanMeasurementKey,
     compact_meta: Option<&models::gguf::GgufCompactMeta>,
 ) -> Result<(
     String,
@@ -856,6 +902,11 @@ async fn start_local_package_v2_model(
         )
     };
     let context_length = plan.context_length;
+    emit_memory_plan_resolved(
+        &model_name,
+        plan.breakdown.as_ref(),
+        MemoryPlanStartPath::PackageV2,
+    );
     let fallback_projector_path = package_projector_path
         .or_else(|| mmproj_path_for_model(&model_name).filter(|path| path.exists()));
     let mut resolved = resolve_local_openai_skippy_config(
@@ -952,6 +1003,7 @@ async fn start_local_package_v2_model(
     })
     .await
     .context("join load skippy package-v2 task")??;
+    emit_measured_memory_reconciliation(&model_name, &measurement_key, &plan);
     let _ = emit_event(OutputEvent::ModelLoaded {
         model: model_ref,
         bytes: None,

--- a/crates/mesh-llm-host-runtime/src/runtime/local_memory_plan.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/local_memory_plan.rs
@@ -1,0 +1,259 @@
+use std::sync::Mutex;
+
+use super::context_planning::{
+    MeasuredBufferFootprint, RuntimeResourcePlan, RuntimeResourcePlanBreakdown,
+    reconcile_memory_plan_with_measurements,
+};
+
+#[derive(Clone, Copy)]
+pub(super) enum MemoryPlanStartPath {
+    Direct,
+    PackageV2,
+}
+
+/// Host-side tie between this process's measured native buffers and the plan
+/// that produced them. The model key, context length, and lane count are
+/// written together after model open so later planning cannot combine state
+/// from two different starts.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub(super) struct MemoryPlanMeasurementKey(String);
+
+impl MemoryPlanMeasurementKey {
+    pub(super) fn new(value: String) -> Self {
+        Self(value)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+struct MeasuredPlanSnapshot {
+    key: MemoryPlanMeasurementKey,
+    footprint: MeasuredBufferFootprint,
+}
+
+static MEASURED_PLAN_SNAPSHOT: Mutex<Option<MeasuredPlanSnapshot>> = Mutex::new(None);
+
+fn completed_measurement_snapshot(
+    key: &MemoryPlanMeasurementKey,
+    breakdown: &RuntimeResourcePlanBreakdown,
+    measured: Option<skippy_runtime::MeasuredNativeBuffers>,
+) -> Option<MeasuredPlanSnapshot> {
+    let measured = measured?;
+    if measured.host_memory_observed {
+        return None;
+    }
+    let mib_to_bytes = |mib: f64| (mib * 1024.0 * 1024.0).round() as u64;
+    Some(MeasuredPlanSnapshot {
+        key: key.clone(),
+        footprint: MeasuredBufferFootprint {
+            compute_bytes: mib_to_bytes(measured.compute_mib?),
+            kv_bytes: mib_to_bytes(measured.kv_mib?),
+            context_length: breakdown.context_length,
+            lane_count: breakdown.slots as u32,
+        },
+    })
+}
+
+/// Return a completed native buffer measurement only when its model identity,
+/// capacity pool, and allocation-affecting configuration all match.
+pub(super) fn measured_buffers_footprint(
+    key: &MemoryPlanMeasurementKey,
+) -> Option<MeasuredBufferFootprint> {
+    let snapshot = MEASURED_PLAN_SNAPSHOT.lock().ok()?.clone()?;
+    if snapshot.key != *key || snapshot.footprint.context_length == 0 {
+        return None;
+    }
+    Some(snapshot.footprint)
+}
+
+/// Emit the structured plan-time estimate while preserving the package-v2
+/// discriminator used by existing telemetry queries.
+pub(super) fn emit_memory_plan_resolved(
+    model_name: &str,
+    breakdown: Option<&RuntimeResourcePlanBreakdown>,
+    start_path: MemoryPlanStartPath,
+) {
+    let Some(breakdown) = breakdown else {
+        return;
+    };
+    let slots_source = plan_value_source(breakdown.slots_auto);
+    let context_source = plan_value_source(breakdown.context_auto);
+
+    macro_rules! emit {
+        ($($package_field:tt)*) => {
+            tracing::info!(
+                model = model_name,
+                $($package_field)*
+                memory_plan.vram_bytes = breakdown.vram_bytes,
+                memory_plan.model_bytes = breakdown.model_bytes,
+                memory_plan.kv_budget_bytes = breakdown.kv_budget_bytes,
+                memory_plan.planned_kv_bytes = breakdown.planned_kv_bytes,
+                memory_plan.kv_bytes_per_token = breakdown.kv_bytes_per_token,
+                memory_plan.compute_charge_bytes = breakdown.compute_charge_bytes,
+                memory_plan.planning_source = breakdown.planning_source.as_str(),
+                memory_plan.measured_fit = breakdown.measured_fit.unwrap_or(true),
+                memory_plan.measured_fit_available = breakdown.measured_fit.is_some(),
+                memory_plan.context_length = breakdown.context_length,
+                memory_plan.slots = breakdown.slots,
+                memory_plan.slots_source = slots_source,
+                memory_plan.context_source = context_source,
+                "memory plan resolved: charged estimates at plan time; compare with measured buffer_mib native events"
+            )
+        };
+    }
+
+    match start_path {
+        MemoryPlanStartPath::Direct => emit!(),
+        MemoryPlanStartPath::PackageV2 => emit!(memory_plan.package = "v2",),
+    }
+}
+
+fn plan_value_source(automatic: bool) -> &'static str {
+    if automatic { "auto" } else { "override" }
+}
+
+/// Reconcile a resolved plan against the native buffers captured during open.
+pub(super) fn emit_measured_memory_reconciliation(
+    model_name: &str,
+    measurement_key: &MemoryPlanMeasurementKey,
+    plan: &RuntimeResourcePlan,
+) {
+    let Some(breakdown) = plan.breakdown.as_ref() else {
+        return;
+    };
+    let measured = skippy_runtime::measured_native_buffers();
+    let reconciliation = reconcile_memory_plan_with_measurements(breakdown, measured);
+    if let Ok(mut snapshot) = MEASURED_PLAN_SNAPSHOT.lock() {
+        *snapshot = completed_measurement_snapshot(measurement_key, breakdown, measured);
+    }
+    let memory_plan_measured =
+        measured.is_some_and(|m| m.compute_mib.is_some() || m.kv_mib.is_some());
+    let measurement_reusable = measured.is_some_and(|measurement| {
+        !measurement.host_memory_observed
+            && measurement.compute_mib.is_some()
+            && measurement.kv_mib.is_some()
+    });
+    tracing::info!(
+        model = model_name,
+        memory_plan.measured_available = memory_plan_measured,
+        memory_plan.charged_compute_reserve_bytes = reconciliation.charged_compute_reserve_bytes,
+        memory_plan.measured_compute_bytes = reconciliation.measured_compute_bytes.unwrap_or(0),
+        memory_plan.measured_kv_bytes = reconciliation.measured_kv_bytes.unwrap_or(0),
+        memory_plan.residual_free_bytes = reconciliation.residual_free_bytes.unwrap_or(0),
+        memory_plan.measured_residual_available = reconciliation.residual_free_bytes.is_some(),
+        memory_plan.measurement_reusable = measurement_reusable,
+        "memory plan reconciled with measured native buffers"
+    );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        MEASURED_PLAN_SNAPSHOT, MeasuredPlanSnapshot, MemoryPlanMeasurementKey,
+        completed_measurement_snapshot, measured_buffers_footprint,
+    };
+    use crate::runtime::context_planning::{
+        MeasuredBufferFootprint, RuntimeResourcePlanBreakdown, RuntimeResourcePlanSource,
+    };
+
+    #[test]
+    fn measured_footprint_reads_one_coherent_plan_snapshot() {
+        let mut snapshot = MEASURED_PLAN_SNAPSHOT.lock().unwrap();
+        *snapshot = None;
+        drop(snapshot);
+        let first_key = MemoryPlanMeasurementKey::new("first".to_string());
+        let second_key = MemoryPlanMeasurementKey::new("second".to_string());
+        assert!(measured_buffers_footprint(&first_key).is_none());
+
+        snapshot = MEASURED_PLAN_SNAPSHOT.lock().unwrap();
+        *snapshot = Some(MeasuredPlanSnapshot {
+            key: second_key,
+            footprint: MeasuredBufferFootprint {
+                compute_bytes: 10,
+                kv_bytes: 20,
+                context_length: 32768,
+                lane_count: 4,
+            },
+        });
+        drop(snapshot);
+        assert!(measured_buffers_footprint(&first_key).is_none());
+
+        snapshot = MEASURED_PLAN_SNAPSHOT.lock().unwrap();
+        *snapshot = Some(MeasuredPlanSnapshot {
+            key: first_key.clone(),
+            footprint: MeasuredBufferFootprint {
+                compute_bytes: 30,
+                kv_bytes: 40,
+                context_length: 8192,
+                lane_count: 2,
+            },
+        });
+        drop(snapshot);
+        let footprint = measured_buffers_footprint(&first_key).expect("matching snapshot");
+        assert_eq!(footprint.compute_bytes, 30);
+        assert_eq!(footprint.kv_bytes, 40);
+        assert_eq!(footprint.context_length, 8192);
+        assert_eq!(footprint.lane_count, 2);
+
+        snapshot = MEASURED_PLAN_SNAPSHOT.lock().unwrap();
+        *snapshot = Some(MeasuredPlanSnapshot {
+            key: first_key.clone(),
+            footprint: MeasuredBufferFootprint {
+                compute_bytes: 30,
+                kv_bytes: 40,
+                context_length: 0,
+                lane_count: 4,
+            },
+        });
+        drop(snapshot);
+        assert!(measured_buffers_footprint(&first_key).is_none());
+
+        *MEASURED_PLAN_SNAPSHOT.lock().unwrap() = None;
+    }
+
+    #[test]
+    fn completed_snapshot_rejects_host_offload_and_incomplete_measurements() {
+        let key = MemoryPlanMeasurementKey::new("config".to_string());
+        let breakdown = RuntimeResourcePlanBreakdown {
+            vram_bytes: 10_000,
+            model_bytes: 2_000,
+            kv_budget_bytes: 6_000,
+            planned_kv_bytes: 4_000,
+            kv_bytes_per_token: 4,
+            compute_charge_bytes: 2_000,
+            planning_source: RuntimeResourcePlanSource::StaticEstimate,
+            measured_fit: None,
+            slots: 4,
+            context_length: 1_000,
+            slots_auto: true,
+            context_auto: true,
+        };
+        let measured = skippy_runtime::MeasuredNativeBuffers {
+            compute_mib: Some(1.0),
+            kv_mib: Some(2.0),
+            host_memory_observed: false,
+        };
+        assert!(completed_measurement_snapshot(&key, &breakdown, Some(measured)).is_some());
+        assert!(
+            completed_measurement_snapshot(
+                &key,
+                &breakdown,
+                Some(skippy_runtime::MeasuredNativeBuffers {
+                    host_memory_observed: true,
+                    ..measured
+                })
+            )
+            .is_none()
+        );
+        assert!(
+            completed_measurement_snapshot(
+                &key,
+                &breakdown,
+                Some(skippy_runtime::MeasuredNativeBuffers {
+                    kv_mib: None,
+                    ..measured
+                })
+            )
+            .is_none()
+        );
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/runtime/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/mod.rs
@@ -12,6 +12,7 @@ mod instance_lifecycle;
 mod interactive;
 pub(crate) mod kv_disk_config;
 mod local;
+mod local_memory_plan;
 mod local_model_only;
 mod local_package;
 mod local_split;

--- a/crates/mesh-llm-routing/src/lib.rs
+++ b/crates/mesh-llm-routing/src/lib.rs
@@ -26,7 +26,112 @@ pub fn total_model_bytes(model: &Path) -> u64 {
             return total;
         }
     }
-    std::fs::metadata(model).map(|m| m.len()).unwrap_or(0)
+    match std::fs::metadata(model) {
+        Ok(metadata) if metadata.is_dir() => {
+            // A SafeTensors checkpoint directory (model.safetensors +
+            // tokenizer/config siblings) reports the directory inode's size
+            // (~4 KiB) as its length. Sum the checkpoint files instead so
+            // memory planning charges the real weight bytes; a directory of
+            // plain GGUFs is not a loadable single model, but summing its
+            // files is still the least-wrong size estimate for routing.
+            dir_file_bytes(model)
+        }
+        Ok(metadata) => metadata.len(),
+        Err(_) => 0,
+    }
+}
+
+/// Sum the regular-file sizes directly inside `dir` (non-recursive; model
+/// checkpoint directories are flat).
+fn dir_file_bytes(dir: &Path) -> u64 {
+    std::fs::read_dir(dir)
+        .map(|entries| {
+            entries
+                .filter_map(|entry| entry.ok())
+                // Follow symlinks: HuggingFace-style snapshot entries are
+                // symlinks into a blobs/ store, and DirEntry::metadata is
+                // lstat — it would report the link itself (is_file() false,
+                // len 0), zeroing the total. fs::metadata follows the link
+                // and reports the target file.
+                .filter_map(|entry| std::fs::metadata(entry.path()).ok())
+                .filter(|metadata| metadata.is_file())
+                .map(|metadata| metadata.len())
+                .sum()
+        })
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn directory_model_reports_summed_file_bytes() {
+        // A SafeTensors checkpoint dir must report the summed weight-file
+        // bytes, not the directory inode's ~4 KiB st_size — memory planning
+        // charges this quantity against the KV budget.
+        let dir =
+            std::env::temp_dir().join(format!("mesh-routing-total-bytes-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        std::fs::write(dir.join("model.safetensors"), vec![0u8; 4096]).unwrap();
+        std::fs::write(dir.join("config.json"), vec![0u8; 128]).unwrap();
+        std::fs::create_dir(dir.join("nested")).unwrap();
+        std::fs::write(dir.join("nested").join("ignored.bin"), vec![0u8; 999_999]).unwrap();
+        let total = total_model_bytes(&dir);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(total, 4096 + 128);
+    }
+
+    #[test]
+    fn file_model_reports_its_own_bytes() {
+        let file = std::env::temp_dir().join(format!(
+            "mesh-routing-total-bytes-file-{}",
+            std::process::id()
+        ));
+        std::fs::write(&file, vec![0u8; 2048]).unwrap();
+        let total = total_model_bytes(&file);
+        let _ = std::fs::remove_file(&file);
+        assert_eq!(total, 2048);
+    }
+
+    #[test]
+    fn symlinked_snapshot_entries_report_target_bytes() {
+        // HuggingFace-style snapshot dirs symlink weight files into a blobs/
+        // store. DirEntry::metadata is lstat: it sees the link itself
+        // (is_file() false, len 0) and would total zero — worse than the
+        // directory-inode bug this replaced. The reader must follow links.
+        let root = std::env::temp_dir().join(format!(
+            "mesh-routing-total-bytes-symlink-{}",
+            std::process::id()
+        ));
+        let blobs = root.join("blobs");
+        let snapshot = root.join("snapshots").join("abc123");
+        std::fs::create_dir_all(&blobs).unwrap();
+        std::fs::create_dir_all(&snapshot).unwrap();
+        std::fs::write(blobs.join("blob-weights"), vec![0u8; 8192]).unwrap();
+        std::fs::write(blobs.join("blob-config"), vec![0u8; 256]).unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(
+            "../../blobs/blob-weights",
+            snapshot.join("model.safetensors"),
+        )
+        .unwrap();
+        #[cfg(unix)]
+        std::os::unix::fs::symlink("../../blobs/blob-config", snapshot.join("config.json"))
+            .unwrap();
+        let total = total_model_bytes(&snapshot);
+        let _ = std::fs::remove_dir_all(&root);
+        #[cfg(unix)]
+        assert_eq!(total, 8192 + 256);
+    }
+
+    #[test]
+    fn missing_model_reports_zero() {
+        assert_eq!(
+            total_model_bytes(Path::new("/nonexistent/mesh-routing-missing-model")),
+            0
+        );
+    }
 }
 
 /// The current inference target selected by runtime planning.

--- a/crates/mesh-llm-ui/src/features/app-tabs/configuration-defaults-runtime.ts
+++ b/crates/mesh-llm-ui/src/features/app-tabs/configuration-defaults-runtime.ts
@@ -411,7 +411,8 @@ export const CONFIGURATION_DEFAULT_RUNTIME_SETTINGS = [
     categoryId: 'memory',
     icon: 'layers',
     label: 'Micro-batch size',
-    description: 'Set the default decode micro-batch size.',
+    description:
+      'Set the default micro-batch (physical prefill chunk) size. Values at or below 128 keep the CUDA SSM sequential-scan fallback; larger values enable the SSD chunked kernel for recurrent models.',
     inheritedLabel: 'Applied when a placement does not override micro-batch size',
     visibility: 'advanced',
     tomlSection: MODEL_FIT_TOML_SECTION,

--- a/crates/skippy-runtime/src/lib.rs
+++ b/crates/skippy-runtime/src/lib.rs
@@ -34,10 +34,10 @@ pub use gguf_writer::{
     ModelInfo, SlicePlan, write_gguf_from_parts, write_gguf_metadata_from_parts,
 };
 pub use logging::{
-    LLAMA_LOG_LEVEL_DEBUG, NativeLogEvent, disable_verbose_native_logs, enable_verbose_native_logs,
-    redirect_native_logs_to_file, register_filtered_native_logs, restore_native_logs,
-    set_filtered_native_logs_enabled, suppress_native_logs, unregister_filtered_native_logs,
-    write_native_log_note,
+    LLAMA_LOG_LEVEL_DEBUG, MeasuredNativeBuffers, NativeLogEvent, disable_verbose_native_logs,
+    enable_verbose_native_logs, measured_native_buffers, redirect_native_logs_to_file,
+    register_filtered_native_logs, restore_native_logs, set_filtered_native_logs_enabled,
+    suppress_native_logs, unregister_filtered_native_logs, write_native_log_note,
 };
 pub use native::{StageModel, StageModelReader};
 pub use native_mtp::NativeMtpDraft;

--- a/crates/skippy-runtime/src/logging.rs
+++ b/crates/skippy-runtime/src/logging.rs
@@ -503,6 +503,19 @@ fn summarize_native_log_line(line: &str) -> Option<NativeLogEvent> {
         });
     }
 
+    if line.starts_with("llama_context: n_ubatch") || line.starts_with("llama_context: flash_attn")
+    {
+        // Forward the resolved micro-batch size and flash-attention mode so a live
+        // deployment can prove which values the runtime actually constructed with.
+        // These lines come from the llama_context parameter dump
+        // (llama-context.cpp, `n_ubatch = ...` / `flash_attn = ...`).
+        return Some(NativeLogEvent {
+            message: line.to_string(),
+            category: "runtime",
+            params: Vec::new(),
+        });
+    }
+
     if line.contains("VRAM")
         || line.contains("vram")
         || line.contains("mem_alloc")
@@ -964,6 +977,37 @@ mod tests {
                 category: "backend",
                 params: Vec::new(),
             }]
+        );
+    }
+
+    #[test]
+    fn aggregator_forwards_llama_context_config_lines() {
+        let mut aggregator = NativeLogAggregator::default();
+        assert_eq!(
+            aggregator.process_line("llama_context: n_ubatch      = 512"),
+            vec![NativeLogEvent {
+                message: "llama_context: n_ubatch      = 512".to_string(),
+                category: "runtime",
+                params: Vec::new(),
+            }]
+        );
+        assert_eq!(
+            aggregator.process_line("llama_context: flash_attn    = enabled"),
+            vec![NativeLogEvent {
+                message: "llama_context: flash_attn    = enabled".to_string(),
+                category: "runtime",
+                params: Vec::new(),
+            }]
+        );
+        assert!(
+            aggregator
+                .process_line("llama_context: n_ctx         = 8192")
+                .is_empty()
+        );
+        assert!(
+            aggregator
+                .process_line("llama_context: causal_attn   = 1")
+                .is_empty()
         );
     }
 

--- a/crates/skippy-runtime/src/logging.rs
+++ b/crates/skippy-runtime/src/logging.rs
@@ -98,6 +98,30 @@ impl ProgressTracker {
     }
 }
 
+/// Latest measured buffer sizes parsed from native log lines, keyed by the
+/// line's kind (compute vs KV). These are what llama.cpp actually allocated
+/// during `sched_reserve`, and are the ground truth the memory planner should
+/// charge instead of the KV-scaled estimate.
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
+pub struct MeasuredNativeBuffers {
+    pub compute_mib: Option<f64>,
+    pub kv_mib: Option<f64>,
+    /// A CPU-resident compute or KV allocation was observed, so the device
+    /// footprint is incomplete for a capacity pool that includes host RAM.
+    pub host_memory_observed: bool,
+}
+
+/// Snapshot of the measured native buffer sizes observed so far in this
+/// process. The native log callback is synchronous with model open, so by the
+/// time `skippy_model_open` returns, the `sched_reserve` buffer lines have
+/// already been parsed. The snapshot is returned whenever the aggregator is
+/// reachable; its fields stay `None` until a buffer line is observed (e.g.
+/// native log forwarding disabled).
+pub fn measured_native_buffers() -> Option<MeasuredNativeBuffers> {
+    let aggregator = native_log_aggregator().lock().ok()?;
+    Some(aggregator.measured_snapshot())
+}
+
 #[derive(Debug, Default)]
 struct ModelMetadataHighlights {
     architecture: Option<String>,
@@ -194,6 +218,19 @@ struct NativeLogAggregator {
     tensor_groups: Vec<(String, usize)>,
     tensor_groups_emitted: bool,
     kv_layers_seen: BTreeSet<usize>,
+    /// Latest measured buffer sizes parsed from native log lines, keyed by
+    /// backend device name (e.g. `CUDA0`, `Metal`). Updated by the
+    /// memory/kv_cache arms of `summarize_native_log_line`; read via
+    /// [`measured_native_buffers`] after model open completes. Multiple
+    /// reserves on the same device keep the high-water mark; distinct devices
+    /// are summed by [`measured_native_buffers`] (one buffer line is printed
+    /// per device, so a plain per-kind max would under-measure multi-GPU by a
+    /// factor of N). Host-pinned buffers (`CUDA_Host`) and CPU buffers are
+    /// excluded at record time — they are not device memory and must never be
+    /// charged against a VRAM budget.
+    measured_compute_mib: BTreeMap<String, f64>,
+    measured_kv_mib: BTreeMap<String, f64>,
+    host_memory_observed: bool,
 }
 
 fn native_log_file() -> &'static Mutex<Option<LineWriter<File>>> {
@@ -233,6 +270,20 @@ pub fn set_filtered_native_logs_enabled(enabled: bool) {
 }
 
 impl NativeLogAggregator {
+    /// Per-device-summed measured buffer snapshot (see
+    /// [`measured_native_buffers`] for the accounting rules).
+    fn measured_snapshot(&self) -> MeasuredNativeBuffers {
+        let compute_mib = (!self.measured_compute_mib.is_empty())
+            .then(|| self.measured_compute_mib.values().sum::<f64>());
+        let kv_mib =
+            (!self.measured_kv_mib.is_empty()).then(|| self.measured_kv_mib.values().sum::<f64>());
+        MeasuredNativeBuffers {
+            compute_mib,
+            kv_mib,
+            host_memory_observed: self.host_memory_observed,
+        }
+    }
+
     fn reset(&mut self) {
         *self = Self::default();
     }
@@ -250,6 +301,12 @@ impl NativeLogAggregator {
         self.tensor_groups.clear();
         self.tensor_groups_emitted = false;
         self.kv_layers_seen.clear();
+        // A new model load invalidates the previous model's measured buffer
+        // sizes: buffer scales are model/shape-specific, and charging one
+        // model's HWM against another's budget would be wrong both directions.
+        self.measured_compute_mib.clear();
+        self.measured_kv_mib.clear();
+        self.host_memory_observed = false;
     }
 
     fn process_line(&mut self, line: &str) -> Vec<NativeLogEvent> {
@@ -338,11 +395,56 @@ impl NativeLogAggregator {
             return events;
         }
 
+        self.record_measured_buffer_size(s);
+
         if let Some(event) = summarize_native_log_line(s) {
             events.push(event);
         }
 
         events
+    }
+
+    /// Track the largest measured buffer size per kind. A later, smaller line
+    /// (e.g. a per-graph reserve for a shorter context) must not lower the
+    /// high-water mark recorded at full context init. CPU-offload lines are
+    /// skipped: the snapshot feeds VRAM planning, and a CPU-resident buffer
+    /// larger than the accelerator's must not be charged against VRAM.
+    fn record_measured_buffer_size(&mut self, line: &str) {
+        if !line.contains("buffer size") {
+            return;
+        }
+        let Some(device) = buffer_size_device(line) else {
+            return;
+        };
+        let is_compute = line.contains("compute buffer size");
+        let is_kv = line.contains("KV buffer size");
+        if !is_compute && !is_kv {
+            return;
+        }
+        if device == "CPU" || device.starts_with("CPU_") {
+            self.host_memory_observed = true;
+            return;
+        }
+        let Some(mib) = parse_buffer_size_mib(line) else {
+            return;
+        };
+        // Host-pinned staging buffers (CUDA_Host and friends) are host RAM,
+        // not device memory — never charge them against a VRAM budget.
+        if is_host_pinned_device_name(&device) {
+            return;
+        }
+        let field = if is_compute {
+            &mut self.measured_compute_mib
+        } else {
+            &mut self.measured_kv_mib
+        };
+        // One line per device per reserve: keep the high-water mark within a
+        // device (larger of repeated reserves) so a smaller re-reserve on the
+        // same device cannot shrink the measured footprint.
+        let slot = field.entry(device).or_insert(0.0);
+        if mib > *slot {
+            *slot = mib;
+        }
     }
 
     fn record_layer_assignment(&mut self, layer_index: usize, device: &str) -> Vec<NativeLogEvent> {
@@ -462,6 +564,59 @@ fn should_suppress_native_log_line(line: &str) -> bool {
             && (line.contains(": filtered") || line.contains(": dev =")))
 }
 
+fn parse_buffer_size_mib(line: &str) -> Option<f64> {
+    // Native buffer-size lines print the value with a fixed-width field, e.g.
+    // `sched_reserve:        CUDA0 compute buffer size =   579.83 MiB` or
+    // `llama_kv_cache:        CUDA0 KV buffer size =  1088.00 MiB`. Capture the
+    // last `<number> MiB` occurrence on the line.
+    let rest = line.rfind("MiB")?;
+    let prefix = line[..rest].trim_end();
+    let start = prefix
+        .rfind(|c: char| !(c.is_ascii_digit() || c == '.'))
+        .map(|idx| idx + 1)
+        .unwrap_or(0);
+    prefix[start..].trim().parse::<f64>().ok()
+}
+
+/// Host-pinned buffer names some CUDA backends report (e.g. `CUDA_Host`).
+/// Their memory is host RAM pinned for device transfers, not device memory —
+/// it must not be charged against a VRAM budget.
+fn is_host_pinned_device_name(device: &str) -> bool {
+    device == "CUDA_Host" || device.ends_with("_Host")
+}
+
+/// Backend device a buffer-size line belongs to, from the buffer name token
+/// that precedes `KV buffer size` / `compute buffer size` (e.g. `CUDA0`,
+/// `CUDA1`, `CUDA_Host`, `Metal`, `CPU`). `None` when the device cannot be
+/// determined.
+fn buffer_size_device(line: &str) -> Option<String> {
+    let marker = if line.contains("KV buffer size") {
+        "KV buffer size"
+    } else if line.contains("compute buffer size") {
+        "compute buffer size"
+    } else {
+        return None;
+    };
+    let idx = line.find(marker)?;
+    let name = line[..idx].trim();
+    name.rsplit(' ').next().map(str::to_string)
+}
+
+fn buffer_size_params(line: &str) -> Vec<(String, Value)> {
+    // Structured facts for memory-planning telemetry: the measured buffer size
+    // (the number llama.cpp actually allocated) plus the device the line names.
+    // These are the inputs the topology planner will consume in place of its
+    // KV-scaled compute-buffer estimate.
+    let mut params = Vec::new();
+    if let Some(mib) = parse_buffer_size_mib(line) {
+        params.push(("buffer_mib".to_string(), Value::from(mib)));
+    }
+    if let Some(device) = buffer_size_device(line) {
+        params.push(("backend_device".to_string(), Value::String(device)));
+    }
+    params
+}
+
 fn summarize_native_log_line(line: &str) -> Option<NativeLogEvent> {
     if let Some((category, params)) = cpu_offload_diagnostic_params(line) {
         return Some(NativeLogEvent {
@@ -524,20 +679,30 @@ fn summarize_native_log_line(line: &str) -> Option<NativeLogEvent> {
         || line.contains("compute buffer size")
         || line.contains("scratch buffer")
     {
+        let params = if line.contains("buffer size") {
+            buffer_size_params(line)
+        } else {
+            Vec::new()
+        };
         return Some(NativeLogEvent {
             message: line.to_string(),
             category: "memory",
-            params: Vec::new(),
+            params,
         });
     }
 
     if line.starts_with("llama_kv_cache:")
         && (line.contains("buffer size") || line.contains("size = ") || line.contains("attn_rot"))
     {
+        let params = if line.contains("buffer size") {
+            buffer_size_params(line)
+        } else {
+            Vec::new()
+        };
         return Some(NativeLogEvent {
             message: line.to_string(),
             category: "kv_cache",
-            params: Vec::new(),
+            params,
         });
     }
 
@@ -1116,6 +1281,207 @@ mod tests {
                     .iter()
                     .any(|(key, value)| key == "q4_K" && value == &Value::from(70_u64))
         }));
+    }
+
+    #[test]
+    fn aggregator_records_measured_buffers_for_snapshot_api() {
+        let mut aggregator = NativeLogAggregator::default();
+        aggregator.process_line("sched_reserve:        CUDA0 compute buffer size =   579.83 MiB");
+        aggregator.process_line("llama_kv_cache:        CUDA0 KV buffer size =  1088.00 MiB");
+        assert_eq!(
+            aggregator.measured_snapshot(),
+            MeasuredNativeBuffers {
+                compute_mib: Some(579.83),
+                kv_mib: Some(1088.00),
+                host_memory_observed: false,
+            }
+        );
+
+        // A later, smaller reserve for a shorter context must not lower the
+        // recorded high-water mark for either kind.
+        aggregator.process_line("sched_reserve:        CUDA0 compute buffer size =   512.00 MiB");
+        aggregator.process_line("llama_kv_cache:        CUDA0 KV buffer size =  1024.00 MiB");
+        assert_eq!(
+            aggregator.measured_snapshot(),
+            MeasuredNativeBuffers {
+                compute_mib: Some(579.83),
+                kv_mib: Some(1088.00),
+                host_memory_observed: false,
+            }
+        );
+
+        // CPU-offloaded buffers stay excluded from device totals, but make the
+        // device-only snapshot ineligible for reuse against a mixed pool.
+        aggregator.process_line("load_tensors: CPU_Mapped model buffer size =  2048.00 MiB");
+        aggregator.process_line("llama_kv_cache:        CPU KV buffer size =  4096.00 MiB");
+        aggregator.process_line("llama_kv_cache:        CPU compute buffer size =  8192.00 MiB");
+        assert_eq!(
+            aggregator.measured_snapshot(),
+            MeasuredNativeBuffers {
+                compute_mib: Some(579.83),
+                kv_mib: Some(1088.00),
+                host_memory_observed: true,
+            }
+        );
+
+        // Model-agnostic summary lines carry no buffer size to record.
+        aggregator.process_line("VRAM used: 12.4 GB");
+        assert_eq!(
+            aggregator.measured_snapshot(),
+            MeasuredNativeBuffers {
+                compute_mib: Some(579.83),
+                kv_mib: Some(1088.00),
+                host_memory_observed: true,
+            }
+        );
+
+        // register/unregister reset clears the snapshot for the next model.
+        aggregator.reset();
+        assert_eq!(
+            aggregator.measured_snapshot(),
+            MeasuredNativeBuffers {
+                compute_mib: None,
+                kv_mib: None,
+                host_memory_observed: false,
+            }
+        );
+    }
+
+    #[test]
+    fn aggregator_sums_measured_buffers_across_devices() {
+        // One buffer line is printed per backend device: on multi-GPU the
+        // measured footprint must SUM across devices (a per-kind max would
+        // under-measure by the device count and the planner would buy
+        // roughly N x too much context).
+        let mut aggregator = NativeLogAggregator::default();
+        aggregator.process_line("sched_reserve:        CUDA0 compute buffer size =   544.00 MiB");
+        aggregator.process_line("sched_reserve:        CUDA1 compute buffer size =   544.00 MiB");
+        aggregator.process_line("llama_kv_cache:        CUDA0 KV buffer size =  544.00 MiB");
+        aggregator.process_line("llama_kv_cache:        CUDA1 KV buffer size =  544.00 MiB");
+        assert_eq!(
+            aggregator.measured_snapshot(),
+            MeasuredNativeBuffers {
+                compute_mib: Some(1088.00),
+                kv_mib: Some(1088.00),
+                host_memory_observed: false,
+            }
+        );
+    }
+
+    #[test]
+    fn aggregator_excludes_host_pinned_buffers() {
+        // CUDA_Host is host RAM pinned for device transfers, not device
+        // memory — charging it against a VRAM budget would over-reserve.
+        let mut aggregator = NativeLogAggregator::default();
+        aggregator.process_line("sched_reserve:        CUDA0 compute buffer size =   400.00 MiB");
+        aggregator.process_line("sched_reserve:      CUDA_Host compute buffer size =  128.00 MiB");
+        aggregator.process_line("llama_kv_cache:      CUDA_Host KV buffer size =   64.00 MiB");
+        assert_eq!(
+            aggregator.measured_snapshot(),
+            MeasuredNativeBuffers {
+                compute_mib: Some(400.00),
+                kv_mib: None,
+                host_memory_observed: false,
+            }
+        );
+    }
+
+    #[test]
+    fn aggregator_reset_clears_stale_measured_buffers_on_model_load() {
+        // Review blocker (PR #1719): the model-load "loaded meta data" line
+        // fires reset_model_loading_state mid-open. A new model load
+        // invalidates the previous model's measured buffer sizes (buffer
+        // scales are model/shape-specific), so the reset clears them; buffer
+        // lines emitted after the reset are measured normally, and the host
+        // plan tuple (model/context/lanes) lives outside the aggregator
+        // entirely so it is untouched by the reset.
+        let mut aggregator = NativeLogAggregator::default();
+        aggregator.process_line("sched_reserve:        CUDA0 compute buffer size =   579.83 MiB");
+        // Use a fully parsable line so `process_line` actually invokes
+        // reset_model_loading_state (see parse_loaded_metadata_counts).
+        aggregator.process_line(
+            "llama_model_loader: loaded meta data with 26 key-value pairs and 291 tensors from model.gguf (version GGUF V3)",
+        );
+        // The pre-reset measurement belongs to the previous model and must be
+        // cleared, not stranded into the new model's footprint.
+        assert_eq!(
+            aggregator.measured_snapshot(),
+            MeasuredNativeBuffers {
+                compute_mib: None,
+                kv_mib: None,
+                host_memory_observed: false,
+            }
+        );
+        aggregator.process_line("llama_kv_cache:        CUDA0 KV buffer size =  1088.00 MiB");
+        assert_eq!(
+            aggregator.measured_snapshot(),
+            MeasuredNativeBuffers {
+                compute_mib: None,
+                kv_mib: Some(1088.00),
+                host_memory_observed: false,
+            }
+        );
+    }
+
+    #[test]
+    fn aggregator_parses_measured_compute_buffer_size() {
+        let mut aggregator = NativeLogAggregator::default();
+        assert_eq!(
+            aggregator
+                .process_line("sched_reserve:        CUDA0 compute buffer size =   579.83 MiB"),
+            vec![NativeLogEvent {
+                message: "sched_reserve:        CUDA0 compute buffer size =   579.83 MiB"
+                    .to_string(),
+                category: "memory",
+                params: vec![
+                    ("buffer_mib".to_string(), Value::from(579.83_f64)),
+                    (
+                        "backend_device".to_string(),
+                        Value::String("CUDA0".to_string())
+                    ),
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn aggregator_parses_measured_kv_buffer_size() {
+        let mut aggregator = NativeLogAggregator::default();
+        assert_eq!(
+            aggregator.process_line("llama_kv_cache:        CUDA0 KV buffer size =  1088.00 MiB"),
+            vec![NativeLogEvent {
+                message: "llama_kv_cache:        CUDA0 KV buffer size =  1088.00 MiB".to_string(),
+                category: "kv_cache",
+                params: vec![
+                    ("buffer_mib".to_string(), Value::from(1088.00_f64)),
+                    (
+                        "backend_device".to_string(),
+                        Value::String("CUDA0".to_string())
+                    ),
+                ],
+            }]
+        );
+    }
+
+    #[test]
+    fn aggregator_parses_metal_compute_buffer_size() {
+        let mut aggregator = NativeLogAggregator::default();
+        assert_eq!(
+            aggregator
+                .process_line("sched_reserve:        Metal compute buffer size =  312.50 MiB"),
+            vec![NativeLogEvent {
+                message: "sched_reserve:        Metal compute buffer size =  312.50 MiB"
+                    .to_string(),
+                category: "memory",
+                params: vec![
+                    ("buffer_mib".to_string(), Value::from(312.5_f64)),
+                    (
+                        "backend_device".to_string(),
+                        Value::String("Metal".to_string())
+                    ),
+                ],
+            }]
+        );
     }
 
     #[test]


### PR DESCRIPTION
> [!NOTE]
> This will be merged after https://github.com/Mesh-LLM/mesh-llm/pull/1705 has run its first baseline  


## What

One default flip plus observability: `BUILTIN_UBATCH` 128 -> 512.

The 128 default (PR #564, May 24, no recorded rationale) diverged from llama.cpp's own `LLAMA_SERVER_DEFAULT_N_UBATCH = 512` and missed the CUDA SSM SSD kernel gate (`n_tok > SSM_SSD_MIN_TOKENS`, 128, strict — ssm-scan.cu:829) by exactly one token, forcing every default recurrent (mamba) prefill onto the sequential-scan fallback.

Changes:

1. `BUILTIN_UBATCH` 128 -> 512 (resolver/types.rs) + the gpu-tune planner's own copy (`recommended_ubatch` now clamps to 512), with corrected setting descriptions ("physical prefill chunk size", not "decode micro-batch").
2. Forward the resolved `n_ubatch` / `flash_attn` `llama_context` lines into mesh.log (allowlist gap, same class as the FA-line bug #2), so config landing is observable without compute-buffer fingerprinting.

Out of scope (separate native PR): the SSD gate itself (`n_t >= 128`) and per-prefill scan-vs-SSD path logging — that lives in the vendored llama.cpp patch queue.

## Proof it wins — Granite-4.0-h-1b (recurrent)

Same binary (ce683ca59b), same protocol, same safetensors, 2 passes; config landing verified per-leg by compute-buffer fingerprint in the retained mesh.log.

| Metric | Mesh 128 (default) | Mesh 512 | Delta | vLLM | 512 closes gap to vLLM |
|---|---:|---:|---:|---:|---:|
| C1 TTFT p50 (s) | 0.670 | 0.415 | -38% | 0.248 | 62% |
| C1 TTFT p95 (s) | 1.282 | 0.795 | -38% | 0.434 | 57% |
| C1 decode tok/s | 154.9 | 164.0 | +6% | 237.6 | - |
| C1 agent steps/s | 0.894 | 1.313 | +47% | - | - |
| C8 TTFT p50 (s) | 6.376 | 3.971 | -38% | 1.466 | 48% |
| C8 TTFT p95 (s) | 9.40 | 6.68 | -29% | 2.71 | 43% |
| C8 decode tok/s | 22.2 | 39.4 | +77% | 32.5 | **now ABOVE vLLM** |
| C8 burst clear (8 cold reqs, s) | 9.40 | 6.63 | -29% | - | - |

## Proof it is recurrent-specific — Qwen3-1.7B (dense, negative control)

| Metric | Mesh 128 | Mesh 512 | Delta |
|---|---:|---:|---:|
| C1 TTFT p50 (s) | 0.907 | 0.973 | noise |
| C1 decode tok/s | 148.3 | 148.4 | flat |

## Proof of mechanism — why it fires

| Evidence | 128 default | 512 |
|---|---|---|
| SSD kernel gate `n_t > 128` (ssm-scan.cu:829, strict) | misses by 1 token -> sequential scan | SSD path runs |
| CUDA compute buffer (n_ubatch fingerprint, granite) | 579.83 MiB | 783.09 MiB |
| llama.cpp native default (`LLAMA_SERVER_DEFAULT_N_UBATCH`) | - | 512 (ours was the divergence) |

Cost: +203 MiB CUDA compute buffer. No regression found on any leg.

## Verification

- `cargo test -p mesh-llm-config -p mesh-llm-commands -p mesh-llm-host-runtime -p skippy-runtime`: 2979 passed, 0 failed (11 ignored).
- `cargo fmt --check` clean; xtask repo-consistency (no-console-print, ci-crate-lists, release-targets) all green.

## Follow-ups queued (not in this PR)

- Native PR: SSD gate inclusive (`n_t >= 128`) + per-prefill scan-vs-SSD path logging (vendored llama.cpp patch queue).
- Re-measure recurrent prefill serialization (`max_prefill_sequences_per_iteration = 1`, iteration_scheduler.rs:1373) under ubatch=512 — the dominant C8 TTFT residual (3.97 vs 1.47 s).
- Dense-side gap (2.8x prefill, chunked-prefill priority, CUDA graphs on decode) is llama.cpp kernel/fusion work, explicitly not a config lever.

Full leg citations: `RESEARCH/WHITE_UBATCH_512_FALSIFICATION_2026_09_08.md` (2026-09-08 competitive bench, skippy-competitive-bench channel).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Updated GPU tuning to recommend a 512-token physical prefill chunk by default, improving recurrent-model prefill performance.
  - Throughput tuning profiles now retain their configured micro-batch size instead of being overwritten by the default recommendation.
  - Expanded guidance explains how prefill chunk sizes affect recurrent-model execution.

- **Configuration**
  - Added presentation and help information for prompt-cache disk settings, including mode, directory, budget, and minimum free space.

- **Diagnostics**
  - Runtime logs now surface relevant context configuration details, including micro-batch size and flash-attention status.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->