### PR TITLE
ci: guard the two planner drift holes with tests

### DIFF
--- a/ci/ownership.yml
+++ b/ci/ownership.yml
@@ -330,7 +330,21 @@
     },
     {
       "domain": "platform-windows",
-      "crates": ["mesh-llm-nodejs", "skippy-ffi"]
+      "crates": [
+        "mesh-llm-commands",
+        "mesh-llm-config",
+        "mesh-llm-events",
+        "mesh-llm-hardware-profile",
+        "mesh-llm-host-runtime",
+        "mesh-llm-identity",
+        "mesh-llm-native-runtime",
+        "mesh-llm-nodejs",
+        "mesh-llm-plugin",
+        "mesh-llm-system",
+        "mesh-llm-tui",
+        "skippy-ffi",
+        "skippy-runtime"
+      ]
     },
     {
       "domain": "platform-windows-storage",

--- a/scripts/tests/test_ci_lane_workflows.py
+++ b/scripts/tests/test_ci_lane_workflows.py
@@ -479,6 +479,31 @@ class CiLaneWorkflowTests(unittest.TestCase):
                 self.assertIn("use_depot:", workflow)
                 self.assertIn("${{ inputs.use_depot }}", workflow)
 
+    def test_every_planned_smoke_id_has_a_matching_lane_job(self) -> None:
+        """Smoke jobs are selected by id, and a missed id skips silently.
+
+        Each smoke job gates on ``contains(fromJson(inputs.smoke_matrix).*.id,
+        '<id>')``. When a planned id matches no job the whole domain's smoke
+        coverage is skipped, and the lane summary fails the run with
+        ``planned job ... finished with "skipped"`` far from the cause.
+        """
+        slices = json.loads((ROOT / "ci" / "slices.yml").read_text())
+        planned = {row["id"] for row in slices["smoke_rows"]}
+        for domain, ids in slices["smoke_domain_rows"].items():
+            with self.subTest(domain=domain):
+                self.assertEqual(set(), set(ids) - planned)
+
+        gated = set()
+        for path in sorted(WORKFLOWS.glob("ci-*-product-smoke-slice.yml")):
+            gated |= set(
+                re.findall(
+                    r"contains\(fromJson\(inputs\.smoke_matrix\)\.\*\.id, '([^']+)'\)",
+                    path.read_text(encoding="utf-8"),
+                )
+            )
+
+        self.assertEqual(set(), planned - gated)
+
     def test_superseded_pr_runs_cancel_by_pull_request_identity(self) -> None:
         for lane in ("quality", "website", "linux", "macos", "windows"):
             pr_workflow = self.workflow(f"pr_{lane}.yml")

--- a/scripts/tests/test_plan_ci.py
+++ b/scripts/tests/test_plan_ci.py
@@ -255,14 +255,18 @@ class PlanCiTests(unittest.TestCase):
             plan["affected_crates"],
             ["mesh-llm-host-runtime", "mesh-llm"],
         )
-        self.assertEqual(plan["domains"], ["rust", "runtime-product"])
+        # mesh-llm-host-runtime holds cfg(windows) code, so it is claimed by
+        # the platform-windows domain and pulls the Windows rows in as well.
+        self.assertEqual(
+            plan["domains"], ["rust", "runtime-product", "platform-windows"]
+        )
         self.assertEqual(
             plan["required_slices"],
-            ["quality", "ui-artifact", "static-abi", "rust-tests", "runtime-product", "product-smoke"],
+            ["quality", "ui-artifact", "static-abi", "rust-tests", "runtime-product", "platform-checks", "product-smoke"],
         )
         self.assertEqual(
             [row["id"] for row in plan["matrices"]["runtime_products"]],
-            ["linux-cpu"],
+            ["linux-cpu", "windows-cpu"],
         )
         self.assertEqual(
             plan["dependencies"]["runtime-product"],
@@ -581,6 +585,46 @@ class PlanCiTests(unittest.TestCase):
             "profile pr-ready.budgets platform ceilings exceed total_max_workers",
         ):
             PLANNER._validate_manifests(ownership, slices)
+
+    def test_every_crate_with_windows_code_is_claimed_by_a_windows_domain(self) -> None:
+        """Windows-only code must pull the Windows lane into the plan.
+
+        The Windows lane runs only when the plan contains Windows rows, and
+        Windows rows come exclusively from the ``platform-windows*`` domains.
+        A crate holding ``cfg(windows)`` code but claimed only by the ``rust``
+        wildcard therefore gets a green Windows check that never compiled for
+        Windows.
+        """
+        ownership = json.loads((ROOT / "ci" / "ownership.yml").read_text())
+        windows_domains = {
+            domain
+            for domain in ownership["domains"]
+            if domain.startswith("platform-windows")
+        }
+        claimed = {
+            crate
+            for rule in ownership["crate_rules"]
+            if rule["domain"] in windows_domains
+            for crate in rule["crates"]
+        }
+
+        tracked = subprocess.check_output(
+            ["git", "ls-files", "--", "crates/*/src/**/*.rs", "crates/*/src/*.rs"],
+            cwd=ROOT,
+            text=True,
+        ).splitlines()
+        needles = ("cfg(windows)", 'target_os = "windows"')
+        with_windows_code = set()
+        for path in tracked:
+            crate_dir = Path(path).parts[1]
+            if crate_dir in with_windows_code:
+                continue
+            source = (ROOT / path).read_text(encoding="utf-8", errors="ignore")
+            if any(needle in source for needle in needles):
+                with_windows_code.add(crate_dir)
+
+        # Crate directory names match package names across the workspace.
+        self.assertEqual(set(), with_windows_code - claimed)
 
     def test_manifest_domain_row_mapping_rejects_unknown_ids(self) -> None:
         ownership = json.loads((ROOT / "ci" / "ownership.yml").read_text())


### PR DESCRIPTION
Two independent gaps let CI report green without running the coverage the plan asked for. Both surfaced while reviewing #1685 and #1659.

## 1. Planned smoke ids vs lane job names

Smoke jobs gate on `contains(fromJson(inputs.smoke_matrix).*.id, '<id>')`. An id in `ci/slices.yml` `smoke_domain_rows` that matches no job condition silently skips the whole domain's smoke coverage, and the lane summary then fails with `ERROR: planned job "product_smoke" finished with "skipped"` — far from the cause.

This is exactly what reddened #1685: #1672 renamed the smoke jobs, `slices.yml` still planned `core` / `two-node-client` / `two-node-split`, and #1693 restored them ~2h later. Anyone merging main in that window got an unexplained red PR.

New test in `scripts/tests/test_ci_lane_workflows.py` asserts every planned smoke id resolves to a job condition, and that `smoke_domain_rows` only references declared `smoke_rows`.

## 2. Windows-only code that never reaches a Windows lane

The Windows lane runs only when `windows_lane_plan.required` is true (`pr_windows.yml:67`), which is `>0 rows` across `hosts` / `runtime_products` / `platform_checks` filtered to `platform == "windows"` (`.github/actions/plan-ci/action.yml:293-308`). Those rows come exclusively from the `platform-windows*` domains (`ci/slices.yml:171,191-192`); every other domain maps to linux-cpu.

`mesh-llm-system` and `skippy-runtime` were claimed only by the `{"domain": "rust", "crates": ["*"]}` wildcard, so #1659 — whose entire purpose is silencing Windows-only `dead_code` warnings — got `Windows = skipping` and a green check.

New test asserts every crate whose sources contain `cfg(windows)` or `target_os = "windows"` is claimed by a windows domain, and `ci/ownership.yml` `platform-windows` `crate_rules` is completed from that census (13 crates).

## Cost

This is not free. A PR touching `skippy-runtime`, `mesh-llm-system`, `mesh-llm-host-runtime` etc. now also plans a Windows host build, `windows-cpu` runtime product, `windows-portable` check and a `core` smoke row. That is the intended trade — those crates carry Windows code and currently have zero Windows compile coverage on PRs — but it is a real runner-minutes decision, so flagging it explicitly rather than burying it.

Worth noting separately: **`-D warnings` never runs against a Windows target on any profile.** `rust_clippy` is a single Linux-container job (`ci-quality-slice.yml:177-233`), and the Windows lane's only cargo invocations are `cargo check --locked -p mesh-llm --bin mesh-llm` and `cargo check -p mesh-llm-nodejs` (`ci-platform-checks-slice.yml:132-141`) — no `--all-targets`, no `-D warnings`. This PR gets Windows *compiled*; it does not get Windows *linted*. That would need a new job on a Windows runner and is deliberately out of scope.

## Verification

At `e60868f68`, base `origin/main` `695b4d089`:

- `python3 -m unittest discover -s scripts/tests -p 'test_*.py'` — 945 tests, same 10 pre-existing import errors as `origin/main` (943 tests, missing local `pyyaml`), no new failures
- **Both new tests verified to fail against the state that produced the bug:** test 1 against `ci-linux-product-smoke-slice.yml` at `afa36ab02` (#1672, pre-restore) — reports the three missing ids; test 2 against `ci/ownership.yml` at `origin/main` — reports `skippy-runtime`, `mesh-llm-system`, `mesh-llm-tui`, `mesh-llm-hardware-profile` and the rest
- `test_runtime_change_separates_direct_and_affected_crates` updated: `mesh-llm-host-runtime` now correctly pulls `platform-windows`, `platform-checks` and `windows-cpu` into the plan

Diff is 3 files, +87/-4. No workflow or planner logic changed — only the ownership list and two assertions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows platform coverage so relevant runtime components are included in platform checks and Windows CPU validation.

- **Tests**
  - Added validation to ensure every planned smoke test is assigned to a matching workflow job, preventing tests from being silently skipped.
  - Added checks to confirm Windows-specific Rust components are correctly included in platform ownership rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->