### PR TITLE
ci: publish SDK smoke cache policy

### DIFF
--- a/ci/slices.yml
+++ b/ci/slices.yml
@@ -237,7 +237,7 @@
     {"id": "platform-checks", "kind": "platform-checks", "depends_on": [], "runner_role": "platform-build", "cache_mode": "none"},
     {"id": "product-smoke", "kind": "product-smoke", "depends_on": ["runtime-product"], "runner_role": "linux-build-4", "cache_mode": "none"},
     {"id": "model-download", "kind": "model-download", "depends_on": [], "runner_role": "linux-build-4", "cache_mode": "none"},
-    {"id": "sdk", "kind": "sdk", "depends_on": ["runtime-product"], "runner_role": "platform-build", "cache_mode": "none"},
+    {"id": "sdk", "kind": "sdk", "depends_on": ["runtime-product"], "runner_role": "platform-build", "cache_mode": "pr-isolated"},
     {"id": "runner-contract", "kind": "runner-contract", "depends_on": [], "runner_role": "linux-plan", "cache_mode": "none"}
   ]
 }


### PR DESCRIPTION
## Summary

- mark the `sdk` CI slice as `pr-isolated` in `ci/slices.yml`
- enable the existing exact, main-seeded Rust SDK Cargo/target cache policy in the protected planner output
- preserve the existing hosted-only credential-smoke workflow and cache-key/save policy from #1556

This is the catalog-only follow-up required by #1556: the operational `Swatinem/rust-cache` integration is already present, but the protected slice catalog still advertises `cache_mode: none`.

## Validation

- focused CI-contract suite: 94 tests passed under ephemeral Python 3.12 + PyYAML
- `actionlint .github/workflows/sdk-smoke.yml` passed
- planner probe: `sdk` resolves to `pr-isolated` for PRs, `trusted-readwrite` for main, and `trusted-readonly` for manual-full
- `git diff --check` passed

The full local `just ci-validate` suite was also attempted; this macOS checkout has unrelated host failures from missing PyYAML in the default Python environment, a protected `/usr/sbin` permission probe, and an existing llama-canary fixture failure.

Fixes #1381


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved SDK build cache isolation for pull-request builds.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->