### PR TITLE
test(ci): guard Linux product smoke selector drift

### DIFF
--- a/scripts/tests/test_ci_lane_workflows.py
+++ b/scripts/tests/test_ci_lane_workflows.py
@@ -339,6 +339,35 @@ class CiLaneWorkflowTests(unittest.TestCase):
                     )
             self.assertNotIn("contains(inputs.smoke_matrix,", workflow)
 
+    def test_every_planned_smoke_id_matches_a_product_smoke_job(self) -> None:
+        """Prevent planner rows from silently skipping their smoke jobs.
+
+        The product smoke workflows gate each job on an id from the formatted
+        ``smoke_matrix``. A stale id in ``smoke_domain_rows`` can therefore
+        leave the selected smoke coverage absent while the lane summary only
+        reports a skipped planned job.
+        """
+        slices = json.loads((ROOT / "ci" / "slices.yml").read_text())
+        declared = {row["id"] for row in slices["smoke_rows"]}
+        planned = {
+            smoke_id
+            for ids in slices["smoke_domain_rows"].values()
+            for smoke_id in ids
+        }
+
+        self.assertEqual(set(), planned - declared)
+
+        gated = set()
+        for path in sorted(WORKFLOWS.glob("ci-*-product-smoke-slice.yml")):
+            gated.update(
+                re.findall(
+                    r"contains\(fromJson\(inputs\.smoke_matrix\)\.\*\.id, '([^']+)'\)",
+                    path.read_text(encoding="utf-8"),
+                )
+            )
+
+        self.assertEqual(set(), planned - gated)
+
     def test_runtime_and_product_artifact_ids_preserve_architecture(self) -> None:
         for platform in ("linux", "macos", "windows"):
             with self.subTest(platform=platform):


### PR DESCRIPTION
Fixes #1698

The Linux smoke selector restoration is already present on current main. Add a regression contract test so future changes cannot leave a planner smoke id unmatched by any product-smoke lane job, which otherwise causes coverage to disappear and the lane summary to report only a skipped planned job.

Validation:
- `actionlint -config-file .github/actionlint.yaml`
- `python3 -m unittest scripts.tests.test_ci_lane_workflows scripts.tests.test_ci_workflow_artifacts scripts.tests.test_plan_ci` (72 passed)
- `just ci-crate-lists`
- `just ci-validate` reached the full suite but remains blocked by 10 missing `yaml` dependency errors and one unrelated canary preflight failure in this macOS environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Added automated validation to ensure every planned smoke test is represented in the product smoke test workflows.
  - This helps detect missing workflow coverage and improves confidence that planned smoke checks are executed consistently in continuous integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->