### PR TITLE
fix(identity): reject self-identity joins and add node key override

### DIFF
--- a/crates/mesh-llm-host-runtime/Cargo.toml
+++ b/crates/mesh-llm-host-runtime/Cargo.toml
@@ -59,7 +59,7 @@ skippy-model = { path = "../skippy-model", version = "0.76.0" }
 skippy-server = { path = "../skippy-server", version = "0.76.0"  }
 skippy-topology = { path = "../skippy-topology", version = "0.76.0"  }
 skippy-package-format = { path = "../skippy-package-format", version = "0.76.0"  }
-iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs"] }
+iroh = { version = "1.0.3", default-features = false, features = ["metrics", "fast-apple-datapath", "portmapper", "tls-aws-lc-rs", "unstable-net-report"] }
 tokio = { version = "1", features = ["full"] }
 clap = { version = "4", features = ["derive"] }
 tracing = "0.1"

--- a/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/gossip.rs
@@ -514,6 +514,10 @@ impl Node {
     ) -> Result<()> {
         let remote = context.remote;
         if peer_id == self.endpoint.id() {
+            // Our own announcement echoed back is normal gossip: peers
+            // rebroadcast their full peer table, including us. A peer sharing
+            // our key is detected at join time instead, where the token
+            // names our own id (#1699).
             return Ok(());
         }
         if peer_id == remote {

--- a/crates/mesh-llm-host-runtime/src/mesh/identity_persistence.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/identity_persistence.rs
@@ -45,25 +45,16 @@ pub(crate) fn generate_random_mesh_id_at(path: &std::path::Path) -> Result<Strin
 }
 
 pub(crate) fn mesh_id_path() -> std::path::PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join(".mesh-llm")
-        .join("mesh-id")
+    identity_state_dir().join("mesh-id")
 }
 
 pub(crate) fn mesh_genesis_policy_path() -> std::path::PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join(".mesh-llm")
-        .join("mesh-genesis-policy.json")
+    identity_state_dir().join("mesh-genesis-policy.json")
 }
 
 /// Save the mesh ID of the last mesh we successfully joined.
 pub fn save_last_mesh_id(mesh_id: &str) -> Result<()> {
-    let path = dirs::home_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join(".mesh-llm")
-        .join("last-mesh");
+    let path = identity_state_dir().join("last-mesh");
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
     }
@@ -73,10 +64,7 @@ pub fn save_last_mesh_id(mesh_id: &str) -> Result<()> {
 
 /// Load the mesh ID of the last mesh we successfully joined.
 pub fn load_last_mesh_id() -> Option<String> {
-    let path = dirs::home_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join(".mesh-llm")
-        .join("last-mesh");
+    let path = identity_state_dir().join("last-mesh");
     std::fs::read_to_string(&path)
         .ok()
         .map(|s| s.trim().to_string())
@@ -87,11 +75,77 @@ pub fn load_last_mesh_id() -> Option<String> {
 // Public-to-private identity transition
 // ---------------------------------------------------------------------------
 
+/// Return the state directory owned by the active node key.
+///
+/// The historical default key keeps using `~/.mesh-llm`, while an explicit
+/// key path gets a private namespace under `~/.mesh-llm/identities`. This
+/// prevents one process from rotating another process's Nostr and mesh state.
+pub(crate) fn identity_state_dir() -> std::path::PathBuf {
+    let home = identity_home_dir();
+    let active_key_path =
+        default_node_key_path().unwrap_or_else(|_| home.join(".mesh-llm").join("key"));
+    identity_state_dir_for(&home, &active_key_path)
+}
+
+pub(crate) fn identity_home_dir() -> std::path::PathBuf {
+    #[cfg(test)]
+    if let Some(home) = std::env::var_os("MESH_LLM_TEST_HOME") {
+        return home.into();
+    }
+    dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."))
+}
+
+fn identity_state_dir_for(
+    home: &std::path::Path,
+    active_key_path: &std::path::Path,
+) -> std::path::PathBuf {
+    let dir = home.join(".mesh-llm");
+    if active_key_path == dir.join("key") {
+        return dir;
+    }
+    dir.join("identities")
+        .join(key_path_digest(active_key_path))
+}
+
+fn key_path_digest(path: &std::path::Path) -> String {
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(key_path_bytes(path));
+    hex::encode(hasher.finalize())
+}
+
+#[cfg(unix)]
+fn key_path_bytes(path: &std::path::Path) -> Vec<u8> {
+    use std::os::unix::ffi::OsStrExt;
+    path.as_os_str().as_bytes().to_vec()
+}
+
+#[cfg(windows)]
+fn key_path_bytes(path: &std::path::Path) -> Vec<u8> {
+    use std::os::windows::ffi::OsStrExt;
+    path.as_os_str()
+        .encode_wide()
+        .flat_map(u16::to_le_bytes)
+        .collect()
+}
+
+#[cfg(not(any(unix, windows)))]
+fn key_path_bytes(path: &std::path::Path) -> Vec<u8> {
+    path.to_string_lossy().as_bytes().to_vec()
+}
+
 pub(crate) fn was_public_path() -> std::path::PathBuf {
-    dirs::home_dir()
-        .unwrap_or_else(|| std::path::PathBuf::from("."))
-        .join(".mesh-llm")
-        .join("was-public")
+    let home = identity_home_dir();
+    let active_key_path =
+        default_node_key_path().unwrap_or_else(|_| home.join(".mesh-llm").join("key"));
+    identity_state_dir_for(&home, &active_key_path).join("was-public")
+}
+
+fn was_public_path_for(
+    home: &std::path::Path,
+    active_key_path: &std::path::Path,
+) -> std::path::PathBuf {
+    identity_state_dir_for(home, active_key_path).join("was-public")
 }
 
 pub(crate) fn clear_public_identity_file(path: &std::path::Path) -> Result<()> {
@@ -106,7 +160,13 @@ pub(crate) fn clear_public_identity_file(path: &std::path::Path) -> Result<()> {
 /// Record that this node was started in public mode (--auto / --publish / --mesh-name).
 /// Called at startup so we can detect a public→private transition next time.
 pub fn mark_was_public() -> Result<()> {
-    let path = was_public_path();
+    let home = identity_home_dir();
+    let key_path = default_node_key_path()?;
+    mark_was_public_at(&home, &key_path)
+}
+
+fn mark_was_public_at(home: &std::path::Path, active_key_path: &std::path::Path) -> Result<()> {
+    let path = was_public_path_for(home, active_key_path);
     if let Some(parent) = path.parent() {
         std::fs::create_dir_all(parent).with_context(|| format!("create {}", parent.display()))?;
     }
@@ -119,16 +179,37 @@ pub fn was_previously_public() -> bool {
     was_public_path().exists()
 }
 
-/// Clear identity files (key, nostr.nsec, mesh-id, last-mesh, was-public) so the
-/// next start gets a completely fresh identity. Called when transitioning from
-/// public → private to avoid reusing a publicly-known identity in a private mesh.
+#[cfg(test)]
+fn was_previously_public_at(home: &std::path::Path, active_key_path: &std::path::Path) -> bool {
+    was_public_path_for(home, active_key_path).exists()
+}
+
+/// Clear identity files (key, nostr.nsec, mesh-id, last-mesh, and the marker for
+/// the active key) so the next start gets a completely fresh identity. Called
+/// when transitioning from public → private to avoid reusing a publicly-known
+/// identity in a private mesh.
 pub fn clear_public_identity() -> Result<()> {
-    let home = dirs::home_dir().unwrap_or_else(|| std::path::PathBuf::from("."));
-    let dir = home.join(".mesh-llm");
-    for name in &["key", "nostr.nsec", "mesh-id", "last-mesh"] {
-        clear_public_identity_file(&dir.join(name))?;
+    let home = identity_home_dir();
+    let key_path = default_node_key_path()?;
+    clear_public_identity_at(&home, &key_path)
+}
+
+fn clear_public_identity_at(
+    home: &std::path::Path,
+    active_key_path: &std::path::Path,
+) -> Result<()> {
+    // The active key may live outside ~/.mesh-llm when a second process uses
+    // MESH_LLM_NODE_KEY_PATH. Rotate that key too; otherwise a public-to-private
+    // transition claims to rotate identity and immediately reloads the old key.
+    clear_public_identity_file(active_key_path)?;
+    let state_dir = identity_state_dir_for(home, active_key_path);
+    if active_key_path == home.join(".mesh-llm").join("key") {
+        clear_public_identity_file(&state_dir.join("key"))?;
     }
-    let marker = dir.join("was-public");
+    for name in &["nostr.nsec", "mesh-id", "last-mesh"] {
+        clear_public_identity_file(&state_dir.join(name))?;
+    }
+    let marker = state_dir.join("was-public");
     match std::fs::remove_file(&marker) {
         Ok(()) => Ok(()),
         Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(()),
@@ -152,7 +233,19 @@ pub(crate) async fn load_or_create_key() -> Result<SecretKey> {
 }
 
 pub fn default_node_key_path() -> Result<std::path::PathBuf> {
-    Ok(mesh_llm_identity::default_node_key_path()?)
+    #[cfg(test)]
+    if std::env::var_os("MESH_LLM_TEST_HOME").is_some()
+        && !std::env::var_os("MESH_LLM_NODE_KEY_PATH").is_some_and(|path| !path.is_empty())
+    {
+        return Ok(identity_home_dir().join(".mesh-llm").join("key"));
+    }
+    let path = mesh_llm_identity::default_node_key_path()?;
+    if path.is_absolute() {
+        return Ok(path);
+    }
+    Ok(std::env::current_dir()
+        .context("resolve relative MESH_LLM_NODE_KEY_PATH")?
+        .join(path))
 }
 
 pub fn load_node_key_from_path(path: &std::path::Path) -> Result<SecretKey> {
@@ -164,4 +257,149 @@ pub fn load_node_key_from_path(path: &std::path::Path) -> Result<SecretKey> {
 pub fn save_node_key_to_path(path: &std::path::Path, key: &SecretKey) -> Result<()> {
     mesh_llm_identity::save_node_key_bytes_to_path(path, &key.to_bytes())?;
     Ok(())
+}
+
+#[cfg(test)]
+mod clear_identity_tests {
+    use super::*;
+    use serial_test::serial;
+    use std::ffi::OsString;
+
+    struct NodeKeyPathEnvGuard(Option<OsString>);
+
+    impl NodeKeyPathEnvGuard {
+        fn set(value: &str) -> Self {
+            let previous = std::env::var_os("MESH_LLM_NODE_KEY_PATH");
+            // SAFETY: this guard is used only by #[serial] tests and restores the prior value.
+            unsafe { std::env::set_var("MESH_LLM_NODE_KEY_PATH", value) };
+            Self(previous)
+        }
+    }
+
+    impl Drop for NodeKeyPathEnvGuard {
+        fn drop(&mut self) {
+            match self.0.take() {
+                Some(value) => {
+                    // SAFETY: this guard is used only by #[serial] tests and restores the prior value.
+                    unsafe { std::env::set_var("MESH_LLM_NODE_KEY_PATH", value) }
+                }
+                None => {
+                    // SAFETY: this guard is used only by #[serial] tests and restores the prior value.
+                    unsafe { std::env::remove_var("MESH_LLM_NODE_KEY_PATH") }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn custom_rotation_preserves_default_and_clears_owned_state() {
+        let root = tempfile::tempdir().expect("temp identity root");
+        let home = root.path().join("home");
+        let state_dir = home.join(".mesh-llm");
+        let custom_key = root.path().join("second-node.key");
+        let custom_state_dir = identity_state_dir_for(&home, &custom_key);
+        std::fs::create_dir_all(&state_dir).expect("create state dir");
+        std::fs::create_dir_all(&custom_state_dir).expect("create custom state dir");
+        std::fs::write(&custom_key, b"public custom key").expect("write custom key");
+        for name in ["key", "nostr.nsec", "mesh-id", "last-mesh"] {
+            std::fs::write(state_dir.join(name), b"public state").expect("write public state");
+        }
+        for name in ["nostr.nsec", "mesh-id", "last-mesh"] {
+            std::fs::write(custom_state_dir.join(name), b"custom public state")
+                .expect("write custom public state");
+        }
+        let marker = was_public_path_for(&home, &custom_key);
+        std::fs::write(&marker, b"public state").expect("write public marker");
+
+        clear_public_identity_at(&home, &custom_key).expect("clear public identity");
+
+        assert!(!custom_key.exists());
+        for name in ["key", "nostr.nsec", "mesh-id", "last-mesh"] {
+            assert!(state_dir.join(name).exists(), "default {name} was removed");
+        }
+        for name in ["nostr.nsec", "mesh-id", "last-mesh"] {
+            assert!(
+                !custom_state_dir.join(name).exists(),
+                "custom {name} was not removed"
+            );
+        }
+        assert!(!marker.exists());
+    }
+
+    #[test]
+    fn public_transition_preserves_the_other_custom_key_marker() {
+        let root = tempfile::tempdir().expect("temp identity root");
+        let home = root.path().join("home");
+        let state_dir = home.join(".mesh-llm");
+        let first_key = root.path().join("first-node.key");
+        let second_key = root.path().join("second-node.key");
+        std::fs::create_dir_all(&state_dir).expect("create state dir");
+        std::fs::write(&first_key, b"first public key").expect("write first key");
+        std::fs::write(&second_key, b"second private key").expect("write second key");
+
+        mark_was_public_at(&home, &first_key).expect("mark first key public");
+
+        assert!(was_previously_public_at(&home, &first_key));
+        assert!(!was_previously_public_at(&home, &second_key));
+        assert!(second_key.exists());
+
+        // A later public run for the second process gets its own marker, and
+        // clearing the first process must preserve it.
+        mark_was_public_at(&home, &second_key).expect("mark second key public");
+        assert!(was_previously_public_at(&home, &second_key));
+
+        clear_public_identity_at(&home, &first_key).expect("clear first identity");
+        assert!(!first_key.exists());
+        assert!(second_key.exists());
+        assert!(was_previously_public_at(&home, &second_key));
+    }
+
+    #[test]
+    fn default_key_keeps_legacy_marker_mapping() {
+        let root = tempfile::tempdir().expect("temp identity root");
+        let home = root.path().join("home");
+        let state_dir = home.join(".mesh-llm");
+        let default_key = state_dir.join("key");
+        std::fs::create_dir_all(&state_dir).expect("create state dir");
+        std::fs::write(&default_key, b"default public key").expect("write default key");
+        std::fs::write(state_dir.join("was-public"), b"public state").expect("write legacy marker");
+
+        assert_eq!(
+            was_public_path_for(&home, &default_key),
+            state_dir.join("was-public")
+        );
+        assert!(was_previously_public_at(&home, &default_key));
+
+        clear_public_identity_at(&home, &default_key).expect("clear default identity");
+        assert!(!default_key.exists());
+        assert!(!state_dir.join("was-public").exists());
+    }
+
+    #[test]
+    #[serial]
+    fn relative_custom_key_paths_resolve_before_use() {
+        let _env = NodeKeyPathEnvGuard::set("relative-node.key");
+        let expected = std::env::current_dir()
+            .expect("current dir")
+            .join("relative-node.key");
+
+        assert_eq!(
+            default_node_key_path().expect("resolve node key path"),
+            expected
+        );
+        assert!(expected.is_absolute());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn key_path_digest_preserves_non_utf8_path_bytes() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let first =
+            std::path::PathBuf::from(OsString::from_vec(vec![b'n', b'o', b'd', b'e', 0x80]));
+        let second =
+            std::path::PathBuf::from(OsString::from_vec(vec![b'n', b'o', b'd', b'e', 0x81]));
+
+        assert_ne!(key_path_digest(&first), key_path_digest(&second));
+    }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/mod.rs
@@ -147,6 +147,11 @@ pub use identity_persistence::{
 };
 #[expect(
     unused_imports,
+    reason = "test-only home resolver used by environment-isolated identity tests"
+)]
+pub(crate) use identity_persistence::{identity_home_dir, identity_state_dir};
+#[expect(
+    unused_imports,
     reason = "public compatibility re-export for existing mesh node callers"
 )]
 pub use node::{

--- a/crates/mesh-llm-host-runtime/src/mesh/node.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node.rs
@@ -71,7 +71,7 @@ pub struct RouteEntry {
 pub struct Node {
     pub(crate) endpoint: Endpoint,
     pub(crate) endpoint_secret_key: SecretKey,
-    pub(crate) public_addr: Option<std::net::SocketAddr>,
+    pub(crate) public_addr: Option<stun::PublicAddr>,
     pub(crate) quic_bind: QuicBindSelection,
     pub(crate) relay_policy: RelayPolicy,
     pub(crate) owner_keypair: Option<crate::crypto::OwnerKeypair>,
@@ -730,10 +730,10 @@ impl Node {
         }
 
         // Use iroh's net report because it probes through the endpoint's actual QUIC sockets.
-        // Its direct address includes the observed NAT-mapped port; substituting the configured
+        // Its observed address includes the NAT-mapped port; substituting the configured
         // bind port would advertise an address that was never verified externally.
         let public_addr = if relay.policy.uses_raw_stun() {
-            stun_public_addr(&endpoint).await
+            stun_public_addr(&endpoint, relay.policy.uses_relay()).await
         } else {
             tracing::info!("Raw STUN: disabled by LAN-only discovery mode");
             None

--- a/crates/mesh-llm-host-runtime/src/mesh/node_identity.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node_identity.rs
@@ -1,6 +1,38 @@
 use super::*;
 use crate::mesh::node::RequirementAwareMeshState;
 
+/// Merge the startup-discovered public address into an advertisement set.
+///
+/// An [`PublicAddr::Observed`] address carries the NAT-mapped port
+/// (#1300), so it *replaces* every IP candidate on the same address —
+/// advertising both leaves a dead candidate that sorts first in the
+/// `BTreeSet`. A [`PublicAddr::LocallyEnumerated`] address only fills a
+/// gap: the port was never verified externally, so it must not displace an
+/// existing public candidate.
+pub(crate) fn merge_public_addr_into_advertisement(
+    addr: &mut EndpointAddr,
+    pub_addr: &stun::PublicAddr,
+) {
+    match *pub_addr {
+        stun::PublicAddr::Observed(observed) => {
+            addr.addrs.retain(|candidate| match candidate {
+                TransportAddr::Ip(socket) => socket.ip() != observed.ip(),
+                _ => true,
+            });
+            addr.addrs.insert(TransportAddr::Ip(observed));
+        }
+        stun::PublicAddr::LocallyEnumerated(enumerated) => {
+            if !endpoint_addr_has_public_ipv4(addr) {
+                addr.addrs.insert(TransportAddr::Ip(enumerated));
+            }
+        }
+        stun::PublicAddr::RejectPublicIpv4 => addr.addrs.retain(|candidate| match candidate {
+            TransportAddr::Ip(socket) => !is_public_ipv4_candidate(socket),
+            _ => true,
+        }),
+    }
+}
+
 pub(crate) fn direct_admission_attestation_hash(
     release_attestation: Option<&crate::ReleaseBuildAttestation>,
 ) -> String {
@@ -104,11 +136,13 @@ impl Node {
 
     pub async fn invite_token(&self) -> String {
         let mut addr = self.endpoint_addr_for_advertisement();
-        // Inject STUN-discovered public address if relay STUN didn't provide one.
-        if let Some(pub_addr) = self.public_addr
-            && !endpoint_addr_has_public_ipv4(&addr)
-        {
-            addr.addrs.insert(TransportAddr::Ip(pub_addr));
+        // Inject the public address discovered at startup, preferring the
+        // externally observed tuple. An observed address carries the NAT-mapped
+        // port, so it *replaces* any enumerated candidate for the same purpose
+        // (advertising both leaves a dead candidate that sorts first in the
+        // BTreeSet, #1300); an enumerated one only fills a gap.
+        if let Some(pub_addr) = self.public_addr.as_ref() {
+            merge_public_addr_into_advertisement(&mut addr, pub_addr);
         }
         addr = filter_endpoint_addr_for_bind_ip(
             addr,

--- a/crates/mesh-llm-host-runtime/src/mesh/node_identity.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/node_identity.rs
@@ -442,11 +442,10 @@ impl Node {
         });
     }
 
-    pub async fn join(&self, invite_token: &str) -> Result<()> {
+    async fn prepare_join_target(&self, invite_token: &str) -> Result<EndpointAddr> {
         let addr = match parse_invite_token(invite_token)
             .map_err(|reason| anyhow::anyhow!("join rejected: {}", reason.code()))?
         {
-            InviteTokenMaterial::Legacy(addr) => addr,
             InviteTokenMaterial::Signed(token) => {
                 let addrs = match self.validate_bootstrap_token(&token).await {
                     Ok(addrs) => addrs,
@@ -460,6 +459,10 @@ impl Node {
                         return Err(anyhow::anyhow!("join rejected: {}", reason.code()));
                     }
                 };
+                let addr = addrs.into_iter().next().ok_or_else(|| {
+                    anyhow::anyhow!("bootstrap token does not contain any endpoint addresses")
+                })?;
+                self.reject_join_to_own_identity(&addr).await?;
                 self.install_requirement_aware_mesh_state(
                     token.mesh_id.clone(),
                     token.policy_hash.clone(),
@@ -468,15 +471,43 @@ impl Node {
                     Some(*token),
                 )
                 .await?;
-                addrs.into_iter().next().ok_or_else(|| {
-                    anyhow::anyhow!("bootstrap token does not contain any endpoint addresses")
-                })?
+                addr
+            }
+            InviteTokenMaterial::Legacy(addr) => {
+                self.reject_join_to_own_identity(&addr).await?;
+                addr
             }
         };
+        Ok(addr)
+    }
+
+    pub async fn join(&self, invite_token: &str) -> Result<()> {
+        let addr = self.prepare_join_target(invite_token).await?;
         // Clear dead status — explicit join should always attempt connection
         self.state.lock().await.dead_peers.remove(&addr.id);
         self.remember_join_target(addr.clone()).await;
         self.connect_to_peer(addr).await
+    }
+
+    /// A join token that names our own endpoint id means a second node
+    /// process on this machine is loading the same node key (#1699). iroh
+    /// refuses self-connections, so both meshes silently collapse to one node
+    /// — fail loudly instead, naming the two escape hatches.
+    async fn reject_join_to_own_identity(&self, addr: &EndpointAddr) -> Result<()> {
+        if addr.id != self.endpoint.id() {
+            return Ok(());
+        }
+        let message = format!(
+            "join rejected: the invite token names this node's own id ({}) — \
+             another process on this machine is almost certainly serving with \
+             the same node key. Give this node its own key with \
+             MESH_LLM_NODE_KEY_PATH, or set MESH_LLM_EPHEMERAL_KEY for a \
+             throwaway identity",
+            self.endpoint.id().fmt_short()
+        );
+        tracing::error!("{message}");
+        emit_mesh_info(format!("⛔ {message}"));
+        anyhow::bail!("{message}")
     }
 
     /// Record a join target address so the LAN beacon can unicast a dial-back
@@ -509,36 +540,7 @@ impl Node {
     /// Like [`join`], but retries once after a delay on transient (connect/timeout)
     /// errors.  Decode errors (invalid base64/JSON) fail immediately.
     pub async fn join_with_retry(&self, invite_token: &str) -> Result<()> {
-        let addr = match parse_invite_token(invite_token)
-            .map_err(|reason| anyhow::anyhow!("join rejected: {}", reason.code()))?
-        {
-            InviteTokenMaterial::Legacy(addr) => addr,
-            InviteTokenMaterial::Signed(token) => {
-                let addrs = match self.validate_bootstrap_token(&token).await {
-                    Ok(addrs) => addrs,
-                    Err(reason) => {
-                        self.record_mesh_requirement_rejection(
-                            MeshRequirementRejectionSource::Join,
-                            None,
-                            reason.clone(),
-                        )
-                        .await;
-                        return Err(anyhow::anyhow!("join rejected: {}", reason.code()));
-                    }
-                };
-                self.install_requirement_aware_mesh_state(
-                    token.mesh_id.clone(),
-                    token.policy_hash.clone(),
-                    token.genesis_policy.clone(),
-                    None,
-                    Some(*token),
-                )
-                .await?;
-                addrs.into_iter().next().ok_or_else(|| {
-                    anyhow::anyhow!("bootstrap token does not contain any endpoint addresses")
-                })?
-            }
-        };
+        let addr = self.prepare_join_target(invite_token).await?;
 
         // Three attempts with increasing backoff.  Relay-only joins need
         // WebSocket setup + QUIC handshake at high RTT — two attempts at

--- a/crates/mesh-llm-host-runtime/src/mesh/public_identity_tests.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/public_identity_tests.rs
@@ -1,32 +1,77 @@
 use super::*;
+use serial_test::serial;
+use std::ffi::OsString;
 use std::fs;
 
-/// Test that mark_was_public / was_previously_public / clear_public_identity
-/// work correctly.  Uses the real ~/.mesh-llm/ directory (same approach as
-/// the rotate_keys tests) and restores originals afterward.
-#[test]
-pub(crate) fn public_to_private_transition_clears_identity() {
-    let dir = dirs::home_dir().unwrap().join(".mesh-llm");
-    fs::create_dir_all(&dir).ok();
+struct IdentityEnvGuard {
+    home: Option<OsString>,
+    test_home: Option<OsString>,
+    node_key_path: Option<OsString>,
+}
 
-    // Files we may touch:
-    let paths: Vec<std::path::PathBuf> =
-        ["key", "nostr.nsec", "mesh-id", "last-mesh", "was-public"]
-            .iter()
-            .map(|n| dir.join(n))
-            .collect();
+impl IdentityEnvGuard {
+    fn set_home(home: &std::path::Path) -> Self {
+        let previous = Self {
+            home: std::env::var_os("HOME"),
+            test_home: std::env::var_os("MESH_LLM_TEST_HOME"),
+            node_key_path: std::env::var_os("MESH_LLM_NODE_KEY_PATH"),
+        };
+        unsafe {
+            // SAFETY: this guard is used only by the #[serial] test and restores both values.
+            std::env::set_var("HOME", home);
+            // SAFETY: this guard is used only by the #[serial] test and restores all values.
+            std::env::set_var("MESH_LLM_TEST_HOME", home);
+            // SAFETY: this guard is used only by the #[serial] test and restores both values.
+            std::env::remove_var("MESH_LLM_NODE_KEY_PATH");
+        }
+        previous
+    }
+}
 
-    // Save originals so we can restore after the test.
-    let originals: Vec<Option<Vec<u8>>> = paths
-        .iter()
-        .map(|p| {
-            if p.exists() {
-                Some(fs::read(p).unwrap())
-            } else {
-                None
+impl Drop for IdentityEnvGuard {
+    fn drop(&mut self) {
+        match self.home.take() {
+            Some(value) => {
+                // SAFETY: this guard is used only by the #[serial] test and restores both values.
+                unsafe { std::env::set_var("HOME", value) }
             }
-        })
-        .collect();
+            None => {
+                // SAFETY: this guard is used only by the #[serial] test and restores both values.
+                unsafe { std::env::remove_var("HOME") }
+            }
+        }
+        match self.test_home.take() {
+            Some(value) => {
+                // SAFETY: this guard is used only by the #[serial] test and restores all values.
+                unsafe { std::env::set_var("MESH_LLM_TEST_HOME", value) }
+            }
+            None => {
+                // SAFETY: this guard is used only by the #[serial] test and restores all values.
+                unsafe { std::env::remove_var("MESH_LLM_TEST_HOME") }
+            }
+        }
+        match self.node_key_path.take() {
+            Some(value) => {
+                // SAFETY: this guard is used only by the #[serial] test and restores both values.
+                unsafe { std::env::set_var("MESH_LLM_NODE_KEY_PATH", value) }
+            }
+            None => {
+                // SAFETY: this guard is used only by the #[serial] test and restores both values.
+                unsafe { std::env::remove_var("MESH_LLM_NODE_KEY_PATH") }
+            }
+        }
+    }
+}
+
+/// Test that mark_was_public / was_previously_public / clear_public_identity
+/// work correctly in an isolated temporary home and key namespace.
+#[test]
+#[serial]
+pub(crate) fn public_to_private_transition_clears_identity() {
+    let temp = tempfile::tempdir().expect("temp home");
+    let _env = IdentityEnvGuard::set_home(temp.path());
+    let dir = identity_home_dir().join(".mesh-llm");
+    fs::create_dir_all(&dir).ok();
 
     // --- Scenario 1: no marker → was_previously_public is false ---
     let _ = fs::remove_file(dir.join("was-public"));
@@ -57,13 +102,4 @@ pub(crate) fn public_to_private_transition_clears_identity() {
 
     // --- Scenario 4: clear on already-clean directory is fine ---
     clear_public_identity().expect("clear already-clean public identity");
-
-    // Restore originals.
-    for (path, orig) in paths.iter().zip(originals.iter()) {
-        if let Some(data) = orig {
-            fs::write(path, data).ok();
-        } else {
-            let _ = fs::remove_file(path);
-        }
-    }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/stun.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/stun.rs
@@ -1,56 +1,273 @@
 use super::*;
 use iroh::Watcher;
 
-fn public_ipv4_addr(endpoint_addr: &iroh::EndpointAddr) -> Option<std::net::SocketAddr> {
+/// Provenance of a public IPv4 candidate advertised in the invite token.
+///
+/// The #1300 defect was exactly that these two were indistinguishable: a
+/// locally enumerated interface address carries the *bound* port, which a
+/// port-remapping host never verifies externally.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum PublicAddr {
+    /// Observed by a relay probe (QAD) through the endpoint's own socket, so
+    /// the tuple includes the NAT-mapped port by construction.
+    Observed(std::net::SocketAddr),
+    /// Enumerated from local interfaces. The port is the bound port and was
+    /// never verified externally; only fills a gap when nothing better exists.
+    LocallyEnumerated(std::net::SocketAddr),
+    /// A relay report observed address-dependent IPv4 mappings. Public IPv4
+    /// candidates in `EndpointAddr` come from the same untrusted report/local
+    /// mixture and must be suppressed from the invite.
+    RejectPublicIpv4,
+}
+
+fn locally_enumerated_public_ipv4(
+    endpoint_addr: &iroh::EndpointAddr,
+) -> Option<std::net::SocketAddr> {
     endpoint_addr
         .ip_addrs()
         .copied()
         .find(is_public_ipv4_candidate)
 }
 
-pub(crate) async fn stun_public_addr(endpoint: &iroh::Endpoint) -> Option<std::net::SocketAddr> {
-    let mut addresses = endpoint.watch_addr();
+fn observed_public_ipv4(report: &iroh::unstable_net_report::NetReport) -> Option<PublicAddr> {
+    if report.mapping_varies_by_dest_ipv4 == Some(true) {
+        tracing::warn!(
+            "QUIC endpoint public address varies by probe destination \
+             (address-dependent mapping); direct UDP unlikely, not advertising it"
+        );
+        return Some(PublicAddr::RejectPublicIpv4);
+    }
+    report
+        .global_v4
+        .map(std::net::SocketAddr::V4)
+        .map(PublicAddr::Observed)
+}
+
+/// Wait (bounded by `iroh::NET_REPORT_TIMEOUT`) for a net report yielding a
+/// usable observed public IPv4.
+async fn wait_for_observed_public_ipv4(endpoint: &iroh::Endpoint) -> Option<PublicAddr> {
+    let mut net_report = endpoint.net_report();
     let deadline =
         tokio::time::Instant::now() + std::time::Duration::from_secs(iroh::NET_REPORT_TIMEOUT);
 
     loop {
-        if let Some(addr) = public_ipv4_addr(&addresses.get()) {
-            tracing::info!(%addr, "QUIC endpoint discovered public address");
-            return Some(addr);
+        if let Some(report) = net_report.get() {
+            return observed_public_ipv4(&report);
         }
 
         let remaining = deadline
             .checked_duration_since(tokio::time::Instant::now())
             .unwrap_or_default();
-        match tokio::time::timeout(remaining, addresses.updated()).await {
+        match tokio::time::timeout(remaining, net_report.updated()).await {
             Ok(Ok(_)) => {}
             Ok(Err(_)) | Err(_) => {
-                tracing::warn!("QUIC endpoint could not discover a public address");
+                tracing::warn!(
+                    "QUIC endpoint could not discover a public address \
+                     (net report unavailable within timeout)"
+                );
                 return None;
             }
         }
     }
 }
 
+/// The address to advertise for direct connectivity, with its provenance.
+///
+/// Prefers the externally observed tuple from the endpoint's net report: a QAD
+/// probe reply carries the NAT-mapped port, which local interface enumeration
+/// cannot know. Falls back to a locally enumerated public candidate only when
+/// no net report can complete (`relays_configured = false`) or one completes
+/// without a usable observation — preserving relay-less hosts, whose port is
+/// logged as unverified.
+pub(crate) async fn stun_public_addr(
+    endpoint: &iroh::Endpoint,
+    relays_configured: bool,
+) -> Option<PublicAddr> {
+    if relays_configured && let Some(discovery) = wait_for_observed_public_ipv4(endpoint).await {
+        if let PublicAddr::Observed(addr) = discovery {
+            tracing::info!(%addr, "QUIC endpoint discovered public address (observed by relay probe)");
+        }
+        return Some(discovery);
+    }
+
+    let addr = locally_enumerated_public_ipv4(&endpoint.addr());
+    if let Some(addr) = addr {
+        tracing::warn!(
+            %addr,
+            "advertising locally enumerated public address; port not externally verified"
+        );
+    }
+    addr.map(PublicAddr::LocallyEnumerated)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn preserves_port_discovered_by_quic_endpoint() {
-        let endpoint_id = iroh::SecretKey::generate().public();
-        let mapped = std::net::SocketAddr::from(([9, 9, 9, 9], 45_678));
-        let endpoint_addr = iroh::EndpointAddr::new(endpoint_id).with_ip_addr(mapped);
-
-        assert_eq!(public_ipv4_addr(&endpoint_addr), Some(mapped));
+    fn observed_report(
+        global_v4: Option<std::net::SocketAddrV4>,
+        mapping_varies: Option<bool>,
+    ) -> iroh::unstable_net_report::NetReport {
+        let mut report = iroh::unstable_net_report::NetReport::default();
+        report.udp_v4 = true;
+        report.global_v4 = global_v4;
+        report.mapping_varies_by_dest_ipv4 = mapping_varies;
+        report
     }
 
     #[test]
-    fn ignores_local_quic_endpoint_addresses() {
+    fn observed_tuple_preserves_nat_mapped_port() {
+        // The #1300 shape: container binds 41842, NAT maps it to 23555. The
+        // relay-observed tuple carries the mapped port; the locally enumerated
+        // candidate (same IP, port 41842) must never win over it.
+        let mapped = std::net::SocketAddrV4::new("213.5.72.196".parse().unwrap(), 23_555);
+        let report = observed_report(Some(mapped), Some(false));
+
+        assert_eq!(
+            observed_public_ipv4(&report),
+            Some(PublicAddr::Observed(std::net::SocketAddr::from(mapped)))
+        );
+    }
+
+    #[test]
+    fn observed_tuple_rejected_when_mapping_varies_by_destination() {
+        let mapped = std::net::SocketAddrV4::new("213.5.72.196".parse().unwrap(), 23_555);
+        let report = observed_report(Some(mapped), Some(true));
+
+        assert_eq!(
+            observed_public_ipv4(&report),
+            Some(PublicAddr::RejectPublicIpv4)
+        );
+    }
+
+    #[test]
+    fn unmeasured_mapping_variance_is_still_accepted() {
+        // Only one relay probed: variance is None, which is not evidence of
+        // an address-dependent mapping.
+        let mapped = std::net::SocketAddrV4::new("213.5.72.196".parse().unwrap(), 23_555);
+        let report = observed_report(Some(mapped), None);
+
+        assert_eq!(
+            observed_public_ipv4(&report),
+            Some(PublicAddr::Observed(std::net::SocketAddr::from(mapped)))
+        );
+    }
+
+    #[test]
+    fn no_observation_yields_none() {
+        assert_eq!(observed_public_ipv4(&observed_report(None, None)), None);
+    }
+
+    #[test]
+    fn enumeration_fallback_finds_public_ipv4() {
         let endpoint_id = iroh::SecretKey::generate().public();
-        let endpoint_addr = iroh::EndpointAddr::new(endpoint_id)
+        let addr = iroh::EndpointAddr::new(endpoint_id)
+            .with_ip_addr(std::net::SocketAddr::from(([9, 9, 9, 9], 45_678)));
+
+        assert_eq!(
+            locally_enumerated_public_ipv4(&addr),
+            Some(std::net::SocketAddr::from(([9, 9, 9, 9], 45_678)))
+        );
+    }
+
+    #[test]
+    fn enumeration_ignores_private_addrs() {
+        let endpoint_id = iroh::SecretKey::generate().public();
+        let addr = iroh::EndpointAddr::new(endpoint_id)
             .with_ip_addr(std::net::SocketAddr::from(([192, 168, 1, 8], 45_678)));
 
-        assert_eq!(public_ipv4_addr(&endpoint_addr), None);
+        assert_eq!(locally_enumerated_public_ipv4(&addr), None);
+    }
+
+    #[test]
+    fn merge_observed_replaces_enumerated_candidate_on_same_ip() {
+        use crate::mesh::node_identity::merge_public_addr_into_advertisement;
+
+        // Exact #1300 field shape: the container's local interface holds the
+        // public IP with the bound port (41842); the relay observed the same
+        // IP behind the NAT-mapped port (23555). The observed tuple must
+        // replace the enumerated one — advertising both leaves the dead
+        // candidate first in the token's BTreeSet.
+        let endpoint_id = iroh::SecretKey::generate().public();
+        let mut addr = iroh::EndpointAddr::new(endpoint_id)
+            .with_ip_addr(std::net::SocketAddr::from(([213, 5, 72, 196], 41_842)));
+        let observed =
+            PublicAddr::Observed(std::net::SocketAddr::from(([213, 5, 72, 196], 23_555)));
+
+        merge_public_addr_into_advertisement(&mut addr, &observed);
+
+        let ip_addrs: Vec<_> = addr.ip_addrs().copied().collect();
+        assert_eq!(
+            ip_addrs,
+            vec![std::net::SocketAddr::from(([213, 5, 72, 196], 23_555))]
+        );
+    }
+
+    #[test]
+    fn merge_enumerated_only_fills_a_gap() {
+        use crate::mesh::node_identity::merge_public_addr_into_advertisement;
+
+        // An enumerated candidate must not displace an existing public one.
+        let endpoint_id = iroh::SecretKey::generate().public();
+        let existing = std::net::SocketAddr::from(([93, 184, 216, 34], 9));
+        let mut addr = iroh::EndpointAddr::new(endpoint_id).with_ip_addr(existing);
+        let enumerated_addr = std::net::SocketAddr::from(([213, 5, 72, 211], 41_842));
+        let enumerated = PublicAddr::LocallyEnumerated(enumerated_addr);
+
+        merge_public_addr_into_advertisement(&mut addr, &enumerated);
+
+        assert!(addr.ip_addrs().copied().any(|a| a == existing));
+        assert!(!addr.ip_addrs().copied().any(|a| a == enumerated_addr));
+    }
+
+    #[test]
+    fn merge_enumerated_inserts_when_no_public_candidate_exists() {
+        use crate::mesh::node_identity::merge_public_addr_into_advertisement;
+
+        // Relay-less host: enumeration is the only source, and it must still
+        // fill a completely empty advertisement.
+        let endpoint_id = iroh::SecretKey::generate().public();
+        let mut addr = iroh::EndpointAddr::new(endpoint_id)
+            .with_ip_addr(std::net::SocketAddr::from(([192, 168, 1, 8], 45_678)));
+        let enumerated_addr = std::net::SocketAddr::from(([213, 5, 72, 211], 41_842));
+        let enumerated = PublicAddr::LocallyEnumerated(enumerated_addr);
+
+        merge_public_addr_into_advertisement(&mut addr, &enumerated);
+
+        assert!(addr.ip_addrs().copied().any(|a| a == enumerated_addr));
+    }
+
+    #[test]
+    fn merge_rejected_mapping_removes_public_ipv4_candidates() {
+        use crate::mesh::node_identity::merge_public_addr_into_advertisement;
+
+        let endpoint_id = iroh::SecretKey::generate().public();
+        let private = std::net::SocketAddr::from(([192, 168, 1, 8], 41_842));
+        let public_bound = std::net::SocketAddr::from(([213, 5, 72, 196], 41_842));
+        let public_observed = std::net::SocketAddr::from(([213, 5, 72, 196], 23_555));
+        let mut addr = iroh::EndpointAddr::new(endpoint_id)
+            .with_ip_addr(private)
+            .with_ip_addr(public_bound)
+            .with_ip_addr(public_observed);
+
+        merge_public_addr_into_advertisement(&mut addr, &PublicAddr::RejectPublicIpv4);
+
+        assert!(
+            addr.ip_addrs()
+                .copied()
+                .any(|candidate| candidate == private)
+        );
+        assert!(
+            !addr
+                .ip_addrs()
+                .copied()
+                .any(|candidate| candidate == public_bound)
+        );
+        assert!(
+            !addr
+                .ip_addrs()
+                .copied()
+                .any(|candidate| candidate == public_observed)
+        );
     }
 }

--- a/crates/mesh-llm-host-runtime/src/mesh/tests/connections.rs
+++ b/crates/mesh-llm-host-runtime/src/mesh/tests/connections.rs
@@ -495,6 +495,46 @@ async fn make_test_node_with_requirements(
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn join_rejects_token_naming_own_identity() -> Result<()> {
+    // #1699: two serve processes on one machine silently load the same node
+    // key, so the joiner's token names its own endpoint id. iroh refuses
+    // self-connections, so before the guard this failed opaquely (or looked
+    // like a successful one-node mesh). It must fail loudly instead.
+    let node = make_test_node(super::NodeRole::Worker).await?;
+    node.start_accepting();
+
+    let self_token = node.invite_token().await;
+    let err = node
+        .join(&self_token)
+        .await
+        .expect_err("joining our own invite token must be rejected");
+
+    assert!(
+        err.to_string().contains("own id"),
+        "unexpected error: {err:#}"
+    );
+
+    assert!(
+        node.active_mesh_policy_state().await.is_none(),
+        "a rejected self-token must not install signed mesh policy state"
+    );
+    assert!(
+        node.bootstrap_token.lock().await.is_none(),
+        "a rejected self-token must not install the bootstrap token"
+    );
+
+    let retry_err = node
+        .join_with_retry(&self_token)
+        .await
+        .expect_err("retrying our own invite token must be rejected");
+    assert!(
+        retry_err.to_string().contains("own id"),
+        "unexpected retry error: {retry_err:#}"
+    );
+    Ok(())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn host_role_claim_transitions_regossip_to_connected_peer() -> Result<()> {
     let host = make_test_node(super::NodeRole::Worker).await?;
     let peer = make_test_node(super::NodeRole::Worker).await?;

--- a/crates/mesh-llm-host-runtime/src/network/nostr/keys.rs
+++ b/crates/mesh-llm-host-runtime/src/network/nostr/keys.rs
@@ -4,13 +4,12 @@ use anyhow::Result;
 use nostr_sdk::prelude::*;
 
 // ---------------------------------------------------------------------------
-// Keys — stored in ~/.mesh-llm/nostr.nsec
+// Keys — stored in ~/.mesh-llm/nostr.nsec for the default node key, or in the
+// active key's private identity namespace when MESH_LLM_NODE_KEY_PATH is set.
 // ---------------------------------------------------------------------------
 
 fn nostr_key_path() -> Result<std::path::PathBuf> {
-    let home =
-        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
-    Ok(home.join(".mesh-llm").join("nostr.nsec"))
+    Ok(crate::mesh::identity_state_dir().join("nostr.nsec"))
 }
 
 /// Load or generate a Nostr keypair for publishing.
@@ -81,10 +80,6 @@ fn ensure_private_nostr_key_file(_path: &std::path::Path) -> Result<()> {
 /// Delete the Nostr key and node identity key.  After rotation the
 /// node gets a fresh identity on next start.
 pub fn rotate_keys() -> Result<()> {
-    let home =
-        dirs::home_dir().ok_or_else(|| anyhow::anyhow!("Cannot determine home directory"))?;
-    let mesh_dir = home.join(".mesh-llm");
-
     let nostr_path = nostr_key_path()?;
     if nostr_path.exists() {
         std::fs::remove_file(&nostr_path)?;
@@ -93,7 +88,7 @@ pub fn rotate_keys() -> Result<()> {
         eprintln!("No Nostr key to rotate (none exists yet).");
     }
 
-    let node_key_path = mesh_dir.join("key");
+    let node_key_path = crate::mesh::default_node_key_path()?;
     if node_key_path.exists() {
         std::fs::remove_file(&node_key_path)?;
         eprintln!("🔑 Deleted {}", node_key_path.display());
@@ -114,22 +109,48 @@ mod rotate_key_tests {
     use std::fs;
 
     struct HomeEnvGuard {
-        previous: Option<OsString>,
+        previous_home: Option<OsString>,
+        previous_node_key_path: Option<OsString>,
     }
 
     impl HomeEnvGuard {
         fn set(path: &std::path::Path) -> Self {
-            let previous = std::env::var_os("HOME");
-            unsafe { std::env::set_var("HOME", path) };
-            Self { previous }
+            let previous_home = std::env::var_os("HOME");
+            let previous_node_key_path = std::env::var_os("MESH_LLM_NODE_KEY_PATH");
+            unsafe {
+                // SAFETY: this guard is used only by #[serial] tests and restores both values.
+                std::env::set_var("HOME", path);
+                // SAFETY: this guard is used only by #[serial] tests and restores both values.
+                std::env::remove_var("MESH_LLM_NODE_KEY_PATH");
+            }
+            Self {
+                previous_home,
+                previous_node_key_path,
+            }
         }
     }
 
     impl Drop for HomeEnvGuard {
         fn drop(&mut self) {
-            match self.previous.take() {
-                Some(value) => unsafe { std::env::set_var("HOME", value) },
-                None => unsafe { std::env::remove_var("HOME") },
+            match self.previous_home.take() {
+                Some(value) => {
+                    // SAFETY: this guard is used only by #[serial] tests and restores both values.
+                    unsafe { std::env::set_var("HOME", value) }
+                }
+                None => {
+                    // SAFETY: this guard is used only by #[serial] tests and restores both values.
+                    unsafe { std::env::remove_var("HOME") }
+                }
+            }
+            match self.previous_node_key_path.take() {
+                Some(value) => {
+                    // SAFETY: this guard is used only by #[serial] tests and restores both values.
+                    unsafe { std::env::set_var("MESH_LLM_NODE_KEY_PATH", value) }
+                }
+                None => {
+                    // SAFETY: this guard is used only by #[serial] tests and restores both values.
+                    unsafe { std::env::remove_var("MESH_LLM_NODE_KEY_PATH") }
+                }
             }
         }
     }
@@ -139,7 +160,11 @@ mod rotate_key_tests {
     fn rotate_deletes_both_keys_and_handles_missing() {
         let temp = tempfile::tempdir().expect("temp home");
         let _home = HomeEnvGuard::set(temp.path());
-        let dir = dirs::home_dir().unwrap().join(".mesh-llm");
+        assert!(
+            std::env::var_os("MESH_LLM_NODE_KEY_PATH").is_none(),
+            "rotate test must use the isolated default key namespace"
+        );
+        let dir = crate::mesh::identity_home_dir().join(".mesh-llm");
         fs::create_dir_all(&dir).ok();
 
         let key_path = dir.join("key");
@@ -158,6 +183,35 @@ mod rotate_key_tests {
         // (files were just deleted above, so the directory is clean)
         let result = rotate_keys();
         assert!(result.is_ok(), "rotate should succeed even with no keys");
+    }
+
+    #[test]
+    #[serial]
+    fn rotate_deletes_active_custom_keys_without_touching_default_state() {
+        let temp = tempfile::tempdir().expect("temp home");
+        let _home = HomeEnvGuard::set(temp.path());
+        let custom_key_path = temp.path().join("custom-node.key");
+        // SAFETY: this #[serial] test owns the process environment and _home restores it.
+        unsafe { std::env::set_var("MESH_LLM_NODE_KEY_PATH", &custom_key_path) };
+
+        let default_dir = crate::mesh::identity_home_dir().join(".mesh-llm");
+        fs::create_dir_all(&default_dir).unwrap();
+        let default_key_path = default_dir.join("key");
+        let default_nostr_path = default_dir.join("nostr.nsec");
+        fs::write(&default_key_path, b"default-node-key").unwrap();
+        fs::write(&default_nostr_path, b"default-nostr-nsec").unwrap();
+
+        let custom_nostr_path = nostr_key_path().unwrap();
+        fs::write(&custom_key_path, b"custom-node-key").unwrap();
+        fs::create_dir_all(custom_nostr_path.parent().unwrap()).unwrap();
+        fs::write(&custom_nostr_path, b"custom-nostr-nsec").unwrap();
+
+        rotate_keys().expect("rotate custom keys");
+
+        assert!(!custom_key_path.exists());
+        assert!(!custom_nostr_path.exists());
+        assert!(default_key_path.exists());
+        assert!(default_nostr_path.exists());
     }
 }
 

--- a/crates/mesh-llm-identity/src/lib.rs
+++ b/crates/mesh-llm-identity/src/lib.rs
@@ -31,8 +31,8 @@ pub use keystore::{
 };
 #[cfg(feature = "host-io")]
 pub use node_key::{
-    NODE_KEY_BYTES, default_node_key_path, load_node_key_bytes_from_path,
-    save_node_key_bytes_to_path,
+    NODE_KEY_BYTES, default_node_key_path, home_node_key_path, load_node_key_bytes_from_path,
+    resolve_node_key_path, save_node_key_bytes_to_path,
 };
 #[cfg(feature = "host-io")]
 pub use ownership::{

--- a/crates/mesh-llm-identity/src/node_key.rs
+++ b/crates/mesh-llm-identity/src/node_key.rs
@@ -5,7 +5,33 @@ use crate::CryptoError;
 
 pub const NODE_KEY_BYTES: usize = 32;
 
+/// Resolve the default node key path, honoring the explicit override.
+///
+/// `MESH_LLM_NODE_KEY_PATH` selects a dedicated key file for hosts running
+/// several node processes side by side (#1699). When unset, the key stays at
+/// `~/.mesh-llm/key` so existing installations keep their node identity.
 pub fn default_node_key_path() -> Result<PathBuf, CryptoError> {
+    resolve_node_key_path(std::env::var_os("MESH_LLM_NODE_KEY_PATH"))
+}
+
+/// Resolve a node key path with explicit inputs so precedence is testable
+/// without mutating process environment variables.
+///
+/// An empty override is treated as unset, so `MESH_LLM_NODE_KEY_PATH=` keeps
+/// the historical default rather than resolving to the working directory.
+pub fn resolve_node_key_path(
+    override_path: Option<std::ffi::OsString>,
+) -> Result<PathBuf, CryptoError> {
+    if let Some(path) = override_path
+        && !path.is_empty()
+    {
+        return Ok(PathBuf::from(path));
+    }
+    home_node_key_path()
+}
+
+/// The historical node key location: `~/.mesh-llm/key`.
+pub fn home_node_key_path() -> Result<PathBuf, CryptoError> {
     let home = dirs::home_dir().ok_or_else(|| {
         CryptoError::Io(std::io::Error::new(
             std::io::ErrorKind::NotFound,
@@ -51,24 +77,62 @@ pub fn save_node_key_bytes_to_path(
     Ok(())
 }
 
-#[cfg(unix)]
 fn ensure_private_node_key_dir(dir: &Path) -> Result<(), CryptoError> {
-    use std::os::unix::fs::PermissionsExt;
+    let mut missing = Vec::new();
+    let mut current = dir;
+    loop {
+        match std::fs::metadata(current) {
+            Ok(metadata) => {
+                if !metadata.is_dir() {
+                    return Err(CryptoError::Io(std::io::Error::new(
+                        std::io::ErrorKind::NotADirectory,
+                        format!("node key parent {} is not a directory", current.display()),
+                    )));
+                }
+                break;
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {
+                missing.push(current);
+                current = current.parent().ok_or_else(|| {
+                    CryptoError::Io(std::io::Error::new(
+                        std::io::ErrorKind::NotFound,
+                        format!("cannot find parent directory for {}", dir.display()),
+                    ))
+                })?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
 
-    std::fs::create_dir_all(dir)?;
-    let metadata = std::fs::metadata(dir)?;
-    let mut perms = metadata.permissions();
-    if perms.mode() & 0o077 != 0 {
-        perms.set_mode(0o700);
-        std::fs::set_permissions(dir, perms)?;
+    for path in missing.into_iter().rev() {
+        match create_private_node_key_dir(path) {
+            Ok(()) => {}
+            Err(error) if error.kind() == std::io::ErrorKind::AlreadyExists => {
+                let metadata = std::fs::metadata(path)?;
+                if !metadata.is_dir() {
+                    return Err(CryptoError::Io(std::io::Error::new(
+                        std::io::ErrorKind::NotADirectory,
+                        format!("node key parent {} is not a directory", path.display()),
+                    )));
+                }
+            }
+            Err(error) => return Err(error.into()),
+        }
     }
     Ok(())
 }
 
+#[cfg(unix)]
+fn create_private_node_key_dir(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::DirBuilderExt;
+
+    let mut builder = std::fs::DirBuilder::new();
+    builder.mode(0o700).create(path)
+}
+
 #[cfg(not(unix))]
-fn ensure_private_node_key_dir(dir: &Path) -> Result<(), CryptoError> {
-    std::fs::create_dir_all(dir)?;
-    Ok(())
+fn create_private_node_key_dir(path: &Path) -> std::io::Result<()> {
+    std::fs::create_dir(path)
 }
 
 #[cfg(unix)]
@@ -181,6 +245,61 @@ mod tests {
         std::fs::remove_dir_all(path.parent().unwrap()).ok();
     }
 
+    #[cfg(unix)]
+    #[test]
+    fn existing_shared_parent_mode_is_unchanged() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp =
+            std::env::temp_dir().join(format!("mesh-node-key-mode-{}", rand::random::<u64>()));
+        std::fs::create_dir(&temp).unwrap();
+        let shared = temp.join("shared");
+        std::fs::create_dir(&shared).unwrap();
+        std::fs::set_permissions(&shared, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        save_node_key_bytes_to_path(&shared.join("key"), &[7u8; NODE_KEY_BYTES]).unwrap();
+
+        assert_eq!(
+            std::fs::metadata(&shared).unwrap().permissions().mode() & 0o777,
+            0o755
+        );
+        assert_eq!(
+            std::fs::metadata(shared.join("key"))
+                .unwrap()
+                .permissions()
+                .mode()
+                & 0o777,
+            0o600
+        );
+        std::fs::remove_dir_all(temp).ok();
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn missing_parent_directories_are_created_private() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let temp =
+            std::env::temp_dir().join(format!("mesh-node-key-missing-{}", rand::random::<u64>()));
+        let private = temp.join("private");
+        let nested = private.join("nested");
+        let key_path = nested.join("key");
+
+        save_node_key_bytes_to_path(&key_path, &[7u8; NODE_KEY_BYTES]).unwrap();
+
+        for dir in [&private, &nested] {
+            assert_eq!(
+                std::fs::metadata(dir).unwrap().permissions().mode() & 0o777,
+                0o700
+            );
+        }
+        assert_eq!(
+            std::fs::metadata(key_path).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
+        std::fs::remove_dir_all(temp).ok();
+    }
+
     #[test]
     fn rejects_wrong_length_node_key() {
         let path = temp_node_key_path();
@@ -190,5 +309,34 @@ mod tests {
 
         assert!(matches!(error, CryptoError::InvalidKeyMaterial { .. }));
         std::fs::remove_dir_all(path.parent().unwrap()).ok();
+    }
+
+    #[test]
+    fn node_key_path_honors_explicit_override() {
+        // #1699: a second node process on one machine gets its own key via
+        // MESH_LLM_NODE_KEY_PATH instead of silently sharing ~/.mesh-llm/key.
+        let override_path = std::path::Path::new("/tmp/mesh-second-node.key");
+
+        let resolved =
+            resolve_node_key_path(Some(override_path.as_os_str().to_os_string())).unwrap();
+
+        assert_eq!(resolved, override_path);
+    }
+
+    #[test]
+    fn empty_node_key_override_falls_back_to_home() {
+        // MESH_LLM_NODE_KEY_PATH= must not resolve to the working directory.
+        let resolved = resolve_node_key_path(Some(std::ffi::OsString::new())).unwrap();
+
+        assert_eq!(resolved, home_node_key_path().unwrap());
+    }
+
+    #[test]
+    fn node_key_path_defaults_to_home_without_override() {
+        // With no override set, the path must remain the historical
+        // ~/.mesh-llm/key so existing installs keep their node identity.
+        let resolved = resolve_node_key_path(None).unwrap();
+
+        assert_eq!(resolved, home_node_key_path().unwrap());
     }
 }

--- a/crates/openai-frontend/src/chat.rs
+++ b/crates/openai-frontend/src/chat.rs
@@ -96,8 +96,9 @@ impl ChatCompletionRequest {
                 "top_logprobs requires logprobs=true",
             ));
         }
-        if self.tools.as_ref().is_some_and(invalid_tools_value) {
-            return Err(OpenAiError::invalid_request("tools must be an array"));
+        if let Some(tools) = self.tools.as_ref() {
+            validate_tools_value(tools)
+                .map_err(|message| OpenAiError::invalid_request(message).with_param("tools"))?;
         }
         if self
             .response_format
@@ -126,8 +127,39 @@ fn invalid_response_format_value(value: &Value) -> bool {
         .is_some_and(Value::is_string)
 }
 
-fn invalid_tools_value(value: &Value) -> bool {
-    !matches!(value, Value::Array(_))
+fn validate_tools_value(value: &Value) -> Result<(), String> {
+    let Some(tools) = value.as_array() else {
+        return Err("tools must be an array".to_string());
+    };
+    for (index, tool) in tools.iter().enumerate() {
+        let Some(tool) = tool.as_object() else {
+            return Err(format!("tools[{index}] must be an object"));
+        };
+        if tool.get("type").and_then(Value::as_str) != Some("function") {
+            return Err(format!("tools[{index}].type must be `function`"));
+        }
+        let Some(function) = tool.get("function").and_then(Value::as_object) else {
+            return Err(format!("tools[{index}].function must be an object"));
+        };
+        if !function
+            .get("name")
+            .and_then(Value::as_str)
+            .is_some_and(|name| !name.trim().is_empty())
+        {
+            return Err(format!(
+                "tools[{index}].function.name must be a non-empty string"
+            ));
+        }
+        if function
+            .get("parameters")
+            .is_some_and(|parameters| !parameters.is_object())
+        {
+            return Err(format!(
+                "tools[{index}].function.parameters must be an object"
+            ));
+        }
+    }
+    Ok(())
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize, PartialEq, Eq)]

--- a/crates/openai-frontend/src/errors.rs
+++ b/crates/openai-frontend/src/errors.rs
@@ -11,6 +11,7 @@ pub struct OpenAiError {
     status: StatusCode,
     message: String,
     error_type: String,
+    param: Option<String>,
     code: Option<String>,
     retry_after_secs: Option<u64>,
 }
@@ -42,6 +43,7 @@ impl OpenAiError {
             status,
             message: message.into(),
             error_type: error_type.to_string(),
+            param: None,
             code: Some(code.to_string()),
             retry_after_secs: None,
         }
@@ -147,6 +149,11 @@ impl OpenAiError {
         self
     }
 
+    pub fn with_param(mut self, param: impl Into<String>) -> Self {
+        self.param = Some(param.into());
+        self
+    }
+
     pub fn with_retry_after_secs(mut self, retry_after_secs: u64) -> Self {
         self.retry_after_secs = Some(retry_after_secs);
         self
@@ -157,7 +164,7 @@ impl OpenAiError {
             error: ErrorBody {
                 message: self.message.clone(),
                 error_type: self.error_type.clone(),
-                param: None,
+                param: self.param.clone(),
                 code: self.code.clone(),
             },
         }

--- a/crates/openai-frontend/src/router_tests.rs
+++ b/crates/openai-frontend/src/router_tests.rs
@@ -1499,6 +1499,30 @@ async fn chat_completion_route_accepts_tools_structured_output_and_logprobs() {
 }
 
 #[tokio::test]
+async fn chat_completion_route_rejects_malformed_tools_as_invalid_requests() {
+    for tools in [
+        json!([{"type": "function"}]),
+        json!([{"type": "banana", "function": {"name": "f", "parameters": {}}}]),
+        json!([{"type": "function", "function": "nope"}]),
+    ] {
+        let response = post_json(
+            "/v1/chat/completions",
+            json!({
+                "model": "test-model",
+                "messages": [{"role": "user", "content": "hi"}],
+                "tools": tools
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_body_json(response).await;
+        assert_eq!(body["error"]["type"], "invalid_request_error");
+        assert_eq!(body["error"]["param"], "tools");
+        assert_eq!(body["error"]["code"], "invalid_value");
+    }
+}
+
+#[tokio::test]
 async fn chat_completion_route_accepts_noop_parity_fields() {
     let response = post_json(
         "/v1/chat/completions",

--- a/crates/skippy-ffi/build.rs
+++ b/crates/skippy-ffi/build.rs
@@ -209,6 +209,7 @@ fn main() {
     println!("cargo:rustc-link-lib=static=ggml-base");
 
     if target.contains("apple") {
+        link_apple_openmp_libs(&cmake_cache);
         println!("cargo:rustc-link-lib=c++");
         println!("cargo:rustc-link-lib=framework=Accelerate");
         if static_archive_exists(
@@ -544,6 +545,20 @@ fn link_windows_openmp_libs(cmake_cache: &std::path::Path) {
     }
 }
 
+fn link_apple_openmp_libs(cmake_cache: &std::path::Path) {
+    let libs = openmp_libs(cmake_cache, "omp");
+    for path in cmake_openmp_search_paths(cmake_cache, &libs) {
+        if path.is_dir() {
+            println!("cargo:rustc-link-search=native={}", path.display());
+        }
+    }
+
+    for lib in libs {
+        let link_name = lib.strip_prefix("lib").unwrap_or(&lib);
+        println!("cargo:rustc-link-lib=dylib={link_name}");
+    }
+}
+
 fn link_linux_hip_libs() {
     // Add ROCm library search paths
     for search_path in ["/opt/rocm/lib", "/opt/rocm/hip/lib"] {
@@ -571,6 +586,21 @@ fn windows_openmp_search_paths(
     cmake_cache: &std::path::Path,
     libs: &[String],
 ) -> Vec<std::path::PathBuf> {
+    let mut paths = cmake_openmp_search_paths(cmake_cache, libs);
+    for env_name in ["ROCM_PATH", "HIP_PATH", "LLVMInstallDir"] {
+        if let Ok(root) = std::env::var(env_name) {
+            for suffix in ["lib", "llvm/lib"] {
+                push_unique_path(&mut paths, std::path::PathBuf::from(&root).join(suffix));
+            }
+        }
+    }
+    paths
+}
+
+fn cmake_openmp_search_paths(
+    cmake_cache: &std::path::Path,
+    libs: &[String],
+) -> Vec<std::path::PathBuf> {
     let mut paths = Vec::new();
     if let Ok(cache) = std::fs::read_to_string(cmake_cache) {
         for lib in libs {
@@ -588,15 +618,6 @@ fn windows_openmp_search_paths(
             }
         }
     }
-
-    for env_name in ["ROCM_PATH", "HIP_PATH", "LLVMInstallDir"] {
-        if let Ok(root) = std::env::var(env_name) {
-            for suffix in ["lib", "llvm/lib"] {
-                push_unique_path(&mut paths, std::path::PathBuf::from(&root).join(suffix));
-            }
-        }
-    }
-
     paths
 }
 

--- a/docs/USAGE.md
+++ b/docs/USAGE.md
@@ -1161,6 +1161,24 @@ mesh-llm models cleanup
 mesh-llm models prune
 ```
 
+## Node identity and multiple nodes per machine
+
+By default, the node key lives at `~/.mesh-llm/key`, independent of
+`MESH_LLM_DATA_DIR`, and defines the node's mesh identity. Set
+`MESH_LLM_NODE_KEY_PATH` to select a different active key file. Running two
+node processes that load the same key makes both present the same node id: the
+mesh silently collapses to one node and no peer ever appears. If you run a
+second `mesh-llm serve` on the same machine, give it its own identity first:
+
+- `MESH_LLM_NODE_KEY_PATH=/path/to/second.key` — stable dedicated identity for
+  the second node (recommended; the key file is created on first start).
+- `MESH_LLM_EPHEMERAL_KEY=1` — throwaway in-memory identity for the process's
+  lifetime; the node gets a fresh id on every restart, which discards owner
+  attestation and node certificates.
+
+`mesh-llm serve --join` now rejects an invite token that names the joiner's
+own node id with an explicit error, instead of failing silently.
+
 ## Model storage
 
 - Hugging Face repo snapshots are the canonical managed model store.

--- a/scripts/check-env-mutation-contract.py
+++ b/scripts/check-env-mutation-contract.py
@@ -34,6 +34,9 @@ AUDITED_FILES = (
     "crates/skippy-protocol/build.rs",
     "crates/mesh-llm-plugin/build.rs",
     "crates/mesh-llm-host-runtime/src/capture.rs",
+    "crates/mesh-llm-host-runtime/src/mesh/identity_persistence.rs",
+    "crates/mesh-llm-host-runtime/src/mesh/public_identity_tests.rs",
+    "crates/mesh-llm-host-runtime/src/network/nostr/keys.rs",
     "crates/mesh-llm-host-runtime/src/runtime/instance.rs",
     "crates/mesh-llm-host-runtime/src/models/maintenance.rs",
     "crates/mesh-llm-host-runtime/src/models/remote_catalog.rs",
@@ -64,7 +67,6 @@ KNOWN_UNAUDITED_MUTATION_COUNTS = {
     "crates/mesh-llm-host-runtime/src/models/inventory.rs": 13,
     "crates/mesh-llm-host-runtime/src/models/resolve/tests.rs": 4,
     "crates/mesh-llm-host-runtime/src/network/nostr/auto.rs": 3,
-    "crates/mesh-llm-host-runtime/src/network/nostr/keys.rs": 3,
     "crates/mesh-llm-host-runtime/src/runtime/config_state_tests/support.rs": 3,
     "crates/mesh-llm-host-runtime/src/runtime/tests/auto_join.rs": 1,
     "crates/mesh-llm-host-runtime/src/runtime/tests/mod.rs": 2,
@@ -100,6 +102,9 @@ SERIAL_ATTR_RE = re.compile(r"^\s*#\[(?:serial|serial_test::serial)\]\s*$")
 # from passing merely because a nearby comment contains the text `#[serial]`.
 SERIAL_TEST_HELPERS = {
     "crates/mesh-llm-host-runtime/src/capture.rs": {"drop"},
+    "crates/mesh-llm-host-runtime/src/mesh/identity_persistence.rs": {"drop", "set"},
+    "crates/mesh-llm-host-runtime/src/mesh/public_identity_tests.rs": {"drop", "set_home"},
+    "crates/mesh-llm-host-runtime/src/network/nostr/keys.rs": {"drop", "set"},
     "crates/mesh-llm-host-runtime/src/inference/skippy/materialization/cache_management.rs": {
         "restore_env"
     },

--- a/scripts/tests/test_env_mutation_contract.py
+++ b/scripts/tests/test_env_mutation_contract.py
@@ -27,9 +27,9 @@ class EnvironmentMutationContractTests(unittest.TestCase):
         result = self.run_checker()
 
         self.assertEqual(result.returncode, 0, result.stderr)
-        self.assertIn("35 Rust files", result.stdout)
-        self.assertIn("200 mutation sites", result.stdout)
-        self.assertIn("18 contract-audited files", result.stdout)
+        self.assertIn("37 Rust files", result.stdout)
+        self.assertIn("216 mutation sites", result.stdout)
+        self.assertIn("21 contract-audited files", result.stdout)
 
     def test_unregistered_mutation_file_is_rejected_by_repository_discovery(self) -> None:
         with tempfile.TemporaryDirectory() as directory:

--- a/tools/xtask/data/console_print_allowlist.json
+++ b/tools/xtask/data/console_print_allowlist.json
@@ -1831,11 +1831,19 @@
   ],
   "crates/mesh-llm-host-runtime/src/network/nostr/keys.rs": [
     {
-      "line": 91,
+      "line": 86,
       "macro_name": "eprintln!"
     },
     {
-      "line": 93,
+      "line": 88,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 94,
+      "macro_name": "eprintln!"
+    },
+    {
+      "line": 96,
       "macro_name": "eprintln!"
     },
     {
@@ -1843,15 +1851,7 @@
       "macro_name": "eprintln!"
     },
     {
-      "line": 101,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 104,
-      "macro_name": "eprintln!"
-    },
-    {
-      "line": 105,
+      "line": 100,
       "macro_name": "eprintln!"
     }
   ],


### PR DESCRIPTION
Two server processes on one machine can load the same `~/.mesh-llm/key`, present one endpoint identity, and silently collapse into separate one-node meshes.

This rejects join tokens naming the local endpoint with an actionable error, adds `MESH_LLM_NODE_KEY_PATH` for a stable per-process identity, and documents that override alongside `MESH_LLM_EPHEMERAL_KEY`. Public-to-private identity rotation clears the configured key as well as the historical default key, while the default path stays unchanged for existing installations.

Fixes #1699.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for running multiple independent node identities on one machine.
  - Added `MESH_LLM_NODE_KEY_PATH` for stable custom identities and `MESH_LLM_EPHEMERAL_KEY=1` for temporary identities.
  - Isolated identity and network key storage per active node identity.
  - Custom identity paths now support relative paths.

- **Bug Fixes**
  - Joining with an invite token for the current node now fails with a clear error instead of attempting a self-connection.
  - Identity and key rotation now affect only the active identity.

- **Documentation**
  - Documented node identity configuration, multiple-node setups, and self-join behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->