### PR TITLE
Report accurate parameter sizes for local GGUF models

### DIFF
--- a/crates/mesh-llm-host-runtime/src/models/profile.rs
+++ b/crates/mesh-llm-host-runtime/src/models/profile.rs
@@ -20,13 +20,7 @@ pub(crate) fn served_model_metadata_for_path(
         .flatten();
     let metadata = match compact {
         Some(meta) => {
-            // Authoritative size: sum the GGUF tensor element counts. This is
-            // the ONLY source — no name-based fallback. If a served model
-            // cannot be summed from its GGUF, it advertises no size and MoA
-            // tiering treats it as the lowest-param (weakest) model rather than
-            // guessing from a brittle name label (per i386 review).
-            //
-            // Summed across the whole shard set: `find_model_path` resolves a
+            // Sum across the whole shard set: `find_model_path` resolves a
             // split GGUF to its first part, and each shard's tensor-info table
             // holds only that shard's weights. Scanning one part reported
             // roughly `total / shard_count` — an ~80B 4-shard model advertised
@@ -35,11 +29,8 @@ pub(crate) fn served_model_metadata_for_path(
                 .exists()
                 .then(|| crate::models::gguf::scan_gguf_bundle_total_parameters(path))
                 .flatten();
-            let parameter_size = meta
-                .parameter_size
-                .clone()
-                .or_else(|| parameter_count.and_then(parameter_size_from_count))
-                .or_else(|| parameter_size_from_text(model_name));
+            let parameter_size =
+                resolve_parameter_size(model_name, meta.parameter_size.clone(), parameter_count);
             let parameter_count_b = parameter_count.map(|total| total as f64 / 1e9);
             let kv_head_count = meta.effective_kv_head_count();
             crate::mesh::ServedModelMetadata {
@@ -62,7 +53,7 @@ pub(crate) fn served_model_metadata_for_path(
             }
         }
         None => crate::mesh::ServedModelMetadata {
-            parameter_size: parameter_size_from_text(model_name),
+            parameter_size: resolve_parameter_size(model_name, None, None),
             // No GGUF to sum -> no authoritative size. Advertise none rather
             // than a name-guessed count (per i386 review); MoA treats a
             // sizeless model as the weakest.
@@ -91,6 +82,18 @@ fn quant_from_text(value: &str) -> Option<String> {
     (!quant.is_empty()).then_some(quant)
 }
 
+/// Resolve a display label consistently: source metadata, verified tensor
+/// count, then a guarded model-name fallback.
+fn resolve_parameter_size(
+    model_name: &str,
+    source_size: Option<String>,
+    parameter_count: Option<u64>,
+) -> Option<String> {
+    source_size
+        .or_else(|| parameter_count.and_then(parameter_size_from_count))
+        .or_else(|| parameter_size_from_text(model_name))
+}
+
 fn parameter_size_from_count(parameter_count: u64) -> Option<String> {
     if parameter_count == 0 {
         return None;
@@ -106,11 +109,8 @@ fn parameter_size_from_count(parameter_count: u64) -> Option<String> {
     }
 
     let billions = parameter_count as f64 / 1e9;
-    Some(if parameter_count.is_multiple_of(1_000_000_000) {
-        format!("{billions:.0}B")
-    } else {
-        format!("{billions:.1}B")
-    })
+    let label = format!("{billions:.1}");
+    Some(format!("{}B", label.strip_suffix(".0").unwrap_or(&label)))
 }
 
 fn parameter_size_from_text(text: &str) -> Option<String> {
@@ -119,10 +119,12 @@ fn parameter_size_from_text(text: &str) -> Option<String> {
     }
 
     static MULTIPLIED_RE: LazyLock<Regex> = LazyLock::new(|| {
-        Regex::new(r"(?i)(?:^|[^a-z0-9.])(\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)([bm])").unwrap()
+        Regex::new(r"(?i)(?:^|[^a-z0-9.])(\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)([bm])(?:$|[^a-z0-9.])")
+            .unwrap()
     });
-    static SIMPLE_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(?i)(?:^|[^a-z0-9.])(\d+(?:\.\d+)?)([bm])").unwrap());
+    static SIMPLE_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)(?:^|[^a-z0-9.])(\d+(?:\.\d+)?)([bm])(?:$|[^a-z0-9.])").unwrap()
+    });
 
     MULTIPLIED_RE
         .captures(text)
@@ -146,7 +148,8 @@ mod tests {
     use std::path::Path;
 
     use super::{
-        parameter_size_from_count, parameter_size_from_text, served_model_metadata_for_path,
+        parameter_size_from_count, parameter_size_from_text, resolve_parameter_size,
+        served_model_metadata_for_path,
     };
 
     #[test]
@@ -168,6 +171,25 @@ mod tests {
             None
         );
         assert_eq!(parameter_size_from_text("model-dead8061beef"), None);
+        assert_eq!(parameter_size_from_text("model-7bfoo"), None);
+        assert_eq!(parameter_size_from_text("model-8x7bfoo"), None);
+    }
+
+    #[test]
+    fn resolves_parameter_size_with_shared_source_precedence() {
+        assert_eq!(
+            resolve_parameter_size("model-7B", Some("6B".to_string()), Some(8_000_000_000))
+                .as_deref(),
+            Some("6B")
+        );
+        assert_eq!(
+            resolve_parameter_size("model-7B", None, Some(8_000_000_000)).as_deref(),
+            Some("8B")
+        );
+        assert_eq!(
+            resolve_parameter_size("model-7B", None, None).as_deref(),
+            Some("7B")
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-host-runtime/src/models/profile.rs
+++ b/crates/mesh-llm-host-runtime/src/models/profile.rs
@@ -20,10 +20,6 @@ pub(crate) fn served_model_metadata_for_path(
         .flatten();
     let metadata = match compact {
         Some(meta) => {
-            let parameter_size = meta
-                .parameter_size
-                .clone()
-                .or_else(|| parameter_size_from_text(model_name));
             // Authoritative size: sum the GGUF tensor element counts. This is
             // the ONLY source — no name-based fallback. If a served model
             // cannot be summed from its GGUF, it advertises no size and MoA
@@ -35,11 +31,16 @@ pub(crate) fn served_model_metadata_for_path(
             // holds only that shard's weights. Scanning one part reported
             // roughly `total / shard_count` — an ~80B 4-shard model advertised
             // 24.6B — which silently mis-ranked every size-based decision.
-            let parameter_count_b = path
+            let parameter_count = path
                 .exists()
                 .then(|| crate::models::gguf::scan_gguf_bundle_total_parameters(path))
-                .flatten()
-                .map(|total| total as f64 / 1e9);
+                .flatten();
+            let parameter_size = meta
+                .parameter_size
+                .clone()
+                .or_else(|| parameter_count.and_then(parameter_size_from_count))
+                .or_else(|| parameter_size_from_text(model_name));
+            let parameter_count_b = parameter_count.map(|total| total as f64 / 1e9);
             let kv_head_count = meta.effective_kv_head_count();
             crate::mesh::ServedModelMetadata {
                 architecture: non_empty(meta.architecture),
@@ -90,11 +91,38 @@ fn quant_from_text(value: &str) -> Option<String> {
     (!quant.is_empty()).then_some(quant)
 }
 
+fn parameter_size_from_count(parameter_count: u64) -> Option<String> {
+    if parameter_count == 0 {
+        return None;
+    }
+
+    if parameter_count < 1_000_000_000 {
+        let millions = parameter_count as f64 / 1e6;
+        return Some(if millions >= 10.0 {
+            format!("{millions:.0}M")
+        } else {
+            format!("{millions:.1}M")
+        });
+    }
+
+    let billions = parameter_count as f64 / 1e9;
+    Some(if parameter_count.is_multiple_of(1_000_000_000) {
+        format!("{billions:.0}B")
+    } else {
+        format!("{billions:.1}B")
+    })
+}
+
 fn parameter_size_from_text(text: &str) -> Option<String> {
-    static MULTIPLIED_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(?i)(\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)([bm])").unwrap());
+    if text.starts_with("local-gguf/sha256-") {
+        return None;
+    }
+
+    static MULTIPLIED_RE: LazyLock<Regex> = LazyLock::new(|| {
+        Regex::new(r"(?i)(?:^|[^a-z0-9.])(\d+(?:\.\d+)?)x(\d+(?:\.\d+)?)([bm])").unwrap()
+    });
     static SIMPLE_RE: LazyLock<Regex> =
-        LazyLock::new(|| Regex::new(r"(?i)(\d+(?:\.\d+)?)([bm])").unwrap());
+        LazyLock::new(|| Regex::new(r"(?i)(?:^|[^a-z0-9.])(\d+(?:\.\d+)?)([bm])").unwrap());
 
     MULTIPLIED_RE
         .captures(text)
@@ -115,7 +143,11 @@ fn parameter_size_from_text(text: &str) -> Option<String> {
 
 #[cfg(test)]
 mod tests {
-    use super::parameter_size_from_text;
+    use std::path::Path;
+
+    use super::{
+        parameter_size_from_count, parameter_size_from_text, served_model_metadata_for_path,
+    };
 
     #[test]
     fn extracts_parameter_size_labels() {
@@ -127,5 +159,65 @@ mod tests {
             parameter_size_from_text("mixtral-8x7b").as_deref(),
             Some("8x7B")
         );
+    }
+
+    #[test]
+    fn rejects_parameter_size_labels_embedded_in_synthetic_names() {
+        assert_eq!(
+            parameter_size_from_text("local-gguf/sha256-74a4da8c9fdbcd15bd1f6e06b796387d397b038d"),
+            None
+        );
+        assert_eq!(parameter_size_from_text("model-dead8061beef"), None);
+    }
+
+    #[test]
+    fn formats_parameter_size_from_tensor_count() {
+        assert_eq!(parameter_size_from_count(0), None);
+        assert_eq!(
+            parameter_size_from_count(494_000_000).as_deref(),
+            Some("494M")
+        );
+        assert_eq!(
+            parameter_size_from_count(1_235_000_000).as_deref(),
+            Some("1.2B")
+        );
+        assert_eq!(
+            parameter_size_from_count(32_000_000_000).as_deref(),
+            Some("32B")
+        );
+    }
+
+    #[test]
+    fn derives_synthetic_model_parameter_size_from_gguf_tensors() {
+        let path = std::env::temp_dir().join(format!(
+            "mesh-llm-profile-parameter-size-{}.gguf",
+            std::process::id()
+        ));
+        write_gguf_with_parameters(&path, 494_000_000);
+
+        let metadata = served_model_metadata_for_path(
+            "local-gguf/sha256-74a4da8c9fdbcd15bd1f6e06b796387d397b038d",
+            &path,
+        )
+        .expect("synthetic GGUF should expose metadata");
+
+        assert_eq!(metadata.parameter_size.as_deref(), Some("494M"));
+        assert_eq!(metadata.parameter_count_b, Some(0.494));
+        let _ = std::fs::remove_file(path);
+    }
+
+    fn write_gguf_with_parameters(path: &Path, parameters: u64) {
+        let mut bytes = Vec::new();
+        bytes.extend_from_slice(b"GGUF");
+        bytes.extend_from_slice(&3u32.to_le_bytes());
+        bytes.extend_from_slice(&1u64.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        bytes.extend_from_slice(&7u64.to_le_bytes());
+        bytes.extend_from_slice(b"weights");
+        bytes.extend_from_slice(&1u32.to_le_bytes());
+        bytes.extend_from_slice(&parameters.to_le_bytes());
+        bytes.extend_from_slice(&0u32.to_le_bytes());
+        bytes.extend_from_slice(&0u64.to_le_bytes());
+        std::fs::write(path, bytes).expect("write synthetic GGUF");
     }
 }


### PR DESCRIPTION
Local GGUF models now report a parameter size derived from the model itself, so synthetic `local-gguf/sha256-*` IDs no longer surface digest fragments such as `15B` or `8061B` in `/v1/models`.

## Original problem

When a GGUF omitted `general.size_label`, the metadata path parsed the served model name. Synthetic local IDs contain a SHA-256 digest, so digit-and-unit fragments inside the digest were reported as the model's parameter size.

Closes #1739.

## Diagnostics

Release validation reproduced this with Qwen2.5-0.5B reporting `15B` and a Llama-3.2-1B package artifact reporting `8061B`. The numeric `parameter_count_b` remained correct because it already came from summed GGUF tensor dimensions.

## Fix

- Resolve `parameter_size` consistently for all model descriptors: source metadata first, then a verified local GGUF tensor count, then a guarded model-name fallback.
- Keep `parameter_count_b` authoritative and sourced only from summed GGUF tensor dimensions, so display-name parsing cannot affect routing or MoA tiering.
- Reject synthetic SHA IDs and size-like text embedded within alphanumeric strings on either boundary.
- Add regression coverage for the shared precedence and a minimal GGUF served under a synthetic SHA ID.

## Validation

- [x] `cargo fmt --all --check`
- [x] `cargo test -p mesh-llm-host-runtime --lib` — 3,022 passed, 11 ignored
- [x] `cargo check -p mesh-llm-host-runtime -p mesh-llm`
- [x] `cargo clippy -p mesh-llm-host-runtime -p mesh-llm --all-targets -- -D warnings`
- [x] No UI changes; screenshots do not apply.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model metadata detection for GGUF shard bundles.
  * Added more accurate parameter size and count reporting when metadata is derived from model paths.
  * Prevented incorrect size detection from labels embedded within synthetic or internal model names.
  * Improved parameter-size formatting by removing unnecessary trailing “.0” values.
  * Added safeguards to reject ambiguous model labels and prioritize the most reliable available metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
