### PR TITLE
feat(skippy-cache): persist native runtime KV pages verbatim

### DIFF
--- a/crates/skippy-cache/README.md
+++ b/crates/skippy-cache/README.md
@@ -122,6 +122,16 @@ continuation state for those models. That is where the largest wins come from:
 llama-server warm slots still have to reprocess the recurrent prefix in many
 request shapes, while Skippy can restore the exact compact state and decode.
 
+Durable L3 manifests identify runtime-native KV segments as
+`native-kv-page/1`. Those segments are the bytes exported by the active runtime
+and are stored and restored verbatim; F32, F16, Q8_0, and Q4_0 remain in their
+active runtime representation when that backend supports the type. Recurrent
+and other auxiliary continuation state stays `raw/1`, with a hard segment
+boundary between the representations. Before reading native segment bytes,
+the server checks the manifest's runtime page descriptor against the located
+prefix and encoded KV length. The exact-state identity already binds the
+runtime ABI, platform, model, layer range, and KV configuration.
+
 ```mermaid
 flowchart LR
     Payload["KV + recurrent payload"] --> Split["1 MiB chunks"]

--- a/crates/skippy-cache/src/l3.rs
+++ b/crates/skippy-cache/src/l3.rs
@@ -70,12 +70,21 @@ pub const LEGACY_MANIFEST_VERSION: u32 = 2;
 /// compatibility, never written. New manifests stamp identity per segment.
 pub const LEGACY_PAYLOAD_CODEC_MANIFEST_VERSION: u32 = 3;
 
-/// Identity of the only implemented payload codec: raw, uncompressed exact
-/// state. Its bytes are the segments verbatim.
+/// Identity of the payload envelope: raw, uncompressed exact state. Its bytes
+/// are the segments verbatim, including segments whose representation is the
+/// runtime's native KV page layout.
 pub const CODEC_RAW: &str = "raw";
 /// Version of the raw codec's on-disk representation. Bumped only if the raw
 /// byte layout itself changes; an unknown version is rejected, never migrated.
 pub const CODEC_RAW_VERSION: u32 = 1;
+
+/// Exact KV bytes exported by the active native runtime and restored directly
+/// into that runtime without a storage transcode.
+pub const CODEC_NATIVE_KV_PAGE: &str = "native-kv-page";
+/// Version of the native KV segment contract. The concrete runtime ABI,
+/// tensor types, geometry, and platform are bound by the exact-state identity
+/// and the serialized runtime page descriptor carried by the manifest.
+pub const CODEC_NATIVE_KV_PAGE_VERSION: u32 = 1;
 
 /// The codec used to encode a payload's segment bytes, stamped into the
 /// manifest so representations are explicit and negotiable.
@@ -186,12 +195,37 @@ impl SegmentCodecIdentity {
         }
     }
 
+    /// Identity for a runtime-native KV page segment stored verbatim. The
+    /// store performs no encode/decode step; restore imports these same bytes
+    /// through the runtime page descriptor associated with the manifest.
+    pub fn native_kv_page(encoded_len: u64) -> Self {
+        Self {
+            name: CODEC_NATIVE_KV_PAGE.to_string(),
+            version: CODEC_NATIVE_KV_PAGE_VERSION,
+            class: CodecClass::Exact,
+            decoded_len: encoded_len,
+            calibration_digest: None,
+        }
+    }
+
+    /// Whether this identity names the supported native KV passthrough
+    /// representation. This is stricter than a name check: an identity with
+    /// the wrong version, class, or calibration is not native passthrough.
+    pub fn is_native_kv_page(&self) -> bool {
+        self.name == CODEC_NATIVE_KV_PAGE
+            && self.version == CODEC_NATIVE_KV_PAGE_VERSION
+            && self.class == CodecClass::Exact
+            && self.calibration_digest.is_none()
+    }
+
     /// Whether this build can assemble a segment encoded with this identity.
-    /// Only the exact raw codec is implemented; anything else is unknown and
-    /// must be refused before assembly.
+    /// Exact raw and native KV passthrough are implemented. Both assemble
+    /// verbatim; anything else is unknown and must be refused before assembly.
     pub fn is_supported(&self) -> bool {
-        self.name == CODEC_RAW
-            && self.version == CODEC_RAW_VERSION
+        let supported_representation = (self.name == CODEC_RAW
+            && self.version == CODEC_RAW_VERSION)
+            || self.is_native_kv_page();
+        supported_representation
             && self.class == CodecClass::Exact
             && self.calibration_digest.is_none()
     }
@@ -293,6 +327,16 @@ impl HandoffManifest {
             continuation_token: 0,
             expected_tokens: Vec::new(),
         }
+    }
+
+    /// Whether this manifest contains runtime-native KV page segments.
+    pub fn uses_native_kv_passthrough(&self) -> bool {
+        self.segments.iter().any(|segment| {
+            segment
+                .codec_identity
+                .as_ref()
+                .is_some_and(SegmentCodecIdentity::is_native_kv_page)
+        })
     }
 }
 
@@ -1844,6 +1888,24 @@ fn manifest_version_is_supported(version: u32) -> bool {
 /// codec that describes the assembled whole. Positional errors name the
 /// segment index so the offending ref is identifiable in the message.
 fn reject_unsupported_segment_codecs(manifest: &HandoffManifest) -> Result<()> {
+    let has_native_kv = manifest.uses_native_kv_passthrough();
+    let has_runtime_descriptor = manifest
+        .kv_desc_json
+        .as_deref()
+        .is_some_and(|descriptor| serde_json::from_str::<serde_json::Value>(descriptor).is_ok());
+    if has_native_kv
+        && (manifest.version != MANIFEST_VERSION
+            || manifest.payload_kind != "kv-recurrent"
+            || manifest.kv_bytes == 0
+            || !has_runtime_descriptor
+            || manifest.kv_bytes.checked_add(manifest.recurrent_bytes)
+                != Some(manifest.total_bytes))
+    {
+        bail!(
+            "manifest {} names native KV segments without a current, complete kv-recurrent payload and runtime page descriptor",
+            manifest.payload_digest
+        );
+    }
     for segment in &manifest.segments {
         let Some(identity) = segment.codec_identity.as_ref() else {
             // Legacy formats carry no per-segment identity by construction;
@@ -1852,13 +1914,15 @@ fn reject_unsupported_segment_codecs(manifest: &HandoffManifest) -> Result<()> {
         };
         if !identity.is_supported() {
             bail!(
-                "manifest {} segment {} uses unsupported codec {}/{}; this build assembles only {}/{}",
+                "manifest {} segment {} uses unsupported codec {}/{}; this build assembles only {}/{} and {}/{}",
                 manifest.payload_digest,
                 segment.index,
                 identity.name,
                 identity.version,
                 CODEC_RAW,
-                CODEC_RAW_VERSION
+                CODEC_RAW_VERSION,
+                CODEC_NATIVE_KV_PAGE,
+                CODEC_NATIVE_KV_PAGE_VERSION
             );
         }
         if !identity.is_self_consistent(segment.bytes) {
@@ -1872,10 +1936,33 @@ fn reject_unsupported_segment_codecs(manifest: &HandoffManifest) -> Result<()> {
                 segment.bytes
             );
         }
-        // Contract note for the compressed-codec slices: the payload codec
-        // describes the assembled whole. Once any segment stops being raw,
-        // the payload codec must be upgraded to name the mixed encoding —
-        // never left claiming raw while per-segment identities disagree.
+        if has_native_kv {
+            let end = segment
+                .offset
+                .checked_add(segment.bytes)
+                .context("segment range overflows")?;
+            let covers_kv = segment.offset < manifest.kv_bytes;
+            if covers_kv && end > manifest.kv_bytes {
+                bail!(
+                    "manifest {} segment {} crosses the native KV boundary at byte {}",
+                    manifest.payload_digest,
+                    segment.index,
+                    manifest.kv_bytes
+                );
+            }
+            if covers_kv != identity.is_native_kv_page() {
+                bail!(
+                    "manifest {} segment {} representation disagrees with the native KV boundary at byte {}",
+                    manifest.payload_digest,
+                    segment.index,
+                    manifest.kv_bytes
+                );
+            }
+        }
+        // The payload codec describes the assembled envelope. Exact native KV
+        // segments remain byte-for-byte members of the raw envelope; a future
+        // codec that transforms stored bytes must upgrade that envelope rather
+        // than leave it claiming raw.
     }
     Ok(())
 }

--- a/crates/skippy-cache/src/l3/tests.rs
+++ b/crates/skippy-cache/src/l3/tests.rs
@@ -1151,6 +1151,69 @@ fn v4_rejects_unsupported_segment_codecs_naming_the_segment() {
 }
 
 #[test]
+fn v4_rejects_unknown_native_kv_version_before_assembly() {
+    let root = temp_root("codec-v4-native-future");
+    let store = store(&root, 0);
+    let payload = vec![15u8; 8192];
+    let manifest = commit_payload(&store, &payload, 4096);
+    let mut future = manifest.clone();
+    future.payload_kind = "kv-recurrent".to_string();
+    future.kv_bytes = future.total_bytes;
+    future.kv_desc_json = Some("{\"runtime\":\"native\"}".to_string());
+    for segment in &mut future.segments {
+        let mut identity = SegmentCodecIdentity::native_kv_page(segment.bytes);
+        identity.version = CODEC_NATIVE_KV_PAGE_VERSION + 1;
+        segment.codec_identity = Some(identity);
+    }
+
+    let error = store
+        .assemble(&future)
+        .expect_err("a future native KV representation must not assemble");
+    let message = error.to_string();
+    assert!(
+        message.contains(CODEC_NATIVE_KV_PAGE) && message.contains("unsupported codec"),
+        "error should name the unsupported native representation: {message}"
+    );
+    assert!(
+        store.commit(&future).is_err(),
+        "a future native KV representation must not commit"
+    );
+}
+
+#[test]
+fn v4_native_kv_segments_must_tile_exactly_to_the_kv_boundary() {
+    let root = temp_root("codec-v4-native-boundary");
+    let store = store(&root, 0);
+    let payload = vec![16u8; 8192];
+    let manifest = commit_payload(&store, &payload, 4096);
+    let mut mixed = manifest.clone();
+    mixed.payload_kind = "kv-recurrent".to_string();
+    mixed.kv_bytes = 4096;
+    mixed.recurrent_bytes = 4096;
+    mixed.kv_desc_json = Some("{\"runtime\":\"native\"}".to_string());
+    mixed.segments[0].codec_identity = Some(SegmentCodecIdentity::native_kv_page(4096));
+    assert_eq!(
+        store.assemble(&mixed).expect("valid mixed manifest"),
+        payload
+    );
+
+    let mut crossing = mixed.clone();
+    crossing.kv_bytes = 5000;
+    crossing.recurrent_bytes = 3192;
+    let error = store
+        .assemble(&crossing)
+        .expect_err("a segment crossing the KV boundary must not assemble");
+    assert!(error.to_string().contains("crosses the native KV boundary"));
+
+    let mut native_auxiliary = mixed;
+    native_auxiliary.segments[1].codec_identity = Some(SegmentCodecIdentity::native_kv_page(4096));
+    let error = store
+        .assemble(&native_auxiliary)
+        .expect_err("auxiliary bytes cannot claim the native KV representation");
+    assert!(error.to_string().contains("representation disagrees"));
+}
+
+#[test]
 fn v4_segment_identity_length_mismatch_is_refused() {
     let root = temp_root("codec-v4-length");
     let store = store(&root, 0);

--- a/crates/skippy-cache/src/lib.rs
+++ b/crates/skippy-cache/src/lib.rs
@@ -18,11 +18,11 @@ pub use identity::{
     prefix_identity_with_namespace, prefix_namespace_hash,
 };
 pub use l3::{
-    CODEC_RAW, CODEC_RAW_VERSION, CodecClass, GeometryBlock, GeometryKind, HandoffManifest,
-    HandoffSegmentRef, HandoffSegmentStore, LEGACY_MANIFEST_VERSION,
-    LEGACY_PAYLOAD_CODEC_MANIFEST_VERSION, MANIFEST_VERSION, ManifestPin, PayloadCodec,
-    PayloadGeometry, Reservation, SegmentCodecIdentity, SegmentHold, SegmentPut, StoreLimits,
-    StoreReconciliation, StoreUsage, StoredSegment, WriteRefusal, segment_digest,
+    CODEC_NATIVE_KV_PAGE, CODEC_NATIVE_KV_PAGE_VERSION, CODEC_RAW, CODEC_RAW_VERSION, CodecClass,
+    GeometryBlock, GeometryKind, HandoffManifest, HandoffSegmentRef, HandoffSegmentStore,
+    LEGACY_MANIFEST_VERSION, LEGACY_PAYLOAD_CODEC_MANIFEST_VERSION, MANIFEST_VERSION, ManifestPin,
+    PayloadCodec, PayloadGeometry, Reservation, SegmentCodecIdentity, SegmentHold, SegmentPut,
+    StoreLimits, StoreReconciliation, StoreUsage, StoredSegment, WriteRefusal, segment_digest,
 };
 pub use manager::{
     L3ActivitySnapshot, L3CacheManager, L3EffectiveState, L3EffectiveStatus, L3InventoryEntry,

--- a/crates/skippy-cache/src/tier.rs
+++ b/crates/skippy-cache/src/tier.rs
@@ -68,6 +68,11 @@ pub struct L3Location {
     /// Manifest key (payload digest) — the identity of the physical entry;
     /// the correct single-flight claim key.
     pub manifest_key: String,
+    /// Metadata copied from the located manifest so the runtime can reject an
+    /// incompatible native page descriptor before reading segment bytes.
+    pub kv_desc_json: Option<String>,
+    pub kv_bytes: u64,
+    pub native_kv_passthrough: bool,
 }
 
 /// A successful fill from the tier.
@@ -86,6 +91,50 @@ pub struct L3Tier {
     model_identity: String,
     state_identity: String,
     segment_bytes: usize,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SegmentRepresentation {
+    Raw,
+    NativeKvPage,
+}
+
+impl SegmentRepresentation {
+    fn identity(self, encoded_len: u64) -> SegmentCodecIdentity {
+        match self {
+            Self::Raw => SegmentCodecIdentity::raw(encoded_len),
+            Self::NativeKvPage => SegmentCodecIdentity::native_kv_page(encoded_len),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SegmentCut {
+    offset: u64,
+    len: u64,
+    label: String,
+    representation: SegmentRepresentation,
+}
+
+fn append_fixed_cuts(
+    cuts: &mut Vec<SegmentCut>,
+    offset: &mut u64,
+    bytes: u64,
+    segment_bytes: u64,
+    representation: SegmentRepresentation,
+) {
+    let mut remaining = bytes;
+    while remaining > 0 {
+        let len = segment_bytes.max(1).min(remaining);
+        cuts.push(SegmentCut {
+            offset: *offset,
+            len,
+            label: String::new(),
+            representation,
+        });
+        *offset = offset.saturating_add(len);
+        remaining -= len;
+    }
 }
 
 impl L3Tier {
@@ -270,6 +319,11 @@ impl L3Tier {
         manifest.payload_digest = payload_digest.clone();
         manifest.kv_bytes = kv_bytes;
         manifest.recurrent_bytes = recurrent_bytes;
+        let native_kv_passthrough = payload.kind() == ExactStatePayloadKind::KvRecurrent
+            && kv_bytes > 0
+            && kv_desc_json
+                .as_deref()
+                .is_some_and(|descriptor| !descriptor.trim().is_empty());
         manifest.kv_desc_json = kv_desc_json;
         manifest.token_count = token_count;
         // Cut on the payload's own geometry when the caller knows it, so a
@@ -278,7 +332,9 @@ impl L3Tier {
         // than trusted: mis-cutting would still reassemble, but silently write
         // the whole payload again every turn.
         let geometry = geometry.filter(|geometry| {
-            let matches = geometry.matches(wire.len() as u64);
+            let geometry_kv_bytes = geometry.total_bytes().saturating_sub(geometry.tail_bytes);
+            let matches = geometry.matches(wire.len() as u64)
+                && (!native_kv_passthrough || geometry_kv_bytes == kv_bytes);
             if !matches {
                 self.manager
                     .activity_counters()
@@ -288,24 +344,56 @@ impl L3Tier {
             matches
         });
         let cuts = match geometry {
-            Some(geometry) => geometry.plan(self.segment_bytes as u64),
+            Some(geometry) => geometry
+                .plan(self.segment_bytes as u64)
+                .into_iter()
+                .map(|(offset, len, label)| SegmentCut {
+                    offset,
+                    len,
+                    representation: if native_kv_passthrough && offset < kv_bytes {
+                        SegmentRepresentation::NativeKvPage
+                    } else {
+                        SegmentRepresentation::Raw
+                    },
+                    label,
+                })
+                .collect(),
             None => {
                 let mut cuts = Vec::new();
                 let mut offset = 0u64;
-                while (offset as usize) < wire.len() {
-                    let len = self.segment_bytes.min(wire.len() - offset as usize) as u64;
-                    cuts.push((offset, len, String::new()));
-                    offset += len;
+                if native_kv_passthrough {
+                    append_fixed_cuts(
+                        &mut cuts,
+                        &mut offset,
+                        kv_bytes,
+                        self.segment_bytes as u64,
+                        SegmentRepresentation::NativeKvPage,
+                    );
+                    append_fixed_cuts(
+                        &mut cuts,
+                        &mut offset,
+                        recurrent_bytes,
+                        self.segment_bytes as u64,
+                        SegmentRepresentation::Raw,
+                    );
+                } else {
+                    append_fixed_cuts(
+                        &mut cuts,
+                        &mut offset,
+                        wire.len() as u64,
+                        self.segment_bytes as u64,
+                        SegmentRepresentation::Raw,
+                    );
                 }
                 cuts
             }
         };
         let segment_slices = cuts
             .iter()
-            .map(|(offset, len, _)| {
-                let start = usize::try_from(*offset).context("segment offset exceeds usize")?;
+            .map(|cut| {
+                let start = usize::try_from(cut.offset).context("segment offset exceeds usize")?;
                 let end = start
-                    .checked_add(usize::try_from(*len).context("segment length exceeds usize")?)
+                    .checked_add(usize::try_from(cut.len).context("segment length exceeds usize")?)
                     .context("segment range overflows")?;
                 Ok(&wire[start..end])
             })
@@ -326,19 +414,17 @@ impl L3Tier {
         // these segments are unreferenced, and an eviction triggered by
         // another writer would collect them mid-build.
         let mut held = Vec::with_capacity(stored_segments.len());
-        for ((index, (offset, len, label)), stored) in
-            cuts.into_iter().enumerate().zip(stored_segments)
-        {
+        for ((index, cut), stored) in cuts.into_iter().enumerate().zip(stored_segments) {
             if stored.put.new {
                 new_bytes = new_bytes.saturating_add(stored.put.bytes);
             }
             manifest.segments.push(HandoffSegmentRef {
                 index: index as u32,
-                offset,
-                bytes: len,
+                offset: cut.offset,
+                bytes: cut.len,
                 digest: stored.digest.clone(),
-                codec_identity: Some(SegmentCodecIdentity::raw(len)),
-                meta_json: (!label.is_empty()).then_some(label),
+                codec_identity: Some(cut.representation.identity(cut.len)),
+                meta_json: (!cut.label.is_empty()).then_some(cut.label),
             });
             held.push(stored);
         }
@@ -450,11 +536,15 @@ impl L3Tier {
                     manifest.token_count
                 );
             }
+            let native_kv_passthrough = manifest.uses_native_kv_passthrough();
             return Ok(Some(L3Location {
                 namespace_key,
                 prefix_key,
                 token_count: length,
                 manifest_key: manifest.payload_digest,
+                kv_desc_json: manifest.kv_desc_json.clone(),
+                kv_bytes: manifest.kv_bytes,
+                native_kv_passthrough,
             }));
         }
         Ok(None)
@@ -566,7 +656,9 @@ impl L3Tier {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::l3::{GeometryBlock, GeometryKind};
+    use crate::l3::{
+        CODEC_NATIVE_KV_PAGE, CODEC_NATIVE_KV_PAGE_VERSION, GeometryBlock, GeometryKind,
+    };
 
     fn temp_root(name: &str) -> std::path::PathBuf {
         let root = std::env::temp_dir()
@@ -642,6 +734,156 @@ mod tests {
             }
         }
         ExactStatePayload::kv_recurrent(wire, Vec::new())
+    }
+
+    fn runtime_kv_desc(kv_type: u32, token_count: u64, payload_bytes: u64) -> String {
+        serde_json::json!({
+            "version": 1,
+            "layer_start": 0,
+            "layer_end": 1,
+            "token_start": 0,
+            "token_count": token_count,
+            "layer_count": 1,
+            "k_type": kv_type,
+            "v_type": kv_type,
+            "k_row_bytes": 16,
+            "v_row_bytes": 16,
+            "v_element_bytes": 2,
+            "k_idx_row_bytes": 0,
+            "payload_bytes": payload_bytes,
+            "flags": 0,
+            "codec": 0,
+            "component_count": 0
+        })
+        .to_string()
+    }
+
+    fn assert_native_kv_identity(segment: &HandoffSegmentRef) {
+        let identity = segment.codec_identity.as_ref().expect("segment identity");
+        assert_eq!(identity.name, CODEC_NATIVE_KV_PAGE);
+        assert_eq!(identity.version, CODEC_NATIVE_KV_PAGE_VERSION);
+        assert_eq!(identity.class, crate::l3::CodecClass::Exact);
+        assert_eq!(identity.decoded_len, segment.bytes);
+        assert_eq!(identity.calibration_digest, None);
+    }
+
+    #[test]
+    fn native_passthrough_preserves_supported_runtime_kv_representations() {
+        // ggml type ids used by the runtime: F32, F16, Q8_0 and Q4_0. The
+        // store treats all four as opaque native bytes and never transcodes.
+        for (name, kv_type) in [("f32", 0u32), ("f16", 1), ("q8_0", 8), ("q4_0", 2)] {
+            let tier = tier(&format!("native-{name}"), "blake3:native");
+            let kv = vec![kv_type as u8; 5_000];
+            let desc = runtime_kv_desc(kv_type, 4, kv.len() as u64);
+            let digest = tier
+                .spill(
+                    "ns",
+                    &tokens(4),
+                    &ExactStatePayload::kv_recurrent(kv.clone(), Vec::new()),
+                    Some(desc.clone()),
+                    None,
+                )
+                .expect("spill native KV");
+            let manifest = tier.store().load_manifest(&digest).expect("load manifest");
+            assert!(manifest.uses_native_kv_passthrough());
+            assert_eq!(manifest.kv_desc_json.as_deref(), Some(desc.as_str()));
+            assert!(
+                manifest
+                    .segments
+                    .iter()
+                    .all(|segment| segment.offset + segment.bytes <= manifest.kv_bytes)
+            );
+            for segment in &manifest.segments {
+                assert_native_kv_identity(segment);
+            }
+
+            let fill = tier
+                .fill_longest("ns", &tokens(4), 8)
+                .expect("fill")
+                .expect("native entry");
+            assert_eq!(
+                fill.payload.kv_bytes().unwrap().unwrap().as_ref(),
+                kv.as_slice(),
+                "{name} bytes changed during the storage round trip"
+            );
+        }
+    }
+
+    #[test]
+    fn fixed_native_and_recurrent_segments_do_not_cross_representation_boundary() {
+        let tier = tier("native-fixed-boundary", "blake3:native");
+        let kv = vec![1u8; 5_000];
+        let recurrent = vec![2u8; 5_000];
+        let digest = tier
+            .spill(
+                "ns",
+                &tokens(4),
+                &ExactStatePayload::kv_recurrent(kv.clone(), recurrent.clone()),
+                Some(runtime_kv_desc(1, 4, kv.len() as u64)),
+                None,
+            )
+            .expect("spill mixed exact state");
+        let manifest = tier.store().load_manifest(&digest).expect("load manifest");
+        assert_eq!(manifest.kv_bytes, 5_000);
+        assert_eq!(manifest.recurrent_bytes, 5_000);
+        assert_eq!(
+            manifest.segments[1].offset + manifest.segments[1].bytes,
+            5_000
+        );
+        for segment in &manifest.segments {
+            let end = segment.offset + segment.bytes;
+            assert!(end <= manifest.kv_bytes || segment.offset >= manifest.kv_bytes);
+            if segment.offset < manifest.kv_bytes {
+                assert_native_kv_identity(segment);
+            } else {
+                assert_eq!(
+                    segment.codec_identity,
+                    Some(SegmentCodecIdentity::raw(segment.bytes))
+                );
+            }
+        }
+        let fill = tier
+            .fill_longest("ns", &tokens(4), 8)
+            .expect("fill")
+            .expect("mixed entry");
+        assert_eq!(fill.payload.kv_bytes().unwrap().unwrap().as_ref(), kv);
+        assert_eq!(
+            fill.payload.recurrent_state_bytes().unwrap().as_ref(),
+            recurrent
+        );
+    }
+
+    #[test]
+    fn geometry_marks_kv_windows_native_and_recurrent_tail_raw() {
+        let tier = tier("native-geometry-boundary", "blake3:native");
+        let geometry = PayloadGeometry {
+            tail_bytes: 50,
+            ..kv_geometry(1, 8, 16, 16, 4)
+        };
+        let kv = vec![3u8; 256];
+        let recurrent = vec![4u8; 50];
+        let digest = tier
+            .spill(
+                "ns",
+                &tokens(8),
+                &ExactStatePayload::kv_recurrent(kv, recurrent),
+                Some(runtime_kv_desc(1, 8, 256)),
+                Some(&geometry),
+            )
+            .expect("spill geometry-native state");
+        let manifest = tier.store().load_manifest(&digest).expect("load manifest");
+        for segment in &manifest.segments {
+            if segment.meta_json.as_deref() == Some("tail") {
+                assert_eq!(
+                    segment.codec_identity,
+                    Some(SegmentCodecIdentity::raw(segment.bytes))
+                );
+                assert!(segment.offset >= manifest.kv_bytes);
+            } else {
+                assert_native_kv_identity(segment);
+                assert!(segment.offset + segment.bytes <= manifest.kv_bytes);
+            }
+        }
     }
 
     #[test]
@@ -799,14 +1041,15 @@ mod tests {
             ),
         ];
         for (namespace, payload) in cases {
-            tier.spill(
-                namespace,
-                &tokens(512),
-                &payload,
-                Some("{\"desc\":1}".to_string()),
-                None,
-            )
-            .expect("spill");
+            let digest = tier
+                .spill(
+                    namespace,
+                    &tokens(512),
+                    &payload,
+                    Some("{\"desc\":1}".to_string()),
+                    None,
+                )
+                .expect("spill");
             let fill = tier
                 .fill_longest(namespace, &tokens(512), 64)
                 .expect("fill")
@@ -814,6 +1057,19 @@ mod tests {
             assert_eq!(fill.token_count, 512);
             assert_eq!(fill.kv_desc_json.as_deref(), Some("{\"desc\":1}"));
             assert_eq!(fill.payload.kind(), payload.kind());
+            let manifest = tier
+                .store()
+                .load_manifest(&digest)
+                .expect("load roundtrip manifest");
+            if payload.kind() != ExactStatePayloadKind::KvRecurrent {
+                assert!(
+                    manifest
+                        .segments
+                        .iter()
+                        .all(|segment| segment.codec_identity
+                            == Some(SegmentCodecIdentity::raw(segment.bytes)))
+                );
+            }
             match payload.kind() {
                 ExactStatePayloadKind::KvRecurrent => {
                     assert_eq!(

--- a/crates/skippy-server/src/kv_integration/exact_state.rs
+++ b/crates/skippy-server/src/kv_integration/exact_state.rs
@@ -19,6 +19,28 @@ fn resident_prefix_is_complete(matched_tokens: usize, requested_tokens: usize) -
     matched_tokens >= requested_tokens
 }
 
+fn preflight_native_kv_location(
+    location: &skippy_cache::L3Location,
+) -> Result<Option<skippy_runtime::RuntimeKvPageDesc>> {
+    if !location.native_kv_passthrough {
+        return Ok(None);
+    }
+    let json = location
+        .kv_desc_json
+        .as_deref()
+        .context("native KV manifest has no runtime page descriptor")?;
+    let desc: skippy_runtime::RuntimeKvPageDesc =
+        serde_json::from_str(json).context("native KV manifest has an invalid page descriptor")?;
+    let kv_bytes =
+        usize::try_from(location.kv_bytes).context("native KV payload length exceeds usize")?;
+    desc.validate_payload(kv_bytes)
+        .context("native KV manifest page descriptor is incompatible")?;
+    if desc.token_start != 0 || desc.token_count != location.token_count {
+        anyhow::bail!("native KV manifest page descriptor does not cover the located prefix");
+    }
+    Ok(Some(desc))
+}
+
 impl KvStageIntegration {
     pub fn restore_exact_state(
         &self,
@@ -478,6 +500,13 @@ impl KvStageIntegration {
         l3: &std::sync::Arc<skippy_cache::L3Tier>,
         location: &skippy_cache::L3Location,
     ) -> Result<Option<ExactStateRestore>> {
+        // Native page capability is checked from manifest metadata before the
+        // tier reads any segment bytes. Runtime ABI, platform and numerical
+        // mode are already bound by the tier's exact-state identity; the page
+        // descriptor completes the representation check.
+        let Ok(native_kv_desc) = preflight_native_kv_location(location) else {
+            return Ok(None);
+        };
         let fill_started = Instant::now();
         // A load failure (corrupt segment, now quarantined) is a miss, not a
         // request failure. Import failures below do propagate: the transaction
@@ -488,12 +517,19 @@ impl KvStageIntegration {
         if fill.payload.byte_len() == 0 {
             return Ok(None);
         }
+        if location.native_kv_passthrough
+            && (fill.token_count != location.token_count
+                || fill.kv_desc_json != location.kv_desc_json)
+        {
+            return Ok(None);
+        }
         let fill_ms = fill_started.elapsed().as_secs_f64() * 1000.0;
         let token_count = fill.token_count;
-        let kv_desc: Option<skippy_runtime::RuntimeKvPageDesc> = fill
-            .kv_desc_json
-            .as_deref()
-            .and_then(|json| serde_json::from_str(json).ok());
+        let kv_desc: Option<skippy_runtime::RuntimeKvPageDesc> = native_kv_desc.or_else(|| {
+            fill.kv_desc_json
+                .as_deref()
+                .and_then(|json| serde_json::from_str(json).ok())
+        });
         let lookup_ms = lookup_started.elapsed().as_secs_f64() * 1000.0;
         let mut kv_import_ms = 0.0;
         let mut recurrent_import_ms = 0.0;
@@ -696,9 +732,9 @@ mod tests {
         time::{Duration, Instant},
     };
 
-    use skippy_cache::UnifiedRadixCache;
+    use skippy_cache::{L3Location, UnifiedRadixCache};
 
-    use super::{resident_prefix_is_complete, try_touch_exact_state};
+    use super::{preflight_native_kv_location, resident_prefix_is_complete, try_touch_exact_state};
 
     type TestRadix = UnifiedRadixCache<
         crate::kv_integration::RadixResidentEntry,
@@ -753,5 +789,58 @@ mod tests {
             try_touch_exact_state(&cache, "namespace", &[1]).unwrap(),
             Some(false)
         );
+    }
+
+    fn native_location(desc: &skippy_runtime::RuntimeKvPageDesc) -> L3Location {
+        L3Location {
+            namespace_key: "namespace".to_string(),
+            prefix_key: "prefix".to_string(),
+            token_count: desc.token_count,
+            manifest_key: "manifest".to_string(),
+            kv_desc_json: Some(serde_json::to_string(desc).unwrap()),
+            kv_bytes: desc.payload_bytes,
+            native_kv_passthrough: true,
+        }
+    }
+
+    fn native_desc() -> skippy_runtime::RuntimeKvPageDesc {
+        skippy_runtime::RuntimeKvPageDesc {
+            version: 1,
+            layer_start: 0,
+            layer_end: 1,
+            token_start: 0,
+            token_count: 8,
+            layer_count: 1,
+            k_type: skippy_runtime::GGML_TYPE_Q8_0,
+            v_type: skippy_runtime::GGML_TYPE_Q8_0,
+            k_row_bytes: 16,
+            v_row_bytes: 16,
+            v_element_bytes: 2,
+            k_idx_row_bytes: 0,
+            payload_bytes: 256,
+            flags: 0,
+            codec: 0,
+            component_count: 0,
+            components: Box::new([Default::default(); 2]),
+        }
+    }
+
+    #[test]
+    fn native_kv_descriptor_is_validated_before_segment_load() {
+        let desc = native_desc();
+        assert_eq!(
+            preflight_native_kv_location(&native_location(&desc)).unwrap(),
+            Some(desc)
+        );
+
+        let mut wrong_length = native_desc();
+        wrong_length.payload_bytes += 1;
+        let mut location = native_location(&wrong_length);
+        location.kv_bytes -= 1;
+        assert!(preflight_native_kv_location(&location).is_err());
+
+        let mut wrong_prefix = native_desc();
+        wrong_prefix.token_start = 1;
+        assert!(preflight_native_kv_location(&native_location(&wrong_prefix)).is_err());
     }
 }

--- a/docs/skippy/CACHEGEN_BACKEND_PLAN.md
+++ b/docs/skippy/CACHEGEN_BACKEND_PLAN.md
@@ -71,6 +71,17 @@ workload. Per the agreed stop rule this evidence comes back before any
 expansion: CubeCL is **not** a committed dependency, the spike lives
 behind the `cachegen-spike` feature, and nothing in the library links it.
 
+## Native exact control
+
+The exact control arm uses `native-kv-page/1` per-segment identity. KV bytes
+exported by the active runtime are written and restored verbatim, including
+F32, F16, Q8_0, and Q4_0 layouts supported by that runtime; there is no storage
+transcode. Mixed KV plus recurrent payloads cut at the representation boundary,
+so auxiliary continuation state remains exact `raw/1`. Runtime page metadata is
+validated before segment reads, while the existing exact-state identity binds
+the runtime ABI, platform, model, layer range, and KV configuration. This is the
+baseline every CacheGen result must beat end to end.
+
 ## Capability failure policy
 
 A backend that cannot run a codec fails explicitly through the v4
@@ -84,9 +95,7 @@ lookup.
 
 ## Sequencing after this slice
 
-1. Native runtime-format passthrough remains the exact control arm
-   (unchanged #1652 scope).
-2. CacheGen quality/performance gate versus native on the ~19K acceptance
+1. CacheGen quality/performance gate versus native on the ~19K acceptance
    workload, matched release builds, before any wiring.
-3. Only then: CUDA and HIP/ROCm on real hardware, each proven against
+2. Only then: CUDA and HIP/ROCm on real hardware, each proven against
    the CPU reference bit-for-bit before either is marked implemented.


### PR DESCRIPTION
## Problem

Manifest v4 can identify each segment independently, but L3 still stamped every segment as `raw/1`. That left the native runtime KV control arm implicit and allowed a fixed-size cut to mix native KV bytes with recurrent state.

## Result

- Add the exact `native-kv-page/1` segment identity and persist F32, F16, Q8_0, and Q4_0 runtime exports byte-for-byte, with no storage transcode.
- Cut mixed payloads at the KV/recurrent boundary so native KV segments never include exact auxiliary continuation state.
- Reject unknown native versions, incomplete descriptors, boundary-crossing segments, and representation mismatches before assembly.
- Copy manifest descriptor metadata into `L3Location` so the server validates the native page descriptor and located prefix before reading segment bytes; recheck metadata after load to close the locate/load race.
- Document native passthrough as the exact control for the remaining CacheGen quality and performance gate.

Advances #1652. This is stacked on #1752.

## Validation

Exact candidate commit: `9be4e30158a34612c818aeef4d47b2a045c62ff5`

- `cargo test -p skippy-cache --lib` — 170 passed, 0 failed, 2 ignored
- `cargo test -p skippy-server --lib` — 708 passed, 0 failed, 3 ignored
- `cargo clippy -p skippy-cache -p skippy-server --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Matched realistic-segment stopwatch on the same Apple Silicon host and debug toolchain:

- Command: `cargo test -p skippy-cache --lib l3::tests::eviction_cost_at_realistic_segment_counts -- --ignored --nocapture`
- Workload: 20 manifests × 9,504 refs, 43,347,990 manifest bytes
- Baseline `aa533c0d45e1b8af025ee9af9887de68a7f02baf`: build 2,021 ms; budget enforcement 1,375 ms
- Candidate `9be4e30158a34612c818aeef4d47b2a045c62ff5`: build 2,113 ms; budget enforcement 1,396 ms

This slice does not change admission, eviction, prefix reuse, or resident capacity, so the competitive c64/c128/c256 policy matrix is unchanged.
