### PR TITLE
fix(ci): stamp the real source revision into release attestations

### DIFF
--- a/.github/actions/prepare-host-input/action.yml
+++ b/.github/actions/prepare-host-input/action.yml
@@ -30,6 +30,10 @@ inputs:
     description: Optional release-attestation public key path used to inspect the stamp.
     required: false
     default: ""
+  commit:
+    description: Source revision recorded in the release attestation. Defaults to the checkout's HEAD.
+    required: false
+    default: ""
 
 outputs:
   binary_path:
@@ -59,6 +63,7 @@ runs:
         INPUT_BUILD_VERSION: ${{ inputs.build_version }}
         INPUT_ATTESTATION_SIGNING_KEY_FILE: ${{ inputs.attestation_signing_key_file }}
         INPUT_ATTESTATION_PUBLIC_KEY_FILE: ${{ inputs.attestation_public_key_file }}
+        INPUT_COMMIT: ${{ inputs.commit }}
       run: |
         set -euo pipefail
 
@@ -97,9 +102,15 @@ runs:
               python3 -c 'import json,sys; print(json.load(sys.stdin)["target_directory"])'
           )"
           attestation_verifier="$cargo_target_dir/debug/xtask"
-          "$attestation_verifier" release-attestation stamp \
-            --binary "$binary_path" \
+          stamp_args=(
+            --binary "$binary_path"
             --signing-key-file "$INPUT_ATTESTATION_SIGNING_KEY_FILE"
+            --require-source-commit
+          )
+          if [[ -n "$INPUT_COMMIT" ]]; then
+            stamp_args+=(--commit "$INPUT_COMMIT")
+          fi
+          "$attestation_verifier" release-attestation stamp "${stamp_args[@]}"
           "$attestation_verifier" release-attestation inspect \
             --binary "$binary_path" \
             --public-key-file "$INPUT_ATTESTATION_PUBLIC_KEY_FILE" \

--- a/.github/actions/prepare-windows-host-input/action.yml
+++ b/.github/actions/prepare-windows-host-input/action.yml
@@ -18,6 +18,10 @@ inputs:
     description: Optional release-attestation public key path used to inspect the stamp.
     required: false
     default: ""
+  commit:
+    description: Source revision recorded in the release attestation. Defaults to the checkout's HEAD.
+    required: false
+    default: ""
 
 outputs:
   binary_path:
@@ -44,6 +48,7 @@ runs:
         INPUT_SKIP_UI: ${{ inputs.skip_ui }}
         INPUT_ATTESTATION_SIGNING_KEY_FILE: ${{ inputs.attestation_signing_key_file }}
         INPUT_ATTESTATION_PUBLIC_KEY_FILE: ${{ inputs.attestation_public_key_file }}
+        INPUT_COMMIT: ${{ inputs.commit }}
       run: |
         $ErrorActionPreference = "Stop"
 
@@ -57,6 +62,7 @@ runs:
 
         $signingKey = "$env:INPUT_ATTESTATION_SIGNING_KEY_FILE".Trim()
         $publicKey = "$env:INPUT_ATTESTATION_PUBLIC_KEY_FILE".Trim()
+        $commit = "$env:INPUT_COMMIT".Trim()
         if ([string]::IsNullOrWhiteSpace($signingKey) -ne [string]::IsNullOrWhiteSpace($publicKey)) {
           throw "both attestation key files are required when release attestation is enabled"
         }
@@ -121,9 +127,15 @@ runs:
             throw "release attestation verifier was not built: $verifier"
           }
 
+          $stampCommitArgs = @()
+          if ($commit) {
+            $stampCommitArgs = @("--commit", $commit)
+          }
           & $verifier release-attestation stamp `
             --binary $binaryPath `
-            --signing-key-file $signingKey
+            --signing-key-file $signingKey `
+            --require-source-commit `
+            @stampCommitArgs
           if ($LASTEXITCODE -ne 0) {
             throw "failed to stamp the Windows release host"
           }

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -304,6 +304,7 @@ jobs:
           output_dir: host-input
           attestation_signing_key_file: ${{ runner.temp }}/mesh-release-attestation-private-key.json
           attestation_public_key_file: ${{ runner.temp }}/mesh-release-attestation-public-key.json
+          commit: ${{ needs.metadata.outputs.source_sha }}
 
       - name: Upload immutable host input
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
@@ -889,6 +890,7 @@ jobs:
           output_dir: host-input
           attestation_signing_key_file: ${{ runner.temp }}/mesh-release-attestation-private-key.json
           attestation_public_key_file: ${{ runner.temp }}/mesh-release-attestation-public-key.json
+          commit: ${{ needs.metadata.outputs.source_sha }}
 
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
@@ -1347,6 +1349,7 @@ jobs:
           skip_ui: "true"
           attestation_signing_key_file: ${{ runner.temp }}/mesh-release-attestation-private-key.json
           attestation_public_key_file: ${{ runner.temp }}/mesh-release-attestation-public-key.json
+          commit: ${{ needs.metadata.outputs.source_sha }}
       - uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: host-input-windows-x86_64

--- a/scripts/tests/test_ci_artifact_actions.py
+++ b/scripts/tests/test_ci_artifact_actions.py
@@ -19,6 +19,7 @@ ACTIONS = ROOT / ".github" / "actions"
 COMPOSE_SCRIPT = ROOT / "scripts" / "ci-compose-product-input.sh"
 RELEASE_FOOTER_MANIFEST = ROOT / "crates" / "mesh-llm-release-footer" / "Cargo.toml"
 XTASK_MANIFEST = ROOT / "tools" / "xtask" / "Cargo.toml"
+RELEASE_WORKFLOW = ROOT / ".github" / "workflows" / "release.yml"
 
 
 class CiArtifactActionTests(unittest.TestCase):
@@ -509,6 +510,28 @@ class CiArtifactActionTests(unittest.TestCase):
         )
         self.assertNotIn("package-native-runtime.sh", action)
         self.assertNotIn("compose-product", action)
+
+    def test_release_stamps_refuse_to_guess_the_source_commit(self) -> None:
+        """A published binary has to say what it was built from (#1596)."""
+        for name in ("prepare-host-input", "prepare-windows-host-input"):
+            action = self.read_action(name)
+            with self.subTest(action=name):
+                self.assertIn("--require-source-commit", action)
+                self.assertIn("--commit", action)
+                self.assertIn("INPUT_COMMIT", action)
+
+    def test_release_workflow_stamps_the_immutable_source_revision(self) -> None:
+        workflow = RELEASE_WORKFLOW.read_text(encoding="utf-8")
+        attest_steps = workflow.count(
+            "attestation_signing_key_file: ${{ runner.temp }}"
+            "/mesh-release-attestation-private-key.json"
+        )
+        stamped_commits = workflow.count(
+            "commit: ${{ needs.metadata.outputs.source_sha }}"
+        )
+
+        self.assertGreater(attest_steps, 0)
+        self.assertEqual(attest_steps, stamped_commits)
 
     def test_windows_attestation_verifier_stays_native_abi_free(self) -> None:
         xtask = tomllib.loads(XTASK_MANIFEST.read_text(encoding="utf-8"))

--- a/tools/xtask/src/attestation.rs
+++ b/tools/xtask/src/attestation.rs
@@ -320,6 +320,7 @@ struct StampArgs {
     target_triple: Option<String>,
     protocol_min: Option<u32>,
     protocol_max: Option<u32>,
+    require_source_commit: bool,
 }
 
 #[derive(Default)]
@@ -372,6 +373,10 @@ pub(crate) fn stamp_release_attestation(args: &[String]) -> DynResult<()> {
         Some(version) => version,
         None => default_node_version()?,
     };
+    let commit = resolve_commit(parsed.commit);
+    if parsed.require_source_commit {
+        require_source_commit(&commit)?;
+    }
 
     let claims = ReleaseBuildAttestationClaims {
         version: RELEASE_BUILD_ATTESTATION_VERSION,
@@ -379,7 +384,7 @@ pub(crate) fn stamp_release_attestation(args: &[String]) -> DynResult<()> {
         build_id: parsed
             .build_id
             .unwrap_or_else(|| default_build_id(&binary, &artifact_digest)),
-        commit: parsed.commit.unwrap_or_else(default_commit),
+        commit,
         target_triple: parsed.target_triple.unwrap_or_else(default_target_triple),
         supported_protocol_generation_min: parsed.protocol_min,
         supported_protocol_generation_max: parsed.protocol_max,
@@ -552,6 +557,10 @@ fn parse_stamp_args(args: &[String]) -> DynResult<StampArgs> {
     let mut parsed = StampArgs::default();
     let mut iter = args.iter();
     while let Some(flag) = iter.next() {
+        if flag.as_str() == "--require-source-commit" {
+            parsed.require_source_commit = true;
+            continue;
+        }
         let value = iter
             .next()
             .ok_or_else(|| format!("missing value for {flag}"))?;
@@ -642,11 +651,136 @@ fn default_build_id(binary: &Path, artifact_digest: &str) -> String {
     format!("{stem}-{}", digest.get(..12).unwrap_or(digest))
 }
 
-fn default_commit() -> String {
-    std::env::var("GIT_COMMIT").unwrap_or_else(|_| "task8-local".to_string())
+/// Stand-in recorded when nothing can say what a binary was built from.
+/// Only ever correct for a local development build.
+const LOCAL_BUILD_COMMIT: &str = "task8-local";
+
+/// Resolves the source revision to record in the attestation.
+///
+/// Explicit wins, then the environment, then the checkout itself. The
+/// placeholder is last, and `--require-source-commit` rejects it outright,
+/// because a provenance field that silently invents a value is worse than one
+/// that refuses to be written.
+fn resolve_commit(explicit: Option<String>) -> String {
+    explicit
+        .map(|commit| commit.trim().to_string())
+        .filter(|commit| !commit.is_empty())
+        .or_else(|| {
+            std::env::var("GIT_COMMIT")
+                .ok()
+                .map(|commit| commit.trim().to_string())
+                .filter(|commit| !commit.is_empty())
+        })
+        .or_else(head_commit)
+        .unwrap_or_else(|| LOCAL_BUILD_COMMIT.to_string())
+}
+
+fn head_commit() -> Option<String> {
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "HEAD"])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let commit = String::from_utf8(output.stdout).ok()?.trim().to_string();
+    is_source_commit(&commit).then_some(commit)
+}
+
+/// A full 40-character lowercase hex object name. Abbreviated names are
+/// rejected too: an attestation is read long after the repository that could
+/// disambiguate one has moved on.
+fn is_source_commit(commit: &str) -> bool {
+    commit.len() == 40
+        && commit
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
+
+/// Fails a release stamp that could not establish what it was built from.
+fn require_source_commit(commit: &str) -> DynResult<()> {
+    if is_source_commit(commit) {
+        return Ok(());
+    }
+    Err(format!(
+        "--require-source-commit is set but the resolved commit {commit:?} is not a full 40-character \
+         lowercase hex object name. Pass --commit <sha>, set GIT_COMMIT, or run the stamp inside the \
+         checkout the binary was built from."
+    )
+    .into())
 }
 
 fn default_target_triple() -> String {
     std::env::var("TARGET")
         .unwrap_or_else(|_| format!("{}-{}", std::env::consts::ARCH, std::env::consts::OS))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const REAL_SHA: &str = "a12b535d7c4e1f09b8d3427a66c5e0f19d8a7b34";
+
+    #[test]
+    fn explicit_commit_wins_over_everything_else() {
+        assert_eq!(resolve_commit(Some(REAL_SHA.to_string())), REAL_SHA);
+    }
+
+    #[test]
+    fn blank_explicit_commit_falls_through_rather_than_stamping_an_empty_field() {
+        // An unset workflow input arrives as an empty string, not as an
+        // absent flag, so it has to fall through instead of being recorded.
+        assert_ne!(resolve_commit(Some("   ".to_string())), "   ");
+    }
+
+    #[test]
+    fn release_stamps_reject_the_local_development_placeholder() {
+        let error = require_source_commit(LOCAL_BUILD_COMMIT)
+            .expect_err("a release stamp must refuse the placeholder");
+
+        assert!(error.to_string().contains(LOCAL_BUILD_COMMIT));
+    }
+
+    #[test]
+    fn release_stamps_reject_abbreviated_and_empty_commits() {
+        for candidate in ["", "a12b535", "a12b535d7", "not-a-sha"] {
+            assert!(
+                require_source_commit(candidate).is_err(),
+                "{candidate:?} is not a full object name"
+            );
+        }
+    }
+
+    #[test]
+    fn release_stamps_accept_a_full_lowercase_object_name() {
+        assert!(require_source_commit(REAL_SHA).is_ok());
+    }
+
+    #[test]
+    fn uppercase_object_names_are_rejected_so_the_field_has_one_spelling() {
+        assert!(!is_source_commit(&REAL_SHA.to_ascii_uppercase()));
+    }
+
+    #[test]
+    fn stamp_args_parse_the_release_flag_alongside_valued_flags() {
+        let args: Vec<String> = [
+            "--binary",
+            "target/release/mesh-llm",
+            "--require-source-commit",
+            "--commit",
+            REAL_SHA,
+        ]
+        .iter()
+        .map(|value| (*value).to_string())
+        .collect();
+
+        let parsed = parse_stamp_args(&args).expect("flags parse");
+
+        assert!(parsed.require_source_commit);
+        assert_eq!(parsed.commit.as_deref(), Some(REAL_SHA));
+        assert_eq!(
+            parsed.binary,
+            Some(PathBuf::from("target/release/mesh-llm"))
+        );
+    }
 }


### PR DESCRIPTION
Closes #1596

Third PR in the 0.76.1 bugfix stack. #1760 and #1762 have both merged, so this now sits directly on `bugfix/0.76.1` as a single commit.

## Original problem

Every released binary reported `"commit": "task8-local"` in its `release_attestation`, on both architectures and on rc8 as well as rc9. The signature and `artifact_digest` verify, so the attestation is genuine. It just does not say what the binary was built from, which is the one question the field exists to answer.

`tools/xtask/src/attestation.rs` fell back to a hardcoded placeholder when `GIT_COMMIT` was unset, and nothing in the release workflow ever set it. The stamp command already accepted `--commit`, and no caller passed it.

## Fix

The stamp resolves the revision in order: `--commit`, then `GIT_COMMIT`, then `git rev-parse HEAD` in the checkout, then the placeholder. The git step on its own fixes local bundling through `scripts/package-release.sh`, which used to stamp the placeholder too.

Release lanes additionally pass `--require-source-commit`, which rejects anything that is not a full 40-character lowercase object name. Abbreviated names are rejected as well, since an attestation gets read long after the repository that could disambiguate one has moved on. A release stamp that cannot establish its provenance now fails with a message naming what it found and what to do about it, rather than inventing a value.

All three attesting call sites in `release.yml` (Linux x86_64, macOS aarch64, Windows) pass `needs.metadata.outputs.source_sha`, the immutable revision the job checked out, rather than letting the resolver guess. The CI host slices do not attest and are unchanged.

## Diagnostics

On carrack, from inside the checkout at `69e70f7e4cd5dfe84f6247dfa11d691c70ec3029`:

```
$ xtask release-attestation stamp --binary ... --signing-key-file ...
commit: 69e70f7e4cd5dfe84f6247dfa11d691c70ec3029
```

and from outside any repository, with the release flag set:

```
error: --require-source-commit is set but the resolved commit "task8-local" is not a full
40-character lowercase hex object name. Pass --commit <sha>, set GIT_COMMIT, or run the
stamp inside the checkout the binary was built from.
```

## Tests

Seven unit tests in `attestation.rs` covering the resolution order, the empty-workflow-input case (an unset `with:` input arrives as `""`, not as an absent flag, so it has to fall through rather than be recorded), and the rejection rules.

Two tests in `scripts/tests/test_ci_artifact_actions.py`. The second one counts attest steps in `release.yml` and asserts the count of `commit:` inputs matches, so a new release lane cannot quietly go back to guessing. `python3 -m unittest scripts.tests.test_ci_artifact_actions` is green at 52, and `cargo test -p xtask` at 32.

## Also worth doing

The issue suggests asserting `/api/status.release_attestation.commit` against the tag SHA before publishing. That belongs in the release checklist rather than here, and it is a better check once this PR makes the field meaningful.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Release attestations now include the immutable source commit used to produce each Linux and Windows build.
  - Release signing fails when a valid source commit cannot be identified, preventing attestations from referencing an incorrect revision.
  - Local builds continue to use an explicit fallback revision when no source commit is available.

- **Quality**
  - Added automated checks to verify that release artifacts consistently record the correct source revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
