### PR TITLE
fix(host-runtime): keep the OpenAI listener alive across accept errors

### DIFF
--- a/crates/mesh-llm-host-runtime/src/network/openai/accept.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/accept.rs
@@ -1,0 +1,102 @@
+//! Accept-loop error handling for the OpenAI ingress listeners.
+//!
+//! A bound `TcpListener` stays valid across every error `accept` can report:
+//! the errors describe one connection or a momentary shortage of host
+//! resources, never the listening socket itself. So an accept loop has no
+//! reason to ever give the listener up, and #1703 is what happens when it
+//! does. A joined node's `:9338` listener disappeared after hours of uptime
+//! while the process, the console, and mesh gossip all kept running, so peers
+//! went on routing to an API surface that no longer accepted anything.
+
+use std::io;
+use std::time::Duration;
+
+/// How long to wait before accepting again after an error that is not a
+/// plain per-connection failure. Short enough that a node recovers promptly
+/// once file descriptors free up, long enough that the loop does not spin.
+const ACCEPT_BACKOFF: Duration = Duration::from_millis(100);
+
+/// What an accept loop should do after `accept` returns an error.
+///
+/// There is deliberately no variant that stops the loop.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum AcceptRecovery {
+    /// One inbound connection failed. The next accept can run immediately and
+    /// is not worth logging: clients abort mid-handshake all the time.
+    Retry,
+    /// Anything else, which in practice means host resource pressure such as
+    /// a per-process descriptor limit. Wait before accepting again.
+    Backoff(Duration),
+}
+
+/// Classifies an accept error. Every input produces a recovery, by design.
+pub(crate) fn recover_from_accept_error(error: &io::Error) -> AcceptRecovery {
+    match error.kind() {
+        io::ErrorKind::ConnectionAborted
+        | io::ErrorKind::ConnectionReset
+        | io::ErrorKind::Interrupted
+        | io::ErrorKind::WouldBlock => AcceptRecovery::Retry,
+        _ => AcceptRecovery::Backoff(ACCEPT_BACKOFF),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn error(kind: io::ErrorKind) -> io::Error {
+        io::Error::new(kind, "accept failed")
+    }
+
+    #[test]
+    fn aborted_connections_retry_immediately() {
+        for kind in [
+            io::ErrorKind::ConnectionAborted,
+            io::ErrorKind::ConnectionReset,
+            io::ErrorKind::Interrupted,
+            io::ErrorKind::WouldBlock,
+        ] {
+            assert_eq!(
+                recover_from_accept_error(&error(kind)),
+                AcceptRecovery::Retry,
+                "{kind:?} is a per-connection failure"
+            );
+        }
+    }
+
+    #[test]
+    fn descriptor_exhaustion_backs_off_instead_of_spinning() {
+        // EMFILE is the error a long-running node hits first, and it has no
+        // stable ErrorKind, so it arrives as Uncategorized.
+        let emfile = io::Error::from_raw_os_error(libc::EMFILE);
+
+        assert_eq!(
+            recover_from_accept_error(&emfile),
+            AcceptRecovery::Backoff(ACCEPT_BACKOFF)
+        );
+    }
+
+    #[test]
+    fn unrecognized_errors_never_stop_the_loop() {
+        for kind in [
+            io::ErrorKind::Other,
+            io::ErrorKind::PermissionDenied,
+            io::ErrorKind::OutOfMemory,
+            io::ErrorKind::InvalidInput,
+        ] {
+            assert!(
+                matches!(
+                    recover_from_accept_error(&error(kind)),
+                    AcceptRecovery::Backoff(_)
+                ),
+                "{kind:?} must not be treated as fatal"
+            );
+        }
+    }
+
+    #[test]
+    fn backoff_is_bounded_so_recovery_stays_prompt() {
+        assert!(ACCEPT_BACKOFF <= Duration::from_millis(250));
+        assert!(ACCEPT_BACKOFF > Duration::ZERO);
+    }
+}

--- a/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/ingress.rs
@@ -2,6 +2,7 @@ use crate::inference::{election, pipeline};
 use crate::logging::{CallerPathType, OpenAiLifecycleAttachment, OpenAiRouteObserver};
 use crate::mesh;
 use crate::network::affinity;
+use crate::network::openai::accept;
 use crate::network::openai::auto_route;
 use crate::network::openai::automatic;
 use crate::network::openai::client_stream::ClientStream;
@@ -120,6 +121,29 @@ pub(super) fn parse_model_with_profile(model: &str) -> (&str, &str) {
         }
     } else {
         (model, "")
+    }
+}
+
+/// Waits out an accept error so the caller can loop again.
+///
+/// Neither ingress loop drops its listener on an accept error. The listening
+/// socket survives every error `accept` reports, so returning here is how
+/// #1703 silently removed `:9338` from a node that otherwise looked healthy.
+/// Resource pressure is logged, because the previous code swallowed it and
+/// left nothing behind to explain the missing listener.
+async fn recover_accept_loop(port: u16, error: &std::io::Error, surface: &'static str) {
+    match accept::recover_from_accept_error(error) {
+        accept::AcceptRecovery::Retry => {}
+        accept::AcceptRecovery::Backoff(delay) => {
+            tracing::warn!(
+                port,
+                surface,
+                error = %error,
+                backoff_ms = delay.as_millis() as u64,
+                "accept failed; retrying without dropping the listener"
+            );
+            tokio::time::sleep(delay).await;
+        }
     }
 }
 
@@ -1209,8 +1233,11 @@ pub(crate) async fn api_proxy(
 
     loop {
         let (tcp_stream, _addr) = match listener.accept().await {
-            Ok(r) => r,
-            Err(_) => break,
+            Ok(accepted) => accepted,
+            Err(error) => {
+                recover_accept_loop(port, &error, "api_proxy").await;
+                continue;
+            }
         };
         let _ = tcp_stream.set_nodelay(true);
 
@@ -1260,8 +1287,11 @@ pub(crate) async fn bootstrap_proxy(
         tokio::select! {
             accept = listener.accept() => {
                 let (tcp_stream, _addr) = match accept {
-                    Ok(r) => r,
-                    Err(_) => continue,
+                    Ok(accepted) => accepted,
+                    Err(error) => {
+                        recover_accept_loop(port, &error, "bootstrap_proxy").await;
+                        continue;
+                    }
                 };
                 let _ = tcp_stream.set_nodelay(true);
                 let node = node.clone();

--- a/crates/mesh-llm-host-runtime/src/network/openai/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/network/openai/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod accept;
 pub(crate) mod auto_route;
 pub(crate) mod automatic;
 pub(crate) mod client_stream;


### PR DESCRIPTION
Closes #1703

Second PR in the 0.76.1 bugfix stack. Base is #1760, so the diff to review is the second commit.

## Original problem

Joined nodes lost the `:9338` OpenAI listener after hours of uptime. The process stayed up, `:3131`, the skippy runtime, and mesh gossip all kept working, and `/api/status` still reported `llama_ready: true` and `state: serving`, so peers kept routing to a node whose API surface no longer accepted anything. Every routed request recorded `unavailable`. Restarting with the identical command line re-bound the port.

## Diagnostics

`api_proxy` in `network/openai/ingress.rs` treated every accept error as fatal:

```rust
let (tcp_stream, _addr) = match listener.accept().await {
    Ok(r) => r,
    Err(_) => break,
};
```

`break` returns from `api_proxy`, which drops the `TcpListener` it owns. `spawn_run_auto_api_proxy` keeps the `JoinHandle` in `serving_surface.rs` but nothing ever awaits it, so the task ending is invisible and the port stays gone for the rest of the process's life. The error was discarded, which is why hours of logs say nothing about the moment it happened.

That is the only path in the ingress code that ends with a live process and a dead `:9338`, and it matches every detail of the report: no crash, no log line, console and gossip unaffected, and a restart fixing it. I have not caught the originating accept error on a live node, so I would not claim the specific errno yet. `EMFILE` on a busy joiner is the obvious candidate, and the creator holding fewer inbound connections than a joiner fits the creator never losing its listener.

`bootstrap_proxy`, a few lines below, already used `Err(_) => continue`, which is another sign the `break` was an oversight rather than a decision.

## Fix

Neither loop gives its listener up. A new `network/openai/accept.rs` classifies the error into `Retry` or `Backoff`, with no variant that stops the loop, because a bound listener stays valid across every error `accept` reports: the errors describe one connection or a momentary shortage of host resources, never the listening socket.

Per-connection failures (`ConnectionAborted`, `ConnectionReset`, `Interrupted`, `WouldBlock`) retry immediately and stay quiet, since clients abort mid-handshake routinely. Everything else backs off 100ms and logs a warning with the port, the surface, and the error. That keeps the loop from spinning on descriptor exhaustion, and it means the next occurrence leaves evidence instead of a silently missing port. `bootstrap_proxy` already continued, but it spun on repeated errors; it uses the same path now.

## Tests

Four unit tests on the classifier in `accept.rs`, including one asserting that no error kind produces a fatal outcome, which is the invariant that broke. `descriptor_exhaustion_backs_off_instead_of_spinning` uses a real `EMFILE` so the `Uncategorized` kind it arrives as is covered explicitly.

`cargo test -p mesh-llm-host-runtime` on carrack: 3042 passed, 4 failed. The same 4 fail on the unmodified base branch in the same checkout, so they are pre-existing and environmental, not from this change.

## Not in this PR

The issue's second suggestion, deriving the advertised `Serving` state from `:9338` reachability, is not here. It is a good idea and it is defense in depth against any other way the listener could die, but it changes when every node in a mesh advertises itself, and a mistake there de-advertises healthy nodes. It wants its own change and its own multi-node testing rather than riding along with a five-line accept-loop fix. Happy to open it as a follow-up if we want it in 0.76.1.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * OpenAI ingress listeners now recover from connection-accept errors instead of stopping unexpectedly.
  * Temporary failures retry immediately, while resource-exhaustion errors use bounded backoff.
  * Recovery attempts now provide warning logs and avoid excessively rapid retries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->