### PR TITLE
test(skippy): qualify durable L3 across Linux, macOS, and Windows

### DIFF
--- a/ci/slices.yml
+++ b/ci/slices.yml
@@ -178,10 +178,10 @@
     "ui": ["core"],
     "native-abi": ["core"],
     "protocol": ["two-node-client"],
-    "split-serving": ["two-node-split"],
+    "split-serving": ["two-node-split", "product-integration-cpu"],
     "model-download": ["model-download"],
-    "platform-macos": ["metal-model-load"],
-    "platform-windows": ["core"],
+    "platform-macos": ["metal-model-load", "product-integration-metal"],
+    "platform-windows": ["product-integration-windows-cpu"],
     "backend-cuda": ["core-cuda"],
     "backend-rocm": ["core"],
     "backend-vulkan": ["core"]
@@ -224,7 +224,10 @@
     {"id": "two-node-client", "kind": "two-node-client", "runner_role": "linux-build-4"},
     {"id": "two-node-split", "kind": "two-node-split", "runner_role": "linux-build-8"},
     {"id": "model-download", "kind": "model-download", "runner_role": "linux-build-4"},
-    {"id": "metal-model-load", "kind": "metal-model-load", "runner_role": "macos-build"}
+    {"id": "metal-model-load", "kind": "metal-model-load", "platform": "macos", "backend": "metal", "runner_role": "macos-build"},
+    {"id": "product-integration-cpu", "kind": "product-integration", "platform": "linux", "backend": "cpu", "runner_role": "linux-build-4"},
+    {"id": "product-integration-metal", "kind": "product-integration", "platform": "macos", "backend": "metal", "runner_role": "macos-build"},
+    {"id": "product-integration-windows-cpu", "kind": "product-integration", "platform": "windows", "backend": "cpu", "runner_role": "windows-build"}
   ],
   "batch_limits": {"clippy": 3, "rust_tests": 4},
   "slices": [

--- a/scripts/tests/test_ci_workflow_artifacts.py
+++ b/scripts/tests/test_ci_workflow_artifacts.py
@@ -247,26 +247,24 @@ class CiWorkflowArtifactTests(unittest.TestCase):
         self.assertIn("-evidence", workflow)
         self.assertIn("if-no-files-found: error", workflow)
 
-    def test_protected_catalog_defers_product_integration_rollout(self):
+    def test_protected_catalog_selects_cpu_metal_and_windows_product_integration(self):
         slices = json.loads(SLICES.read_text())
         smoke_ids = {row["id"] for row in slices["smoke_rows"]}
         linux = (WORKFLOWS / "ci-linux-product-smoke-slice.yml").read_text()
-        windows = (WORKFLOWS / "ci-windows-product-smoke-slice.yml").read_text()
         product_workflow = (WORKFLOWS / "product-integration-smoke.yml").read_text()
 
-        self.assertNotIn("product-integration-cpu", smoke_ids)
-        self.assertNotIn("product-integration-metal", smoke_ids)
-        self.assertNotIn("product-integration-windows-cpu", smoke_ids)
+        self.assertIn("product-integration-cpu", smoke_ids)
+        self.assertIn("product-integration-metal", smoke_ids)
         self.assertNotIn("qwen-recurrent-gate", smoke_ids)
         self.assertIn("core", smoke_ids)
         self.assertIn("two-node-client", smoke_ids)
         self.assertIn("two-node-split", smoke_ids)
+        self.assertIn("product-integration-windows-cpu", smoke_ids)
         self.assertIn(
             "binary_name: ${{ inputs.platform == 'windows' && 'mesh-llm.exe' || 'mesh-llm' }}",
             product_workflow,
         )
-        self.assertIn("product-integration-windows-cpu", windows)
-        for smoke_id in ("core", "two-node-client", "two-node-split"):
+        for smoke_id in ("core", "two-node-client", "two-node-split", "product-integration-cpu"):
             self.assertIn(
                 f"contains(fromJson(inputs.smoke_matrix).*.id, '{smoke_id}')",
                 linux,

--- a/scripts/tests/test_plan_ci.py
+++ b/scripts/tests/test_plan_ci.py
@@ -369,6 +369,9 @@ class PlanCiTests(unittest.TestCase):
                 "two-node-split",
                 "model-download",
                 "metal-model-load",
+                "product-integration-cpu",
+                "product-integration-metal",
+                "product-integration-windows-cpu",
             },
         )
         self.assertIn(


### PR DESCRIPTION
The complete local durable-L3 stack will run restart and restore qualification on Linux CPU, macOS Metal, and Windows CPU once its supporting workflow plumbing and feature stack are present on `main`.

This PR is now the catalog-only activation required by the protected planner. The planner intentionally requires `ci/slices.yml` to match the default-branch catalog during ordinary feature PRs, so the safe landing sequence is:

1. land dormant workflow plumbing in #1743 with the catalog unchanged;
2. land the durable-L3 feature stack;
3. rebase and land this catalog-only activation.

Linux and macOS activate the dense and recurrent product suites. Windows activates the durable-L3 phase on the composed CPU product.

## Stack

- Base: draft #1514, after the complete durable-L3 and remote-handoff feature stack
- Prerequisite on `main`: #1743
- This PR: platform qualification catalog activation
- Complete GitHub stack: #1817, rooted at `kvcache-ng`

## Validation

- `git diff --check`
- `actionlint -config-file .github/actionlint.yaml`
- `python3 -m unittest -v scripts.tests.test_ci_workflow_artifacts scripts.tests.test_plan_ci` — 50 passed

The branch was rebased onto the exact #1514 head. Its unique diff is limited to `ci/slices.yml` and the two planner/workflow contract test files at `4fdab0f070edca9d18938642ecf974d595f4ddf6`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - Added product-integration smoke coverage for Linux CPU, macOS Metal, and Windows CPU environments.
  - Updated platform smoke coverage to use product-integration checks where applicable.
  - Added explicit platform and backend details for Metal model loading validation.
  - Expanded CI planning and workflow validation to include the new smoke test scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->