### PR TITLE
Fix complete package-v2 model downloads

### DIFF
--- a/crates/mesh-llm-host-runtime/src/command_support.rs
+++ b/crates/mesh-llm-host-runtime/src/command_support.rs
@@ -28,9 +28,10 @@ pub mod models {
     pub mod skippy {
         pub use crate::inference::skippy::{
             CertificationGateStatus, SkippyCertificationRequest, certify_layer_package,
-            identity_from_layer_package, is_layer_package_ref, materialized_stage_cache_dir,
-            materialized_stages_for_sources, prune_unpinned_materialized_stages,
-            remove_materialized_stages_for_sources, resolve_hf_package_to_local,
+            download_package_v2_to_local, identity_from_layer_package, is_layer_package_ref,
+            materialized_stage_cache_dir, materialized_stages_for_sources,
+            prune_unpinned_materialized_stages, remove_materialized_stages_for_sources,
+            resolve_hf_package_to_local,
         };
     }
 

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/materialization.rs
@@ -20,8 +20,9 @@ pub use cache_management::{
     remove_materialized_stages_for_sources,
 };
 pub use package_download::{
-    StagePackageRef, is_layer_package_ref, resolve_hf_package_to_local,
-    resolve_package_v2_full_model_to_local, resolve_package_v2_stage_to_local,
+    StagePackageRef, download_package_v2_to_local, is_layer_package_ref,
+    resolve_hf_package_to_local, resolve_package_v2_full_model_to_local,
+    resolve_package_v2_stage_to_local,
 };
 
 pub fn configure_materialized_stage_cache() {

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/materialization/package_download.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/materialization/package_download.rs
@@ -1255,6 +1255,20 @@ pub fn resolve_package_v2_stage_to_local(
 pub fn resolve_package_v2_full_model_to_local(
     package_ref: &str,
 ) -> Result<(Vec<PathBuf>, Option<PathBuf>)> {
+    let (_, model_parts, projector) = resolve_package_v2_full_model_with_root(package_ref)?;
+    Ok((model_parts, projector))
+}
+
+/// Download every artifact needed to use a package-v2 model and return its
+/// local package root.
+pub fn download_package_v2_to_local(package_ref: &str) -> Result<PathBuf> {
+    let (package_dir, _, _) = resolve_package_v2_full_model_with_root(package_ref)?;
+    Ok(package_dir)
+}
+
+fn resolve_package_v2_full_model_with_root(
+    package_ref: &str,
+) -> Result<(PathBuf, Vec<PathBuf>, Option<PathBuf>)> {
     let local_ref = resolve_hf_package_to_local(package_ref, 0, 0, false, false)?;
     let manifest_path = Path::new(&local_ref).join("model-package.json");
     let manifest: PackageManifestV2 = serde_json::from_slice(
@@ -1286,7 +1300,7 @@ pub fn resolve_package_v2_full_model_to_local(
         sidecars,
     };
     let (_, model_parts, projector) = resolve_package_v2_stage_to_local(package_ref, &admission)?;
-    Ok((model_parts, projector))
+    Ok((PathBuf::from(local_ref), model_parts, projector))
 }
 
 fn safe_manifest_file_path(path: &str) -> Result<PathBuf> {
@@ -1327,6 +1341,35 @@ mod tests {
 
     fn sha256_hex(bytes: &[u8]) -> String {
         hex::encode(Sha256::digest(bytes))
+    }
+
+    #[test]
+    fn complete_package_v2_download_returns_the_package_root() {
+        let root = tempfile::tempdir().unwrap();
+        crate::inference::skippy::write_test_package_v2_fixture(
+            root.path(),
+            "fixture/llama-1b",
+            &[
+                (
+                    "layer-00000",
+                    "layers/layer-00000.gguf",
+                    "blk.0.attn.weight",
+                ),
+                (
+                    "layer-00001",
+                    "layers/layer-00001.gguf",
+                    "blk.1.attn.weight",
+                ),
+            ],
+        )
+        .unwrap();
+
+        let package_dir = download_package_v2_to_local(&root.path().to_string_lossy()).unwrap();
+
+        assert_eq!(package_dir, root.path());
+        assert!(package_dir.join("model-package.json").is_file());
+        assert!(package_dir.join("layers/layer-00000.gguf").is_file());
+        assert!(package_dir.join("layers/layer-00001.gguf").is_file());
     }
 
     struct EnvRestore {

--- a/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/mod.rs
@@ -64,10 +64,11 @@ pub(crate) use local_source::{
 #[cfg(test)]
 pub(crate) use materialization::resolve_package_v2_stage_to_local;
 pub use materialization::{
-    configure_materialized_stage_cache, is_layer_package_ref, materialized_stage_cache_dir,
-    materialized_stages_for_sources, prune_unpinned_materialized_stages,
-    remove_materialized_stages_for_sources, resolve_hf_package_to_local,
-    resolve_package_v2_full_model_to_local, resolve_stage_load_package,
+    configure_materialized_stage_cache, download_package_v2_to_local, is_layer_package_ref,
+    materialized_stage_cache_dir, materialized_stages_for_sources,
+    prune_unpinned_materialized_stages, remove_materialized_stages_for_sources,
+    resolve_hf_package_to_local, resolve_package_v2_full_model_to_local,
+    resolve_stage_load_package,
 };
 #[cfg(test)]
 pub(crate) use package::write_test_package_v2_fixture;

--- a/crates/mesh-llm/src/commands/models/mod.rs
+++ b/crates/mesh-llm/src/commands/models/mod.rs
@@ -9,7 +9,7 @@ use mesh_llm_cli::models::ModelSearchSort;
 use mesh_llm_cli::models::ModelsCommand;
 use mesh_llm_host_runtime::command_support::models::skippy::{
     CertificationGateStatus, SkippyCertificationRequest, certify_layer_package,
-    identity_from_layer_package, is_layer_package_ref, resolve_hf_package_to_local,
+    download_package_v2_to_local, is_layer_package_ref,
 };
 use mesh_llm_host_runtime::command_support::models::{
     DownloadTransferStats, ModelCleanupPlan, ModelCleanupResult, SearchArtifactFilter,
@@ -418,11 +418,7 @@ async fn download_layer_package_for_model_ref(
     };
     let package_dir = tokio::task::spawn_blocking({
         let package_ref = package_ref.clone();
-        move || {
-            let identity = identity_from_layer_package(&package_ref)?;
-            resolve_hf_package_to_local(&package_ref, 0, identity.layer_count, true, true)
-                .map(std::path::PathBuf::from)
-        }
+        move || download_package_v2_to_local(&package_ref)
     })
     .await??;
     Ok(Some((package_ref, package_dir)))

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -2533,35 +2533,43 @@
       "macro_name": "eprintln!"
     },
     {
-      "line": 566,
+      "line": 562,
       "macro_name": "println!"
     },
     {
-      "line": 575,
+      "line": 571,
       "macro_name": "println!"
     },
     {
-      "line": 576,
+      "line": 572,
       "macro_name": "println!"
     },
     {
-      "line": 577,
+      "line": 573,
       "macro_name": "println!"
     },
     {
-      "line": 578,
+      "line": 574,
       "macro_name": "println!"
     },
     {
-      "line": 586,
+      "line": 582,
       "macro_name": "println!"
     },
     {
-      "line": 595,
+      "line": 591,
       "macro_name": "println!"
     },
     {
-      "line": 596,
+      "line": 592,
+      "macro_name": "println!"
+    },
+    {
+      "line": 629,
+      "macro_name": "println!"
+    },
+    {
+      "line": 631,
       "macro_name": "println!"
     },
     {
@@ -2569,15 +2577,15 @@
       "macro_name": "println!"
     },
     {
-      "line": 635,
-      "macro_name": "println!"
-    },
-    {
       "line": 637,
       "macro_name": "println!"
     },
     {
-      "line": 641,
+      "line": 638,
+      "macro_name": "println!"
+    },
+    {
+      "line": 640,
       "macro_name": "println!"
     },
     {
@@ -2585,15 +2593,15 @@
       "macro_name": "println!"
     },
     {
-      "line": 644,
+      "line": 645,
       "macro_name": "println!"
     },
     {
-      "line": 646,
+      "line": 648,
       "macro_name": "println!"
     },
     {
-      "line": 649,
+      "line": 650,
       "macro_name": "println!"
     },
     {
@@ -2601,11 +2609,11 @@
       "macro_name": "println!"
     },
     {
-      "line": 654,
+      "line": 660,
       "macro_name": "println!"
     },
     {
-      "line": 656,
+      "line": 662,
       "macro_name": "println!"
     },
     {
@@ -2621,23 +2629,19 @@
       "macro_name": "println!"
     },
     {
-      "line": 670,
-      "macro_name": "println!"
-    },
-    {
       "line": 672,
       "macro_name": "println!"
     },
     {
-      "line": 676,
+      "line": 677,
       "macro_name": "println!"
     },
     {
-      "line": 681,
+      "line": 678,
       "macro_name": "println!"
     },
     {
-      "line": 682,
+      "line": 679,
       "macro_name": "println!"
     },
     {
@@ -2645,47 +2649,43 @@
       "macro_name": "println!"
     },
     {
-      "line": 687,
+      "line": 684,
       "macro_name": "println!"
     },
     {
-      "line": 688,
+      "line": 689,
       "macro_name": "println!"
     },
     {
-      "line": 693,
+      "line": 696,
       "macro_name": "println!"
     },
     {
-      "line": 700,
+      "line": 703,
       "macro_name": "println!"
     },
     {
-      "line": 707,
+      "line": 709,
       "macro_name": "println!"
+    },
+    {
+      "line": 710,
+      "macro_name": "println!"
+    },
+    {
+      "line": 711,
+      "macro_name": "print!"
     },
     {
       "line": 713,
-      "macro_name": "println!"
-    },
-    {
-      "line": 714,
-      "macro_name": "println!"
+      "macro_name": "print!"
     },
     {
       "line": 715,
-      "macro_name": "print!"
-    },
-    {
-      "line": 717,
-      "macro_name": "print!"
-    },
-    {
-      "line": 719,
       "macro_name": "println!"
     },
     {
-      "line": 729,
+      "line": 725,
       "macro_name": "println!"
     }
   ],


### PR DESCRIPTION
## Original problem

`mesh-llm models download <package-v2-ref>` fetched the manifest and metadata carrier, then failed with `package-v2 artifact selection requires an exact stage admission descriptor`. The command used the generic range resolver even though package-v2 downloads require the exact tensor closure used by full-model serving.

For example:

```console
$ mesh-llm models download 'hf://meshllm/Llama-3.2-1B-Instruct-Q4_K_M-layers@7ad0d24934d3e0127e31bb48646ebcacb2028970' --json
Error: package-v2 artifact selection requires an exact stage admission descriptor
```

## Diagnostics

The failure reproduced from the extracted v0.76.0 release candidate in an empty data and Hugging Face cache. That fixture is a schema-v2 package with 16 layers and 20 catalog artifacts.

## Fix

Route explicit package-v2 downloads through the existing full-model resolver. It constructs an exact admission descriptor from the package tensor catalog, downloads and verifies the complete artifact closure, and returns the local package root. The serving and wire protocols are unchanged.

After this change, the same command exits successfully:

```json
{
  "package_ref": "hf://meshllm/Llama-3.2-1B-Instruct-Q4_K_M-layers@7ad0d24934d3e0127e31bb48646ebcacb2028970",
  "path": "<HF_HOME>/hub/models--meshllm--Llama-3.2-1B-Instruct-Q4_K_M-layers/snapshots/7ad0d24934d3e0127e31bb48646ebcacb2028970",
  "requested_ref": "hf://meshllm/Llama-3.2-1B-Instruct-Q4_K_M-layers@7ad0d24934d3e0127e31bb48646ebcacb2028970",
  "type": "layer_package"
}
```

## Validation

- [x] `cargo fmt --all --check`
- [x] `just no-console-print`
- [x] `cargo test -p mesh-llm-host-runtime --lib` (2,984 passed, 11 ignored)
- [x] `cargo test -p mesh-llm`
- [x] `cargo check -p mesh-llm-host-runtime`
- [x] `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- [x] `cargo check -p mesh-llm`
- [x] `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- [x] Live exact-ref download in an empty cache completed successfully; all 20 manifest artifacts are present.
- [x] No UI changes; screenshots and video do not apply.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for downloading complete package-v2 models directly to a local package directory.
  - Layer-package downloads now use the updated package-v2 download workflow, improving consistency for model materialization.

- **Bug Fixes**
  - Updated package download handling to ensure required model artifacts are collected and available together in the resulting local package.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->