### PR TITLE
feat(skippy): add durable local KV cache and restart restore

### DIFF
--- a/crates/mesh-llm-host-runtime/src/inference/skippy/certification.rs
+++ b/crates/mesh-llm-host-runtime/src/inference/skippy/certification.rs
@@ -579,7 +579,7 @@ mod tests {
     use crate::inference::skippy::materialization::{StagePackageInfo, StagePackageLayerInfo};
     use serde_json::json;
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
-    use tokio::net::TcpListener;
+    use tokio::net::{TcpListener, TcpStream};
 
     #[test]
     fn certification_ranges_split_two_stage_package() {
@@ -835,6 +835,34 @@ mod tests {
         format!("http://{addr}")
     }
 
+    async fn read_complete_http_request(stream: &mut TcpStream) -> Vec<u8> {
+        let mut request = Vec::new();
+        loop {
+            let mut chunk = [0u8; 4096];
+            let n = stream.read(&mut chunk).await.unwrap();
+            assert!(n > 0, "unexpected EOF while reading certification request");
+            request.extend_from_slice(&chunk[..n]);
+            let Some(header_end) = request.windows(4).position(|window| window == b"\r\n\r\n")
+            else {
+                continue;
+            };
+            let body_start = header_end + 4;
+            let headers = String::from_utf8_lossy(&request[..header_end]);
+            let content_length = headers
+                .lines()
+                .find_map(|line| {
+                    let (name, value) = line.split_once(':')?;
+                    name.eq_ignore_ascii_case("content-length")
+                        .then(|| value.trim().parse::<usize>().ok())
+                        .flatten()
+                })
+                .unwrap_or(0);
+            if request.len() >= body_start + content_length {
+                return request;
+            }
+        }
+    }
+
     /// Mimics a node that only recognizes `served_model_id` — anything else 404s,
     /// the same way a real host does when a client asks for a model name it
     /// doesn't advertise.
@@ -844,9 +872,8 @@ mod tests {
         tokio::spawn(async move {
             for _ in 0..3 {
                 let (mut stream, _) = listener.accept().await.unwrap();
-                let mut buf = [0u8; 4096];
-                let n = stream.read(&mut buf).await.unwrap();
-                let request = String::from_utf8_lossy(&buf[..n]);
+                let request = read_complete_http_request(&mut stream).await;
+                let request = String::from_utf8_lossy(&request);
                 let response = if request.starts_with("GET") {
                     let body = json!({
                         "object": "list",
@@ -899,5 +926,24 @@ mod tests {
         for gate in &gates {
             assert_eq!(gate.status, CertificationGateStatus::Passed, "{gate:?}");
         }
+    }
+
+    #[tokio::test]
+    async fn certification_stub_reads_a_body_split_from_its_headers() {
+        let model = "hf://meshllm/split-request@abc123";
+        let api_base = spawn_certification_stub_server(model.to_string()).await;
+        let addr = api_base.strip_prefix("http://").unwrap();
+        let body = json!({"model": model, "messages": []}).to_string();
+        let headers = format!(
+            "POST /v1/chat/completions HTTP/1.1\r\nHost: {addr}\r\nContent-Length: {}\r\n\r\n",
+            body.len()
+        );
+        let mut stream = TcpStream::connect(addr).await.unwrap();
+        stream.write_all(headers.as_bytes()).await.unwrap();
+        tokio::task::yield_now().await;
+        stream.write_all(body.as_bytes()).await.unwrap();
+        let mut response = Vec::new();
+        stream.read_to_end(&mut response).await.unwrap();
+        assert!(String::from_utf8_lossy(&response).starts_with("HTTP/1.1 200 OK"));
     }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -321,7 +321,6 @@ pub(super) fn apply_transitive_ann(
     existing.hosted_models_known = ann.hosted_models.is_some();
     existing.role = ann.role.clone();
     merge_first_joined_mesh_ts(&mut existing.first_joined_mesh_ts, ann.first_joined_mesh_ts);
-    let capacity_changed = existing.vram_bytes != ann.vram_bytes;
     existing.vram_bytes = ann.vram_bytes;
     // Only advance addr if the transitive announcement is at least as path-rich,
     // so a direct peer's richer address is not overwritten by a weaker transitive one.
@@ -346,15 +345,10 @@ pub(super) fn apply_transitive_ann(
     if ann.gpu_reserved_bytes.is_some() {
         existing.gpu_reserved_bytes = ann.gpu_reserved_bytes.clone();
     }
-    match ann.memory {
-        Some(memory) => existing.memory = Some(memory),
-        // A relay that predates the block strips it. The cached block only
-        // explains the capacity it arrived with: keep it while that capacity
-        // is unchanged, drop it once the capacity moved, so a stale breakdown
-        // is never paired with the new budget and rebroadcast as such.
-        None if capacity_changed => existing.memory = None,
-        None => {}
-    }
+    // A transitive announcement is a complete snapshot at its revision. An
+    // omitted memory block must clear an older cached value; retaining it can
+    // rebroadcast a breakdown the announcing peer no longer claims.
+    existing.memory = ann.memory;
     if ann.gpu_mem_bandwidth_gbps.is_some() {
         existing.gpu_mem_bandwidth_gbps = ann.gpu_mem_bandwidth_gbps.clone();
     }

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/gossip/merge_and_refresh.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/gossip/merge_and_refresh.rs
@@ -74,6 +74,26 @@ pub(crate) fn test_merge_equal_values_unchanged() {
 }
 
 #[test]
+pub(crate) fn test_transitive_snapshot_clears_omitted_memory_breakdown() {
+    let mut existing = test_peer(Some(100));
+    existing.memory = Some(crate::mesh::AdvertisedMemory {
+        total_bytes: 1024,
+        usable_bytes: 1024,
+        ..Default::default()
+    });
+    let ann = test_announcement(Some(100));
+
+    apply_transitive_ann(
+        &mut existing,
+        &test_addr(0x33),
+        &ann,
+        test_endpoint_id(0xee),
+    );
+
+    assert_eq!(existing.memory, None);
+}
+
+#[test]
 pub(crate) fn test_meaningfully_changed_first_joined_mesh_ts() {
     let old_peer = test_peer(Some(100));
     let new_peer = test_peer(Some(200));

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/peer_state.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/peer_state.rs
@@ -1859,9 +1859,8 @@ fn transitive_peer_update_refreshes_memory_only_when_advertised() {
     let mut ann = peer_state_test_announcement(addr.clone());
     apply_transitive_ann(&mut existing, &addr, &ann, make_test_endpoint_id(0xee));
     assert_eq!(
-        existing.memory,
-        Some(advertised),
-        "a relay without the block keeps the last advertised one"
+        existing.memory, None,
+        "an omitted block cannot prove the cached breakdown is current"
     );
 
     let refreshed = crate::mesh::AdvertisedMemory {
@@ -1905,10 +1904,10 @@ fn transitive_peer_update_drops_the_cached_memory_when_the_capacity_moves() {
         "a stale breakdown must not be paired with a new capacity"
     );
 
-    // The same relay with the unchanged capacity keeps the block.
+    // An unchanged capacity is not provenance for the omitted breakdown.
     existing.memory = Some(advertised);
     apply_transitive_ann(&mut existing, &addr, &ann, make_test_endpoint_id(0xee));
-    assert_eq!(existing.memory, Some(advertised));
+    assert_eq!(existing.memory, None);
 }
 
 #[test]

--- a/crates/mesh-llm-host-runtime/src/models/profile.rs
+++ b/crates/mesh-llm-host-runtime/src/models/profile.rs
@@ -90,6 +90,7 @@ fn resolve_parameter_size(
     parameter_count: Option<u64>,
 ) -> Option<String> {
     source_size
+        .and_then(non_empty)
         .or_else(|| parameter_count.and_then(parameter_size_from_count))
         .or_else(|| parameter_size_from_text(model_name))
 }
@@ -190,6 +191,13 @@ mod tests {
             resolve_parameter_size("model-7B", None, None).as_deref(),
             Some("7B")
         );
+        for blank in ["", "   ", "\t\n"] {
+            assert_eq!(
+                resolve_parameter_size("model-7B", Some(blank.to_string()), Some(8_000_000_000),)
+                    .as_deref(),
+                Some("8B")
+            );
+        }
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/self_fill.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/self_fill.rs
@@ -1,9 +1,10 @@
 //! Same-model committees: distinct physical clones, reserved for the turn.
+use super::pool::canonical_base_name;
 use super::workers::{LocalModelBackend, RemoteModelBackend, ReservedModelBackend};
 use crate::inference::election::{InferenceTarget, ModelTargets};
 use crate::mesh;
 use crate::network::affinity::AffinityRouter;
-use crate::network::openai::routing_rank::rank_targets_by_context;
+use crate::network::openai::routing_rank::rank_aliased_targets_by_context;
 use crate::network::reservations::RoutingReservation;
 use mesh_mixture_of_agents as moa;
 use std::sync::Arc;
@@ -11,6 +12,7 @@ use std::sync::Arc;
 /// Measured self-MoA width; fleet capacity must not increase fan-out cost.
 const SELF_FILL_TARGET_WORKERS: usize = 2;
 
+#[cfg(test)]
 async fn select_clones(
     node: &mesh::Node,
     name: &str,
@@ -18,6 +20,29 @@ async fn select_clones(
     candidates: Vec<InferenceTarget>,
     affinity: Option<&AffinityRouter>,
 ) -> Vec<(InferenceTarget, Option<RoutingReservation>)> {
+    select_aliased_clones(
+        node,
+        &canonical_base_name(name),
+        required_tokens,
+        candidates
+            .into_iter()
+            .map(|target| (target, name.to_string()))
+            .collect(),
+        affinity,
+    )
+    .await
+    .into_iter()
+    .map(|(target, _, reservation)| (target, reservation))
+    .collect()
+}
+
+async fn select_aliased_clones(
+    node: &mesh::Node,
+    reservation_key: &str,
+    required_tokens: Option<u32>,
+    candidates: Vec<(InferenceTarget, String)>,
+    affinity: Option<&AffinityRouter>,
+) -> Vec<(InferenceTarget, String, Option<RoutingReservation>)> {
     use crate::proto::node::InferenceAdmissionState;
 
     let deprioritized: std::collections::HashSet<_> = node
@@ -32,36 +57,48 @@ async fn select_clones(
     // Preserve admission priority before context/throughput ranking. Local and
     // legacy peers stay healthy; hosts_for_model already excludes paused peers.
     let (mut healthy, mut spillover): (Vec<_>, Vec<_>) = candidates.into_iter().partition(
-        |target| !matches!(target, InferenceTarget::Remote(id) if deprioritized.contains(id)),
+        |(target, _)| !matches!(target, InferenceTarget::Remote(id) if deprioritized.contains(id)),
     );
     let mut selected = Vec::with_capacity(SELF_FILL_TARGET_WORKERS);
     while selected.len() < SELF_FILL_TARGET_WORKERS {
         // Exhaust context-eligible healthy endpoints before considering spillover,
         // even when every healthy clone already has reservations from other turns.
-        let mut ranked = rank_targets_by_context(node, name, required_tokens, &healthy).await;
+        let mut ranked = rank_aliased_targets_by_context(node, required_tokens, &healthy).await;
         if ranked.ordered.is_empty() {
-            ranked = rank_targets_by_context(node, name, required_tokens, &spillover).await;
+            ranked = rank_aliased_targets_by_context(node, required_tokens, &spillover).await;
         }
         let Some(preferred) = ranked.ordered.first() else {
             break;
         };
+        let physical = ranked
+            .ordered
+            .iter()
+            .map(|(target, _)| target.clone())
+            .collect::<Vec<_>>();
+        let preferred_target = &preferred.0;
         let (target, reservation) = affinity
             .and_then(|router| {
                 router.reserve_route(
-                    name,
-                    &ranked.ordered,
+                    reservation_key,
+                    &physical,
                     ranked.equivalent_prefix,
-                    preferred,
+                    preferred_target,
                     false,
                 )
             })
             .map(|(target, guard)| (target, Some(guard)))
-            .unwrap_or_else(|| (preferred.clone(), None));
+            .unwrap_or_else(|| (preferred_target.clone(), None));
+        let alias = ranked
+            .ordered
+            .iter()
+            .find(|(candidate, _)| candidate == &target)
+            .map(|(_, alias)| alias.clone())
+            .expect("reserved aliased target came from ranked candidates");
         // Selection+reservation is atomic per slot; removing the endpoint
         // prevents duplicate workers even when other turns interleave slots.
-        healthy.retain(|candidate| candidate != &target);
-        spillover.retain(|candidate| candidate != &target);
-        selected.push((target, reservation));
+        healthy.retain(|(candidate, _)| candidate != &target);
+        spillover.retain(|(candidate, _)| candidate != &target);
+        selected.push((target, alias, reservation));
     }
     selected
 }
@@ -78,61 +115,85 @@ pub(super) async fn self_fill_from_extra_instances(
     let Some(existing) = models.first().cloned() else {
         return;
     };
-    let name = &existing.name;
-    let mut candidates = Vec::new();
-    if let Some(local) = targets
-        .and_then(|targets| targets.targets.get(name))
-        .and_then(|targets| {
-            targets
-                .iter()
-                .find(|t| matches!(t, InferenceTarget::Local(_)))
-        })
-    {
-        candidates.push(local.clone());
+    let base = canonical_base_name(&existing.name);
+    let mut aliases = node.models_being_served().await;
+    if let Some(targets) = targets {
+        aliases.extend(targets.targets.keys().cloned());
     }
-    candidates.extend(
-        node.hosts_for_model(name)
-            .await
-            .into_iter()
-            .map(InferenceTarget::Remote),
-    );
+    aliases.retain(|alias| canonical_base_name(alias) == base);
+    aliases.push(existing.name.clone());
+    aliases.sort_by(|a, b| {
+        (b == &existing.name)
+            .cmp(&(a == &existing.name))
+            .then_with(|| a.len().cmp(&b.len()))
+            .then_with(|| a.cmp(b))
+    });
+    aliases.dedup();
+    let mut candidates = Vec::new();
+    for alias in &aliases {
+        if let Some(local) = targets
+            .and_then(|targets| targets.targets.get(alias))
+            .and_then(|targets| {
+                targets
+                    .iter()
+                    .find(|t| matches!(t, InferenceTarget::Local(_)))
+            })
+        {
+            candidates.push((local.clone(), alias.clone()));
+        }
+        candidates.extend(
+            node.hosts_for_model(alias)
+                .await
+                .into_iter()
+                .map(|peer_id| (InferenceTarget::Remote(peer_id), alias.clone())),
+        );
+    }
+    let mut physical = Vec::new();
+    candidates.retain(|(target, _)| {
+        if physical.contains(target) {
+            false
+        } else {
+            physical.push(target.clone());
+            true
+        }
+    });
     if candidates.len() < 2 {
         return;
     }
-    let selected = select_clones(node, name, required_tokens, candidates, affinity).await;
+    let selected = select_aliased_clones(node, &base, required_tokens, candidates, affinity).await;
     if selected.len() < 2 {
         return; // Context filtering must not fabricate a second worker.
     }
-    *backends = selected
-        .into_iter()
-        .map(|(target, reservation)| {
-            let inner: Arc<dyn moa::ModelBackend> = match target {
-                InferenceTarget::Local(port) => Arc::new(LocalModelBackend {
-                    port,
-                    http: http.clone(),
-                }),
-                // No failover onto a sibling slot: every worker is a distinct sample.
-                InferenceTarget::Remote(peer_id) => Arc::new(RemoteModelBackend {
-                    node: node.clone(),
-                    peer_ids: vec![peer_id],
-                }),
-                InferenceTarget::None => unreachable!("self-fill only collects physical endpoints"),
-            };
-            match reservation {
-                Some(reservation) => Arc::new(ReservedModelBackend {
-                    inner,
-                    _reservation: reservation,
-                }) as Arc<dyn moa::ModelBackend>,
-                None => inner,
-            }
-        })
-        .collect();
-    *models = (0..backends.len())
-        .map(|backend_index| moa::ModelEntry {
+    let mut filled_backends = Vec::with_capacity(selected.len());
+    let mut filled_models = Vec::with_capacity(selected.len());
+    for (backend_index, (target, name, reservation)) in selected.into_iter().enumerate() {
+        let inner: Arc<dyn moa::ModelBackend> = match target {
+            InferenceTarget::Local(port) => Arc::new(LocalModelBackend {
+                port,
+                http: http.clone(),
+            }),
+            // No failover onto a sibling slot: every worker is a distinct sample.
+            InferenceTarget::Remote(peer_id) => Arc::new(RemoteModelBackend {
+                node: node.clone(),
+                peer_ids: vec![peer_id],
+            }),
+            InferenceTarget::None => unreachable!("self-fill only collects physical endpoints"),
+        };
+        filled_backends.push(match reservation {
+            Some(reservation) => Arc::new(ReservedModelBackend {
+                inner,
+                _reservation: reservation,
+            }) as Arc<dyn moa::ModelBackend>,
+            None => inner,
+        });
+        filled_models.push(moa::ModelEntry {
+            name,
             backend_index,
             ..existing.clone()
-        })
-        .collect();
+        });
+    }
+    *backends = filled_backends;
+    *models = filled_models;
 }
 
 #[cfg(test)]

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/self_fill/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/self_fill/tests.rs
@@ -17,6 +17,49 @@ async fn fleet(count: u32) -> (mesh::Node, Vec<InferenceTarget>) {
     (node, candidates)
 }
 
+fn rename_peer_model(peer: &mut mesh::PeerInfo, name: &str) {
+    peer.models = vec![name.to_string()];
+    peer.serving_models = vec![name.to_string()];
+    peer.hosted_models = vec![name.to_string()];
+    for descriptor in &mut peer.served_model_descriptors {
+        descriptor.identity.model_name = name.to_string();
+    }
+    for runtime in &mut peer.served_model_runtime {
+        runtime.model_name = name.to_string();
+    }
+}
+
+#[tokio::test]
+async fn self_fill_preserves_each_physical_workers_routable_alias() {
+    let node = mesh::Node::new_for_tests(mesh::NodeRole::Client)
+        .await
+        .unwrap();
+    let model = BIG_MODELS[1];
+    let short = model.name;
+    let long = "unsloth/Qwen3-32B-GGUF:Q4_K_M";
+    assert_eq!(
+        super::super::pool::canonical_base_name(short),
+        super::super::pool::canonical_base_name(long)
+    );
+    let first = fleet_peer_with_health(1, model, None, Some(100_000));
+    let mut second = fleet_peer_with_health(2, model, None, Some(100_000));
+    rename_peer_model(&mut second, long);
+    node.insert_test_peer(first).await;
+    node.insert_test_peer(second).await;
+
+    let (backends, models) =
+        assemble_worker_pool(&node, None, Some(13_000), &reqwest::Client::new(), None).await;
+
+    assert_eq!(backends.len(), 2);
+    assert_eq!(
+        models
+            .iter()
+            .map(|model| model.name.as_str())
+            .collect::<HashSet<_>>(),
+        HashSet::from([short, long])
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn concurrent_committees_spread_across_twenty_clones() {
     let (node, candidates) = fleet(20).await;

--- a/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/self_fill/tests.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/moa_gateway/self_fill/tests.rs
@@ -44,6 +44,11 @@ async fn self_fill_preserves_each_physical_workers_routable_alias() {
     let first = fleet_peer_with_health(1, model, None, Some(100_000));
     let mut second = fleet_peer_with_health(2, model, None, Some(100_000));
     rename_peer_model(&mut second, long);
+    let expected_aliases = first
+        .http_routable_models()
+        .into_iter()
+        .chain(second.http_routable_models())
+        .collect::<HashSet<_>>();
     node.insert_test_peer(first).await;
     node.insert_test_peer(second).await;
 
@@ -54,9 +59,9 @@ async fn self_fill_preserves_each_physical_workers_routable_alias() {
     assert_eq!(
         models
             .iter()
-            .map(|model| model.name.as_str())
+            .map(|model| model.name.clone())
             .collect::<HashSet<_>>(),
-        HashSet::from([short, long])
+        expected_aliases
     );
 }
 

--- a/crates/mesh-llm-host-runtime/src/network/openai/routing_rank.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/routing_rank.rs
@@ -309,6 +309,31 @@ pub(super) async fn rank_targets_by_context(
     rank_candidates_by_context_and_throughput(&candidates, required_tokens)
 }
 
+pub(super) async fn rank_aliased_targets_by_context(
+    node: &mesh::Node,
+    required_tokens: Option<u32>,
+    targets: &[(election::InferenceTarget, String)],
+) -> RankedCandidates<(election::InferenceTarget, String)> {
+    let mut candidates = Vec::with_capacity(targets.len());
+    for (target, model) in targets {
+        let context_length = match target {
+            election::InferenceTarget::Local(_) => node.local_model_context_length(model).await,
+            election::InferenceTarget::Remote(peer_id) => {
+                node.peer_model_context_length(*peer_id, model).await
+            }
+            election::InferenceTarget::None => None,
+        };
+        let throughput = match target {
+            election::InferenceTarget::Remote(peer_id) => {
+                remote_target_throughput_rank(node, model, *peer_id).await
+            }
+            _ => local_target_throughput_rank(node, model, target),
+        };
+        candidates.push(((target.clone(), model.clone()), context_length, throughput));
+    }
+    rank_candidates_by_context_and_throughput(&candidates, required_tokens)
+}
+
 #[cfg(test)]
 pub(super) async fn order_targets_by_context(
     node: &mesh::Node,

--- a/crates/mesh-llm-host-runtime/src/runtime/proxy/tests/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/proxy/tests/mod.rs
@@ -378,7 +378,8 @@ async fn spawn_held_upstream(
             tokio::spawn(async move {
                 let _raw = read_raw_http_request(&mut stream).await;
                 accepted.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
-                let _permit = release.acquire().await.expect("release semaphore");
+                let permit = release.acquire().await.expect("release semaphore");
+                permit.forget();
                 let reply = format!(
                     "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
                     response.len(),

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -1,6 +1,55 @@
 use super::*;
 use serial_test::serial;
 
+#[cfg(all(
+    target_os = "linux",
+    any(
+        not(feature = "skippy-devices"),
+        feature = "dynamic-native-runtime",
+        test
+    )
+))]
+struct TestDirectory(std::path::PathBuf);
+
+#[cfg(all(
+    target_os = "linux",
+    any(
+        not(feature = "skippy-devices"),
+        feature = "dynamic-native-runtime",
+        test
+    )
+))]
+impl TestDirectory {
+    fn new(label: &str) -> Self {
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let id = NEXT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let timestamp = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .expect("test clock follows Unix epoch")
+            .as_nanos();
+        let path = std::env::temp_dir().join(format!(
+            "mesh-llm-{label}-{}-{timestamp}-{id}",
+            std::process::id()
+        ));
+        std::fs::create_dir(&path).expect("create collision-resistant test directory");
+        Self(path)
+    }
+}
+
+#[cfg(all(
+    target_os = "linux",
+    any(
+        not(feature = "skippy-devices"),
+        feature = "dynamic-native-runtime",
+        test
+    )
+))]
+impl Drop for TestDirectory {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
 fn synthetic_gpu(index: usize, stable_id: Option<&str>) -> GpuFacts {
     GpuFacts {
         index,
@@ -414,11 +463,12 @@ fn test_tegra_collector_gpu_name_absent_leaves_source_none() {
     // model file present, which made the old `TegraCollector.collect` form flip
     // on such a host). With the model file absent, both the name and its source
     // must stay absent — never a guessed source for a name that was never read.
-    let missing = std::path::Path::new("/nonexistent/mesh-llm/tegra/devicetree/base/model");
+    let directory = TestDirectory::new("tegra-model-absent");
+    let missing = directory.0.join("missing-model");
     assert!(!missing.exists());
 
     let mut survey = HardwareSurvey::default();
-    tegra_gpu_name_from_model_path(&mut survey, missing);
+    tegra_gpu_name_from_model_path(&mut survey, &missing);
 
     assert_eq!(survey.gpu_name, None);
     assert_eq!(survey.gpu_name_source, None);
@@ -439,15 +489,14 @@ fn test_tegra_collector_gpu_name_absent_leaves_source_none() {
 fn test_tegra_collector_gpu_name_present_tags_sysfs_source() {
     use std::io::Write as _;
 
-    let path = std::env::temp_dir().join("mesh_llm_test_tegra_model_present");
+    let directory = TestDirectory::new("tegra-model-present");
+    let path = directory.0.join("model");
     let mut f = std::fs::File::create(&path).expect("create temp model file");
     write!(f, "NVIDIA Jetson AGX Orin Developer Kit\0").expect("write model file");
     drop(f);
 
     let mut survey = HardwareSurvey::default();
     tegra_gpu_name_from_model_path(&mut survey, &path);
-
-    let _ = std::fs::remove_file(&path);
 
     assert_eq!(survey.gpu_name.as_deref(), Some("Jetson AGX Orin"));
     assert_eq!(survey.gpu_name_source, Some(GpuNameSource::Sysfs));

--- a/crates/skippy-cache/src/l3.rs
+++ b/crates/skippy-cache/src/l3.rs
@@ -482,6 +482,15 @@ impl HandoffSegmentStore {
     /// filesystem: both break the atomic-rename and containment assumptions
     /// every later guarantee rests on, and neither is worth a partial mode.
     pub fn open_with_limits(root: impl Into<PathBuf>, limits: StoreLimits) -> Result<Self> {
+        let store = Self::open_unreconciled_with_limits(root, limits)?;
+        store.reconcile_startup()?;
+        Ok(store)
+    }
+
+    pub(crate) fn open_unreconciled_with_limits(
+        root: impl Into<PathBuf>,
+        limits: StoreLimits,
+    ) -> Result<Self> {
         let root = root.into();
         if !root.is_absolute() {
             bail!("cache root must be absolute: {}", root.display());
@@ -1627,7 +1636,14 @@ impl HandoffSegmentStore {
             .into_iter()
             .collect::<std::collections::HashSet<_>>();
         freed = freed.saturating_add(self.packed.remove_orphan_indexes(&manifests)?);
-        freed = freed.saturating_add(self.packed.remove_orphan_packs(&referenced, &held)?);
+        freed = freed.saturating_add(self.packed.remove_orphan_packs(&referenced, || {
+            self.inflight_segments
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .keys()
+                .cloned()
+                .collect()
+        })?);
         Ok(freed)
     }
 }

--- a/crates/skippy-cache/src/l3.rs
+++ b/crates/skippy-cache/src/l3.rs
@@ -938,7 +938,7 @@ impl HandoffSegmentStore {
             }];
             let len = usize::try_from(location.bytes).context("segment exceeds usize")?;
             let mut bytes = Vec::with_capacity(len);
-            return match self.packed.append_many(&requests, &mut bytes) {
+            return match self.packed.append_many(&requests, &mut bytes, None) {
                 Ok(()) => Ok(bytes),
                 Err(failure) => {
                     let path = self.packed.pack_path(&failure.pack_digest);
@@ -1146,6 +1146,7 @@ impl HandoffSegmentStore {
     pub fn assemble(&self, manifest: &HandoffManifest) -> Result<Vec<u8>> {
         let total = usize::try_from(manifest.total_bytes).context("payload exceeds usize")?;
         let mut payload = Vec::with_capacity(total);
+        let mut payload_hasher = blake3::Hasher::new();
         let locations = self
             .packed
             .load_manifest_index(&manifest.payload_digest, manifest.segments.len())?;
@@ -1178,20 +1179,21 @@ impl HandoffSegmentStore {
                     output_offset: segment.offset,
                 });
             } else {
-                self.append_packed(&packed_requests, &mut payload)?;
+                self.append_packed(&packed_requests, &mut payload, &mut payload_hasher)?;
                 packed_requests.clear();
                 let bytes = self.read_segment(&segment.digest)?;
+                payload_hasher.update(&bytes);
                 payload.extend_from_slice(&bytes);
             }
         }
-        self.append_packed(&packed_requests, &mut payload)?;
+        self.append_packed(&packed_requests, &mut payload, &mut payload_hasher)?;
         if payload.len() != total {
             bail!(
                 "assembled {} bytes but manifest records {total}",
                 payload.len()
             );
         }
-        if segment_digest(&payload) != manifest.payload_digest {
+        if payload_hasher.finalize().to_hex().as_str() != manifest.payload_digest {
             bail!("assembled payload failed manifest digest verification");
         }
         Ok(payload)
@@ -1201,8 +1203,12 @@ impl HandoffSegmentStore {
         &self,
         requests: &[PackedReadRequest<'_>],
         payload: &mut Vec<u8>,
+        payload_hasher: &mut blake3::Hasher,
     ) -> Result<()> {
-        match self.packed.append_many(requests, payload) {
+        match self
+            .packed
+            .append_many(requests, payload, Some(payload_hasher))
+        {
             Ok(()) => Ok(()),
             Err(failure) => {
                 let path = self.packed.pack_path(&failure.pack_digest);

--- a/crates/skippy-cache/src/l3.rs
+++ b/crates/skippy-cache/src/l3.rs
@@ -14,7 +14,7 @@
 //!   is present and the assembled payload digest matches. Partial state can
 //!   never be loaded — there is nothing to load until commit.
 //! - **Idempotency**: putting a segment that already exists is a no-op;
-//!   concurrent writers of the same bytes converge on one file via
+//!   concurrent writers of the same bytes converge on one object via
 //!   temp-file + atomic rename.
 //! - **Capped budget**: `enforce_budget` evicts oldest manifests first (the
 //!   newest is never evicted) and garbage-collects unreferenced segments.
@@ -33,6 +33,9 @@ use anyhow::{Context, Result, bail};
 use serde::{Deserialize, Serialize};
 
 use crate::fsinfo;
+
+mod packed;
+use packed::{PACK_DIR, PACK_INDEX_DIR, PackedReadRequest, PackedSegmentStore};
 
 const SEGMENT_DIR: &str = "segments";
 const MANIFEST_DIR: &str = "manifests";
@@ -433,6 +436,7 @@ pub struct HandoffSegmentStore {
     /// them. Left unprotected this fails as "manifest references missing
     /// segment" under exactly the pressure the cache is for.
     inflight_segments: Mutex<std::collections::BTreeMap<String, usize>>,
+    packed: PackedSegmentStore,
 }
 
 pub fn segment_digest(bytes: &[u8]) -> String {
@@ -495,7 +499,13 @@ impl HandoffSegmentStore {
                 root.display()
             );
         }
-        for directory in [SEGMENT_DIR, MANIFEST_DIR, PREFIX_INDEX_DIR] {
+        for directory in [
+            SEGMENT_DIR,
+            MANIFEST_DIR,
+            PREFIX_INDEX_DIR,
+            PACK_DIR,
+            PACK_INDEX_DIR,
+        ] {
             let path = root.join(directory);
             fsinfo::refuse_symlinked_descendant(&root, &path)?;
             fs::create_dir_all(&path).with_context(|| {
@@ -505,6 +515,7 @@ impl HandoffSegmentStore {
         }
         fsinfo::restrict_to_owner(&root, 0o700)?;
         let root_lock = acquire_root_lock(&root)?;
+        let packed = PackedSegmentStore::open(&root)?;
         Ok(Self {
             root,
             limits: RwLock::new(limits),
@@ -519,6 +530,7 @@ impl HandoffSegmentStore {
             evicted_manifests: AtomicU64::new(0),
             quarantined_objects: AtomicU64::new(0),
             inflight_segments: Mutex::new(std::collections::BTreeMap::new()),
+            packed,
         })
     }
 
@@ -559,7 +571,13 @@ impl HandoffSegmentStore {
     /// the manager exposes this root to any stage.
     pub fn reconcile_startup(&self) -> Result<StoreReconciliation> {
         let mut report = StoreReconciliation::default();
-        for directory in [SEGMENT_DIR, MANIFEST_DIR, PREFIX_INDEX_DIR] {
+        for directory in [
+            SEGMENT_DIR,
+            MANIFEST_DIR,
+            PREFIX_INDEX_DIR,
+            PACK_DIR,
+            PACK_INDEX_DIR,
+        ] {
             report.removed_temporary_files = report
                 .removed_temporary_files
                 .saturating_add(remove_temporary_files(&self.root.join(directory))?);
@@ -571,6 +589,7 @@ impl HandoffSegmentStore {
                 report.quarantined_manifests += 1;
             }
         }
+        self.rebuild_packed_index()?;
         report.removed_prefix_links = self.remove_dangling_prefix_links()?;
         report.removed_orphan_bytes = self.collect_unreferenced_segments()?;
         Ok(report)
@@ -585,15 +604,15 @@ impl HandoffSegmentStore {
             );
         }
         let mut expected_offset = 0u64;
-        for (position, segment) in manifest.segments.iter().enumerate() {
+        let locations = self
+            .packed
+            .load_manifest_index(key, manifest.segments.len())?;
+        for (position, (segment, location)) in manifest.segments.iter().zip(locations).enumerate() {
             if segment.index as usize != position || segment.offset != expected_offset {
                 bail!("manifest {key} has invalid segment ordering");
             }
-            let metadata = fs::metadata(self.segment_path(&segment.digest))
+            self.validate_segment_ref(segment, location.as_ref())
                 .with_context(|| format!("manifest {key} references a missing segment"))?;
-            if metadata.len() != segment.bytes {
-                bail!("manifest {key} references a truncated segment");
-            }
             expected_offset = expected_offset
                 .checked_add(segment.bytes)
                 .context("manifest segment offsets overflow")?;
@@ -628,6 +647,38 @@ impl HandoffSegmentStore {
 
     fn segment_path(&self, digest: &str) -> PathBuf {
         self.root.join(SEGMENT_DIR).join(format!("{digest}.seg"))
+    }
+
+    fn validate_segment_ref(
+        &self,
+        segment: &HandoffSegmentRef,
+        location: Option<&packed::PackedSegmentLocation>,
+    ) -> Result<()> {
+        if let Some(location) = location {
+            return self.packed.validate(location, segment.bytes);
+        }
+        let metadata = fs::metadata(self.segment_path(&segment.digest))?;
+        if metadata.len() != segment.bytes {
+            bail!("segment {} is truncated", segment.digest);
+        }
+        Ok(())
+    }
+
+    fn rebuild_packed_index(&self) -> Result<()> {
+        let mut entries = Vec::new();
+        for key in self.list_manifests()? {
+            let Ok(manifest) = self.load_manifest(&key) else {
+                continue;
+            };
+            let locations = self
+                .packed
+                .load_manifest_index(&key, manifest.segments.len())?;
+            entries.extend(manifest.segments.into_iter().zip(locations).filter_map(
+                |(segment, location)| location.map(|location| (segment.digest, location)),
+            ));
+        }
+        self.packed.rebuild(entries);
+        Ok(())
     }
 
     fn manifest_path(&self, payload_digest: &str) -> PathBuf {
@@ -824,12 +875,75 @@ impl HandoffSegmentStore {
         }))
     }
 
+    /// Store one spill's logical segments in one immutable physical pack.
+    pub fn try_put_segments<'store>(
+        &'store self,
+        segments: &[&[u8]],
+    ) -> Result<Result<Vec<StoredSegment<'store>>, WriteRefusal>> {
+        let digests = segments
+            .iter()
+            .map(|bytes| segment_digest(bytes))
+            .collect::<Vec<_>>();
+        let holds = digests
+            .iter()
+            .map(|digest| self.hold_segment(digest))
+            .collect::<Vec<_>>();
+        let inputs = digests
+            .iter()
+            .zip(segments)
+            .map(|(digest, bytes)| (digest.as_str(), *bytes))
+            .collect::<Vec<_>>();
+        let estimated = self.packed.estimated_new_bytes(&inputs);
+        let reservation = match self.reserve(estimated)? {
+            Ok(reservation) => reservation,
+            Err(refusal) => return Ok(Err(refusal)),
+        };
+        let (packed, new_bytes) = match self.packed.write_batch(&inputs) {
+            Ok(result) => result,
+            Err(error) => {
+                self.invalidate_usage();
+                return Err(error);
+            }
+        };
+        self.add_usage_bytes(new_bytes);
+        drop(reservation);
+        Ok(Ok(digests
+            .into_iter()
+            .zip(holds)
+            .zip(packed)
+            .zip(segments)
+            .map(|(((digest, hold), packed), bytes)| StoredSegment {
+                digest,
+                put: SegmentPut {
+                    new: packed.new,
+                    bytes: bytes.len() as u64,
+                },
+                _hold: hold,
+            })
+            .collect()))
+    }
+
     pub fn has_segment(&self, digest: &str) -> bool {
-        self.segment_path(digest).exists()
+        self.segment_path(digest).exists() || self.packed.location(digest).is_some()
     }
 
     /// Read one segment, verifying its content digest.
     pub fn read_segment(&self, digest: &str) -> Result<Vec<u8>> {
+        if let Some(location) = self.packed.location(digest) {
+            let requests = [PackedReadRequest {
+                digest,
+                bytes: location.bytes,
+                location: &location,
+            }];
+            return match self.packed.read_many(&requests) {
+                Ok(mut bytes) => bytes.pop().context("packed segment read was empty"),
+                Err(failure) => {
+                    let path = self.packed.pack_path(&failure.pack_digest);
+                    let _ = self.quarantine(&path);
+                    Err(failure.error)
+                }
+            };
+        }
         let path = self.segment_path(digest);
         let bytes = fs::read(&path).with_context(|| format!("failed to read segment {digest}"))?;
         if segment_digest(&bytes) != digest {
@@ -893,7 +1007,13 @@ impl HandoffSegmentStore {
             bail!("manifest has no payload digest");
         }
         let mut expected_offset = 0u64;
-        for (position, segment) in manifest.segments.iter().enumerate() {
+        let locations = manifest
+            .segments
+            .iter()
+            .map(|segment| self.packed.location(&segment.digest))
+            .collect::<Vec<_>>();
+        for (position, (segment, location)) in manifest.segments.iter().zip(&locations).enumerate()
+        {
             if segment.index as usize != position {
                 bail!(
                     "manifest segment order broken: index {} at position {position}",
@@ -907,21 +1027,13 @@ impl HandoffSegmentStore {
                     segment.offset
                 );
             }
-            let path = self.segment_path(&segment.digest);
-            let metadata = fs::metadata(&path).with_context(|| {
-                format!(
-                    "manifest references missing segment {} ({})",
-                    segment.index, segment.digest
-                )
-            })?;
-            if metadata.len() != segment.bytes {
-                bail!(
-                    "segment {} has {} bytes on disk but manifest records {}",
-                    segment.digest,
-                    metadata.len(),
-                    segment.bytes
-                );
-            }
+            self.validate_segment_ref(segment, location.as_ref())
+                .with_context(|| {
+                    format!(
+                        "manifest references missing segment {} ({})",
+                        segment.index, segment.digest
+                    )
+                })?;
             expected_offset = expected_offset
                 .checked_add(segment.bytes)
                 .context("manifest offsets overflow")?;
@@ -941,6 +1053,14 @@ impl HandoffSegmentStore {
         // build its reference map. Indentation is pure cost on a file nobody
         // reads by hand.
         let serialized = serde_json::to_vec(manifest).context("failed to serialize manifest")?;
+        let segment_digests = manifest
+            .segments
+            .iter()
+            .map(|segment| segment.digest.clone())
+            .collect::<Vec<_>>();
+        let packed_index = self
+            .packed
+            .encode_manifest_index(&manifest.payload_digest, &segment_digests)?;
         // The manifest is what makes the segments loadable, so it is pinned
         // while it lands: eviction triggered by its own admission check must
         // not remove the entry being committed.
@@ -956,8 +1076,23 @@ impl HandoffSegmentStore {
                 }
             })?;
         let growth_bytes = (serialized.len() as u64).saturating_sub(replaced_bytes);
-        match self.reserve_write(serialized.len() as u64, growth_bytes)? {
+        let packed_index_path = self.packed.index_path(&manifest.payload_digest);
+        let replaced_index_bytes = fs::metadata(&packed_index_path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        let index_bytes = packed_index.as_ref().map_or(0, |bytes| bytes.len() as u64);
+        let write_bytes = (serialized.len() as u64).saturating_add(index_bytes);
+        let total_growth =
+            growth_bytes.saturating_add(index_bytes.saturating_sub(replaced_index_bytes));
+        match self.reserve_write(write_bytes, total_growth)? {
             Ok(_reservation) => {
+                if let Some(index) = &packed_index {
+                    self.packed
+                        .publish_manifest_index(&manifest.payload_digest, index)?;
+                } else {
+                    self.packed
+                        .remove_manifest_index(&manifest.payload_digest)?;
+                }
                 write_atomically(&manifest_path, &serialized)?;
                 fsinfo::restrict_to_owner(&manifest_path, 0o600)?;
             }
@@ -1008,7 +1143,30 @@ impl HandoffSegmentStore {
     pub fn assemble(&self, manifest: &HandoffManifest) -> Result<Vec<u8>> {
         let total = usize::try_from(manifest.total_bytes).context("payload exceeds usize")?;
         let mut payload = Vec::with_capacity(total);
-        for segment in &manifest.segments {
+        let locations = self
+            .packed
+            .load_manifest_index(&manifest.payload_digest, manifest.segments.len())?;
+        let packed_requests = manifest
+            .segments
+            .iter()
+            .zip(&locations)
+            .filter_map(|(segment, location)| {
+                location.as_ref().map(|location| PackedReadRequest {
+                    digest: &segment.digest,
+                    bytes: segment.bytes,
+                    location,
+                })
+            })
+            .collect::<Vec<_>>();
+        let mut packed_bytes = match self.packed.read_many(&packed_requests) {
+            Ok(bytes) => bytes.into_iter(),
+            Err(failure) => {
+                let path = self.packed.pack_path(&failure.pack_digest);
+                let _ = self.quarantine(&path);
+                return Err(failure.error);
+            }
+        };
+        for (segment, location) in manifest.segments.iter().zip(locations) {
             if segment.offset != payload.len() as u64 {
                 bail!(
                     "segment {} offset {} does not match assembled length {}",
@@ -1017,7 +1175,12 @@ impl HandoffSegmentStore {
                     payload.len()
                 );
             }
-            payload.extend_from_slice(&self.read_segment(&segment.digest)?);
+            let bytes = if location.is_some() {
+                packed_bytes.next().context("missing packed segment read")?
+            } else {
+                self.read_segment(&segment.digest)?
+            };
+            payload.extend_from_slice(&bytes);
         }
         if payload.len() != total {
             bail!(
@@ -1032,7 +1195,8 @@ impl HandoffSegmentStore {
     }
 
     pub fn segment_footprint_bytes(&self) -> Result<u64> {
-        directory_bytes(&self.root.join(SEGMENT_DIR))
+        Ok(directory_bytes(&self.root.join(SEGMENT_DIR))?
+            .saturating_add(self.packed.footprint_bytes()?))
     }
 
     /// Every byte the store manages: committed segments, the manifests that
@@ -1054,6 +1218,8 @@ impl HandoffSegmentStore {
     /// Stat every managed file and adopt the result as the running total.
     fn rescan_usage_bytes(&self) -> Result<u64> {
         let mut total = directory_bytes(&self.root.join(SEGMENT_DIR))?;
+        total = total.saturating_add(self.packed.footprint_bytes()?);
+        total = total.saturating_add(self.packed.index_footprint_bytes()?);
         total = total.saturating_add(directory_bytes(&self.root.join(MANIFEST_DIR))?);
         total = total.saturating_add(directory_bytes_recursive(
             &self.root.join(PREFIX_INDEX_DIR),
@@ -1261,18 +1427,30 @@ impl HandoffSegmentStore {
             let Ok(manifest) = self.load_manifest(key) else {
                 continue;
             };
-            for segment in &manifest.segments {
-                let entry = reference_counts
-                    .entry(segment.digest.clone())
-                    .or_insert((0, segment.bytes));
+            let locations = self
+                .packed
+                .load_manifest_index(key, manifest.segments.len())?;
+            for (segment, location) in manifest.segments.iter().zip(&locations) {
+                let (object, bytes) = location.as_ref().map_or_else(
+                    || (segment.digest.clone(), segment.bytes),
+                    |location| {
+                        (
+                            format!("pack:{}", location.pack_digest),
+                            fs::metadata(self.packed.pack_path(&location.pack_digest))
+                                .map(|metadata| metadata.len())
+                                .unwrap_or(0),
+                        )
+                    },
+                );
+                let entry = reference_counts.entry(object).or_insert((0, bytes));
                 entry.0 += 1;
             }
-            manifests.push(manifest);
+            manifests.push((manifest, locations));
         }
         let mut freeable = usage_before;
         let mut evicted_any = false;
         while freeable > target_bytes {
-            let Some(position) = manifests.iter().rposition(|manifest| {
+            let Some(position) = manifests.iter().rposition(|(manifest, _)| {
                 !self.is_pinned(&manifest.payload_digest)
                     && model_identity.is_none_or(|identity| manifest.model_identity == identity)
             }) else {
@@ -1280,7 +1458,7 @@ impl HandoffSegmentStore {
                 // tearing state out from under a live operation is not.
                 break;
             };
-            let evicted = manifests.remove(position);
+            let (evicted, locations) = manifests.remove(position);
             let manifest_path = self.manifest_path(&evicted.payload_digest);
             let manifest_bytes = fs::metadata(&manifest_path)
                 .map(|metadata| metadata.len())
@@ -1288,10 +1466,17 @@ impl HandoffSegmentStore {
             self.invalidate_usage();
             fs::remove_file(&manifest_path)
                 .with_context(|| format!("failed to evict manifest {}", evicted.payload_digest))?;
+            let index_bytes = self.packed.remove_manifest_index(&evicted.payload_digest)?;
             self.evicted_manifests.fetch_add(1, Ordering::Relaxed);
-            freeable = freeable.saturating_sub(manifest_bytes);
-            for segment in &evicted.segments {
-                if let Some(entry) = reference_counts.get_mut(&segment.digest) {
+            freeable = freeable
+                .saturating_sub(manifest_bytes)
+                .saturating_sub(index_bytes);
+            for (segment, location) in evicted.segments.iter().zip(locations) {
+                let object = location.map_or_else(
+                    || segment.digest.clone(),
+                    |location| format!("pack:{}", location.pack_digest),
+                );
+                if let Some(entry) = reference_counts.get_mut(&object) {
                     entry.0 = entry.0.saturating_sub(1);
                     if entry.0 == 0 {
                         freeable = freeable.saturating_sub(entry.1);
@@ -1358,6 +1543,7 @@ impl HandoffSegmentStore {
                     return Err(error).with_context(|| format!("failed to clear manifest {key}"));
                 }
             }
+            self.packed.remove_manifest_index(&key)?;
         }
         self.remove_dangling_prefix_links()?;
         self.collect_unreferenced_segments()?;
@@ -1382,14 +1568,22 @@ impl HandoffSegmentStore {
         // Files are about to be removed or rewritten in bulk.
         self.invalidate_usage();
         let mut referenced = std::collections::HashSet::new();
-        for key in self.list_manifests()? {
-            if let Ok(manifest) = self.load_manifest(&key) {
+        let manifest_keys = self.list_manifests()?;
+        for key in &manifest_keys {
+            if let Ok(manifest) = self.load_manifest(key) {
                 for segment in manifest.segments {
                     referenced.insert(segment.digest);
                 }
             }
         }
         let mut freed = 0u64;
+        let held = self
+            .inflight_segments
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .keys()
+            .cloned()
+            .collect::<std::collections::HashSet<_>>();
         for entry in fs::read_dir(self.root.join(SEGMENT_DIR))? {
             let entry = entry?;
             let path = entry.path();
@@ -1399,17 +1593,17 @@ impl HandoffSegmentStore {
             else {
                 continue;
             };
-            let held = self
-                .inflight_segments
-                .lock()
-                .unwrap_or_else(std::sync::PoisonError::into_inner)
-                .contains_key(&stem);
-            if !referenced.contains(&stem) && !held {
+            if !referenced.contains(&stem) && !held.contains(&stem) {
                 freed = freed.saturating_add(entry.metadata()?.len());
                 fs::remove_file(&path)
                     .with_context(|| format!("failed to collect segment {stem}"))?;
             }
         }
+        let manifests = manifest_keys
+            .into_iter()
+            .collect::<std::collections::HashSet<_>>();
+        freed = freed.saturating_add(self.packed.remove_orphan_indexes(&manifests)?);
+        freed = freed.saturating_add(self.packed.remove_orphan_packs(&referenced, &held)?);
         Ok(freed)
     }
 }

--- a/crates/skippy-cache/src/l3.rs
+++ b/crates/skippy-cache/src/l3.rs
@@ -934,9 +934,12 @@ impl HandoffSegmentStore {
                 digest,
                 bytes: location.bytes,
                 location: &location,
+                output_offset: 0,
             }];
-            return match self.packed.read_many(&requests) {
-                Ok(mut bytes) => bytes.pop().context("packed segment read was empty"),
+            let len = usize::try_from(location.bytes).context("segment exceeds usize")?;
+            let mut bytes = Vec::with_capacity(len);
+            return match self.packed.append_many(&requests, &mut bytes) {
+                Ok(()) => Ok(bytes),
                 Err(failure) => {
                     let path = self.packed.pack_path(&failure.pack_digest);
                     let _ = self.quarantine(&path);
@@ -1146,42 +1149,42 @@ impl HandoffSegmentStore {
         let locations = self
             .packed
             .load_manifest_index(&manifest.payload_digest, manifest.segments.len())?;
-        let packed_requests = manifest
-            .segments
-            .iter()
-            .zip(&locations)
-            .filter_map(|(segment, location)| {
-                location.as_ref().map(|location| PackedReadRequest {
+        let mut expected_offset = 0u64;
+        for segment in &manifest.segments {
+            if segment.offset != expected_offset {
+                bail!(
+                    "segment {} offset {} does not match assembled length {expected_offset}",
+                    segment.index,
+                    segment.offset,
+                );
+            }
+            expected_offset = expected_offset
+                .checked_add(segment.bytes)
+                .context("assembled payload size overflows")?;
+        }
+        if expected_offset != manifest.total_bytes {
+            bail!(
+                "assembled {expected_offset} bytes but manifest records {}",
+                manifest.total_bytes
+            );
+        }
+        let mut packed_requests = Vec::new();
+        for (segment, location) in manifest.segments.iter().zip(&locations) {
+            if let Some(location) = location.as_ref() {
+                packed_requests.push(PackedReadRequest {
                     digest: &segment.digest,
                     bytes: segment.bytes,
                     location,
-                })
-            })
-            .collect::<Vec<_>>();
-        let mut packed_bytes = match self.packed.read_many(&packed_requests) {
-            Ok(bytes) => bytes.into_iter(),
-            Err(failure) => {
-                let path = self.packed.pack_path(&failure.pack_digest);
-                let _ = self.quarantine(&path);
-                return Err(failure.error);
-            }
-        };
-        for (segment, location) in manifest.segments.iter().zip(locations) {
-            if segment.offset != payload.len() as u64 {
-                bail!(
-                    "segment {} offset {} does not match assembled length {}",
-                    segment.index,
-                    segment.offset,
-                    payload.len()
-                );
-            }
-            let bytes = if location.is_some() {
-                packed_bytes.next().context("missing packed segment read")?
+                    output_offset: segment.offset,
+                });
             } else {
-                self.read_segment(&segment.digest)?
-            };
-            payload.extend_from_slice(&bytes);
+                self.append_packed(&packed_requests, &mut payload)?;
+                packed_requests.clear();
+                let bytes = self.read_segment(&segment.digest)?;
+                payload.extend_from_slice(&bytes);
+            }
         }
+        self.append_packed(&packed_requests, &mut payload)?;
         if payload.len() != total {
             bail!(
                 "assembled {} bytes but manifest records {total}",
@@ -1192,6 +1195,21 @@ impl HandoffSegmentStore {
             bail!("assembled payload failed manifest digest verification");
         }
         Ok(payload)
+    }
+
+    fn append_packed(
+        &self,
+        requests: &[PackedReadRequest<'_>],
+        payload: &mut Vec<u8>,
+    ) -> Result<()> {
+        match self.packed.append_many(requests, payload) {
+            Ok(()) => Ok(()),
+            Err(failure) => {
+                let path = self.packed.pack_path(&failure.pack_digest);
+                let _ = self.quarantine(&path);
+                Err(failure.error)
+            }
+        }
     }
 
     pub fn segment_footprint_bytes(&self) -> Result<u64> {

--- a/crates/skippy-cache/src/l3/packed.rs
+++ b/crates/skippy-cache/src/l3/packed.rs
@@ -52,6 +52,7 @@ pub(super) struct PackedReadRequest<'a> {
     pub digest: &'a str,
     pub bytes: u64,
     pub location: &'a PackedSegmentLocation,
+    pub output_offset: u64,
 }
 
 #[derive(Debug)]
@@ -301,48 +302,130 @@ impl PackedSegmentStore {
         Ok(())
     }
 
-    /// Read requests in logical order while opening each physical pack once.
-    pub(super) fn read_many(
+    /// Append requests directly into their final payload ranges.
+    ///
+    /// Consecutive logical segments that are also consecutive in one pack are
+    /// issued as one read. Digest verification still happens per logical
+    /// segment, preserving the manifest contract without allocating one
+    /// temporary `Vec` for every segment and then copying it into the payload.
+    pub(super) fn append_many(
         &self,
         requests: &[PackedReadRequest<'_>],
-    ) -> Result<Vec<Vec<u8>>, PackedReadError> {
+        output: &mut Vec<u8>,
+    ) -> Result<(), PackedReadError> {
         let mut files = HashMap::<String, File>::new();
-        let mut output = Vec::with_capacity(requests.len());
-        for request in requests {
-            let result = (|| -> Result<Vec<u8>> {
-                let file = match files.entry(request.location.pack_digest.clone()) {
+        let mut first = 0usize;
+        while first < requests.len() {
+            let first_request = &requests[first];
+            let mut last = first + 1;
+            let mut physical_end = first_request
+                .location
+                .offset
+                .checked_add(first_request.bytes)
+                .context("packed read range overflows")
+                .map_err(|error| PackedReadError {
+                    pack_digest: first_request.location.pack_digest.clone(),
+                    error,
+                })?;
+            let mut output_end = first_request
+                .output_offset
+                .checked_add(first_request.bytes)
+                .context("packed output range overflows")
+                .map_err(|error| PackedReadError {
+                    pack_digest: first_request.location.pack_digest.clone(),
+                    error,
+                })?;
+            while let Some(next) = requests.get(last) {
+                if next.location.pack_digest != first_request.location.pack_digest
+                    || next.location.offset != physical_end
+                    || next.output_offset != output_end
+                {
+                    break;
+                }
+                physical_end =
+                    physical_end
+                        .checked_add(next.bytes)
+                        .ok_or_else(|| PackedReadError {
+                            pack_digest: first_request.location.pack_digest.clone(),
+                            error: anyhow::anyhow!("packed read range overflows"),
+                        })?;
+                output_end = output_end
+                    .checked_add(next.bytes)
+                    .ok_or_else(|| PackedReadError {
+                        pack_digest: first_request.location.pack_digest.clone(),
+                        error: anyhow::anyhow!("packed output range overflows"),
+                    })?;
+                last += 1;
+            }
+
+            let result = (|| -> Result<()> {
+                if usize::try_from(first_request.output_offset)
+                    .context("packed output offset exceeds usize")?
+                    != output.len()
+                {
+                    bail!("packed output range is not contiguous with the payload");
+                }
+                let file = match files.entry(first_request.location.pack_digest.clone()) {
                     std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
                     std::collections::hash_map::Entry::Vacant(entry) => {
-                        let file = File::open(self.pack_path(&request.location.pack_digest))
+                        let file = File::open(self.pack_path(&first_request.location.pack_digest))
                             .with_context(|| {
-                                format!("failed to open pack {}", request.location.pack_digest)
+                                format!(
+                                    "failed to open pack {}",
+                                    first_request.location.pack_digest
+                                )
                             })?;
                         entry.insert(file)
                     }
                 };
-                file.seek(SeekFrom::Start(request.location.offset))?;
-                let len = usize::try_from(request.bytes).context("segment exceeds usize")?;
-                let mut bytes = vec![0u8; len];
-                file.read_exact(&mut bytes)?;
-                if segment_digest(&bytes) != request.digest {
-                    bail!(
-                        "packed segment {} failed digest verification",
-                        request.digest
-                    );
+                let output_end =
+                    usize::try_from(output_end).context("packed output end exceeds usize")?;
+                file.seek(SeekFrom::Start(first_request.location.offset))?;
+                let run_bytes = output_end
+                    .checked_sub(output.len())
+                    .context("packed output range precedes payload")?;
+                let read = file
+                    .take(run_bytes as u64)
+                    .read_to_end(output)
+                    .context("failed to read packed payload range")?;
+                if read != run_bytes {
+                    bail!("packed payload range ended after {read} of {run_bytes} bytes");
                 }
-                Ok(bytes)
+
+                for request in &requests[first..last] {
+                    let start = usize::try_from(request.output_offset)
+                        .context("segment output offset exceeds usize")?;
+                    let end = usize::try_from(
+                        request
+                            .output_offset
+                            .checked_add(request.bytes)
+                            .context("segment output range overflows")?,
+                    )
+                    .context("segment output end exceeds usize")?;
+                    let bytes = output
+                        .get(start..end)
+                        .context("segment output range exceeds payload")?;
+                    if segment_digest(bytes) != request.digest {
+                        bail!(
+                            "packed segment {} failed digest verification",
+                            request.digest
+                        );
+                    }
+                }
+                Ok(())
             })();
             match result {
-                Ok(bytes) => output.push(bytes),
+                Ok(()) => {}
                 Err(error) => {
                     return Err(PackedReadError {
-                        pack_digest: request.location.pack_digest.clone(),
+                        pack_digest: first_request.location.pack_digest.clone(),
                         error,
                     });
                 }
             }
+            first = last;
         }
-        Ok(output)
+        Ok(())
     }
 
     pub(super) fn rebuild(

--- a/crates/skippy-cache/src/l3/packed.rs
+++ b/crates/skippy-cache/src/l3/packed.rs
@@ -447,12 +447,16 @@ impl PackedSegmentStore {
     pub(super) fn remove_orphan_packs(
         &self,
         referenced_segments: &HashSet<String>,
-        held_segments: &HashSet<String>,
+        held_segments: impl FnOnce() -> HashSet<String>,
     ) -> Result<u64> {
         let _mutation = self
             .mutation
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // Snapshot in-flight publications only after taking the same lock that
+        // serializes pack publication, so collection cannot race a completed
+        // pack into existence before its manifest is committed.
+        let held_segments = held_segments();
         let locations = self
             .locations
             .read()

--- a/crates/skippy-cache/src/l3/packed.rs
+++ b/crates/skippy-cache/src/l3/packed.rs
@@ -312,6 +312,7 @@ impl PackedSegmentStore {
         &self,
         requests: &[PackedReadRequest<'_>],
         output: &mut Vec<u8>,
+        mut payload_hasher: Option<&mut blake3::Hasher>,
     ) -> Result<(), PackedReadError> {
         let mut files = HashMap::<String, File>::new();
         let mut first = 0usize;
@@ -411,6 +412,9 @@ impl PackedSegmentStore {
                             request.digest
                         );
                     }
+                }
+                if let Some(hasher) = payload_hasher.as_deref_mut() {
+                    hasher.update(&output[output_end - run_bytes..output_end]);
                 }
                 Ok(())
             })();

--- a/crates/skippy-cache/src/l3/packed.rs
+++ b/crates/skippy-cache/src/l3/packed.rs
@@ -1,0 +1,479 @@
+//! Append-only physical storage for logical L3 segments.
+//!
+//! One spill publishes at most one immutable pack. A local sidecar maps the
+//! manifest's portable segment digests to pack offsets, keeping the handoff
+//! manifest independent of this node's physical layout.
+
+use std::{
+    collections::{HashMap, HashSet},
+    fs::{self, File},
+    io::{Read, Seek, SeekFrom, Write},
+    path::{Path, PathBuf},
+    sync::{Mutex, RwLock},
+};
+
+use anyhow::{Context, Result, bail};
+use serde::{Deserialize, Serialize};
+
+use super::{segment_digest, tempfile_in, write_atomically};
+use crate::fsinfo;
+
+pub(super) const PACK_DIR: &str = "packs";
+pub(super) const PACK_INDEX_DIR: &str = "pack-indexes";
+const PACK_INDEX_VERSION: u32 = 1;
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub(super) struct PackedSegmentLocation {
+    pub pack_digest: String,
+    pub offset: u64,
+    pub bytes: u64,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct PackedManifestIndex {
+    version: u32,
+    payload_digest: String,
+    segments: Vec<Option<PackedSegmentLocation>>,
+}
+
+#[derive(Debug)]
+pub(super) struct PackedStoredSegment {
+    pub new: bool,
+}
+
+#[derive(Debug)]
+pub(super) struct PackedReadError {
+    pub pack_digest: String,
+    pub error: anyhow::Error,
+}
+
+#[derive(Debug)]
+pub(super) struct PackedReadRequest<'a> {
+    pub digest: &'a str,
+    pub bytes: u64,
+    pub location: &'a PackedSegmentLocation,
+}
+
+#[derive(Debug)]
+pub(super) struct PackedSegmentStore {
+    directory: PathBuf,
+    index_directory: PathBuf,
+    locations: RwLock<HashMap<String, PackedSegmentLocation>>,
+    /// Serializes immutable pack publication with orphan collection.
+    mutation: Mutex<()>,
+}
+
+impl PackedSegmentStore {
+    pub(super) fn open(root: &Path) -> Result<Self> {
+        let directory = root.join(PACK_DIR);
+        let index_directory = root.join(PACK_INDEX_DIR);
+        for path in [&directory, &index_directory] {
+            fsinfo::refuse_symlinked_descendant(root, path)?;
+            fs::create_dir_all(path)
+                .with_context(|| format!("failed to create {}", path.display()))?;
+            fsinfo::restrict_to_owner(path, 0o700)?;
+        }
+        Ok(Self {
+            directory,
+            index_directory,
+            locations: RwLock::new(HashMap::new()),
+            mutation: Mutex::new(()),
+        })
+    }
+
+    pub(super) fn pack_path(&self, pack_digest: &str) -> PathBuf {
+        self.directory.join(format!("{pack_digest}.pack"))
+    }
+
+    pub(super) fn index_path(&self, payload_digest: &str) -> PathBuf {
+        self.index_directory.join(format!("{payload_digest}.json"))
+    }
+
+    pub(super) fn estimated_new_bytes(&self, segments: &[(&str, &[u8])]) -> u64 {
+        let locations = self
+            .locations
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut unique = HashSet::new();
+        segments
+            .iter()
+            .filter(|(digest, _)| unique.insert(*digest))
+            .filter(|(digest, _)| {
+                locations
+                    .get(*digest)
+                    .is_none_or(|location| !self.location_is_present(location))
+            })
+            .map(|(_, bytes)| bytes.len() as u64)
+            .fold(0u64, u64::saturating_add)
+    }
+
+    /// Publish all missing logical segments as one immutable pack.
+    pub(super) fn write_batch(
+        &self,
+        segments: &[(&str, &[u8])],
+    ) -> Result<(Vec<PackedStoredSegment>, u64)> {
+        let _mutation = self
+            .mutation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let existing = self
+            .locations
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clone();
+        let mut planned = HashMap::<String, PackedSegmentLocation>::new();
+        let mut pack_segments = Vec::new();
+        let mut pack_hasher = blake3::Hasher::new();
+        let mut candidate_bytes = 0u64;
+        let mut new_digests = HashSet::new();
+
+        for (digest, bytes) in segments {
+            if existing
+                .get(*digest)
+                .is_some_and(|location| self.location_is_present(location))
+                || planned.contains_key(*digest)
+            {
+                continue;
+            }
+            let offset = candidate_bytes;
+            candidate_bytes = candidate_bytes
+                .checked_add(bytes.len() as u64)
+                .context("packed object size overflows u64")?;
+            pack_hasher.update(bytes);
+            pack_segments.push(*bytes);
+            planned.insert(
+                (*digest).to_string(),
+                PackedSegmentLocation {
+                    pack_digest: String::new(),
+                    offset,
+                    bytes: bytes.len() as u64,
+                },
+            );
+            new_digests.insert((*digest).to_string());
+        }
+
+        let mut new_bytes = 0u64;
+        if !pack_segments.is_empty() {
+            let pack_digest = pack_hasher.finalize().to_hex().to_string();
+            let path = self.pack_path(&pack_digest);
+            if path.exists() {
+                let actual = fs::metadata(&path)?.len();
+                if actual != candidate_bytes {
+                    bail!(
+                        "packed object {pack_digest} has {actual} bytes but the write has {candidate_bytes}"
+                    );
+                }
+            } else {
+                write_pack_atomically(&path, &pack_segments)?;
+                fsinfo::restrict_to_owner(&path, 0o600)?;
+                new_bytes = candidate_bytes;
+            }
+            for location in planned.values_mut() {
+                location.pack_digest.clone_from(&pack_digest);
+            }
+        }
+
+        let mut locations = self
+            .locations
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        for (digest, location) in &planned {
+            locations.insert(digest.clone(), location.clone());
+        }
+        let published_new_pack = new_bytes > 0;
+        let mut reported_new = HashSet::new();
+        let stored = segments
+            .iter()
+            .map(|(digest, _)| PackedStoredSegment {
+                new: published_new_pack
+                    && new_digests.contains(*digest)
+                    && reported_new.insert(*digest),
+            })
+            .collect();
+        Ok((stored, new_bytes))
+    }
+
+    pub(super) fn location(&self, digest: &str) -> Option<PackedSegmentLocation> {
+        self.locations
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .get(digest)
+            .filter(|location| self.location_is_present(location))
+            .cloned()
+    }
+
+    pub(super) fn encode_manifest_index(
+        &self,
+        payload_digest: &str,
+        segment_digests: &[String],
+    ) -> Result<Option<Vec<u8>>> {
+        let segments = segment_digests
+            .iter()
+            .map(|digest| self.location(digest))
+            .collect::<Vec<_>>();
+        if segments.iter().all(Option::is_none) {
+            return Ok(None);
+        }
+        serde_json::to_vec(&PackedManifestIndex {
+            version: PACK_INDEX_VERSION,
+            payload_digest: payload_digest.to_string(),
+            segments,
+        })
+        .context("failed to serialize packed manifest index")
+        .map(Some)
+    }
+
+    pub(super) fn publish_manifest_index(
+        &self,
+        payload_digest: &str,
+        encoded: &[u8],
+    ) -> Result<()> {
+        let path = self.index_path(payload_digest);
+        write_atomically(&path, encoded)?;
+        fsinfo::restrict_to_owner(&path, 0o600)
+    }
+
+    pub(super) fn load_manifest_index(
+        &self,
+        payload_digest: &str,
+        segment_count: usize,
+    ) -> Result<Vec<Option<PackedSegmentLocation>>> {
+        let path = self.index_path(payload_digest);
+        let bytes = match fs::read(&path) {
+            Ok(bytes) => bytes,
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                return Ok(vec![None; segment_count]);
+            }
+            Err(error) => return Err(error.into()),
+        };
+        let index: PackedManifestIndex =
+            serde_json::from_slice(&bytes).context("malformed packed manifest index")?;
+        if index.version != PACK_INDEX_VERSION
+            || index.payload_digest != payload_digest
+            || index.segments.len() != segment_count
+        {
+            bail!("packed manifest index does not match manifest {payload_digest}");
+        }
+        for location in index.segments.iter().flatten() {
+            if !is_digest(&location.pack_digest) || location.bytes == 0 {
+                bail!("packed manifest index contains an invalid location");
+            }
+            location
+                .offset
+                .checked_add(location.bytes)
+                .context("packed manifest index range overflows")?;
+        }
+        Ok(index.segments)
+    }
+
+    pub(super) fn remove_manifest_index(&self, payload_digest: &str) -> Result<u64> {
+        let path = self.index_path(payload_digest);
+        let bytes = fs::metadata(&path)
+            .map(|metadata| metadata.len())
+            .unwrap_or(0);
+        match fs::remove_file(&path) {
+            Ok(()) => Ok(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(0),
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    pub(super) fn validate(&self, location: &PackedSegmentLocation, bytes: u64) -> Result<()> {
+        if location.bytes != bytes {
+            bail!(
+                "packed index records {} bytes but manifest records {bytes}",
+                location.bytes
+            );
+        }
+        let pack_bytes = fs::metadata(self.pack_path(&location.pack_digest))
+            .with_context(|| format!("missing pack {}", location.pack_digest))?
+            .len();
+        let end = location
+            .offset
+            .checked_add(bytes)
+            .context("packed segment range overflows")?;
+        if end > pack_bytes {
+            bail!(
+                "pack {} has {pack_bytes} bytes but segment range ends at {end}",
+                location.pack_digest
+            );
+        }
+        Ok(())
+    }
+
+    /// Read requests in logical order while opening each physical pack once.
+    pub(super) fn read_many(
+        &self,
+        requests: &[PackedReadRequest<'_>],
+    ) -> Result<Vec<Vec<u8>>, PackedReadError> {
+        let mut files = HashMap::<String, File>::new();
+        let mut output = Vec::with_capacity(requests.len());
+        for request in requests {
+            let result = (|| -> Result<Vec<u8>> {
+                let file = match files.entry(request.location.pack_digest.clone()) {
+                    std::collections::hash_map::Entry::Occupied(entry) => entry.into_mut(),
+                    std::collections::hash_map::Entry::Vacant(entry) => {
+                        let file = File::open(self.pack_path(&request.location.pack_digest))
+                            .with_context(|| {
+                                format!("failed to open pack {}", request.location.pack_digest)
+                            })?;
+                        entry.insert(file)
+                    }
+                };
+                file.seek(SeekFrom::Start(request.location.offset))?;
+                let len = usize::try_from(request.bytes).context("segment exceeds usize")?;
+                let mut bytes = vec![0u8; len];
+                file.read_exact(&mut bytes)?;
+                if segment_digest(&bytes) != request.digest {
+                    bail!(
+                        "packed segment {} failed digest verification",
+                        request.digest
+                    );
+                }
+                Ok(bytes)
+            })();
+            match result {
+                Ok(bytes) => output.push(bytes),
+                Err(error) => {
+                    return Err(PackedReadError {
+                        pack_digest: request.location.pack_digest.clone(),
+                        error,
+                    });
+                }
+            }
+        }
+        Ok(output)
+    }
+
+    pub(super) fn rebuild(
+        &self,
+        entries: impl IntoIterator<Item = (String, PackedSegmentLocation)>,
+    ) {
+        let mut locations = self
+            .locations
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        locations.clear();
+        locations.extend(entries);
+    }
+
+    pub(super) fn remove_orphan_packs(
+        &self,
+        referenced_segments: &HashSet<String>,
+        held_segments: &HashSet<String>,
+    ) -> Result<u64> {
+        let _mutation = self
+            .mutation
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let locations = self
+            .locations
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let protected = locations
+            .iter()
+            .filter(|(digest, _)| {
+                referenced_segments.contains(*digest) || held_segments.contains(*digest)
+            })
+            .map(|(_, location)| location.pack_digest.clone())
+            .collect::<HashSet<_>>();
+        let mut freed = 0u64;
+        for entry in fs::read_dir(&self.directory)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().is_none_or(|extension| extension != "pack") {
+                continue;
+            }
+            let Some(pack_digest) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                continue;
+            };
+            if protected.contains(pack_digest) {
+                continue;
+            }
+            freed = freed.saturating_add(entry.metadata()?.len());
+            fs::remove_file(&path)
+                .with_context(|| format!("failed to collect pack {pack_digest}"))?;
+        }
+        Ok(freed)
+    }
+
+    pub(super) fn remove_orphan_indexes(&self, manifests: &HashSet<String>) -> Result<u64> {
+        let mut freed = 0u64;
+        for entry in fs::read_dir(&self.index_directory)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().is_none_or(|extension| extension != "json") {
+                continue;
+            }
+            let Some(payload_digest) = path.file_stem().and_then(|stem| stem.to_str()) else {
+                continue;
+            };
+            if manifests.contains(payload_digest) {
+                continue;
+            }
+            freed = freed.saturating_add(entry.metadata()?.len());
+            fs::remove_file(&path)?;
+        }
+        Ok(freed)
+    }
+
+    pub(super) fn footprint_bytes(&self) -> Result<u64> {
+        directory_bytes(&self.directory)
+    }
+
+    pub(super) fn index_footprint_bytes(&self) -> Result<u64> {
+        directory_bytes(&self.index_directory)
+    }
+
+    fn location_is_present(&self, location: &PackedSegmentLocation) -> bool {
+        self.pack_path(&location.pack_digest)
+            .metadata()
+            .is_ok_and(|metadata| location.offset < metadata.len())
+    }
+}
+
+fn directory_bytes(directory: &Path) -> Result<u64> {
+    let mut total = 0u64;
+    for entry in fs::read_dir(directory)? {
+        let entry = entry?;
+        if entry.file_type()?.is_file() {
+            total = total.saturating_add(entry.metadata()?.len());
+        }
+    }
+    Ok(total)
+}
+
+fn write_pack_atomically(path: &Path, segments: &[&[u8]]) -> Result<()> {
+    let directory = path.parent().context("pack path has no parent directory")?;
+    let (temp_path, mut temp_file) = tempfile_in(directory)?;
+    let write_result = (|| -> Result<()> {
+        for segment in segments {
+            temp_file
+                .write_all(segment)
+                .with_context(|| format!("failed to write {}", temp_path.display()))?;
+        }
+        temp_file
+            .sync_all()
+            .with_context(|| format!("failed to sync {}", temp_path.display()))
+    })();
+    drop(temp_file);
+    let publish_result = write_result.and_then(|()| fsinfo::replace_file(&temp_path, path));
+    if let Err(error) = publish_result {
+        return match fs::remove_file(&temp_path) {
+            Ok(()) => Err(error),
+            Err(cleanup) if cleanup.kind() == std::io::ErrorKind::NotFound => Err(error),
+            Err(cleanup) => Err(error.context(format!(
+                "also failed to remove temporary pack {}: {cleanup}",
+                temp_path.display()
+            ))),
+        };
+    }
+    Ok(())
+}
+
+fn is_digest(value: &str) -> bool {
+    value.len() == 64
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || (b'a'..=b'f').contains(&byte))
+}

--- a/crates/skippy-cache/src/l3/tests.rs
+++ b/crates/skippy-cache/src/l3/tests.rs
@@ -116,10 +116,9 @@ fn packed_roundtrip_uses_one_physical_file_and_survives_reopen() {
         manifest
     };
 
+    // Direct callers receive a fully reconciled store, including the packed
+    // location map needed to read manifests from the previous process.
     let reopened = store(&root, 0);
-    reopened
-        .reconcile_startup()
-        .expect("reconcile packed store");
     let loaded = reopened
         .load_manifest(&manifest.payload_digest)
         .expect("load packed manifest after restart");
@@ -326,28 +325,24 @@ fn a_segment_larger_than_the_budget_is_refused() {
 
 #[test]
 fn an_entry_larger_than_a_shrunken_budget_is_refused_at_commit() {
-    // A budget shrunk between runs is the realistic way an entry ends up
-    // bigger than the cap: it was admissible when its segments were
-    // written and is not any more.
+    // A live budget update can make an in-flight entry larger than the cap:
+    // it was admissible when its segments were written and is not any more.
     let root = temp_root("oversize-commit");
-    let uncapped = store(&root, 0);
-    let manifest = {
-        let (manifest, held) = manifest_for(&uncapped, &vec![7u8; 16_000], 4_000);
-        drop(held);
-        manifest
-    };
-    drop(uncapped);
-
-    let capped = store(&root, 8_000);
-    let error = capped
+    let store = store(&root, 0);
+    let (manifest, held) = manifest_for(&store, &vec![7u8; 16_000], 4_000);
+    store
+        .update_limits(StoreLimits::new(8_000, 0))
+        .expect("shrink limits");
+    let error = store
         .commit(&manifest)
         .expect_err("an entry larger than the budget was committed");
+    drop(held);
     assert!(
         format!("{error:#}").contains("skipped_oversize"),
         "refusal did not carry the reason code: {error:#}"
     );
     assert!(
-        capped.list_manifests().expect("list").is_empty(),
+        store.list_manifests().expect("list").is_empty(),
         "the refused entry was left loadable"
     );
 }

--- a/crates/skippy-cache/src/l3/tests.rs
+++ b/crates/skippy-cache/src/l3/tests.rs
@@ -50,6 +50,36 @@ fn commit_payload(
     manifest
 }
 
+fn commit_packed_payload(
+    store: &HandoffSegmentStore,
+    payload: &[u8],
+    segment_bytes: usize,
+) -> HandoffManifest {
+    let chunks = payload.chunks(segment_bytes).collect::<Vec<_>>();
+    let held = store
+        .try_put_segments(&chunks)
+        .expect("packed put")
+        .expect("packed put admitted");
+    let mut manifest = HandoffManifest::new("blake3:test".to_string(), "full-state".into());
+    let mut offset = 0u64;
+    for (index, stored) in held.iter().enumerate() {
+        let bytes = chunks[index].len() as u64;
+        manifest.segments.push(HandoffSegmentRef {
+            index: index as u32,
+            offset,
+            bytes,
+            digest: stored.digest.clone(),
+            meta_json: None,
+        });
+        offset += bytes;
+    }
+    manifest.total_bytes = payload.len() as u64;
+    manifest.payload_digest = segment_digest(payload);
+    store.commit(&manifest).expect("packed commit");
+    drop(held);
+    manifest
+}
+
 fn temp_root(name: &str) -> PathBuf {
     let root = std::env::temp_dir()
         .join("skippy-l3-tests")
@@ -68,6 +98,73 @@ fn roundtrip_assembles_identical_payload() {
         .load_manifest(&manifest.payload_digest)
         .expect("load manifest");
     assert_eq!(store.assemble(&loaded).expect("assemble"), payload);
+}
+
+#[test]
+fn packed_roundtrip_uses_one_physical_file_and_survives_reopen() {
+    let root = temp_root("packed-roundtrip");
+    let payload: Vec<u8> = (0..100_000u32).map(|value| value as u8).collect();
+    let manifest = {
+        let store = store(&root, 0);
+        let manifest = commit_packed_payload(&store, &payload, 4096);
+        assert_eq!(fs::read_dir(root.join(PACK_DIR)).unwrap().count(), 1);
+        assert_eq!(fs::read_dir(root.join(SEGMENT_DIR)).unwrap().count(), 0);
+        let manifest_json = fs::read_to_string(store.manifest_path(&manifest.payload_digest))
+            .expect("read portable manifest");
+        assert!(!manifest_json.contains("pack_digest"));
+        assert_eq!(store.assemble(&manifest).expect("assemble"), payload);
+        manifest
+    };
+
+    let reopened = store(&root, 0);
+    reopened
+        .reconcile_startup()
+        .expect("reconcile packed store");
+    let loaded = reopened
+        .load_manifest(&manifest.payload_digest)
+        .expect("load packed manifest after restart");
+    assert_eq!(reopened.assemble(&loaded).expect("assemble"), payload);
+}
+
+#[test]
+fn corrupt_pack_is_quarantined_and_never_served() {
+    let root = temp_root("packed-corruption");
+    let store = store(&root, 0);
+    let payload: Vec<u8> = (0..32_000u32).map(|value| value as u8).collect();
+    let manifest = commit_packed_payload(&store, &payload, 4096);
+    let pack = fs::read_dir(root.join(PACK_DIR))
+        .unwrap()
+        .next()
+        .unwrap()
+        .unwrap()
+        .path();
+    let mut bytes = fs::read(&pack).unwrap();
+    bytes[0] ^= 0xff;
+    fs::write(&pack, bytes).unwrap();
+
+    assert!(store.assemble(&manifest).is_err());
+    assert!(!pack.exists());
+    assert!(root.join(QUARANTINE_DIR).exists());
+}
+
+#[test]
+fn uncommitted_pack_is_collected_after_holds_release() {
+    let root = temp_root("packed-orphan");
+    let store = store(&root, 0);
+    let payload = (0..16_000)
+        .map(|index| (index / 1024) as u8)
+        .collect::<Vec<_>>();
+    let chunks = payload.chunks(1024).collect::<Vec<_>>();
+    let held = store
+        .try_put_segments(&chunks)
+        .unwrap()
+        .expect("packed put admitted");
+    assert_eq!(store.collect_unreferenced_segments().unwrap(), 0);
+    drop(held);
+    assert_eq!(
+        store.collect_unreferenced_segments().unwrap(),
+        payload.len() as u64
+    );
 }
 
 #[test]

--- a/crates/skippy-cache/src/manager.rs
+++ b/crates/skippy-cache/src/manager.rs
@@ -430,7 +430,7 @@ fn open_store_for_acquire(
     let attempts = if expiring_owner { HANDOFF_ATTEMPTS } else { 1 };
     let mut last = None;
     for attempt in 0..attempts {
-        match HandoffSegmentStore::open_with_limits(root, limits) {
+        match HandoffSegmentStore::open_unreconciled_with_limits(root, limits) {
             Ok(store) => return Ok(store),
             Err(error) => {
                 last = Some(error);

--- a/crates/skippy-cache/src/tier.rs
+++ b/crates/skippy-cache/src/tier.rs
@@ -300,27 +300,35 @@ impl L3Tier {
                 cuts
             }
         };
+        let segment_slices = cuts
+            .iter()
+            .map(|(offset, len, _)| {
+                let start = usize::try_from(*offset).context("segment offset exceeds usize")?;
+                let end = start
+                    .checked_add(usize::try_from(*len).context("segment length exceeds usize")?)
+                    .context("segment range overflows")?;
+                Ok(&wire[start..end])
+            })
+            .collect::<Result<Vec<_>>>()?;
+        let stored_segments = match self.store().try_put_segments(&segment_slices) {
+            Ok(Ok(stored)) => stored,
+            Ok(Err(refusal)) => {
+                self.manager.record_write_refusal(refusal);
+                bail!("cannot store packed segments: {}", refusal.reason());
+            }
+            Err(error) => {
+                self.manager.record_storage_error();
+                return Err(error);
+            }
+        };
         let mut new_bytes = 0u64;
         // Held until after the commit below: until the manifest names them
         // these segments are unreferenced, and an eviction triggered by
         // another writer would collect them mid-build.
-        let mut held = Vec::with_capacity(manifest.segments.capacity());
-        for (index, (offset, len, label)) in cuts.into_iter().enumerate() {
-            let start = usize::try_from(offset).context("segment offset exceeds usize")?;
-            let end = start
-                .checked_add(usize::try_from(len).context("segment length exceeds usize")?)
-                .context("segment range overflows")?;
-            let stored = match self.store().try_put_segment(&wire[start..end]) {
-                Ok(Ok(stored)) => stored,
-                Ok(Err(refusal)) => {
-                    self.manager.record_write_refusal(refusal);
-                    bail!("cannot store segment: {}", refusal.reason());
-                }
-                Err(error) => {
-                    self.manager.record_storage_error();
-                    return Err(error);
-                }
-            };
+        let mut held = Vec::with_capacity(stored_segments.len());
+        for ((index, (offset, len, label)), stored) in
+            cuts.into_iter().enumerate().zip(stored_segments)
+        {
             if stored.put.new {
                 new_bytes = new_bytes.saturating_add(stored.put.bytes);
             }

--- a/crates/skippy-server/src/frontend/generation/queue.rs
+++ b/crates/skippy-server/src/frontend/generation/queue.rs
@@ -804,10 +804,11 @@ pub(in crate::frontend) fn prewarm_generation_sessions(
     event_name: &'static str,
 ) -> Result<()> {
     let timer = PhaseTimer::start();
-    let sessions = runtime
+    let mut runtime = runtime
         .lock()
-        .map_err(|_| anyhow!("runtime lock poisoned"))?
-        .prewarm_idle_sessions(generation_concurrency)?;
+        .map_err(|_| anyhow!("runtime lock poisoned"))?;
+    let generation_graph_warmed = runtime.warmup_generation_graph()?;
+    let sessions = runtime.prewarm_idle_sessions(generation_concurrency)?;
     let mut attrs = lifecycle_attrs(config);
     attrs.insert(
         "llama_stage.generation_concurrency".to_string(),
@@ -824,6 +825,10 @@ pub(in crate::frontend) fn prewarm_generation_sessions(
     attrs.insert(
         "llama_stage.runtime_sessions_idle".to_string(),
         json!(sessions.idle_sessions),
+    );
+    attrs.insert(
+        "llama_stage.generation_graph_warmed".to_string(),
+        json!(generation_graph_warmed),
     );
     attrs.insert(
         "llama_stage.elapsed_ms".to_string(),

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -85,7 +85,7 @@ impl KvStageIntegration {
             emit_cache_disabled_warning(config, reason);
             return Ok(None);
         }
-        let mut payload = effective_cache_payload(cache_config.payload, &model_capability);
+        let payload = effective_cache_payload(cache_config.payload, &model_capability);
         if payload == StagePrefixCachePayload::Disabled {
             return Ok(None);
         }
@@ -109,18 +109,24 @@ impl KvStageIntegration {
             return Ok(None);
         }
         let l3_manager = manager()?;
-        if l3_manager.is_some()
-            && payload == StagePrefixCachePayload::ResidentKv
-            && dense_without_recurrent
-        {
-            // The durable tier needs exportable state and ResidentKv is
-            // borrow-only. Dense families record KV pages with an empty
-            // recurrent snapshot so they reach disk; the model is known
-            // dense, so the empty snapshot is expected rather than corrupt.
-            payload = StagePrefixCachePayload::KvRecurrent;
-        }
+        let durable_payload = l3_manager.as_ref().map(|_| {
+            if payload == StagePrefixCachePayload::ResidentKv && dense_without_recurrent {
+                // Resident KV stays the in-process fast path. Dense families
+                // export KV pages with an empty recurrent snapshot for L3;
+                // the known-dense capability makes that empty component valid.
+                StagePrefixCachePayload::KvRecurrent
+            } else {
+                payload
+            }
+        });
         let l3 = l3_manager
-            .map(|manager| l3_tier_for_manager(config, payload, manager))
+            .map(|manager| {
+                l3_tier_for_manager(
+                    config,
+                    durable_payload.expect("enabled cache has a durable payload"),
+                    manager,
+                )
+            })
             .transpose()?;
         // FullState is architecture-neutral: the native runtime serializes the
         // complete session state for both dense and recurrent model families.
@@ -206,6 +212,7 @@ impl KvStageIntegration {
         Ok(Some(Self {
             mode,
             payload,
+            durable_payload,
             correctness_mode: false,
             trust_local_writes: true,
             checkpoint_policy,
@@ -1315,7 +1322,7 @@ mod tests {
     }
 
     #[test]
-    fn dense_auto_cache_becomes_exportable_when_disk_is_injected() {
+    fn dense_disk_cache_preserves_resident_fast_path_and_exports_exact_state() {
         let root = std::env::temp_dir()
             .join("skippy-server-l3-manager-tests")
             .join(format!("dense-export-{}", std::process::id()));
@@ -1331,7 +1338,15 @@ mod tests {
         .unwrap()
         .expect("dense disk cache should remain enabled");
 
-        assert_eq!(kv.payload, StagePrefixCachePayload::KvRecurrent);
+        assert_eq!(kv.payload, StagePrefixCachePayload::ResidentKv);
+        assert_eq!(
+            kv.durable_payload,
+            Some(StagePrefixCachePayload::KvRecurrent)
+        );
+        assert_eq!(
+            kv.exact_state_payload(),
+            Some(StagePrefixCachePayload::KvRecurrent)
+        );
         assert!(kv.l3.is_some());
     }
 

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -120,13 +120,8 @@ impl KvStageIntegration {
             }
         });
         let l3 = l3_manager
-            .map(|manager| {
-                l3_tier_for_manager(
-                    config,
-                    durable_payload.expect("enabled cache has a durable payload"),
-                    manager,
-                )
-            })
+            .zip(durable_payload)
+            .map(|(manager, payload)| l3_tier_for_manager(config, payload, manager))
             .transpose()?;
         // FullState is architecture-neutral: the native runtime serializes the
         // complete session state for both dense and recurrent model families.
@@ -1348,6 +1343,11 @@ mod tests {
             Some(StagePrefixCachePayload::KvRecurrent)
         );
         assert!(kv.l3.is_some());
+
+        let mut invalid = kv;
+        invalid.payload = StagePrefixCachePayload::Disabled;
+        invalid.durable_payload = Some(StagePrefixCachePayload::ResidentKv);
+        assert_eq!(invalid.exact_state_payload(), None);
     }
 
     #[test]

--- a/crates/skippy-server/src/kv_integration/config.rs
+++ b/crates/skippy-server/src/kv_integration/config.rs
@@ -169,7 +169,7 @@ impl KvStageIntegration {
         let worker_exact_state_record_worker_healthy = exact_state_record_worker_healthy.clone();
         let exact_state_record_worker_panics = Arc::new(std::sync::atomic::AtomicU64::new(0));
         let worker_exact_state_record_worker_panics = exact_state_record_worker_panics.clone();
-        std::thread::Builder::new()
+        let exact_state_record_task = std::thread::Builder::new()
             .name(format!("skippy-exact-cache-{}", config.stage_id))
             .spawn(move || {
                 while let Ok(pending) = exact_state_record_rx.recv() {
@@ -204,6 +204,10 @@ impl KvStageIntegration {
                     }
                 }
             })?;
+        let exact_state_record_worker = Arc::new(super::ExactStateRecordWorker::new(
+            exact_state_record_tx,
+            exact_state_record_task,
+        ));
         Ok(Some(Self {
             mode,
             payload,
@@ -222,7 +226,7 @@ impl KvStageIntegration {
             exact_blobs,
             exact_max_entries,
             exact_byte_limits,
-            exact_state_record_tx,
+            exact_state_record_worker,
             exact_state_records_queued,
             exact_state_records_dropped,
             exact_state_records_pending,

--- a/crates/skippy-server/src/kv_integration/exact_state.rs
+++ b/crates/skippy-server/src/kv_integration/exact_state.rs
@@ -33,7 +33,18 @@ impl KvStageIntegration {
         session_id: &str,
         identities: &[PrefillKvIdentity],
     ) -> Result<Option<ExactStateRestore>> {
-        if !self.should_lookup() || !self.payload.is_exact_state() {
+        if !self.should_lookup() || self.exact_state_payload().is_none() {
+            return Ok(None);
+        }
+        // Dense L3 uses serialized exact state only as the durable floor.
+        // Prefer a native resident-prefix hit whenever one is already warm;
+        // importing the serialized snapshot would otherwise make enabling L3
+        // slower than the ordinary L1 path on every repeated request.
+        if self.payload == StagePrefixCachePayload::ResidentKv
+            && identities
+                .iter()
+                .any(|identity| self.probe_resident_prefix(identity).is_some())
+        {
             return Ok(None);
         }
         for identity in identities {
@@ -253,7 +264,10 @@ impl KvStageIntegration {
         session_id: &str,
         identity: &PrefillKvIdentity,
     ) -> Result<Option<ExactStateRecord>> {
-        if !self.should_record() || !self.payload.is_exact_state() {
+        let Some(exact_state_payload) = self.exact_state_payload() else {
+            return Ok(None);
+        };
+        if !self.should_record() {
             return Ok(None);
         }
         let token_count = identity.identity.token_count;
@@ -288,7 +302,7 @@ impl KvStageIntegration {
             self.finish_record(&identity.page_id);
             return Ok(None);
         }
-        let exported = match self.payload {
+        let exported = match exact_state_payload {
             StagePrefixCachePayload::FullState => {
                 runtime.export_full_state(session_id).map(|state| {
                     (

--- a/crates/skippy-server/src/kv_integration/exact_state.rs
+++ b/crates/skippy-server/src/kv_integration/exact_state.rs
@@ -15,6 +15,10 @@ fn l3_fill_claim_key(l3: &skippy_cache::L3Tier, location: &skippy_cache::L3Locat
     format!("{}:{}", l3.state_identity(), location.manifest_key)
 }
 
+fn resident_prefix_is_complete(matched_tokens: usize, requested_tokens: usize) -> bool {
+    matched_tokens >= requested_tokens
+}
+
 impl KvStageIntegration {
     pub fn restore_exact_state(
         &self,
@@ -41,9 +45,12 @@ impl KvStageIntegration {
         // importing the serialized snapshot would otherwise make enabling L3
         // slower than the ordinary L1 path on every repeated request.
         if self.payload == StagePrefixCachePayload::ResidentKv
-            && identities
-                .iter()
-                .any(|identity| self.probe_resident_prefix(identity).is_some())
+            && identities.iter().any(|identity| {
+                self.probe_resident_prefix(identity)
+                    .is_some_and(|resident| {
+                        resident_prefix_is_complete(resident.token_count, identity.token_ids.len())
+                    })
+            })
         {
             return Ok(None);
         }
@@ -691,12 +698,19 @@ mod tests {
 
     use skippy_cache::UnifiedRadixCache;
 
-    use super::try_touch_exact_state;
+    use super::{resident_prefix_is_complete, try_touch_exact_state};
 
     type TestRadix = UnifiedRadixCache<
         crate::kv_integration::RadixResidentEntry,
         crate::kv_integration::RadixExactEntry,
     >;
+
+    #[test]
+    fn only_complete_resident_prefixes_skip_exact_restore() {
+        assert!(resident_prefix_is_complete(4_000, 4_000));
+        assert!(resident_prefix_is_complete(4_001, 4_000));
+        assert!(!resident_prefix_is_complete(200, 4_000));
+    }
 
     #[test]
     fn busy_exact_state_lock_skips_touch_without_waiting() {

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -148,7 +148,13 @@ pub(crate) struct ExactStateByteLimits {
 #[derive(Clone)]
 pub struct KvStageIntegration {
     pub(crate) mode: StageKvMode,
+    /// The in-process cache representation. Dense models keep native resident
+    /// KV here even when a durable tier is configured, so enabling disk does
+    /// not replace the fast warm path with serialized state import.
     pub(crate) payload: StagePrefixCachePayload,
+    /// Exportable representation written to and restored from L3. This is
+    /// separate from `payload` because resident KV is native and borrow-only.
+    pub(crate) durable_payload: Option<StagePrefixCachePayload>,
     pub(crate) correctness_mode: bool,
     pub(crate) trust_local_writes: bool,
     pub(crate) checkpoint_policy: SparseCheckpointPolicy,
@@ -502,7 +508,14 @@ impl KvStageIntegration {
     }
 
     pub(crate) fn payload_is_exact_state(&self) -> bool {
-        self.payload.is_exact_state()
+        self.exact_state_payload().is_some()
+    }
+
+    pub(crate) fn exact_state_payload(&self) -> Option<StagePrefixCachePayload> {
+        self.payload
+            .is_exact_state()
+            .then_some(self.payload)
+            .or(self.durable_payload)
     }
 
     pub fn should_lookup(&self) -> bool {

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -515,7 +515,9 @@ impl KvStageIntegration {
         self.payload
             .is_exact_state()
             .then_some(self.payload)
-            .or(self.durable_payload)
+            .or(self
+                .durable_payload
+                .filter(|payload| payload.is_exact_state()))
     }
 
     pub fn should_lookup(&self) -> bool {

--- a/crates/skippy-server/src/kv_integration/mod.rs
+++ b/crates/skippy-server/src/kv_integration/mod.rs
@@ -5,6 +5,7 @@ use std::{
         atomic::{AtomicBool, AtomicU64, AtomicUsize},
         mpsc::{SyncSender, TrySendError},
     },
+    thread::JoinHandle,
 };
 
 use anyhow::{Result, bail};
@@ -167,7 +168,7 @@ pub struct KvStageIntegration {
     pub(crate) exact_blobs: Arc<Mutex<CacheBlobStore>>,
     pub(crate) exact_max_entries: usize,
     pub(crate) exact_byte_limits: ExactStateByteLimits,
-    pub(crate) exact_state_record_tx: SyncSender<PendingExactStateRecord>,
+    pub(crate) exact_state_record_worker: Arc<ExactStateRecordWorker>,
     pub(crate) exact_state_records_queued: Arc<AtomicU64>,
     pub(crate) exact_state_records_dropped: Arc<AtomicU64>,
     pub(crate) exact_state_records_pending: Arc<AtomicUsize>,
@@ -225,6 +226,49 @@ pub(crate) struct PendingExactStateRecord {
     /// so requests arriving during the asynchronous re-warm prefill normally
     /// instead of duplicating the disk read.
     pub(crate) l3_fill_claim: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct ExactStateRecordWorker {
+    sender: Mutex<Option<SyncSender<PendingExactStateRecord>>>,
+    task: Mutex<Option<JoinHandle<()>>>,
+}
+
+impl ExactStateRecordWorker {
+    pub(crate) fn new(sender: SyncSender<PendingExactStateRecord>, task: JoinHandle<()>) -> Self {
+        Self {
+            sender: Mutex::new(Some(sender)),
+            task: Mutex::new(Some(task)),
+        }
+    }
+
+    fn with_sender<T>(
+        &self,
+        use_sender: impl FnOnce(Option<&SyncSender<PendingExactStateRecord>>) -> T,
+    ) -> T {
+        let sender = self
+            .sender
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        use_sender(sender.as_ref())
+    }
+}
+
+impl Drop for ExactStateRecordWorker {
+    fn drop(&mut self) {
+        self.sender
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take();
+        if let Some(task) = self
+            .task
+            .get_mut()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .take()
+        {
+            let _ = task.join();
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -596,17 +640,25 @@ impl KvStageIntegration {
         &self,
         pending: PendingExactStateRecord,
     ) -> ExactStateRecordAdmission {
-        enqueue_exact_state_record(
-            &self.exact_state_record_tx,
-            &self.inflight_records,
-            &self.exact_state_records_queued,
-            &self.exact_state_records_dropped,
-            &self.exact_state_records_pending,
-            &self.exact_state_record_queue_bytes,
-            EXACT_STATE_RECORD_QUEUE_BYTES,
-            &self.exact_state_record_worker_healthy,
-            pending,
-        )
+        self.exact_state_record_worker.with_sender(|sender| {
+            let Some(sender) = sender else {
+                self.finish_record(&pending.page_id);
+                self.exact_state_records_dropped
+                    .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+                return ExactStateRecordAdmission::WorkerStopped;
+            };
+            enqueue_exact_state_record(
+                sender,
+                &self.inflight_records,
+                &self.exact_state_records_queued,
+                &self.exact_state_records_dropped,
+                &self.exact_state_records_pending,
+                &self.exact_state_record_queue_bytes,
+                EXACT_STATE_RECORD_QUEUE_BYTES,
+                &self.exact_state_record_worker_healthy,
+                pending,
+            )
+        })
     }
 
     pub async fn hello(&self) -> Result<()> {
@@ -1013,8 +1065,8 @@ mod exact_state_record_queue_tests {
 
     use super::{
         BTreeSet, EXACT_STATE_RECORD_CAPACITY, ExactStateExtra, ExactStateRecordAdmission,
-        PendingExactStateRecord, enqueue_exact_state_record, has_exact_state_record_capacity,
-        run_exact_state_record_job,
+        ExactStateRecordWorker, PendingExactStateRecord, enqueue_exact_state_record,
+        has_exact_state_record_capacity, run_exact_state_record_job,
     };
 
     fn pending(page_id: &str) -> PendingExactStateRecord {
@@ -1036,6 +1088,24 @@ mod exact_state_record_queue_tests {
     }
 
     const CAP: u64 = 1024;
+
+    #[test]
+    fn final_worker_owner_drains_queued_records_before_drop_returns() {
+        let (sender, receiver) = sync_channel(2);
+        let completed = Arc::new(AtomicUsize::new(0));
+        let worker_completed = completed.clone();
+        let task = std::thread::spawn(move || {
+            while receiver.recv().is_ok() {
+                worker_completed.fetch_add(1, Ordering::Release);
+            }
+        });
+        let worker = Arc::new(ExactStateRecordWorker::new(sender, task));
+        worker.with_sender(|sender| sender.unwrap().send(pending("latest")).unwrap());
+
+        drop(worker);
+
+        assert_eq!(completed.load(Ordering::Acquire), 1);
+    }
 
     #[test]
     fn pending_capacity_signal_rejects_work_before_export() {

--- a/crates/skippy-server/src/runtime_state/lane_lifecycle.rs
+++ b/crates/skippy-server/src/runtime_state/lane_lifecycle.rs
@@ -127,6 +127,24 @@ impl RuntimeState {
         Ok(self.session_stats())
     }
 
+    pub(crate) fn warmup_generation_graph(&self) -> Result<bool> {
+        if self.model.input_activation_boundary().is_some()
+            || self.model.output_activation_boundary().is_some()
+        {
+            return Ok(false);
+        }
+        let token_id = self
+            .model
+            .tokenize("", true)?
+            .into_iter()
+            .next()
+            .unwrap_or(0);
+        let mut session = self.model.create_session()?;
+        session.decode_step(token_id)?;
+        session.reset()?;
+        Ok(true)
+    }
+
     /// Release the session slot identified by `session_id`.
     ///
     /// This is the cleanup path called at the end of every chat

--- a/evals/kv-restart-replay.py
+++ b/evals/kv-restart-replay.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""KV restart replay: measure serving latency across a process restart.
+
+Issue #1647-A. Runs one frozen multi-turn conversation against a default-startup
+``mesh-llm serve`` in three cohorts:
+
+- ``fill``    — cold server, conversation grows turn by turn (prefix reuse).
+- ``restore`` — the server is stopped and restarted on the same state directory,
+                then the frozen full conversation is replayed. On a build with a
+                durable KV tier this measures first-request-after-restart
+                restoration; without one it is the cold-prefill reference.
+- ``warm``    — repeat replays without restart (resident reuse reference).
+
+The runner never sets context size, lanes, KV budget, or backend tuning; the
+only serving arguments are ``--model``, ``--log-format json`` and the explicit
+``--serve-extra-args`` pass-through an operator asks for (for example a
+``--kv-cache-disk`` mode under test). Everything measured is observational:
+streaming TTFT from the first chunk, usage from ``stream_options.include_usage``,
+cached tokens from ``prompt_tokens_details``.
+
+Artifacts: ``run.json`` (schema_version 1, provenance + config + cohort
+summaries), ``requests.jsonl`` (one row per request), ``report.md`` (human
+summary). The manifest itself is deterministic from ``--turns`` and
+``--turn-target-tokens`` and is embedded (with its SHA-256) into ``run.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import http.client
+import json
+import math
+import os
+import re
+import signal
+import socket
+import statistics
+import subprocess
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional, Sequence
+
+REPO = Path(__file__).resolve().parents[1]
+DEFAULT_BASE_URL = "http://127.0.0.1:9337/v1"
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 9337
+SCHEMA_VERSION = 1
+
+# Same discipline as evals/agentic-replay.py: a default-startup benchmark may
+# not tune the server. Extra serving arguments must arrive explicitly via
+# --serve-extra-args and are recorded verbatim in run.json.
+FORBIDDEN_STARTUP_OPTIONS = (
+    "--ctx-size",
+    "--generation-concurrency",
+    "--generation-queue-capacity",
+    "--max-vram",
+    "--parallel",
+)
+
+# Deterministic manifest vocabulary. The conversation simulates a long-running
+# coding-agent session: a stable scaffold, a growing project brief, and a
+# per-turn request. Content is drawn from a fixed word list with a fixed PRNG
+# seed so the same settings always produce the same conversation.
+SEED = 20260909
+_VOCAB = (
+    "cache prefix token restore restart segment manifest budget eviction "
+    "prefill decode latency throughput checkpoint durable radix tier admission "
+    "pipeline stream verify digest commit quarantine pin lease reserve node "
+    "mesh relay model runtime kernel attention matrix layer head batch queue "
+    "trace replay harness baseline cohort percentile regression gate promote"
+).split()
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def stable_hash(value: Any) -> str:
+    return hashlib.sha256(
+        json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    ).hexdigest()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1 << 20), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Manifest
+# ---------------------------------------------------------------------------
+
+
+class DeterministicRandom:
+    """Small LCG so manifests do not depend on the host Python random module."""
+
+    def __init__(self, seed: int) -> None:
+        self.state = seed & 0xFFFFFFFFFFFF
+
+    def next(self) -> int:
+        self.state = (self.state * 25214903917 + 11) & 0xFFFFFFFFFFFF
+        return self.state >> 16
+
+    def below(self, bound: int) -> int:
+        return self.next() % bound
+
+    def words(self, count: int) -> list[str]:
+        return [_VOCAB[self.below(len(_VOCAB))] for _ in range(count)]
+
+
+def build_manifest(turns: int, turn_target_tokens: int, system_tokens: int) -> dict[str, Any]:
+    """Build the frozen conversation. Turn sizes are approximate (words * 4/3);
+    the authoritative prompt token counts come from server usage at run time."""
+
+    rng = DeterministicRandom(SEED)
+
+    def block(target_tokens: int, topic: str) -> str:
+        words = max(1, int(target_tokens * 3 / 4))
+        chunks = []
+        while len(chunks) * 8 < words:
+            chunks.append(" ".join(rng.words(8)))
+        return f"[{topic}] " + " ".join(chunks)
+
+    scaffold = block(system_tokens, "scaffold")
+    turn_specs = []
+    for index in range(turns):
+        body = block(turn_target_tokens, f"turn-{index + 1}-context")
+        request = (
+            f"Turn {index + 1}: given the project brief above, summarize the "
+            f"{' '.join(rng.words(6))} constraint in one sentence and list the "
+            f"{' '.join(rng.words(4))} next step."
+        )
+        turn_specs.append({"context": body, "request": request})
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "kv-restart-replay/manifest",
+        "seed": SEED,
+        "settings": {
+            "turns": turns,
+            "turn_target_tokens": turn_target_tokens,
+            "system_tokens": system_tokens,
+            "approx_total_prompt_tokens": system_tokens + turns * turn_target_tokens,
+        },
+        "system": scaffold,
+        "turns": turn_specs,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Server lifecycle (mirrors evals/agentic-replay.py)
+# ---------------------------------------------------------------------------
+
+
+def server_command(binary: Path, model: str, extra_args: Sequence[str]) -> list[str]:
+    command = [str(binary), "serve", "--model", model, "--log-format", "json"]
+    command.extend(extra_args)
+    for option in FORBIDDEN_STARTUP_OPTIONS:
+        if option in command:
+            raise AssertionError(f"default-startup benchmark cannot use {option}")
+    return command
+
+
+def port_is_open(host: str = DEFAULT_HOST, port: int = DEFAULT_PORT) -> bool:
+    with socket.socket() as connection:
+        connection.settimeout(0.2)
+        return connection.connect_ex((host, port)) == 0
+
+
+def wait_for_model(timeout: float, process: subprocess.Popen[bytes]) -> str:
+    deadline = time.monotonic() + timeout
+    last_error = "not ready"
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(f"Mesh exited before readiness with status {process.returncode}")
+        connection = http.client.HTTPConnection(DEFAULT_HOST, DEFAULT_PORT, timeout=5)
+        try:
+            connection.request("GET", "/v1/models")
+            response = connection.getresponse()
+            body = response.read()
+            if response.status == 200:
+                document = json.loads(body)
+                models = document.get("data") or []
+                if models:
+                    return models[0]["id"]
+            last_error = f"HTTP {response.status}: {body[:300]!r}"
+        except (OSError, json.JSONDecodeError) as error:
+            last_error = str(error)
+        finally:
+            connection.close()
+        time.sleep(1)
+    raise TimeoutError(f"Mesh did not become ready after {timeout}s: {last_error}")
+
+
+def stop_server(process: subprocess.Popen[bytes]) -> None:
+    if process.poll() is None:
+        os.killpg(process.pid, signal.SIGINT)
+        try:
+            process.wait(timeout=30)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=10)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=10)
+    deadline = time.monotonic() + 10
+    while port_is_open() and time.monotonic() < deadline:
+        time.sleep(0.2)
+    if port_is_open():
+        raise RuntimeError("Mesh stopped but the serving port is still occupied")
+
+
+def isolated_server_env(state_dir: Path) -> dict[str, str]:
+    env = os.environ.copy()
+    home = state_dir / "home"
+    home.mkdir(parents=True, exist_ok=True)
+    env.update(
+        {
+            "HOME": str(home),
+            "XDG_CACHE_HOME": str(state_dir / "xdg-cache"),
+            "XDG_CONFIG_HOME": str(state_dir / "xdg-config"),
+            "MESH_LLM_RUNTIME_ROOT": str(state_dir / "runtime"),
+        }
+    )
+    if "HF_HOME" not in env:
+        env["HF_HOME"] = str(Path.home() / ".cache/huggingface")
+    return env
+
+
+def start_server(
+    binary: Path,
+    model: str,
+    extra_args: Sequence[str],
+    state_dir: Path,
+    log_path: Path,
+) -> tuple[subprocess.Popen[bytes], list[str]]:
+    if port_is_open():
+        raise RuntimeError(f"TCP {DEFAULT_PORT} is already in use; stop the existing Mesh instance")
+    command = server_command(binary, model, extra_args)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    log_handle = log_path.open("wb")
+    process = subprocess.Popen(
+        command,
+        cwd=str(REPO),
+        env=isolated_server_env(state_dir),
+        stdout=log_handle,
+        stderr=subprocess.STDOUT,
+        start_new_session=True,
+    )
+    log_handle.close()
+    return process, command
+
+
+# ---------------------------------------------------------------------------
+# Requests (mirrors evals/agentic-replay.py stream_request)
+# ---------------------------------------------------------------------------
+
+
+def stream_request(
+    request_id: str,
+    messages: Sequence[dict[str, Any]],
+    model_id: str,
+    max_output_tokens: int,
+    timeout: float,
+) -> dict[str, Any]:
+    started = time.monotonic()
+    first_token_at: Optional[float] = None
+    completion_tokens = 0
+    prompt_tokens = 0
+    cached_tokens = 0
+    saw_done = False
+    connection = http.client.HTTPConnection(DEFAULT_HOST, DEFAULT_PORT, timeout=timeout)
+    payload = {
+        "model": model_id,
+        "messages": list(messages),
+        "max_tokens": max_output_tokens,
+        "temperature": 0,
+        "seed": 42,
+        "stream": True,
+        "stream_options": {"include_usage": True},
+    }
+    try:
+        connection.request(
+            "POST",
+            "/v1/chat/completions",
+            json.dumps(payload),
+            {"Content-Type": "application/json", "Authorization": "Bearer EMPTY"},
+        )
+        response = connection.getresponse()
+        if response.status != 200:
+            body = response.read(4096).decode("utf-8", errors="replace")
+            return {"request_id": request_id, "error": f"HTTP {response.status}: {body}"}
+        for raw_line in response:
+            line = raw_line.strip()
+            if not line.startswith(b"data: "):
+                continue
+            event_bytes = line[6:]
+            if event_bytes == b"[DONE]":
+                saw_done = True
+                break
+            try:
+                event = json.loads(event_bytes)
+            except json.JSONDecodeError:
+                continue
+            server_error = event.get("error")
+            if server_error is not None:
+                return {
+                    "request_id": request_id,
+                    "error": f"stream failed with server error: {server_error}",
+                }
+            usage = event.get("usage")
+            if isinstance(usage, dict):
+                completion_tokens = int(usage.get("completion_tokens") or completion_tokens)
+                prompt_tokens = int(usage.get("prompt_tokens") or prompt_tokens)
+                details = usage.get("prompt_tokens_details")
+                if isinstance(details, dict):
+                    cached_tokens = int(details.get("cached_tokens") or cached_tokens)
+            choices = event.get("choices")
+            if not isinstance(choices, list) or not choices:
+                continue
+            delta = choices[0].get("delta") if isinstance(choices[0], dict) else None
+            if isinstance(delta, dict) and delta.get("content") and first_token_at is None:
+                first_token_at = time.monotonic()
+        if first_token_at is None:
+            return {"request_id": request_id, "error": "stream completed without content tokens"}
+        if not saw_done and completion_tokens == 0:
+            return {"request_id": request_id, "error": "stream completed without completion-token usage"}
+        ended = time.monotonic()
+        return {
+            "request_id": request_id,
+            "ttft_seconds": first_token_at - started,
+            "total_seconds": ended - started,
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "cached_tokens": cached_tokens,
+            "decode_tokens_per_second": (
+                completion_tokens / (ended - first_token_at) if ended > first_token_at else None
+            ),
+        }
+    except (OSError, TimeoutError) as error:
+        return {"request_id": request_id, "error": str(error)}
+    finally:
+        connection.close()
+
+
+# ---------------------------------------------------------------------------
+# Provenance
+# ---------------------------------------------------------------------------
+
+
+def hardware_fingerprint() -> dict[str, Any]:
+    fingerprint: dict[str, Any] = {
+        "platform": sys.platform,
+        "python": sys.version.split()[0],
+        "hostname": socket.gethostname(),
+    }
+    if sys.platform == "darwin":
+        try:
+            fingerprint["chip"] = (
+                subprocess.run(
+                    ["sysctl", "-n", "machdep.cpu.brand_string"],
+                    capture_output=True,
+                    text=True,
+                    check=True,
+                ).stdout.strip()
+            )
+            fingerprint["machine_model"] = (
+                subprocess.run(
+                    ["sysctl", "-n", "hw.model"], capture_output=True, text=True, check=True
+                ).stdout.strip()
+            )
+        except subprocess.CalledProcessError:
+            pass
+        try:
+            fingerprint["physical_memory_bytes"] = os.sysconf("HW_PHYSMEM")
+        except (ValueError, OSError):
+            fingerprint["physical_memory_bytes"] = None
+        fingerprint["cpu_core_count"] = os.cpu_count()
+    else:
+        fingerprint["cpu_core_count"] = os.cpu_count()
+        try:
+            meminfo = Path("/proc/meminfo").read_text(encoding="utf-8")
+            match = re.search(r"MemTotal:\s+(\d+)\s+kB", meminfo)
+            if match:
+                fingerprint["physical_memory_bytes"] = int(match.group(1)) * 1024
+        except OSError:
+            pass
+    return fingerprint
+
+
+def binary_provenance(binary: Path) -> dict[str, Any]:
+    provenance: dict[str, Any] = {"binary": str(binary), "binary_sha256": sha256_file(binary)}
+    try:
+        described = subprocess.run(
+            ["git", "describe", "--always", "--dirty", "--tags"],
+            cwd=str(REPO),
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        provenance["git_describe"] = described.stdout.strip()
+        commit = subprocess.run(
+            ["git", "rev-parse", "HEAD"], cwd=str(REPO), capture_output=True, text=True, check=True
+        )
+        provenance["source_sha"] = commit.stdout.strip()
+    except subprocess.CalledProcessError:
+        provenance["git_describe"] = "unknown"
+    return provenance
+
+
+# ---------------------------------------------------------------------------
+# Cohorts and run
+# ---------------------------------------------------------------------------
+
+
+def summarize_cohort(name: str, rows: Sequence[dict[str, Any]]) -> dict[str, Any]:
+    successful = [row for row in rows if "error" not in row]
+    failed = [row for row in rows if "error" in row]
+    ttft = [row["ttft_seconds"] for row in successful]
+
+    def percentile(values: Sequence[float], fraction: float) -> Optional[float]:
+        if not values:
+            return None
+        ordered = sorted(values)
+        index = min(math.ceil(len(ordered) * fraction) - 1, len(ordered) - 1)
+        return ordered[max(index, 0)]
+
+    prompt_tokens = sum(row.get("prompt_tokens", 0) for row in successful)
+    cached_tokens = sum(row.get("cached_tokens", 0) for row in successful)
+    decode = [row["decode_tokens_per_second"] for row in successful if row.get("decode_tokens_per_second")]
+    return {
+        "cohort": name,
+        "requests": len(rows),
+        "failed": len(failed),
+        "ttft_p50_seconds": percentile(ttft, 0.50),
+        "ttft_p95_seconds": percentile(ttft, 0.95),
+        "total_seconds_mean": statistics.fmean(row["total_seconds"] for row in successful) if successful else None,
+        "prompt_tokens": prompt_tokens,
+        "cached_tokens": cached_tokens,
+        "cache_pct": (100 * cached_tokens / prompt_tokens) if prompt_tokens else None,
+        "decode_tokens_per_second_mean": statistics.fmean(decode) if decode else None,
+    }
+
+
+def messages_through(messages: list[dict[str, Any]], turn_index: int) -> list[dict[str, Any]]:
+    """Conversation prefix up to and including turn ``turn_index`` (0-based)."""
+    return messages[: 2 * (turn_index + 1) + 1]
+
+
+def run_arm(args: argparse.Namespace, output: Path) -> dict[str, Any]:
+    binary = Path(args.binary).resolve()
+    model_path = Path(args.model).resolve()
+    if not binary.exists():
+        raise FileNotFoundError(f"binary not found: {binary}")
+    if not model_path.exists():
+        raise FileNotFoundError(f"model not found: {model_path}")
+
+    manifest = build_manifest(args.turns, args.turn_target_tokens, args.system_tokens)
+    manifest_sha = stable_hash(manifest)
+    conversation: list[dict[str, Any]] = [{"role": "system", "content": manifest["system"]}]
+    for spec in manifest["turns"]:
+        conversation.append({"role": "user", "content": f"{spec['context']}\n\n{spec['request']}"})
+        conversation.append({"role": "assistant", "content": spec["request"]})
+
+    state_dir = (output / "server-state").resolve()
+    state_dir.mkdir(parents=True, exist_ok=True)
+    requests_path = output / "requests.jsonl"
+    rows: list[dict[str, Any]] = []
+
+    def record(cohort: str, index: int, result: dict[str, Any]) -> None:
+        row = {"cohort": cohort, "request_index": index, **result}
+        rows.append(row)
+        with requests_path.open("a", encoding="utf-8") as handle:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+    def replay_frozen(cohort: str) -> None:
+        connection = http.client.HTTPConnection(DEFAULT_HOST, DEFAULT_PORT, timeout=5)
+        try:
+            connection.request("GET", "/v1/models")
+            document = json.loads(connection.getresponse().read())
+            model_id = (document.get("data") or [{}])[0].get("id", "default")
+        finally:
+            connection.close()
+        for repeat in range(args.restore_repeats):
+            result = stream_request(
+                f"{cohort}-{repeat + 1}",
+                conversation,
+                model_id,
+                args.max_output_tokens,
+                args.request_timeout,
+            )
+            record(cohort, repeat, result)
+
+    provenance = {
+        "schema_version": SCHEMA_VERSION,
+        "kind": "kv-restart-replay/run",
+        "started_at": utc_now(),
+        "binary": binary_provenance(binary),
+        "model": {
+            "path": str(model_path),
+            "sha256": sha256_file(model_path),
+            "size_bytes": model_path.stat().st_size,
+        },
+        "hardware": hardware_fingerprint(),
+        "config": {
+            "base_url": DEFAULT_BASE_URL,
+            "turns": args.turns,
+            "turn_target_tokens": args.turn_target_tokens,
+            "system_tokens": args.system_tokens,
+            "restore_repeats": args.restore_repeats,
+            "max_output_tokens": args.max_output_tokens,
+            "request_timeout": args.request_timeout,
+            "serve_extra_args": list(args.serve_extra_args),
+        },
+        "manifest_sha256": manifest_sha,
+        "manifest": manifest,
+    }
+
+    process = None
+    try:
+        # Cohort: fill — cold server, conversation grows turn by turn.
+        process, command = start_server(
+            binary, str(model_path), args.serve_extra_args, state_dir, output / "logs" / "fill.log"
+        )
+        provenance["serve_command"] = command
+        model_id = wait_for_model(args.ready_timeout, process)
+        for index in range(args.turns):
+            result = stream_request(
+                f"fill-{index + 1}",
+                messages_through(conversation, index),
+                model_id,
+                args.max_output_tokens,
+                args.request_timeout,
+            )
+            record("fill", index, result)
+
+        # Cohort: restore — full process restart on the same state directory.
+        stop_server(process)
+        process = None
+        stopped_at = time.monotonic()
+        process, _ = start_server(
+            binary, str(model_path), args.serve_extra_args, state_dir, output / "logs" / "restore.log"
+        )
+        wait_for_model(args.ready_timeout, process)
+        restart_gap_seconds = time.monotonic() - stopped_at
+        provenance["restart"] = {
+            "method": "SIGINT to the serving process group, then fresh start on the same state directory",
+            "restart_to_ready_seconds": restart_gap_seconds,
+        }
+        replay_frozen("restore")
+
+        # Cohort: warm — repeat replays without restart.
+        replay_frozen("warm")
+    finally:
+        if process is not None:
+            try:
+                stop_server(process)
+            except RuntimeError:
+                pass
+
+    provenance["cohorts"] = [
+        summarize_cohort("fill", [row for row in rows if row["cohort"] == "fill"]),
+        summarize_cohort("restore", [row for row in rows if row["cohort"] == "restore"]),
+        summarize_cohort("warm", [row for row in rows if row["cohort"] == "warm"]),
+    ]
+    provenance["completed_at"] = utc_now()
+    return provenance
+
+
+def write_report(run: dict[str, Any], path: Path) -> None:
+    lines = [
+        "# KV restart replay",
+        "",
+        f"- source: `{run['binary'].get('source_sha', 'unknown')}` (`{run['binary'].get('git_describe', '?')}`)",
+        f"- model sha256: `{run['model']['sha256'][:16]}…`",
+        f"- manifest sha256: `{run['manifest_sha256'][:16]}…` ({run['config']['turns']} turns, "
+        f"≈{run['manifest']['settings']['approx_total_prompt_tokens']} prompt tokens)",
+        f"- serve extra args: `{run['config']['serve_extra_args'] or 'none'}`",
+        f"- restart-to-ready: {run.get('restart', {}).get('restart_to_ready_seconds', float('nan')):.1f}s",
+        "",
+        "| cohort | requests | failed | TTFT p50 (s) | TTFT p95 (s) | cached % | decode tok/s |",
+        "|---|---:|---:|---:|---:|---:|---:|",
+    ]
+    for cohort in run["cohorts"]:
+        fmt = lambda value: "—" if value is None else f"{value:.3f}" if isinstance(value, float) else value
+        lines.append(
+            f"| {cohort['cohort']} | {cohort['requests']} | {cohort['failed']} "
+            f"| {fmt(cohort['ttft_p50_seconds'])} | {fmt(cohort['ttft_p95_seconds'])} "
+            f"| {fmt(cohort['cache_pct'])} | {fmt(cohort['decode_tokens_per_second_mean'])} |"
+        )
+    lines += [
+        "",
+        "`restore` is the first-request-after-restart cohort; on a build without a",
+        "durable KV tier it is the cold-prefill reference. `warm` repeats the same",
+        "replay without restart (resident reuse reference).",
+        "",
+    ]
+    path.write_text("\n".join(lines), encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", default=str(REPO / "target/release/mesh-llm"))
+    parser.add_argument("--model", required=True, help="path to a GGUF model file")
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--turns", type=int, default=4)
+    parser.add_argument("--turn-target-tokens", type=int, default=4750)
+    parser.add_argument("--system-tokens", type=int, default=500)
+    parser.add_argument("--restore-repeats", type=int, default=3)
+    parser.add_argument("--max-output-tokens", type=int, default=256)
+    parser.add_argument("--request-timeout", type=float, default=900.0)
+    parser.add_argument("--ready-timeout", type=float, default=900.0)
+    parser.add_argument(
+        "--serve-extra-args",
+        nargs=argparse.REMAINDER,
+        default=[],
+        help="explicit extra serving arguments (recorded verbatim in run.json)",
+    )
+    args = parser.parse_args()
+
+    output = args.output.resolve()
+    if (output / "run.json").exists():
+        raise SystemExit(f"output already contains run.json: {output}")
+    output.mkdir(parents=True, exist_ok=True)
+
+    run = run_arm(args, output)
+    write_json = output / "run.json"
+    write_json.write_text(json.dumps(run, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    write_report(run, output / "report.md")
+    print(f"wrote {write_json}")
+    for cohort in run["cohorts"]:
+        p50 = cohort["ttft_p50_seconds"]
+        print(
+            f"  {cohort['cohort']:8s} p50={p50 if p50 is None else round(p50, 3)}s "
+            f"cache={cohort['cache_pct'] if cohort['cache_pct'] is None else round(cohort['cache_pct'], 1)}% "
+            f"failed={cohort['failed']}"
+        )
+    return 0 if all(cohort["failed"] == 0 for cohort in run["cohorts"]) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/evals/kv-restart-replay.py
+++ b/evals/kv-restart-replay.py
@@ -161,9 +161,10 @@ def build_manifest(turns: int, turn_target_tokens: int, system_tokens: int) -> d
 def server_command(binary: Path, model: str, extra_args: Sequence[str]) -> list[str]:
     command = [str(binary), "serve", "--model", model, "--log-format", "json"]
     command.extend(extra_args)
-    for option in FORBIDDEN_STARTUP_OPTIONS:
-        if option in command:
-            raise AssertionError(f"default-startup benchmark cannot use {option}")
+    for argument in command:
+        for option in FORBIDDEN_STARTUP_OPTIONS:
+            if argument == option or argument.startswith(f"{option}="):
+                raise AssertionError(f"default-startup benchmark cannot use {option}")
     return command
 
 
@@ -344,7 +345,7 @@ def stream_request(
                 completion_tokens / (ended - first_token_at) if ended > first_token_at else None
             ),
         }
-    except (OSError, TimeoutError) as error:
+    except (OSError, TimeoutError, http.client.HTTPException) as error:
         return {"request_id": request_id, "error": str(error)}
     finally:
         connection.close()
@@ -410,7 +411,7 @@ def binary_provenance(binary: Path) -> dict[str, Any]:
             ["git", "rev-parse", "HEAD"], cwd=str(REPO), capture_output=True, text=True, check=True
         )
         provenance["source_sha"] = commit.stdout.strip()
-    except subprocess.CalledProcessError:
+    except (subprocess.CalledProcessError, OSError):
         provenance["git_describe"] = "unknown"
     return provenance
 
@@ -450,8 +451,13 @@ def summarize_cohort(name: str, rows: Sequence[dict[str, Any]]) -> dict[str, Any
 
 
 def messages_through(messages: list[dict[str, Any]], turn_index: int) -> list[dict[str, Any]]:
-    """Conversation prefix up to and including turn ``turn_index`` (0-based)."""
-    return messages[: 2 * (turn_index + 1) + 1]
+    """Conversation prefix ending on the user message of ``turn_index`` (0-based).
+
+    Fill requests must look like the requests a real session produces: the last
+    message is always the user turn being answered, never the canned assistant
+    reply that follows it in the canonical conversation.
+    """
+    return messages[: 2 * (turn_index + 1)]
 
 
 def run_arm(args: argparse.Namespace, output: Path) -> dict[str, Any]:
@@ -480,7 +486,7 @@ def run_arm(args: argparse.Namespace, output: Path) -> dict[str, Any]:
         with requests_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(row, sort_keys=True) + "\n")
 
-    def replay_frozen(cohort: str) -> None:
+    def replay_frozen(cohort: str, repeats: Optional[int] = None) -> None:
         connection = http.client.HTTPConnection(DEFAULT_HOST, DEFAULT_PORT, timeout=5)
         try:
             connection.request("GET", "/v1/models")
@@ -488,7 +494,7 @@ def run_arm(args: argparse.Namespace, output: Path) -> dict[str, Any]:
             model_id = (document.get("data") or [{}])[0].get("id", "default")
         finally:
             connection.close()
-        for repeat in range(args.restore_repeats):
+        for repeat in range(args.restore_repeats if repeats is None else repeats):
             result = stream_request(
                 f"{cohort}-{repeat + 1}",
                 conversation,
@@ -554,7 +560,11 @@ def run_arm(args: argparse.Namespace, output: Path) -> dict[str, Any]:
             "method": "SIGINT to the serving process group, then fresh start on the same state directory",
             "restart_to_ready_seconds": restart_gap_seconds,
         }
-        replay_frozen("restore")
+        # Cohort: restore — the FIRST post-restart replay alone is the
+        # first-request-after-restart measurement; later replays warm from the
+        # resident cache and are recorded under the warm cohort instead.
+        replay_frozen("restore", repeats=1)
+        replay_frozen("warm", repeats=max(args.restore_repeats - 1, 0))
 
         # Cohort: warm — repeat replays without restart.
         replay_frozen("warm")

--- a/evals/kv-restart-replay.py
+++ b/evals/kv-restart-replay.py
@@ -282,6 +282,8 @@ def stream_request(
     completion_tokens = 0
     prompt_tokens = 0
     cached_tokens = 0
+    saw_prompt_tokens = False
+    saw_cached_tokens = False
     saw_done = False
     connection = http.client.HTTPConnection(DEFAULT_HOST, DEFAULT_PORT, timeout=timeout)
     payload = {
@@ -325,10 +327,17 @@ def stream_request(
             usage = event.get("usage")
             if isinstance(usage, dict):
                 completion_tokens = int(usage.get("completion_tokens") or completion_tokens)
-                prompt_tokens = int(usage.get("prompt_tokens") or prompt_tokens)
+                if "prompt_tokens" in usage and usage["prompt_tokens"] is not None:
+                    prompt_tokens = int(usage["prompt_tokens"])
+                    saw_prompt_tokens = True
                 details = usage.get("prompt_tokens_details")
-                if isinstance(details, dict):
-                    cached_tokens = int(details.get("cached_tokens") or cached_tokens)
+                if (
+                    isinstance(details, dict)
+                    and "cached_tokens" in details
+                    and details["cached_tokens"] is not None
+                ):
+                    cached_tokens = int(details["cached_tokens"])
+                    saw_cached_tokens = True
             choices = event.get("choices")
             if not isinstance(choices, list) or not choices:
                 continue
@@ -339,6 +348,10 @@ def stream_request(
             return {"request_id": request_id, "error": "stream completed without content tokens"}
         if not saw_done:
             return {"request_id": request_id, "error": "stream ended without terminal [DONE] marker"}
+        if not saw_prompt_tokens:
+            return {"request_id": request_id, "error": "stream completed without prompt token usage"}
+        if not saw_cached_tokens:
+            return {"request_id": request_id, "error": "stream completed without cached token usage"}
         ended = time.monotonic()
         return {
             "request_id": request_id,
@@ -578,10 +591,7 @@ def run_arm(args: argparse.Namespace, output: Path) -> dict[str, Any]:
         replay_frozen("warm", model_id, repeats=max(args.restore_repeats - 1, 0))
     finally:
         if process is not None:
-            try:
-                stop_server(process)
-            except RuntimeError:
-                pass
+            stop_server(process)
 
     provenance["cohorts"] = [
         summarize_cohort("fill", [row for row in rows if row["cohort"] == "fill"]),
@@ -649,8 +659,8 @@ def main() -> int:
     args = parser.parse_args()
 
     output = args.output.resolve()
-    if (output / "run.json").exists():
-        raise SystemExit(f"output already contains run.json: {output}")
+    if output.exists() and any(output.iterdir()):
+        raise SystemExit(f"output directory is not empty: {output}")
     output.mkdir(parents=True, exist_ok=True)
 
     run = run_arm(args, output)

--- a/evals/kv-restart-replay.py
+++ b/evals/kv-restart-replay.py
@@ -56,8 +56,10 @@ FORBIDDEN_STARTUP_OPTIONS = (
     "--ctx-size",
     "--generation-concurrency",
     "--generation-queue-capacity",
+    "--host",
     "--max-vram",
     "--parallel",
+    "--port",
 )
 
 # Deterministic manifest vocabulary. The conversation simulates a long-running
@@ -136,7 +138,11 @@ def build_manifest(turns: int, turn_target_tokens: int, system_tokens: int) -> d
             f"{' '.join(rng.words(6))} constraint in one sentence and list the "
             f"{' '.join(rng.words(4))} next step."
         )
-        turn_specs.append({"context": body, "request": request})
+        response = (
+            f"Turn {index + 1} answer: preserve the {' '.join(rng.words(5))} "
+            f"constraint. Next step: verify {' '.join(rng.words(4))}."
+        )
+        turn_specs.append({"context": body, "request": request, "response": response})
 
     return {
         "schema_version": SCHEMA_VERSION,
@@ -331,8 +337,8 @@ def stream_request(
                 first_token_at = time.monotonic()
         if first_token_at is None:
             return {"request_id": request_id, "error": "stream completed without content tokens"}
-        if not saw_done and completion_tokens == 0:
-            return {"request_id": request_id, "error": "stream completed without completion-token usage"}
+        if not saw_done:
+            return {"request_id": request_id, "error": "stream ended without terminal [DONE] marker"}
         ended = time.monotonic()
         return {
             "request_id": request_id,
@@ -377,11 +383,17 @@ def hardware_fingerprint() -> dict[str, Any]:
                     ["sysctl", "-n", "hw.model"], capture_output=True, text=True, check=True
                 ).stdout.strip()
             )
-        except subprocess.CalledProcessError:
+        except (OSError, subprocess.CalledProcessError):
             pass
         try:
-            fingerprint["physical_memory_bytes"] = os.sysconf("HW_PHYSMEM")
-        except (ValueError, OSError):
+            memory = subprocess.run(
+                ["sysctl", "-n", "hw.memsize"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+            fingerprint["physical_memory_bytes"] = int(memory.stdout.strip())
+        except (OSError, subprocess.CalledProcessError, ValueError):
             fingerprint["physical_memory_bytes"] = None
         fingerprint["cpu_core_count"] = os.cpu_count()
     else:
@@ -413,6 +425,7 @@ def binary_provenance(binary: Path) -> dict[str, Any]:
         provenance["source_sha"] = commit.stdout.strip()
     except (subprocess.CalledProcessError, OSError):
         provenance["git_describe"] = "unknown"
+        provenance["source_sha"] = "unknown"
     return provenance
 
 
@@ -441,7 +454,7 @@ def summarize_cohort(name: str, rows: Sequence[dict[str, Any]]) -> dict[str, Any
         "requests": len(rows),
         "failed": len(failed),
         "ttft_p50_seconds": percentile(ttft, 0.50),
-        "ttft_p95_seconds": percentile(ttft, 0.95),
+        "ttft_p95_seconds": percentile(ttft, 0.95) if len(ttft) > 1 else None,
         "total_seconds_mean": statistics.fmean(row["total_seconds"] for row in successful) if successful else None,
         "prompt_tokens": prompt_tokens,
         "cached_tokens": cached_tokens,
@@ -467,13 +480,18 @@ def run_arm(args: argparse.Namespace, output: Path) -> dict[str, Any]:
         raise FileNotFoundError(f"binary not found: {binary}")
     if not model_path.exists():
         raise FileNotFoundError(f"model not found: {model_path}")
+    if args.turns < 1:
+        raise ValueError("turns must be at least 1")
+    if args.restore_repeats < 1:
+        raise ValueError("restore-repeats must be at least 1")
 
     manifest = build_manifest(args.turns, args.turn_target_tokens, args.system_tokens)
     manifest_sha = stable_hash(manifest)
     conversation: list[dict[str, Any]] = [{"role": "system", "content": manifest["system"]}]
     for spec in manifest["turns"]:
         conversation.append({"role": "user", "content": f"{spec['context']}\n\n{spec['request']}"})
-        conversation.append({"role": "assistant", "content": spec["request"]})
+        conversation.append({"role": "assistant", "content": spec["response"]})
+    frozen_prompt = messages_through(conversation, args.turns - 1)
 
     state_dir = (output / "server-state").resolve()
     state_dir.mkdir(parents=True, exist_ok=True)
@@ -486,18 +504,11 @@ def run_arm(args: argparse.Namespace, output: Path) -> dict[str, Any]:
         with requests_path.open("a", encoding="utf-8") as handle:
             handle.write(json.dumps(row, sort_keys=True) + "\n")
 
-    def replay_frozen(cohort: str, repeats: Optional[int] = None) -> None:
-        connection = http.client.HTTPConnection(DEFAULT_HOST, DEFAULT_PORT, timeout=5)
-        try:
-            connection.request("GET", "/v1/models")
-            document = json.loads(connection.getresponse().read())
-            model_id = (document.get("data") or [{}])[0].get("id", "default")
-        finally:
-            connection.close()
+    def replay_frozen(cohort: str, model_id: str, repeats: Optional[int] = None) -> None:
         for repeat in range(args.restore_repeats if repeats is None else repeats):
             result = stream_request(
                 f"{cohort}-{repeat + 1}",
-                conversation,
+                frozen_prompt,
                 model_id,
                 args.max_output_tokens,
                 args.request_timeout,
@@ -554,7 +565,7 @@ def run_arm(args: argparse.Namespace, output: Path) -> dict[str, Any]:
         process, _ = start_server(
             binary, str(model_path), args.serve_extra_args, state_dir, output / "logs" / "restore.log"
         )
-        wait_for_model(args.ready_timeout, process)
+        model_id = wait_for_model(args.ready_timeout, process)
         restart_gap_seconds = time.monotonic() - stopped_at
         provenance["restart"] = {
             "method": "SIGINT to the serving process group, then fresh start on the same state directory",
@@ -563,11 +574,8 @@ def run_arm(args: argparse.Namespace, output: Path) -> dict[str, Any]:
         # Cohort: restore — the FIRST post-restart replay alone is the
         # first-request-after-restart measurement; later replays warm from the
         # resident cache and are recorded under the warm cohort instead.
-        replay_frozen("restore", repeats=1)
-        replay_frozen("warm", repeats=max(args.restore_repeats - 1, 0))
-
-        # Cohort: warm — repeat replays without restart.
-        replay_frozen("warm")
+        replay_frozen("restore", model_id, repeats=1)
+        replay_frozen("warm", model_id, repeats=max(args.restore_repeats - 1, 0))
     finally:
         if process is not None:
             try:
@@ -623,7 +631,12 @@ def main() -> int:
     parser.add_argument("--turns", type=int, default=4)
     parser.add_argument("--turn-target-tokens", type=int, default=4750)
     parser.add_argument("--system-tokens", type=int, default=500)
-    parser.add_argument("--restore-repeats", type=int, default=3)
+    parser.add_argument(
+        "--restore-repeats",
+        type=int,
+        default=3,
+        help="total post-restart requests: one restore followed by warm repeats",
+    )
     parser.add_argument("--max-output-tokens", type=int, default=256)
     parser.add_argument("--request-timeout", type=float, default=900.0)
     parser.add_argument("--ready-timeout", type=float, default=900.0)

--- a/scripts/tests/test_kv_restart_replay.py
+++ b/scripts/tests/test_kv_restart_replay.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import importlib.util
+import json
 import subprocess
 import sys
 import tempfile
@@ -103,6 +104,47 @@ class KvRestartReplayTest(unittest.TestCase):
 
         self.assertEqual(result["error"], "stream ended without terminal [DONE] marker")
 
+    def test_stream_request_requires_prompt_and_cached_usage(self) -> None:
+        class Response:
+            status = 200
+
+            def __init__(self, usage):
+                self.usage = usage
+
+            def __iter__(self):
+                return iter(
+                    [
+                        b'data: {"choices":[{"delta":{"content":"ok"}}]}\n',
+                        f'data: {json.dumps({"choices": [], "usage": self.usage})}\n'.encode(),
+                        b"data: [DONE]\n",
+                    ]
+                )
+
+        class Connection:
+            usage = {}
+
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def request(self, *_args, **_kwargs):
+                pass
+
+            def getresponse(self):
+                return Response(self.usage)
+
+            def close(self):
+                pass
+
+        for usage, expected in [
+            ({"prompt_tokens_details": {"cached_tokens": 0}}, "prompt token usage"),
+            ({"prompt_tokens": 10}, "cached token usage"),
+        ]:
+            with self.subTest(expected=expected):
+                Connection.usage = usage
+                with mock.patch.object(BENCH.http.client, "HTTPConnection", Connection):
+                    result = BENCH.stream_request("request", [], "model", 8, 10)
+                self.assertIn(expected, result["error"])
+
     def test_single_restore_sample_does_not_report_p95(self) -> None:
         summary = BENCH.summarize_cohort(
             "restore",
@@ -178,6 +220,62 @@ class KvRestartReplayTest(unittest.TestCase):
         self.assertTrue(all(messages[-1]["role"] == "user" for _, messages in calls))
         self.assertEqual(calls[1][1], calls[2][1])
         self.assertEqual(calls[2][1], calls[3][1])
+
+    def test_run_arm_propagates_final_server_shutdown_failure(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            binary = root / "mesh-llm"
+            model = root / "model.gguf"
+            binary.write_bytes(b"binary")
+            model.write_bytes(b"model")
+            args = SimpleNamespace(
+                binary=str(binary),
+                model=str(model),
+                turns=1,
+                turn_target_tokens=32,
+                system_tokens=16,
+                restore_repeats=1,
+                max_output_tokens=8,
+                request_timeout=10.0,
+                ready_timeout=10.0,
+                serve_extra_args=[],
+            )
+            with (
+                mock.patch.object(BENCH, "start_server", return_value=(SimpleNamespace(), [])),
+                mock.patch.object(BENCH, "wait_for_model", return_value="model"),
+                mock.patch.object(BENCH, "stop_server", side_effect=[None, RuntimeError("did not stop")]),
+                mock.patch.object(
+                    BENCH,
+                    "stream_request",
+                    return_value={
+                        "request_id": "fill-1",
+                        "ttft_seconds": 0.1,
+                        "total_seconds": 0.2,
+                        "prompt_tokens": 10,
+                        "completion_tokens": 1,
+                        "cached_tokens": 0,
+                        "decode_tokens_per_second": 10.0,
+                    },
+                ),
+                mock.patch.object(BENCH, "binary_provenance", return_value={"source_sha": "a" * 40}),
+                mock.patch.object(BENCH, "hardware_fingerprint", return_value={"platform": "test"}),
+            ):
+                with self.assertRaisesRegex(RuntimeError, "did not stop"):
+                    BENCH.run_arm(args, root / "output")
+
+    def test_main_rejects_any_nonempty_output_directory(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            output = root / "output"
+            output.mkdir()
+            (output / "partial.log").write_text("partial", encoding="utf-8")
+            with mock.patch.object(
+                sys,
+                "argv",
+                ["kv-restart-replay.py", "--model", str(root / "model.gguf"), "--output", str(output)],
+            ):
+                with self.assertRaisesRegex(SystemExit, "not empty"):
+                    BENCH.main()
 
 
 if __name__ == "__main__":

--- a/scripts/tests/test_kv_restart_replay.py
+++ b/scripts/tests/test_kv_restart_replay.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+
+REPO = Path(__file__).resolve().parents[2]
+SCRIPT = REPO / "evals/kv-restart-replay.py"
+
+
+def load_module():
+    spec = importlib.util.spec_from_file_location("kv_restart_replay", SCRIPT)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"cannot import {SCRIPT}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+BENCH = load_module()
+
+
+class KvRestartReplayTest(unittest.TestCase):
+    def test_server_command_rejects_endpoint_overrides(self) -> None:
+        binary = Path("/tmp/mesh-llm")
+
+        with self.assertRaisesRegex(AssertionError, "--port"):
+            BENCH.server_command(binary, "model.gguf", ["--port=9447"])
+        with self.assertRaisesRegex(AssertionError, "--host"):
+            BENCH.server_command(binary, "model.gguf", ["--host", "0.0.0.0"])
+
+    def test_manifest_uses_distinct_deterministic_assistant_responses(self) -> None:
+        manifest = BENCH.build_manifest(2, 32, 16)
+
+        self.assertNotEqual(manifest["turns"][0]["request"], manifest["turns"][0]["response"])
+        self.assertEqual(manifest, BENCH.build_manifest(2, 32, 16))
+
+    def test_macos_memory_uses_sysctl(self) -> None:
+        results = [
+            subprocess.CompletedProcess([], 0, stdout="Apple M2\n"),
+            subprocess.CompletedProcess([], 0, stdout="Mac14,6\n"),
+            subprocess.CompletedProcess([], 0, stdout="17179869184\n"),
+        ]
+        with (
+            mock.patch.object(BENCH.sys, "platform", "darwin"),
+            mock.patch.object(BENCH.subprocess, "run", side_effect=results) as run,
+        ):
+            fingerprint = BENCH.hardware_fingerprint()
+
+        self.assertEqual(fingerprint["physical_memory_bytes"], 17179869184)
+        self.assertEqual(run.call_args_list[-1].args[0], ["sysctl", "-n", "hw.memsize"])
+
+    def test_binary_provenance_keeps_unknown_source_sha_without_git(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            binary = Path(directory) / "mesh-llm"
+            binary.write_bytes(b"binary")
+            with mock.patch.object(BENCH.subprocess, "run", side_effect=FileNotFoundError):
+                provenance = BENCH.binary_provenance(binary)
+
+        self.assertEqual(provenance["git_describe"], "unknown")
+        self.assertEqual(provenance["source_sha"], "unknown")
+
+    def test_stream_request_rejects_truncated_stream_with_usage(self) -> None:
+        class TruncatedResponse:
+            status = 200
+
+            def __iter__(self):
+                return iter(
+                    [
+                        b'data: {"choices":[{"delta":{"content":"partial"}}]}\n',
+                        b'data: {"choices":[],"usage":{"completion_tokens":1,"prompt_tokens":10}}\n',
+                    ]
+                )
+
+        class TruncatedConnection:
+            def __init__(self, *_args, **_kwargs):
+                pass
+
+            def request(self, *_args, **_kwargs):
+                pass
+
+            def getresponse(self):
+                return TruncatedResponse()
+
+            def close(self):
+                pass
+
+        with mock.patch.object(BENCH.http.client, "HTTPConnection", TruncatedConnection):
+            result = BENCH.stream_request(
+                "request-1",
+                [{"role": "user", "content": "task"}],
+                "model",
+                8,
+                10,
+            )
+
+        self.assertEqual(result["error"], "stream ended without terminal [DONE] marker")
+
+    def test_single_restore_sample_does_not_report_p95(self) -> None:
+        summary = BENCH.summarize_cohort(
+            "restore",
+            [
+                {
+                    "ttft_seconds": 0.2,
+                    "total_seconds": 0.3,
+                    "prompt_tokens": 10,
+                    "cached_tokens": 5,
+                    "decode_tokens_per_second": 10.0,
+                }
+            ],
+        )
+
+        self.assertEqual(summary["ttft_p50_seconds"], 0.2)
+        self.assertIsNone(summary["ttft_p95_seconds"])
+
+    def test_run_arm_replays_the_last_fill_prompt_once_per_post_restart_request(self) -> None:
+        calls: list[tuple[str, list[dict[str, str]]]] = []
+
+        def fake_stream(request_id, messages, *_args):
+            calls.append((request_id, list(messages)))
+            return {
+                "request_id": request_id,
+                "ttft_seconds": 0.1,
+                "total_seconds": 0.2,
+                "prompt_tokens": 10,
+                "completion_tokens": 1,
+                "cached_tokens": 5,
+                "decode_tokens_per_second": 10.0,
+            }
+
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            binary = root / "mesh-llm"
+            model = root / "model.gguf"
+            binary.write_bytes(b"binary")
+            model.write_bytes(b"model")
+            args = SimpleNamespace(
+                binary=str(binary),
+                model=str(model),
+                turns=2,
+                turn_target_tokens=32,
+                system_tokens=16,
+                restore_repeats=3,
+                max_output_tokens=8,
+                request_timeout=10.0,
+                ready_timeout=10.0,
+                serve_extra_args=[],
+            )
+            with (
+                mock.patch.object(
+                    BENCH,
+                    "start_server",
+                    side_effect=lambda *_args: (SimpleNamespace(), ["mesh-llm", "serve"]),
+                ),
+                mock.patch.object(BENCH, "stop_server"),
+                mock.patch.object(BENCH, "wait_for_model", return_value="model"),
+                mock.patch.object(BENCH, "stream_request", side_effect=fake_stream),
+                mock.patch.object(BENCH, "binary_provenance", return_value={"source_sha": "a" * 40}),
+                mock.patch.object(BENCH, "hardware_fingerprint", return_value={"platform": "test"}),
+            ):
+                run = BENCH.run_arm(args, root / "output")
+
+        self.assertEqual([row["requests"] for row in run["cohorts"]], [2, 1, 2])
+        self.assertEqual([request_id for request_id, _ in calls], [
+            "fill-1",
+            "fill-2",
+            "restore-1",
+            "warm-1",
+            "warm-2",
+        ])
+        self.assertTrue(all(messages[-1]["role"] == "user" for _, messages in calls))
+        self.assertEqual(calls[1][1], calls[2][1])
+        self.assertEqual(calls[2][1], calls[3][1])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -3713,7 +3713,7 @@
   ],
   "crates/skippy-cache/src/l3/tests.rs": [
     {
-      "line": 605,
+      "line": 600,
       "macro_name": "println!"
     }
   ],

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -3713,7 +3713,7 @@
   ],
   "crates/skippy-cache/src/l3/tests.rs": [
     {
-      "line": 508,
+      "line": 605,
       "macro_name": "println!"
     }
   ],


### PR DESCRIPTION
Enabling durable disk-backed KV reuse exposed four tightly coupled requirements: a reproducible restart gate, preservation of the resident warm path, atomic checkpoint persistence, and a restore path fast enough to beat cold prefill. Reviewing those steps separately obscured their shared invariants, so this PR presents the complete durable-L3 implementation as one change.

## What this adds

- A deterministic fill / restart / warm replay harness with source, binary, model, hardware, manifest, and restart provenance.
- Configurable node-local disk-backed prompt caching, runtime status/prune/clear controls, and restart recovery.
- A resident-native in-process fast path while disk L3 keeps a separate exportable exact-state payload.
- Immutable checkpoint packs with a validated offset index, physical-byte eviction accounting, startup reconstruction, and graceful-shutdown drain.
- Coalesced packed reads directly into the final payload while accumulating its BLAKE3 digest.
- A temporary generation warmup before readiness so first-request graph setup does not erase the restore benefit.

Transactional import, per-segment and whole-payload verification, corrupt-pack quarantine, legacy loose-segment fallback, and portable manifests remain intact.

## Measured behavior

The resident-path repair kept warm reuse near the control: 18 ms with L3 versus 13 ms without it on the recorded matched replay.

Packed checkpoints restored 1,951 of 1,957 prompt tokens after restart. The final read-side optimization then produced three matched 3,994-token restart pairs:

| Pair | Disk off | Packed L3 | Speedup |
|---:|---:|---:|---:|
| 1 | 295.2 ms | 109.5 ms | 2.70x |
| 2 | 396.0 ms | 117.0 ms | 3.38x |
| 3 | 394.5 ms | 108.6 ms | 3.63x |
| **Median** | **394.5 ms** | **109.5 ms** | **3.60x** |

Every L3 treatment restored 3,993 of 3,994 prompt tokens, and all 42 requests across the final six runs succeeded.

## Validation

- exact consolidated head `1414471d5049033530a61b35d1c8725dd8cb440a` passes the full local `just ci-validate` suite: 1,076 tests with eight skipped, plus repository consistency checks;
- component commits passed the full skippy-cache and skippy-server suites, warning-denying Clippy, formatting, release host/native builds, and matched restart replays;
- fresh exact-head CI is terminal green: 93 passed checks and 14 expected skips.

## Review shape

Base: #1707  
This PR supersedes #1710, #1714, and #1726. The consolidated tree preserves every implementation and review fix. Two now-prohibited agent attribution trailers were removed while normalizing the combined history, and the resulting tree is byte-identical to the pre-normalization tree (`3a51b676d0296a398b3662ecbf9d87f18881e76b`).  
Follow-on: #1514, then the protected catalog activation in #1712.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added packed cache storage for more efficient segment writes, reads, recovery, and cleanup.
  * Improved model parameter detection, including split-model metadata and formatted model names.
  * Preserved advertised model aliases during automatic backend selection.
  * Added generation-graph warmup during session prewarming.
  * Added restart-and-replay evaluation tooling for measuring serving latency and cache restoration.

* **Bug Fixes**
  * Corrected runtime validation to use the served package reference.
  * Ensured stale peer memory information is cleared when announcements omit it.
  * Improved durable cache handling while retaining the resident fast path.
  * Added more accurate hardware memory and GPU-name reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->