### PR TITLE
feat(skippy): decode CacheGen pages on CUDA and ROCm

### DIFF
--- a/third_party/llama.cpp/patches/0028-ggml-cuda-decode-CacheGen-pages-into-resident-KV.patch
+++ b/third_party/llama.cpp/patches/0028-ggml-cuda-decode-CacheGen-pages-into-resident-KV.patch
@@ -1,0 +1,481 @@
+From 3391262f8620a3d1a7ddb6a174e75e0c6129c804 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Fri, 11 Sep 2026 16:58:10 +1000
+Subject: [PATCH] ggml-cuda: decode CacheGen pages into resident KV
+
+Share the F16 decoder across CUDA and HIP, batch launches before synchronization, and write directly into the allocated Skippy cell layout.
+
+Assisted-by: scama
+---
+ ggml/src/ggml-cuda/cachegen.cu  | 111 +++++++++++++
+ ggml/src/ggml-cuda/cachegen.cuh |  26 +++
+ ggml/src/ggml-cuda/ggml-cuda.cu | 281 ++++++++++++++++++++++++++++++++
+ 3 files changed, 418 insertions(+)
+ create mode 100644 ggml/src/ggml-cuda/cachegen.cu
+ create mode 100644 ggml/src/ggml-cuda/cachegen.cuh
+
+diff --git a/ggml/src/ggml-cuda/cachegen.cu b/ggml/src/ggml-cuda/cachegen.cu
+new file mode 100644
+index 000000000..5d91aa0ca
+--- /dev/null
++++ b/ggml/src/ggml-cuda/cachegen.cu
+@@ -0,0 +1,111 @@
++#include "cachegen.cuh"
++
++#if !defined(GGML_USE_MUSA)
++
++static __device__ __forceinline__ uint32_t cachegen_read_bit(
++        const uint8_t * stream, uint32_t stream_bytes, uint32_t & bit) {
++    const uint32_t byte_index = bit >> 3;
++    const uint32_t value      = byte_index < stream_bytes ? stream[byte_index] : 0;
++    const uint32_t result     = (value >> (7 - (bit & 7))) & 1;
++    ++bit;
++    return result;
++}
++
++static __global__ void cachegen_decode_f16(
++        const uint8_t * payload,
++        const ggml_cuda_cachegen_tile * tiles,
++        const uint32_t * prefixes,
++        const uint32_t * cells,
++        uint8_t * dst,
++        uint32_t channels,
++        uint32_t tile_count,
++        uint64_t token_stride,
++        uint64_t channel_stride) {
++    const uint32_t channel    = blockIdx.x * blockDim.x + threadIdx.x;
++    const uint32_t tile_index = blockIdx.y;
++    if (channel >= channels || tile_index >= tile_count) {
++        return;
++    }
++
++    const ggml_cuda_cachegen_tile tile = tiles[tile_index];
++    const uint8_t * segment            = payload + tile.payload_offset;
++    const uint32_t bins                = segment[4];
++    const float * maxes                = reinterpret_cast<const float *>(segment + 16);
++    const uint16_t * cdfs = reinterpret_cast<const uint16_t *>(segment + 16 + tile.rows * sizeof(float));
++    const uint16_t * cdf  = cdfs + channel * 33;
++    const uint32_t prefix_index = tile.prefix_offset + channel;
++    const uint32_t stream_start = prefixes[prefix_index];
++    const uint32_t stream_bytes = prefixes[prefix_index + 1] - stream_start;
++    const uint32_t lengths_offset = 16 + tile.rows * sizeof(float) + channels * 33 * sizeof(uint16_t);
++    const uint32_t streams_offset = lengths_offset + channels * sizeof(uint16_t);
++    const uint8_t * stream = segment + streams_offset + stream_start;
++
++    uint32_t bit   = 0;
++    uint32_t value = 0;
++    for (uint32_t i = 0; i < 32; ++i) {
++        value = (value << 1) | cachegen_read_bit(stream, stream_bytes, bit);
++    }
++    uint32_t low    = 0;
++    uint32_t high   = 0xffffffffu;
++    const float center = float(bins / 2 - 1);
++    for (uint32_t row = 0; row < tile.rows; ++row) {
++        const uint64_t span = uint64_t(high) - uint64_t(low) + 1;
++        const uint16_t count = uint16_t((((uint64_t(value) - uint64_t(low) + 1) * 65536ull - 1) / span));
++        uint32_t symbol = 0;
++        while (symbol + 1 < 33 && cdf[symbol + 1] <= count) {
++            ++symbol;
++        }
++        if (symbol >= 32) {
++            return;
++        }
++
++        const float normalized = (float(symbol) - center) / center;
++        const half decoded     = __float2half(normalized * maxes[row]);
++        const uint64_t destination =
++            uint64_t(cells[tile.token_offset + row]) * token_stride + uint64_t(channel) * channel_stride;
++        *reinterpret_cast<half *>(dst + destination) = decoded;
++
++        if (row + 1 == tile.rows) {
++            break;
++        }
++        const uint64_t cdf_low  = cdf[symbol];
++        const uint64_t cdf_high = symbol == 31 ? 65536ull : cdf[symbol + 1];
++        high = low - 1 + uint32_t((span * cdf_high) >> 16);
++        low  = low + uint32_t((span * cdf_low) >> 16);
++        while (true) {
++            if (low >= 0x80000000u || high < 0x80000000u) {
++                low <<= 1;
++                high  = (high << 1) | 1;
++                value = (value << 1) | cachegen_read_bit(stream, stream_bytes, bit);
++            } else if (low >= 0x40000000u && high < 0xc0000000u) {
++                low  = (low << 1) & 0x7fffffffu;
++                high = (high << 1) | 0x80000001u;
++                value -= 0x40000000u;
++                value = (value << 1) | cachegen_read_bit(stream, stream_bytes, bit);
++            } else {
++                break;
++            }
++        }
++    }
++}
++
++cudaError_t ggml_cuda_cachegen_decode_f16_launch(
++        const uint8_t * payload,
++        const ggml_cuda_cachegen_tile * tiles,
++        const uint32_t * prefixes,
++        const uint32_t * cells,
++        uint8_t * dst,
++        uint32_t channels,
++        uint32_t tile_count,
++        uint64_t token_stride,
++        uint64_t channel_stride,
++        cudaStream_t stream) {
++    constexpr uint32_t block_size = 64;
++    const dim3 block(block_size, 1, 1);
++    const dim3 grid((channels + block_size - 1) / block_size, tile_count, 1);
++    cachegen_decode_f16<<<grid, block, 0, stream>>>(
++        payload, tiles, prefixes, cells, dst, channels, tile_count, token_stride, channel_stride);
++    return cudaGetLastError();
++}
++
++#endif // !defined(GGML_USE_MUSA)
+diff --git a/ggml/src/ggml-cuda/cachegen.cuh b/ggml/src/ggml-cuda/cachegen.cuh
+new file mode 100644
+index 000000000..d6d216675
+--- /dev/null
++++ b/ggml/src/ggml-cuda/cachegen.cuh
+@@ -0,0 +1,26 @@
++#pragma once
++
++#include "common.cuh"
++
++#if !defined(GGML_USE_MUSA)
++
++struct ggml_cuda_cachegen_tile {
++    uint32_t payload_offset;
++    uint32_t prefix_offset;
++    uint32_t token_offset;
++    uint32_t rows;
++};
++
++cudaError_t ggml_cuda_cachegen_decode_f16_launch(
++        const uint8_t * payload,
++        const ggml_cuda_cachegen_tile * tiles,
++        const uint32_t * prefixes,
++        const uint32_t * cells,
++        uint8_t * dst,
++        uint32_t channels,
++        uint32_t tile_count,
++        uint64_t token_stride,
++        uint64_t channel_stride,
++        cudaStream_t stream);
++
++#endif // !defined(GGML_USE_MUSA)
+diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
+index 38bd4c9a0..e955c4394 100644
+--- a/ggml/src/ggml-cuda/ggml-cuda.cu
++++ b/ggml/src/ggml-cuda/ggml-cuda.cu
+@@ -10,6 +10,7 @@
+ #include "ggml-cuda/argmax.cuh"
+ #include "ggml-cuda/argsort.cuh"
+ #include "ggml-cuda/binbcast.cuh"
++#include "ggml-cuda/cachegen.cuh"
+ #include "ggml-cuda/clamp.cuh"
+ #include "ggml-cuda/col2im-1d.cuh"
+ #include "ggml-cuda/concat.cuh"
+@@ -85,6 +86,7 @@
+ #include <map>
+ #include <memory>
+ #include <mutex>
++#include <new>
+ #include <cstdarg>
+ #include <cstdio>
+ #include <cstdlib>
+@@ -5667,6 +5669,280 @@ static ggml_backend_feature * ggml_backend_cuda_get_features(ggml_backend_reg_t
+     GGML_UNUSED(reg);
+ }
+ 
++#if !defined(GGML_USE_MUSA)
++
++struct ggml_cuda_cachegen_staged_job {
++    int physical_device = -1;
++    uint8_t * dst = nullptr;
++    uint32_t channels = 0;
++    uint64_t token_stride = 0;
++    uint64_t channel_stride = 0;
++    std::vector<uint8_t> payload;
++    std::vector<ggml_cuda_cachegen_tile> tiles;
++    std::vector<uint32_t> prefixes;
++    std::vector<uint32_t> cells;
++    uint8_t * payload_device = nullptr;
++    ggml_cuda_cachegen_tile * tiles_device = nullptr;
++    uint32_t * prefixes_device = nullptr;
++    uint32_t * cells_device = nullptr;
++};
++
++static bool ggml_cuda_cachegen_error(char * error, size_t capacity, const char * message) {
++    if (error != nullptr && capacity > 0) {
++        snprintf(error, capacity, "%s", message);
++    }
++    return false;
++}
++
++static bool ggml_cuda_cachegen_cuda_error(
++        char * error, size_t capacity, const char * operation, cudaError_t status) {
++    if (error != nullptr && capacity > 0) {
++        snprintf(error, capacity, "%s: %s", operation, cudaGetErrorString(status));
++    }
++    return false;
++}
++
++static cudaError_t ggml_cuda_cachegen_synchronize(const std::vector<ggml_cuda_cachegen_staged_job> & jobs) {
++    std::vector<int> devices;
++    for (const ggml_cuda_cachegen_staged_job & job : jobs) {
++        if (std::find(devices.begin(), devices.end(), job.physical_device) != devices.end()) {
++            continue;
++        }
++        const cudaError_t set_status = cudaSetDevice(job.physical_device);
++        if (set_status != cudaSuccess) {
++            return set_status;
++        }
++        const cudaError_t sync_status = cudaStreamSynchronize(cudaStreamPerThread);
++        if (sync_status != cudaSuccess) {
++            return sync_status;
++        }
++        devices.push_back(job.physical_device);
++    }
++    return cudaSuccess;
++}
++
++static cudaError_t ggml_cuda_cachegen_release(std::vector<ggml_cuda_cachegen_staged_job> & jobs) {
++    cudaError_t first_error = cudaSuccess;
++    for (ggml_cuda_cachegen_staged_job & job : jobs) {
++        cudaError_t status = cudaSetDevice(job.physical_device);
++        if (status != cudaSuccess) {
++            if (first_error == cudaSuccess) {
++                first_error = status;
++            }
++            continue;
++        }
++        void * allocations[] = { job.payload_device, job.tiles_device, job.prefixes_device, job.cells_device };
++        for (void * allocation : allocations) {
++            if (allocation == nullptr) {
++                continue;
++            }
++            status = cudaFree(allocation);
++            if (status != cudaSuccess && first_error == cudaSuccess) {
++                first_error = status;
++            }
++        }
++        job.payload_device = nullptr;
++        job.tiles_device = nullptr;
++        job.prefixes_device = nullptr;
++        job.cells_device = nullptr;
++    }
++    return first_error;
++}
++
++static bool ggml_cuda_cachegen_decode_f16(
++        const struct ggml_backend_cachegen_job * jobs,
++        size_t job_count,
++        char * error,
++        size_t error_capacity) {
++    if (jobs == nullptr || job_count == 0) {
++        return ggml_cuda_cachegen_error(error, error_capacity, "CUDA/HIP CacheGen jobs are required");
++    }
++
++    std::vector<ggml_cuda_cachegen_staged_job> staged_jobs;
++    try {
++        staged_jobs.reserve(job_count);
++        for (size_t job_index = 0; job_index < job_count; ++job_index) {
++            const struct ggml_backend_cachegen_job * job = &jobs[job_index];
++            if (job->dst == nullptr || job->dst->data == nullptr || job->dst->buffer == nullptr ||
++                    !ggml_backend_buffer_is_cuda(job->dst->buffer) || job->dst->buffer->context == nullptr ||
++                    job->tiles == nullptr || job->tile_count == 0 || job->tile_count > UINT32_MAX ||
++                    job->cells == nullptr || job->cell_count == 0 || job->cell_count > UINT32_MAX ||
++                    job->cell_count > SIZE_MAX / sizeof(uint32_t) || job->channels == 0 ||
++                    job->channels == UINT32_MAX ||
++                    job->dst->type != GGML_TYPE_F16 || job->token_stride == 0 || job->channel_stride == 0 ||
++                    job->token_stride % sizeof(uint16_t) != 0 || job->channel_stride % sizeof(uint16_t) != 0) {
++                return ggml_cuda_cachegen_error(error, error_capacity, "invalid CUDA/HIP CacheGen job");
++            }
++
++            staged_jobs.emplace_back();
++            ggml_cuda_cachegen_staged_job & staged = staged_jobs.back();
++            auto * buffer_context = static_cast<ggml_backend_cuda_buffer_context *>(job->dst->buffer->context);
++            staged.physical_device = ggml_cuda_get_physical_device(buffer_context->device);
++            staged.dst = static_cast<uint8_t *>(job->dst->data);
++            staged.channels = job->channels;
++            staged.token_stride = job->token_stride;
++            staged.channel_stride = job->channel_stride;
++            staged.cells.assign(job->cells, job->cells + job->cell_count);
++
++            uint64_t max_cell = 0;
++            for (uint32_t cell : staged.cells) {
++                max_cell = std::max(max_cell, static_cast<uint64_t>(cell));
++            }
++            const uint64_t max_channel = static_cast<uint64_t>(job->channels) - 1;
++            if (max_cell > (UINT64_MAX - sizeof(uint16_t)) / job->token_stride ||
++                    max_channel > (UINT64_MAX - max_cell * job->token_stride - sizeof(uint16_t)) /
++                        job->channel_stride ||
++                    max_cell * job->token_stride + max_channel * job->channel_stride + sizeof(uint16_t) >
++                        ggml_nbytes(job->dst)) {
++                return ggml_cuda_cachegen_error(
++                    error, error_capacity, "CUDA/HIP CacheGen destination geometry is out of bounds");
++            }
++
++            if (job->tile_count > SIZE_MAX / sizeof(ggml_cuda_cachegen_tile)) {
++                return ggml_cuda_cachegen_error(error, error_capacity, "CUDA/HIP CacheGen tile geometry overflows");
++            }
++            staged.tiles.reserve(job->tile_count);
++            for (size_t tile_index = 0; tile_index < job->tile_count; ++tile_index) {
++                const struct ggml_backend_cachegen_tile * tile = &job->tiles[tile_index];
++                if (tile->payload == nullptr || tile->payload_bytes < 16 || tile->payload_bytes > UINT32_MAX ||
++                        tile->token_count == 0 || tile->token_offset > job->cell_count ||
++                        tile->token_count > job->cell_count - tile->token_offset ||
++                        staged.payload.size() > UINT32_MAX - 3 ||
++                        staged.prefixes.size() > UINT32_MAX - (static_cast<size_t>(job->channels) + 1)) {
++                    return ggml_cuda_cachegen_error(
++                        error, error_capacity, "CUDA/HIP CacheGen tile exceeds bounded geometry");
++                }
++
++                const size_t aligned_payload_size = (staged.payload.size() + 3) & ~size_t(3);
++                if (tile->payload_bytes > UINT32_MAX - aligned_payload_size) {
++                    return ggml_cuda_cachegen_error(
++                        error, error_capacity, "CUDA/HIP CacheGen payload offsets overflow");
++                }
++                staged.payload.resize(aligned_payload_size, 0);
++
++                const uint8_t * payload = static_cast<const uint8_t *>(tile->payload);
++                const uint64_t streams_offset_u64 = 16ull + static_cast<uint64_t>(tile->token_count) * sizeof(float) +
++                    static_cast<uint64_t>(job->channels) * 33 * sizeof(uint16_t) +
++                    static_cast<uint64_t>(job->channels) * sizeof(uint16_t);
++                if (streams_offset_u64 > tile->payload_bytes || streams_offset_u64 > UINT32_MAX) {
++                    return ggml_cuda_cachegen_error(
++                        error, error_capacity, "CUDA/HIP CacheGen tile metadata is truncated");
++                }
++                const size_t lengths_offset = static_cast<size_t>(streams_offset_u64) -
++                    static_cast<size_t>(job->channels) * sizeof(uint16_t);
++                const size_t streams_offset = static_cast<size_t>(streams_offset_u64);
++                const ggml_cuda_cachegen_tile encoded_tile = {
++                    static_cast<uint32_t>(staged.payload.size()),
++                    static_cast<uint32_t>(staged.prefixes.size()),
++                    tile->token_offset,
++                    tile->token_count,
++                };
++                uint32_t prefix = 0;
++                staged.prefixes.push_back(prefix);
++                for (uint32_t channel = 0; channel < job->channels; ++channel) {
++                    const size_t offset = lengths_offset + static_cast<size_t>(channel) * sizeof(uint16_t);
++                    const uint32_t length = static_cast<uint32_t>(payload[offset]) |
++                        static_cast<uint32_t>(payload[offset + 1]) << 8;
++                    if (prefix > UINT32_MAX - length) {
++                        return ggml_cuda_cachegen_error(
++                            error, error_capacity, "CUDA/HIP CacheGen stream offsets overflow");
++                    }
++                    prefix += length;
++                    staged.prefixes.push_back(prefix);
++                }
++                const uint32_t declared_stream_bytes = static_cast<uint32_t>(payload[12]) |
++                    static_cast<uint32_t>(payload[13]) << 8 | static_cast<uint32_t>(payload[14]) << 16 |
++                    static_cast<uint32_t>(payload[15]) << 24;
++                if (prefix != declared_stream_bytes || prefix != tile->payload_bytes - streams_offset) {
++                    return ggml_cuda_cachegen_error(
++                        error, error_capacity, "CUDA/HIP CacheGen stream length is inconsistent");
++                }
++                staged.tiles.push_back(encoded_tile);
++                staged.payload.insert(staged.payload.end(), payload, payload + tile->payload_bytes);
++            }
++        }
++    } catch (const std::bad_alloc &) {
++        return ggml_cuda_cachegen_error(error, error_capacity, "CUDA/HIP CacheGen host staging allocation failed");
++    }
++
++    int original_device = -1;
++    cudaError_t status = cudaGetDevice(&original_device);
++    if (status != cudaSuccess) {
++        return ggml_cuda_cachegen_cuda_error(error, error_capacity, "CUDA/HIP CacheGen device query failed", status);
++    }
++
++    const auto fail = [&](const char * operation, cudaError_t failure) {
++        (void) ggml_cuda_cachegen_synchronize(staged_jobs);
++        (void) ggml_cuda_cachegen_release(staged_jobs);
++        (void) cudaSetDevice(original_device);
++        return ggml_cuda_cachegen_cuda_error(error, error_capacity, operation, failure);
++    };
++
++    for (ggml_cuda_cachegen_staged_job & job : staged_jobs) {
++        status = cudaSetDevice(job.physical_device);
++        if (status != cudaSuccess) {
++            return fail("CUDA/HIP CacheGen device selection failed", status);
++        }
++#define GGML_CACHEGEN_CUDA_CALL(call, operation) \
++        do { \
++            status = (call); \
++            if (status != cudaSuccess) { \
++                return fail((operation), status); \
++            } \
++        } while (0)
++        GGML_CACHEGEN_CUDA_CALL(cudaMalloc(reinterpret_cast<void **>(&job.payload_device), job.payload.size()),
++                                "CUDA/HIP CacheGen payload allocation failed");
++        GGML_CACHEGEN_CUDA_CALL(cudaMalloc(reinterpret_cast<void **>(&job.tiles_device),
++                                           job.tiles.size() * sizeof(ggml_cuda_cachegen_tile)),
++                                "CUDA/HIP CacheGen tile allocation failed");
++        GGML_CACHEGEN_CUDA_CALL(cudaMalloc(reinterpret_cast<void **>(&job.prefixes_device),
++                                           job.prefixes.size() * sizeof(uint32_t)),
++                                "CUDA/HIP CacheGen prefix allocation failed");
++        GGML_CACHEGEN_CUDA_CALL(cudaMalloc(reinterpret_cast<void **>(&job.cells_device),
++                                           job.cells.size() * sizeof(uint32_t)),
++                                "CUDA/HIP CacheGen cell allocation failed");
++        GGML_CACHEGEN_CUDA_CALL(cudaMemcpyAsync(job.payload_device, job.payload.data(), job.payload.size(),
++                                                cudaMemcpyHostToDevice, cudaStreamPerThread),
++                                "CUDA/HIP CacheGen payload upload failed");
++        GGML_CACHEGEN_CUDA_CALL(cudaMemcpyAsync(job.tiles_device, job.tiles.data(),
++                                                job.tiles.size() * sizeof(ggml_cuda_cachegen_tile),
++                                                cudaMemcpyHostToDevice, cudaStreamPerThread),
++                                "CUDA/HIP CacheGen tile upload failed");
++        GGML_CACHEGEN_CUDA_CALL(cudaMemcpyAsync(job.prefixes_device, job.prefixes.data(),
++                                                job.prefixes.size() * sizeof(uint32_t),
++                                                cudaMemcpyHostToDevice, cudaStreamPerThread),
++                                "CUDA/HIP CacheGen prefix upload failed");
++        GGML_CACHEGEN_CUDA_CALL(cudaMemcpyAsync(job.cells_device, job.cells.data(),
++                                                job.cells.size() * sizeof(uint32_t),
++                                                cudaMemcpyHostToDevice, cudaStreamPerThread),
++                                "CUDA/HIP CacheGen cell upload failed");
++        GGML_CACHEGEN_CUDA_CALL(
++            ggml_cuda_cachegen_decode_f16_launch(job.payload_device, job.tiles_device, job.prefixes_device,
++                                                 job.cells_device, job.dst, job.channels,
++                                                 static_cast<uint32_t>(job.tiles.size()), job.token_stride,
++                                                 job.channel_stride, cudaStreamPerThread),
++            "CUDA/HIP CacheGen kernel launch failed");
++#undef GGML_CACHEGEN_CUDA_CALL
++    }
++
++    status = ggml_cuda_cachegen_synchronize(staged_jobs);
++    if (status != cudaSuccess) {
++        return fail("CUDA/HIP CacheGen kernel execution failed", status);
++    }
++    status = ggml_cuda_cachegen_release(staged_jobs);
++    if (status != cudaSuccess) {
++        (void) cudaSetDevice(original_device);
++        return ggml_cuda_cachegen_cuda_error(error, error_capacity, "CUDA/HIP CacheGen staging release failed", status);
++    }
++    status = cudaSetDevice(original_device);
++    if (status != cudaSuccess) {
++        return ggml_cuda_cachegen_cuda_error(error, error_capacity, "CUDA/HIP CacheGen device restore failed", status);
++    }
++    return true;
++}
++
++#endif // !defined(GGML_USE_MUSA)
++
+ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, const char * name) {
+     GGML_UNUSED(reg);
+     if (strcmp(name, "ggml_backend_comm_init") == 0) {
+@@ -5687,6 +5963,11 @@ static void * ggml_backend_cuda_reg_get_proc_address(ggml_backend_reg_t reg, con
+     if (strcmp(name, "ggml_backend_get_features") == 0) {
+         return (void *)ggml_backend_cuda_get_features;
+     }
++#if !defined(GGML_USE_MUSA)
++    if (strcmp(name, "ggml_backend_cachegen_decode_f16") == 0) {
++        return (void *)ggml_cuda_cachegen_decode_f16;
++    }
++#endif // !defined(GGML_USE_MUSA)
+     return nullptr;
+ }
+ 
+-- 
+2.54.0 (Apple Git-157)
+

--- a/third_party/llama.cpp/patches/0029-ggml-metal-align-staged-CacheGen-tiles.patch
+++ b/third_party/llama.cpp/patches/0029-ggml-metal-align-staged-CacheGen-tiles.patch
@@ -1,0 +1,117 @@
+From 717bca3cc3cc9ef8272cb37c63c7c700ab567009 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Fri, 11 Sep 2026 17:43:11 +1000
+Subject: [PATCH] ggml-metal: align staged CacheGen tiles
+
+Assisted-by: scama
+---
+ ggml/src/ggml-metal/ggml-metal-device.m | 15 ++++++++++++--
+ tests/test-skippy-cachegen-metal.cpp    | 27 ++++++++++++++++++++++++-
+ 2 files changed, 39 insertions(+), 3 deletions(-)
+
+diff --git a/ggml/src/ggml-metal/ggml-metal-device.m b/ggml/src/ggml-metal/ggml-metal-device.m
+index c6e22a863..d05b7c32c 100644
+--- a/ggml/src/ggml-metal/ggml-metal-device.m
++++ b/ggml/src/ggml-metal/ggml-metal-device.m
+@@ -2721,7 +2721,7 @@ bool ggml_metal_cachegen_decode_f16(
+                 const struct ggml_backend_cachegen_tile * tile = &job->tiles[tile_index];
+                 if (tile->payload == NULL || tile->payload_bytes < 16 || tile->token_count == 0 ||
+                         tile->token_offset > job->cell_count || tile->token_count > job->cell_count - tile->token_offset ||
+-                        payload_data.length > UINT32_MAX || tile->payload_bytes > UINT32_MAX - payload_data.length ||
++                        payload_data.length > UINT32_MAX - 3 ||
+                         prefix_data.length / sizeof(uint32_t) > UINT32_MAX - ((size_t) job->channels + 1)) {
+                     [payload_data release];
+                     [tile_data release];
+@@ -2730,6 +2730,17 @@ bool ggml_metal_cachegen_decode_f16(
+                     [temporary_buffers release];
+                     return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen tile exceeds bounded geometry");
+                 }
++                const size_t aligned_payload_size = (payload_data.length + 3) & ~(size_t) 3;
++                if (tile->payload_bytes > UINT32_MAX - aligned_payload_size) {
++                    [payload_data release];
++                    [tile_data release];
++                    [prefix_data release];
++                    [encoder endEncoding];
++                    [temporary_buffers release];
++                    return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen payload offsets overflow");
++                }
++                const uint8_t padding[3] = { 0 };
++                [payload_data appendBytes:padding length:aligned_payload_size - payload_data.length];
+                 const uint8_t * payload = (const uint8_t *) tile->payload;
+                 const size_t lengths_offset = 16 + (size_t) tile->token_count * sizeof(float) +
+                     (size_t) job->channels * 33 * sizeof(uint16_t);
+@@ -2743,7 +2754,7 @@ bool ggml_metal_cachegen_decode_f16(
+                     return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen tile metadata is truncated");
+                 }
+                 struct ggml_metal_cachegen_tile encoded_tile = {
+-                    (uint32_t) payload_data.length,
++                    (uint32_t) aligned_payload_size,
+                     (uint32_t) (prefix_data.length / sizeof(uint32_t)),
+                     tile->token_offset,
+                     tile->token_count,
+diff --git a/tests/test-skippy-cachegen-metal.cpp b/tests/test-skippy-cachegen-metal.cpp
+index b64ba373c..f300b18b0 100644
+--- a/tests/test-skippy-cachegen-metal.cpp
++++ b/tests/test-skippy-cachegen-metal.cpp
+@@ -148,6 +148,8 @@ int main() {
+     ggml_tensor * transposed16 = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, capacity, channels);
+     ggml_tensor * row_major32 = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, channels, capacity);
+     ggml_tensor * transposed32 = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, capacity, channels);
++    constexpr uint32_t multi_capacity = rows * 2 + 5;
++    ggml_tensor * multi_tile = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, channels, multi_capacity);
+     ggml_backend_buffer_t buffer = ggml_backend_alloc_ctx_tensors(ctx, backend);
+     if (buffer == nullptr) {
+         ggml_free(ctx);
+@@ -167,11 +169,20 @@ int main() {
+     }
+     const ggml_backend_cachegen_tile tile16 = { encoded16, sizeof(encoded16), 0, rows };
+     const ggml_backend_cachegen_tile tile32 = { encoded32, sizeof(encoded32), 0, rows };
++    const ggml_backend_cachegen_tile multi_tiles[] = {
++        { encoded16, sizeof(encoded16), 0, rows },
++        { encoded32, sizeof(encoded32), rows, rows },
++    };
++    std::vector<uint32_t> multi_cells(rows * 2);
++    for (uint32_t row = 0; row < rows * 2; ++row) {
++        multi_cells[row] = multi_capacity - 1 - row;
++    }
+     const ggml_backend_cachegen_job jobs[] = {
+         { row_major16, &tile16, 1, cells.data(), cells.size(), channels, channels * 2, 2 },
+         { transposed16, &tile16, 1, cells.data(), cells.size(), channels, 2, capacity * 2 },
+         { row_major32, &tile32, 1, cells.data(), cells.size(), channels, channels * 2, 2 },
+         { transposed32, &tile32, 1, cells.data(), cells.size(), channels, 2, capacity * 2 },
++        { multi_tile, multi_tiles, 2, multi_cells.data(), multi_cells.size(), channels, channels * 2, 2 },
+     };
+     ggml_backend_dev_t device = ggml_backend_get_device(backend);
+     auto decode = reinterpret_cast<ggml_backend_cachegen_decode_f16_t>(
+@@ -181,7 +192,7 @@ int main() {
+         return finish(4);
+     }
+     char error[256] = {};
+-    if (!decode(jobs, 4, error, sizeof(error))) {
++    if (!decode(jobs, 5, error, sizeof(error))) {
+         return finish(5);
+     }
+     ggml_backend_cachegen_job invalid_job = jobs[0];
+@@ -220,5 +231,19 @@ int main() {
+     if (const int status = check_fixture(row_major32, transposed32, expected32, 7)) {
+         return finish(status);
+     }
++    std::vector<uint8_t> multi_bytes(ggml_nbytes(multi_tile));
++    ggml_backend_tensor_get(multi_tile, multi_bytes.data(), 0, multi_bytes.size());
++    const uint8_t * expected_tiles[] = { expected16, expected32 };
++    for (uint32_t tile = 0; tile < 2; ++tile) {
++        for (uint32_t row = 0; row < rows; ++row) {
++            const uint32_t source_row = tile * rows + row;
++            if (std::memcmp(
++                    multi_bytes.data() + static_cast<size_t>(multi_cells[source_row]) * channels * 2,
++                    expected_tiles[tile] + static_cast<size_t>(row) * channels * 2,
++                    channels * 2) != 0) {
++                return finish(9);
++            }
++        }
++    }
+     return finish(0);
+ }
+-- 
+2.54.0 (Apple Git-157)
+

--- a/third_party/llama.cpp/patches/0030-ggml-optimize-CacheGen-arithmetic-decode.patch
+++ b/third_party/llama.cpp/patches/0030-ggml-optimize-CacheGen-arithmetic-decode.patch
@@ -1,0 +1,126 @@
+From c18e4c75324d89f866236ca2fa631c23801a0830 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Fri, 11 Sep 2026 17:51:30 +1000
+Subject: [PATCH] ggml: optimize CacheGen arithmetic decode
+
+Assisted-by: scama
+---
+ ggml/src/ggml-cuda/cachegen.cu             | 39 +++++++++++++++++++---
+ ggml/src/ggml-metal/kernels/cachegen.metal | 37 +++++++++++++++++---
+ 2 files changed, 66 insertions(+), 10 deletions(-)
+
+diff --git a/ggml/src/ggml-cuda/cachegen.cu b/ggml/src/ggml-cuda/cachegen.cu
+index 5d91aa0ca..e8460cc99 100644
+--- a/ggml/src/ggml-cuda/cachegen.cu
++++ b/ggml/src/ggml-cuda/cachegen.cu
+@@ -11,6 +11,38 @@ static __device__ __forceinline__ uint32_t cachegen_read_bit(
+     return result;
+ }
+ 
++static __device__ __forceinline__ uint16_t cachegen_scaled_count(
++        uint32_t value, uint32_t low, uint64_t span) {
++    const uint64_t delta     = uint64_t(value) - uint64_t(low) + 1;
++    const uint64_t numerator = delta * 65536ull - 1;
++    uint32_t count = min(uint32_t(float(delta) * (65536.0f / float(span))), 65535u);
++    uint64_t product = uint64_t(count) * span;
++    while (product > numerator) {
++        --count;
++        product -= span;
++    }
++    while (count < 65535u && product + span <= numerator) {
++        ++count;
++        product += span;
++    }
++    return uint16_t(count);
++}
++
++static __device__ __forceinline__ uint32_t cachegen_find_symbol(
++        const uint16_t * cdf, uint16_t count) {
++    uint32_t first = 0;
++    uint32_t last  = 33;
++    while (first < last) {
++        const uint32_t middle = (first + last) >> 1;
++        if (cdf[middle] <= count) {
++            first = middle + 1;
++        } else {
++            last = middle;
++        }
++    }
++    return first - 1;
++}
++
+ static __global__ void cachegen_decode_f16(
+         const uint8_t * payload,
+         const ggml_cuda_cachegen_tile * tiles,
+@@ -50,11 +82,8 @@ static __global__ void cachegen_decode_f16(
+     const float center = float(bins / 2 - 1);
+     for (uint32_t row = 0; row < tile.rows; ++row) {
+         const uint64_t span = uint64_t(high) - uint64_t(low) + 1;
+-        const uint16_t count = uint16_t((((uint64_t(value) - uint64_t(low) + 1) * 65536ull - 1) / span));
+-        uint32_t symbol = 0;
+-        while (symbol + 1 < 33 && cdf[symbol + 1] <= count) {
+-            ++symbol;
+-        }
++        const uint16_t count  = cachegen_scaled_count(value, low, span);
++        const uint32_t symbol = cachegen_find_symbol(cdf, count);
+         if (symbol >= 32) {
+             return;
+         }
+diff --git a/ggml/src/ggml-metal/kernels/cachegen.metal b/ggml/src/ggml-metal/kernels/cachegen.metal
+index 82684a71e..22592c070 100644
+--- a/ggml/src/ggml-metal/kernels/cachegen.metal
++++ b/ggml/src/ggml-metal/kernels/cachegen.metal
+@@ -22,6 +22,36 @@ static inline uint cachegen_read_bit(const device uchar * stream, uint stream_by
+     return result;
+ }
+ 
++static inline ushort cachegen_scaled_count(uint value, uint low, ulong span) {
++    const ulong delta     = ulong(value) - ulong(low) + 1;
++    const ulong numerator = delta * 65536ul - 1;
++    uint count = min(uint(float(delta) * (65536.0f / float(span))), 65535u);
++    ulong product = ulong(count) * span;
++    while (product > numerator) {
++        --count;
++        product -= span;
++    }
++    while (count < 65535u && product + span <= numerator) {
++        ++count;
++        product += span;
++    }
++    return ushort(count);
++}
++
++static inline uint cachegen_find_symbol(const device ushort * cdf, ushort count) {
++    uint first = 0;
++    uint last  = 33;
++    while (first < last) {
++        const uint middle = (first + last) >> 1;
++        if (cdf[middle] <= count) {
++            first = middle + 1;
++        } else {
++            last = middle;
++        }
++    }
++    return first - 1;
++}
++
+ kernel void kernel_cachegen_decode_f16(const device uchar *         payload [[buffer(0)]],
+                                        const device cachegen_tile * tiles [[buffer(1)]],
+                                        const device uint *          prefixes [[buffer(2)]],
+@@ -58,11 +88,8 @@ kernel void kernel_cachegen_decode_f16(const device uchar *         payload [[bu
+     const float center = float(bins / 2 - 1);
+     for (uint row = 0; row < tile.rows; ++row) {
+         const ulong  span   = ulong(high) - ulong(low) + 1;
+-        const ushort count  = ushort((((ulong(value) - ulong(low) + 1) * 65536ul - 1) / span));
+-        uint         symbol = 0;
+-        while (symbol + 1 < 33 && cdf[symbol + 1] <= count) {
+-            ++symbol;
+-        }
++        const ushort count  = cachegen_scaled_count(value, low, span);
++        const uint   symbol = cachegen_find_symbol(cdf, count);
+         if (symbol >= 32) {
+             return;
+         }
+-- 
+2.54.0 (Apple Git-157)
+


### PR DESCRIPTION
CacheGen restore still falls back to a 41-second scalar decode on discrete GPU hosts because only the Metal backend implements the native Skippy decode hook. This adds one F16 arithmetic decoder that llama.cpp compiles through CUDA and HIP, so validated CacheGen records can be decoded directly into the resident K/V cells allocated by the Skippy transaction.

The backend stages compact payload, tile, prefix, and exact cell-index buffers; launches every tensor job on the per-thread stream; and synchronizes once per physical device. It preserves row-major K and transposed/noncontiguous V addressing through the native token and channel strides. Allocation, upload, launch, execution, and cleanup failures return through the existing backend error channel so Skippy can roll back the uncommitted cells. MUSA does not advertise the hook, and there is no scalar fallback.

Two follow-up fixes are included at the current head. Metal now aligns every staged tile before typed metadata reads, with a two-tile regression fixture covering encoded16 and encoded32 records. Metal and CUDA/HIP also replace the arithmetic hot loop's 64-bit division with a reciprocal estimate plus exact integer correction and replace the linear CDF scan with binary search. The optimized Metal implementation remains bit-exact on the fixtures and reduced the 19K direct resident import from 744.95 ms to 540.74 ms.

This is stacked on #1796. It advances #1652 and the #1732 roadmap.

Validation:
- clean replay of all 30 pinned llama.cpp patches
- native Metal `test-skippy-cachegen-metal` passes exact single- and multi-tile fixtures
- static Metal `ggml-metal` target rebuild and linked direct-device runtime gate passed
- 64/64 token agreement in the 19K Apple M1 Ultra device gate at the optimized head
- initial explicit [CUDA 12.9.2 and ROCm gfx1100 compile/package run](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34572596586) passed at `b3c9a2c690d4ccb87b99db2b0698c43af5f42888`
- exact optimized-head [CUDA 12.9.2 and ROCm gfx1100 compile/package rerun](https://github.com/Mesh-LLM/mesh-llm/actions/runs/34577082594) is in progress at `fb9b06fe1cd0c2028136f19bae1b210137e56e05`
- real NVIDIA and AMD fixture parity remains a separate hardware gate
