### PR TITLE
ci: stop duplicate release tag runs

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -21,7 +21,7 @@ Read it with `../SKILL.md` and `ci/ci.md` before editing CI.
 | `main_windows.yml` (`Main · Windows`) | push to `main` | Exhaustive main planning plus the same-commit reusable Windows lane |
 | `ci.yml` | `workflow_call` only | Temporary inert shim for the former main ingress filename; pending protected-main runner-contract update; no push trigger or dispatch |
 | `ci-control.yml` (`CI · Manual Full`) | dispatch on default branch | Explicit operator-only full plan, bounded lane dispatch and correlated diagnostic checks |
-| `release.yml` | release tags, dispatch | Canonical version synchronization, release-only signing, assets, publication, and a preflighted downstream `mesh-packaging` dispatch |
+| `release.yml` | dispatch on the default branch | Canonical version synchronization, release-only signing, assets, publication, and a preflighted downstream `mesh-packaging` dispatch |
 | `website-pages.yml` | main website paths, dispatch | Public website deployment |
 | `pr_cleanup.yml` | PR close, dispatch | Positively matched cleanup only |
 | `pr_auto_assign.yml` | PR lifecycle | Metadata only |
@@ -118,10 +118,8 @@ For a non-canary manual dispatch, `release.yml` runs the checked-in
 `scripts/release-version.sh`, creates one linear release-source commit when the
 tracked version surface changes, and fast-forwards `main` before any release
 build starts. `just release` is a preflight and synchronous dispatcher for that
-same workflow. A tag-push release is read-only with respect to `main` and is
-accepted only when the tag is already reachable from `main` and applying the
-same version script produces no tracked diff. Canary dispatches never update
-`main` or publish. The publish job creates only the release-specific tag commit
+same workflow. Canary dispatches never update `main` or publish. The publish job
+creates only the release-specific tag commit
 for generated Swift/SDK resources and enables GitHub-generated release notes.
 The comparison base is the highest stable `vMAJOR.MINOR.PATCH` tag below the
 target; prerelease tags are excluded so RC and final notes use the same stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ name: Release
 # GPU runner; unset or false uses GitHub-hosted runners.
 
 on:
-  push:
-    tags: ['v*']
   workflow_dispatch:
     inputs:
       version:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -151,9 +151,11 @@ just release-build-cuda
 just release-bundle-cuda v0.X.Y
 ```
 
-Before manually cutting a tag that should be consumable through SwiftPM,
-prepare the Swift binary target manifest on macOS and commit the resulting
-`Package.swift` change:
+Before dispatching a release that should be consumable through SwiftPM,
+prepare the Swift binary target manifest on macOS and land the resulting
+`Package.swift` change on `main`. This is local preparation only; it publishes
+nothing, and the release itself is still cut by dispatching the Release
+workflow, which creates the tag:
 
 ```bash
 scripts/prepare-swift-package-release.sh v0.X.Y

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -29,12 +29,11 @@ dispatch the full packaging matrix.
 
 Do not use GitHub's bare **Draft a new release** form as an alternate release
 path. It bypasses the verified artifact graph. The Release workflow is the only
-supported GitHub release publisher; the Actions UI, `just release`, and a
-pre-versioned tag all enter that workflow.
+supported GitHub release publisher; use the Actions UI or `just release` to
+dispatch it from `main`.
 
-The sections below document the underlying steps. They matter when releasing
-manually via a tag push, debugging the workflow, or validating bundles
-locally.
+The sections below document the underlying steps, workflow debugging, and local
+bundle validation.
 
 ## Prerequisites
 
@@ -169,10 +168,10 @@ exact platform and architecture slices plus the macOS framework layout, runs a
 zipped-artifact SwiftPM consumer smoke, and checks that the tagged
 `Package.swift` already points at the exact release URL and checksum. The
 producer also uploads the generated `mesh_ffi.swift` as a separate immutable
-companion artifact. Main and tag builds fail when that generated binding drifts
-from the tracked source. If `Package.swift` still contains placeholders on a
-tag push, if the generated binding is stale, or if the checksum does not match
-the artifact built in release CI, the release fails before publishing.
+companion artifact. Main release builds fail when that generated binding drifts
+from the tracked source. If the generated binding is stale, or if the checksum
+does not match the artifact built in release CI, the release fails before
+publishing.
 Producer and smoke use the pinned `macos-15` image and an explicit native/Xcode
 cache epoch. Downstream Swift smoke consumes both verified producer artifacts
 and never compiles an XCFramework replacement.
@@ -231,23 +230,8 @@ Verify:
 
 ## Publish
 
-Push a `v*` tag to run `.github/workflows/release.yml`. This lower-level path is
-accepted only when the tag points to `main` history and already contains the
-complete matching version update. Prepare and commit it before creating the
-tag:
-
-```bash
-scripts/release-version.sh v0.X.Y
-git add --update
-git commit -m "v0.X.Y: prepare release source"
-git push origin main
-git tag v0.X.Y
-git push origin v0.X.Y
-```
-
-The workflow rejects version-drifted tags instead of publishing binaries whose
-source version disagrees with the release. The upstream release workflow owns
-release archive production, but it does not publish OCI images.
+The dispatched release workflow owns release archive production, but it does
+not publish OCI images.
 `Mesh-LLM/mesh-packaging` is the canonical package, GHCR, and npm producer. It
 starts only after a stable GitHub release and its complete CPU/GPU archive set
 have published successfully. Prereleases never dispatch it. The upstream
@@ -281,14 +265,6 @@ The script builds `crates/mesh-llm-ui/dist` in release mode and copies it to
 the canonical SDK resource locations: `sdk/node/console`,
 `sdk/swift/Sources/MeshLLM/Resources/Console`, and
 `sdk/kotlin/src/main/resources/mesh-llm/console`.
-
-These generated directories are ignored during normal development. For a
-manual tag push, force-add them into the release commit before tagging because
-SwiftPM resolves package resources from the Git tag:
-
-```bash
-git add -f sdk/node/console sdk/swift/Sources/MeshLLM/Resources/Console sdk/kotlin/src/main/resources/mesh-llm/console
-```
 
 Workflow-dispatch releases generate and force-add these resources into the
 release tag commit automatically.

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -152,10 +152,8 @@ Release efficiency TODOs:
 surface. On a non-canary `release.yml` dispatch, the metadata job applies that
 script, creates a linear release-source commit when needed, and fast-forwards
 `main` before the build graph begins. `just release` only performs local
-preflight, dispatches that workflow, and waits for its result. A tag push must
-already be reachable from `main` and version-complete; the metadata job applies
-the same script and rejects any tracked diff. Canary dispatches do not mutate
-`main` or publish.
+preflight, dispatches that workflow, and waits for its result. Canary dispatches
+do not mutate `main` or publish.
 
 Release calls the existing UI producer once with the immutable source SHA and
 release tag. It prepares that version, builds the TypeScript console in release
@@ -199,24 +197,17 @@ the token access or replace the secret.
 flowchart TD
     JUST["just release VERSION<br/>preflight + dispatch + wait"] --> DISPATCH["Release workflow dispatch"]
     UI["GitHub Actions UI"] --> DISPATCH
-    TAG["Pre-versioned v* tag push"] --> VERIFY["Verify tag is on main history<br/>and already version-complete"]
     DISPATCH --> META["Resolve version and highest prior stable notes tag"]
-    VERIFY --> META
-    META --> PATH{"Release path"}
+    META --> PATH{"Canary?"}
     PATH -- "canary dispatch" --> CANARY["Use dispatch SHA<br/>do not update main"]
     PATH -- "non-canary dispatch" --> BUMP["Run release-version.sh"]
     BUMP --> VERSION_COMMIT["Commit tracked version surface<br/>fast-forward main"]
-    PATH -- "tag push" --> TAG_SOURCE["Use validated tag source"]
     CANARY --> BUILD["Build, compose, and smoke artifact matrix"]
     VERSION_COMMIT --> BUILD
-    TAG_SOURCE --> BUILD
     BUILD --> PUBLISHABLE{"Canary?"}
     PUBLISHABLE -- "yes" --> CANARY_DONE["Stop without tag or publication"]
-    PUBLISHABLE -- "no" --> TAG_PATH{"Entry path"}
-    TAG_PATH -- "dispatch" --> PREPARE_TAG["Add generated SDK resources<br/>create and push immutable tag"]
-    TAG_PATH -- "tag push" --> EXISTING_TAG["Use existing immutable tag"]
+    PUBLISHABLE -- "no" --> PREPARE_TAG["Add generated SDK resources<br/>create and push immutable tag"]
     PREPARE_TAG --> RELEASE["Publish GitHub release<br/>notes compare from prior stable tag"]
-    EXISTING_TAG --> RELEASE
     RELEASE --> KIND{"Prerelease?"}
     KIND -- "yes" --> RC_DONE["Stop after GitHub prerelease"]
     KIND -- "no" --> DOWNSTREAM["Publish crates and dispatch<br/>packages, images, and npm"]

--- a/scripts/tests/test_release_workflow_artifacts.py
+++ b/scripts/tests/test_release_workflow_artifacts.py
@@ -21,11 +21,13 @@ def job_block(workflow: str, job_name: str, next_job_name: str) -> str:
 
 class ReleaseWorkflowArtifactTests(unittest.TestCase):
     def test_release_is_dispatch_only(self) -> None:
-        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
-        header = workflow[: workflow.index("\njobs:\n")]
+        document = yaml.safe_load(RELEASE_WORKFLOW.read_text(encoding="utf-8"))
+        # YAML 1.1 resolves an unquoted `on` key to the boolean True.
+        triggers = document.get("on", document.get(True))
 
-        self.assertIn("  workflow_dispatch:\n", header)
-        self.assertNotIn("  push:\n", header)
+        self.assertIsInstance(triggers, dict)
+        self.assertIn("workflow_dispatch", triggers)
+        self.assertNotIn("push", triggers)
 
     def test_release_ui_version_preparation_handles_container_ownership(self) -> None:
         workflow = yaml.safe_load(

--- a/scripts/tests/test_release_workflow_artifacts.py
+++ b/scripts/tests/test_release_workflow_artifacts.py
@@ -20,6 +20,13 @@ def job_block(workflow: str, job_name: str, next_job_name: str) -> str:
 
 
 class ReleaseWorkflowArtifactTests(unittest.TestCase):
+    def test_release_is_dispatch_only(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        header = workflow[: workflow.index("\njobs:\n")]
+
+        self.assertIn("  workflow_dispatch:\n", header)
+        self.assertNotIn("  push:\n", header)
+
     def test_release_ui_version_preparation_handles_container_ownership(self) -> None:
         workflow = yaml.safe_load(
             (ROOT / ".github/workflows/ci-ui-artifact-slice.yml").read_text()


### PR DESCRIPTION
## Original problem

The Release workflow also ran on every `v*` tag push. Normal releases are driven by the successful `workflow_dispatch` run from `main`, leaving a duplicate tag-ref run that could fail in metadata and make the release appear red.

## Diagnostics

Issue #1597 and live run evidence confirmed the duplicate pair: tag push run [33549644311](https://github.com/Mesh-LLM/mesh-llm/actions/runs/33549644311) failed in `Resolve release metadata`, while main dispatch run [33549875856](https://github.com/Mesh-LLM/mesh-llm/actions/runs/33549875856) successfully published the release.

## Fix

- Remove the obsolete `push` tag trigger from `.github/workflows/release.yml`.
- Keep the dispatch-driven release and its generated immutable tag creation unchanged.
- Update the CI inventory and release documentation to describe the dispatch-only path.
- Add a focused contract test preventing the tag trigger from returning.

Fixes #1597

## Validation

- `python3 -m unittest scripts.tests.test_release_workflow_artifacts -v` — 26 passed.
- `python3 -m unittest scripts.tests.test_release_script -v` — 4 passed.
- `actionlint -config-file .github/actionlint.yaml` — passed.
- `just check-release` — passed.
- `git diff --check` — passed.
- `just ci-validate` reached the full 936-test suite but is blocked by the macOS host system Python 3.9/Bash 3.2 lacking repository-required features, plus unrelated environment/fixture failures; changed-file-focused checks pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changes**
  * Release workflows now run only through manual dispatch from the Actions interface or supported release command.
  * Releases initiated this way create the release-specific tag automatically.
  * Pushing version tags no longer starts a release.
  * Preflight checks now verify access and write permissions before downstream packaging.
  * Canary dispatch behavior remains unchanged.

* **Documentation**
  * Updated release guidance for dispatch-only publishing and credential verification.

* **Tests**
  * Added coverage for dispatch-only releases and target repository permission checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->