### PR TITLE
fix(models): resolve Hugging Face GGUF snapshot symlinks

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/package/content_addressed.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/package/content_addressed.rs
@@ -308,6 +308,25 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
+    fn identity_rejects_user_supplied_symlink() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("model-target.gguf");
+        let link = dir.path().join("model.gguf");
+        write_test_metadata_gguf(&target, 4096);
+        symlink(&target, &link).unwrap();
+
+        let error = synthetic_content_addressed_gguf_package("logical/model", &link)
+            .unwrap_err()
+            .to_string();
+
+        assert!(error.contains("non-symlink file"));
+        assert!(error.contains("model.gguf"));
+    }
+
+    #[cfg(unix)]
+    #[test]
     fn split_rejects_symlinked_secondary_shard() {
         use std::os::unix::fs::symlink;
 

--- a/crates/mesh-llm-host-runtime/src/models/resolve/downloaded_path.rs
+++ b/crates/mesh-llm-host-runtime/src/models/resolve/downloaded_path.rs
@@ -1,0 +1,69 @@
+use std::path::{Path, PathBuf};
+
+use anyhow::{Context, Result};
+
+use super::huggingface_identity_for_path;
+
+pub(super) fn canonicalize_hf_download_path(path: PathBuf) -> Result<PathBuf> {
+    if !is_monolithic_gguf(&path)
+        || !path
+            .symlink_metadata()
+            .with_context(|| format!("Inspect downloaded Hugging Face model {}", path.display()))?
+            .file_type()
+            .is_symlink()
+    {
+        return Ok(path);
+    }
+    path.canonicalize().with_context(|| {
+        format!(
+            "Canonicalize downloaded Hugging Face model {}",
+            path.display()
+        )
+    })
+}
+
+pub(super) fn canonicalize_cached_hf_path(path: &Path) -> Result<PathBuf> {
+    if !is_monolithic_gguf(path) || huggingface_identity_for_path(path).is_none() {
+        return Ok(path.to_path_buf());
+    }
+    canonicalize_hf_download_path(path.to_path_buf())
+}
+
+fn is_monolithic_gguf(path: &Path) -> bool {
+    let Some(filename) = path.file_name().and_then(|name| name.to_str()) else {
+        return false;
+    };
+    let Some((stem, extension)) = filename.rsplit_once('.') else {
+        return false;
+    };
+    extension.eq_ignore_ascii_case("gguf")
+        && model_ref::split_gguf_shard_info(&format!("{stem}.gguf")).is_none()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn non_gguf_and_split_gguf_downloads_keep_their_snapshot_names() {
+        for filename in [
+            "model.safetensors",
+            "model-00001-of-00002.gguf",
+            "model-00001-of-00002.GGUF",
+            "model-00001-of-00002.GgUf",
+            "README.md",
+        ] {
+            let path = PathBuf::from("/cache/snapshots/revision").join(filename);
+            assert_eq!(canonicalize_hf_download_path(path.clone()).unwrap(), path);
+        }
+    }
+
+    #[test]
+    fn regular_gguf_download_keeps_its_original_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("model.gguf");
+        std::fs::write(&path, b"gguf").unwrap();
+
+        assert_eq!(canonicalize_hf_download_path(path.clone()).unwrap(), path);
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/models/resolve/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/models/resolve/mod.rs
@@ -268,7 +268,7 @@ pub async fn resolve_model_spec_with_progress(input: &Path, progress: bool) -> R
                 progress,
             )
             .await
-            .map(|download| download.path);
+            .and_then(|download| canonicalize_hf_download_path(download.path));
         }
         let installed_path = find_model_path(installed_name);
         if installed_path.exists() {
@@ -276,13 +276,14 @@ pub async fn resolve_model_spec_with_progress(input: &Path, progress: bool) -> R
                 .map(|identity| identity.canonical_ref)
                 .unwrap_or_else(|| installed_name.to_string());
             record_resolved_model_usage(&installed_path, Some(&model_ref));
-            return Ok(installed_path);
+            return canonicalize_cached_hf_path(&installed_path);
         }
         if let Ok(canonical) = canonicalize_model_ref_input(&raw).await
             && canonical != raw
         {
             return download_exact_ref_with_progress(&canonical, progress)
                 .await
+                .and_then(canonicalize_hf_download_path)
                 .with_context(|| format!("Resolve model spec {raw}"));
         }
         bail!(
@@ -294,14 +295,18 @@ pub async fn resolve_model_spec_with_progress(input: &Path, progress: bool) -> R
     let installed_path = find_model_path(&raw);
     if installed_path.exists() {
         record_resolved_model_usage(&installed_path, Some(raw.as_ref()));
-        return Ok(installed_path);
+        return canonicalize_cached_hf_path(&installed_path);
     }
 
     let download = download_model_ref_with_progress_details(&raw, progress)
         .await
         .with_context(|| format!("Resolve model spec {raw}"))?;
-    Ok(download.path)
+    canonicalize_hf_download_path(download.path)
 }
+
+mod downloaded_path;
+
+use downloaded_path::{canonicalize_cached_hf_path, canonicalize_hf_download_path};
 
 fn record_resolved_model_usage(path: &Path, model_ref: Option<&str>) {
     if let Err(err) = track_model_usage(path, None, model_ref, Some("resolve")) {

--- a/crates/mesh-llm-host-runtime/src/models/resolve/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/models/resolve/tests.rs
@@ -104,6 +104,91 @@ fn remote_catalog_entry_with_mmproj(
     entry
 }
 
+#[cfg(unix)]
+fn hf_snapshot_symlink(
+    cache: &Path,
+    repo: &str,
+    revision: &str,
+    filename: &str,
+) -> (PathBuf, PathBuf) {
+    use std::os::unix::fs::symlink;
+
+    let repo_dir = cache.join(format!("models--{}", repo.replace('/', "--")));
+    let blob_name = "78f1dbb60dedc080b99d26b8098f719f020b0f9bafe9e12a20c7d25652d4fd86";
+    let blob = repo_dir.join("blobs").join(blob_name);
+    let snapshot = repo_dir.join("snapshots").join(revision).join(filename);
+    std::fs::create_dir_all(blob.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(snapshot.parent().unwrap()).unwrap();
+    std::fs::create_dir_all(repo_dir.join("refs")).unwrap();
+    std::fs::write(&blob, b"verified gguf bytes").unwrap();
+    std::fs::write(repo_dir.join("refs").join("main"), revision).unwrap();
+    symlink(Path::new("../../blobs").join(blob_name), &snapshot).unwrap();
+    (snapshot, blob)
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn fresh_hf_snapshot_symlink_resolves_to_verified_blob() {
+    let cache = tempfile::tempdir().unwrap();
+    let variant = "Fresh-HF-Snapshot-Q8_0";
+    let repo = "mesh-test/fresh-hf-snapshot";
+    let filename = "Fresh-HF-Snapshot-Q8_0.gguf";
+    let (snapshot, blob) = hf_snapshot_symlink(cache.path(), repo, "revision-a", filename);
+    let _cache_guard = EnvGuard::set_path("HF_HUB_CACHE", cache.path());
+    let _hf_home_guard = EnvGuard::remove("HF_HOME");
+    let _catalog_guard =
+        crate::models::remote_catalog::set_catalog_entries_for_test(vec![remote_catalog_entry(
+            variant, variant, repo, filename,
+        )]);
+    let _download_guard = crate::models::catalog::set_download_hf_assets_label_override(
+        variant.to_string(),
+        Arc::new({
+            let snapshot = snapshot.clone();
+            move |_| Ok(vec![snapshot.clone()])
+        }),
+    );
+
+    let resolved = resolve_model_spec_with_progress(Path::new(variant), false)
+        .await
+        .unwrap();
+
+    assert_eq!(resolved, blob.canonicalize().unwrap());
+    assert!(
+        !std::fs::symlink_metadata(resolved)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
+#[cfg(unix)]
+#[tokio::test]
+#[serial]
+async fn cached_hf_snapshot_symlink_resolves_to_verified_blob() {
+    let cache = tempfile::tempdir().unwrap();
+    let repo = "mesh-test/cached-hf-snapshot";
+    let revision = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+    let filename = "Cached-HF-Snapshot-Q8_0.gguf";
+    let (_snapshot, blob) = hf_snapshot_symlink(cache.path(), repo, revision, filename);
+    let _cache_guard = EnvGuard::set_path("HF_HUB_CACHE", cache.path());
+    let _hf_home_guard = EnvGuard::remove("HF_HOME");
+    let _catalog_guard = crate::models::remote_catalog::set_catalog_entries_for_test(Vec::new());
+    let model_ref = format!("{repo}@{revision}:Q8_0");
+
+    let resolved = resolve_model_spec_with_progress(Path::new(&model_ref), false)
+        .await
+        .unwrap();
+
+    assert_eq!(resolved, blob.canonicalize().unwrap());
+    assert!(
+        !std::fs::symlink_metadata(resolved)
+            .unwrap()
+            .file_type()
+            .is_symlink()
+    );
+}
+
 #[tokio::test]
 async fn existing_model_path_resolves_to_canonical_path() {
     let temp = tempfile::tempdir().expect("create temp model dir");


### PR DESCRIPTION
A GGUF downloaded into a standard Hugging Face cache is returned as a snapshot symlink. Startup then rejects that path during content-addressed indexing, so `models download unsloth/SmolLM2-135M-Instruct-GGUF:Q8_0` succeeds but `serve --model ...` fails before model load.

Canonicalize only downloader-owned monolithic GGUF snapshot symlinks, plus cached paths that can be identified as Hugging Face cache entries, to their verified blob paths before indexing. Regular files, SafeTensors, split-GGUF snapshot names, and rejection of arbitrary local symlinks retain their existing behavior.

Validation:
- `cargo test -p mesh-llm-host-runtime --lib -- --test-threads=1` — 2,989 passed, 11 ignored
- `python3 scripts/check-env-mutation-contract.py` — 35 files, 200 sites, contract satisfied
- `cargo run -p xtask -- repo-consistency no-console-print`
- `cargo fmt --all --check`
- `cargo check -p mesh-llm-host-runtime`
- `cargo clippy -p mesh-llm-host-runtime --all-targets -- -D warnings`
- `cargo check -p mesh-llm`
- `cargo clippy -p mesh-llm --all-targets -- -D warnings`
- Release-shaped macOS bundle: fresh Hugging Face cache download, startup by model ref, `/v1/models`, and chat inference passed
- Same extracted product restarted from the populated cache and reached `llama_ready=true`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of downloaded and cached Hugging Face model files by resolving symlinks for monolithic GGUF models.
  - Ensured resolved model paths point to verified target files for both new downloads and cached revisions.
  - Preserved existing paths for regular files, non-GGUF downloads, and split GGUF shards, including uppercase shard filenames.
  - Added validation to reject user-supplied symlinks where a regular GGUF file is required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->