### PR TITLE
fix(runtime): honor native runtime selection across startup paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3817,6 +3817,7 @@ version = "0.76.0"
 dependencies = [
  "anyhow",
  "dirs",
+ "mesh-llm-native-runtime",
  "mesh-llm-types",
  "semver",
  "serde",

--- a/crates/mesh-llm-commands/src/runtime_native.rs
+++ b/crates/mesh-llm-commands/src/runtime_native.rs
@@ -12,6 +12,7 @@ use mesh_llm_runtime_install::{
     discover_native_runtime_bundle_dirs, host_runtime_profile, install_native_runtime,
     load_release_manifest_with_sources, native_runtime_cache,
 };
+use mesh_llm_system::backend::BinaryFlavor;
 use mesh_llm_tui::terminal_progress::{
     ratio_complete_u64, render_inline_gauge_with_reserved_width,
 };
@@ -342,14 +343,16 @@ pub fn run_native_runtime_prune(
 pub fn run_native_runtime_doctor(
     mesh_version: Option<&str>,
     skippy_abi_version: Option<&str>,
+    llama_flavor: Option<BinaryFlavor>,
     configured_selection: Option<&str>,
     json_output: bool,
 ) -> Result<()> {
+    let effective_selection = native_runtime_selection(llama_flavor, configured_selection);
     let cache = native_runtime_cache(None)?;
     let profile = host_runtime_profile();
     let installed = discover_local_native_runtimes(&[], &cache)?;
     let selected_mesh_version = mesh_version.unwrap_or(CURRENT_MESH_VERSION);
-    let runtime_selection = RuntimeSelection::parse(configured_selection)?;
+    let runtime_selection = RuntimeSelection::parse(effective_selection)?;
     let selected_version_runtimes = installed
         .iter()
         .filter(|runtime| runtime.mesh_version == selected_mesh_version)
@@ -382,7 +385,7 @@ pub fn run_native_runtime_doctor(
         running_mesh_version: CURRENT_MESH_VERSION.to_string(),
         selected_mesh_version: selected_mesh_version.to_string(),
         configured_skippy_abi: skippy_abi_version.map(ToString::to_string),
-        configured_selection: configured_selection.map(ToString::to_string),
+        configured_selection: effective_selection.map(ToString::to_string),
         host: profile,
         cache_path: cache.root().to_path_buf(),
         selected_runtime_id: selected.map(|runtime| runtime.native_runtime_id.clone()),
@@ -404,6 +407,15 @@ pub fn run_native_runtime_doctor(
         );
     }
     Ok(())
+}
+
+fn native_runtime_selection(
+    llama_flavor: Option<BinaryFlavor>,
+    configured_selection: Option<&str>,
+) -> Option<&str> {
+    llama_flavor
+        .map(BinaryFlavor::suffix)
+        .or(configured_selection)
 }
 
 fn native_runtime_doctor_readiness(
@@ -490,6 +502,19 @@ mod tests {
         }
         .write_to_dir(path)
         .unwrap();
+    }
+
+    #[test]
+    fn doctor_prefers_cli_flavor_over_configured_runtime_selection() {
+        assert_eq!(
+            native_runtime_selection(Some(BinaryFlavor::Vulkan), Some("cuda")),
+            Some("vulkan")
+        );
+    }
+
+    #[test]
+    fn doctor_uses_configured_runtime_selection_without_cli_flavor() {
+        assert_eq!(native_runtime_selection(None, Some("cuda")), Some("cuda"));
     }
 
     #[test]

--- a/crates/mesh-llm-commands/src/runtime_native.rs
+++ b/crates/mesh-llm-commands/src/runtime_native.rs
@@ -186,11 +186,15 @@ fn cli_native_runtime_install_options(
 }
 
 fn print_configured_selector(configured: NativeRuntimeConfigSelection<'_>, json_output: bool) {
-    if json_output || configured.mesh_version.is_none() {
+    if json_output
+        || (configured.mesh_version.is_none()
+            && configured.skippy_abi_version.is_none()
+            && configured.selection.is_none())
+    {
         return;
     }
     let mesh_version = configured.mesh_version_or_current();
-    eprintln!("🔒 Using native runtime selector from config");
+    eprintln!("🔒 Using native runtime selector");
     eprintln!("   mesh version: {mesh_version}");
     if let Some(skippy_abi_version) = configured.skippy_abi_version {
         eprintln!("   Skippy ABI: {skippy_abi_version}");
@@ -409,7 +413,7 @@ pub fn run_native_runtime_doctor(
     Ok(())
 }
 
-fn native_runtime_selection(
+pub fn native_runtime_selection(
     llama_flavor: Option<BinaryFlavor>,
     configured_selection: Option<&str>,
 ) -> Option<&str> {
@@ -515,6 +519,27 @@ mod tests {
     #[test]
     fn doctor_uses_configured_runtime_selection_without_cli_flavor() {
         assert_eq!(native_runtime_selection(None, Some("cuda")), Some("cuda"));
+    }
+
+    #[test]
+    fn runtime_install_prefers_cli_flavor_over_configured_backend() {
+        let resolved = resolve_runtime_selection(
+            None,
+            NativeRuntimeConfigSelection {
+                mesh_version: None,
+                skippy_abi_version: None,
+                selection: native_runtime_selection(Some(BinaryFlavor::Vulkan), Some("rocm")),
+            },
+        )
+        .expect("runtime install selection should resolve");
+
+        assert_eq!(
+            resolved.selection,
+            RuntimeSelection::Backend {
+                kind: mesh_llm_native_runtime::NativeRuntimeBackendKind::Vulkan,
+                cuda_toolkit_major: None,
+            }
+        );
     }
 
     #[test]

--- a/crates/mesh-llm-commands/src/runtime_native/setup_helpers.rs
+++ b/crates/mesh-llm-commands/src/runtime_native/setup_helpers.rs
@@ -230,6 +230,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn setup_runtime_helper_installs_effective_cli_selected_backend() {
+        let install_calls = Arc::new(Mutex::new(Vec::new()));
+        let install_calls_for_executor = Arc::clone(&install_calls);
+
+        install_and_prune_native_runtime_for_setup_with(
+            SetupNativeRuntimeOptions {
+                skip_runtime: false,
+                requested_runtime: None,
+                manifest_path: None,
+                bundle_dirs: &[],
+                cache_dir: None,
+                configured: NativeRuntimeConfigSelection {
+                    mesh_version: None,
+                    skippy_abi_version: None,
+                    selection: Some("vulkan"),
+                },
+                progress: None,
+            },
+            move |options| {
+                install_calls_for_executor
+                    .lock()
+                    .expect("lock install calls")
+                    .push(options.clone());
+                async move { Ok(fake_install_outcome(CURRENT_MESH_VERSION)) }
+            },
+            |_mesh_version, _cache_dir| {
+                Ok(CachePrunePlan {
+                    remove_dirs: Vec::new(),
+                })
+            },
+        )
+        .await
+        .expect("setup runtime helper should install the CLI-selected backend");
+
+        let calls = install_calls.lock().expect("lock install calls");
+        assert_eq!(calls.len(), 1);
+        assert_eq!(
+            calls[0].selection,
+            RuntimeSelection::Backend {
+                kind: NativeRuntimeBackendKind::Vulkan,
+                cuda_toolkit_major: None,
+            }
+        );
+    }
+
+    #[tokio::test]
     async fn setup_runtime_helper_skips_install_and_prune() {
         let install_called = AtomicBool::new(false);
         let prune_called = AtomicBool::new(false);

--- a/crates/mesh-llm-config/Cargo.toml
+++ b/crates/mesh-llm-config/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 
 [dependencies]
 anyhow = { workspace = true }
+mesh-llm-native-runtime = { path = "../mesh-llm-native-runtime", version = "0.76.0" }
 mesh-llm-types = { path = "../mesh-llm-types", version = "0.76.0"  }
 semver = "1"
 serde = { workspace = true }

--- a/crates/mesh-llm-config/src/lib.rs
+++ b/crates/mesh-llm-config/src/lib.rs
@@ -242,6 +242,23 @@ selection = "vulcan"
     }
 
     #[test]
+    fn native_runtime_override_rejects_empty_exact_id_selections() {
+        for selection in ["exact:", "exact:   "] {
+            let error = parse_config_toml(&format!(
+                "[runtime.native_runtime]\nselection = \"{selection}\"\n"
+            ))
+            .expect_err("empty exact runtime selection should fail validation");
+
+            assert!(
+                error.to_string().contains(
+                    "runtime.native_runtime.selection must be one of recommended, cpu, metal, cuda or cudaNN, rocm, vulkan, exact:<id>, or meshllm-<id>"
+                ),
+                "unexpected validation error for {selection:?}: {error}"
+            );
+        }
+    }
+
+    #[test]
     fn config_store_add_model_preserves_existing_fields() {
         let temp_dir = TempDir::new().unwrap();
         let path = temp_dir.path().join("config.toml");

--- a/crates/mesh-llm-config/src/lib.rs
+++ b/crates/mesh-llm-config/src/lib.rs
@@ -176,20 +176,69 @@ mesh_version = "0.68.0"
         )
         .expect("mesh-version-only native runtime selector should parse");
 
-        let err = parse_config_toml(
+        let config = parse_config_toml(
             r#"
 [runtime.native_runtime]
 selection = "cuda12"
 "#,
         )
-        .expect_err("partial native runtime selector should fail validation");
+        .expect("selection-only native runtime selector should parse");
+
+        assert_eq!(config.runtime.native_runtime.mesh_version, None);
+        assert_eq!(
+            config.runtime.native_runtime.selection.as_deref(),
+            Some("cuda12")
+        );
+    }
+
+    #[test]
+    fn native_runtime_override_rejects_abi_without_mesh_version() {
+        let err = parse_config_toml(
+            r#"
+[runtime.native_runtime]
+skippy_abi = "0.1.25"
+"#,
+        )
+        .expect_err("ABI-only native runtime selector should fail validation");
 
         assert!(
             err.to_string().contains(
-                "runtime.native_runtime override must set mesh_version when skippy_abi or selection is set"
+                "runtime.native_runtime override must set mesh_version when skippy_abi is set"
             ),
             "unexpected validation error: {err}"
         );
+    }
+
+    #[test]
+    fn native_runtime_override_rejects_unknown_backend_selection() {
+        let err = parse_config_toml(
+            r#"
+[runtime.native_runtime]
+selection = "vulcan"
+"#,
+        )
+        .expect_err("unknown native runtime backend should fail validation");
+
+        assert!(
+            err.to_string().contains(
+                "runtime.native_runtime.selection must be one of recommended, cpu, metal, cuda or cudaNN, rocm, vulkan, exact:<id>, or meshllm-<id>"
+            ),
+            "unexpected validation error: {err}"
+        );
+    }
+
+    #[test]
+    fn native_runtime_override_accepts_cuda_major_and_exact_id_selections() {
+        for selection in [
+            "cuda12",
+            "exact:meshllm-native-runtime-linux-x86_64-cuda12",
+            "meshllm-native-runtime-linux-x86_64-vulkan",
+        ] {
+            parse_config_toml(&format!(
+                "[runtime.native_runtime]\nselection = \"{selection}\"\n"
+            ))
+            .unwrap_or_else(|error| panic!("selection {selection} should parse: {error}"));
+        }
     }
 
     #[test]

--- a/crates/mesh-llm-config/src/model/built_in_schema/control_behavior/runtime_controls.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema/control_behavior/runtime_controls.rs
@@ -1,7 +1,8 @@
 use super::shared::{
     absent_condition, equals_bool_condition, present_condition, push_allowed_pattern_constraint,
     push_dependency_disable, push_non_empty_constraint, push_range_constraint,
-    push_requires_constraint, set_numeric, set_static_options, set_text_format,
+    push_requires_constraint, set_numeric, set_runtime_native_backend_options, set_static_options,
+    set_text_format,
 };
 use super::*;
 
@@ -74,6 +75,10 @@ pub(super) fn apply_runtime_controls_behavior(setting: &mut ConfigSettingSchema,
             set_static_options(setting)
         }
         "runtime.mode" | "runtime.startup_failure_policy" => set_static_options(setting),
+        "runtime.native_runtime.selection" => {
+            set_runtime_native_backend_options(setting);
+            push_non_empty_constraint(setting);
+        }
         "runtime.drain_timeout_secs" => {
             set_numeric(setting, Some(1.0), Some(3600.0), Some(1.0), Some("sec"));
             push_range_constraint(

--- a/crates/mesh-llm-config/src/model/built_in_schema/control_behavior/shared.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema/control_behavior/shared.rs
@@ -26,6 +26,10 @@ pub(super) fn set_runtime_gpu_options(setting: &mut ConfigSettingSchema) {
     control_behavior_mut(setting).options_source = Some(ConfigOptionsSource::RuntimeGpus);
 }
 
+pub(super) fn set_runtime_native_backend_options(setting: &mut ConfigSettingSchema) {
+    control_behavior_mut(setting).options_source = Some(ConfigOptionsSource::RuntimeNativeBackends);
+}
+
 pub(super) fn set_static_unavailable(setting: &mut ConfigSettingSchema, reason: &str) {
     control_behavior_mut(setting).availability = Some(ConfigControlAvailability {
         enabled: false,

--- a/crates/mesh-llm-config/src/model/built_in_schema/declarations.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema/declarations.rs
@@ -107,7 +107,7 @@ fn build_built_in_config_schema() -> ConfigSchema {
         ),
         native_runtime_setting(
             "runtime.native_runtime.selection",
-            ConfigValueSchema::String,
+            one_of([string_enum(["recommended"]), ConfigValueSchema::String]),
         ),
         runtime_setting(
             "runtime.model_target_demand_upgrade_min_requests",

--- a/crates/mesh-llm-config/src/model/built_in_schema/presentation.rs
+++ b/crates/mesh-llm-config/src/model/built_in_schema/presentation.rs
@@ -107,6 +107,7 @@ struct SettingPresentation {
 fn setting_presentation_for_path(rendered: &str) -> Option<SettingPresentation> {
     logging_presentation(rendered)
         .or_else(|| process_setting_presentation(rendered))
+        .or_else(|| native_runtime_presentation(rendered))
         .or_else(|| runtime_defaults_presentation(rendered))
         .or_else(|| generation_defaults_presentation(rendered))
         .or_else(|| skippy_multimodal_presentation(rendered))
@@ -294,6 +295,45 @@ fn process_setting_presentation(rendered: &str) -> Option<SettingPresentation> {
         )
         .placeholder("ed25519:<64 hex characters>")
         .hint("text")),
+        _ => None,
+    }
+}
+
+fn native_runtime_presentation(rendered: &str) -> Option<SettingPresentation> {
+    match rendered {
+        "runtime.native_runtime.selection" => Some(
+            sp(
+                "Native runtime backend",
+                "Pin the native runtime backend loaded on startup. Recommended auto-detects from host hardware; cpu, metal, cuda (or cudaNN), rocm, and vulkan force a backend, and exact:<id> or meshllm-<id> pin a specific installed runtime.",
+                MESHLLM_CATEGORY,
+                40,
+            )
+            .hint("select")
+            .choices(&[(
+                "recommended",
+                "Recommended (auto-detect)",
+                "Auto-detect the best backend for this host.",
+            )]),
+        ),
+        "runtime.native_runtime.mesh_version" => Some(
+            sp(
+                "Native runtime Mesh version",
+                "Pin the Mesh release whose native runtime bundle is loaded. Leave unset to track the current release.",
+                MESHLLM_CATEGORY,
+                50,
+            )
+            .placeholder("track current release")
+            .hint("text"),
+        ),
+        "runtime.native_runtime.skippy_abi" => Some(
+            sp(
+                "Native runtime Skippy ABI",
+                "Pin the Skippy ABI string of the native runtime bundle. Only meaningful alongside a pinned Mesh version.",
+                MESHLLM_CATEGORY,
+                60,
+            )
+            .hint("text"),
+        ),
         _ => None,
     }
 }

--- a/crates/mesh-llm-config/src/validate.rs
+++ b/crates/mesh-llm-config/src/validate.rs
@@ -220,14 +220,13 @@ fn validate_runtime_config(config: &RuntimeConfig) -> Vec<ConfigDiagnostic> {
             "runtime.native_runtime.selection",
             "runtime.native_runtime.selection must not be empty",
         ));
-    } else if selection.is_some_and(|value| {
-        matches!(
-            RuntimeSelection::parse(Some(value)),
-            Ok(RuntimeSelection::Backend {
-                kind: NativeRuntimeBackendKind::Other(_),
-                ..
-            })
-        )
+    } else if selection.is_some_and(|value| match RuntimeSelection::parse(Some(value)) {
+        Ok(RuntimeSelection::Backend {
+            kind: NativeRuntimeBackendKind::Other(_),
+            ..
+        }) => true,
+        Ok(RuntimeSelection::Id(id)) => id.trim().is_empty(),
+        _ => false,
     }) {
         diagnostics.push(validation_diagnostic(
             "runtime.native_runtime.selection",

--- a/crates/mesh-llm-config/src/validate.rs
+++ b/crates/mesh-llm-config/src/validate.rs
@@ -21,6 +21,7 @@ use crate::validation_support::{
 };
 use crate::*;
 use anyhow::Result;
+use mesh_llm_native_runtime::{NativeRuntimeBackendKind, RuntimeSelection};
 
 pub fn validate_config_diagnostics(config: &MeshConfig) -> Vec<ConfigDiagnostic> {
     let mut diagnostics = Vec::new();
@@ -196,10 +197,10 @@ fn validate_runtime_config(config: &RuntimeConfig) -> Vec<ConfigDiagnostic> {
     let mesh_version = config.native_runtime.mesh_version.as_deref();
     let skippy_abi = config.native_runtime.skippy_abi.as_deref();
     let selection = config.native_runtime.selection.as_deref();
-    if mesh_version.is_none() && (skippy_abi.is_some() || selection.is_some()) {
+    if mesh_version.is_none() && skippy_abi.is_some() {
         diagnostics.push(validation_diagnostic(
             "runtime.native_runtime",
-            "runtime.native_runtime override must set mesh_version when skippy_abi or selection is set",
+            "runtime.native_runtime override must set mesh_version when skippy_abi is set",
         ));
     }
     if matches!(mesh_version, Some(value) if value.trim().is_empty()) {
@@ -218,6 +219,19 @@ fn validate_runtime_config(config: &RuntimeConfig) -> Vec<ConfigDiagnostic> {
         diagnostics.push(validation_diagnostic(
             "runtime.native_runtime.selection",
             "runtime.native_runtime.selection must not be empty",
+        ));
+    } else if selection.is_some_and(|value| {
+        matches!(
+            RuntimeSelection::parse(Some(value)),
+            Ok(RuntimeSelection::Backend {
+                kind: NativeRuntimeBackendKind::Other(_),
+                ..
+            })
+        )
+    }) {
+        diagnostics.push(validation_diagnostic(
+            "runtime.native_runtime.selection",
+            "runtime.native_runtime.selection must be one of recommended, cpu, metal, cuda or cudaNN, rocm, vulkan, exact:<id>, or meshllm-<id>",
         ));
     }
     for (path, value, min, max) in [

--- a/crates/mesh-llm-host-runtime/src/api/tests/runtime_control_state.rs
+++ b/crates/mesh-llm-host-runtime/src/api/tests/runtime_control_state.rs
@@ -203,3 +203,67 @@ fn runtime_config_control_state_builder_uses_disabled_or_omitted_policy_for_miss
             .contains_key("plugin.demo.settings.plugin_name")
     );
 }
+
+#[test]
+fn native_runtime_selection_setting_surfaces_native_backend_options() {
+    let path = mesh_llm_config::ConfigPath::parse_rendered("runtime.native_runtime.selection")
+        .expect("selection path should parse");
+    let setting = mesh_llm_config::built_in_config_schema_descriptor(&path)
+        .expect("built-in schema should define runtime.native_runtime.selection");
+
+    assert_eq!(
+        setting
+            .control_behavior
+            .as_ref()
+            .and_then(|behavior| behavior.options_source),
+        Some(ConfigOptionsSource::RuntimeNativeBackends),
+        "selection must be backed by the native runtime backend options source"
+    );
+    assert!(
+        setting
+            .constraints
+            .iter()
+            .any(|constraint| matches!(constraint, mesh_llm_config::ConfigConstraint::NonEmpty)),
+        "selection must reject an empty backend choice"
+    );
+
+    let payload = crate::api::routes::runtime_control_state::build_runtime_control_state_payload(
+        [&setting],
+        &crate::api::routes::runtime_control_state::RuntimeControlStateSources {
+            native_backends:
+                crate::api::routes::runtime_control_state::RuntimeOptionsState::Options(vec![
+                    super::runtime_control_state_builder::runtime_option(
+                        super::runtime_control_state_builder::RuntimeOptionSpec::enabled(
+                            ConfigOptionsSource::RuntimeNativeBackends,
+                            "cpu",
+                            "CPU",
+                        ),
+                    ),
+                    super::runtime_control_state_builder::runtime_option(
+                        super::runtime_control_state_builder::RuntimeOptionSpec::enabled(
+                            ConfigOptionsSource::RuntimeNativeBackends,
+                            "metal",
+                            "Metal",
+                        ),
+                    ),
+                ]),
+            ..Default::default()
+        },
+    );
+
+    let options = payload
+        .settings
+        .get("runtime.native_runtime.selection")
+        .and_then(|entry| entry.options.as_ref())
+        .expect("selection should surface native backend options");
+    assert_eq!(
+        options
+            .iter()
+            .map(|option| option.value.clone())
+            .collect::<Vec<_>>(),
+        vec![
+            ConfigConditionValue::String("cpu".to_string()),
+            ConfigConditionValue::String("metal".to_string()),
+        ]
+    );
+}

--- a/crates/mesh-llm-host-runtime/src/lib.rs
+++ b/crates/mesh-llm-host-runtime/src/lib.rs
@@ -198,7 +198,8 @@ pub async fn initialize_host_runtime_for_options(options: &RuntimeOptions) -> Re
     if !runtime_options_require_native_runtime(options) {
         return initialize_logging_for_cli(options.config.as_deref()).await;
     }
-    initialize_host_runtime_with_config(options.config.as_deref()).await
+    initialize_host_runtime_with_config_and_flavor(options.config.as_deref(), options.llama_flavor)
+        .await
 }
 
 fn runtime_options_require_native_runtime(options: &RuntimeOptions) -> bool {
@@ -206,6 +207,13 @@ fn runtime_options_require_native_runtime(options: &RuntimeOptions) -> bool {
 }
 
 pub async fn initialize_host_runtime_with_config(config_path: Option<&Path>) -> Result<()> {
+    initialize_host_runtime_with_config_and_flavor(config_path, None).await
+}
+
+async fn initialize_host_runtime_with_config_and_flavor(
+    config_path: Option<&Path>,
+    llama_flavor: Option<mesh_llm_system::backend::BinaryFlavor>,
+) -> Result<()> {
     let config = plugin::load_config(config_path)?;
 
     // Logging config is validated as part of config loading and must be resolved
@@ -215,20 +223,10 @@ pub async fn initialize_host_runtime_with_config(config_path: Option<&Path>) -> 
 
     #[cfg(feature = "dynamic-native-runtime")]
     {
-        let native_runtime = config.runtime.native_runtime;
-        let startup_selection = match native_runtime.mesh_version {
-            Some(mesh_version) => {
-                let runtime_selection = mesh_llm_native_runtime::RuntimeSelection::parse(
-                    native_runtime.selection.as_deref(),
-                )?;
-                system::native_runtime::NativeRuntimeStartupSelection::explicit(
-                    mesh_version,
-                    native_runtime.skippy_abi,
-                    runtime_selection,
-                )
-            }
-            None => system::native_runtime::NativeRuntimeStartupSelection::current(),
-        };
+        let startup_selection = system::native_runtime::NativeRuntimeStartupSelection::from_config(
+            config.runtime.native_runtime,
+            llama_flavor,
+        )?;
         if let Some(runtime) =
             system::native_runtime::try_load_installed_native_runtime(startup_selection).await?
         {
@@ -241,7 +239,7 @@ pub async fn initialize_host_runtime_with_config(config_path: Option<&Path>) -> 
     }
     #[cfg(not(feature = "dynamic-native-runtime"))]
     {
-        let _ = config;
+        let _ = (config, llama_flavor);
     }
 
     Ok(())

--- a/crates/mesh-llm-host-runtime/src/sdk.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk.rs
@@ -140,11 +140,14 @@ impl Drop for EmbeddedServeHandle {
 pub async fn start_embedded_node(
     mut config: EmbeddedMeshNodeConfig,
 ) -> Result<EmbeddedServeHandle> {
-    embedded_startup::prepare_embedded_native_runtime(&config.mode)?;
     let isolated_config = prepare_isolated_config(&mut config)?;
     let config_snapshot =
         embedded_logging::snapshot_validated_config(config.storage.config_path.as_deref())?;
     config.storage.config_path = Some(embedded_logging::snapshot_path(&config_snapshot));
+    embedded_startup::prepare_embedded_native_runtime(
+        &config.mode,
+        config.storage.config_path.as_deref(),
+    )?;
     drop(isolated_config);
     let (control_tx, control_rx) = tokio::sync::mpsc::unbounded_channel();
     let runtime_options = embedded_runtime_options(&config, Some(control_rx));

--- a/crates/mesh-llm-host-runtime/src/sdk/embedded_startup.rs
+++ b/crates/mesh-llm-host-runtime/src/sdk/embedded_startup.rs
@@ -1,9 +1,11 @@
 use super::EmbeddedMeshNodeMode;
 use anyhow::Result;
-#[cfg(any(feature = "dynamic-native-runtime", test))]
 use std::path::Path;
 
-pub(super) fn prepare_embedded_native_runtime(mode: &EmbeddedMeshNodeMode) -> Result<()> {
+pub(super) fn prepare_embedded_native_runtime(
+    mode: &EmbeddedMeshNodeMode,
+    config_path: Option<&Path>,
+) -> Result<()> {
     #[cfg(feature = "dynamic-native-runtime")]
     {
         if *mode == EmbeddedMeshNodeMode::Client || skippy_runtime::native_runtime_loaded() {
@@ -16,17 +18,27 @@ pub(super) fn prepare_embedded_native_runtime(mode: &EmbeddedMeshNodeMode) -> Re
             skippy_abi: &skippy_abi,
             cache_root: cache.root(),
         };
-        let loaded =
-            crate::system::native_runtime::load_local_native_runtime_for_embedded_serving()?
-                .is_some()
-                || skippy_runtime::native_runtime_loaded();
+        let config = crate::plugin::load_config(config_path)?;
+        let selection = embedded_native_runtime_selection(&config.runtime.native_runtime)?;
+        let loaded = crate::system::native_runtime::load_local_native_runtime_for_embedded_serving(
+            &selection,
+        )?
+        .is_some()
+            || skippy_runtime::native_runtime_loaded();
         ensure_embedded_native_runtime_ready(mode, loaded, requirement)?;
     }
     #[cfg(not(feature = "dynamic-native-runtime"))]
     {
-        let _ = mode;
+        let _ = (mode, config_path);
     }
     Ok(())
+}
+
+#[cfg(any(feature = "dynamic-native-runtime", test))]
+fn embedded_native_runtime_selection(
+    config: &mesh_llm_config::NativeRuntimeConfig,
+) -> Result<mesh_llm_native_runtime::RuntimeSelection> {
+    mesh_llm_native_runtime::RuntimeSelection::parse(config.selection.as_deref())
 }
 
 #[cfg(any(feature = "dynamic-native-runtime", test))]
@@ -97,5 +109,31 @@ mod tests {
     fn loaded_native_runtime_allows_embedded_serve() {
         ensure_embedded_native_runtime_ready(&EmbeddedMeshNodeMode::Serve, true, requirement())
             .expect("loaded runtime should allow embedded serving");
+    }
+
+    #[test]
+    fn embedded_serving_uses_configured_runtime_selection() {
+        let selection = embedded_native_runtime_selection(&mesh_llm_config::NativeRuntimeConfig {
+            selection: Some("vulkan".to_string()),
+            ..Default::default()
+        })
+        .expect("configured selection should parse");
+
+        assert_eq!(
+            selection,
+            mesh_llm_native_runtime::RuntimeSelection::Backend {
+                kind: mesh_llm_native_runtime::NativeRuntimeBackendKind::Vulkan,
+                cuda_toolkit_major: None,
+            }
+        );
+    }
+
+    #[test]
+    fn embedded_serving_defaults_to_recommended_runtime_selection() {
+        assert_eq!(
+            embedded_native_runtime_selection(&mesh_llm_config::NativeRuntimeConfig::default())
+                .expect("default selection should parse"),
+            mesh_llm_native_runtime::RuntimeSelection::Recommended
+        );
     }
 }

--- a/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
@@ -62,6 +62,26 @@ mod dynamic {
                 runtime_selection,
             }
         }
+
+        pub(crate) fn from_config(
+            config: mesh_llm_config::NativeRuntimeConfig,
+            llama_flavor: Option<mesh_llm_system::backend::BinaryFlavor>,
+        ) -> Result<Self> {
+            let runtime_selection = RuntimeSelection::parse(
+                llama_flavor
+                    .map(mesh_llm_system::backend::BinaryFlavor::suffix)
+                    .or(config.selection.as_deref()),
+            )?;
+            Ok(match config.mesh_version {
+                Some(mesh_version) => {
+                    Self::explicit(mesh_version, config.skippy_abi, runtime_selection)
+                }
+                None => Self {
+                    runtime_selection,
+                    ..Self::current()
+                },
+            })
+        }
     }
 
     pub(crate) fn load_local_native_runtime_for_embedded_serving()
@@ -1014,6 +1034,72 @@ mod dynamic {
             assert_eq!(
                 startup_install_message(false),
                 "Discovered native runtime bundles take precedence over installed runtimes; attempting one-shot startup install"
+            );
+        }
+
+        #[test]
+        fn cli_llama_flavor_selects_the_current_native_runtime_backend() {
+            let selection = NativeRuntimeStartupSelection::from_config(
+                mesh_llm_config::NativeRuntimeConfig::default(),
+                Some(mesh_llm_system::backend::BinaryFlavor::Vulkan),
+            )
+            .expect("Vulkan CLI flavor should resolve");
+
+            assert_eq!(selection.mesh_version, crate::RELEASE_VERSION);
+            assert_eq!(
+                selection.skippy_abi.as_deref(),
+                Some(crate::system::native_runtime_install::current_skippy_abi_version().as_str())
+            );
+            assert_eq!(
+                selection.runtime_selection,
+                RuntimeSelection::Backend {
+                    kind: mesh_llm_native_runtime::NativeRuntimeBackendKind::Vulkan,
+                    cuda_toolkit_major: None,
+                }
+            );
+        }
+
+        #[test]
+        fn cli_llama_flavor_overrides_configured_backend_without_changing_version() {
+            let selection = NativeRuntimeStartupSelection::from_config(
+                mesh_llm_config::NativeRuntimeConfig {
+                    mesh_version: Some("0.75.0".to_string()),
+                    skippy_abi: Some("0.1.52".to_string()),
+                    selection: Some("cuda13".to_string()),
+                },
+                Some(mesh_llm_system::backend::BinaryFlavor::Vulkan),
+            )
+            .expect("Vulkan CLI flavor should override the configured backend");
+
+            assert_eq!(selection.mesh_version, "0.75.0");
+            assert_eq!(selection.skippy_abi.as_deref(), Some("0.1.52"));
+            assert_eq!(
+                selection.runtime_selection,
+                RuntimeSelection::Backend {
+                    kind: mesh_llm_native_runtime::NativeRuntimeBackendKind::Vulkan,
+                    cuda_toolkit_major: None,
+                }
+            );
+        }
+
+        #[test]
+        fn configured_native_runtime_selection_is_used_without_cli_override() {
+            let selection = NativeRuntimeStartupSelection::from_config(
+                mesh_llm_config::NativeRuntimeConfig {
+                    mesh_version: Some("0.75.0".to_string()),
+                    skippy_abi: Some("0.1.52".to_string()),
+                    selection: Some("cuda13".to_string()),
+                },
+                None,
+            )
+            .expect("configured CUDA selection should resolve");
+
+            assert_eq!(
+                selection.runtime_selection,
+                RuntimeSelection::Backend {
+                    kind: mesh_llm_native_runtime::NativeRuntimeBackendKind::Cuda,
+                    cuda_toolkit_major: Some(13),
+                }
             );
         }
     }

--- a/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
@@ -84,8 +84,9 @@ mod dynamic {
         }
     }
 
-    pub(crate) fn load_local_native_runtime_for_embedded_serving()
-    -> Result<Option<LoadedNativeRuntime>> {
+    pub(crate) fn load_local_native_runtime_for_embedded_serving(
+        runtime_selection: &RuntimeSelection,
+    ) -> Result<Option<LoadedNativeRuntime>> {
         if skippy_runtime::native_runtime_loaded() {
             return Ok(None);
         }
@@ -98,7 +99,7 @@ mod dynamic {
             crate::BUILD_VERSION,
             crate::RELEASE_VERSION,
             Some(&crate::system::native_runtime_install::current_skippy_abi_version()),
-            &RuntimeSelection::Recommended,
+            runtime_selection,
         )?
         else {
             return Ok(None);

--- a/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
+++ b/crates/mesh-llm-host-runtime/src/system/native_runtime.rs
@@ -1102,6 +1102,211 @@ mod dynamic {
                 }
             );
         }
+
+        // Ported from the duplicate PR branch (jian yang's
+        // jy/native-runtime-flavor-selection): end-to-end startup coverage that
+        // the flavor request survives the full resolver, not just
+        // `from_config`. Regression for the white.local scenario where
+        // `--llama-flavor vulkan` loaded the CUDA runtime because startup
+        // never consulted the flavor.
+        #[tokio::test]
+        async fn vulkan_flavor_loads_vulkan_runtime_over_higher_ranked_cuda() {
+            let temp = tempfile::tempdir().unwrap();
+            let cache = NativeRuntimeCache::new(temp.path().join("cache"));
+            let release_version = crate::RELEASE_VERSION.to_string();
+            let vulkan_id = "meshllm-native-runtime-test-vulkan";
+            let cuda_id = "meshllm-native-runtime-test-cuda";
+            let vulkan_dir = cache.runtime_dir(&release_version, vulkan_id);
+            let cuda_dir = cache.runtime_dir(&release_version, cuda_id);
+            write_runtime_with_backend(&vulkan_dir, Some(&release_version), vulkan_id, |backend| {
+                backend.kind = mesh_llm_native_runtime::NativeRuntimeBackendKind::Vulkan;
+            });
+            write_runtime_with_backend(&cuda_dir, Some(&release_version), cuda_id, |backend| {
+                backend.kind = mesh_llm_native_runtime::NativeRuntimeBackendKind::Cuda;
+                backend.cuda = Some(mesh_llm_native_runtime::CudaRuntimeRequirements {
+                    toolkit_major: 12,
+                    min_driver: None,
+                    gpu_arches: Vec::new(),
+                });
+            });
+
+            let startup_selection = NativeRuntimeStartupSelection::from_config(
+                mesh_llm_config::NativeRuntimeConfig::default(),
+                Some(mesh_llm_system::backend::BinaryFlavor::Vulkan),
+            )
+            .expect("Vulkan CLI flavor should resolve");
+
+            let install_calls = Arc::new(Mutex::new(0_usize));
+            let runtime = try_load_installed_native_runtime_with(
+                || false,
+                || Ok(cache.clone()),
+                vulkan_capable_profile,
+                test_install_options,
+                {
+                    let install_calls = Arc::clone(&install_calls);
+                    move |_| {
+                        let install_calls = Arc::clone(&install_calls);
+                        async move {
+                            *install_calls.lock().unwrap() += 1;
+                            anyhow::bail!("selection must resolve from the cache")
+                        }
+                    }
+                },
+                startup_selection,
+                |libraries| {
+                    let _ = libraries;
+                    Ok(())
+                },
+            )
+            .await
+            .unwrap()
+            .expect("expected the Vulkan runtime to load");
+
+            assert_eq!(runtime.native_runtime_id, vulkan_id);
+            assert_eq!(
+                runtime.libraries,
+                vec![vulkan_dir.join(test_library_rel_path())]
+            );
+            assert_eq!(*install_calls.lock().unwrap(), 0);
+        }
+
+        #[test]
+        fn recommended_selection_still_prefers_cuda_over_vulkan() {
+            // Guards the premise of the regression above: the recommended
+            // ranking selects CUDA (650) over Vulkan (350), which is exactly
+            // why an ignored flavor loaded CUDA on white.local. If this
+            // ranking ever changes, revisit the regression's expectations.
+            let profile = vulkan_capable_profile();
+            let recommended = mesh_llm_native_runtime::select_native_runtime_from_artifacts(
+                &[
+                    candidate_with_backend("meshllm-native-runtime-test-vulkan", {
+                        let mut backend = NativeRuntimeBackend::cpu();
+                        backend.kind = mesh_llm_native_runtime::NativeRuntimeBackendKind::Vulkan;
+                        backend
+                    }),
+                    candidate_with_backend("meshllm-native-runtime-test-cuda", {
+                        let mut backend = NativeRuntimeBackend::cpu();
+                        backend.kind = mesh_llm_native_runtime::NativeRuntimeBackendKind::Cuda;
+                        backend.cuda = Some(mesh_llm_native_runtime::CudaRuntimeRequirements {
+                            toolkit_major: 12,
+                            min_driver: None,
+                            gpu_arches: Vec::new(),
+                        });
+                        backend
+                    }),
+                ],
+                &profile,
+                crate::RELEASE_VERSION,
+                None,
+                &RuntimeSelection::Recommended,
+            )
+            .expect("recommended selection");
+            let vulkan = mesh_llm_native_runtime::select_native_runtime_from_artifacts(
+                &[candidate_with_backend(
+                    "meshllm-native-runtime-test-vulkan",
+                    {
+                        let mut backend = NativeRuntimeBackend::cpu();
+                        backend.kind = mesh_llm_native_runtime::NativeRuntimeBackendKind::Vulkan;
+                        backend
+                    },
+                )],
+                &profile,
+                crate::RELEASE_VERSION,
+                None,
+                &RuntimeSelection::Backend {
+                    kind: mesh_llm_native_runtime::NativeRuntimeBackendKind::Vulkan,
+                    cuda_toolkit_major: None,
+                },
+            )
+            .expect("vulkan selection");
+
+            assert_eq!(
+                recommended.artifact.id, "meshllm-native-runtime-test-cuda",
+                "recommended ranking must still prefer CUDA"
+            );
+            assert_eq!(
+                vulkan.artifact.id, "meshllm-native-runtime-test-vulkan",
+                "explicit backend selection must choose Vulkan"
+            );
+        }
+
+        fn vulkan_capable_profile() -> HostRuntimeProfile {
+            let mut profile = HostRuntimeProfile::current_without_gpu_probe();
+            profile
+                .available_flavors
+                .insert(mesh_llm_native_runtime::NativeRuntimeBackendKind::Cuda);
+            profile
+                .available_flavors
+                .insert(mesh_llm_native_runtime::NativeRuntimeBackendKind::Vulkan);
+            profile.cuda = Some(mesh_llm_native_runtime::HostCudaProfile {
+                toolkit_majors: std::collections::BTreeSet::from([12]),
+                driver_max_major: Some(12),
+                driver_version: None,
+                gpu_arches: std::collections::BTreeSet::from(["sm_90".to_string()]),
+            });
+            profile.vulkan = Some(mesh_llm_native_runtime::HostVulkanProfile::default());
+            profile
+        }
+
+        fn write_runtime_with_backend(
+            dir: &Path,
+            version: Option<&str>,
+            id: &str,
+            edit: impl FnOnce(&mut NativeRuntimeBackend),
+        ) {
+            let library_rel_path = test_library_rel_path();
+            fs::create_dir_all(dir.join(library_rel_path.parent().unwrap())).unwrap();
+            fs::write(dir.join(&library_rel_path), b"native runtime").unwrap();
+            let mut backend = NativeRuntimeBackend::cpu();
+            edit(&mut backend);
+            let manifest = NativeRuntimeManifest {
+                runtime: NativeRuntimeArtifact {
+                    id: id.to_string(),
+                    mesh_version: version.map(ToString::to_string),
+                    // Match the ABI the flavor-derived startup selection
+                    // requests so the fixture is loadable in this build.
+                    skippy_abi: crate::system::native_runtime_install::current_skippy_abi_version(),
+                    platform: NativeRuntimePlatform {
+                        os: std::env::consts::OS.to_string(),
+                        arch: std::env::consts::ARCH.to_string(),
+                        target: None,
+                    },
+                    backend,
+                    rank: 0,
+                    libraries: vec![library_rel_path.to_string_lossy().to_string()],
+                    files: Default::default(),
+                    tools: Default::default(),
+                    url: None,
+                    sha256: None,
+                    signature: None,
+                },
+            };
+            manifest.write_to_dir(dir).unwrap();
+        }
+
+        fn candidate_with_backend(
+            id: &str,
+            backend: NativeRuntimeBackend,
+        ) -> mesh_llm_native_runtime::NativeRuntimeArtifact {
+            mesh_llm_native_runtime::NativeRuntimeArtifact {
+                id: id.to_string(),
+                mesh_version: Some(crate::RELEASE_VERSION.to_string()),
+                skippy_abi: crate::system::native_runtime_install::current_skippy_abi_version(),
+                platform: NativeRuntimePlatform {
+                    os: std::env::consts::OS.to_string(),
+                    arch: std::env::consts::ARCH.to_string(),
+                    target: None,
+                },
+                backend,
+                rank: 0,
+                libraries: vec![test_library_rel_path().to_string_lossy().to_string()],
+                files: Default::default(),
+                tools: Default::default(),
+                url: None,
+                sha256: None,
+                signature: None,
+            }
+        }
     }
 }
 

--- a/crates/mesh-llm-ui/e2e/configuration/schema-controls.spec.ts
+++ b/crates/mesh-llm-ui/e2e/configuration/schema-controls.spec.ts
@@ -328,7 +328,7 @@ function auditSetting(
   })
 }
 
-async function installConfigurationBackend(page: Page) {
+async function installConfigurationBackend(page: Page, configOverride: JsonRecord = initialConfig) {
   await page.addInitScript(
     ({ dataModeKey, featureFlagsKey, status, models, bootstrap, schema, controlState, config }) => {
       window.localStorage.setItem(dataModeKey, 'live')
@@ -445,7 +445,7 @@ async function installConfigurationBackend(page: Page) {
       bootstrap: bootstrapPayload,
       schema: schemaPayload,
       controlState: controlStatePayload,
-      config: initialConfig
+      config: configOverride
     }
   )
 }
@@ -638,5 +638,50 @@ test.describe('schema-driven configuration controls', () => {
       body: await page.screenshot({ fullPage: true, animations: 'disabled' }),
       contentType: 'image/png'
     })
+  })
+})
+
+test.describe('native runtime backend pin', () => {
+  // An `exact:` / `meshllm-` runtime pin is a deliberate config-file escape hatch that the runtime
+  // options source cannot enumerate. The backend select must surface it as a synthetic selected
+  // option so editing an unrelated setting and saving preserves the pin verbatim.
+  const NATIVE_BACKEND_PIN = 'exact:meshllm-native-runtime-linux-x86_64-cuda12'
+  const pinnedRuntimeConfig: JsonRecord = {
+    ...initialConfig,
+    runtime: { native_backend: NATIVE_BACKEND_PIN }
+  }
+
+  test('preserves an unmatched runtime backend pin through an unrelated edit and save', async ({ page }, testInfo) => {
+    await installConfigurationBackend(page, pinnedRuntimeConfig)
+    await page.goto(appUrl('/configuration/models', testInfo))
+    await expect(page.getByRole('heading', { name: 'Model settings' })).toBeVisible()
+
+    await page.getByRole('tab', { name: 'Runtime' }).click()
+    await expect(page.getByRole('heading', { name: 'Runtime settings' })).toBeVisible()
+
+    const backendSelect = page.getByRole('combobox', { name: 'Native backend' })
+    await expect(backendSelect).toHaveValue(NATIVE_BACKEND_PIN)
+    await expect(backendSelect.getByRole('option', { name: NATIVE_BACKEND_PIN })).toHaveCount(1)
+    await expect(page.getByText('Set in config file')).toBeVisible()
+
+    // Edit an unrelated setting so the config is dirty, then save.
+    await page.getByRole('tab', { name: 'Models' }).click()
+    await page.getByRole('button', { name: '8K', exact: true }).click()
+    await expect(page.getByRole('slider', { name: 'Context size' })).toHaveAttribute('aria-valuenow', '8192')
+
+    await page.getByRole('button', { name: 'Save config' }).click()
+    await expect
+      .poll(async () => {
+        const state = await readConfigState(page)
+        return state.applyRequests.length
+      })
+      .toBe(1)
+
+    const state = await readConfigState(page)
+    const applyRequest = state.applyRequests[0] as {
+      config: { runtime?: JsonRecord; defaults?: { model_fit?: JsonRecord } }
+    }
+    expect(applyRequest.config.defaults?.model_fit?.ctx_size).toBe(8192)
+    expect(applyRequest.config.runtime?.native_backend).toBe(NATIVE_BACKEND_PIN)
   })
 })

--- a/crates/mesh-llm-ui/src/features/configuration/api/schema-control-factory.test.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/api/schema-control-factory.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest'
+import type { ConfigurationRuntimeControlStateEntry } from '@/features/app-tabs/types'
+import { createSchemaControl, type SchemaControlFactoryEntry } from './schema-control-factory'
+
+const selectionEntry: SchemaControlFactoryEntry = {
+  canonical_path: 'runtime.native_runtime.selection',
+  value_schema: {
+    kind: 'one_of',
+    variants: [{ kind: 'enum', values: ['recommended'] }, { kind: 'string' }]
+  },
+  control_behavior: { options_source: 'runtime_native_backends' },
+  presentation: {
+    control_hint: 'select',
+    choices: [
+      {
+        value: 'recommended',
+        label: 'Recommended (auto-detect)',
+        description: 'Auto-detect the best backend for this host.'
+      }
+    ]
+  }
+}
+
+const backendControlState: ConfigurationRuntimeControlStateEntry = {
+  enabled: true,
+  source: 'runtime',
+  write_policy: 'preserve_existing',
+  options: [
+    { value: { kind: 'string', value: 'cpu' }, label: 'CPU', disabled: false, source: 'runtime_native_backends' },
+    { value: { kind: 'string', value: 'metal' }, label: 'Metal', disabled: false, source: 'runtime_native_backends' }
+  ]
+}
+
+describe('createSchemaControl for the native runtime backend selection', () => {
+  it('renders a select with Recommended ahead of the host backends', () => {
+    const control = createSchemaControl({
+      entry: selectionEntry,
+      name: 'selection',
+      runtimeControlState: backendControlState
+    })
+
+    expect(control).toMatchObject({ kind: 'choice', presentation: 'select' })
+    if (control.kind !== 'choice') throw new Error('expected a choice control')
+
+    expect(control.options.map((option) => option.value)).toEqual(['', 'recommended', 'cpu', 'metal'])
+    expect(control.options[1]).toEqual({
+      value: 'recommended',
+      label: 'Recommended (auto-detect)',
+      description: 'Auto-detect the best backend for this host.'
+    })
+  })
+
+  it('does not duplicate a static value that the runtime already reports', () => {
+    const control = createSchemaControl({
+      entry: {
+        ...selectionEntry,
+        value_schema: {
+          kind: 'one_of',
+          variants: [{ kind: 'enum', values: ['recommended', 'cpu'] }, { kind: 'string' }]
+        }
+      },
+      name: 'selection',
+      runtimeControlState: backendControlState
+    })
+
+    if (control.kind !== 'choice') throw new Error('expected a choice control')
+    expect(control.options.map((option) => option.value)).toEqual(['', 'recommended', 'cpu', 'metal'])
+  })
+})

--- a/crates/mesh-llm-ui/src/features/configuration/api/schema-control-factory.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/api/schema-control-factory.ts
@@ -173,12 +173,16 @@ export function createSchemaControl(input: CreateSchemaControlInput): Configurat
 
   const runtimeOptions = runtimeChoiceOptions(runtimeControlState)
   if (runtimeOptions.length > 0) {
+    const runtimeValues = new Set(runtimeOptions.map((option) => option.value))
+    const staticOptionsAhead = Array.from(new Set(enumValues(entry.value_schema).map(normalizedChoiceValue)))
+      .filter((value) => !runtimeValues.has(value))
+      .map((value) => choiceOption(value, entry.presentation))
     return {
       kind: 'choice',
       name,
       value: '',
       presentation: 'select',
-      options: [runtimeChoicePlaceholder(entry), ...runtimeOptions]
+      options: [runtimeChoicePlaceholder(entry), ...staticOptionsAhead, ...runtimeOptions]
     }
   }
 

--- a/crates/mesh-llm-ui/src/features/configuration/components/settings/SchemaChoiceControl.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/components/settings/SchemaChoiceControl.tsx
@@ -59,7 +59,7 @@ export function SchemaChoiceControl({
   setting,
   value
 }: SchemaSettingControlProps) {
-  const options = resolvedChoiceOptions(setting)
+  const options = resolvedChoiceOptions(setting, value)
   const presentation = setting.control.kind === 'choice' ? (setting.control.presentation ?? 'segmented') : 'segmented'
   const selectedDescription = options.find((option) => option.value === value)?.description
 

--- a/crates/mesh-llm-ui/src/features/configuration/components/settings/schema-control-utils.test.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/components/settings/schema-control-utils.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import type { ConfigurationRuntimeControlStateEntry } from '@/features/app-tabs/types'
+import { choiceSetting } from '@/features/configuration/lib/settings-utils.test-helpers'
+import { resolvedChoiceOptions } from './schema-control-utils'
+
+const nativeBackendControlState: ConfigurationRuntimeControlStateEntry = {
+  enabled: true,
+  source: 'runtime',
+  write_policy: 'preserve_existing',
+  options: [
+    { value: { kind: 'string', value: 'cpu' }, label: 'CPU', disabled: false, source: 'runtime_native_backends' },
+    { value: { kind: 'string', value: 'metal' }, label: 'Metal', disabled: false, source: 'runtime_native_backends' }
+  ]
+}
+
+function selectionSetting(value: string) {
+  return choiceSetting({
+    id: 'runtime.native_runtime.selection',
+    canonicalPath: 'runtime.native_runtime.selection',
+    value,
+    options: ['', 'recommended', 'cpu', 'metal'],
+    controlState: nativeBackendControlState
+  })
+}
+
+describe('resolvedChoiceOptions', () => {
+  it('keeps the runtime backend list when the stored value already matches an option', () => {
+    const options = resolvedChoiceOptions(selectionSetting('metal'), 'metal')
+    expect(options.map((option) => option.value)).toEqual(['', 'recommended', 'cpu', 'metal'])
+  })
+
+  it('surfaces an unmatched exact: pin as a synthetic option so it is not silently dropped', () => {
+    const pin = 'exact:meshllm-native-runtime-linux-x86_64-cuda12'
+    const options = resolvedChoiceOptions(selectionSetting(pin), pin)
+
+    expect(options.map((option) => option.value)).toEqual(['', 'recommended', 'cpu', 'metal', pin])
+    expect(options.at(-1)).toEqual({ value: pin, label: pin, description: 'Set in config file' })
+  })
+})

--- a/crates/mesh-llm-ui/src/features/configuration/components/settings/schema-control-utils.ts
+++ b/crates/mesh-llm-ui/src/features/configuration/components/settings/schema-control-utils.ts
@@ -149,7 +149,10 @@ export function acceptedValuesForSetting(setting: ConfigurationDefaultsSetting) 
   return Array.from(new Set([...fromSchema, ...fromControl]))
 }
 
-export function resolvedChoiceOptions(setting: ConfigurationDefaultsSetting): readonly ResolvedChoiceOption[] {
+export function resolvedChoiceOptions(
+  setting: ConfigurationDefaultsSetting,
+  currentValue?: string
+): readonly ResolvedChoiceOption[] {
   const fromControl: ResolvedChoiceOption[] =
     setting.control.kind === 'choice'
       ? setting.control.options.map((option) => ({
@@ -160,7 +163,7 @@ export function resolvedChoiceOptions(setting: ConfigurationDefaultsSetting): re
       : acceptedValuesForSetting(setting).map((value) => ({ value, label: value, description: undefined }))
 
   const runtimeOptions = setting.controlState?.options ?? []
-  if (runtimeOptions.length === 0) return fromControl
+  if (runtimeOptions.length === 0) return withStoredValueOption(fromControl, currentValue)
 
   const runtimeByValue = new Map(
     runtimeOptions.map((option) => [normalizedChoiceValue(controlConditionValueString(option.value)), option] as const)
@@ -188,7 +191,19 @@ export function resolvedChoiceOptions(setting: ConfigurationDefaultsSetting): re
     })
   }
 
-  return mergedOptions
+  return withStoredValueOption(mergedOptions, currentValue)
+}
+
+// A stored value with no matching option (e.g. an `exact:<id>`, `meshllm-<id>`, or `cudaNN` native
+// runtime pin, or a GPU device that is no longer present) must stay selectable, or a select control
+// would render no match and silently overwrite the deliberate pin on save. Surface it as a synthetic
+// trailing option so the raw value round-trips.
+function withStoredValueOption(
+  options: readonly ResolvedChoiceOption[],
+  currentValue?: string
+): readonly ResolvedChoiceOption[] {
+  if (!currentValue || options.some((option) => option.value === currentValue)) return options
+  return [...options, { value: currentValue, label: currentValue, description: 'Set in config file' }]
 }
 
 export function getSettingAvailability(setting: ConfigurationDefaultsSetting): SettingAvailabilityState {

--- a/crates/mesh-llm-ui/src/features/configuration/pages/ConfigurationEditorTabs.tsx
+++ b/crates/mesh-llm-ui/src/features/configuration/pages/ConfigurationEditorTabs.tsx
@@ -220,8 +220,8 @@ export function ConfigurationEditorTabs({
           screenLabel="Configuration · runtime"
           summaryDescription={
             <>
-              Startup and reconciliation settings that the local process reads from the config file. Native runtime
-              installation and hardware selection are intentionally not presented as switchable UI controls here.
+              Startup and reconciliation settings that the local process reads from the config file. The native runtime
+              backend can be selected here; runtime installation itself is still managed outside this tab.
             </>
           }
           summaryTitle="Runtime settings"

--- a/crates/mesh-llm/src/commands/doctor.rs
+++ b/crates/mesh-llm/src/commands/doctor.rs
@@ -56,26 +56,12 @@ pub(crate) async fn dispatch_doctor_command(
             mesh_llm_commands::runtime_native::run_native_runtime_doctor(
                 native_runtime.mesh_version.as_deref(),
                 native_runtime.skippy_abi.as_deref(),
-                native_runtime_selection(llama_flavor, native_runtime.selection.as_deref()),
+                llama_flavor.map(crate::map_binary_flavor),
+                native_runtime.selection.as_deref(),
                 json_output,
             )
         }
     }
-}
-
-fn native_runtime_selection(
-    llama_flavor: Option<BinaryFlavor>,
-    configured_selection: Option<&str>,
-) -> Option<&str> {
-    llama_flavor
-        .map(|flavor| match flavor {
-            BinaryFlavor::Cpu => "cpu",
-            BinaryFlavor::Cuda => "cuda",
-            BinaryFlavor::Rocm => "rocm",
-            BinaryFlavor::Vulkan => "vulkan",
-            BinaryFlavor::Metal => "metal",
-        })
-        .or(configured_selection)
 }
 
 async fn run_split_doctor(
@@ -403,26 +389,12 @@ fn split_readiness_short_node_list(items: &[Value]) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        SKIPPY_DIAGNOSTIC_ENDPOINTS, capture_skippy_native_log, native_runtime_selection,
-        select_runtime_instance, split_readiness_lines, write_split_readiness_report,
+        SKIPPY_DIAGNOSTIC_ENDPOINTS, capture_skippy_native_log, select_runtime_instance,
+        split_readiness_lines, write_split_readiness_report,
     };
-    use mesh_llm_cli::BinaryFlavor;
     use mesh_llm_host_runtime::command_support::runtime_instances::LocalInstanceSnapshot;
     use serde_json::json;
     use std::path::PathBuf;
-
-    #[test]
-    fn doctor_prefers_cli_flavor_over_configured_runtime_selection() {
-        assert_eq!(
-            native_runtime_selection(Some(BinaryFlavor::Vulkan), Some("cuda")),
-            Some("vulkan")
-        );
-    }
-
-    #[test]
-    fn doctor_uses_configured_runtime_selection_without_cli_flavor() {
-        assert_eq!(native_runtime_selection(None, Some("cuda")), Some("cuda"));
-    }
 
     #[test]
     fn split_readiness_lines_show_waiting_guidance() {

--- a/crates/mesh-llm/src/commands/doctor.rs
+++ b/crates/mesh-llm/src/commands/doctor.rs
@@ -3,7 +3,7 @@ use serde_json::{Map, Value, json};
 use std::path::{Path, PathBuf};
 use std::time::{SystemTime, UNIX_EPOCH};
 
-use mesh_llm_cli::DoctorCommand;
+use mesh_llm_cli::{BinaryFlavor, DoctorCommand};
 use mesh_llm_host_runtime::command_support::plugin::load_config;
 use mesh_llm_host_runtime::command_support::runtime_instances::{
     LocalInstanceSnapshot, runtime_root, scan_local_instances,
@@ -40,6 +40,7 @@ const SKIPPY_DIAGNOSTIC_ENDPOINTS: &[(&str, &str, &str)] = &[
 pub(crate) async fn dispatch_doctor_command(
     command: Option<&DoctorCommand>,
     config_path: Option<&Path>,
+    llama_flavor: Option<BinaryFlavor>,
     json_output: bool,
 ) -> Result<()> {
     match command {
@@ -55,11 +56,26 @@ pub(crate) async fn dispatch_doctor_command(
             mesh_llm_commands::runtime_native::run_native_runtime_doctor(
                 native_runtime.mesh_version.as_deref(),
                 native_runtime.skippy_abi.as_deref(),
-                native_runtime.selection.as_deref(),
+                native_runtime_selection(llama_flavor, native_runtime.selection.as_deref()),
                 json_output,
             )
         }
     }
+}
+
+fn native_runtime_selection(
+    llama_flavor: Option<BinaryFlavor>,
+    configured_selection: Option<&str>,
+) -> Option<&str> {
+    llama_flavor
+        .map(|flavor| match flavor {
+            BinaryFlavor::Cpu => "cpu",
+            BinaryFlavor::Cuda => "cuda",
+            BinaryFlavor::Rocm => "rocm",
+            BinaryFlavor::Vulkan => "vulkan",
+            BinaryFlavor::Metal => "metal",
+        })
+        .or(configured_selection)
 }
 
 async fn run_split_doctor(
@@ -387,12 +403,26 @@ fn split_readiness_short_node_list(items: &[Value]) -> String {
 #[cfg(test)]
 mod tests {
     use super::{
-        SKIPPY_DIAGNOSTIC_ENDPOINTS, capture_skippy_native_log, select_runtime_instance,
-        split_readiness_lines, write_split_readiness_report,
+        SKIPPY_DIAGNOSTIC_ENDPOINTS, capture_skippy_native_log, native_runtime_selection,
+        select_runtime_instance, split_readiness_lines, write_split_readiness_report,
     };
+    use mesh_llm_cli::BinaryFlavor;
     use mesh_llm_host_runtime::command_support::runtime_instances::LocalInstanceSnapshot;
     use serde_json::json;
     use std::path::PathBuf;
+
+    #[test]
+    fn doctor_prefers_cli_flavor_over_configured_runtime_selection() {
+        assert_eq!(
+            native_runtime_selection(Some(BinaryFlavor::Vulkan), Some("cuda")),
+            Some("vulkan")
+        );
+    }
+
+    #[test]
+    fn doctor_uses_configured_runtime_selection_without_cli_flavor() {
+        assert_eq!(native_runtime_selection(None, Some("cuda")), Some("cuda"));
+    }
 
     #[test]
     fn split_readiness_lines_show_waiting_guidance() {

--- a/crates/mesh-llm/src/commands/mod.rs
+++ b/crates/mesh-llm/src/commands/mod.rs
@@ -64,9 +64,12 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
             Ok(())
         }
         Command::Runtime { command } => {
-            dispatch_runtime_command(command.as_ref(), cli.config.as_deref()).await
+            dispatch_runtime_command(command.as_ref(), cli.config.as_deref(), cli.llama_flavor)
+                .await
         }
-        Command::Setup { .. } => dispatch_setup_command(cmd, cli.config.as_deref()).await,
+        Command::Setup { .. } => {
+            dispatch_setup_command(cmd, cli.config.as_deref(), cli.llama_flavor).await
+        }
         Command::Uninstall {
             dry_run,
             yes,

--- a/crates/mesh-llm/src/commands/mod.rs
+++ b/crates/mesh-llm/src/commands/mod.rs
@@ -93,7 +93,13 @@ async fn dispatch_general_command(cli: &Cli, cmd: &Command) -> Result<()> {
         ),
         Command::Config { command } => dispatch_config_command(cli, command),
         Command::Doctor { command, json } => {
-            dispatch_doctor_command(command.as_ref(), cli.config.as_deref(), *json).await
+            dispatch_doctor_command(
+                command.as_ref(),
+                cli.config.as_deref(),
+                cli.llama_flavor,
+                *json,
+            )
+            .await
         }
         Command::Load { name, port } => run_load(name, *port).await,
         Command::Unload { name, port } => run_drop(name, *port).await,

--- a/crates/mesh-llm/src/commands/runtime.rs
+++ b/crates/mesh-llm/src/commands/runtime.rs
@@ -2,14 +2,15 @@ use anyhow::{Context, Result, bail};
 use serde_json::json;
 use std::path::Path;
 
-use mesh_llm_cli::MeshGuardrailCliMode;
 use mesh_llm_cli::runtime::RuntimeCommand;
+use mesh_llm_cli::{BinaryFlavor, MeshGuardrailCliMode};
 use mesh_llm_commands::runtime_native::NativeRuntimeConfigSelection;
 use mesh_llm_host_runtime::command_support::plugin::{MeshConfig, load_config};
 
 pub(crate) async fn dispatch_runtime_command(
     command: Option<&RuntimeCommand>,
     config_path: Option<&Path>,
+    llama_flavor: Option<BinaryFlavor>,
 ) -> Result<()> {
     match command {
         Some(RuntimeCommand::List {
@@ -30,7 +31,7 @@ pub(crate) async fn dispatch_runtime_command(
                 manifest.as_deref(),
                 bundle_dirs,
                 cache_dir.as_deref(),
-                native_runtime_command_selection(selector.as_ref()),
+                native_runtime_command_selection(selector.as_ref(), llama_flavor),
                 *json,
             )
             .await
@@ -48,7 +49,7 @@ pub(crate) async fn dispatch_runtime_command(
                 manifest.as_deref(),
                 bundle_dirs,
                 cache_dir.as_deref(),
-                native_runtime_command_selection(selector.as_ref()),
+                native_runtime_command_selection(selector.as_ref(), llama_flavor),
                 *json,
             )
             .await
@@ -80,7 +81,7 @@ pub(crate) async fn dispatch_runtime_command(
                 mesh_version.as_deref().or_else(|| {
                     selector
                         .as_ref()
-                        .map(|selector| selector.mesh_version.as_str())
+                        .and_then(|selector| selector.mesh_version.as_deref())
                 }),
                 cache_dir.as_deref(),
                 *json,
@@ -166,7 +167,7 @@ pub(crate) async fn dispatch_runtime_command(
 }
 
 pub(crate) struct NativeRuntimeConfigSelector {
-    mesh_version: String,
+    mesh_version: Option<String>,
     skippy_abi: Option<String>,
     selection: Option<String>,
 }
@@ -175,23 +176,32 @@ pub(crate) fn native_runtime_config_selector(
     config_path: Option<&Path>,
 ) -> Result<Option<NativeRuntimeConfigSelector>> {
     let config = load_config(config_path)?;
-    Ok(match config.runtime.native_runtime.mesh_version {
-        Some(mesh_version) => Some(NativeRuntimeConfigSelector {
-            mesh_version,
-            skippy_abi: config.runtime.native_runtime.skippy_abi,
-            selection: config.runtime.native_runtime.selection,
-        }),
-        None => None,
-    })
+    let native_runtime = config.runtime.native_runtime;
+    if native_runtime.mesh_version.is_none()
+        && native_runtime.skippy_abi.is_none()
+        && native_runtime.selection.is_none()
+    {
+        return Ok(None);
+    }
+    Ok(Some(NativeRuntimeConfigSelector {
+        mesh_version: native_runtime.mesh_version,
+        skippy_abi: native_runtime.skippy_abi,
+        selection: native_runtime.selection,
+    }))
 }
 
 pub(crate) fn native_runtime_command_selection<'a>(
     selector: Option<&'a NativeRuntimeConfigSelector>,
+    llama_flavor: Option<BinaryFlavor>,
 ) -> NativeRuntimeConfigSelection<'a> {
+    let configured_selection = selector.and_then(|selector| selector.selection.as_deref());
     NativeRuntimeConfigSelection {
-        mesh_version: selector.map(|selector| selector.mesh_version.as_str()),
+        mesh_version: selector.and_then(|selector| selector.mesh_version.as_deref()),
         skippy_abi_version: selector.and_then(|selector| selector.skippy_abi.as_deref()),
-        selection: selector.and_then(|selector| selector.selection.as_deref()),
+        selection: mesh_llm_commands::runtime_native::native_runtime_selection(
+            llama_flavor.map(crate::map_binary_flavor),
+            configured_selection,
+        ),
     }
 }
 
@@ -754,11 +764,34 @@ mod tests {
     use super::{
         build_apply_config_request, build_control_endpoint_request, build_guardrail_mode_request,
         build_lifecycle_request, control_bootstrap_lines, control_scan_refresh_lines,
-        display_backend_label, runtime_success_lines, yes_no,
+        display_backend_label, native_runtime_command_selection, native_runtime_config_selector,
+        runtime_success_lines, yes_no,
     };
-    use mesh_llm_cli::MeshGuardrailCliMode;
+    use mesh_llm_cli::{BinaryFlavor, MeshGuardrailCliMode};
     use mesh_llm_host_runtime::command_support::plugin::{GpuAssignment, GpuConfig, MeshConfig};
     use serde_json::json;
+
+    #[test]
+    fn native_runtime_selector_preserves_selection_without_pinned_version_and_cli_flavor() {
+        let temp = tempfile::tempdir().expect("temporary config directory");
+        let config_path = temp.path().join("config.toml");
+        std::fs::write(
+            &config_path,
+            "[runtime.native_runtime]\nselection = \"rocm\"\n",
+        )
+        .expect("write selection-only runtime config");
+
+        let selector = native_runtime_config_selector(Some(&config_path))
+            .expect("load runtime config selector")
+            .expect("selection-only config should produce a selector");
+        assert_eq!(selector.mesh_version, None);
+        assert_eq!(selector.selection.as_deref(), Some("rocm"));
+
+        let configured =
+            native_runtime_command_selection(Some(&selector), Some(BinaryFlavor::Vulkan));
+        assert_eq!(configured.mesh_version, None);
+        assert_eq!(configured.selection, Some("vulkan"));
+    }
 
     #[test]
     fn runtime_success_lines_print_loaded_instance_id() {

--- a/crates/mesh-llm/src/commands/setup.rs
+++ b/crates/mesh-llm/src/commands/setup.rs
@@ -1,6 +1,6 @@
 use super::runtime::{native_runtime_command_selection, native_runtime_config_selector};
 use anyhow::{Result, bail};
-use mesh_llm_cli::Command;
+use mesh_llm_cli::{BinaryFlavor, Command};
 use mesh_llm_commands::setup::{SetupCommandArgs, SetupEnvironment, SetupOptions, SetupPlatform};
 use std::io::IsTerminal;
 use std::path::Path;
@@ -8,9 +8,13 @@ use std::path::Path;
 pub(crate) async fn dispatch_setup_command(
     cmd: &Command,
     config_path: Option<&Path>,
+    llama_flavor: Option<BinaryFlavor>,
 ) -> Result<()> {
     let selector = native_runtime_config_selector(config_path)?;
-    let args = setup_command_args(cmd, native_runtime_command_selection(selector.as_ref()))?;
+    let args = setup_command_args(
+        cmd,
+        native_runtime_command_selection(selector.as_ref(), llama_flavor),
+    )?;
     mesh_llm_commands::setup::run_setup_command(args).await
 }
 

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -385,6 +385,7 @@ publish_crates=(
     mesh-llm-log-store
     mesh-llm-build-info
     mesh-llm-release-footer
+    mesh-llm-native-runtime
     mesh-llm-config
     mesh-llm-ui
     mesh-llm-console-server
@@ -394,7 +395,6 @@ publish_crates=(
     model-package
     mesh-llm-node
     mesh-llm-api-server
-    mesh-llm-native-runtime
     mesh-llm-hardware-profile
     skippy-runtime
     skippy-scheduler

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -2173,23 +2173,23 @@
   ],
   "crates/mesh-llm/src/commands/doctor.rs": [
     {
-      "line": 77,
+      "line": 93,
       "macro_name": "println!"
     },
     {
-      "line": 80,
+      "line": 96,
       "macro_name": "println!"
     },
     {
-      "line": 83,
+      "line": 99,
       "macro_name": "println!"
     },
     {
-      "line": 84,
+      "line": 100,
       "macro_name": "println!"
     },
     {
-      "line": 86,
+      "line": 102,
       "macro_name": "println!"
     }
   ],

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -1117,19 +1117,19 @@
   ],
   "crates/mesh-llm-commands/src/runtime_native.rs": [
     {
-      "line": 68,
+      "line": 69,
       "macro_name": "eprintln!"
     },
     {
-      "line": 148,
+      "line": 149,
       "macro_name": "eprintln!"
     },
     {
-      "line": 151,
+      "line": 152,
       "macro_name": "eprintln!"
     },
     {
-      "line": 192,
+      "line": 194,
       "macro_name": "eprintln!"
     },
     {
@@ -1137,27 +1137,27 @@
       "macro_name": "eprintln!"
     },
     {
-      "line": 195,
+      "line": 196,
       "macro_name": "eprintln!"
     },
     {
-      "line": 198,
+      "line": 199,
       "macro_name": "eprintln!"
     },
     {
-      "line": 226,
+      "line": 227,
       "macro_name": "eprintln!"
     },
     {
-      "line": 262,
+      "line": 263,
       "macro_name": "eprint!"
     },
     {
-      "line": 266,
+      "line": 267,
       "macro_name": "eprint!"
     },
     {
-      "line": 274,
+      "line": 275,
       "macro_name": "eprintln!"
     }
   ],
@@ -2173,23 +2173,23 @@
   ],
   "crates/mesh-llm/src/commands/doctor.rs": [
     {
-      "line": 93,
+      "line": 79,
       "macro_name": "println!"
     },
     {
-      "line": 96,
+      "line": 82,
       "macro_name": "println!"
     },
     {
-      "line": 99,
+      "line": 85,
       "macro_name": "println!"
     },
     {
-      "line": 100,
+      "line": 86,
       "macro_name": "println!"
     },
     {
-      "line": 102,
+      "line": 88,
       "macro_name": "println!"
     }
   ],

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -1129,35 +1129,35 @@
       "macro_name": "eprintln!"
     },
     {
-      "line": 194,
+      "line": 197,
       "macro_name": "eprintln!"
     },
     {
-      "line": 193,
+      "line": 198,
       "macro_name": "eprintln!"
     },
     {
-      "line": 196,
+      "line": 200,
       "macro_name": "eprintln!"
     },
     {
-      "line": 199,
+      "line": 203,
       "macro_name": "eprintln!"
     },
     {
-      "line": 227,
+      "line": 231,
       "macro_name": "eprintln!"
-    },
-    {
-      "line": 263,
-      "macro_name": "eprint!"
     },
     {
       "line": 267,
       "macro_name": "eprint!"
     },
     {
-      "line": 275,
+      "line": 271,
+      "macro_name": "eprint!"
+    },
+    {
+      "line": 279,
       "macro_name": "eprintln!"
     }
   ],
@@ -2709,52 +2709,32 @@
   ],
   "crates/mesh-llm/src/commands/runtime.rs": [
     {
-      "line": 252,
+      "line": 262,
       "macro_name": "println!"
     },
     {
-      "line": 256,
+      "line": 266,
       "macro_name": "println!"
-    },
-    {
-      "line": 380,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 383,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 384,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 385,
-      "macro_name": "eprintln!"
     },
     {
       "line": 390,
       "macro_name": "eprintln!"
     },
     {
-      "line": 467,
-      "macro_name": "println!"
+      "line": 393,
+      "macro_name": "eprintln!"
     },
     {
-      "line": 468,
-      "macro_name": "println!"
+      "line": 394,
+      "macro_name": "eprintln!"
     },
     {
-      "line": 471,
-      "macro_name": "println!"
+      "line": 395,
+      "macro_name": "eprintln!"
     },
     {
-      "line": 472,
-      "macro_name": "println!"
-    },
-    {
-      "line": 473,
-      "macro_name": "println!"
+      "line": 400,
+      "macro_name": "eprintln!"
     },
     {
       "line": 477,
@@ -2765,31 +2745,51 @@
       "macro_name": "println!"
     },
     {
-      "line": 480,
+      "line": 481,
       "macro_name": "println!"
     },
     {
-      "line": 496,
+      "line": 482,
       "macro_name": "println!"
     },
     {
-      "line": 512,
+      "line": 483,
       "macro_name": "println!"
     },
     {
-      "line": 517,
+      "line": 487,
       "macro_name": "println!"
     },
     {
-      "line": 687,
+      "line": 488,
       "macro_name": "println!"
     },
     {
-      "line": 688,
+      "line": 490,
       "macro_name": "println!"
     },
     {
-      "line": 690,
+      "line": 506,
+      "macro_name": "println!"
+    },
+    {
+      "line": 522,
+      "macro_name": "println!"
+    },
+    {
+      "line": 527,
+      "macro_name": "println!"
+    },
+    {
+      "line": 697,
+      "macro_name": "println!"
+    },
+    {
+      "line": 698,
+      "macro_name": "println!"
+    },
+    {
+      "line": 700,
       "macro_name": "println!"
     }
   ],


### PR DESCRIPTION
`--llama-flavor` was parsed into `RuntimeOptions`, but native-runtime selection did not consistently receive it. On AMD or NVIDIA hosts, an explicit CPU or Vulkan request could therefore load or install a higher-ranked ROCm or CUDA bundle. Config-only backend selection had related gaps: it required a pinned Mesh version, accepted unknown backend names, and was ignored by install/setup and embedded SDK serving.

This change applies one precedence rule across serve, doctor, runtime install/list, and setup: CLI flavor → configured selection → recommended. Configured Mesh version and Skippy ABI constraints are retained, selection-only configs track the current release, and invalid configured backend names fail validation. Embedded SDK serving now resolves the backend from the same validated config snapshot instead of hardcoding `Recommended`. The existing device selector then resolves against the requested backend, so combinations such as `--llama-flavor vulkan --device Vulkan0` validate against Vulkan.

Validation at `ffd7fba29314ab9b772442ade8f4e1f7f5c26d3c`:
- full `mesh-llm-config`, `mesh-llm-commands`, `mesh-llm-host-runtime`, and `mesh-llm` package test suites
- formatting, warning-denied clippy, default and no-default-feature checks
- repository console-output consistency and diff checks

Closes #1753
