### PR TITLE
fix(skippy): preserve durable restart checkpoints

### DIFF
--- a/crates/skippy-cache/src/l3.rs
+++ b/crates/skippy-cache/src/l3.rs
@@ -14,7 +14,7 @@
 //!   is present and the assembled payload digest matches. Partial state can
 //!   never be loaded — there is nothing to load until commit.
 //! - **Idempotency**: putting a segment that already exists is a no-op;
-//!   concurrent writers of the same bytes converge on one file via
+//!   concurrent writers of the same bytes converge on one object via
 //!   temp-file + atomic rename.
 //! - **Capped budget**: `enforce_budget` evicts oldest manifests first (the
 //!   newest is never evicted) and garbage-collects unreferenced segments.
@@ -33,6 +33,9 @@ use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::fsinfo;
+
+mod packed;
+use packed::{PACK_DIR, PACK_INDEX_DIR, PackedReadRequest, PackedSegmentStore};
 
 const SEGMENT_DIR: &str = "segments";
 const MANIFEST_DIR: &str = "manifests";
@@ -433,6 +436,7 @@ pub struct HandoffSegmentStore {
     /// them. Left unprotected this fails as "manifest references missing
     /// segment" under exactly the pressure the cache is for.
     inflight_segments: Mutex<std::collections::BTreeMap<String, usize>>,
+    packed: PackedSegmentStore,
 }
 
 pub fn segment_digest(bytes: &[u8]) -> String {
@@ -495,7 +499,13 @@ impl HandoffSegmentStore {
                 root.display()
             );
         }
-        for directory in [SEGMENT_DIR, MANIFEST_DIR, PREFIX_INDEX_DIR] {
+        for directory in [
+            SEGMENT_DIR,
+            MANIFEST_DIR,
+            PREFIX_INDEX_DIR,
+            PACK_DIR,
+            PACK_INDEX_DIR,
+        ] {
             let path = root.join(directory);
             fsinfo::refuse_symlinked_descendant(&root, &path)?;
             fs::create_dir_all(&path).with_context(|| {
@@ -505,6 +515,7 @@ impl HandoffSegmentStore {
         }
         fsinfo::restrict_to_owner(&root, 0o700)?;
         let root_lock = acquire_root_lock(&root)?;
+        let packed = PackedSegmentStore::open(&root)?;
         Ok(Self {
             root,
             limits: RwLock::new(limits),
@@ -519,6 +530,7 @@ impl HandoffSegmentStore {
             evicted_manifests: AtomicU64::new(0),
             quarantined_objects: AtomicU64::new(0),
             inflight_segments: Mutex::new(std::collections::BTreeMap::new()),
+            packed,
         })
     }
 
@@ -559,7 +571,13 @@ impl HandoffSegmentStore {
     /// the manager exposes this root to any stage.
     pub fn reconcile_startup(&self) -> Result<StoreReconciliation> {
         let mut report = StoreReconciliation::default();
-        for directory in [SEGMENT_DIR, MANIFEST_DIR, PREFIX_INDEX_DIR] {
+        for directory in [
+            SEGMENT_DIR,
+            MANIFEST_DIR,
+            PREFIX_INDEX_DIR,
+            PACK_DIR,
+            PACK_INDEX_DIR,
+        ] {
             report.removed_temporary_files = report
                 .removed_temporary_files
                 .saturating_add(remove_temporary_files(&self.root.join(directory))?);
@@ -571,6 +589,7 @@ impl HandoffSegmentStore {
                 report.quarantined_manifests += 1;
             }
         }
+        self.rebuild_packed_index()?;
         report.removed_prefix_links = self.remove_dangling_prefix_links()?;
         report.removed_orphan_bytes = self.collect_unreferenced_segments()?;
         Ok(report)
@@ -585,15 +604,15 @@ impl HandoffSegmentStore {
             );
         }
         let mut expected_offset = 0u64;
-        for (position, segment) in manifest.segments.iter().enumerate() {
+        let locations = self
+            .packed
+            .load_manifest_index(key, manifest.segments.len())?;
+        for (position, (segment, location)) in manifest.segments.iter().zip(locations).enumerate() {
             if segment.index as usize != position || segment.offset != expected_offset {
                 bail!("manifest {key} has invalid segment ordering");
             }
-            let metadata = fs::metadata(self.segment_path(&segment.digest))
+            self.validate_segment_ref(segment, location.as_ref())
                 .with_context(|| format!("manifest {key} references a missing segment"))?;
-            if metadata.len() != segment.bytes {
-                bail!("manifest {key} references a truncated segment");
-            }
             expected_offset = expected_offset
                 .checked_add(segment.bytes)
                 .context("manifest segment offsets overflow")?;
@@ -628,6 +647,38 @@ impl HandoffSegmentStore {
 
     fn segment_path(&self, digest: &str) -> PathBuf {
         self.root.join(SEGMENT_DIR).join(format!("{digest}.seg"))
+    }
+
+    fn validate_segment_ref(
+        &self,
+        segment: &HandoffSegmentRef,
+        location: Option<&packed::PackedSegmentLocation>,
+    ) -> Result<()> {
+        if let Some(location) = location {
+            return self.packed.validate(location, segment.bytes);
+        }
+        let metadata = fs::metadata(self.segment_path(&segment.digest))?;
+        if metadata.len() != segment.bytes {
+            bail!("segment {} is truncated", segment.digest);
+        }
+        Ok(())
+    }
+
+    fn rebuild_packed_index(&self) -> Result<()> {
+        let mut entries = Vec::new();
+        for key in self.list_manifests()? {
+            let Ok(manifest) = self.load_manifest(&key) else {
+                continue;
+            };
+            let locations = self
+                .packed
+                .load_manifest_index(&key, manifest.segments.len())?;
+            entries.extend(manifest.segments.into_iter().zip(locations).filter_map(
+                |(segment, location)| location.map(|location| (segment.digest, location)),
+            ));
+        }
+        self.packed.rebuild(entries);
+        Ok(())
     }
 
     fn manifest_path(&self, payload_digest: &str) -> PathBuf {
@@ -824,12 +875,75 @@ impl HandoffSegmentStore {
         }))
     }
 
+    /// Store one spill's logical segments in one immutable physical pack.
+    pub fn try_put_segments<'store>(
+        &'store self,
+        segments: &[&[u8]],
+    ) -> Result<Result<Vec<StoredSegment<'store>>, WriteRefusal>> {
+        let digests = segments
+            .iter()
+            .map(|bytes| segment_digest(bytes))
+            .collect::<Vec<_>>();
+        let holds = digests
+            .iter()
+            .map(|digest| self.hold_segment(digest))
+            .collect::<Vec<_>>();
+        let inputs = digests
+            .iter()
+            .zip(segments)
+            .map(|(digest, bytes)| (digest.as_str(), *bytes))
+            .collect::<Vec<_>>();
+        let estimated = self.packed.estimated_new_bytes(&inputs);
+        let reservation = match self.reserve(estimated)? {
+            Ok(reservation) => reservation,
+            Err(refusal) => return Ok(Err(refusal)),
+        };
+        let (packed, new_bytes) = match self.packed.write_batch(&inputs) {
+            Ok(result) => result,
+            Err(error) => {
+                self.invalidate_usage();
+                return Err(error);
+            }
+        };
+        self.add_usage_bytes(new_bytes);
+        drop(reservation);
+        Ok(Ok(digests
+            .into_iter()
+            .zip(holds)
+            .zip(packed)
+            .zip(segments)
+            .map(|(((digest, hold), packed), bytes)| StoredSegment {
+                digest,
+                put: SegmentPut {
+                    new: packed.new,
+                    bytes: bytes.len() as u64,
+                },
+                _hold: hold,
+            })
+            .collect()))
+    }
+
     pub fn has_segment(&self, digest: &str) -> bool {
-        self.segment_path(digest).exists()
+        self.segment_path(digest).exists() || self.packed.location(digest).is_some()
     }
 
     /// Read one segment, verifying its content digest.
     pub fn read_segment(&self, digest: &str) -> Result<Vec<u8>> {
+        if let Some(location) = self.packed.location(digest) {
+            let requests = [PackedReadRequest {
+                digest,
+                bytes: location.bytes,
+                location: &location,
+            }];
+            return match self.packed.read_many(&requests) {
+                Ok(mut bytes) => bytes.pop().context("packed segment read was empty"),
+                Err(failure) => {
+                    let path = self.packed.pack_path(&failure.pack_digest);
+                    let _ = self.quarantine(&path);
+                    Err(failure.error)
+                }
+            };
+        }
         let path = self.segment_path(digest);
         let bytes = fs::read(&path).with_context(|| format!("failed to read segment {digest}"))?;
         if segment_digest(&bytes) != digest {
@@ -893,7 +1007,13 @@ impl HandoffSegmentStore {
             bail!("manifest has no payload digest");
         }
         let mut expected_offset = 0u64;
-        for (position, segment) in manifest.segments.iter().enumerate() {
+        let locations = manifest
+            .segments
+            .iter()
+            .map(|segment| self.packed.location(&segment.digest))
+            .collect::<Vec<_>>();
+        for (position, (segment, location)) in manifest.segments.iter().zip(&locations).enumerate()
+        {
             if segment.index as usize != position {
                 bail!(
                     "manifest segment order broken: index {} at position {position}",
@@ -907,21 +1027,13 @@ impl HandoffSegmentStore {
                     segment.offset
                 );
             }
-            let path = self.segment_path(&segment.digest);
-            let metadata = fs::metadata(&path).with_context(|| {
-                format!(
-                    "manifest references missing segment {} ({})",
-                    segment.index, segment.digest
-                )
-            })?;
-            if metadata.len() != segment.bytes {
-                bail!(
-                    "segment {} has {} bytes on disk but manifest records {}",
-                    segment.digest,
-                    metadata.len(),
-                    segment.bytes
-                );
-            }
+            self.validate_segment_ref(segment, location.as_ref())
+                .with_context(|| {
+                    format!(
+                        "manifest references missing segment {} ({})",
+                        segment.index, segment.digest
+                    )
+                })?;
             expected_offset = expected_offset
                 .checked_add(segment.bytes)
                 .context("manifest offsets overflow")?;
@@ -941,6 +1053,14 @@ impl HandoffSegmentStore {
         // build its reference map. Indentation is pure cost on a file nobody
         // reads by hand.
         let serialized = serde_json::to_vec(manifest).context("failed to serialize manifest")?;
+        let segment_digests = manifest
+            .segments
+            .iter()
+            .map(|segment| segment.digest.clone())
+            .collect::<Vec<_>>();
+        let packed_index = self
+            .packed
+            .encode_manifest_index(&manifest.payload_digest, &segment_digests)?;
         // The manifest is what makes the segments loadable, so it is pinned
         // while it lands: eviction triggered by its own admission check must
         // not remove the entry being committed.
@@ -956,8 +1076,23 @@ impl HandoffSegmentStore {
                 }
             })?;
         let growth_bytes = (serialized.len() as u64).saturating_sub(replaced_bytes);
-        match self.reserve_write(serialized.len() as u64, growth_bytes)? {
+        let packed_index_path = self.packed.index_path(&manifest.payload_digest);
+        let replaced_index_bytes = fs::metadata(&packed_index_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        let index_bytes = packed_index.as_ref().map_or(0, |bytes| bytes.len() as u64);
+        let write_bytes = (serialized.len() as u64).saturating_add(index_bytes);
+        let total_growth =
+            growth_bytes.saturating_add(index_bytes.saturating_sub(replaced_index_bytes));
+        match self.reserve_write(write_bytes, total_growth)? {
             Ok(_reservation) => {
+                if let Some(index) = &packed_index {
+                    self.packed
+                        .publish_manifest_index(&manifest.payload_digest, index)?;
+                } else {
+                    self.packed
+                        .remove_manifest_index(&manifest.payload_digest)?;
+                }
                 write_atomically(&manifest_path, &serialized)?;
                 fsinfo::restrict_to_owner(&manifest_path, 0o600)?;
             }
@@ -1008,7 +1143,30 @@ impl HandoffSegmentStore {
     pub fn assemble(&self, manifest: &HandoffManifest) -> Result<Vec<u8>> {
         let total = usize::try_from(manifest.total_bytes).context("payload exceeds usize")?;
         let mut payload = Vec::with_capacity(total);
-        for segment in &manifest.segments {
+        let locations = self
+            .packed
+            .load_manifest_index(&manifest.payload_digest, manifest.segments.len())?;
+        let packed_requests = manifest
+            .segments
+            .iter()
+            .zip(&locations)
+            .filter_map(|(segment, location)| {
+                location.as_ref().map(|location| PackedReadRequest {
+                    digest: &segment.digest,
+                    bytes: segment.bytes,
+                    location,
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut packed_bytes = match self.packed.read_many(&packed_requests) {
+            Ok(bytes) => bytes.into_iter(),
+            Err(failure) => {
+                let path = self.packed.pack_path(&failure.pack_digest);
+                let _ = self.quarantine(&path);
+                return Err(failure.error);
+            }
+        };
+        for (segment, location) in manifest.segments.iter().zip(locations) {
             if segment.offset != payload.len() as u64 {
                 bail!(
                     "segment {} offset {} does not match assembled length {}",
@@ -1017,7 +1175,12 @@ impl HandoffSegmentStore {
                     payload.len()
                 );
             }
-            payload.extend_from_slice(&self.read_segment(&segment.digest)?);
+            let bytes = if location.is_some() {
+                packed_bytes.next().context("missing packed segment read")?
+            } else {
+                self.read_segment(&segment.digest)?
+            };
+            payload.extend_from_slice(&bytes);
         }
         if payload.len() != total {
             bail!(
@@ -1032,7 +1195,8 @@ impl HandoffSegmentStore {
     }
 
     pub fn segment_footprint_bytes(&self) -> Result<u64> {
-        directory_bytes(&self.root.join(SEGMENT_DIR))
+        Ok(directory_bytes(&self.root.join(SEGMENT_DIR))?
+            .saturating_add(self.packed.footprint_bytes()?))
     }
 
     /// Every byte the store manages: committed segments, the manifests that
@@ -1054,6 +1218,8 @@ impl HandoffSegmentStore {
     /// Stat every managed file and adopt the result as the running total.
     fn rescan_usage_bytes(&self) -> Result<u64> {
         let mut total = directory_bytes(&self.root.join(SEGMENT_DIR))?;
+        total = total.saturating_add(self.packed.footprint_bytes()?);
+        total = total.saturating_add(self.packed.index_footprint_bytes()?);
         total = total.saturating_add(directory_bytes(&self.root.join(MANIFEST_DIR))?);
         total = total.saturating_add(directory_bytes_recursive(
             &self.root.join(PREFIX_INDEX_DIR),
@@ -1261,18 +1427,30 @@ impl HandoffSegmentStore {
             let Ok(manifest) = self.load_manifest(key) else {
                 continue;
             };
-            for segment in &manifest.segments {
-                let entry = reference_counts
-                    .entry(segment.digest.clone())
-                    .or_insert((0, segment.bytes));
+            let locations = self
+                .packed
+                .load_manifest_index(key, manifest.segments.len())?;
+            for (segment, location) in manifest.segments.iter().zip(&locations) {
+                let (object, bytes) = location.as_ref().map_or_else(
+                    || (segment.digest.clone(), segment.bytes),
+                    |location| {
+                        (
+                            format!("pack:{}", location.pack_digest),
+                            fs::metadata(self.packed.pack_path(&location.pack_digest))
+                                .map(|metadata| metadata.len())
+                                .unwrap_or(0),
+                        )
+                    },
+                );
+                let entry = reference_counts.entry(object).or_insert((0, bytes));
                 entry.0 += 1;
             }
-            manifests.push(manifest);
+            manifests.push((manifest, locations));
         }
         let mut freeable = usage_before;
         let mut evicted_any = false;
         while freeable > target_bytes {
-            let Some(position) = manifests.iter().rposition(|manifest| {
+            let Some(position) = manifests.iter().rposition(|(manifest, _)| {
                 !self.is_pinned(&manifest.payload_digest)
                     && model_identity.is_none_or(|identity| manifest.model_identity == identity)
             }) else {
@@ -1280,7 +1458,7 @@ impl HandoffSegmentStore {
                 // tearing state out from under a live operation is not.
                 break;
             };
-            let evicted = manifests.remove(position);
+            let (evicted, locations) = manifests.remove(position);
             let manifest_path = self.manifest_path(&evicted.payload_digest);
             let manifest_bytes = fs::metadata(&manifest_path)
                 .map(|metadata| metadata.len())
@@ -1288,10 +1466,17 @@ impl HandoffSegmentStore {
             self.invalidate_usage();
             fs::remove_file(&manifest_path)
                 .with_context(|| format!("failed to evict manifest {}", evicted.payload_digest))?;
+            let index_bytes = self.packed.remove_manifest_index(&evicted.payload_digest)?;
             self.evicted_manifests.fetch_add(1, Ordering::Relaxed);
-            freeable = freeable.saturating_sub(manifest_bytes);
-            for segment in &evicted.segments {
-                if let Some(entry) = reference_counts.get_mut(&segment.digest) {
+            freeable = freeable
+                .saturating_sub(manifest_bytes)
+                .saturating_sub(index_bytes);
+            for (segment, location) in evicted.segments.iter().zip(locations) {
+                let object = location.map_or_else(
+                    || segment.digest.clone(),
+                    |location| format!("pack:{}", location.pack_digest),
+                );
+                if let Some(entry) = reference_counts.get_mut(&object) {
                     entry.0 = entry.0.saturating_sub(1);
                     if entry.0 == 0 {
                         freeable = freeable.saturating_sub(entry.1);
@@ -1358,6 +1543,7 @@ impl HandoffSegmentStore {
                     return Err(error).with_context(|| format!("failed to clear manifest {key}"));
                 }
             }
+            self.packed.remove_manifest_index(&key)?;
         }
         self.remove_dangling_prefix_links()?;
         self.collect_unreferenced_segments()?;
@@ -1382,14 +1568,22 @@ impl HandoffSegmentStore {
         // Files are about to be removed or rewritten in bulk.
         self.invalidate_usage();
         let mut referenced = std::collections::HashSet::new();
-        for key in self.list_manifests()? {
-            if let Ok(manifest) = self.load_manifest(&key) {
+        let manifest_keys = self.list_manifests()?;
+        for key in &manifest_keys {
+            if let Ok(manifest) = self.load_manifest(key) {
                 for segment in manifest.segments {
                     referenced.insert(segment.digest);
                 }
             }
         }
         let mut freed = 0u64;
+        let held = self
+            .inflight_segments
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .keys()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
         for entry in fs::read_dir(self.root.join(SEGMENT_DIR))? {
             let entry = entry?;
             let path = entry.path();
@@ -1399,17 +1593,17 @@ impl HandoffSegmentStore {
             else {
                 continue;
             };
-            let held = self
-                .inflight_segments
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .contains_key(&stem);
-            if !referenced.contains(&stem) && !held {
+            if !referenced.contains(&stem) && !held.contains(&stem) {
                 freed = freed.saturating_add(entry.metadata()?.len());
                 fs::remove_file(&path)
                     .with_context(|| format!("failed to collect segment {stem}"))?;
             }
         }
+        let manifests = manifest_keys
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>();
+        freed = freed.saturating_add(self.packed.remove_orphan_indexes(&manifests)?);
+        freed = freed.saturating_add(self.packed.remove_orphan_packs(&referenced, &held)?);
         Ok(freed)
     }
 }

--- a/crates/skippy-cache/src/l3/packed.rs
+++ b/crates/skippy-cache/src/l3/packed.rs
@@ -1,0 +1,479 @@
+//! Append-only physical storage for logical L3 segments.
+//!
+//! One spill publishes at most one immutable pack. A local sidecar maps the
+//! manifest's portable segment digests to pack offsets, keeping the handoff
+//! manifest independent of this node's physical layout.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fs::{self, File},
+    io::{Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    sync::{Mutex, RwLock},
+};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use super::{segment_digest, tempfile_in, write_atomically};
+use crate::fsinfo;
+
+pub(super) const PACK_DIR: &str = "packs";
+pub(super) const PACK_INDEX_DIR: &str = "pack-indexes";
+const PACK_INDEX_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub(super) struct PackedSegmentLocation {
+    pub pack_digest: String,
+    pub offset: u64,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PackedManifestIndex {
+    version: u32,
+    payload_digest: String,
+    segments: Vec<Option<PackedSegmentLocation>>,
+}
+
+#[derive(Debug)]
+pub(super) struct PackedStoredSegment {
+    pub new: bool,
+}
+
+#[derive(Debug)]
+pub(super) struct PackedReadError {
+    pub pack_digest: String,
+    pub error: anyhow::Error,
+}
+
+#[derive(Debug)]
+pub(super) struct PackedReadRequest<'a> {
+    pub digest: &'a str,
+    pub bytes: u64,
+    pub location: &'a PackedSegmentLocation,
+}
+
+#[derive(Debug)]
+pub(super) struct PackedSegmentStore {
+    directory: PathBuf,
+    index_directory: PathBuf,
+    locations: RwLock<HashMap<String, PackedSegmentLocation>>,
+    /// Serializes immutable pack publication with orphan collection.
+    mutation: Mutex<()>,
+}
+
+impl PackedSegmentStore {
+    pub(super) fn open(root: &Path) -> Result<Self> {
+        let directory = root.join(PACK_DIR);
+        let index_directory = root.join(PACK_INDEX_DIR);
+        for path in [&directory, &index_directory] {
+            fsinfo::refuse_symlinked_descendant(root, path)?;
+            fs::create_dir_all(path)
+                .with_context(|| format!("failed to create {}", path.display()))?;
+            fsinfo::restrict_to_owner(path, 0o700)?;
+        }
+        Ok(Self {
+            directory,
+            index_directory,
+            locations: RwLock::new(HashMap::new()),
+            mutation: Mutex::new(()),
+        })
+    }
+
+    pub(super) fn pack_path(&self, pack_digest: &str) -> PathBuf {
+        self.directory.join(format!("{pack_digest}.pack"))
+    }
+
+    pub(super) fn index_path(&self, payload_digest: &str) -> PathBuf {
+        self.index_directory.join(format!("{payload_digest}.json"))
+    }
+
+    pub(super) fn estimated_new_bytes(&self, segments: &[(&str, &[u8])]) -> u64 {
+        let locations = self
+            .locations
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut unique = HashSet::new();
+        segments
+            .iter()
+            .filter(|(digest, _)| unique.insert(*digest))
+            .filter(|(digest, _)| {
+                locations
+                    .get(*digest)
+                    .is_none_or(|location| !self.location_is_present(location))
+            })
+            .map(|(_, bytes)| bytes.len() as u64)
+            .fold(0u64, u64::saturating_add)
+    }
+
+    /// Publish all missing logical segments as one immutable pack.
+    pub(super) fn write_batch(
+        &self,
+        segments: &[(&str, &[u8])],
+    ) -> Result<(Vec<PackedStoredSegment>, u64)> {
+        let _mutation = self
+            .mutation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let existing = self
+            .locations
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        let mut planned = HashMap::<String, PackedSegmentLocation>::new();
+        let mut pack_segments = Vec::new();
+        let mut pack_hasher = blake3::Hasher::new();
+        let mut candidate_bytes = 0u64;
+        let mut new_digests = HashSet::new();
+
+        for (digest, bytes) in segments {
+            if existing
+                .get(*digest)
+                .is_some_and(|location| self.location_is_present(location))
+                || planned.contains_key(*digest)
+            {
+                continue;
+            }
+            let offset = candidate_bytes;
+            candidate_bytes = candidate_bytes
+                .checked_add(bytes.len() as u64)
+                .context("packed object size overflows u64")?;
+            pack_hasher.update(bytes);
+            pack_segments.push(*bytes);
+            planned.insert(
+                (*digest).to_string(),
+                PackedSegmentLocation {
+                    pack_digest: String::new(),
+                    offset,
+                    bytes: bytes.len() as u64,
+                },
+            );
+            new_digests.insert((*digest).to_string());
+        }
+
+        let mut new_bytes = 0u64;
+        if !pack_segments.is_empty() {
+            let pack_digest = pack_hasher.finalize().to_hex().to_string();
+            let path = self.pack_path(&pack_digest);
+            if path.exists() {
+                let actual = fs::metadata(&path)?.len();
+                if actual != candidate_bytes {
+                    bail!(
+                        "packed object {pack_digest} has {actual} bytes but the write has {candidate_bytes}"
+                    );
+                }
+            } else {
+                write_pack_atomically(&path, &pack_segments)?;
+                fsinfo::restrict_to_owner(&path, 0o600)?;
+                new_bytes = candidate_bytes;
+            }
+            for location in planned.values_mut() {
+                location.pack_digest.clone_from(&pack_digest);
+            }
+        }
+
+        let mut locations = self
+            .locations
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for (digest, location) in &planned {
+            locations.insert(digest.clone(), location.clone());
+        }
+        let published_new_pack = new_bytes > 0;
+        let mut reported_new = HashSet::new();
+        let stored = segments
+            .iter()
+            .map(|(digest, _)| PackedStoredSegment {
+                new: published_new_pack
+                    && new_digests.contains(*digest)
+                    && reported_new.insert(*digest),
+            })
+            .collect();
+        Ok((stored, new_bytes))
+    }
+
+    pub(super) fn location(&self, digest: &str) -> Option<PackedSegmentLocation> {
+        self.locations
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(digest)
+            .filter(|location| self.location_is_present(location))
+            .cloned()
+    }
+
+    pub(super) fn encode_manifest_index(
+        &self,
+        payload_digest: &str,
+        segment_digests: &[String],
+    ) -> Result<Option<Vec<u8>>> {
+        let segments = segment_digests
+            .iter()
+            .map(|digest| self.location(digest))
+            .collect::<Vec<_>>();
+        if segments.iter().all(Option::is_none) {
+            return Ok(None);
+        }
+        serde_json::to_vec(&PackedManifestIndex {
+            version: PACK_INDEX_VERSION,
+            payload_digest: payload_digest.to_string(),
+            segments,
+        })
+        .context("failed to serialize packed manifest index")
+        .map(Some)
+    }
+
+    pub(super) fn publish_manifest_index(
+        &self,
+        payload_digest: &str,
+        encoded: &[u8],
+    ) -> Result<()> {
+        let path = self.index_path(payload_digest);
+        write_atomically(&path, encoded)?;
+        fsinfo::restrict_to_owner(&path, 0o600)
+    }
+
+    pub(super) fn load_manifest_index(
+        &self,
+        payload_digest: &str,
+        segment_count: usize,
+    ) -> Result<Vec<Option<PackedSegmentLocation>>> {
+        let path = self.index_path(payload_digest);
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(vec![None; segment_count]);
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let index: PackedManifestIndex =
+            serde_json::from_slice(&bytes).context("malformed packed manifest index")?;
+        if index.version != PACK_INDEX_VERSION
+            || index.payload_digest != payload_digest
+            || index.segments.len() != segment_count
+        {
+            bail!("packed manifest index does not match manifest {payload_digest}");
+        }
+        for location in index.segments.iter().flatten() {
+            if !is_digest(&location.pack_digest) || location.bytes == 0 {
+                bail!("packed manifest index contains an invalid location");
+            }
+            location
+                .offset
+                .checked_add(location.bytes)
+                .context("packed manifest index range overflows")?;
+        }
+        Ok(index.segments)
+    }
+
+    pub(super) fn remove_manifest_index(&self, payload_digest: &str) -> Result<u64> {
+        let path = self.index_path(payload_digest);
+        let bytes = fs::metadata(&path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        match fs::remove_file(&path) {
+            Ok(()) => Ok(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(0),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub(super) fn validate(&self, location: &PackedSegmentLocation, bytes: u64) -> Result<()> {
+        if location.bytes != bytes {
+            bail!(
+                "packed index records {} bytes but manifest records {bytes}",
+                location.bytes
+            );
+        }
+        let pack_bytes = fs::metadata(self.pack_path(&location.pack_digest))
+            .with_context(|| format!("missing pack {}", location.pack_digest))?
+            .len();
+        let end = location
+            .offset
+            .checked_add(bytes)
+            .context("packed segment range overflows")?;
+        if end > pack_bytes {
+            bail!(
+                "pack {} has {pack_bytes} bytes but segment range ends at {end}",
+                location.pack_digest
+            );
+        }
+        Ok(())
+    }
+
+    /// Read requests in logical order while opening each physical pack once.
+    pub(super) fn read_many(
+        &self,
+        requests: &[PackedReadRequest<'_>],
+    ) -> Result<Vec<Vec<u8>>, PackedReadError> {
+        let mut files = HashMap::<String, File>::new();
+        let mut output = Vec::with_capacity(requests.len());
+        for request in requests {
+            let result = (|| -> Result<Vec<u8>> {
+                let file = match files.entry(request.location.pack_digest.clone()) {
+                    std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        let file = File::open(self.pack_path(&request.location.pack_digest))
+                            .with_context(|| {
+                                format!("failed to open pack {}", request.location.pack_digest)
+                            })?;
+                        entry.insert(file)
+                    }
+                };
+                file.seek(SeekFrom::Start(request.location.offset))?;
+                let len = usize::try_from(request.bytes).context("segment exceeds usize")?;
+                let mut bytes = vec![0u8; len];
+                file.read_exact(&mut bytes)?;
+                if segment_digest(&bytes) != request.digest {
+                    bail!(
+                        "packed segment {} failed digest verification",
+                        request.digest
+                    );
+                }
+                Ok(bytes)
+            })();
+            match result {
+                Ok(bytes) => output.push(bytes),
+                Err(error) => {
+                    return Err(PackedReadError {
+                        pack_digest: request.location.pack_digest.clone(),
+                        error,
+                    });
+                }
+            }
+        }
+        Ok(output)
+    }
+
+    pub(super) fn rebuild(
+        &self,
+        entries: impl IntoIterator<Item = (String, PackedSegmentLocation)>,
+    ) {
+        let mut locations = self
+            .locations
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        locations.clear();
+        locations.extend(entries);
+    }
+
+    pub(super) fn remove_orphan_packs(
+        &self,
+        referenced_segments: &HashSet<String>,
+        held_segments: &HashSet<String>,
+    ) -> Result<u64> {
+        let _mutation = self
+            .mutation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let locations = self
+            .locations
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let protected = locations
+            .iter()
+            .filter(|(digest, _)| {
+                referenced_segments.contains(*digest) || held_segments.contains(*digest)
+            })
+            .map(|(_, location)| location.pack_digest.clone())
+            .collect::<HashSet<_>>();
+        let mut freed = 0u64;
+        for entry in fs::read_dir(&self.directory)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().is_none_or(|extension| extension != "pack") {
+                continue;
+            }
+            let Some(pack_digest) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                continue;
+            };
+            if protected.contains(pack_digest) {
+                continue;
+            }
+            freed = freed.saturating_add(entry.metadata()?.len());
+            fs::remove_file(&path)
+                .with_context(|| format!("failed to collect pack {pack_digest}"))?;
+        }
+        Ok(freed)
+    }
+
+    pub(super) fn remove_orphan_indexes(&self, manifests: &HashSet<String>) -> Result<u64> {
+        let mut freed = 0u64;
+        for entry in fs::read_dir(&self.index_directory)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().is_none_or(|extension| extension != "json") {
+                continue;
+            }
+            let Some(payload_digest) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                continue;
+            };
+            if manifests.contains(payload_digest) {
+                continue;
+            }
+            freed = freed.saturating_add(entry.metadata()?.len());
+            fs::remove_file(&path)?;
+        }
+        Ok(freed)
+    }
+
+    pub(super) fn footprint_bytes(&self) -> Result<u64> {
+        directory_bytes(&self.directory)
+    }
+
+    pub(super) fn index_footprint_bytes(&self) -> Result<u64> {
+        directory_bytes(&self.index_directory)
+    }
+
+    fn location_is_present(&self, location: &PackedSegmentLocation) -> bool {
+        self.pack_path(&location.pack_digest)
+            .metadata()
+            .is_ok_and(|metadata| location.offset < metadata.len())
+    }
+}
+
+fn directory_bytes(directory: &Path) -> Result<u64> {
+    let mut total = 0u64;
+    for entry in fs::read_dir(directory)? {
+        let entry = entry?;
+        if entry.file_type()?.is_file() {
+            total = total.saturating_add(entry.metadata()?.len());
+        }
+    }
+    Ok(total)
+}
+
+fn write_pack_atomically(path: &Path, segments: &[&[u8]]) -> Result<()> {
+    let directory = path.parent().context("pack path has no parent directory")?;
+    let (temp_path, mut temp_file) = tempfile_in(directory)?;
+    let write_result = (|| -> Result<()> {
+        for segment in segments {
+            temp_file
+                .write_all(segment)
+                .with_context(|| format!("failed to write {}", temp_path.display()))?;
+        }
+        temp_file
+            .sync_all()
+            .with_context(|| format!("failed to sync {}", temp_path.display()))
+    })();
+    drop(temp_file);
+    let publish_result = write_result.and_then(|()| fsinfo::replace_file(&temp_path, path));
+    if let Err(error) = publish_result {
+        return match fs::remove_file(&temp_path) {
+            Ok(()) => Err(error),
+            Err(cleanup) if cleanup.kind() == std::io::ErrorKind::NotFound => Err(error),
+            Err(cleanup) => Err(error.context(format!(
+                "also failed to remove temporary pack {}: {cleanup}",
+                temp_path.display()
+            ))),
+        };
+    }
+    Ok(())
+}
+
+fn is_digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}

--- a/crates/skippy-cache/src/l3/tests.rs
+++ b/crates/skippy-cache/src/l3/tests.rs
@@ -50,6 +50,36 @@ fn commit_payload(
     manifest
 }
 
+fn commit_packed_payload(
+    store: &HandoffSegmentStore,
+    payload: &[u8],
+    segment_bytes: usize,
+) -> HandoffManifest {
+    let chunks = payload.chunks(segment_bytes).collect::<Vec<_>>();
+    let held = store
+        .try_put_segments(&chunks)
+        .expect("packed put")
+        .expect("packed put admitted");
+    let mut manifest = HandoffManifest::new("blake3:test".to_string(), "full-state".into());
+    let mut offset = 0u64;
+    for (index, stored) in held.iter().enumerate() {
+        let bytes = chunks[index].len() as u64;
+        manifest.segments.push(HandoffSegmentRef {
+            index: index as u32,
+            offset,
+            bytes,
+            digest: stored.digest.clone(),
+            meta_json: None,
+        });
+        offset += bytes;
+    }
+    manifest.total_bytes = payload.len() as u64;
+    manifest.payload_digest = segment_digest(payload);
+    store.commit(&manifest).expect("packed commit");
+    drop(held);
+    manifest
+}
+
 fn temp_root(name: &str) -> PathBuf {
     let root = std::env::temp_dir()
         .join("skippy-l3-tests")
@@ -68,6 +98,73 @@ fn roundtrip_assembles_identical_payload() {
         .load_manifest(&manifest.payload_digest)
         .expect("load manifest");
     assert_eq!(store.assemble(&loaded).expect("assemble"), payload);
+}
+
+#[test]
+fn packed_roundtrip_uses_one_physical_file_and_survives_reopen() {
+    let root = temp_root("packed-roundtrip");
+    let payload: Vec<u8> = (0..100_000u32).map(|value| value as u8).collect();
+    let manifest = {
+        let store = store(&root, 0);
+        let manifest = commit_packed_payload(&store, &payload, 4096);
+        assert_eq!(fs::read_dir(root.join(PACK_DIR)).unwrap().count(), 1);
+        assert_eq!(fs::read_dir(root.join(SEGMENT_DIR)).unwrap().count(), 0);
+        let manifest_json = fs::read_to_string(store.manifest_path(&manifest.payload_digest))
+            .expect("read portable manifest");
+        assert!(!manifest_json.contains("pack_digest"));
+        assert_eq!(store.assemble(&manifest).expect("assemble"), payload);
+        manifest
+    };
+
+    let reopened = store(&root, 0);
+    reopened
+        .reconcile_startup()
+        .expect("reconcile packed store");
+    let loaded = reopened
+        .load_manifest(&manifest.payload_digest)
+        .expect("load packed manifest after restart");
+    assert_eq!(reopened.assemble(&loaded).expect("assemble"), payload);
+}
+
+#[test]
+fn corrupt_pack_is_quarantined_and_never_served() {
+    let root = temp_root("packed-corruption");
+    let store = store(&root, 0);
+    let payload: Vec<u8> = (0..32_000u32).map(|value| value as u8).collect();
+    let manifest = commit_packed_payload(&store, &payload, 4096);
+    let pack = fs::read_dir(root.join(PACK_DIR))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let mut bytes = fs::read(&pack).unwrap();
+    bytes[0] ^= 0xff;
+    fs::write(&pack, bytes).unwrap();
+
+    assert!(store.assemble(&manifest).is_err());
+    assert!(!pack.exists());
+    assert!(root.join(QUARANTINE_DIR).exists());
+}
+
+#[test]
+fn uncommitted_pack_is_collected_after_holds_release() {
+    let root = temp_root("packed-orphan");
+    let store = store(&root, 0);
+    let payload = (0..16_000)
+        .map(|index| (index / 1024) as u8)
+        .collect::<Vec<_>>();
+    let chunks = payload.chunks(1024).collect::<Vec<_>>();
+    let held = store
+        .try_put_segments(&chunks)
+        .unwrap()
+        .expect("packed put admitted");
+    assert_eq!(store.collect_unreferenced_segments().unwrap(), 0);
+    drop(held);
+    assert_eq!(
+        store.collect_unreferenced_segments().unwrap(),
+        payload.len() as u64
+    );
 }
 
 #[test]

--- a/crates/skippy-cache/src/tier.rs
+++ b/crates/skippy-cache/src/tier.rs
@@ -300,27 +300,35 @@ impl L3Tier {
                 cuts
             }
         };
+        let segment_slices = cuts
+            .iter()
+            .map(|(offset, len, _)| {
+                let start = usize::try_from(*offset).context("segment offset exceeds usize")?;
+                let end = start
+                    .checked_add(usize::try_from(*len).context("segment length exceeds usize")?)
+                    .context("segment range overflows")?;
+                Ok(&wire[start..end])
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let stored_segments = match self.store().try_put_segments(&segment_slices) {
+            Ok(Ok(stored)) => stored,
+            Ok(Err(refusal)) => {
+                self.manager.record_write_refusal(refusal);
+                bail!("cannot store packed segments: {}", refusal.reason());
+            }
+            Err(error) => {
+                self.manager.record_storage_error();
+                return Err(error);
+            }
+        };
         let mut new_bytes = 0u64;
         // Held until after the commit below: until the manifest names them
         // these segments are unreferenced, and an eviction triggered by
         // another writer would collect them mid-build.
-        let mut held = Vec::with_capacity(manifest.segments.capacity());
-        for (index, (offset, len, label)) in cuts.into_iter().enumerate() {
-            let start = usize::try_from(offset).context("segment offset exceeds usize")?;
-            let end = start
-                .checked_add(usize::try_from(len).context("segment length exceeds usize")?)
-                .context("segment range overflows")?;
-            let stored = match self.store().try_put_segment(&wire[start..end]) {
-                Ok(Ok(stored)) => stored,
-                Ok(Err(refusal)) => {
-                    self.manager.record_write_refusal(refusal);
-                    bail!("cannot store segment: {}", refusal.reason());
-                }
-                Err(error) => {
-                    self.manager.record_storage_error();
-                    return Err(error);
-                }
-            };
+        let mut held = Vec::with_capacity(stored_segments.len());
+        for ((index, (offset, len, label)), stored) in
+            cuts.into_iter().enumerate().zip(stored_segments)
+        {
             if stored.put.new {
                 new_bytes = new_bytes.saturating_add(stored.put.bytes);
             }

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -169,7 +169,7 @@ impl KvStageIntegration {
         let worker_exact_state_record_worker_healthy = exact_state_record_worker_healthy.clone();
         let exact_state_record_worker_panics = Arc::new(std::sync::atomic::AtomicU64::new(0));
         let worker_exact_state_record_worker_panics = exact_state_record_worker_panics.clone();
-        std::thread::Builder::new()
+        let exact_state_record_task = std::thread::Builder::new()
             .name(format!("skippy-exact-cache-{}", config.stage_id))
             .spawn(move || {
                 while let Ok(pending) = exact_state_record_rx.recv() {
@@ -204,6 +204,10 @@ impl KvStageIntegration {
                     }
                 }
             })?;
+        let exact_state_record_worker = Arc::new(super::ExactStateRecordWorker::new(
+            exact_state_record_tx,
+            exact_state_record_task,
+        ));
         Ok(Some(Self {
             mode,
             payload,
@@ -222,7 +226,7 @@ impl KvStageIntegration {
             exact_blobs,
             exact_max_entries,
             exact_byte_limits,
-            exact_state_record_tx,
+            exact_state_record_worker,
             exact_state_records_queued,
             exact_state_records_dropped,
             exact_state_records_pending,

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -5,6 +5,7 @@ use std::{
         atomic::{AtomicBool, AtomicU64, AtomicUsize},
         mpsc::{SyncSender, TrySendError},
     },
+    thread::JoinHandle,
 };
 
 use anyhow::{Result, bail};
@@ -167,7 +168,7 @@ pub struct KvStageIntegration {
     pub(crate) exact_blobs: Arc<Mutex<CacheBlobStore>>,
     pub(crate) exact_max_entries: usize,
     pub(crate) exact_byte_limits: ExactStateByteLimits,
-    pub(crate) exact_state_record_tx: SyncSender<PendingExactStateRecord>,
+    pub(crate) exact_state_record_worker: Arc<ExactStateRecordWorker>,
     pub(crate) exact_state_records_queued: Arc<AtomicU64>,
     pub(crate) exact_state_records_dropped: Arc<AtomicU64>,
     pub(crate) exact_state_records_pending: Arc<AtomicUsize>,
@@ -225,6 +226,49 @@ pub(crate) struct PendingExactStateRecord {
     /// so requests arriving during the asynchronous re-warm prefill normally
     /// instead of duplicating the disk read.
     pub(crate) l3_fill_claim: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ExactStateRecordWorker {
+    sender: Mutex<Option<SyncSender<PendingExactStateRecord>>>,
+    task: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl ExactStateRecordWorker {
+    pub(crate) fn new(sender: SyncSender<PendingExactStateRecord>, task: JoinHandle<()>) -> Self {
+        Self {
+            sender: Mutex::new(Some(sender)),
+            task: Mutex::new(Some(task)),
+        }
+    }
+
+    fn with_sender<T>(
+        &self,
+        use_sender: impl FnOnce(Option<&SyncSender<PendingExactStateRecord>>) -> T,
+    ) -> T {
+        let sender = self
+            .sender
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        use_sender(sender.as_ref())
+    }
+}
+
+impl Drop for ExactStateRecordWorker {
+    fn drop(&mut self) {
+        self.sender
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(task) = self
+            .task
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+        {
+            let _ = task.join();
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -596,17 +640,25 @@ impl KvStageIntegration {
         &self,
         pending: PendingExactStateRecord,
     ) -> ExactStateRecordAdmission {
-        enqueue_exact_state_record(
-            &self.exact_state_record_tx,
-            &self.inflight_records,
-            &self.exact_state_records_queued,
-            &self.exact_state_records_dropped,
-            &self.exact_state_records_pending,
-            &self.exact_state_record_queue_bytes,
-            EXACT_STATE_RECORD_QUEUE_BYTES,
-            &self.exact_state_record_worker_healthy,
-            pending,
-        )
+        self.exact_state_record_worker.with_sender(|sender| {
+            let Some(sender) = sender else {
+                self.finish_record(&pending.page_id);
+                self.exact_state_records_dropped
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                return ExactStateRecordAdmission::WorkerStopped;
+            };
+            enqueue_exact_state_record(
+                sender,
+                &self.inflight_records,
+                &self.exact_state_records_queued,
+                &self.exact_state_records_dropped,
+                &self.exact_state_records_pending,
+                &self.exact_state_record_queue_bytes,
+                EXACT_STATE_RECORD_QUEUE_BYTES,
+                &self.exact_state_record_worker_healthy,
+                pending,
+            )
+        })
     }
 
     pub async fn hello(&self) -> Result<()> {
@@ -1013,8 +1065,8 @@ mod exact_state_record_queue_tests {
 
     use super::{
         BTreeSet, EXACT_STATE_RECORD_CAPACITY, ExactStateExtra, ExactStateRecordAdmission,
-        PendingExactStateRecord, enqueue_exact_state_record, has_exact_state_record_capacity,
-        run_exact_state_record_job,
+        ExactStateRecordWorker, PendingExactStateRecord, enqueue_exact_state_record,
+        has_exact_state_record_capacity, run_exact_state_record_job,
     };
 
     fn pending(page_id: &str) -> PendingExactStateRecord {
@@ -1036,6 +1088,24 @@ mod exact_state_record_queue_tests {
     }
 
     const CAP: u64 = 1024;
+
+    #[test]
+    fn final_worker_owner_drains_queued_records_before_drop_returns() {
+        let (sender, receiver) = sync_channel(2);
+        let completed = Arc::new(AtomicUsize::new(0));
+        let worker_completed = completed.clone();
+        let task = std::thread::spawn(move || {
+            while receiver.recv().is_ok() {
+                worker_completed.fetch_add(1, Ordering::Release);
+            }
+        });
+        let worker = Arc::new(ExactStateRecordWorker::new(sender, task));
+        worker.with_sender(|sender| sender.unwrap().send(pending("latest")).unwrap());
+
+        drop(worker);
+
+        assert_eq!(completed.load(Ordering::Acquire), 1);
+    }
 
     #[test]
     fn pending_capacity_signal_rejects_work_before_export() {

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -3699,7 +3699,7 @@
   ],
   "crates/skippy-cache/src/l3/tests.rs": [
     {
-      "line": 508,
+      "line": 605,
       "macro_name": "println!"
     }
   ],


### PR DESCRIPTION
The durable L3 writer emitted one file per logical segment and let the background record worker outlive server shutdown. A 1,792-token checkpoint therefore required 1,680 segment publications and was committed only after the restart began, leaving the first restored request with 501 usable tokens.

This change writes each checkpoint's missing logical segments into one immutable pack with a local offset index, rebuilds and validates that index at startup, accounts for the physical pack and sidecar in eviction, and drains the final record worker during graceful shutdown. Portable manifests and logical segment digests stay unchanged.

The pre-restack release replay on the patch-equivalent commit `eb1718386` produced:

| cohort | control | packed L3 |
|---|---:|---:|
| restore p50 | 370 ms, 0% cached | 264 ms, 99.7% cached |
| warm p50 | 13 ms, 99.9% cached | 13 ms, 99.9% cached |
| failed requests | 0 | 0 |

The fix makes the latest useful checkpoint durable before restart: 1,951 of 1,957 prompt tokens restore. The resulting 1.40x speedup remains below #1576's 2x gate; #1736 reduces the next read-side cost.

## Stack

- Base: #1714
- This PR: packed physical storage and shutdown drain for #1648
- Next: #1736 streaming restore

## Validation

- `cargo test -p skippy-cache --lib` — 121 passed, 1 ignored
- `cargo test -p skippy-server --lib` — 706 passed, 3 ignored
- warning-denying Clippy for `skippy-cache`, `skippy-server`, and `mesh-llm`
- `cargo check -p mesh-llm`
- `cargo fmt --all --check`
- release host and native runtime builds
