### PR TITLE
fix(ci): Fly console image build: pin pnpm and copy the whole crates tree

### DIFF
--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -16,10 +16,14 @@
 
 FROM node:24.20.0-alpine AS ui-builder
 ARG TARGETARCH
-RUN --mount=type=cache,id=mesh-llm-npm-alpine-node24-${TARGETARCH},target=/root/.npm,sharing=locked \
-    npm install -g pnpm
 WORKDIR /app
 COPY crates/mesh-llm-ui/package.json crates/mesh-llm-ui/pnpm-lock.yaml crates/mesh-llm-ui/pnpm-workspace.yaml ./
+# Install the pnpm pinned by package.json's packageManager field. An unpinned
+# `npm install -g pnpm` resolves to pnpm 12, which self-switches to the pinned
+# 10.x and then fails with ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE because a
+# pnpm 10 lockfile does not record the @pnpm/exe integrity that pnpm 12 checks.
+RUN --mount=type=cache,id=mesh-llm-npm-alpine-node24-${TARGETARCH},target=/root/.npm,sharing=locked \
+    npm install -g "$(node -p 'JSON.parse(require("fs").readFileSync("package.json", "utf8")).packageManager')"
 RUN --mount=type=cache,id=mesh-llm-pnpm-store-alpine-node24-${TARGETARCH},target=/root/.local/share/pnpm/store,sharing=locked \
     pnpm install --frozen-lockfile
 COPY crates/mesh-llm-ui/ ./

--- a/docker/Dockerfile.client
+++ b/docker/Dockerfile.client
@@ -51,60 +51,12 @@ RUN --mount=type=cache,id=mesh-llm-cargo-registry-debian-bookworm-rust-stable-${
 WORKDIR /src
 # Satisfy GitHub Actions preflight checks (exact strings required)
 COPY Cargo.toml Cargo.lock ./
-COPY crates/mesh-llm-ui/ crates/mesh-llm-ui/
-COPY crates/mesh-llm-identity/ crates/mesh-llm-identity/
-COPY crates/mesh-llm-native-runtime/ crates/mesh-llm-native-runtime/
-COPY crates/mesh-llm-protocol/ crates/mesh-llm-protocol/
-COPY crates/mesh-llm-release-footer/ crates/mesh-llm-release-footer/
-COPY crates/mesh-llm-routing/ crates/mesh-llm-routing/
-COPY crates/mesh-llm-guardrails/ crates/mesh-llm-guardrails/
-COPY crates/mesh-llm-system/ crates/mesh-llm-system/
-COPY crates/mesh-llm-gpu-bench/ crates/mesh-llm-gpu-bench/
-COPY crates/mesh-llm-types/ crates/mesh-llm-types/
-COPY crates/mesh-llm-config/ crates/mesh-llm-config/
-COPY crates/mesh-llm-console-server/ crates/mesh-llm-console-server/
-COPY crates/mesh-llm-host-runtime/Cargo.toml crates/mesh-llm-host-runtime/Cargo.toml
-COPY crates/mesh-llm/Cargo.toml crates/mesh-llm/Cargo.toml
-COPY crates/mesh-llm/build.rs crates/mesh-llm/build.rs
-COPY crates/mesh-llm-plugin/Cargo.toml crates/mesh-llm-plugin/Cargo.toml
-COPY crates/mesh-llm-plugin/build.rs crates/mesh-llm-plugin/build.rs
-COPY crates/mesh-llm-skills/Cargo.toml crates/mesh-llm-skills/Cargo.toml
-COPY crates/mesh-llm-plugin-manager/Cargo.toml crates/mesh-llm-plugin-manager/Cargo.toml
-# Satisfy Cargo workspace member resolution
-COPY crates/mesh-llm-host-runtime/ crates/mesh-llm-host-runtime/
-COPY crates/mesh-llm/ crates/mesh-llm/
-COPY crates/mesh-llm-plugin/ crates/mesh-llm-plugin/
-COPY crates/mesh-llm-skills/ crates/mesh-llm-skills/
-COPY crates/mesh-llm-plugin-manager/ crates/mesh-llm-plugin-manager/
-COPY crates/mesh-client/ crates/mesh-client/
-COPY crates/mesh-llm-api-client/ crates/mesh-llm-api-client/
-COPY crates/mesh-llm-api-server/ crates/mesh-llm-api-server/
-COPY crates/mesh-llm-node/ crates/mesh-llm-node/
-COPY crates/mesh-llm-nodejs/ crates/mesh-llm-nodejs/
-COPY crates/mesh-llm-ffi/ crates/mesh-llm-ffi/
-COPY crates/mesh-llm-test-harness/ crates/mesh-llm-test-harness/
-COPY crates/model-ref/ crates/model-ref/
-COPY crates/model-artifact/ crates/model-artifact/
-COPY crates/model-hf/ crates/model-hf/
-COPY crates/model-package/ crates/model-package/
-COPY crates/model-resolver/ crates/model-resolver/
-COPY crates/skippy-protocol/ crates/skippy-protocol/
-COPY crates/skippy-topology/ crates/skippy-topology/
-COPY crates/skippy-cache/ crates/skippy-cache/
-COPY crates/skippy-metrics/ crates/skippy-metrics/
-COPY crates/openai-frontend/ crates/openai-frontend/
-COPY crates/skippy-ffi/ crates/skippy-ffi/
-COPY crates/skippy-model/ crates/skippy-model/
-COPY crates/skippy-runtime/ crates/skippy-runtime/
-COPY crates/skippy-server/ crates/skippy-server/
-COPY crates/metrics-server/ crates/metrics-server/
-COPY crates/skippy-model-package/ crates/skippy-model-package/
-COPY crates/skippy-coordinator/ crates/skippy-coordinator/
-COPY crates/skippy-correctness/ crates/skippy-correctness/
-COPY crates/llama-spec-bench/ crates/llama-spec-bench/
-COPY crates/skippy-bench/ crates/skippy-bench/
-COPY crates/skippy-prompt/ crates/skippy-prompt/
-COPY crates/mesh-mixture-of-agents/ crates/mesh-mixture-of-agents/
+# Copy the whole crates tree. A hand-maintained per-crate list went stale twice
+# (#1241, and again once skippy-package-format, skippy-scheduler, and
+# mesh-llm-log-store landed), which breaks `cargo build --locked` at deploy time.
+# .dockerignore already drops node_modules, dist, and target, so this costs no
+# extra context and invalidates the same downstream layers as the list did.
+COPY crates/ crates/
 COPY tools/xtask/ tools/xtask/
 COPY scripts/prepare-llama.sh scripts/build-llama.sh scripts/
 COPY third_party/llama.cpp/upstream.txt third_party/llama.cpp/upstream.txt
@@ -130,60 +82,8 @@ COPY --from=ui-builder /app/dist crates/mesh-llm-ui/dist
 # Restore real build scripts (cargo-chef stubs them during cook)
 # Satisfy GitHub Actions preflight checks (exact strings required)
 COPY Cargo.toml Cargo.lock ./
-COPY crates/mesh-llm-ui/ crates/mesh-llm-ui/
-COPY crates/mesh-llm-identity/ crates/mesh-llm-identity/
-COPY crates/mesh-llm-native-runtime/ crates/mesh-llm-native-runtime/
-COPY crates/mesh-llm-protocol/ crates/mesh-llm-protocol/
-COPY crates/mesh-llm-release-footer/ crates/mesh-llm-release-footer/
-COPY crates/mesh-llm-routing/ crates/mesh-llm-routing/
-COPY crates/mesh-llm-guardrails/ crates/mesh-llm-guardrails/
-COPY crates/mesh-llm-system/ crates/mesh-llm-system/
-COPY crates/mesh-llm-gpu-bench/ crates/mesh-llm-gpu-bench/
-COPY crates/mesh-llm-types/ crates/mesh-llm-types/
-COPY crates/mesh-llm-config/ crates/mesh-llm-config/
-COPY crates/mesh-llm-console-server/ crates/mesh-llm-console-server/
-COPY crates/mesh-llm-host-runtime/Cargo.toml crates/mesh-llm-host-runtime/Cargo.toml
-COPY crates/mesh-llm/Cargo.toml crates/mesh-llm/Cargo.toml
-COPY crates/mesh-llm/build.rs crates/mesh-llm/build.rs
-COPY crates/mesh-llm-plugin/Cargo.toml crates/mesh-llm-plugin/Cargo.toml
-COPY crates/mesh-llm-plugin/build.rs crates/mesh-llm-plugin/build.rs
-COPY crates/mesh-llm-skills/Cargo.toml crates/mesh-llm-skills/Cargo.toml
-COPY crates/mesh-llm-plugin-manager/Cargo.toml crates/mesh-llm-plugin-manager/Cargo.toml
-# Satisfy Cargo workspace member resolution
-COPY crates/mesh-llm-host-runtime/ crates/mesh-llm-host-runtime/
-COPY crates/mesh-llm/ crates/mesh-llm/
-COPY crates/mesh-llm-plugin/ crates/mesh-llm-plugin/
-COPY crates/mesh-llm-skills/ crates/mesh-llm-skills/
-COPY crates/mesh-llm-plugin-manager/ crates/mesh-llm-plugin-manager/
-COPY crates/mesh-client/ crates/mesh-client/
-COPY crates/mesh-llm-api-client/ crates/mesh-llm-api-client/
-COPY crates/mesh-llm-api-server/ crates/mesh-llm-api-server/
-COPY crates/mesh-llm-node/ crates/mesh-llm-node/
-COPY crates/mesh-llm-nodejs/ crates/mesh-llm-nodejs/
-COPY crates/mesh-llm-ffi/ crates/mesh-llm-ffi/
-COPY crates/mesh-llm-test-harness/ crates/mesh-llm-test-harness/
-COPY crates/model-ref/ crates/model-ref/
-COPY crates/model-artifact/ crates/model-artifact/
-COPY crates/model-hf/ crates/model-hf/
-COPY crates/model-package/ crates/model-package/
-COPY crates/model-resolver/ crates/model-resolver/
-COPY crates/skippy-protocol/ crates/skippy-protocol/
-COPY crates/skippy-topology/ crates/skippy-topology/
-COPY crates/skippy-cache/ crates/skippy-cache/
-COPY crates/skippy-metrics/ crates/skippy-metrics/
-COPY crates/openai-frontend/ crates/openai-frontend/
-COPY crates/skippy-ffi/ crates/skippy-ffi/
-COPY crates/skippy-model/ crates/skippy-model/
-COPY crates/skippy-runtime/ crates/skippy-runtime/
-COPY crates/skippy-server/ crates/skippy-server/
-COPY crates/metrics-server/ crates/metrics-server/
-COPY crates/skippy-model-package/ crates/skippy-model-package/
-COPY crates/skippy-coordinator/ crates/skippy-coordinator/
-COPY crates/skippy-correctness/ crates/skippy-correctness/
-COPY crates/llama-spec-bench/ crates/llama-spec-bench/
-COPY crates/skippy-bench/ crates/skippy-bench/
-COPY crates/skippy-prompt/ crates/skippy-prompt/
-COPY crates/mesh-mixture-of-agents/ crates/mesh-mixture-of-agents/
+# Same rationale as the rust-deps stage above: copy the whole tree, not a list.
+COPY crates/ crates/
 COPY tools/xtask/ tools/xtask/
 RUN --mount=type=cache,id=mesh-llm-cargo-registry-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/registry,sharing=locked \
     --mount=type=cache,id=mesh-llm-cargo-git-debian-bookworm-rust-stable-${TARGETARCH},target=/root/.cargo/git,sharing=locked \

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -15,10 +15,14 @@ ARG NODE_ENV=production
 ENV NODE_ENV=$NODE_ENV
 ENV VITE_API_URL=$VITE_API_URL
 ENV VITE_STORAGE_NAMESPACE=$VITE_STORAGE_NAMESPACE
-RUN --mount=type=cache,id=mesh-llm-npm-alpine-node24-${TARGETARCH},target=/root/.npm,sharing=locked \
-    npm install -g pnpm
 WORKDIR /app
 COPY crates/mesh-llm-ui/package.json crates/mesh-llm-ui/pnpm-lock.yaml crates/mesh-llm-ui/pnpm-workspace.yaml ./
+# Install the pnpm pinned by package.json's packageManager field. An unpinned
+# `npm install -g pnpm` resolves to pnpm 12, which self-switches to the pinned
+# 10.x and then fails with ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE because a
+# pnpm 10 lockfile does not record the @pnpm/exe integrity that pnpm 12 checks.
+RUN --mount=type=cache,id=mesh-llm-npm-alpine-node24-${TARGETARCH},target=/root/.npm,sharing=locked \
+    npm install -g "$(node -p 'JSON.parse(require("fs").readFileSync("package.json", "utf8")).packageManager')"
 RUN --mount=type=cache,id=mesh-llm-pnpm-store-alpine-node24-${TARGETARCH},target=/root/.local/share/pnpm/store,sharing=locked \
     pnpm install --frozen-lockfile
 COPY crates/mesh-llm-ui/ ./

--- a/fly/Dockerfile
+++ b/fly/Dockerfile
@@ -44,73 +44,12 @@ RUN --mount=type=cache,id=mesh-llm-rustup-stable-debian-bookworm-${TARGETARCH},t
 ENV PATH="/root/.cargo/bin:$PATH"
 WORKDIR /src
 COPY Cargo.toml Cargo.lock ./
-COPY crates/mesh-llm-ui/ crates/mesh-llm-ui/
-COPY crates/mesh-llm-gpu-bench/ crates/mesh-llm-gpu-bench/
-COPY crates/mesh-llm-identity/ crates/mesh-llm-identity/
-COPY crates/mesh-llm-protocol/ crates/mesh-llm-protocol/
-COPY crates/mesh-llm-release-footer/ crates/mesh-llm-release-footer/
-COPY crates/mesh-llm-routing/ crates/mesh-llm-routing/
-COPY crates/mesh-llm-guardrails/ crates/mesh-llm-guardrails/
-COPY crates/mesh-llm-system/ crates/mesh-llm-system/
-COPY crates/mesh-llm-types/ crates/mesh-llm-types/
-COPY crates/mesh-llm-config/ crates/mesh-llm-config/
-COPY crates/mesh-llm-console-server/ crates/mesh-llm-console-server/
-COPY crates/mesh-llm-host-runtime/Cargo.toml crates/mesh-llm-host-runtime/Cargo.toml
-COPY crates/mesh-llm/Cargo.toml crates/mesh-llm/Cargo.toml
-COPY crates/mesh-llm/build.rs crates/mesh-llm/build.rs
-COPY crates/mesh-llm-plugin/Cargo.toml crates/mesh-llm-plugin/Cargo.toml
-COPY crates/mesh-llm-plugin/build.rs crates/mesh-llm-plugin/build.rs
-COPY crates/mesh-llm-skills/Cargo.toml crates/mesh-llm-skills/Cargo.toml
-COPY crates/mesh-llm-plugin-manager/Cargo.toml crates/mesh-llm-plugin-manager/Cargo.toml
-COPY crates/mesh-llm-host-runtime/ crates/mesh-llm-host-runtime/
-COPY crates/mesh-llm/ crates/mesh-llm/
-COPY crates/mesh-llm-plugin/ crates/mesh-llm-plugin/
-COPY crates/mesh-llm-skills/ crates/mesh-llm-skills/
-COPY crates/mesh-llm-plugin-manager/ crates/mesh-llm-plugin-manager/
-COPY crates/mesh-client/ crates/mesh-client/
-COPY crates/mesh-llm-api-client/ crates/mesh-llm-api-client/
-COPY crates/mesh-llm-api-server/ crates/mesh-llm-api-server/
-COPY crates/mesh-llm-node/ crates/mesh-llm-node/
-COPY crates/mesh-llm-ffi/ crates/mesh-llm-ffi/
-COPY crates/mesh-llm-nodejs/ crates/mesh-llm-nodejs/
-COPY crates/mesh-llm-test-harness/ crates/mesh-llm-test-harness/
-COPY crates/model-ref/ crates/model-ref/
-COPY crates/model-artifact/ crates/model-artifact/
-COPY crates/model-hf/ crates/model-hf/
-COPY crates/model-package/ crates/model-package/
-COPY crates/model-resolver/ crates/model-resolver/
-COPY crates/skippy-protocol/ crates/skippy-protocol/
-COPY crates/skippy-topology/ crates/skippy-topology/
-COPY crates/skippy-cache/ crates/skippy-cache/
-COPY crates/skippy-metrics/ crates/skippy-metrics/
-COPY crates/openai-frontend/ crates/openai-frontend/
-COPY crates/skippy-ffi/ crates/skippy-ffi/
-COPY crates/skippy-model/ crates/skippy-model/
-COPY crates/skippy-quantize/ crates/skippy-quantize/
-COPY crates/llama-quant-ffi/ crates/llama-quant-ffi/
-COPY crates/skippy-runtime/ crates/skippy-runtime/
-COPY crates/skippy-server/ crates/skippy-server/
-COPY crates/metrics-server/ crates/metrics-server/
-COPY crates/skippy-model-package/ crates/skippy-model-package/
-COPY crates/skippy-coordinator/ crates/skippy-coordinator/
-COPY crates/skippy-correctness/ crates/skippy-correctness/
-COPY crates/llama-spec-bench/ crates/llama-spec-bench/
-COPY crates/skippy-bench/ crates/skippy-bench/
-COPY crates/skippy-prompt/ crates/skippy-prompt/
-COPY crates/mesh-mixture-of-agents/ crates/mesh-mixture-of-agents/
-COPY crates/mesh-llm-cli/ crates/mesh-llm-cli/
-COPY crates/mesh-llm-commands/ crates/mesh-llm-commands/
-COPY crates/mesh-llm-embedded-runtime/ crates/mesh-llm-embedded-runtime/
-COPY crates/mesh-llm-events/ crates/mesh-llm-events/
-COPY crates/mesh-llm-build-info/ crates/mesh-llm-build-info/
-COPY crates/mesh-llm-hardware-profile/ crates/mesh-llm-hardware-profile/
-COPY crates/mesh-llm-native-runtime/ crates/mesh-llm-native-runtime/
-COPY crates/mesh-llm-runtime-install/ crates/mesh-llm-runtime-install/
-COPY crates/mesh-llm-sdk/ crates/mesh-llm-sdk/
-COPY crates/mesh-llm-tui/ crates/mesh-llm-tui/
-COPY crates/skippy-tokenizer/ crates/skippy-tokenizer/
-COPY crates/mesh-native-serving-plugin-api/ crates/mesh-native-serving-plugin-api/
-COPY crates/mesh-native-serving-plugin-host/ crates/mesh-native-serving-plugin-host/
+# Copy the whole crates tree. A hand-maintained per-crate list went stale twice
+# (#1241, and again once skippy-package-format, skippy-scheduler, and
+# mesh-llm-log-store landed), which breaks `cargo build --locked` at deploy time.
+# .dockerignore already drops node_modules, dist, and target, so this costs no
+# extra context and invalidates the same downstream layers as the list did.
+COPY crates/ crates/
 COPY tools/xtask/ tools/xtask/
 COPY scripts/prepare-llama.sh scripts/build-llama.sh scripts/
 COPY scripts/lib/ scripts/lib/


### PR DESCRIPTION
## Original problem

The manual [Deploy Fly Console](https://github.com/Mesh-LLM/mesh-llm/actions/workflows/fly-deploy-console.yml) workflow fails on `main`. Two separate build-context problems, found one after the other:

1. Run [34556490498](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34556490498) dies in the `ui-builder` stage:
   ```
   #13 [ui-builder 5/7] RUN ... pnpm install --frozen-lockfile
   #13 1.228 Error: ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE
   #13 1.228   ╰─▶ Cannot verify the identity of the @pnpm/exe.linux-x64 native binary: it
   #13 1.228       is missing from pnpm-lock.yaml.
   ```
2. With that fixed, run [34556833615](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34556833615) dies in `cargo build --locked`:
   ```
   error: failed to load manifest for workspace member `/src/crates/mesh-llm`
     failed to read `/src/crates/skippy-package-format/Cargo.toml`
   ```

`docker/Dockerfile.client` has the same `ui-builder` stage and the same (worse) crate-list drift. Nothing in CI builds either Dockerfile end to end; `docker.yml` only runs `buildx build --check`, which doesn't catch either failure.

## Diagnostics

**pnpm.** Both Dockerfiles ran an unpinned `npm install -g pnpm`, which now resolves to pnpm 12.3.4. `crates/mesh-llm-ui/package.json` pins `packageManager: pnpm@10.34.5`, so pnpm 12 tries to self-switch and refuses because a pnpm 10 lockfile doesn't carry the `@pnpm/exe` integrity entry it checks. The last successful deploy was July 14, before pnpm 12 shipped. Reproduced outside Fly in `node:24.20.0-alpine` with the three files the stage copies.

**Crate list.** `fly/Dockerfile` hand-listed 60 `COPY crates/<name>/` lines and was missing `skippy-package-format`, `skippy-scheduler`, and `mesh-llm-log-store` (all added since July). `docker/Dockerfile.client` was missing 17. #1241 fixed exactly this drift in August.

## Fix

- Install the pnpm version named by `packageManager` instead of latest, in both Dockerfiles. The install moves after `COPY package.json ...` so it can read the field, using the same `node -p` JSON read the fly stage already uses for `VITE_APP_VERSION`.
- Replace the per-crate COPY lists with a single `COPY crates/ crates/` in both Dockerfiles. `.dockerignore` already excludes `node_modules`, `dist`, and `target`, so the build context is the same size and any crate edit invalidates the same downstream layers it did before. The list just can't go stale again.

No runtime or protocol impact. `ci/linux-test.dockerfile` also hand-lists crates; I left it alone since CI exercises it directly and it isn't part of this failure.

## Validation

- [x] I ran the relevant local checks, or explained why they do not apply.
- [x] UI changes include screenshots or video, or explain why visual aids are not needed. (No UI change.)

Local, on this branch:

- `docker buildx build --check` on both Dockerfiles: no warnings.
- `docker buildx build --target ui-builder -f fly/Dockerfile .` succeeds; the image reports `pnpm 10.34.5`, `node v24.20.0`, and a populated `dist/`.
- A throwaway stage with the builder's exact COPY set (`Cargo.toml`, `Cargo.lock`, `crates/`, `tools/xtask/`) runs `cargo metadata --locked --no-deps` clean across all 63 workspace crates.

On Fly:

- The pnpm fix alone got run 34556833615 through the UI stage and into `cargo build` (where the crate-list failure surfaced).
- Full deploy from this branch: see the linked run below once it finishes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated UI build environments to use the project’s specified pnpm version.
  * Improved build reliability by avoiding automatic installation of incompatible pnpm versions.
  * Improved containerized build consistency by ensuring required project components are included during build preparation.
  * Reduced the risk of build failures caused by differences between local and container environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->