### PR TITLE
fix(mesh): advertise externally observed public address

### DIFF
--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -59,7 +59,7 @@ skippy-model = { path = "../skippy-model", version = "0.76.0" }
 skippy-server = { path = "../skippy-server", version = "0.76.0"  }
 skippy-topology = { path = "../skippy-topology", version = "0.76.0"  }
 skippy-package-format = { path = "../skippy-package-format", version = "0.76.0"  }
-iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
+iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs", "unstable-net-report"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/crates/mesh-llm-host-runtime/src/mesh/node.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node.rs
@@ -71,7 +71,7 @@ pub struct RouteEntry {
 pub struct Node {
     pub(crate) endpoint: Endpoint,
     pub(crate) endpoint_secret_key: SecretKey,
-    pub(crate) public_addr: Option<std::net::SocketAddr>,
+    pub(crate) public_addr: Option<stun::PublicAddr>,
     pub(crate) quic_bind: QuicBindSelection,
     pub(crate) relay_policy: RelayPolicy,
     pub(crate) owner_keypair: Option<crate::crypto::OwnerKeypair>,
@@ -730,10 +730,10 @@ impl Node {
         }
 
         // Use iroh's net report because it probes through the endpoint's actual QUIC sockets.
-        // Its direct address includes the observed NAT-mapped port; substituting the configured
+        // Its observed address includes the NAT-mapped port; substituting the configured
         // bind port would advertise an address that was never verified externally.
         let public_addr = if relay.policy.uses_raw_stun() {
-            stun_public_addr(&endpoint).await
+            stun_public_addr(&endpoint, relay.policy.uses_relay()).await
         } else {
             tracing::info!("Raw STUN: disabled by LAN-only discovery mode");
             None

--- a/crates/mesh-llm-host-runtime/src/mesh/node_identity.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node_identity.rs
@@ -1,6 +1,38 @@
 use super::*;
 use crate::mesh::node::RequirementAwareMeshState;
 
+/// Merge the startup-discovered public address into an advertisement set.
+///
+/// An [`PublicAddr::Observed`] address carries the NAT-mapped port
+/// (#1300), so it *replaces* every IP candidate on the same address —
+/// advertising both leaves a dead candidate that sorts first in the
+/// `BTreeSet`. A [`PublicAddr::LocallyEnumerated`] address only fills a
+/// gap: the port was never verified externally, so it must not displace an
+/// existing public candidate.
+pub(crate) fn merge_public_addr_into_advertisement(
+    addr: &mut EndpointAddr,
+    pub_addr: &stun::PublicAddr,
+) {
+    match *pub_addr {
+        stun::PublicAddr::Observed(observed) => {
+            addr.addrs.retain(|candidate| match candidate {
+                TransportAddr::Ip(socket) => socket.ip() != observed.ip(),
+                _ => true,
+            });
+            addr.addrs.insert(TransportAddr::Ip(observed));
+        }
+        stun::PublicAddr::LocallyEnumerated(enumerated) => {
+            if !endpoint_addr_has_public_ipv4(addr) {
+                addr.addrs.insert(TransportAddr::Ip(enumerated));
+            }
+        }
+        stun::PublicAddr::RejectPublicIpv4 => addr.addrs.retain(|candidate| match candidate {
+            TransportAddr::Ip(socket) => !is_public_ipv4_candidate(socket),
+            _ => true,
+        }),
+    }
+}
+
 pub(crate) fn direct_admission_attestation_hash(
     release_attestation: Option<&crate::ReleaseBuildAttestation>,
 ) -> String {
@@ -104,11 +136,13 @@ impl Node {
 
     pub async fn invite_token(&self) -> String {
         let mut addr = self.endpoint_addr_for_advertisement();
-        // Inject STUN-discovered public address if relay STUN didn't provide one.
-        if let Some(pub_addr) = self.public_addr
-            && !endpoint_addr_has_public_ipv4(&addr)
-        {
-            addr.addrs.insert(TransportAddr::Ip(pub_addr));
+        // Inject the public address discovered at startup, preferring the
+        // externally observed tuple. An observed address carries the NAT-mapped
+        // port, so it *replaces* any enumerated candidate for the same purpose
+        // (advertising both leaves a dead candidate that sorts first in the
+        // BTreeSet, #1300); an enumerated one only fills a gap.
+        if let Some(pub_addr) = self.public_addr.as_ref() {
+            merge_public_addr_into_advertisement(&mut addr, pub_addr);
         }
         addr = filter_endpoint_addr_for_bind_ip(
             addr,

--- a/crates/mesh-llm-host-runtime/src/mesh/stun.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/stun.rs
@@ -1,56 +1,273 @@
 use super::*;
 use iroh::Watcher;
 
-fn public_ipv4_addr(endpoint_addr: &iroh::EndpointAddr) -> Option<std::net::SocketAddr> {
+/// Provenance of a public IPv4 candidate advertised in the invite token.
+///
+/// The #1300 defect was exactly that these two were indistinguishable: a
+/// locally enumerated interface address carries the *bound* port, which a
+/// port-remapping host never verifies externally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PublicAddr {
+    /// Observed by a relay probe (QAD) through the endpoint's own socket, so
+    /// the tuple includes the NAT-mapped port by construction.
+    Observed(std::net::SocketAddr),
+    /// Enumerated from local interfaces. The port is the bound port and was
+    /// never verified externally; only fills a gap when nothing better exists.
+    LocallyEnumerated(std::net::SocketAddr),
+    /// A relay report observed address-dependent IPv4 mappings. Public IPv4
+    /// candidates in `EndpointAddr` come from the same untrusted report/local
+    /// mixture and must be suppressed from the invite.
+    RejectPublicIpv4,
+}
+
+fn locally_enumerated_public_ipv4(
+    endpoint_addr: &iroh::EndpointAddr,
+) -> Option<std::net::SocketAddr> {
     endpoint_addr
         .ip_addrs()
         .copied()
         .find(is_public_ipv4_candidate)
 }
 
-pub(crate) async fn stun_public_addr(endpoint: &iroh::Endpoint) -> Option<std::net::SocketAddr> {
-    let mut addresses = endpoint.watch_addr();
+fn observed_public_ipv4(report: &iroh::unstable_net_report::NetReport) -> Option<PublicAddr> {
+    if report.mapping_varies_by_dest_ipv4 == Some(true) {
+        tracing::warn!(
+            "QUIC endpoint public address varies by probe destination \
+             (address-dependent mapping); direct UDP unlikely, not advertising it"
+        );
+        return Some(PublicAddr::RejectPublicIpv4);
+    }
+    report
+        .global_v4
+        .map(std::net::SocketAddr::V4)
+        .map(PublicAddr::Observed)
+}
+
+/// Wait (bounded by `iroh::NET_REPORT_TIMEOUT`) for a net report yielding a
+/// usable observed public IPv4.
+async fn wait_for_observed_public_ipv4(endpoint: &iroh::Endpoint) -> Option<PublicAddr> {
+    let mut net_report = endpoint.net_report();
     let deadline =
         tokio::time::Instant::now() + std::time::Duration::from_secs(iroh::NET_REPORT_TIMEOUT);
 
     loop {
-        if let Some(addr) = public_ipv4_addr(&addresses.get()) {
-            tracing::info!(%addr, "QUIC endpoint discovered public address");
-            return Some(addr);
+        if let Some(report) = net_report.get() {
+            return observed_public_ipv4(&report);
         }
 
         let remaining = deadline
             .checked_duration_since(tokio::time::Instant::now())
             .unwrap_or_default();
-        match tokio::time::timeout(remaining, addresses.updated()).await {
+        match tokio::time::timeout(remaining, net_report.updated()).await {
             Ok(Ok(_)) => {}
             Ok(Err(_)) | Err(_) => {
-                tracing::warn!("QUIC endpoint could not discover a public address");
+                tracing::warn!(
+                    "QUIC endpoint could not discover a public address \
+                     (net report unavailable within timeout)"
+                );
                 return None;
             }
         }
     }
 }
 
+/// The address to advertise for direct connectivity, with its provenance.
+///
+/// Prefers the externally observed tuple from the endpoint's net report: a QAD
+/// probe reply carries the NAT-mapped port, which local interface enumeration
+/// cannot know. Falls back to a locally enumerated public candidate only when
+/// no net report can complete (`relays_configured = false`) or one completes
+/// without a usable observation — preserving relay-less hosts, whose port is
+/// logged as unverified.
+pub(crate) async fn stun_public_addr(
+    endpoint: &iroh::Endpoint,
+    relays_configured: bool,
+) -> Option<PublicAddr> {
+    if relays_configured && let Some(discovery) = wait_for_observed_public_ipv4(endpoint).await {
+        if let PublicAddr::Observed(addr) = discovery {
+            tracing::info!(%addr, "QUIC endpoint discovered public address (observed by relay probe)");
+        }
+        return Some(discovery);
+    }
+
+    let addr = locally_enumerated_public_ipv4(&endpoint.addr());
+    if let Some(addr) = addr {
+        tracing::warn!(
+            %addr,
+            "advertising locally enumerated public address; port not externally verified"
+        );
+    }
+    addr.map(PublicAddr::LocallyEnumerated)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn preserves_port_discovered_by_quic_endpoint() {
-        let endpoint_id = iroh::SecretKey::generate().public();
-        let mapped = std::net::SocketAddr::from(([9, 9, 9, 9], 45_678));
-        let endpoint_addr = iroh::EndpointAddr::new(endpoint_id).with_ip_addr(mapped);
-
-        assert_eq!(public_ipv4_addr(&endpoint_addr), Some(mapped));
+    fn observed_report(
+        global_v4: Option<std::net::SocketAddrV4>,
+        mapping_varies: Option<bool>,
+    ) -> iroh::unstable_net_report::NetReport {
+        let mut report = iroh::unstable_net_report::NetReport::default();
+        report.udp_v4 = true;
+        report.global_v4 = global_v4;
+        report.mapping_varies_by_dest_ipv4 = mapping_varies;
+        report
     }
 
     #[test]
-    fn ignores_local_quic_endpoint_addresses() {
+    fn observed_tuple_preserves_nat_mapped_port() {
+        // The #1300 shape: container binds 41842, NAT maps it to 23555. The
+        // relay-observed tuple carries the mapped port; the locally enumerated
+        // candidate (same IP, port 41842) must never win over it.
+        let mapped = std::net::SocketAddrV4::new("213.5.72.196".parse().unwrap(), 23_555);
+        let report = observed_report(Some(mapped), Some(false));
+
+        assert_eq!(
+            observed_public_ipv4(&report),
+            Some(PublicAddr::Observed(std::net::SocketAddr::from(mapped)))
+        );
+    }
+
+    #[test]
+    fn observed_tuple_rejected_when_mapping_varies_by_destination() {
+        let mapped = std::net::SocketAddrV4::new("213.5.72.196".parse().unwrap(), 23_555);
+        let report = observed_report(Some(mapped), Some(true));
+
+        assert_eq!(
+            observed_public_ipv4(&report),
+            Some(PublicAddr::RejectPublicIpv4)
+        );
+    }
+
+    #[test]
+    fn unmeasured_mapping_variance_is_still_accepted() {
+        // Only one relay probed: variance is None, which is not evidence of
+        // an address-dependent mapping.
+        let mapped = std::net::SocketAddrV4::new("213.5.72.196".parse().unwrap(), 23_555);
+        let report = observed_report(Some(mapped), None);
+
+        assert_eq!(
+            observed_public_ipv4(&report),
+            Some(PublicAddr::Observed(std::net::SocketAddr::from(mapped)))
+        );
+    }
+
+    #[test]
+    fn no_observation_yields_none() {
+        assert_eq!(observed_public_ipv4(&observed_report(None, None)), None);
+    }
+
+    #[test]
+    fn enumeration_fallback_finds_public_ipv4() {
         let endpoint_id = iroh::SecretKey::generate().public();
-        let endpoint_addr = iroh::EndpointAddr::new(endpoint_id)
+        let addr = iroh::EndpointAddr::new(endpoint_id)
+            .with_ip_addr(std::net::SocketAddr::from(([9, 9, 9, 9], 45_678)));
+
+        assert_eq!(
+            locally_enumerated_public_ipv4(&addr),
+            Some(std::net::SocketAddr::from(([9, 9, 9, 9], 45_678)))
+        );
+    }
+
+    #[test]
+    fn enumeration_ignores_private_addrs() {
+        let endpoint_id = iroh::SecretKey::generate().public();
+        let addr = iroh::EndpointAddr::new(endpoint_id)
             .with_ip_addr(std::net::SocketAddr::from(([192, 168, 1, 8], 45_678)));
 
-        assert_eq!(public_ipv4_addr(&endpoint_addr), None);
+        assert_eq!(locally_enumerated_public_ipv4(&addr), None);
+    }
+
+    #[test]
+    fn merge_observed_replaces_enumerated_candidate_on_same_ip() {
+        use crate::mesh::node_identity::merge_public_addr_into_advertisement;
+
+        // Exact #1300 field shape: the container's local interface holds the
+        // public IP with the bound port (41842); the relay observed the same
+        // IP behind the NAT-mapped port (23555). The observed tuple must
+        // replace the enumerated one — advertising both leaves the dead
+        // candidate first in the token's BTreeSet.
+        let endpoint_id = iroh::SecretKey::generate().public();
+        let mut addr = iroh::EndpointAddr::new(endpoint_id)
+            .with_ip_addr(std::net::SocketAddr::from(([213, 5, 72, 196], 41_842)));
+        let observed =
+            PublicAddr::Observed(std::net::SocketAddr::from(([213, 5, 72, 196], 23_555)));
+
+        merge_public_addr_into_advertisement(&mut addr, &observed);
+
+        let ip_addrs: Vec<_> = addr.ip_addrs().copied().collect();
+        assert_eq!(
+            ip_addrs,
+            vec![std::net::SocketAddr::from(([213, 5, 72, 196], 23_555))]
+        );
+    }
+
+    #[test]
+    fn merge_enumerated_only_fills_a_gap() {
+        use crate::mesh::node_identity::merge_public_addr_into_advertisement;
+
+        // An enumerated candidate must not displace an existing public one.
+        let endpoint_id = iroh::SecretKey::generate().public();
+        let existing = std::net::SocketAddr::from(([93, 184, 216, 34], 9));
+        let mut addr = iroh::EndpointAddr::new(endpoint_id).with_ip_addr(existing);
+        let enumerated_addr = std::net::SocketAddr::from(([213, 5, 72, 211], 41_842));
+        let enumerated = PublicAddr::LocallyEnumerated(enumerated_addr);
+
+        merge_public_addr_into_advertisement(&mut addr, &enumerated);
+
+        assert!(addr.ip_addrs().copied().any(|a| a == existing));
+        assert!(!addr.ip_addrs().copied().any(|a| a == enumerated_addr));
+    }
+
+    #[test]
+    fn merge_enumerated_inserts_when_no_public_candidate_exists() {
+        use crate::mesh::node_identity::merge_public_addr_into_advertisement;
+
+        // Relay-less host: enumeration is the only source, and it must still
+        // fill a completely empty advertisement.
+        let endpoint_id = iroh::SecretKey::generate().public();
+        let mut addr = iroh::EndpointAddr::new(endpoint_id)
+            .with_ip_addr(std::net::SocketAddr::from(([192, 168, 1, 8], 45_678)));
+        let enumerated_addr = std::net::SocketAddr::from(([213, 5, 72, 211], 41_842));
+        let enumerated = PublicAddr::LocallyEnumerated(enumerated_addr);
+
+        merge_public_addr_into_advertisement(&mut addr, &enumerated);
+
+        assert!(addr.ip_addrs().copied().any(|a| a == enumerated_addr));
+    }
+
+    #[test]
+    fn merge_rejected_mapping_removes_public_ipv4_candidates() {
+        use crate::mesh::node_identity::merge_public_addr_into_advertisement;
+
+        let endpoint_id = iroh::SecretKey::generate().public();
+        let private = std::net::SocketAddr::from(([192, 168, 1, 8], 41_842));
+        let public_bound = std::net::SocketAddr::from(([213, 5, 72, 196], 41_842));
+        let public_observed = std::net::SocketAddr::from(([213, 5, 72, 196], 23_555));
+        let mut addr = iroh::EndpointAddr::new(endpoint_id)
+            .with_ip_addr(private)
+            .with_ip_addr(public_bound)
+            .with_ip_addr(public_observed);
+
+        merge_public_addr_into_advertisement(&mut addr, &PublicAddr::RejectPublicIpv4);
+
+        assert!(
+            addr.ip_addrs()
+                .copied()
+                .any(|candidate| candidate == private)
+        );
+        assert!(
+            !addr
+                .ip_addrs()
+                .copied()
+                .any(|candidate| candidate == public_bound)
+        );
+        assert!(
+            !addr
+                .ip_addrs()
+                .copied()
+                .any(|candidate| candidate == public_observed)
+        );
     }
 }

--- a/crates/openai-frontend/src/chat.rs
+++ b/crates/openai-frontend/src/chat.rs
@@ -96,8 +96,9 @@ impl ChatCompletionRequest {
                 "top_logprobs requires logprobs=true",
             ));
         }
-        if self.tools.as_ref().is_some_and(invalid_tools_value) {
-            return Err(OpenAiError::invalid_request("tools must be an array"));
+        if let Some(tools) = self.tools.as_ref() {
+            validate_tools_value(tools)
+                .map_err(|message| OpenAiError::invalid_request(message).with_param("tools"))?;
         }
         if self
             .response_format
@@ -126,8 +127,39 @@ fn invalid_response_format_value(value: &Value) -> bool {
         .is_some_and(Value::is_string)
 }
 
-fn invalid_tools_value(value: &Value) -> bool {
-    !matches!(value, Value::Array(_))
+fn validate_tools_value(value: &Value) -> Result<(), String> {
+    let Some(tools) = value.as_array() else {
+        return Err("tools must be an array".to_string());
+    };
+    for (index, tool) in tools.iter().enumerate() {
+        let Some(tool) = tool.as_object() else {
+            return Err(format!("tools[{index}] must be an object"));
+        };
+        if tool.get("type").and_then(Value::as_str) != Some("function") {
+            return Err(format!("tools[{index}].type must be `function`"));
+        }
+        let Some(function) = tool.get("function").and_then(Value::as_object) else {
+            return Err(format!("tools[{index}].function must be an object"));
+        };
+        if !function
+            .get("name")
+            .and_then(Value::as_str)
+            .is_some_and(|name| !name.trim().is_empty())
+        {
+            return Err(format!(
+                "tools[{index}].function.name must be a non-empty string"
+            ));
+        }
+        if function
+            .get("parameters")
+            .is_some_and(|parameters| !parameters.is_object())
+        {
+            return Err(format!(
+                "tools[{index}].function.parameters must be an object"
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/openai-frontend/src/errors.rs
+++ b/crates/openai-frontend/src/errors.rs
@@ -11,6 +11,7 @@ pub struct OpenAiError {
     status: StatusCode,
     message: String,
     error_type: String,
+    param: Option<String>,
     code: Option<String>,
     retry_after_secs: Option<u64>,
 }
@@ -42,6 +43,7 @@ impl OpenAiError {
             status,
             message: message.into(),
             error_type: error_type.to_string(),
+            param: None,
             code: Some(code.to_string()),
             retry_after_secs: None,
         }
@@ -147,6 +149,11 @@ impl OpenAiError {
         self
     }
 
+    pub fn with_param(mut self, param: impl Into<String>) -> Self {
+        self.param = Some(param.into());
+        self
+    }
+
     pub fn with_retry_after_secs(mut self, retry_after_secs: u64) -> Self {
         self.retry_after_secs = Some(retry_after_secs);
         self
@@ -157,7 +164,7 @@ impl OpenAiError {
             error: ErrorBody {
                 message: self.message.clone(),
                 error_type: self.error_type.clone(),
-                param: None,
+                param: self.param.clone(),
                 code: self.code.clone(),
             },
         }

--- a/crates/openai-frontend/src/router_tests.rs
+++ b/crates/openai-frontend/src/router_tests.rs
@@ -1499,6 +1499,30 @@ async fn chat_completion_route_accepts_tools_structured_output_and_logprobs() {
 }
 
 #[tokio::test]
+async fn chat_completion_route_rejects_malformed_tools_as_invalid_requests() {
+    for tools in [
+        json!([{"type": "function"}]),
+        json!([{"type": "banana", "function": {"name": "f", "parameters": {}}}]),
+        json!([{"type": "function", "function": "nope"}]),
+    ] {
+        let response = post_json(
+            "/v1/chat/completions",
+            json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": tools
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_body_json(response).await;
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["param"], "tools");
+        assert_eq!(body["error"]["code"], "invalid_value");
+    }
+}
+
+#[tokio::test]
 async fn chat_completion_route_accepts_noop_parity_fields() {
     let response = post_json(
         "/v1/chat/completions",

--- a/crates/skippy-ffi/build.rs
+++ b/crates/skippy-ffi/build.rs
@@ -209,6 +209,7 @@ fn main() {
     println!("cargo:rustc-link-lib=static=ggml-base");
 
     if target.contains("apple") {
+        link_apple_openmp_libs(&cmake_cache);
         println!("cargo:rustc-link-lib=c++");
         println!("cargo:rustc-link-lib=framework=Accelerate");
         if static_archive_exists(
@@ -544,6 +545,20 @@ fn link_windows_openmp_libs(cmake_cache: &std::path::Path) {
     }
 }
 
+fn link_apple_openmp_libs(cmake_cache: &std::path::Path) {
+    let libs = openmp_libs(cmake_cache, "omp");
+    for path in cmake_openmp_search_paths(cmake_cache, &libs) {
+        if path.is_dir() {
+            println!("cargo:rustc-link-search=native={}", path.display());
+        }
+    }
+
+    for lib in libs {
+        let link_name = lib.strip_prefix("lib").unwrap_or(&lib);
+        println!("cargo:rustc-link-lib=dylib={link_name}");
+    }
+}
+
 fn link_linux_hip_libs() {
     // Add ROCm library search paths
     for search_path in ["/opt/rocm/lib", "/opt/rocm/hip/lib"] {
@@ -571,6 +586,21 @@ fn windows_openmp_search_paths(
     cmake_cache: &std::path::Path,
     libs: &[String],
 ) -> Vec<std::path::PathBuf> {
+    let mut paths = cmake_openmp_search_paths(cmake_cache, libs);
+    for env_name in ["ROCM_PATH", "HIP_PATH", "LLVMInstallDir"] {
+        if let Ok(root) = std::env::var(env_name) {
+            for suffix in ["lib", "llvm/lib"] {
+                push_unique_path(&mut paths, std::path::PathBuf::from(&root).join(suffix));
+            }
+        }
+    }
+    paths
+}
+
+fn cmake_openmp_search_paths(
+    cmake_cache: &std::path::Path,
+    libs: &[String],
+) -> Vec<std::path::PathBuf> {
     let mut paths = Vec::new();
     if let Ok(cache) = std::fs::read_to_string(cmake_cache) {
         for lib in libs {
@@ -588,15 +618,6 @@ fn windows_openmp_search_paths(
             }
         }
     }
-
-    for env_name in ["ROCM_PATH", "HIP_PATH", "LLVMInstallDir"] {
-        if let Ok(root) = std::env::var(env_name) {
-            for suffix in ["lib", "llvm/lib"] {
-                push_unique_path(&mut paths, std::path::PathBuf::from(&root).join(suffix));
-            }
-        }
-    }
-
     paths
 }
 


### PR DESCRIPTION
A port-remapping host could advertise its locally bound UDP port instead of the externally observed mapping, leaving peers with an unreachable direct address and forcing relay fallback.

This reads the public tuple from iroh's relay-backed net report, records whether an address was observed or locally enumerated, and lets an observed tuple replace the dead same-IP candidate in invite tokens. When the report detects destination-dependent mapping, the invite omits every public IPv4 candidate because they share the same untrusted report/local provenance. Relay-disabled hosts retain the existing enumeration fallback.

This enables iroh's `unstable-net-report` feature; pinned iroh upgrades must recheck the two report fields used here. Addresses #1300. The issue should remain open until the direct path is field-verified on a port-remapping provider.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved invite connectivity by advertising more accurate public network addresses and NAT-mapped ports.
  * When relay connectivity is available, the system now prefers relay-observed address information.
  * Better handles networks where public addresses vary by destination, avoiding unreliable IPv4 advertisements.
  * Retains locally detected public addresses when verified observations are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->