### PR TITLE
fix(openai): reject malformed tool definitions

### DIFF
--- a/crates/openai-frontend/src/chat.rs
+++ b/crates/openai-frontend/src/chat.rs
@@ -96,8 +96,9 @@ impl ChatCompletionRequest {
                 "top_logprobs requires logprobs=true",
             ));
         }
-        if self.tools.as_ref().is_some_and(invalid_tools_value) {
-            return Err(OpenAiError::invalid_request("tools must be an array"));
+        if let Some(tools) = self.tools.as_ref() {
+            validate_tools_value(tools)
+                .map_err(|message| OpenAiError::invalid_request(message).with_param("tools"))?;
         }
         if self
             .response_format
@@ -126,8 +127,39 @@ fn invalid_response_format_value(value: &Value) -> bool {
         .is_some_and(Value::is_string)
 }
 
-fn invalid_tools_value(value: &Value) -> bool {
-    !matches!(value, Value::Array(_))
+fn validate_tools_value(value: &Value) -> Result<(), String> {
+    let Some(tools) = value.as_array() else {
+        return Err("tools must be an array".to_string());
+    };
+    for (index, tool) in tools.iter().enumerate() {
+        let Some(tool) = tool.as_object() else {
+            return Err(format!("tools[{index}] must be an object"));
+        };
+        if tool.get("type").and_then(Value::as_str) != Some("function") {
+            return Err(format!("tools[{index}].type must be `function`"));
+        }
+        let Some(function) = tool.get("function").and_then(Value::as_object) else {
+            return Err(format!("tools[{index}].function must be an object"));
+        };
+        if !function
+            .get("name")
+            .and_then(Value::as_str)
+            .is_some_and(|name| !name.trim().is_empty())
+        {
+            return Err(format!(
+                "tools[{index}].function.name must be a non-empty string"
+            ));
+        }
+        if function
+            .get("parameters")
+            .is_some_and(|parameters| !parameters.is_object())
+        {
+            return Err(format!(
+                "tools[{index}].function.parameters must be an object"
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/openai-frontend/src/errors.rs
+++ b/crates/openai-frontend/src/errors.rs
@@ -11,6 +11,7 @@ pub struct OpenAiError {
     status: StatusCode,
     message: String,
     error_type: String,
+    param: Option<String>,
     code: Option<String>,
     retry_after_secs: Option<u64>,
 }
@@ -42,6 +43,7 @@ impl OpenAiError {
             status,
             message: message.into(),
             error_type: error_type.to_string(),
+            param: None,
             code: Some(code.to_string()),
             retry_after_secs: None,
         }
@@ -147,6 +149,11 @@ impl OpenAiError {
         self
     }
 
+    pub fn with_param(mut self, param: impl Into<String>) -> Self {
+        self.param = Some(param.into());
+        self
+    }
+
     pub fn with_retry_after_secs(mut self, retry_after_secs: u64) -> Self {
         self.retry_after_secs = Some(retry_after_secs);
         self
@@ -157,7 +164,7 @@ impl OpenAiError {
             error: ErrorBody {
                 message: self.message.clone(),
                 error_type: self.error_type.clone(),
-                param: None,
+                param: self.param.clone(),
                 code: self.code.clone(),
             },
         }

--- a/crates/openai-frontend/src/router_tests.rs
+++ b/crates/openai-frontend/src/router_tests.rs
@@ -1499,6 +1499,30 @@ async fn chat_completion_route_accepts_tools_structured_output_and_logprobs() {
 }
 
 #[tokio::test]
+async fn chat_completion_route_rejects_malformed_tools_as_invalid_requests() {
+    for tools in [
+        json!([{"type": "function"}]),
+        json!([{"type": "banana", "function": {"name": "f", "parameters": {}}}]),
+        json!([{"type": "function", "function": "nope"}]),
+    ] {
+        let response = post_json(
+            "/v1/chat/completions",
+            json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": tools
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_body_json(response).await;
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["param"], "tools");
+        assert_eq!(body["error"]["code"], "invalid_value");
+    }
+}
+
+#[tokio::test]
 async fn chat_completion_route_accepts_noop_parity_fields() {
     let response = post_json(
         "/v1/chat/completions",


### PR DESCRIPTION
Malformed `tools` entries currently reach the native chat-template parser and surface as retryable 502 errors. Validate the supported function-tool shape at OpenAI ingress and return a 400 `invalid_request_error` with `param: "tools"` for malformed definitions.

Closes #1595


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Chat completion requests now reject malformed tool definitions, including invalid tool types, missing function names, and improperly structured functions.
  * Invalid tool errors now identify the `tools` parameter and provide more specific validation details.
* **Tests**
  * Added coverage confirming malformed tool payloads return clear invalid-request responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->