### PR TITLE
ci: declare and enforce the Linux glibc floor for shipped artifacts

### DIFF
--- a/.github/actions/prepare-host-input/action.yml
+++ b/.github/actions/prepare-host-input/action.yml
@@ -110,7 +110,8 @@ runs:
 
         python3 scripts/verify-host-dependencies.py \
           "$binary_path" \
-          --report "$imports_path"
+          --report "$imports_path" \
+          --max-glibc declared
         if command -v sha256sum >/dev/null 2>&1; then
           checksum="$(sha256sum "$binary_path" | awk '{print $1}')"
         else

--- a/scripts/linux-glibc-floor.txt
+++ b/scripts/linux-glibc-floor.txt
@@ -1,0 +1,13 @@
+# Highest GLIBC symbol version any shipped Linux artifact may require.
+#
+# Read by scripts/verify-host-dependencies.py through --max-glibc. The host,
+# the native runtime libraries, and the executable tools packaged beside them
+# are all checked against it, so the floor is a declared number rather than a
+# side effect of whichever base image the release lane happened to build in.
+#
+# 2.39 is what v0.76.0 actually shipped: the host requires GLIBC_2.39 and the
+# native runtime libraries require GLIBC_2.38, because both are built on
+# Ubuntu 24.04 images. That excludes Ubuntu 22.04 (glibc 2.35), which is
+# mesh-llm#1522. Lowering this number is the real fix for that issue and it
+# means changing the build base image, not editing this file on its own.
+2.39

--- a/scripts/tests/test_native_artifact_verifiers.py
+++ b/scripts/tests/test_native_artifact_verifiers.py
@@ -667,6 +667,163 @@ class NativeArtifactVerifierTests(unittest.TestCase):
                         result.stdout + result.stderr,
                     )
 
+    def write_linux_runtime_artifact(
+        self,
+        root: Path,
+        *,
+        library_glibc: str,
+        tool_glibc: str,
+    ) -> Path:
+        """A Linux runtime package whose library and tool are ELF objects.
+
+        The contents are four magic bytes, not real ELF. What the glibc
+        floor check reads is `readelf -V` output, which
+        `stub_readelf` below supplies per file, so the versions each
+        artifact "needs" are set here rather than compiled in.
+        """
+        architecture = native_architecture()
+        artifact = root / f"meshllm-native-runtime-linux-{architecture}-cpu"
+        library = artifact / "lib" / "libllama.so"
+        tool = artifact / "tools" / "mesh-llm-gpu-bench"
+        library.parent.mkdir(parents=True)
+        tool.parent.mkdir(parents=True)
+        library.write_bytes(b"\x7fELF" + library_glibc.encode())
+        tool.write_bytes(b"\x7fELF" + tool_glibc.encode())
+        tool.chmod(0o755)
+        self.write_manifest(
+            artifact,
+            {
+                "runtime": {
+                    "id": artifact.name,
+                    "mesh_version": "0.75.0",
+                    "skippy_abi": "0.1.32",
+                    "platform": {
+                        "os": "linux",
+                        "arch": architecture,
+                        "target": native_linux_target(),
+                    },
+                    "backend": {"kind": "cpu"},
+                    "libraries": ["lib/libllama.so"],
+                    "files": {"lib/libllama.so": sha256(library)},
+                    "tools": {"tools/mesh-llm-gpu-bench": sha256(tool)},
+                },
+                "build": {
+                    "primary_library": "lib/libllama.so",
+                    "library_sha256": sha256(library),
+                },
+            },
+        )
+        return artifact
+
+    def stub_readelf(self, root: Path) -> Path:
+        """A `readelf` that reports the GLIBC version baked into each file.
+
+        Real ELF objects with a chosen version-needs section would have to
+        be hand-assembled or cross-compiled, and neither tests what is
+        actually in question here: whether the verifier ENUMERATES tools
+        alongside libraries. `readelf` parsing has its own tests in
+        `test_verify_host_dependencies.py`.
+        """
+        bin_dir = root / "stub-bin"
+        bin_dir.mkdir(exist_ok=True)
+        readelf = bin_dir / "readelf"
+        readelf.write_text(
+            "#!/usr/bin/env python3\n"
+            "import sys\n"
+            "path = sys.argv[-1]\n"
+            "flag = sys.argv[1] if len(sys.argv) > 2 else ''\n"
+            "with open(path, 'rb') as handle:\n"
+            "    version = handle.read()[4:].decode('utf-8', 'replace')\n"
+            "if flag == '-V':\n"
+            "    print('Version needs section \\'.gnu.version_r\\' contains 1 entry:')\n"
+            "    print('  000000: Name: libc.so.6  Flags: none  Version: 2')\n"
+            "    print(f'  0x0010:   Name: GLIBC_{version}  Flags: none  Version: 2')\n"
+            "else:\n"
+            "    print(' 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]')\n"
+            "    print(' 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]')\n",
+            encoding="utf-8",
+        )
+        readelf.chmod(0o755)
+        return bin_dir
+
+    def run_verifier_with_stub_readelf(
+        self,
+        artifact: Path,
+        stub_bin: Path,
+    ) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                bash_executable(),
+                RUNTIME_VERIFIER.as_posix(),
+                artifact.as_posix(),
+            ],
+            cwd=ROOT,
+            check=False,
+            capture_output=True,
+            text=True,
+            env={**os.environ, "PATH": f"{stub_bin}{os.pathsep}{os.environ['PATH']}"},
+        )
+
+    def test_runtime_rejects_an_over_floor_elf_tool(self) -> None:
+        """A packaged tool above the declared ceiling has to fail the gate.
+
+        The package ships executables as well as libraries:
+        `package-native-runtime.sh` builds the GPU benchmark and
+        `skippy-model-package`, and the host runs the benchmark from
+        `crates/mesh-llm-system/src/benchmark.rs`. Enumerating only
+        `runtime.libraries` let a tool needing a newer glibc than the floor
+        pass here and then fail on a supported host.
+        """
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            stub_bin = self.stub_readelf(root)
+            artifact = self.write_linux_runtime_artifact(
+                root,
+                library_glibc="2.35",
+                tool_glibc="2.99",
+            )
+
+            result = self.run_verifier_with_stub_readelf(artifact, stub_bin)
+
+            output = result.stdout + result.stderr
+            self.assertNotEqual(result.returncode, 0, output)
+            self.assertIn("mesh-llm-gpu-bench", output)
+            self.assertIn("GLIBC_2.99", output)
+
+    def test_runtime_accepts_a_tool_within_the_declared_floor(self) -> None:
+        """The control. Without it the test above would still pass if the
+        verifier rejected every package it was handed."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            stub_bin = self.stub_readelf(root)
+            artifact = self.write_linux_runtime_artifact(
+                root,
+                library_glibc="2.35",
+                tool_glibc="2.35",
+            )
+
+            result = self.run_verifier_with_stub_readelf(artifact, stub_bin)
+
+            output = result.stdout + result.stderr
+            self.assertNotIn("GLIBC", output, output)
+
+    def test_runtime_still_rejects_an_over_floor_library(self) -> None:
+        """Libraries were already covered. Adding tools must not drop them."""
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            stub_bin = self.stub_readelf(root)
+            artifact = self.write_linux_runtime_artifact(
+                root,
+                library_glibc="2.99",
+                tool_glibc="2.35",
+            )
+
+            result = self.run_verifier_with_stub_readelf(artifact, stub_bin)
+
+            output = result.stdout + result.stderr
+            self.assertNotEqual(result.returncode, 0, output)
+            self.assertIn("libllama.so", output)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/scripts/tests/test_verify_host_dependencies.py
+++ b/scripts/tests/test_verify_host_dependencies.py
@@ -42,6 +42,75 @@ class VerifyHostDependenciesTests(unittest.TestCase):
         )
         self.assertNotIn("verify-host-dependencies.py", workflow)
 
+    def test_declared_linux_glibc_floor_is_a_single_parseable_version(self) -> None:
+        floor = MODULE.read_declared_glibc_floor(
+            ROOT / "scripts" / "linux-glibc-floor.txt"
+        )
+
+        self.assertEqual(len(floor), 2)
+        self.assertGreaterEqual(floor, (2, 17))
+
+    def test_glibc_floor_reads_only_the_version_needs_section(self) -> None:
+        # A shared library defines its own versions in the same readelf
+        # output. Counting those would report a floor the loader never checks.
+        output = """
+Version definition section '.gnu.version_d' contains 2 entries:
+  000000: Rev: 1  Flags: BASE  Index: 1  Cnt: 1  Name: GLIBC_2.99
+
+Version needs section '.gnu.version_r' contains 1 entry:
+  0x0000: Version: 1  File: libc.so.6  Cnt: 3
+  0x0010:   Name: GLIBC_2.14  Flags: none  Version: 4
+  0x0020:   Name: GLIBC_2.38  Flags: none  Version: 3
+  0x0030:   Name: GLIBC_2.4  Flags: none  Version: 2
+"""
+
+        self.assertEqual(MODULE.parse_elf_glibc_floor(output), (2, 38))
+
+    def test_glibc_floor_orders_versions_numerically_not_lexically(self) -> None:
+        output = """
+Version needs section '.gnu.version_r' contains 1 entry:
+  0x0010:   Name: GLIBC_2.9  Flags: none  Version: 3
+  0x0020:   Name: GLIBC_2.34  Flags: none  Version: 2
+"""
+
+        self.assertEqual(MODULE.parse_elf_glibc_floor(output), (2, 34))
+
+    def test_binaries_without_a_version_needs_section_have_no_floor(self) -> None:
+        self.assertIsNone(MODULE.parse_elf_glibc_floor("no versions here"))
+
+    def test_max_glibc_accepts_a_literal_version_or_the_declared_file(self) -> None:
+        self.assertEqual(MODULE.resolve_max_glibc("2.35"), (2, 35))
+        self.assertIsNone(MODULE.resolve_max_glibc(None))
+        self.assertEqual(
+            MODULE.resolve_max_glibc("declared"),
+            MODULE.read_declared_glibc_floor(
+                ROOT / "scripts" / "linux-glibc-floor.txt"
+            ),
+        )
+
+    def test_host_and_runtime_lanes_both_enforce_the_declared_floor(self) -> None:
+        unix_action = (
+            ROOT / ".github" / "actions" / "prepare-host-input" / "action.yml"
+        ).read_text(encoding="utf-8")
+        runtime_verifier = (
+            ROOT / "scripts" / "verify-native-runtime-package.sh"
+        ).read_text(encoding="utf-8")
+
+        self.assertIn("--max-glibc declared", unix_action)
+        self.assertIn("--max-glibc declared", runtime_verifier)
+        self.assertIn("verify_linux_glibc_floor", runtime_verifier)
+        # Tools ship in the package too and the host executes the GPU
+        # benchmark, so enumerating only libraries let an over-floor tool
+        # through. Behavior is covered in test_native_artifact_verifiers.
+        self.assertIn(
+            'for rel_path in [*runtime["libraries"], *(runtime.get("tools") or {})]:',
+            runtime_verifier,
+        )
+        # Runtime libraries import each other, so the host policy is off for
+        # them and stays on for the host.
+        self.assertIn("--no-import-policy", runtime_verifier)
+        self.assertNotIn("--no-import-policy", unix_action)
+
     def test_parses_elf_needed_entries(self) -> None:
         imports = MODULE.parse_elf_imports(
             """

--- a/scripts/verify-host-dependencies.py
+++ b/scripts/verify-host-dependencies.py
@@ -35,6 +35,49 @@ FORBIDDEN_IMPORTS = tuple(
 )
 
 
+GLIBC_VERSION_RE = re.compile(r"GLIBC_(\d+)\.(\d+)")
+VERSION_NEEDS_HEADING = "Version needs section"
+
+
+def parse_version(value: str) -> tuple[int, int]:
+    major, _, minor = value.strip().partition(".")
+    return int(major), int(minor)
+
+
+def format_version(version: tuple[int, int]) -> str:
+    return f"{version[0]}.{version[1]}"
+
+
+def read_declared_glibc_floor(path: Path) -> tuple[int, int]:
+    """Reads the shared floor file, ignoring its explanatory comments."""
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if stripped and not stripped.startswith("#"):
+            return parse_version(stripped)
+    raise ValueError(f"no glibc floor declared in {path}")
+
+
+def parse_elf_glibc_floor(output: str) -> tuple[int, int] | None:
+    """Highest GLIBC symbol version the binary needs from the host's libc.
+
+    Only the version-needs section counts. A shared library's own version
+    definitions live in the same `readelf -V` output and say nothing about
+    what libc it will refuse to load against.
+    """
+    _, heading, needs = output.partition(VERSION_NEEDS_HEADING)
+    if not heading:
+        return None
+    versions = [
+        (int(major), int(minor))
+        for major, minor in GLIBC_VERSION_RE.findall(needs)
+    ]
+    return max(versions) if versions else None
+
+
+def inspect_glibc_floor(path: Path) -> tuple[int, int] | None:
+    return parse_elf_glibc_floor(run_tool(("readelf", "-V", str(path))))
+
+
 def binary_format(path: Path) -> str:
     header = path.read_bytes()[:4]
     if header == b"\x7fELF":
@@ -115,19 +158,48 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
     parser.add_argument("binary", type=Path)
     parser.add_argument("--format", choices=("elf", "macho", "pe"))
     parser.add_argument("--report", type=Path)
+    parser.add_argument(
+        "--no-import-policy",
+        action="store_true",
+        help=(
+            "Report imports without enforcing the host policy. Native runtime "
+            "libraries legitimately import each other, so only the glibc floor "
+            "applies to them."
+        ),
+    )
+    parser.add_argument(
+        "--max-glibc",
+        help=(
+            "Reject an ELF binary that needs a GLIBC symbol version above this "
+            "one, or the literal 'declared' to read scripts/linux-glibc-floor.txt."
+        ),
+    )
     return parser.parse_args(argv)
+
+
+def resolve_max_glibc(value: str | None) -> tuple[int, int] | None:
+    if value is None:
+        return None
+    if value == "declared":
+        return read_declared_glibc_floor(
+            Path(__file__).resolve().parent / "linux-glibc-floor.txt"
+        )
+    return parse_version(value)
 
 
 def main(argv: list[str]) -> int:
     args = parse_args(argv)
     try:
         format_name, imports = inspect_dependencies(args.binary, args.format)
-        rejected = forbidden_imports(imports)
+        rejected = [] if args.no_import_policy else forbidden_imports(imports)
+        max_glibc = resolve_max_glibc(args.max_glibc)
+        glibc_floor = inspect_glibc_floor(args.binary) if format_name == "elf" else None
         report = {
             "binary": args.binary.name,
             "format": format_name,
+            "glibc_floor": format_version(glibc_floor) if glibc_floor else None,
             "imports": imports,
-            "policy": "mesh-llm-dynamic-host-v2",
+            "policy": "none" if args.no_import_policy else "mesh-llm-dynamic-host-v2",
             "rejected_imports": rejected,
         }
         if args.report:
@@ -140,6 +212,14 @@ def main(argv: list[str]) -> int:
         if rejected:
             print(
                 "host dependency policy rejected: " + ", ".join(rejected),
+                file=sys.stderr,
+            )
+            return 1
+        if max_glibc and glibc_floor and glibc_floor > max_glibc:
+            print(
+                f"{args.binary.name} needs GLIBC_{format_version(glibc_floor)} but the "
+                f"declared floor is {format_version(max_glibc)}. Raising the floor drops "
+                "Linux distributions that were supported before; see mesh-llm#1522.",
                 file=sys.stderr,
             )
             return 1

--- a/scripts/verify-native-runtime-package.sh
+++ b/scripts/verify-native-runtime-package.sh
@@ -17,6 +17,7 @@ Verifies MeshLLM native runtime artifacts:
   - artifact directory name matches runtime.id
   - all runtime.libraries exist
   - library_sha256 matches the primary library
+  - Linux ELF libraries and tools stay within the declared glibc floor
   - Linux shared-library RUNPATH/RPATH is relocatable and resolves packaged deps
   - Windows non-system DLL imports are present in the artifact
   - required archive checksum sidecar
@@ -372,6 +373,52 @@ for rel_path in [*libraries, *tools]:
 PY
 }
 
+# Keeps the packaged runtime loadable on every Linux distribution the release
+# claims to support. Without this the floor is whatever the build image
+# happened to provide, which is how mesh-llm#1522 shipped libraries needing
+# GLIBC_2.38 to hosts running 2.35. Covers runtime.libraries AND runtime.tools:
+# both ship in the package, and a tool linked above the ceiling fails on a
+# supported host exactly like a library does. The host import policy does not
+# apply here: runtime libraries legitimately import each other.
+verify_linux_glibc_floor() {
+    local artifact_dir="$1" manifest="$2"
+    local py rel_path
+    py="$(python_bin)"
+    while IFS= read -r rel_path; do
+        [[ -n "$rel_path" ]] || continue
+        "$py" "$SCRIPT_DIR/verify-host-dependencies.py" \
+            "$artifact_dir/$rel_path" \
+            --no-import-policy \
+            --max-glibc declared \
+            >/dev/null
+    done < <("$py" - "$artifact_dir" "$manifest" <<'PY'
+import json
+import os
+import sys
+
+artifact_dir, manifest_path = sys.argv[1:3]
+with open(manifest_path, encoding="utf-8") as fh:
+    manifest = json.load(fh)
+runtime = manifest["runtime"]
+# Tools ship in the package too: package-native-runtime.sh builds the GPU
+# benchmark and skippy-model-package, and the host executes the benchmark
+# from crates/mesh-llm-system/src/benchmark.rs. A tool linked above the
+# declared ceiling fails on a supported host exactly like a library does,
+# so the floor in scripts/linux-glibc-floor.txt covers both.
+for rel_path in [*runtime["libraries"], *(runtime.get("tools") or {})]:
+    # Only ELF objects have a glibc floor. Anything else in the package is
+    # the surrounding verifier's business, not this check's.
+    try:
+        with open(os.path.join(artifact_dir, rel_path), "rb") as handle:
+            if handle.read(4) != b"\x7fELF":
+                continue
+    except OSError:
+        continue
+    print(rel_path)
+PY
+    )
+}
+
 verify_linux_runtime_paths() {
     local artifact_dir="$1"
     local manifest="$2"
@@ -390,6 +437,7 @@ PY
         echo "readelf is required to verify Linux native runtime shared libraries" >&2
         exit 1
     fi
+    verify_linux_glibc_floor "$artifact_dir" "$manifest"
     "$(python_bin)" - "$artifact_dir" "$manifest" <<'PY'
 import json
 import os


### PR DESCRIPTION
Refs #1522

Fourth PR in the 0.76.1 bugfix stack. Base is #1765, so the diff to review is the fourth commit.

## What I found

The issue asked whether the 0.76.0-rc6 native runtime is supposed to require glibc 2.38. I measured the **published v0.76.0** x86_64 cuda-13 bundle, checksum-verified, on carrack:

| Artifact | Requires |
|---|---|
| `mesh-llm` (host) | **GLIBC_2.39** |
| `libllama.so.0.4.0` | GLIBC_2.38 |
| `libggml-cuda.so.0.23.0` | GLIBC_2.38 |
| `libggml-cpu.so.0.23.0` | GLIBC_2.38 |
| `libmtmd.so.0.4.0` | GLIBC_2.38 |
| `libggml.so.0.23.0` | GLIBC_2.34 |

Ubuntu 22.04 ships glibc 2.35, so v0.76.0 does not run there at all, and the floor is higher than the report says. The **host** needs 2.39 and fails before the native runtime anyone would blame ever gets loaded. The reporter hit the runtime error because they had built the host locally on the box; a stock install would not get that far.

The cause is that everything Linux is built on Ubuntu 24.04: `build_native_runtime` uses `ubuntu-24.04` and `ubuntu-24.04-arm`, and the CUDA and ROCm runtimes build inside `ghcr.io/mesh-llm/mesh-llm-cuda-runner`, which is 24.04-based. The floor was never chosen. It is a side effect of the base image, and nothing in the build measured it.

## What this PR does

It makes the floor a declared number instead of an accident.

`scripts/linux-glibc-floor.txt` holds one version that both Linux lanes check. `verify-host-dependencies.py` gains a `--max-glibc` flag: it reads the highest GLIBC symbol version the binary needs from its `.gnu.version_r` section, reports it as `glibc_floor`, and fails when it exceeds the declared value. `prepare-host-input` checks the host and `verify-native-runtime-package.sh` checks every packaged Linux runtime library in the same Linux-gated, non-portable path that already runs `readelf` over them.

Only the version-needs section counts. A shared library's own version definitions appear in the same `readelf -V` output and say nothing about which libc it will refuse to load against, so counting them would report a floor the loader never checks.

Runtime libraries import each other, so the host import policy cannot apply to them. `--no-import-policy` measures the floor without it, and the host keeps the policy on.

## What this PR does not do

It does not make Ubuntu 22.04 work. The floor starts at **2.39**, which is what already shipped, and `linux-glibc-floor.txt` says so in as many words.

Lowering it is the real fix and it belongs in `mesh-llm-runner-images` plus the two `ubuntu-24.04` runners in `release.yml`: build the Linux host and native runtimes against a 22.04 or manylinux_2_28 base. That is not a point-release change, it needs a full release lane to validate, and it partly lives in another repo. I would keep #1522 open for it and treat this PR as the guard that stops the number drifting further while that happens.

Two other things from the issue that are still open and worth their own work: `doctor` reports `status: ok` because it only checks file presence, so it should either dlopen the resolved artifact or compare its floor against the host's glibc; and the `vulkan` flavor is not offered at all on linux/x86_64 for Skippy ABI 0.1.39.

## Diagnostics

Against the published bundle:

```
$ python3 scripts/verify-host-dependencies.py mesh-bundle/mesh-llm --max-glibc 2.35
mesh-llm needs GLIBC_2.39 but the declared floor is 2.35. Raising the floor drops
Linux distributions that were supported before; see mesh-llm#1522.
exit=1

$ python3 scripts/verify-host-dependencies.py mesh-bundle/mesh-llm --max-glibc declared
exit=0
```

## Tests

Six tests in `scripts/tests/test_verify_host_dependencies.py`, including one that a version-definitions section is ignored and one that versions sort numerically rather than lexically, so `2.9` does not outrank `2.34`. The file is green at 11.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Linux compatibility validation by detecting binaries that require unsupported GLIBC versions.
  - Linux runtime packages are now checked against the declared GLIBC 2.39 compatibility ceiling before release.
  - Verification reports now include detected GLIBC requirements and clearly indicate when import-policy checks are disabled.
  - Added coverage for version parsing and compatibility enforcement to reduce the risk of shipping packages that fail to load on supported distributions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->