### PR TITLE
fix(skippy): keep warm KV reuse fast with disk L3

### DIFF
--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -85,7 +85,7 @@ impl KvStageIntegration {
             emit_cache_disabled_warning(config, reason);
             return Ok(None);
         }
-        let mut payload = effective_cache_payload(cache_config.payload, &model_capability);
+        let payload = effective_cache_payload(cache_config.payload, &model_capability);
         if payload == StagePrefixCachePayload::Disabled {
             return Ok(None);
         }
@@ -109,18 +109,24 @@ impl KvStageIntegration {
             return Ok(None);
         }
         let l3_manager = manager()?;
-        if l3_manager.is_some()
-            && payload == StagePrefixCachePayload::ResidentKv
-            && dense_without_recurrent
-        {
-            // The durable tier needs exportable state and ResidentKv is
-            // borrow-only. Dense families record KV pages with an empty
-            // recurrent snapshot so they reach disk; the model is known
-            // dense, so the empty snapshot is expected rather than corrupt.
-            payload = StagePrefixCachePayload::KvRecurrent;
-        }
+        let durable_payload = l3_manager.as_ref().map(|_| {
+            if payload == StagePrefixCachePayload::ResidentKv && dense_without_recurrent {
+                // Resident KV stays the in-process fast path. Dense families
+                // export KV pages with an empty recurrent snapshot for L3;
+                // the known-dense capability makes that empty component valid.
+                StagePrefixCachePayload::KvRecurrent
+            } else {
+                payload
+            }
+        });
         let l3 = l3_manager
-            .map(|manager| l3_tier_for_manager(config, payload, manager))
+            .map(|manager| {
+                l3_tier_for_manager(
+                    config,
+                    durable_payload.expect("enabled cache has a durable payload"),
+                    manager,
+                )
+            })
             .transpose()?;
         // FullState is architecture-neutral: the native runtime serializes the
         // complete session state for both dense and recurrent model families.
@@ -206,6 +212,7 @@ impl KvStageIntegration {
         Ok(Some(Self {
             mode,
             payload,
+            durable_payload,
             correctness_mode: false,
             trust_local_writes: true,
             checkpoint_policy,
@@ -1315,7 +1322,7 @@ mod tests {
     }
 
     #[test]
-    fn dense_auto_cache_becomes_exportable_when_disk_is_injected() {
+    fn dense_disk_cache_preserves_resident_fast_path_and_exports_exact_state() {
         let root = std::env::temp_dir()
             .join("skippy-server-l3-manager-tests")
             .join(format!("dense-export-{}", std::process::id()));
@@ -1331,7 +1338,15 @@ mod tests {
         .unwrap()
         .expect("dense disk cache should remain enabled");
 
-        assert_eq!(kv.payload, StagePrefixCachePayload::KvRecurrent);
+        assert_eq!(kv.payload, StagePrefixCachePayload::ResidentKv);
+        assert_eq!(
+            kv.durable_payload,
+            Some(StagePrefixCachePayload::KvRecurrent)
+        );
+        assert_eq!(
+            kv.exact_state_payload(),
+            Some(StagePrefixCachePayload::KvRecurrent)
+        );
         assert!(kv.l3.is_some());
     }
 

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -120,13 +120,8 @@ impl KvStageIntegration {
             }
         });
         let l3 = l3_manager
-            .map(|manager| {
-                l3_tier_for_manager(
-                    config,
-                    durable_payload.expect("enabled cache has a durable payload"),
-                    manager,
-                )
-            })
+            .zip(durable_payload)
+            .map(|(manager, payload)| l3_tier_for_manager(config, payload, manager))
             .transpose()?;
         // FullState is architecture-neutral: the native runtime serializes the
         // complete session state for both dense and recurrent model families.
@@ -1348,6 +1343,11 @@ mod tests {
             Some(StagePrefixCachePayload::KvRecurrent)
         );
         assert!(kv.l3.is_some());
+
+        let mut invalid = kv;
+        invalid.payload = StagePrefixCachePayload::Disabled;
+        invalid.durable_payload = Some(StagePrefixCachePayload::ResidentKv);
+        assert_eq!(invalid.exact_state_payload(), None);
     }
 
     #[test]

--- a/crates/skippy-server/src/kv_integration/exact_state.rs
+++ b/crates/skippy-server/src/kv_integration/exact_state.rs
@@ -33,7 +33,18 @@ impl KvStageIntegration {
         session_id: &str,
         identities: &[PrefillKvIdentity],
     ) -> Result<Option<ExactStateRestore>> {
-        if !self.should_lookup() || !self.payload.is_exact_state() {
+        if !self.should_lookup() || self.exact_state_payload().is_none() {
+            return Ok(None);
+        }
+        // Dense L3 uses serialized exact state only as the durable floor.
+        // Prefer a native resident-prefix hit whenever one is already warm;
+        // importing the serialized snapshot would otherwise make enabling L3
+        // slower than the ordinary L1 path on every repeated request.
+        if self.payload == StagePrefixCachePayload::ResidentKv
+            && identities
+                .iter()
+                .any(|identity| self.probe_resident_prefix(identity).is_some())
+        {
             return Ok(None);
         }
         for identity in identities {
@@ -253,7 +264,10 @@ impl KvStageIntegration {
         session_id: &str,
         identity: &PrefillKvIdentity,
     ) -> Result<Option<ExactStateRecord>> {
-        if !self.should_record() || !self.payload.is_exact_state() {
+        let Some(exact_state_payload) = self.exact_state_payload() else {
+            return Ok(None);
+        };
+        if !self.should_record() {
             return Ok(None);
         }
         let token_count = identity.identity.token_count;
@@ -288,7 +302,7 @@ impl KvStageIntegration {
             self.finish_record(&identity.page_id);
             return Ok(None);
         }
-        let exported = match self.payload {
+        let exported = match exact_state_payload {
             StagePrefixCachePayload::FullState => {
                 runtime.export_full_state(session_id).map(|state| {
                     (

--- a/crates/skippy-server/src/kv_integration/exact_state.rs
+++ b/crates/skippy-server/src/kv_integration/exact_state.rs
@@ -15,6 +15,10 @@ fn l3_fill_claim_key(l3: &skippy_cache::L3Tier, location: &skippy_cache::L3Locat
     format!("{}:{}", l3.state_identity(), location.manifest_key)
 }
 
+fn resident_prefix_is_complete(matched_tokens: usize, requested_tokens: usize) -> bool {
+    matched_tokens >= requested_tokens
+}
+
 impl KvStageIntegration {
     pub fn restore_exact_state(
         &self,
@@ -41,9 +45,12 @@ impl KvStageIntegration {
         // importing the serialized snapshot would otherwise make enabling L3
         // slower than the ordinary L1 path on every repeated request.
         if self.payload == StagePrefixCachePayload::ResidentKv
-            && identities
-                .iter()
-                .any(|identity| self.probe_resident_prefix(identity).is_some())
+            && identities.iter().any(|identity| {
+                self.probe_resident_prefix(identity)
+                    .is_some_and(|resident| {
+                        resident_prefix_is_complete(resident.token_count, identity.token_ids.len())
+                    })
+            })
         {
             return Ok(None);
         }
@@ -691,12 +698,19 @@ mod tests {
 
     use skippy_cache::UnifiedRadixCache;
 
-    use super::try_touch_exact_state;
+    use super::{resident_prefix_is_complete, try_touch_exact_state};
 
     type TestRadix = UnifiedRadixCache<
         crate::kv_integration::RadixResidentEntry,
         crate::kv_integration::RadixExactEntry,
     >;
+
+    #[test]
+    fn only_complete_resident_prefixes_skip_exact_restore() {
+        assert!(resident_prefix_is_complete(4_000, 4_000));
+        assert!(resident_prefix_is_complete(4_001, 4_000));
+        assert!(!resident_prefix_is_complete(200, 4_000));
+    }
 
     #[test]
     fn busy_exact_state_lock_skips_touch_without_waiting() {

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -148,7 +148,13 @@ pub(crate) struct ExactStateByteLimits {
 #[derive(Clone)]
 pub struct KvStageIntegration {
     pub(crate) mode: StageKvMode,
+    /// The in-process cache representation. Dense models keep native resident
+    /// KV here even when a durable tier is configured, so enabling disk does
+    /// not replace the fast warm path with serialized state import.
     pub(crate) payload: StagePrefixCachePayload,
+    /// Exportable representation written to and restored from L3. This is
+    /// separate from `payload` because resident KV is native and borrow-only.
+    pub(crate) durable_payload: Option<StagePrefixCachePayload>,
     pub(crate) correctness_mode: bool,
     pub(crate) trust_local_writes: bool,
     pub(crate) checkpoint_policy: SparseCheckpointPolicy,
@@ -502,7 +508,14 @@ impl KvStageIntegration {
     }
 
     pub(crate) fn payload_is_exact_state(&self) -> bool {
-        self.payload.is_exact_state()
+        self.exact_state_payload().is_some()
+    }
+
+    pub(crate) fn exact_state_payload(&self) -> Option<StagePrefixCachePayload> {
+        self.payload
+            .is_exact_state()
+            .then_some(self.payload)
+            .or(self.durable_payload)
     }
 
     pub fn should_lookup(&self) -> bool {

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -515,7 +515,9 @@ impl KvStageIntegration {
         self.payload
             .is_exact_state()
             .then_some(self.payload)
-            .or(self.durable_payload)
+            .or(self
+                .durable_payload
+                .filter(|payload| payload.is_exact_state()))
     }
 
     pub fn should_lookup(&self) -> bool {


### PR DESCRIPTION
Enabling disk L3 for a dense model changed the in-process payload from native resident KV to serialized exact state. Repeated warm requests then imported snapshots instead of taking the resident prefix path: the reported replay regressed from 23 ms without L3 to 453 ms with L3.

This keeps resident KV as the dense in-process fast path and gives L3 a separate exportable exact-state payload. Exact restore remains available after restart, while an existing resident hit wins on warm requests.

The pre-restack release replay on the patch-equivalent commit `99e4db903` used identical binary SHA-256 `86d2853dbde9316c67bbe19a006ac62edcee550a7b74387330b00cc683707e28`, model, and workload:

| cohort | control | L3 enabled |
|---|---:|---:|
| fill p50 | 69 ms, 60.4% cached | 86 ms, 60.4% cached |
| restore p50 | 397 ms, 0% cached | 386 ms, 25.6% cached |
| warm p50 | 13 ms, 99.95% cached | 18 ms, 99.95% cached |

Both arms completed with zero failed requests. This removes the warm-path regression. Durable restore is still near parity on this small-model workload, so the 2x restart target remains optimization work.

## Stack

- Base: #1710, following #1707 and #1632 on `kvcache-ng`
- This PR: resident fast-path repair
- Next: #1726 packed durability

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p skippy-server --lib` — 705 passed, 3 ignored
- `cargo clippy -p skippy-server --all-targets -- -D warnings`
- patch-equivalent release host replay with zero failed requests
