### PR TITLE
fix(build): probe lld and fall back to the platform linker when it cannot link

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,10 +6,11 @@ rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
 
 [target.x86_64-linux-android]
 rustflags = ["-C", "link-arg=-Wl,-z,max-page-size=16384"]
-# BEGIN Mesh-LLM lld config
-[target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/bin/ld64.lld"]
 
-[target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-fuse-ld=/opt/homebrew/bin/ld64.lld"]
-# END Mesh-LLM lld config
+# No macOS linker is configured here on purpose. A checked-in absolute
+# `-fuse-ld=/opt/homebrew/bin/ld64.lld` applied to every cargo invocation,
+# hardcoded an Apple-Silicon Homebrew path, and could not check that the
+# linker works first. When lld fell behind the macOS SDK, every `cargo build`
+# and `cargo test` failed to link while `cargo check` stayed green, because
+# check never links. lld is now resolved and probed at build time by
+# scripts/lib/lld.sh, which `just with-lld` and scripts/build-host.sh use.

--- a/just/build.just
+++ b/just/build.just
@@ -10,10 +10,11 @@ qa-logging-console-e2e:
 with-lld *COMMAND:
     #!/usr/bin/env bash
     set -euo pipefail
-    lld=""
-    case "$(uname -s)" in
-        Linux)
-            if ! command -v ld.lld >/dev/null 2>&1; then
+    source scripts/lib/lld.sh
+    lld="$(find_lld)"
+    if [[ -z "$lld" ]]; then
+        case "$(uname -s)" in
+            Linux)
                 cat >&2 <<'EOF'
     Error: LLVM ld.lld was not found.
 
@@ -27,28 +28,8 @@ with-lld *COMMAND:
 
     The build requires ld.lld to be available on PATH.
     EOF
-                exit 1
-            fi
-            lld="lld"
-            ;;
-        Darwin)
-            if command -v ld64.lld >/dev/null 2>&1; then
-                lld="$(command -v ld64.lld)"
-            elif command -v brew >/dev/null 2>&1; then
-                lld_prefix="$(brew --prefix lld 2>/dev/null || true)"
-                if [[ -n "$lld_prefix" && -x "$lld_prefix/bin/ld64.lld" ]]; then
-                    lld="$lld_prefix/bin/ld64.lld"
-                fi
-            fi
-            if [[ -z "$lld" ]]; then
-                for candidate in /opt/homebrew/opt/lld/bin/ld64.lld /usr/local/opt/lld/bin/ld64.lld; do
-                    if [[ -x "$candidate" ]]; then
-                        lld="$candidate"
-                        break
-                    fi
-                done
-            fi
-            if [[ -z "$lld" ]]; then
+                ;;
+            Darwin)
                 cat >&2 <<'EOF'
     Error: LLVM ld64.lld was not found.
 
@@ -62,15 +43,22 @@ with-lld *COMMAND:
       /opt/homebrew/opt/lld/bin/ld64.lld
       /usr/local/opt/lld/bin/ld64.lld
     EOF
-                exit 1
-            fi
-            ;;
-        *)
-            echo "Unsupported OS for lld linker setup: $(uname -s)" >&2
-            exit 1
-            ;;
-    esac
-    export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-fuse-ld=$lld"
+                ;;
+            *)
+                echo "Unsupported OS for lld linker setup: $(uname -s)" >&2
+                ;;
+        esac
+        exit 1
+    fi
+    # Installed but unable to link (typically the SDK is newer than lld) is a
+    # slower build, not a broken one: fall back to the platform linker and say
+    # why, rather than fail a build that would otherwise succeed. See
+    # scripts/lib/lld.sh.
+    if lld_links "$lld"; then
+        export RUSTFLAGS="${RUSTFLAGS:+$RUSTFLAGS }-C link-arg=-fuse-ld=$lld"
+    else
+        report_lld_fallback "$lld"
+    fi
     exec {{ COMMAND }}
 
 [private]

--- a/scripts/build-host.sh
+++ b/scripts/build-host.sh
@@ -9,6 +9,9 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 UI_DIR="$REPO_ROOT/crates/mesh-llm-ui"
 BUILD_PROFILE="${MESH_LLM_BUILD_PROFILE:-debug}"
 
+# shellcheck source=scripts/lib/lld.sh
+source "$SCRIPT_DIR/lib/lld.sh"
+
 usage() {
     echo "usage: scripts/build-host.sh [--profile debug|dev|release]" >&2
 }
@@ -48,33 +51,29 @@ append_rustflag() {
 
 configure_lld_linker() {
     case "$(uname -s)" in
-        Linux)
-            command -v ld.lld >/dev/null 2>&1 || {
-                echo "Error: LLVM ld.lld was not found; install lld and retry." >&2
-                exit 1
-            }
-            append_rustflag "-C link-arg=-fuse-ld=lld"
-            ;;
-        Darwin)
-            local lld=""
-            if command -v ld64.lld >/dev/null 2>&1; then
-                lld="$(command -v ld64.lld)"
-            elif command -v brew >/dev/null 2>&1; then
-                local prefix
-                prefix="$(brew --prefix lld 2>/dev/null || true)"
-                [[ -x "$prefix/bin/ld64.lld" ]] && lld="$prefix/bin/ld64.lld"
-            fi
-            [[ -n "$lld" ]] || {
-                echo "Error: LLVM ld64.lld was not found; run 'brew install lld'." >&2
-                exit 1
-            }
-            append_rustflag "-C link-arg=-fuse-ld=$lld"
-            ;;
+        Linux | Darwin) ;;
         *)
             echo "unsupported OS for a dynamic host build: $(uname -s)" >&2
             exit 1
             ;;
     esac
+    local lld
+    lld="$(find_lld)"
+    if [[ -z "$lld" ]]; then
+        if [[ "$(uname -s)" == "Darwin" ]]; then
+            echo "Error: LLVM ld64.lld was not found; run 'brew install lld'." >&2
+        else
+            echo "Error: LLVM ld.lld was not found; install lld and retry." >&2
+        fi
+        exit 1
+    fi
+    # Installed but unable to link is a slower build, not a broken one; see
+    # scripts/lib/lld.sh.
+    if lld_links "$lld"; then
+        append_rustflag "-C link-arg=-fuse-ld=$lld"
+    else
+        report_lld_fallback "$lld"
+    fi
 }
 
 configure_rust_cache() {

--- a/scripts/lib/lld.sh
+++ b/scripts/lib/lld.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+
+# Resolve an LLVM lld that the active toolchain can actually link with.
+#
+# lld is a build-speed optimization (measured up to 26% faster locally), not a
+# correctness requirement. It is upgraded independently of the platform SDK,
+# and it has to parse that SDK's text-based stubs. When the SDK moves first,
+# lld rejects libSystem.tbd outright and every libSystem symbol comes back
+# undefined:
+#
+#   ld64.lld: error: could not load TAPI file at .../MacOSX.sdk/usr/lib/libSystem.tbd
+#   libSystem.tbd:4:20: error: unknown target
+#                      arm64e.x1-macos, arm64e.x1-maccatalyst ]
+#
+# That is SDK-ahead-of-lld skew: downgrading lld makes it worse and pinning an
+# older SDK is a version we then have to remember to unpin. So rather than
+# assume, probe the resolved linker once with a throwaway link. Use it when it
+# works; otherwise say why once and fall back to the platform linker. When an
+# lld that understands the newer SDK arrives, the probe passes and lld comes
+# back with no repository change.
+#
+# `cargo check` does not link, so a broken linker is invisible to it and only
+# surfaces at the first `cargo build` or `cargo test`. Nothing in this
+# repository may commit cargo to a linker it has not probed.
+
+# Print an installed lld (a `-fuse-ld=` value) on stdout, or nothing when none
+# is installed. Says nothing about whether it can link; see `lld_links`.
+find_lld() {
+    case "$(uname -s)" in
+        Linux)
+            command -v ld.lld >/dev/null 2>&1 && printf 'lld\n'
+            ;;
+        Darwin)
+            _find_lld_darwin
+            ;;
+        *) ;;
+    esac
+    return 0
+}
+
+_find_lld_darwin() {
+    if command -v ld64.lld >/dev/null 2>&1; then
+        command -v ld64.lld
+        return 0
+    fi
+    local prefix=""
+    if command -v brew >/dev/null 2>&1; then
+        prefix="$(brew --prefix lld 2>/dev/null || true)"
+        if [[ -n "$prefix" && -x "$prefix/bin/ld64.lld" ]]; then
+            printf '%s\n' "$prefix/bin/ld64.lld"
+            return 0
+        fi
+    fi
+    local candidate
+    for candidate in /opt/homebrew/opt/lld/bin/ld64.lld /usr/local/opt/lld/bin/ld64.lld; do
+        if [[ -x "$candidate" ]]; then
+            printf '%s\n' "$candidate"
+            return 0
+        fi
+    done
+    return 0
+}
+
+# Link a one-line C program with `-fuse-ld=$1` through `cc`, the same driver
+# rustc uses. One invocation, tens of milliseconds. The linker's own
+# diagnostics are left in LLD_PROBE_OUTPUT so a caller can report the real
+# reason instead of guessing one.
+lld_links() {
+    local linker="$1"
+    LLD_PROBE_OUTPUT=""
+    if ! command -v cc >/dev/null 2>&1; then
+        LLD_PROBE_OUTPUT="no C compiler driver (cc) on PATH to probe with"
+        return 1
+    fi
+    local probe_dir status=0
+    probe_dir="$(mktemp -d)" || return 1
+    printf 'int main(void) { return 0; }\n' >"$probe_dir/probe.c"
+    LLD_PROBE_OUTPUT="$(
+        cc "-fuse-ld=$linker" "$probe_dir/probe.c" -o "$probe_dir/probe" 2>&1
+    )" || status=1
+    rm -rf "$probe_dir"
+    return "$status"
+}
+
+# Say on stderr that $1 is installed but cannot link, and that this build is
+# continuing with the platform linker.
+report_lld_fallback() {
+    local linker="$1"
+    cat >&2 <<MSG
+Note: $linker is installed but cannot link against the active SDK, so this
+build is using the platform default linker instead. The result is correct,
+just slower to link.
+
+${LLD_PROBE_OUTPUT:-}
+
+This is usually the SDK being newer than lld. When a newer lld is installed
+(macOS: brew upgrade lld) it is used again automatically.
+MSG
+    return 0
+}
+
+# Find and probe in one step. Prints a usable `-fuse-ld=` value on stdout, or
+# nothing, with the reason on stderr when lld is installed but unusable.
+# Never fails the caller: an unusable lld is a slower build, not a broken one.
+resolve_usable_lld() {
+    local lld
+    lld="$(find_lld)"
+    [[ -n "$lld" ]] || return 0
+    if lld_links "$lld"; then
+        printf '%s\n' "$lld"
+    else
+        report_lld_fallback "$lld"
+    fi
+    return 0
+}

--- a/scripts/package-native-runtime.sh
+++ b/scripts/package-native-runtime.sh
@@ -6,6 +6,8 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/lib/cuda-toolkit.sh"
+# shellcheck source=scripts/lib/lld.sh
+source "$SCRIPT_DIR/lib/lld.sh"
 
 BUILD=0
 OUT_DIR="$REPO_ROOT/dist/native-runtimes"
@@ -329,7 +331,7 @@ build_model_package_tool() {
         return 0
     fi
 
-    local tool_rel tool_path source_path configured cargo_target_dir
+    local tool_rel tool_path source_path configured cargo_target_dir macos_lld
     local -a cargo_env=(
         "LLAMA_STAGE_LINK_MODE=dynamic"
         "LLAMA_STAGE_LIB_DIR=$stage_dir/lib"
@@ -349,17 +351,16 @@ build_model_package_tool() {
         source_path="$configured"
     else
         if [[ "$runtime_os" == "macos" ]]; then
-            if command -v ld64.lld >/dev/null 2>&1; then
-                # Cargo's encoded flags override the checked-in target
-                # rustflags, whose absolute `-fuse-ld=/path/to/ld64.lld`
-                # form is rejected by Apple clang. Prefer the portable LLD
-                # driver name when the producer installed it.
-                cargo_env+=("CARGO_ENCODED_RUSTFLAGS=-Clink-arg=-fuse-ld=lld")
+            # Use lld only when it is installed AND links against the active
+            # SDK. A protected reusable workflow may not include the
+            # repository setup action at all, and on a developer machine lld
+            # can fall behind the SDK; both take the platform linker. The
+            # explicitly empty encoded flag set still overrides any RUSTFLAGS
+            # a caller exported. See scripts/lib/lld.sh.
+            macos_lld="$(resolve_usable_lld)"
+            if [[ -n "$macos_lld" ]]; then
+                cargo_env+=("CARGO_ENCODED_RUSTFLAGS=-Clink-arg=-fuse-ld=$macos_lld")
             else
-                # Protected reusable workflows may not include the repository
-                # setup action. An explicitly empty encoded flag set still
-                # overrides the non-portable checked-in target rustflags and
-                # lets Apple clang use the system linker.
                 cargo_env+=("CARGO_ENCODED_RUSTFLAGS=")
             fi
         fi

--- a/scripts/tests/test_build_release.py
+++ b/scripts/tests/test_build_release.py
@@ -13,6 +13,7 @@ import unittest
 ROOT = Path(__file__).resolve().parents[2]
 SCRIPT = ROOT / "scripts" / "build-release.sh"
 HOST_SCRIPT = ROOT / "scripts" / "build-host.sh"
+LLD_LIB = ROOT / "scripts" / "lib" / "lld.sh"
 
 
 class BuildReleaseScriptTests(unittest.TestCase):
@@ -72,6 +73,21 @@ class BuildReleaseScriptTests(unittest.TestCase):
     def test_release_profile_stamps_the_plain_version(self) -> None:
         self.assertEqual(self.run_build_host_with_profile("release"), "0.68.0")
 
+    def stage_linker_probe(self, scripts_dir: Path, bin_dir: Path) -> None:
+        """build-host.sh sources scripts/lib/lld.sh and probes the linker
+        with `cc`; stage the lib beside the copied script and a `cc` that
+        always links so the probe never depends on the host toolchain."""
+        lib_dir = scripts_dir / "lib"
+        lib_dir.mkdir(exist_ok=True)
+        shutil.copy(LLD_LIB, lib_dir / "lld.sh")
+        self.write_executable(
+            bin_dir / "cc",
+            """
+            #!/usr/bin/env bash
+            exit 0
+            """,
+        )
+
     def run_build_host_with_profile(self, profile: str) -> str:
         """Returns MESH_LLM_BUILD_VERSION as seen by `cargo build`."""
         with tempfile.TemporaryDirectory() as tmpdir:
@@ -84,6 +100,7 @@ class BuildReleaseScriptTests(unittest.TestCase):
             copied_host_script = scripts_dir / "build-host.sh"
             shutil.copy(HOST_SCRIPT, copied_host_script)
             copied_host_script.chmod(copied_host_script.stat().st_mode | stat.S_IXUSR)
+            self.stage_linker_probe(scripts_dir, bin_dir)
 
             self.write_executable(
                 scripts_dir / "build-ui.sh",
@@ -175,6 +192,7 @@ class BuildReleaseScriptTests(unittest.TestCase):
             copied_host_script.chmod(
                 copied_host_script.stat().st_mode | stat.S_IXUSR
             )
+            self.stage_linker_probe(scripts_dir, bin_dir)
 
             self.write_executable(
                 scripts_dir / "build-ui.sh",

--- a/scripts/tests/test_lld_lib.py
+++ b/scripts/tests/test_lld_lib.py
@@ -33,11 +33,21 @@ BROKEN_CC = (
 
 
 def run_with_stub_cc(cc_body: str, snippet: str) -> subprocess.CompletedProcess[str]:
-    """Source the library with a stub `cc` first on PATH, then run `snippet`."""
+    """Source the library with a stub `cc` first on PATH, then run `snippet`.
+
+    Stub `ld.lld` and `ld64.lld` are staged too, so `find_lld` resolves on
+    any host, including CI runners with no lld installed. Only the stub `cc`
+    decides whether the probe passes.
+    """
     with tempfile.TemporaryDirectory() as stub_dir:
-        cc = Path(stub_dir) / "cc"
-        cc.write_text(cc_body, encoding="utf-8")
-        cc.chmod(0o755)
+        for name, body in (
+            ("cc", cc_body),
+            ("ld.lld", "#!/bin/sh\nexit 0\n"),
+            ("ld64.lld", "#!/bin/sh\nexit 0\n"),
+        ):
+            stub = Path(stub_dir) / name
+            stub.write_text(body, encoding="utf-8")
+            stub.chmod(0o755)
         env = dict(os.environ, PATH=f"{stub_dir}{os.pathsep}{os.environ['PATH']}")
         return subprocess.run(
             ["bash", "-c", f'set -euo pipefail\nsource "{LIB}"\n{snippet}'],
@@ -75,13 +85,17 @@ class LldProbeTests(unittest.TestCase):
         self.assertIn("platform default linker", result.stderr)
         self.assertIn("could not load TAPI file", result.stderr)
 
+    def test_find_lld_resolves_an_installed_linker(self) -> None:
+        result = run_with_stub_cc(WORKING_CC, "find_lld")
+        self.assertNotEqual(result.stdout.strip(), "", result.stderr)
+
     def test_resolve_prints_the_linker_when_the_probe_passes(self) -> None:
-        # Skip cleanly where no lld is installed: then there is nothing to resolve.
-        found = run_with_stub_cc(WORKING_CC, "find_lld")
-        if not found.stdout.strip():
-            self.skipTest("no lld installed on this machine")
-        result = run_with_stub_cc(WORKING_CC, "resolve_usable_lld")
-        self.assertEqual(result.stdout.strip(), found.stdout.strip(), result.stderr)
+        result = run_with_stub_cc(
+            WORKING_CC,
+            'resolved="$(resolve_usable_lld)"\n'
+            '[[ -n "$resolved" && "$resolved" == "$(find_lld)" ]] && echo SAME',
+        )
+        self.assertEqual(result.stdout.strip(), "SAME", result.stderr)
         self.assertEqual(result.stderr, "")
 
     def test_an_unusable_linker_never_fails_the_caller(self) -> None:

--- a/scripts/tests/test_lld_lib.py
+++ b/scripts/tests/test_lld_lib.py
@@ -1,0 +1,134 @@
+"""Contract for `scripts/lib/lld.sh`.
+
+lld is a build-speed optimization, so an lld that cannot link must degrade to
+the platform linker with a stated reason rather than fail a build that would
+otherwise succeed. The probe is driven with a stub `cc` so these tests do not
+depend on what is installed on the machine running them.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts.tests.justfile_source import read_justfile_source
+
+ROOT = Path(__file__).resolve().parents[2]
+LIB = ROOT / "scripts" / "lib" / "lld.sh"
+JUSTFILE = ROOT / "Justfile"
+BUILD_HOST = ROOT / "scripts" / "build-host.sh"
+
+WORKING_CC = "#!/bin/sh\nexit 0\n"
+# Mirrors the real failure: lld rejects the SDK's text-based stub, after which
+# every libSystem symbol comes back undefined.
+BROKEN_CC = (
+    "#!/bin/sh\n"
+    "echo 'ld64.lld: error: could not load TAPI file at "
+    "/SDK/usr/lib/libSystem.tbd: malformed file' >&2\n"
+    "exit 1\n"
+)
+
+
+def run_with_stub_cc(cc_body: str, snippet: str) -> subprocess.CompletedProcess[str]:
+    """Source the library with a stub `cc` first on PATH, then run `snippet`."""
+    with tempfile.TemporaryDirectory() as stub_dir:
+        cc = Path(stub_dir) / "cc"
+        cc.write_text(cc_body, encoding="utf-8")
+        cc.chmod(0o755)
+        env = dict(os.environ, PATH=f"{stub_dir}{os.pathsep}{os.environ['PATH']}")
+        return subprocess.run(
+            ["bash", "-c", f'set -euo pipefail\nsource "{LIB}"\n{snippet}'],
+            capture_output=True,
+            text=True,
+            env=env,
+            check=False,
+        )
+
+
+class LldProbeTests(unittest.TestCase):
+    def test_a_linker_that_links_is_usable(self) -> None:
+        result = run_with_stub_cc(WORKING_CC, 'lld_links lld && echo USABLE || echo UNUSABLE')
+        self.assertEqual(result.stdout.strip(), "USABLE", result.stderr)
+
+    def test_a_linker_that_cannot_link_is_not_usable(self) -> None:
+        result = run_with_stub_cc(BROKEN_CC, 'lld_links lld && echo USABLE || echo UNUSABLE')
+        self.assertEqual(result.stdout.strip(), "UNUSABLE", result.stderr)
+
+    def test_the_probe_keeps_the_linker_diagnostics(self) -> None:
+        """The fallback note has to state the real reason, not guess one."""
+        result = run_with_stub_cc(BROKEN_CC, 'lld_links lld || printf %s "$LLD_PROBE_OUTPUT"')
+        self.assertIn("could not load TAPI file", result.stdout)
+
+    def test_the_probe_passes_the_same_fuse_ld_value_cargo_will_get(self) -> None:
+        """Probing one linker and exporting another would prove nothing."""
+        recording_cc = "#!/bin/sh\necho \"$@\" >&2\nexit 0\n"
+        result = run_with_stub_cc(recording_cc, 'lld_links /opt/x/ld64.lld; printf %s "$LLD_PROBE_OUTPUT"')
+        self.assertIn("-fuse-ld=/opt/x/ld64.lld", result.stdout)
+
+    def test_resolve_prints_nothing_and_explains_when_the_probe_fails(self) -> None:
+        result = run_with_stub_cc(BROKEN_CC, 'printf "[%s]" "$(resolve_usable_lld)"')
+        self.assertEqual(result.stdout.strip(), "[]")
+        self.assertIn("cannot link against the active SDK", result.stderr)
+        self.assertIn("platform default linker", result.stderr)
+        self.assertIn("could not load TAPI file", result.stderr)
+
+    def test_resolve_prints_the_linker_when_the_probe_passes(self) -> None:
+        # Skip cleanly where no lld is installed: then there is nothing to resolve.
+        found = run_with_stub_cc(WORKING_CC, "find_lld")
+        if not found.stdout.strip():
+            self.skipTest("no lld installed on this machine")
+        result = run_with_stub_cc(WORKING_CC, "resolve_usable_lld")
+        self.assertEqual(result.stdout.strip(), found.stdout.strip(), result.stderr)
+        self.assertEqual(result.stderr, "")
+
+    def test_an_unusable_linker_never_fails_the_caller(self) -> None:
+        """`set -e` callers must survive a failed probe."""
+        result = run_with_stub_cc(BROKEN_CC, "resolve_usable_lld >/dev/null\necho SURVIVED")
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertIn("SURVIVED", result.stdout)
+
+
+class CallSiteTests(unittest.TestCase):
+    """Every place that hands cargo an lld must probe it first."""
+
+    def test_the_with_lld_recipe_probes_before_exporting_the_linker(self) -> None:
+        source = read_justfile_source(JUSTFILE)
+        start = source.index("[unix]\nwith-lld *COMMAND:")
+        end = source.index("[windows]\nwith-lld *COMMAND:", start)
+        recipe = source[start:end]
+        self.assertIn("source scripts/lib/lld.sh", recipe)
+        self.assertIn('lld="$(find_lld)"', recipe)
+        self.assertIn('if lld_links "$lld"; then', recipe)
+        self.assertIn('report_lld_fallback "$lld"', recipe)
+        # Not installed stays fatal with install instructions; only an
+        # installed-but-unusable lld degrades to a note.
+        self.assertIn("brew install lld", recipe)
+        self.assertIn("exit 1", recipe)
+
+    def test_build_host_probes_before_exporting_the_linker(self) -> None:
+        script = BUILD_HOST.read_text(encoding="utf-8")
+        self.assertIn('source "$SCRIPT_DIR/lib/lld.sh"', script)
+        start = script.index("configure_lld_linker() {")
+        end = script.index("configure_rust_cache() {", start)
+        function = script[start:end]
+        self.assertIn('if lld_links "$lld"; then', function)
+        self.assertIn('report_lld_fallback "$lld"', function)
+        self.assertNotIn("command -v ld64.lld", function)
+
+    def test_no_unprobed_linker_directive_in_cargo_config(self) -> None:
+        """A checked-in `-fuse-ld=` applies to every cargo invocation with no
+        way to probe first, and breaks `cargo build`/`cargo test` while
+        `cargo check` stays green."""
+        config = (ROOT / ".cargo" / "config.toml").read_text(encoding="utf-8")
+        directives = [
+            line for line in config.splitlines()
+            if "fuse-ld" in line and not line.lstrip().startswith("#")
+        ]
+        self.assertEqual(directives, [], f"unexpected linker directives: {directives}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_package_native_runtime.py
+++ b/scripts/tests/test_package_native_runtime.py
@@ -19,14 +19,19 @@ def write_failing_nvcc(path: Path) -> None:
 
 
 class PackageNativeRuntimeTests(unittest.TestCase):
-    def test_macos_model_package_tool_uses_portable_linker_flags(self) -> None:
+    def test_macos_model_package_tool_uses_only_a_probed_linker(self) -> None:
+        """Installed is not enough: lld must also link against the active
+        SDK, and a protected reusable workflow may not have installed it at
+        all. Both cases take an explicitly empty encoded flag set."""
         script = SCRIPT.read_text(encoding="utf-8")
+        self.assertIn('source "$SCRIPT_DIR/lib/lld.sh"', script)
         start = script.index("build_model_package_tool() {")
         end = script.index("collect_runtime_libraries() {", start)
         function = script[start:end]
-        self.assertIn('command -v ld64.lld', function)
+        self.assertNotIn('command -v ld64.lld', function)
+        self.assertIn('macos_lld="$(resolve_usable_lld)"', function)
         self.assertIn(
-            'CARGO_ENCODED_RUSTFLAGS=-Clink-arg=-fuse-ld=lld',
+            'CARGO_ENCODED_RUSTFLAGS=-Clink-arg=-fuse-ld=$macos_lld',
             function,
         )
         self.assertIn('cargo_env+=("CARGO_ENCODED_RUSTFLAGS=")', function)


### PR DESCRIPTION
## Original problem

`cargo build` and `cargo test` fail to link on macOS whenever Homebrew lld falls behind the macOS SDK, while `cargo check` stays green. Today that is LLVM 23.1.1 against the 27.0 SDK:

```
ld64.lld: error: could not load TAPI file at
  /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/libSystem.tbd: malformed file
libSystem.tbd:4:20: error: unknown target
                   arm64e.x1-macos, arm64e.x1-maccatalyst ]
```

After that every libSystem symbol is undefined. It is SDK-ahead-of-lld skew, so downgrading lld does not help, and it reproduces on `main` with plain `clang -fuse-ld=ld64.lld hello.c`.

Three places committed cargo to lld without checking it: the `# BEGIN Mesh-LLM lld config` block in `.cargo/config.toml` (also hardcoded to `/opt/homebrew`), `just with-lld`, and `scripts/build-host.sh`. `scripts/package-native-runtime.sh` only checked that `ld64.lld` existed.

## Diagnostics

On unmodified `origin/main` (d4ffbbacd):

```
$ cargo test -p mesh-llm-build-info --no-run
error: linking with `cc` failed: exit status: 1
  ld64.lld: error: could not load TAPI file at .../MacOSX.sdk/usr/lib/libSystem.tbd: malformed file
```

## Fix

New `scripts/lib/lld.sh` resolves lld and probes it with a one-line C link through `cc` (the same driver rustc uses) before anything uses it. Usable: used exactly as before. Installed but unusable: the linker's own diagnostic is printed once and the build continues with the platform linker. Not installed: still a hard error with install instructions.

`just with-lld`, `build-host.sh`, and `package-native-runtime.sh` all go through it. The `.cargo/config.toml` lld block is removed, so a bare `cargo test` no longer depends on a linker nothing has probed. When Homebrew ships an lld that parses the new SDK, the probe passes and lld returns on its own.

CI macOS is unaffected: `setup-macos-lld` already fail-louds on its own probe and sets `CARGO_ENCODED_RUSTFLAGS` job-wide, which takes precedence over anything here.

## Validation

- [x] `cargo test -p mesh-llm-build-info` links and passes with no lld config.
- [x] `just with-lld cargo test -p mesh-llm-build-info` prints the fallback note once, links, 9 tests pass.
- [x] `scripts/build-host.sh --profile dev` builds `target/debug/mesh-llm` end to end on this machine.
- [x] `python3.12 -m unittest discover -s scripts/tests -p 'test_*.py'`: failing set is identical to `origin/main` on this machine (pre-existing, unrelated), plus 10 new tests passing.
- [x] `shellcheck -x` clean on the three scripts.
- [ ] UI changes: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS and Linux build reliability by verifying LLVM’s linker compatibility with the active SDK before use.
  * Automatically falls back to the platform linker when LLVM’s linker is unavailable or incompatible.
  * Removed reliance on fixed linker paths, improving portability across development environments.
  * Improved native runtime packaging by using only verified linker configurations.

* **Tests**
  * Added coverage for linker discovery, compatibility checks, diagnostics, fallback behavior, and native runtime packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->