### PR TITLE
ci: reject backward llama.cpp pin moves

### DIFF
--- a/.github/workflows/ci-quality-lane.yml
+++ b/.github/workflows/ci-quality-lane.yml
@@ -92,7 +92,21 @@ jobs:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
           ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
           persist-credentials: false
+      - name: Guard PR llama.cpp upstream pin monotonicity
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$BASE_SHA" =~ ^[0-9a-f]{40}$ ]] || [[ ! "$HEAD_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "pull request base/head identity is malformed" >&2
+            exit 1
+          fi
+          git fetch --no-tags origin "$BASE_SHA" "$HEAD_SHA"
+          python3 scripts/check-llama-upstream-pin.py "$BASE_SHA" "$HEAD_SHA"
       - name: Validate planned quality jobs
         id: validate
         continue-on-error: true

--- a/.github/workflows/pr_quality.yml
+++ b/.github/workflows/pr_quality.yml
@@ -2,7 +2,7 @@ name: PR · Quality
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, ready_for_review]
+    types: [opened, synchronize, reopened, ready_for_review, edited]
 
 permissions:
   checks: write

--- a/scripts/check-llama-upstream-pin.py
+++ b/scripts/check-llama-upstream-pin.py
@@ -21,19 +21,33 @@ import tempfile
 SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 PIN_PATH = "third_party/llama.cpp/upstream.txt"
 DEFAULT_UPSTREAM_URL = "https://github.com/ggml-org/llama.cpp.git"
+UPSTREAM_FETCH_TIMEOUT_SECONDS = 300
 
 
 class PinGuardError(RuntimeError):
     """Raised when the pin comparison cannot be proved safe."""
 
 
-def git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
-    result = subprocess.run(
-        ["git", "-C", str(repo), *args],
-        check=False,
-        text=True,
-        capture_output=True,
-    )
+def git(
+    repo: Path,
+    *args: str,
+    check: bool = True,
+    timeout: float | None = None,
+) -> subprocess.CompletedProcess[str]:
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            check=False,
+            text=True,
+            capture_output=True,
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired as error:
+        timeout_detail = f" after {timeout:g} seconds" if timeout is not None else ""
+        raise PinGuardError(
+            f"git {' '.join(args)} timed out{timeout_detail}; "
+            "the guard cannot prove llama.cpp upstream ancestry and will fail closed"
+        ) from error
     if check and result.returncode != 0:
         detail = result.stderr.strip() or result.stdout.strip() or "no git output"
         raise PinGuardError(f"git {' '.join(args)} failed: {detail}")
@@ -91,6 +105,7 @@ def fetch_upstream(upstream_url: str, base_pin: str, proposed_pin: str) -> tempf
             base_pin,
             proposed_pin,
             check=False,
+            timeout=UPSTREAM_FETCH_TIMEOUT_SECONDS,
         )
         if fetched.returncode != 0:
             detail = fetched.stderr.strip() or fetched.stdout.strip() or "no git output"
@@ -111,6 +126,7 @@ def fetch_upstream(upstream_url: str, base_pin: str, proposed_pin: str) -> tempf
                 "--unshallow",
                 "origin",
                 check=False,
+                timeout=UPSTREAM_FETCH_TIMEOUT_SECONDS,
             )
             if unshallow.returncode != 0 or git(
                 upstream, "rev-parse", "--is-shallow-repository"

--- a/scripts/check-llama-upstream-pin.py
+++ b/scripts/check-llama-upstream-pin.py
@@ -1,0 +1,250 @@
+#!/usr/bin/env python3
+"""Reject PRs that move the pinned llama.cpp revision backwards.
+
+The script is intended to run from a protected workflow checkout.  It reads
+the pin files from the immutable base and head commits, then builds a fresh
+blobless mirror of the upstream repository.  Fetching both pins without a
+depth limit is deliberate: a shallow or incomplete local upstream checkout
+must never turn an unknown ancestry result into a passing check.
+"""
+
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+import re
+import subprocess
+import sys
+import tempfile
+
+
+SHA_RE = re.compile(r"^[0-9a-f]{40}$")
+PIN_PATH = "third_party/llama.cpp/upstream.txt"
+DEFAULT_UPSTREAM_URL = "https://github.com/ggml-org/llama.cpp.git"
+
+
+class PinGuardError(RuntimeError):
+    """Raised when the pin comparison cannot be proved safe."""
+
+
+def git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        check=False,
+        text=True,
+        capture_output=True,
+    )
+    if check and result.returncode != 0:
+        detail = result.stderr.strip() or result.stdout.strip() or "no git output"
+        raise PinGuardError(f"git {' '.join(args)} failed: {detail}")
+    return result
+
+
+def validate_revision(value: str, label: str) -> str:
+    if not SHA_RE.fullmatch(value):
+        raise PinGuardError(f"{label} must be a lowercase 40-character SHA: {value!r}")
+    return value
+
+
+def read_pin(repo: Path, revision: str, label: str) -> str:
+    tree = git(repo, "ls-tree", "-z", revision, "--", PIN_PATH)
+    entries = [entry for entry in tree.stdout.split("\0") if entry]
+    if len(entries) != 1:
+        raise PinGuardError(
+            f"{label} commit {revision} must contain exactly one {PIN_PATH} entry"
+        )
+    metadata, path = entries[0].split("\t", 1)
+    metadata_parts = metadata.split()
+    if (
+        path != PIN_PATH
+        or len(metadata_parts) != 3
+        or metadata_parts[0] != "100644"
+        or metadata_parts[1] != "blob"
+    ):
+        raise PinGuardError(
+            f"{label} commit {revision} {PIN_PATH} must be a regular 100644 blob"
+        )
+    result = git(repo, "show", f"{revision}:{PIN_PATH}")
+    pin = result.stdout.strip()
+    if not SHA_RE.fullmatch(pin):
+        raise PinGuardError(
+            f"{label} commit {revision} has an invalid {PIN_PATH} value: {pin!r}"
+        )
+    return pin
+
+
+def fetch_upstream(upstream_url: str, base_pin: str, proposed_pin: str) -> tempfile.TemporaryDirectory[str]:
+    checkout = tempfile.TemporaryDirectory(prefix="mesh-llm-llama-pin-")
+    upstream = Path(checkout.name) / "upstream.git"
+    upstream.mkdir()
+    try:
+        git(upstream, "init", "--bare", "--quiet")
+        git(upstream, "remote", "add", "origin", upstream_url)
+        fetched = git(
+            upstream,
+            "-c",
+            "protocol.version=2",
+            "fetch",
+            "--no-tags",
+            "--filter=blob:none",
+            "origin",
+            base_pin,
+            proposed_pin,
+            check=False,
+        )
+        if fetched.returncode != 0:
+            detail = fetched.stderr.strip() or fetched.stdout.strip() or "no git output"
+            raise PinGuardError(
+                "unable to fetch both llama.cpp upstream pins; "
+                "the guard cannot prove ancestry and will fail closed: "
+                f"{detail}"
+            )
+
+        shallow = git(upstream, "rev-parse", "--is-shallow-repository").stdout.strip()
+        if shallow == "true":
+            # The fetch above intentionally has no depth limit.  Keep this
+            # fallback for mirrors configured as shallow by their server.
+            unshallow = git(
+                upstream,
+                "fetch",
+                "--no-tags",
+                "--unshallow",
+                "origin",
+                check=False,
+            )
+            if unshallow.returncode != 0 or git(
+                upstream, "rev-parse", "--is-shallow-repository"
+            ).stdout.strip() == "true":
+                detail = unshallow.stderr.strip() or unshallow.stdout.strip() or "no git output"
+                raise PinGuardError(
+                    "llama.cpp upstream history is shallow after fetch; "
+                    f"cannot prove ancestry: {detail}"
+                )
+
+        for pin in (base_pin, proposed_pin):
+            if git(upstream, "cat-file", "-e", f"{pin}^{{commit}}", check=False).returncode != 0:
+                raise PinGuardError(
+                    f"llama.cpp upstream object {pin} is unavailable after fetch; "
+                    "cannot prove ancestry"
+                )
+
+        missing = git(
+            upstream,
+            "rev-list",
+            "--missing=print",
+            base_pin,
+            proposed_pin,
+            check=False,
+        )
+        if missing.returncode != 0:
+            detail = missing.stderr.strip() or missing.stdout.strip() or "no git output"
+            raise PinGuardError(f"cannot walk llama.cpp upstream history: {detail}")
+        if any(line.startswith("?") for line in missing.stdout.splitlines()):
+            raise PinGuardError(
+                "llama.cpp upstream history is incomplete after fetch; "
+                "cannot prove ancestry"
+            )
+        return checkout
+    except Exception:
+        checkout.cleanup()
+        raise
+
+
+def check_pin(repository: Path, base_revision: str, head_revision: str, upstream_url: str) -> int:
+    base_revision = validate_revision(base_revision, "base revision")
+    head_revision = validate_revision(head_revision, "head revision")
+    for revision in (base_revision, head_revision):
+        if git(repository, "cat-file", "-e", f"{revision}^{{commit}}", check=False).returncode != 0:
+            raise PinGuardError(f"repository is missing {revision}; cannot inspect PR pin")
+
+    merge_base_result = git(
+        repository,
+        "merge-base",
+        base_revision,
+        head_revision,
+        check=False,
+    )
+    if merge_base_result.returncode != 0:
+        detail = merge_base_result.stderr.strip() or merge_base_result.stdout.strip() or "no git output"
+        raise PinGuardError(f"cannot determine the PR merge base: {detail}")
+    merge_base = merge_base_result.stdout.strip()
+    if not SHA_RE.fullmatch(merge_base):
+        raise PinGuardError(f"git returned an invalid PR merge base: {merge_base!r}")
+
+    base_pin = read_pin(repository, merge_base, "PR merge-base")
+    proposed_pin = read_pin(repository, head_revision, "head")
+    print(f"PR merge-base commit:   {merge_base}")
+    print(f"merge-base llama.cpp pin: {base_pin}")
+    print(f"proposed llama.cpp pin: {proposed_pin}")
+
+    if base_pin == proposed_pin:
+        print("llama.cpp upstream pin is unchanged")
+        return 0
+
+    checkout = fetch_upstream(upstream_url, base_pin, proposed_pin)
+    try:
+        upstream = Path(checkout.name) / "upstream.git"
+        proposed_ancestor = git(
+            upstream,
+            "merge-base",
+            "--is-ancestor",
+            proposed_pin,
+            base_pin,
+            check=False,
+        )
+        if proposed_ancestor.returncode == 0:
+            raise PinGuardError(
+                "PR moves third_party/llama.cpp/upstream.txt backward: "
+                f"{proposed_pin} is an ancestor of the base pin {base_pin}"
+            )
+        if proposed_ancestor.returncode != 1:
+            detail = proposed_ancestor.stderr.strip() or proposed_ancestor.stdout.strip() or "no git output"
+            raise PinGuardError(f"cannot compare llama.cpp upstream pins: {detail}")
+
+        base_ancestor = git(
+            upstream,
+            "merge-base",
+            "--is-ancestor",
+            base_pin,
+            proposed_pin,
+            check=False,
+        )
+        if base_ancestor.returncode == 0:
+            print("llama.cpp upstream pin moves forward")
+            return 0
+        if base_ancestor.returncode != 1:
+            detail = base_ancestor.stderr.strip() or base_ancestor.stdout.strip() or "no git output"
+            raise PinGuardError(f"cannot compare llama.cpp upstream pins: {detail}")
+        raise PinGuardError(
+            "PR proposes a divergent llama.cpp upstream history; "
+            "the guard cannot prove a forward pin update"
+        )
+    finally:
+        checkout.cleanup()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("base_revision", help="PR base repository commit")
+    parser.add_argument("head_revision", help="PR head repository commit")
+    parser.add_argument(
+        "--repository",
+        type=Path,
+        default=Path(__file__).resolve().parents[1],
+        help="mesh-llm checkout containing the base and head commits",
+    )
+    parser.add_argument(
+        "--upstream-url",
+        default=DEFAULT_UPSTREAM_URL,
+        help="llama.cpp git URL (for hermetic tests, a local repository URL)",
+    )
+    args = parser.parse_args()
+    try:
+        return check_pin(args.repository.resolve(), args.base_revision, args.head_revision, args.upstream_url)
+    except PinGuardError as error:
+        print(f"ERROR: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/tests/test_llama_upstream_pin_guard.py
+++ b/scripts/tests/test_llama_upstream_pin_guard.py
@@ -1,0 +1,248 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+GUARD = ROOT / "scripts" / "check-llama-upstream-pin.py"
+QUALITY_LANE = ROOT / ".github" / "workflows" / "ci-quality-lane.yml"
+PR_QUALITY = ROOT / ".github" / "workflows" / "pr_quality.yml"
+PIN_PATH = Path("third_party/llama.cpp/upstream.txt")
+
+
+def run_git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
+    result = subprocess.run(
+        ["git", "-C", str(repo), *args],
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    if check and result.returncode != 0:
+        raise AssertionError(result.stderr)
+    return result
+
+
+class LlamaUpstreamPinGuardTests(unittest.TestCase):
+    def create_upstream(self, root: Path) -> tuple[Path, str, str, str]:
+        upstream = root / "llama-upstream"
+        upstream.mkdir()
+        run_git(upstream, "init", "--quiet")
+        run_git(upstream, "config", "user.name", "fixture")
+        run_git(upstream, "config", "user.email", "fixture@example.com")
+        (upstream / "history.txt").write_text("base\n", encoding="utf-8")
+        run_git(upstream, "add", "history.txt")
+        run_git(upstream, "commit", "--quiet", "-m", "base")
+        base_pin = run_git(upstream, "rev-parse", "HEAD").stdout.strip()
+        (upstream / "history.txt").write_text("base\nforward\n", encoding="utf-8")
+        run_git(upstream, "commit", "--quiet", "-am", "forward")
+        forward_pin = run_git(upstream, "rev-parse", "HEAD").stdout.strip()
+        (upstream / "history.txt").write_text("base\nforward\nlatest\n", encoding="utf-8")
+        run_git(upstream, "commit", "--quiet", "-am", "latest")
+        latest_pin = run_git(upstream, "rev-parse", "HEAD").stdout.strip()
+        return upstream, base_pin, forward_pin, latest_pin
+
+    def create_mesh_history(self, root: Path, base_pin: str, proposed_pin: str) -> tuple[Path, str, str]:
+        mesh = root / "mesh"
+        (mesh / PIN_PATH.parent).mkdir(parents=True)
+        run_git(mesh, "init", "--quiet")
+        run_git(mesh, "config", "user.name", "fixture")
+        run_git(mesh, "config", "user.email", "fixture@example.com")
+        (mesh / PIN_PATH).write_text(f"{base_pin}\n", encoding="utf-8")
+        run_git(mesh, "add", str(PIN_PATH))
+        run_git(mesh, "commit", "--quiet", "-m", "base")
+        base_revision = run_git(mesh, "rev-parse", "HEAD").stdout.strip()
+        (mesh / PIN_PATH).write_text(f"{proposed_pin}\n", encoding="utf-8")
+        (mesh / "change.txt").write_text("proposed\n", encoding="utf-8")
+        run_git(mesh, "add", "-A")
+        run_git(mesh, "commit", "--quiet", "-m", "propose pin")
+        head_revision = run_git(mesh, "rev-parse", "HEAD").stdout.strip()
+        return mesh, base_revision, head_revision
+
+    def create_stale_mesh_history(
+        self,
+        root: Path,
+        merge_base_pin: str,
+        target_pin: str,
+        proposed_pin: str,
+    ) -> tuple[Path, str, str]:
+        mesh = root / "mesh-stale"
+        (mesh / PIN_PATH.parent).mkdir(parents=True)
+        run_git(mesh, "init", "--quiet")
+        run_git(mesh, "config", "user.name", "fixture")
+        run_git(mesh, "config", "user.email", "fixture@example.com")
+        (mesh / PIN_PATH).write_text(f"{merge_base_pin}\n", encoding="utf-8")
+        run_git(mesh, "add", str(PIN_PATH))
+        run_git(mesh, "commit", "--quiet", "-m", "merge base")
+        merge_base_revision = run_git(mesh, "rev-parse", "HEAD").stdout.strip()
+        run_git(mesh, "branch", "target")
+
+        run_git(mesh, "checkout", "--quiet", "-b", "pr")
+        (mesh / PIN_PATH).write_text(f"{proposed_pin}\n", encoding="utf-8")
+        (mesh / "pr-change.txt").write_text("pr\n", encoding="utf-8")
+        run_git(mesh, "add", "-A")
+        run_git(mesh, "commit", "--quiet", "-m", "PR change")
+        head_revision = run_git(mesh, "rev-parse", "HEAD").stdout.strip()
+
+        run_git(mesh, "checkout", "--quiet", "target")
+        (mesh / PIN_PATH).write_text(f"{target_pin}\n", encoding="utf-8")
+        (mesh / "target-change.txt").write_text("target\n", encoding="utf-8")
+        run_git(mesh, "add", "-A")
+        run_git(mesh, "commit", "--quiet", "-m", "target advances pin")
+        base_revision = run_git(mesh, "rev-parse", "HEAD").stdout.strip()
+        self.assertEqual(
+            merge_base_revision,
+            run_git(mesh, "merge-base", base_revision, head_revision).stdout.strip(),
+        )
+        return mesh, base_revision, head_revision
+
+    def create_symlink_pin_history(
+        self, root: Path, merge_base_pin: str, dereferenced_pin: str
+    ) -> tuple[Path, str, str]:
+        mesh = root / "mesh-symlink"
+        (mesh / PIN_PATH.parent).mkdir(parents=True)
+        run_git(mesh, "init", "--quiet")
+        run_git(mesh, "config", "user.name", "fixture")
+        run_git(mesh, "config", "user.email", "fixture@example.com")
+        (mesh / PIN_PATH).write_text(f"{merge_base_pin}\n", encoding="utf-8")
+        run_git(mesh, "add", str(PIN_PATH))
+        run_git(mesh, "commit", "--quiet", "-m", "merge base")
+        base_revision = run_git(mesh, "rev-parse", "HEAD").stdout.strip()
+
+        (mesh / PIN_PATH).unlink()
+        (mesh / merge_base_pin).write_text(f"{dereferenced_pin}\n", encoding="utf-8")
+        os.symlink(merge_base_pin, mesh / PIN_PATH)
+        run_git(mesh, "add", "-A")
+        run_git(mesh, "commit", "--quiet", "-m", "symlink pin")
+        head_revision = run_git(mesh, "rev-parse", "HEAD").stdout.strip()
+        return mesh, base_revision, head_revision
+
+    def run_guard(self, mesh: Path, base: str, head: str, upstream: Path) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                "python3",
+                str(GUARD),
+                "--repository",
+                str(mesh),
+                "--upstream-url",
+                str(upstream),
+                base,
+                head,
+            ],
+            text=True,
+            capture_output=True,
+            check=False,
+        )
+
+    def test_equal_pin_passes(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            upstream, base_pin, _, _ = self.create_upstream(root)
+            mesh, base, head = self.create_mesh_history(root, base_pin, base_pin)
+            result = self.run_guard(mesh, base, head, upstream)
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertIn("unchanged", result.stdout)
+
+    def test_descendant_pin_passes_after_fetching_history(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            upstream, base_pin, _, latest_pin = self.create_upstream(root)
+            mesh, base, head = self.create_mesh_history(root, base_pin, latest_pin)
+            result = self.run_guard(mesh, base, head, upstream)
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertIn("moves forward", result.stdout)
+
+    def test_ancestor_pin_fails_as_backward(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            upstream, base_pin, _, latest_pin = self.create_upstream(root)
+            mesh, base, head = self.create_mesh_history(root, latest_pin, base_pin)
+            result = self.run_guard(mesh, base, head, upstream)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("moves", result.stderr)
+            self.assertIn("backward", result.stderr)
+
+    def test_stale_pr_uses_merge_base_pin_when_target_advanced(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            upstream, base_pin, forward_pin, _ = self.create_upstream(root)
+            mesh, base, head = self.create_stale_mesh_history(
+                root,
+                merge_base_pin=base_pin,
+                target_pin=forward_pin,
+                proposed_pin=base_pin,
+            )
+            result = self.run_guard(mesh, base, head, upstream)
+            self.assertEqual(0, result.returncode, result.stderr)
+            self.assertIn("unchanged", result.stdout)
+
+    def test_backward_pin_is_compared_to_merge_base(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            upstream, base_pin, _, latest_pin = self.create_upstream(root)
+            mesh, base, head = self.create_stale_mesh_history(
+                root,
+                merge_base_pin=latest_pin,
+                target_pin=latest_pin,
+                proposed_pin=base_pin,
+            )
+            result = self.run_guard(mesh, base, head, upstream)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("backward", result.stderr)
+
+    def test_missing_upstream_pin_fails_closed(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            upstream, base_pin, _, _ = self.create_upstream(root)
+            missing_pin = "f" * 40
+            mesh, base, head = self.create_mesh_history(root, base_pin, missing_pin)
+            result = self.run_guard(mesh, base, head, upstream)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("fail closed", result.stderr)
+
+    def test_symlink_pin_is_rejected_before_dereferencing_sibling_content(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            upstream, base_pin, _, latest_pin = self.create_upstream(root)
+            mesh, base, head = self.create_symlink_pin_history(
+                root, merge_base_pin=latest_pin, dereferenced_pin=base_pin
+            )
+            result = self.run_guard(mesh, base, head, upstream)
+            self.assertNotEqual(0, result.returncode)
+            self.assertIn("regular 100644 blob", result.stderr)
+
+    def test_workflow_runs_guard_from_protected_checkout(self) -> None:
+        workflow = QUALITY_LANE.read_text(encoding="utf-8")
+        summary = workflow.split("  summary:\n", 1)[1]
+        self.assertIn("ref: ${{ github.event.repository.default_branch }}", summary)
+        self.assertIn("fetch-depth: 0", summary)
+        self.assertIn("persist-credentials: false", summary)
+        self.assertIn("if: ${{ github.event_name == 'pull_request' }}", summary)
+        self.assertIn('git fetch --no-tags origin "$BASE_SHA" "$HEAD_SHA"', summary)
+        self.assertIn(
+            'python3 scripts/check-llama-upstream-pin.py "$BASE_SHA" "$HEAD_SHA"',
+            summary,
+        )
+        self.assertNotIn("ref: ${{ inputs.source_sha || github.sha }}", summary)
+
+    def test_pr_base_retargeting_retriggers_the_guard(self) -> None:
+        workflow = PR_QUALITY.read_text(encoding="utf-8")
+        self.assertIn(
+            "types: [opened, synchronize, reopened, ready_for_review, edited]",
+            workflow,
+        )
+        self.assertIn(
+            "BASE_SHA: ${{ github.event.pull_request.base.sha }}",
+            QUALITY_LANE.read_text(encoding="utf-8"),
+        )
+        self.assertIn(
+            "HEAD_SHA: ${{ github.event.pull_request.head.sha }}",
+            QUALITY_LANE.read_text(encoding="utf-8"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/tests/test_llama_upstream_pin_guard.py
+++ b/scripts/tests/test_llama_upstream_pin_guard.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+import importlib.util
 import os
 from pathlib import Path
 import subprocess
 import tempfile
+from unittest import mock
 import unittest
 
 
@@ -12,6 +14,11 @@ GUARD = ROOT / "scripts" / "check-llama-upstream-pin.py"
 QUALITY_LANE = ROOT / ".github" / "workflows" / "ci-quality-lane.yml"
 PR_QUALITY = ROOT / ".github" / "workflows" / "pr_quality.yml"
 PIN_PATH = Path("third_party/llama.cpp/upstream.txt")
+GUARD_SPEC = importlib.util.spec_from_file_location("check_llama_upstream_pin", GUARD)
+if GUARD_SPEC is None or GUARD_SPEC.loader is None:
+    raise RuntimeError(f"cannot load {GUARD}")
+GUARD_MODULE = importlib.util.module_from_spec(GUARD_SPEC)
+GUARD_SPEC.loader.exec_module(GUARD_MODULE)
 
 
 def run_git(repo: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess[str]:
@@ -202,6 +209,53 @@ class LlamaUpstreamPinGuardTests(unittest.TestCase):
             result = self.run_guard(mesh, base, head, upstream)
             self.assertNotEqual(0, result.returncode)
             self.assertIn("fail closed", result.stderr)
+
+    def test_initial_upstream_fetch_timeout_fails_closed(self) -> None:
+        calls: list[tuple[list[str], dict[str, object]]] = []
+
+        def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append((command, kwargs))
+            if "fetch" in command:
+                raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with mock.patch.object(GUARD_MODULE.subprocess, "run", side_effect=run):
+            with self.assertRaises(GUARD_MODULE.PinGuardError) as raised:
+                GUARD_MODULE.fetch_upstream("fixture", "a" * 40, "b" * 40)
+
+        self.assertIn("timed out", str(raised.exception))
+        self.assertIn("fail closed", str(raised.exception))
+        fetch_calls = [(command, kwargs) for command, kwargs in calls if "fetch" in command]
+        self.assertEqual(1, len(fetch_calls))
+        self.assertEqual(
+            GUARD_MODULE.UPSTREAM_FETCH_TIMEOUT_SECONDS,
+            fetch_calls[0][1]["timeout"],
+        )
+
+    def test_unshallow_fetch_timeout_fails_closed(self) -> None:
+        calls: list[tuple[list[str], dict[str, object]]] = []
+
+        def run(command: list[str], **kwargs: object) -> subprocess.CompletedProcess[str]:
+            calls.append((command, kwargs))
+            if "fetch" in command and "--unshallow" in command:
+                raise subprocess.TimeoutExpired(command, kwargs["timeout"])
+            if "rev-parse" in command:
+                return subprocess.CompletedProcess(command, 0, "true\n", "")
+            return subprocess.CompletedProcess(command, 0, "", "")
+
+        with mock.patch.object(GUARD_MODULE.subprocess, "run", side_effect=run):
+            with self.assertRaises(GUARD_MODULE.PinGuardError) as raised:
+                GUARD_MODULE.fetch_upstream("fixture", "a" * 40, "b" * 40)
+
+        self.assertIn("timed out", str(raised.exception))
+        self.assertIn("fail closed", str(raised.exception))
+        fetch_calls = [(command, kwargs) for command, kwargs in calls if "fetch" in command]
+        self.assertEqual(2, len(fetch_calls))
+        self.assertEqual(
+            [GUARD_MODULE.UPSTREAM_FETCH_TIMEOUT_SECONDS] * 2,
+            [kwargs["timeout"] for _, kwargs in fetch_calls],
+        )
+        self.assertIn("--unshallow", fetch_calls[1][0])
 
     def test_symlink_pin_is_rejected_before_dereferencing_sibling_content(self) -> None:
         with tempfile.TemporaryDirectory() as directory:


### PR DESCRIPTION
PR #1478 moved `third_party/llama.cpp/upstream.txt` to an older upstream commit, allowing already-landed architecture support to disappear without CI noticing.

This adds a protected quality-lane guard that compares the proposed pin with the PR merge-base pin, fetches complete upstream history, and accepts only unchanged or descendant revisions. It fails closed for missing, shallow, incomplete, or divergent history and requires `upstream.txt` to remain a regular `100644` blob so symlinks cannot bypass the comparison.

The PR targets `main` because pull requests execute the trusted reusable quality workflow from `main`; after this lands, rerunning the 0.76.1 stack will apply the guard there as well.

Fixes #1593.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Quality Improvements**
  * Pull requests now verify that llama.cpp upstream pins move forward or remain unchanged, preventing backward or unverifiable revisions.
  * Validation uses complete commit history and fails safely when required history or pin information is unavailable.
  * Upstream checks now stop after a bounded wait if the upstream source is unresponsive.
  * Pull-request quality checks now run when a pull request is marked ready for review.

* **Tests**
  * Added coverage for unchanged, forward, backward, stale, missing, and invalid upstream pin scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->