### PR TITLE
feat(console): surface the advertised memory breakdown

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/mod.rs
@@ -1260,6 +1260,7 @@ async fn node_hardware_input(
         gpu_compute_tflops_fp16: node_metric_csv(&node.gpu_compute_tflops_fp16).await,
         my_hostname: node.hostname.clone(),
         my_is_soc: node.is_soc,
+        memory: node.advertised_memory,
         my_vram_gb,
         model_size_gb: model_size_bytes as f64 / 1e9,
         first_joined_mesh_ts: node.first_joined_mesh_ts().await,

--- a/crates/mesh-llm-host-runtime/src/api/status.rs
+++ b/crates/mesh-llm-host-runtime/src/api/status.rs
@@ -8,8 +8,10 @@ use crate::mesh::requirements::{MeshRequirementPolicySummary, MeshRequirementRej
 use crate::network::{affinity, metrics};
 use crate::runtime_data;
 use crate::system::hardware::expand_gpu_names;
+mod memory;
 mod runtime;
 
+pub(crate) use memory::MemoryPayload;
 pub(crate) use runtime::*;
 use serde::Serialize;
 use skippy_server::OpenAiGuardrailsStatus;
@@ -409,6 +411,8 @@ pub(crate) struct StatusPayload {
     pub(crate) publication_state: String,
     pub(crate) my_hostname: Option<String>,
     pub(crate) my_is_soc: Option<bool>,
+    /// Itemized view of `my_vram_gb`, the capacity this node advertises.
+    pub(crate) my_memory: MemoryPayload,
     pub(crate) gpus: Vec<GpuEntry>,
     pub(crate) routing_affinity: affinity::AffinityStatsSnapshot,
     /// Local-only routing outcome and current-node pressure snapshot measured on
@@ -534,6 +538,10 @@ pub(crate) struct PeerPayload {
     pub(crate) latency_observer_id: Option<String>,
     pub(crate) hostname: Option<String>,
     pub(crate) is_soc: Option<bool>,
+    /// Itemized view of `vram_gb` when the peer advertised one; absent from
+    /// peers that predate it or that hide their hardware.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) memory: Option<MemoryPayload>,
     pub(crate) gpus: Vec<GpuEntry>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) first_joined_mesh_ts: Option<u64>,
@@ -1086,6 +1094,7 @@ mod tests {
     #[test]
     fn test_peer_payload_serializes_version_field() {
         let peer = PeerPayload {
+            memory: None,
             id: "test-id".to_string(),
             owner: test_owner_payload(),
             release_attestation: test_release_attestation_summary(),
@@ -1119,6 +1128,7 @@ mod tests {
     #[test]
     fn test_peer_payload_serializes_null_version() {
         let peer = PeerPayload {
+            memory: None,
             id: "test-id".to_string(),
             owner: test_owner_payload(),
             release_attestation: test_release_attestation_summary(),
@@ -1158,6 +1168,7 @@ mod tests {
     #[test]
     fn status_payload_serializes_node_state_and_node_status_alias() {
         let status = StatusPayload {
+            my_memory: crate::api::status::MemoryPayload::default(),
             version: "0.60.2".to_string(),
             latest_version: None,
             node_id: "node-1".to_string(),
@@ -1229,6 +1240,7 @@ mod tests {
     #[test]
     fn status_payload_keeps_node_status_for_compatibility() {
         let status = StatusPayload {
+            my_memory: crate::api::status::MemoryPayload::default(),
             version: "0.60.2".to_string(),
             latest_version: None,
             node_id: "node-1".to_string(),
@@ -1293,6 +1305,7 @@ mod tests {
     #[test]
     fn status_payload_serializes_wakeable_nodes_separately() {
         let status = StatusPayload {
+            my_memory: crate::api::status::MemoryPayload::default(),
             version: "0.60.2".to_string(),
             latest_version: None,
             node_id: "node-1".to_string(),
@@ -1366,6 +1379,7 @@ mod tests {
     #[test]
     fn status_payload_defaults_to_empty_wakeable_inventory() {
         let status = StatusPayload {
+            my_memory: crate::api::status::MemoryPayload::default(),
             version: "0.60.2".to_string(),
             latest_version: None,
             node_id: "node-1".to_string(),
@@ -1430,6 +1444,7 @@ mod tests {
     #[test]
     fn peer_status_serializes_state_without_mutating_role() {
         let peer = PeerPayload {
+            memory: None,
             id: "test-id".to_string(),
             owner: test_owner_payload(),
             release_attestation: test_release_attestation_summary(),

--- a/crates/mesh-llm-host-runtime/src/api/status/memory.rs
+++ b/crates/mesh-llm-host-runtime/src/api/status/memory.rs
@@ -1,0 +1,80 @@
+//! Advertised memory breakdown payload, extracted from oversized status.rs.
+//!
+//! Mirrors `crate::mesh::AdvertisedMemory` for `/api/status` (`my_memory` and
+//! `peers[].memory`); keep the shape stable, the console reads it as is.
+
+use serde::Serialize;
+
+/// Itemized capacity behind a node's advertised `vram_gb`, in bytes, exactly
+/// as the node announces it on the mesh: `total_bytes` is the enumerated
+/// accelerator memory, the three reserves are what is withheld from it, and
+/// `usable_bytes` is what remains for placement, so that
+/// `total_bytes == reserved_bytes + platform_reserve_bytes + configured_reserve_bytes + usable_bytes`.
+/// `system_ram_bytes` and `ram_offload_bytes` describe the node's local fit
+/// budget and are informational only.
+#[derive(Clone, Copy, Debug, Default, Eq, PartialEq, Serialize)]
+pub(crate) struct MemoryPayload {
+    pub(crate) total_bytes: u64,
+    pub(crate) reserved_bytes: u64,
+    pub(crate) platform_reserve_bytes: u64,
+    pub(crate) configured_reserve_bytes: u64,
+    pub(crate) usable_bytes: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub(crate) system_ram_bytes: Option<u64>,
+    pub(crate) ram_offload_bytes: u64,
+}
+
+impl From<crate::mesh::AdvertisedMemory> for MemoryPayload {
+    fn from(memory: crate::mesh::AdvertisedMemory) -> Self {
+        Self {
+            total_bytes: memory.total_bytes,
+            reserved_bytes: memory.reserved_bytes,
+            platform_reserve_bytes: memory.platform_reserve_bytes,
+            configured_reserve_bytes: memory.configured_reserve_bytes,
+            usable_bytes: memory.usable_bytes,
+            system_ram_bytes: memory.system_ram_bytes,
+            ram_offload_bytes: memory.ram_offload_bytes,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn memory_payload_mirrors_the_advertised_breakdown_and_keeps_absent_ram_absent() {
+        let payload = MemoryPayload::from(crate::mesh::AdvertisedMemory {
+            total_bytes: 12_000_000_000,
+            reserved_bytes: 500_000_000,
+            platform_reserve_bytes: 0,
+            configured_reserve_bytes: 2_000_000_000,
+            usable_bytes: 9_500_000_000,
+            system_ram_bytes: None,
+            ram_offload_bytes: 18_000_000_000,
+        });
+
+        let json = serde_json::to_value(payload).expect("memory payload serializes");
+        assert_eq!(json["total_bytes"], 12_000_000_000u64);
+        assert_eq!(json["reserved_bytes"], 500_000_000u64);
+        assert_eq!(json["platform_reserve_bytes"], 0u64);
+        assert_eq!(json["configured_reserve_bytes"], 2_000_000_000u64);
+        assert_eq!(json["usable_bytes"], 9_500_000_000u64);
+        assert_eq!(json["ram_offload_bytes"], 18_000_000_000u64);
+        assert!(
+            json.get("system_ram_bytes").is_none(),
+            "absent system RAM must stay absent: {json}"
+        );
+    }
+
+    #[test]
+    fn memory_payload_reports_system_ram_when_the_survey_knows_it() {
+        let payload = MemoryPayload::from(crate::mesh::AdvertisedMemory {
+            system_ram_bytes: Some(32_000_000_000),
+            ..crate::mesh::AdvertisedMemory::default()
+        });
+
+        let json = serde_json::to_value(payload).expect("memory payload serializes");
+        assert_eq!(json["system_ram_bytes"], 32_000_000_000u64);
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/api/tests/ui_routes.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests/ui_routes.rs
@@ -136,6 +136,7 @@ fn status_view_input(
                 gpu_name: None,
                 gpu_vram: None,
                 gpu_reserved_bytes: None,
+                memory: crate::mesh::AdvertisedMemory::default(),
                 gpu_mem_bandwidth_gbps: None,
                 gpu_compute_tflops_fp32: None,
                 gpu_compute_tflops_fp16: None,

--- a/crates/mesh-llm-host-runtime/src/runtime_data/api_views.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/api_views.rs
@@ -71,6 +71,7 @@ pub(crate) fn status_payload(snapshot: StatusViewSnapshot) -> StatusPayload {
         publication_state: snapshot.publication_state,
         my_hostname: snapshot.hardware.my_hostname,
         my_is_soc: snapshot.hardware.my_is_soc,
+        my_memory: snapshot.hardware.my_memory,
         gpus: snapshot.hardware.gpus,
         routing_affinity: snapshot.routing_affinity,
         routing_metrics: snapshot.routing_metrics,
@@ -116,6 +117,7 @@ mod tests {
             gpu_name: Some("RTX 4090".into()),
             gpu_vram: Some("25769803776".into()),
             gpu_reserved_bytes: None,
+            memory: crate::mesh::AdvertisedMemory::default(),
             gpu_mem_bandwidth_gbps: None,
             gpu_compute_tflops_fp32: None,
             gpu_compute_tflops_fp16: None,
@@ -165,6 +167,7 @@ mod tests {
 
         let payload = status_payload(snapshot);
         let expected = StatusPayload {
+            my_memory: crate::api::status::MemoryPayload::default(),
             version: "0.68.0".into(),
             latest_version: Some("0.68.0".into()),
             node_id: "node-1".into(),

--- a/crates/mesh-llm-host-runtime/src/runtime_data/collector.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/collector.rs
@@ -29,8 +29,8 @@ use super::{
     RuntimeLlamaRuntimeSnapshot, RuntimeLlamaSlotItem, RuntimeLlamaSlotsSnapshot,
 };
 use crate::api::status::{
-    LatencySource, LocalInstance, MeshModelPayload, NodeState, PeerPayload, WakeableNode,
-    WakeableNodeState, build_gpus, build_ownership_payload,
+    LatencySource, LocalInstance, MemoryPayload, MeshModelPayload, NodeState, PeerPayload,
+    WakeableNode, WakeableNodeState, build_gpus, build_ownership_payload,
 };
 use crate::mesh;
 use crate::models::LocalModelInventorySnapshot;
@@ -353,6 +353,7 @@ impl RuntimeDataCollector {
         HardwareViewSnapshot {
             my_hostname: input.my_hostname,
             my_is_soc: input.my_is_soc,
+            my_memory: MemoryPayload::from(input.memory),
             my_vram_gb: input.my_vram_gb,
             model_size_gb: input.model_size_gb,
             gpus: build_gpus(
@@ -1122,6 +1123,7 @@ fn build_peer_payload(peer: &mesh::PeerInfo) -> PeerPayload {
             .map(|id| id.fmt_short().to_string()),
         hostname: peer.hostname.clone(),
         is_soc: peer.is_soc,
+        memory: peer.memory.map(MemoryPayload::from),
         gpus: build_gpus(
             peer.gpu_name.as_deref(),
             peer.gpu_vram.as_deref(),

--- a/crates/mesh-llm-host-runtime/src/runtime_data/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/mod.rs
@@ -364,6 +364,7 @@ pub(crate) mod tests {
             gpu_name: Some("RTX 4090".into()),
             gpu_vram: Some("25769803776".into()),
             gpu_reserved_bytes: None,
+            memory: crate::mesh::AdvertisedMemory::default(),
             gpu_mem_bandwidth_gbps: None,
             gpu_compute_tflops_fp32: None,
             gpu_compute_tflops_fp16: None,
@@ -413,6 +414,7 @@ pub(crate) mod tests {
 
         let payload = status_payload(snapshot);
         let expected = StatusPayload {
+            my_memory: crate::api::status::MemoryPayload::default(),
             version: "0.68.0".into(),
             latest_version: Some("0.68.0".into()),
             node_id: "node-1".into(),
@@ -559,6 +561,7 @@ pub(crate) mod tests {
             gpu_name: None,
             gpu_vram: None,
             gpu_reserved_bytes: None,
+            memory: crate::mesh::AdvertisedMemory::default(),
             gpu_mem_bandwidth_gbps: None,
             gpu_compute_tflops_fp32: None,
             gpu_compute_tflops_fp16: None,
@@ -702,6 +705,7 @@ pub(crate) mod tests {
             gpu_name: None,
             gpu_vram: None,
             gpu_reserved_bytes: None,
+            memory: crate::mesh::AdvertisedMemory::default(),
             gpu_mem_bandwidth_gbps: None,
             gpu_compute_tflops_fp32: None,
             gpu_compute_tflops_fp16: None,

--- a/crates/mesh-llm-host-runtime/src/runtime_data/snapshots.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime_data/snapshots.rs
@@ -2,8 +2,8 @@ use super::plugins::PluginDataValue;
 use super::processes::RuntimeProcessSnapshot;
 use crate::api::RuntimeProcessPayload;
 use crate::api::status::{
-    GpuEntry, LocalInstance, MeshModelPayload, NodeState, OwnershipPayload, PeerPayload,
-    WakeableNode,
+    GpuEntry, LocalInstance, MemoryPayload, MeshModelPayload, NodeState, OwnershipPayload,
+    PeerPayload, WakeableNode,
 };
 use crate::crypto::{OwnershipSummary, ReleaseAttestationSummary};
 use crate::mesh::{MeshCatalogEntry, ModelDemand, PeerInfo};
@@ -78,6 +78,8 @@ pub(crate) struct HardwareViewInput {
     pub gpu_compute_tflops_fp16: Option<String>,
     pub my_hostname: Option<String>,
     pub my_is_soc: Option<bool>,
+    /// The itemized capacity this node advertises next to `my_vram_gb`.
+    pub memory: crate::mesh::AdvertisedMemory,
     pub my_vram_gb: f64,
     pub model_size_gb: f64,
     pub first_joined_mesh_ts: Option<u64>,
@@ -87,6 +89,7 @@ pub(crate) struct HardwareViewInput {
 pub(crate) struct HardwareViewSnapshot {
     pub my_hostname: Option<String>,
     pub my_is_soc: Option<bool>,
+    pub my_memory: MemoryPayload,
     pub my_vram_gb: f64,
     pub model_size_gb: f64,
     pub gpus: Vec<GpuEntry>,

--- a/crates/mesh-llm-ui/src/features/app-tabs/types.ts
+++ b/crates/mesh-llm-ui/src/features/app-tabs/types.ts
@@ -1,5 +1,6 @@
 import type { ReactNode } from 'react'
 import type { LatencySource } from '@/lib/api/types'
+import type { MemoryBreakdownGB } from '@/lib/vram'
 import type { ChatMessage } from '@/features/chat/lib/chat-types'
 import type { WakeableNode } from '@/features/app-shell/lib/status-types'
 
@@ -41,6 +42,8 @@ export type Peer = {
   nodeState?: 'client' | 'standby' | 'loading' | 'serving'
   version?: string
   vramGB?: number
+  /** Itemized view of `vramGB` when the node advertised one. */
+  memory?: MemoryBreakdownGB
   toksPerSec?: number
   hardwareLabel?: string
   ownership?: string

--- a/crates/mesh-llm-ui/src/features/drawers/components/NodeDrawer.test.tsx
+++ b/crates/mesh-llm-ui/src/features/drawers/components/NodeDrawer.test.tsx
@@ -332,3 +332,48 @@ describe('NodeDrawer runtime section', () => {
     expect(screen.queryByText('Client')).not.toBeInTheDocument()
   })
 })
+
+describe('NodeDrawer advertised memory', () => {
+  const memory = {
+    totalGB: 12,
+    reservedGB: 0.5,
+    platformReserveGB: 0,
+    configuredReserveGB: 2,
+    usableGB: 9.5,
+    systemRamGB: 32,
+    ramOffloadGB: 18
+  }
+
+  it('itemizes the memory a peer advertises', () => {
+    render(<NodeDrawer open node={PEER_NODE} peer={{ ...PEER, vramGB: 9.5, memory }} onClose={() => {}} />)
+
+    expect(screen.getByText('Memory')).toBeInTheDocument()
+    expect(screen.getByText('12.0 GB')).toBeInTheDocument()
+    expect(screen.getAllByText('9.5 GB').length).toBeGreaterThanOrEqual(2)
+    expect(screen.getByText('Driver reserved')).toBeInTheDocument()
+    expect(screen.getByText('Configured reserve')).toBeInTheDocument()
+    expect(screen.getByText('System RAM')).toBeInTheDocument()
+    expect(screen.getByText('RAM-backed local budget')).toBeInTheDocument()
+    expect(screen.queryByText('Platform reserve')).not.toBeInTheDocument()
+  })
+
+  it('shows the platform reserve only when the node reports one', () => {
+    render(
+      <NodeDrawer
+        open
+        node={PEER_NODE}
+        peer={{ ...PEER, vramGB: 55, memory: { ...memory, totalGB: 64, platformReserveGB: 6.4, usableGB: 55 } }}
+        onClose={() => {}}
+      />
+    )
+
+    expect(screen.getByText('Platform reserve')).toBeInTheDocument()
+    expect(screen.getByText('6.4 GB')).toBeInTheDocument()
+  })
+
+  it('renders no memory section for peers without a breakdown', () => {
+    render(<NodeDrawer open node={PEER_NODE} peer={PEER} onClose={() => {}} />)
+
+    expect(screen.queryByText('Configured reserve')).not.toBeInTheDocument()
+  })
+})

--- a/crates/mesh-llm-ui/src/features/drawers/components/NodeDrawer.tsx
+++ b/crates/mesh-llm-ui/src/features/drawers/components/NodeDrawer.tsx
@@ -13,6 +13,7 @@ import { meshNodeStatusSource, meshStatusLabel, meshStatusTone } from '@/feature
 import { useLlamaRuntime } from '@/features/network/api/use-llama-runtime'
 import { LatencySource } from '@/lib/api/types'
 import { formatPeerLatencySummary } from '@/lib/format-latency'
+import { formatDecimalVramGB } from '@/lib/vram'
 import type { ConfigNode, MeshNode, ModelSummary, Peer } from '@/features/app-tabs/types'
 import type { LlamaRuntimeMetricSample, LlamaRuntimePayload, LlamaRuntimeSlotItem } from '@/lib/api/types'
 
@@ -369,6 +370,32 @@ function NodeDrawerContent({
                 {hardwareLabel(peer, node)}
               </KV>
             </div>
+
+            {peer.memory ? (
+              <>
+                <h3 className="sr-only">Advertised memory</h3>
+                <SectionHead icon={drawerIcon(HardDrive)}>Memory</SectionHead>
+                <div className="space-y-2 px-[18px]">
+                  <p className="text-[length:var(--density-type-caption)] leading-5 text-fg-faint">
+                    As advertised to the mesh. Placement counts on the usable share; the reserves are withheld from the
+                    total before it.
+                  </p>
+                  <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+                    <KV label="Total">{formatDecimalVramGB(peer.memory.totalGB)}</KV>
+                    <KV label="Usable">{formatDecimalVramGB(peer.memory.usableGB)}</KV>
+                    <KV label="Driver reserved">{formatDecimalVramGB(peer.memory.reservedGB)}</KV>
+                    {peer.memory.platformReserveGB > 0 ? (
+                      <KV label="Platform reserve">{formatDecimalVramGB(peer.memory.platformReserveGB)}</KV>
+                    ) : null}
+                    <KV label="Configured reserve">{formatDecimalVramGB(peer.memory.configuredReserveGB)}</KV>
+                    {peer.memory.systemRamGB != null ? (
+                      <KV label="System RAM">{formatDecimalVramGB(peer.memory.systemRamGB)}</KV>
+                    ) : null}
+                    <KV label="RAM-backed local budget">{formatDecimalVramGB(peer.memory.ramOffloadGB)}</KV>
+                  </div>
+                </div>
+              </>
+            ) : null}
           </>
         ) : null}
 

--- a/crates/mesh-llm-ui/src/features/network/api/status-adapter.test.ts
+++ b/crates/mesh-llm-ui/src/features/network/api/status-adapter.test.ts
@@ -615,3 +615,63 @@ describe('adaptStatusToDashboard', () => {
     expect(peer!.latencyMs).toBe(12.5)
   })
 })
+
+describe('advertised memory in the dashboard adapter', () => {
+  const memory = {
+    total_bytes: 12_000_000_000,
+    reserved_bytes: 500_000_000,
+    platform_reserve_bytes: 0,
+    configured_reserve_bytes: 2_000_000_000,
+    usable_bytes: 9_500_000_000,
+    system_ram_bytes: 32_000_000_000,
+    ram_offload_bytes: 18_000_000_000
+  }
+
+  it('carries the breakdown each node advertises into the node model without touching totals', () => {
+    const dashboard = adaptStatusToDashboard({
+      ...PUBLIC_STATUS_PAYLOAD,
+      my_vram_gb: 9.5,
+      my_memory: memory,
+      peers: [
+        {
+          ...PUBLIC_STATUS_PAYLOAD.peers[0],
+          role: 'Worker',
+          state: 'serving',
+          vram_gb: 37,
+          memory: {
+            ...memory,
+            total_bytes: 40_000_000_000,
+            reserved_bytes: 1_000_000_000,
+            usable_bytes: 37_000_000_000
+          }
+        }
+      ]
+    })
+
+    const [self, worker] = dashboard.peers
+    expect(self.memory).toEqual({
+      totalGB: 12,
+      reservedGB: 0.5,
+      platformReserveGB: 0,
+      configuredReserveGB: 2,
+      usableGB: 9.5,
+      systemRamGB: 32,
+      ramOffloadGB: 18
+    })
+    expect(self.vramGB).toBe(9.5)
+    expect(worker.memory?.totalGB).toBe(40)
+    expect(worker.memory?.usableGB).toBe(37)
+    expect(worker.vramGB).toBe(37)
+  })
+
+  it('leaves the breakdown absent for nodes that did not advertise one', () => {
+    const dashboard = adaptStatusToDashboard({
+      ...PUBLIC_STATUS_PAYLOAD,
+      peers: [{ ...PUBLIC_STATUS_PAYLOAD.peers[0], role: 'Worker', state: 'serving', vram_gb: 39 }]
+    })
+
+    const [self, worker] = dashboard.peers
+    expect(self.memory).toBeUndefined()
+    expect(worker.memory).toBeUndefined()
+  })
+})

--- a/crates/mesh-llm-ui/src/features/network/api/status-adapter.ts
+++ b/crates/mesh-llm-ui/src/features/network/api/status-adapter.ts
@@ -1,7 +1,13 @@
 import { DASHBOARD_HARNESS } from '@/features/app-tabs/data'
 import type { StatusPayload, PeerInfo, ServingModelEntry } from '@/lib/api/types'
 import { isPublicMesh } from '@/lib/api/mesh-visibility'
-import { isClientPeer, meshAdvertisedVramGB, meshCapacityInputFromStatus, nodeAdvertisedVramGB } from '@/lib/vram'
+import {
+  isClientPeer,
+  memoryBreakdownGB,
+  meshAdvertisedVramGB,
+  meshCapacityInputFromStatus,
+  nodeAdvertisedVramGB
+} from '@/lib/vram'
 import type {
   DashboardHarnessData,
   DashboardConnectData,
@@ -150,6 +156,7 @@ function adaptPeer(peer: PeerInfo, fallbackIndex: number): Peer {
     shortId: id.slice(0, 8),
     version: peer.version,
     vramGB: peerVramGb(peer),
+    memory: memoryBreakdownGB(peer.memory) ?? undefined,
     role: resolvePeerRole(peer),
     nodeState,
     toksPerSec: peer.tok_per_sec,
@@ -191,6 +198,7 @@ function adaptSelfPeer(payload: StatusPayload): Peer {
     nodeState: effectiveState,
     version: payload.version,
     vramGB: selfVramGb(payload),
+    memory: memoryBreakdownGB(payload.my_memory) ?? undefined,
     toksPerSec: payload.tok_per_sec,
     firstJoinedMeshTs: payload.first_joined_mesh_ts
   }

--- a/crates/mesh-llm-ui/src/lib/api/types.ts
+++ b/crates/mesh-llm-ui/src/lib/api/types.ts
@@ -22,6 +22,22 @@ export interface GpuInfo {
   mem_bandwidth_gbps?: number
 }
 
+/**
+ * Itemized capacity behind a node's advertised VRAM, in bytes, as the node
+ * announces it on the mesh: total = reserved + platform_reserve +
+ * configured_reserve + usable. System RAM and the RAM-backed share of the
+ * local budget are informational only.
+ */
+export interface MemoryBreakdown {
+  total_bytes: number
+  reserved_bytes: number
+  platform_reserve_bytes?: number
+  configured_reserve_bytes: number
+  usable_bytes: number
+  system_ram_bytes?: number
+  ram_offload_bytes: number
+}
+
 export interface ServingModel {
   name: string
   node_id: string
@@ -101,6 +117,7 @@ export interface PeerInfo {
   models?: string[]
   my_vram_gb?: number
   vram_gb?: number
+  memory?: MemoryBreakdown
   latency_ms?: number
   latency_source?: LatencySource
   latency_age_ms?: number
@@ -155,6 +172,7 @@ export interface StatusPayload {
   models: MeshModelRaw[]
   my_vram_gb: number
   my_is_soc?: boolean
+  my_memory?: MemoryBreakdown
   api_port?: number
   gpus: GpuInfo[]
   serving_models: ServingModelEntry[]

--- a/crates/mesh-llm-ui/src/lib/vram.test.ts
+++ b/crates/mesh-llm-ui/src/lib/vram.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest'
 
 import {
   allocatableVramBytes,
+  formatDecimalVramGB,
   formatRatedVramBytes,
   gpuAllocatableVramGB,
   gpuRatedVramGB,
@@ -10,6 +11,7 @@ import {
   meshAdvertisedVramGB,
   isClientPeer,
   meshCapacityInputFromStatus,
+  memoryBreakdownGB,
   nodeAdvertisedVramGB,
   nodeRatedVramGB,
   ratedVramGBFromBytes
@@ -116,5 +118,40 @@ describe('VRAM accounting utilities', () => {
     expect(isClientPeer({ state: 'client' })).toBe(true)
     expect(isClientPeer({ role: 'Client' })).toBe(true)
     expect(isClientPeer({ node_state: 'serving', role: 'Host' })).toBe(false)
+  })
+})
+
+describe('advertised memory breakdown', () => {
+  const memory = {
+    total_bytes: 12_000_000_000,
+    reserved_bytes: 500_000_000,
+    platform_reserve_bytes: 0,
+    configured_reserve_bytes: 2_000_000_000,
+    usable_bytes: 9_500_000_000,
+    system_ram_bytes: 32_000_000_000,
+    ram_offload_bytes: 18_000_000_000
+  }
+
+  it('converts the breakdown to decimal GB and leaves absent system RAM absent', () => {
+    expect(memoryBreakdownGB(memory)).toEqual({
+      totalGB: 12,
+      reservedGB: 0.5,
+      platformReserveGB: 0,
+      configuredReserveGB: 2,
+      usableGB: 9.5,
+      systemRamGB: 32,
+      ramOffloadGB: 18
+    })
+    expect(memoryBreakdownGB({ ...memory, system_ram_bytes: undefined })?.systemRamGB).toBeNull()
+    expect(memoryBreakdownGB({ ...memory, platform_reserve_bytes: undefined })?.platformReserveGB).toBe(0)
+    expect(memoryBreakdownGB({ ...memory, usable_bytes: Number.NaN })).toBeNull()
+    expect(memoryBreakdownGB(null)).toBeNull()
+    expect(memoryBreakdownGB(undefined)).toBeNull()
+  })
+
+  it('formats itemized values with one decimal instead of a capacity class', () => {
+    expect(formatDecimalVramGB(9.5)).toBe('9.5 GB')
+    expect(formatDecimalVramGB(0)).toBe('0.0 GB')
+    expect(formatDecimalVramGB(null)).toBe('Unknown')
   })
 })

--- a/crates/mesh-llm-ui/src/lib/vram.ts
+++ b/crates/mesh-llm-ui/src/lib/vram.ts
@@ -177,3 +177,61 @@ export function meshCapacityInputFromStatus(status: VramStatusLike): VramMeshInp
     }))
   }
 }
+
+/** The itemized capacity a node advertises, as `/api/status` reports it (bytes). */
+export type MemoryBreakdownInput = {
+  total_bytes: number
+  reserved_bytes: number
+  platform_reserve_bytes?: number
+  configured_reserve_bytes: number
+  usable_bytes: number
+  system_ram_bytes?: number
+  ram_offload_bytes: number
+}
+
+/** The same breakdown in decimal GB, ready to display. */
+export type MemoryBreakdownGB = {
+  totalGB: number
+  reservedGB: number
+  platformReserveGB: number
+  configuredReserveGB: number
+  usableGB: number
+  systemRamGB: number | null
+  ramOffloadGB: number
+}
+
+function finiteNonNegative(value: number | null | undefined): number | null {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : null
+}
+
+function decimalGBOrZero(bytes: number | null | undefined): number {
+  return (finiteNonNegative(bytes) ?? 0) / DECIMAL_GB_BYTES
+}
+
+/**
+ * The advertised breakdown in decimal GB, or null when the node sent none or
+ * the block is unusable. Zero reserves are real values, not gaps; only the
+ * optional system RAM stays null when it was not reported. Totals do not go
+ * through here: they keep `nodeAdvertisedVramGB`.
+ */
+export function memoryBreakdownGB(memory: MemoryBreakdownInput | null | undefined): MemoryBreakdownGB | null {
+  if (!memory) return null
+  if (finiteNonNegative(memory.total_bytes) == null || finiteNonNegative(memory.usable_bytes) == null) return null
+  const systemRam = finiteNonNegative(memory.system_ram_bytes)
+  return {
+    totalGB: decimalGBOrZero(memory.total_bytes),
+    reservedGB: decimalGBOrZero(memory.reserved_bytes),
+    platformReserveGB: decimalGBOrZero(memory.platform_reserve_bytes),
+    configuredReserveGB: decimalGBOrZero(memory.configured_reserve_bytes),
+    usableGB: decimalGBOrZero(memory.usable_bytes),
+    systemRamGB: systemRam == null ? null : systemRam / DECIMAL_GB_BYTES,
+    ramOffloadGB: decimalGBOrZero(memory.ram_offload_bytes)
+  }
+}
+
+/** Exact decimal GB with one decimal, for itemized values that are not capacity classes. */
+export function formatDecimalVramGB(valueGB: number | null | undefined): string {
+  const value = finiteNonNegative(valueGB)
+  if (value == null) return 'Unknown'
+  return `${value.toFixed(1)} GB`
+}

--- a/docs/design/DESIGN.md
+++ b/docs/design/DESIGN.md
@@ -475,9 +475,12 @@ By default, nodes broadcast their GPU name, hostname, VRAM capacity, reserved by
 {
   "my_hostname": "carrack",
   "my_is_soc": false,
+  "my_memory": {"total_bytes": 34359738368, "reserved_bytes": 1073741824, "platform_reserve_bytes": 0, "configured_reserve_bytes": 2147483648, "usable_bytes": 31138512896, "system_ram_bytes": 68719476736, "ram_offload_bytes": 30923764531},
   "gpus": [{"name": "NVIDIA RTX 5090", "vram_bytes": 34359738368, "reserved_bytes": 1073741824, "mem_bandwidth_gbps": 1792.0, "compute_tflops_fp32": 104.8, "compute_tflops_fp16": 209.6}]
 }
 ```
+
+`my_memory` (and `memory` on the `peers[]` entries that advertise it) is the itemized capacity behind `my_vram_gb` / `vram_gb`, in bytes, exactly as the node announces it (see `hardware.memory` in [message_protocol.md](message_protocol.md)). The console renders a node's VRAM from the advertised `usable_bytes` when the block is present and only falls back to summing the per-GPU rated capacities for peers that predate it.
 
 For ROCm and Intel hosts, `reserved_bytes` is omitted because their standard CLI telemetry exposes live used-memory counters rather than a true reserved/system-memory value.
 

--- a/docs/specs/vram-accounting.md
+++ b/docs/specs/vram-accounting.md
@@ -24,8 +24,10 @@ but never serve, and the scheduler excludes them from the aggregate, so totals
 exclude them as well. Summing rated classes across GPUs is display-only and
 overstates schedulable capacity; the UI helpers fall back to allocatable, then
 rated, inventory only for legacy payloads that carry no advertised value, never
-as the primary source of a total (see #1656 for the itemized total / reserved /
-usable breakdown that will replace the single value).
+as the primary source of a total. The itemized total / reserved / usable
+breakdown from #1656 rides alongside that value: `/api/status` reports it as
+`my_memory` and `peers[].memory`, and the node drawer itemizes it, while totals
+keep using the single advertised figure.
 
 ![Dashboard showing Mesh Capacity 115.4 GB from the advertised capacity](assets/vram-dashboard-advertised.png)
 
@@ -41,19 +43,20 @@ usable breakdown that will replace the single value).
 | `crates/mesh-llm-host-runtime/src/mesh/mod.rs` | `HardwareSurvey` startup snapshot | internal and protocol | Stores node `vram_bytes`, `gpu_vram`, and `gpu_reserved_bytes` for runtime, gossip, and status. |
 | `crates/mesh-llm-host-runtime/src/mesh/capacity.rs` | `HardwareSurvey` startup snapshot and the effective safety margin | internal and protocol | Derives the advertised placement budget and its itemized breakdown (total, driver reserve, platform reserve, configured reserve, usable, system RAM, RAM-backed share) for gossip. |
 | `crates/mesh-llm-host-runtime/src/protocol/convert.rs` | peer announcements and protobuf GPU fields | protocol/internal | Preserves additive per-GPU totals and reserved bytes across mixed-version gossip. |
-| `crates/mesh-llm-host-runtime/src/api/status.rs` | node fields and GPU CSV fields | API for user-facing console | Emits raw `vram_bytes`, `reserved_bytes`, rated VRAM, and allocatable VRAM per GPU. |
+| `crates/mesh-llm-host-runtime/src/api/status.rs` | node fields and GPU CSV fields | API for user-facing console | Emits raw `vram_bytes`, `reserved_bytes`, rated VRAM, and allocatable VRAM per GPU, plus the advertised breakdown as `my_memory` and `peers[].memory` (`MemoryPayload`). |
 | `crates/mesh-llm-host-runtime/src/runtime/local.rs` | startup model specs and pinned GPU targets | internal | Skippy fit targets use allocatable capacity for pinned GPUs. |
 | `crates/mesh-llm-host-runtime/src/runtime/split_planning.rs` | participant `vram_bytes` | internal | Plans splits from advertised capacity, with separate runtime headroom. |
 | `crates/mesh-llm-host-runtime/src/runtime/context_planning.rs` | local/split capacity bytes | internal | Computes KV/context budget from capacity after model bytes. |
 | `crates/mesh-llm-host-runtime/src/api/model_target_capacity.rs` | local and peer `vram_bytes` | internal/API advice | Computes fit summaries and capacity advice. |
 | `crates/mesh-llm-host-runtime/src/runtime_data/collector.rs` | peer `vram_bytes` | API/user-facing aggregate | Produces mesh and peer VRAM summaries for status views. |
 | `crates/mesh-llm-ui/src/lib/vram.ts` | status GPU and node fields | shared UI semantic utility | Computes rated, system-reported, reserved, and allocatable values per GPU, and advertised node and mesh totals (`nodeAdvertisedVramGB`, `meshAdvertisedVramGB`). |
-| `crates/mesh-llm-ui/src/features/network/api/status-adapter.ts` | `/api/status` | user-facing dashboard | Node rows and the `Mesh Capacity` tile use advertised capacity (`my_vram_gb` / `vram_gb`), falling back to allocatable then rated inventory only when nothing is advertised. |
+| `crates/mesh-llm-ui/src/features/network/api/status-adapter.ts` | `/api/status` | user-facing dashboard | Node rows and the `Mesh Capacity` tile use advertised capacity (`my_vram_gb` / `vram_gb`), falling back to allocatable then rated inventory only when nothing is advertised; carries the advertised breakdown (`my_memory`, `peers[].memory`) into the node model as `Peer.memory`. |
 | `crates/mesh-llm-ui/src/features/app-shell/lib/status-helpers.ts` | `/api/status` and topology data | user-facing dashboard helpers | Formats GPU inventory with rated capacity; node and mesh totals (`displayVramGb`, `meshGpuVram`) use advertised capacity. |
 | `crates/mesh-llm-ui/src/features/chat/lib/live-chat-metrics.ts` | `/api/status` | user-facing chat header | Node count and advertised mesh capacity badges, from the same helper as the dashboard so both tabs agree. |
 | `crates/mesh-llm-ui/src/features/configuration/api/config-adapter.ts` | `/api/status.gpus[]` | bridge from API to UI math | Maps rated total, system total, reserved, and allocatable fields into config nodes. |
 | `crates/mesh-llm-ui/src/features/configuration/lib/config-math.ts` | config node GPU fields | internal UI calculation | Uses system/allocatable capacity for fit math while preserving rated total for labels. |
 | `crates/mesh-llm-ui/src/features/configuration/components/VRAMBar.tsx` | config math props | user-facing and internal UI | Displays total/reserved/free lanes; sizing is driven by system capacity. |
 | `crates/mesh-llm-ui/src/features/dashboard/components/details/NodeSidebar.tsx` | node GPU inventory | user-facing console | Displays per-GPU rated capacity. |
+| `crates/mesh-llm-ui/src/features/drawers/components/NodeDrawer.tsx` | adapted node breakdown (`Peer.memory`) | user-facing console | Itemizes the advertised memory (total, usable, driver reserve, platform reserve, configured reserve, system RAM, RAM-backed local budget). |
 | `crates/mesh-llm-ui/src/features/dashboard/components/topology/**` | adapted node VRAM | user-facing visual weighting | Uses adapted display VRAM for labels and node sizing. |
 | `crates/mesh-llm-ui/src/features/reserves/**` | wakeable node/status VRAM fields | user-facing reserve planning | Live mesh comparisons use GPU rated capacity when status inventory is available; reserve-provider VRAM still depends on wakeable upstream inventory. |


### PR DESCRIPTION
Part 2 of #1656, on top of #1673.

#1673 made every node announce what its `vram_bytes` actually contains, and #1746 made the node and mesh totals read that advertised figure. The breakdown itself is still invisible: `/api/status` reports the single number, so an operator who sees a node offering less than its GPUs hold has no way to find out which reserve took the difference.

## What this adds

`/api/status` now carries the block the node announces, as `my_memory` for the local node and `peers[].memory` for the others. It is a field-by-field copy of `AdvertisedMemory`, omitted for peers that did not send one, so an older peer simply has no `memory` key:

```json
"my_memory": {
  "total_bytes": 12878086144,
  "reserved_bytes": 0,
  "platform_reserve_bytes": 0,
  "configured_reserve_bytes": 2147483648,
  "usable_bytes": 10730602496,
  "system_ram_bytes": 33488429056,
  "ram_offload_bytes": 18549308620
}
```

`system_ram_bytes` is present only when the node reports it. The block above is the real output of this branch on a 12 GB RTX 4070 Ti, not an illustration, and it reads directly: the 2.15 GB configured reserve is the entire difference between the 12.88 GB the card enumerates and the 10.73 GB the node offers the mesh, which is exactly the question an operator could not answer before. The four-term partition from #1673 holds here as well: `total_bytes == reserved_bytes + platform_reserve_bytes + configured_reserve_bytes + usable_bytes`.

In the console, the dashboard adapter carries the block into the node model and the node drawer gains a Memory section that itemizes it, in the order the issue describes: the usable share first, then the reserves withheld from the total, then the informational figures. Platform reserve and system RAM only appear when they are non-zero or reported, so a discrete-GPU node does not grow two empty rows.

Totals are untouched. The node and mesh capacity tiles keep the precedence #1746 established; this change only explains the number they already show.

## Shape and placement

`api/status.rs` was already over 1,000 lines, so per the 1k LoC refactoring rule in AGENTS.md the payload went into a sibling module, `api/status/memory.rs`, 80 lines including its own serialization test, rather than growing the existing file by the same amount. `status.rs` goes from 1770 to 1785 lines for the wiring.

Docs follow: the `/api/status` example in `docs/design/DESIGN.md`, and the surface table in `docs/specs/vram-accounting.md` where the forward-looking sentence about #1656 is replaced by what the field now does.

## Validation

Windows 11, rebased on `main` at 80ffde505:

- `cargo fmt --check`, targeted `cargo test -p mesh-llm-host-runtime --lib` on the status, runtime_data and ui_routes trees (74 tests), `xtask repo-consistency no-console-print` and the environment mutation census: all clean. `cargo clippy --all-targets -- -D warnings` on the touched crates is clean once the four Windows-only lints that already fail on an untouched `main` on this machine are allowed; none of them sit in a file this change touches.
- Console: `eslint --max-warnings=0`, `prettier --check`, typecheck and `vite build` clean; `vitest` 1670 passed, with 14 failures spread over nine locale test files that fail the same way on an untouched checkout. The four test files this change touches are green, 55 tests.

End to end on the rebased tree: a node started from this branch serves the block shown above on `/api/status`, with the partition holding on the real numbers.

Not covered: Playwright end to end, and the drawer rendered in a real browser rather than through the component tests.

## Still open from the follow-up list on #1656

Two of the four items you listed are outside this change and I have not started either: the configuration UI representing the reserve and the resulting usable memory case by case for SoCs, and split planning consuming the usable value rather than the total. Happy to take them in that order if the direction here looks right.

Refs #1656.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added detailed advertised memory information to node status data, including usable capacity, reserved memory, platform reserves, configured reserves, system RAM, and RAM-backed capacity.
  * The node details panel now displays memory breakdowns for nodes that provide this information.
  * Existing VRAM totals remain available, with detailed advertised capacity used when provided.

* **Documentation**
  * Updated API and VRAM accounting documentation to describe the new memory fields and display behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->