### PR TITLE
ci: preflight packaging dispatch credentials

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -21,7 +21,7 @@ Read it with `../SKILL.md` and `ci/ci.md` before editing CI.
 | `main_windows.yml` (`Main · Windows`) | push to `main` | Exhaustive main planning plus the same-commit reusable Windows lane |
 | `ci.yml` | `workflow_call` only | Temporary inert shim for the former main ingress filename; pending protected-main runner-contract update; no push trigger or dispatch |
 | `ci-control.yml` (`CI · Manual Full`) | dispatch on default branch | Explicit operator-only full plan, bounded lane dispatch and correlated diagnostic checks |
-| `release.yml` | release tags, dispatch | Canonical version synchronization, release-only signing, assets and publication |
+| `release.yml` | release tags, dispatch | Canonical version synchronization, release-only signing, assets, publication, and a preflighted downstream `mesh-packaging` dispatch |
 | `website-pages.yml` | main website paths, dispatch | Public website deployment |
 | `pr_cleanup.yml` | PR close, dispatch | Positively matched cleanup only |
 | `pr_auto_assign.yml` | PR lifecycle | Metadata only |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1862,12 +1862,21 @@ jobs:
       - name: Dispatch verified release to mesh-packaging
         env:
           GH_TOKEN: ${{ secrets.MESH_AGENT_IMAGES_DISPATCH_TOKEN }}
+          TARGET_REPOSITORY: Mesh-LLM/mesh-packaging
           RELEASE_TAG: ${{ needs.metadata.outputs.tag }}
           RELEASE_VERSION: ${{ needs.metadata.outputs.version }}
         run: |
           set -euo pipefail
           [[ -n "${GH_TOKEN:-}" ]] || {
             echo "MESH_AGENT_IMAGES_DISPATCH_TOKEN must grant Contents write access to Mesh-LLM/mesh-packaging for cross-repository dispatch" >&2
+            exit 1
+          }
+          target_permissions="$(gh api "repos/${TARGET_REPOSITORY}")" || {
+            echo "MESH_AGENT_IMAGES_DISPATCH_TOKEN cannot access ${TARGET_REPOSITORY}; update the secret with a credential that grants Contents write access" >&2
+            exit 1
+          }
+          [[ "$(jq -r '.permissions.push // false' <<<"$target_permissions")" == "true" ]] || {
+            echo "MESH_AGENT_IMAGES_DISPATCH_TOKEN must grant Contents write access to ${TARGET_REPOSITORY}; update the secret before retrying this release" >&2
             exit 1
           }
           jq -n \
@@ -1888,7 +1897,7 @@ jobs:
             }' |
             gh api \
               --method POST \
-              repos/Mesh-LLM/mesh-packaging/dispatches \
+              "repos/${TARGET_REPOSITORY}/dispatches" \
               --input -
 
   publish_crates_preflight:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -46,8 +46,9 @@ locally.
 - `MESH_AGENT_IMAGES_DISPATCH_TOKEN` configured as a fine-grained repository
   token or GitHub App token with Contents write access to
   `Mesh-LLM/mesh-packaging`, which is the permission required to create a
-  repository dispatch event. The legacy secret name is retained so existing
-  release environments do not require a coordinated secret rename.
+  repository dispatch event. The workflow checks this access without printing
+  the credential before it sends the event. The legacy secret name is retained
+  so existing release environments do not require a coordinated secret rename.
 
 ## Release Attestation Signing Keys
 
@@ -252,6 +253,13 @@ starts only after a stable GitHub release and its complete CPU/GPU archive set
 have published successfully. Prereleases never dispatch it. The upstream
 `docker.yml` workflow performs Dockerfile validation only and is not a
 distribution channel.
+
+If the downstream dispatch preflight fails, update the repository Actions secret
+`MESH_AGENT_IMAGES_DISPATCH_TOKEN` with a fine-grained token or GitHub App token
+that has Contents write access to `Mesh-LLM/mesh-packaging`, then retry the
+failed dispatch job. A repository secret's presence does not prove that its
+credential can write the target repository. Do not put the token in workflow
+logs or command output.
 
 On non-prerelease tags, the release workflow also publishes the Rust SDK crate
 chain to crates.io in dependency order:

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -180,6 +180,13 @@ the final notes retain the RC changes and add any post-RC changes.
 The workflow-scoped token push does not fan out another main CI run; the release
 graph is the evidence for that version-only source commit.
 
+After a stable release with the full GPU matrix succeeds, the downstream
+`mesh-packaging` dispatch job first checks that its
+`MESH_AGENT_IMAGES_DISPATCH_TOKEN` credential can write the target repository.
+That repository secret is external GitHub configuration. The checked-in
+workflow can report a missing or insufficient credential, but it cannot grant
+the token access or replace the secret.
+
 ```mermaid
 flowchart TD
     JUST["just release VERSION<br/>preflight + dispatch + wait"] --> DISPATCH["Release workflow dispatch"]

--- a/scripts/tests/test_release_workflow_artifacts.py
+++ b/scripts/tests/test_release_workflow_artifacts.py
@@ -561,6 +561,30 @@ class ReleaseWorkflowArtifactTests(unittest.TestCase):
         self.assertIn("publish_release_assets: true", dispatch)
         self.assertIn("publish_npm: true", dispatch)
 
+    def test_packaging_dispatch_preflights_target_write_access(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        dispatch = job_block(
+            workflow,
+            "dispatch_packaging_release",
+            "publish_crates_preflight",
+        )
+
+        self.assertIn(
+            "GH_TOKEN: ${{ secrets.MESH_AGENT_IMAGES_DISPATCH_TOKEN }}",
+            dispatch,
+        )
+        self.assertIn("TARGET_REPOSITORY: Mesh-LLM/mesh-packaging", dispatch)
+        self.assertIn(
+            'target_permissions="$(gh api "repos/${TARGET_REPOSITORY}")"',
+            dispatch,
+        )
+        self.assertIn(".permissions.push // false", dispatch)
+        self.assertIn(
+            "MESH_AGENT_IMAGES_DISPATCH_TOKEN must grant Contents write access",
+            dispatch,
+        )
+        self.assertIn('"repos/${TARGET_REPOSITORY}/dispatches"', dispatch)
+
     def test_release_assets_and_manual_tags_are_immutable(self) -> None:
         workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
         publish = job_block(


### PR DESCRIPTION
## Summary

Fixes #1088

The release workflow now checks the dispatch credential's effective push access to `Mesh-LLM/mesh-packaging` before attempting the cross-repository `repository_dispatch`. The check never prints or persists the secret and reports whether the credential is missing, inaccessible, or insufficient.

The release guide and CI inventory now document that the repository secret is external configuration, and the release workflow contract test covers the target and preflight.

## Validation

- `python3 -m unittest scripts.tests.test_release_workflow_artifacts` (26 passed)
- `uv run --with-requirements ci/requirements-ci-python.txt python -m unittest scripts.tests.test_release_workflow_artifacts` (26 passed)
- `actionlint -config-file .github/actionlint.yaml` (passed)
- `just check-release` (passed)
- `git diff --check` (passed)
- Full `just ci-validate` reached the full suite but remains red on unrelated host/toolchain issues: the local Python environment selected by `uv` was 3.10 for tests requiring newer standard-library APIs, `sha256sum` is not installed, and an existing llama-canary fixture fails before any release workflow code runs.

## External prerequisite

Update the `MESH_AGENT_IMAGES_DISPATCH_TOKEN` Actions secret with a fine-grained token or GitHub App token that has Contents: write access to `Mesh-LLM/mesh-packaging`, then retry the failed dispatch job. This repository change cannot grant or replace that credential.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Release Workflow**
  * Downstream packaging releases now verify required repository write access before dispatching, reducing failed or incomplete release handoffs.
  * The packaging destination can be configured without changing the workflow.

* **Documentation**
  * Added guidance for downstream packaging dispatches following stable releases.
  * Expanded troubleshooting information for permission failures and credential configuration, including reminders not to expose tokens in logs.

* **Tests**
  * Added coverage to verify access checks and successful dispatch behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->