### PR TITLE
fix(runtime): report client mode from --client --auto console state

### DIFF
--- a/crates/mesh-llm-host-runtime/src/api/mod.rs
+++ b/crates/mesh-llm-host-runtime/src/api/mod.rs
@@ -372,10 +372,6 @@ impl MeshApi {
         self.inner.lock().await.draft_name = Some(name);
     }
 
-    #[expect(
-        dead_code,
-        reason = "retained for embedded callers that toggle client presentation state"
-    )]
     pub async fn set_client(&self, is_client: bool) {
         let mut inner = self.inner.lock().await;
         inner.is_client = is_client;

--- a/crates/mesh-llm-host-runtime/src/runtime/serving_surface.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/serving_surface.rs
@@ -1033,6 +1033,9 @@ pub(super) async fn setup_run_auto_console_state(
             ctx.options.max_clients,
         )
         .await;
+    if ctx.options.client {
+        console_state.set_client(true).await;
+    }
     Ok(Some(console_state))
 }
 

--- a/crates/mesh-llm-host-runtime/src/runtime/tests/serving_surface.rs
+++ b/crates/mesh-llm-host-runtime/src/runtime/tests/serving_surface.rs
@@ -154,3 +154,71 @@ fn test_console_session_mode_no_explicit_surface_uses_none() {
 // for `serve --auto`, leaving :9337 unbound while the local model
 // loaded. These tests pin the gate so both client and serve get the
 // bootstrap proxy whenever there is a candidate to tunnel to.
+
+async fn build_run_auto_console_state(
+    options: &RuntimeOptions,
+    role: mesh::NodeRole,
+) -> api::MeshApi {
+    let node = mesh::Node::new_for_tests(role).await.expect("test node");
+    let resolved_plugins = plugin::ResolvedPlugins {
+        externals: vec![],
+        inactive: vec![],
+    };
+    let (mesh_tx, _mesh_rx) = tokio::sync::mpsc::channel(1);
+    let plugin_manager = plugin::PluginManager::start(
+        &resolved_plugins,
+        plugin::PluginHostMode {
+            mesh_visibility: mesh_llm_plugin::MeshVisibility::Private,
+        },
+        mesh_tx,
+    )
+    .await
+    .expect("plugin manager");
+    let affinity_router = affinity::AffinityRouter::default();
+    let (control_tx, _control_rx) = tokio::sync::mpsc::unbounded_channel();
+
+    crate::runtime::serving_surface::setup_run_auto_console_state(
+        crate::runtime::serving_surface::RunAutoConsoleStateContext {
+            options,
+            node: &node,
+            console_enabled: true,
+            model_name: "",
+            model_path: Path::new(""),
+            api_port: 3131,
+            plugin_manager: &plugin_manager,
+            affinity_router: &affinity_router,
+            control_tx: &control_tx,
+            owner_key_path: &None,
+        },
+    )
+    .await
+    .expect("console state setup")
+    .expect("console enabled")
+}
+
+async fn console_status_json(state: &api::MeshApi) -> serde_json::Value {
+    serde_json::from_str(&state.status_snapshot_string().await).expect("status json")
+}
+
+#[tokio::test]
+async fn run_auto_console_state_reports_client_mode_for_client_nodes() {
+    let options = RuntimeOptions {
+        client: true,
+        ..Default::default()
+    };
+    let state = build_run_auto_console_state(&options, mesh::NodeRole::Client).await;
+    let status = console_status_json(&state).await;
+
+    assert_eq!(status["is_client"], serde_json::Value::Bool(true));
+    assert_eq!(status["node_state"], "client");
+}
+
+#[tokio::test]
+async fn run_auto_console_state_keeps_worker_nodes_out_of_client_mode() {
+    let options = RuntimeOptions::default();
+    let state = build_run_auto_console_state(&options, mesh::NodeRole::Worker).await;
+    let status = console_status_json(&state).await;
+
+    assert_eq!(status["is_client"], serde_json::Value::Bool(false));
+    assert_ne!(status["node_state"], "client");
+}


### PR DESCRIPTION
## Original problem

Nodes started with `--client --auto` report `is_client: false` and `node_state: "standby"` from `/api/status`. The public Fly console (`mesh-llm --client --auto --port 9337 --console 3131 --listen-all`) shows this live on v0.76.0, so the UI has no way to tell it's talking to a client-only node. Fixes #1786, and unblocks the console tab and route hiding in #1785.

## Diagnostics

```
$ curl -s https://public.meshllm.cloud/api/status | jq '{is_client, node_state, version}'
{ "is_client": false, "node_state": "standby", "version": "0.76.0" }
```

`MeshApi::new` initialises `is_client: false`. The only setter, `MeshApi::set_client`, is `#[expect(dead_code)]`, and its single caller lives in `setup_passive_console_runtime`, which is itself dead code. The live `--client --auto` path, `setup_run_auto_console_state`, never calls it. Regressed in ed286b909 (#1082), first shipped in v0.75.0.

Wrote the test first. Before the fix:

```
test runtime::tests::serving_surface::run_auto_console_state_reports_client_mode_for_client_nodes ... FAILED
assertion `left == right` failed
  left: Bool(false)
 right: Bool(true)
```

## Fix

`setup_run_auto_console_state` now calls `console_state.set_client(true)` when `options.client` is set, matching what the passive lane already did. The `#[expect(dead_code)]` on `set_client` is removed since it has a live caller again. No protocol or config changes.

## Validation

- [x] `cargo test --locked -p mesh-llm-host-runtime --lib` (the CI invocation for this crate) passes locally after the fix. The two new tests in `runtime/tests/serving_surface.rs` cover client and worker nodes.
- [x] No UI changes in this PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Console status now correctly identifies runtime instances configured as clients.
  * Worker instances continue to report their non-client status accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->