### PR TITLE
test(skippy): qualify typed CacheGen restore at 19K

### DIFF
--- a/crates/skippy-correctness/src/cli.rs
+++ b/crates/skippy-correctness/src/cli.rs
@@ -89,6 +89,29 @@ pub enum FlashAttentionArg {
     Enabled,
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum CacheTypeArg {
+    #[value(name = "f16")]
+    F16,
+    #[value(name = "f32")]
+    F32,
+    #[value(name = "q8_0")]
+    Q8Zero,
+    #[value(name = "q4_0")]
+    Q4Zero,
+}
+
+impl CacheTypeArg {
+    pub(crate) const fn ggml_type(self) -> u32 {
+        match self {
+            Self::F16 => skippy_runtime::GGML_TYPE_F16,
+            Self::F32 => skippy_runtime::GGML_TYPE_F32,
+            Self::Q8Zero => skippy_runtime::GGML_TYPE_Q8_0,
+            Self::Q4Zero => skippy_runtime::GGML_TYPE_Q4_0,
+        }
+    }
+}
+
 #[derive(Args, Clone)]
 pub struct ServerArgs {
     #[arg(long, default_value = "target/debug/skippy-server")]
@@ -216,6 +239,12 @@ pub struct StateHandoffArgs {
     /// scalar restore fallback.
     #[arg(long)]
     pub cachegen_gate: bool,
+    /// Native K cache type used by the state-handoff and CacheGen control arms.
+    #[arg(long, value_enum, default_value = "f16")]
+    pub cache_type_k: CacheTypeArg,
+    /// Native V cache type used by the state-handoff and CacheGen control arms.
+    #[arg(long, value_enum, default_value = "f16")]
+    pub cache_type_v: CacheTypeArg,
     /// Teacher-forced continuation steps used for CacheGen quality and
     /// steady-state decode measurements.
     #[arg(long, default_value_t = 64)]

--- a/crates/skippy-correctness/src/report.rs
+++ b/crates/skippy-correctness/src/report.rs
@@ -213,6 +213,8 @@ pub struct CacheGenGateReport {
     pub passed: bool,
     pub failure_reasons: Vec<String>,
     pub restore_path: &'static str,
+    pub cache_type_k: &'static str,
+    pub cache_type_v: &'static str,
     pub continuation_steps: usize,
     pub native_storage_bytes: usize,
     pub cachegen_storage_bytes: usize,

--- a/crates/skippy-correctness/src/runner/cachegen_gate.rs
+++ b/crates/skippy-correctness/src/runner/cachegen_gate.rs
@@ -140,6 +140,8 @@ pub(in crate::runner) fn run_cachegen_gate(
         passed: failure_reasons.is_empty(),
         failure_reasons,
         restore_path: "native-device",
+        cache_type_k: cache_type_name(kv_desc.k_type)?,
+        cache_type_v: cache_type_name(kv_desc.v_type)?,
         continuation_steps: args.cachegen_continuation_steps,
         native_storage_bytes,
         cachegen_storage_bytes,
@@ -397,6 +399,16 @@ fn cachegen_value_type(value: u32) -> Result<ValueType> {
         GGML_TYPE_F16 => Ok(ValueType::F16),
         GGML_TYPE_Q8_0 => Ok(ValueType::Q8_0),
         GGML_TYPE_Q4_0 => Ok(ValueType::Q4_0),
+        _ => bail!("CacheGen gate does not support runtime K/V type {value}"),
+    }
+}
+
+fn cache_type_name(value: u32) -> Result<&'static str> {
+    match value {
+        GGML_TYPE_F32 => Ok("f32"),
+        GGML_TYPE_F16 => Ok("f16"),
+        GGML_TYPE_Q8_0 => Ok("q8_0"),
+        GGML_TYPE_Q4_0 => Ok("q4_0"),
         _ => bail!("CacheGen gate does not support runtime K/V type {value}"),
     }
 }

--- a/crates/skippy-correctness/src/runner/stage_execution.rs
+++ b/crates/skippy-correctness/src/runner/stage_execution.rs
@@ -100,6 +100,8 @@ pub(in crate::runner) struct BinaryStateHandoffConfig {
     pub(in crate::runner) synthetic_input_activation: bool,
     pub(in crate::runner) binary_control: bool,
     pub(in crate::runner) cachegen_gate: bool,
+    pub(in crate::runner) cache_type_k: u32,
+    pub(in crate::runner) cache_type_v: u32,
     pub(in crate::runner) cachegen_continuation_steps: usize,
     pub(in crate::runner) cachegen_min_token_agreement: f64,
     pub(in crate::runner) cachegen_max_p99_decode_regression: f64,

--- a/crates/skippy-correctness/src/runner/state_handoff.rs
+++ b/crates/skippy-correctness/src/runner/state_handoff.rs
@@ -9,8 +9,7 @@ use skippy_protocol::binary::{
     write_stage_message,
 };
 use skippy_runtime::{
-    ActivationFrame, GGML_TYPE_F16, MtpSource, RuntimeConfig, RuntimeKvPageDesc, StageModel,
-    StageSession,
+    ActivationFrame, MtpSource, RuntimeConfig, RuntimeKvPageDesc, StageModel, StageSession,
 };
 
 use crate::{
@@ -209,6 +208,8 @@ pub fn state_handoff(args: StateHandoffArgs) -> Result<()> {
         synthetic_input_activation: args.synthetic_input_activation,
         binary_control: args.binary_control,
         cachegen_gate: args.cachegen_gate,
+        cache_type_k: args.cache_type_k.ggml_type(),
+        cache_type_v: args.cache_type_v.ggml_type(),
         cachegen_continuation_steps: args.cachegen_continuation_steps,
         cachegen_min_token_agreement: args.cachegen_min_token_agreement,
         cachegen_max_p99_decode_regression: args.cachegen_max_p99_decode_regression,
@@ -415,6 +416,8 @@ fn run_binary_state_handoff(args: BinaryStateHandoffConfig) -> Result<BinaryStat
         "n_batch": args.n_batch,
         "n_ubatch": args.n_ubatch,
         "n_gpu_layers": args.n_gpu_layers,
+        "cache_type_k": cache_type_name(args.cache_type_k)?,
+        "cache_type_v": cache_type_name(args.cache_type_v)?,
         "flash_attn_type": protocol_flash_attn(args.flash_attn),
         "filter_tensors_on_load": should_filter_state_handoff_tensors(&args),
         "load_mode": protocol_load_mode(args.stage_load_mode),
@@ -444,6 +447,8 @@ fn run_binary_state_handoff(args: BinaryStateHandoffConfig) -> Result<BinaryStat
         "n_batch": args.n_batch,
         "n_ubatch": args.n_ubatch,
         "n_gpu_layers": args.n_gpu_layers,
+        "cache_type_k": cache_type_name(args.cache_type_k)?,
+        "cache_type_v": cache_type_name(args.cache_type_v)?,
         "flash_attn_type": protocol_flash_attn(args.flash_attn),
         "filter_tensors_on_load": should_filter_state_handoff_tensors(&args),
         "load_mode": protocol_load_mode(args.stage_load_mode),
@@ -714,8 +719,8 @@ fn run_local_state_handoff(
         checkpoint_quantization: skippy_runtime::CheckpointQuantization::Preserve,
         checkpoint_imatrix: None,
         checkpoint_imatrix_sha256: None,
-        cache_type_k: GGML_TYPE_F16,
-        cache_type_v: GGML_TYPE_F16,
+        cache_type_k: args.cache_type_k,
+        cache_type_v: args.cache_type_v,
         flash_attn_type: runtime_flash_attn(args.flash_attn),
         kv_offload: None,
         kv_unified: None,
@@ -1497,8 +1502,8 @@ fn build_state_handoff_inputs(
         checkpoint_quantization: skippy_runtime::CheckpointQuantization::Preserve,
         checkpoint_imatrix: None,
         checkpoint_imatrix_sha256: None,
-        cache_type_k: GGML_TYPE_F16,
-        cache_type_v: GGML_TYPE_F16,
+        cache_type_k: args.cache_type_k,
+        cache_type_v: args.cache_type_v,
         flash_attn_type: runtime_flash_attn(args.flash_attn),
         kv_offload: None,
         kv_unified: None,
@@ -1523,6 +1528,16 @@ fn build_state_handoff_inputs(
         );
     }
     Ok((Some(prefill_input), Some(decode_input), prefill_width))
+}
+
+fn cache_type_name(value: u32) -> Result<&'static str> {
+    match value {
+        skippy_runtime::GGML_TYPE_F16 => Ok("f16"),
+        skippy_runtime::GGML_TYPE_F32 => Ok("f32"),
+        skippy_runtime::GGML_TYPE_Q8_0 => Ok("q8_0"),
+        skippy_runtime::GGML_TYPE_Q4_0 => Ok("q4_0"),
+        _ => bail!("unsupported state-handoff K/V cache type {value}"),
+    }
 }
 
 fn synthetic_activation_frame(

--- a/docs/skippy/CACHEGEN_BACKEND_PLAN.md
+++ b/docs/skippy/CACHEGEN_BACKEND_PLAN.md
@@ -10,8 +10,8 @@ contract, CPU+Metal parity, six measurements, stop rule).
 
 | Backend | Kernel | Status | Evidence |
 |---|---|---|---|
-| CPU (reference) | scalar Rust | **Correctness reference only** — portable F32, F16, Q8_0, Q4_0, and mixed K/V adapters are implemented; only F16 has passed the 19K quality gate | Python/Rust fixtures pin LMCache revision `b5d109e`; typed archive fixtures cover every current user-selectable runtime K/V type |
-| Metal (Apple GPU) | native MSL | **All typed restores implemented, not promoted** — F16, F32, Q8_0, and Q4_0 match native fixture layouts; the F16 local 19K gate has 64/64 continuation agreement but 604.84 ms TTFT versus 385.41 ms native | Apple M1 Ultra device fixture and F16 gate below; quantized 19K gates remain |
+| CPU (reference) | scalar Rust | **Correctness reference only** — portable F32, F16, Q8_0, Q4_0, and mixed K/V adapters are implemented | Python/Rust fixtures pin LMCache revision `b5d109e`; typed archive fixtures cover every current user-selectable runtime K/V type |
+| Metal (Apple GPU) | native MSL | **All typed restores implemented, not promoted** — F16, F32, Q8_0, and Q4_0 match native fixture layouts; representative 19K F16, Q8_0, Q4_0, and mixed gates meet the 95% quality floor but all lose the local latency gate, and Q4_0/Q4_0 is larger than native | Apple M1 Ultra device fixture and typed 19K gates below |
 | CUDA (NVIDIA) | shared native CUDA/HIP source | **All typed restores implemented, compile/package qualification pending** — no runtime claim yet | Real NVIDIA fixture and typed 19K gates remain |
 | HIP/ROCm (AMD) | shared native CUDA/HIP source | **All typed restores implemented, compile/package qualification pending** — no runtime claim yet | Real AMD fixture and typed 19K gates remain |
 
@@ -231,6 +231,32 @@ the native 2.18 GB copy is unusually fast: CacheGen's 242.04 ms read saving does
 not recover its 484.05 ms reconstruction penalty. The result does not decide a
 remote tier, where transfer time and pipelining differ; that tier needs its own
 matched end-to-end gate under #1427.
+
+## 19K typed Metal matrix (2026-09-11): QUALITY FLOOR PASS, LOCAL PROMOTION STOP
+
+The typed gate was run from exact commit
+`2e26d46ea87e1b8ee783460998e703f669513f91` on the same Apple M1 Ultra,
+pinned Qwen3 0.6B Q8_0 model, 19,000-token prefix, and 64-step continuation.
+The gate now accepts independent `--cache-type-k` and `--cache-type-v` values
+and records them in its report. The compact matrix is
+[`cachegen-metal-typed-qwen3-0.6b-19k-summary.json`](cachegen-metal-typed-qwen3-0.6b-19k-summary.json).
+
+| K/V type | Native bytes | CacheGen bytes | CacheGen/native | Agreement | Native TTFT | CacheGen TTFT | Decision |
+|---|---:|---:|---:|---:|---:|---:|---|
+| Q8_0/Q8_0 | 1,157,632,000 | 589,803,358 | 50.95% | 64/64 (100%) | 333.36 ms | 650.64 ms | Quality and size pass; local latency fails |
+| Q4_0/Q4_0 | 612,864,000 | 635,037,607 | 103.62% | 61/64 (95.31%) | 189.84 ms | 699.35 ms | Quality floor passes; size and local latency fail |
+| Q8_0/F16 | 1,668,352,000 | 565,441,003 | 33.89% | 64/64 (100%) | 558.28 ms | 792.05 ms | Quality and size pass; local latency fails |
+| Q4_0/F16 | 1,395,968,000 | 610,269,862 | 43.72% | 61/64 (95.31%) | 483.98 ms | 807.03 ms | Quality and size pass; local latency fails |
+
+These are representative homogeneous and mixed layouts, not qualification of
+all 16 pairings. The quantized K cases expose a consistent quality split:
+Q8_0 preserves all 64 greedy continuation tokens, while Q4_0 first diverges at
+step 15 and finishes at 61/64, barely above the declared 95% floor. All four
+CacheGen continuations stay within the p99 decode-regression budget after
+restore. None may be promoted for the local tier because end-to-end restore is
+slower than native; Q4_0/Q4_0 also has no storage benefit. F32 and the remaining
+mixed permutations retain fixture-level coverage and need separate 19K runs
+before any broader typed qualification claim.
 
 ## 19K LMCache-compatible CPU result (2026-09-11): QUALITY PASS, LATENCY STOP
 

--- a/docs/skippy/CACHEGEN_BACKEND_PLAN.md
+++ b/docs/skippy/CACHEGEN_BACKEND_PLAN.md
@@ -1,8 +1,8 @@
 # CacheGen Backend Qualification (#1652)
 
-Status: **LMCache-compatible direct Metal restore passes correctness and quality
-but fails the local-tier latency gate; native passthrough remains the promoted
-path**. Owner: jian yang.
+Status: **LMCache-compatible direct Metal restore passes the local F32/F32 gate;
+F16 and the sampled quantized/mixed types remain stopped on local latency, and
+CacheGen remains opt-in pending selection-path wiring**. Owner: jian yang.
 Reviewed against: #1652 scope, scama's directives of 2026-09-10 (v4
 contract, CPU+Metal parity, six measurements, stop rule).
 
@@ -11,9 +11,9 @@ contract, CPU+Metal parity, six measurements, stop rule).
 | Backend | Kernel | Status | Evidence |
 |---|---|---|---|
 | CPU (reference) | scalar Rust | **Correctness reference only** — portable F32, F16, Q8_0, Q4_0, and mixed K/V adapters are implemented | Python/Rust fixtures pin LMCache revision `b5d109e`; typed archive fixtures cover every current user-selectable runtime K/V type |
-| Metal (Apple GPU) | native MSL | **All typed restores implemented, not promoted** — F16, F32, Q8_0, and Q4_0 match native fixture layouts; representative 19K F16, Q8_0, Q4_0, and mixed gates meet the 95% quality floor but all lose the local latency gate, and Q4_0/Q4_0 is larger than native | Apple M1 Ultra device fixture and typed 19K gates below |
-| CUDA (NVIDIA) | shared native CUDA/HIP source | **All typed restores implemented, compile/package qualification pending** — no runtime claim yet | Real NVIDIA fixture and typed 19K gates remain |
-| HIP/ROCm (AMD) | shared native CUDA/HIP source | **All typed restores implemented, compile/package qualification pending** — no runtime claim yet | Real AMD fixture and typed 19K gates remain |
+| Metal (Apple GPU) | native MSL | **All typed restores implemented; F32/F32 clears the local gate** — F16, F32, Q8_0, and Q4_0 match native fixture layouts; the 19K F32/F32 gate passes quality, size, latency, and p99 criteria, while F16 and the sampled quantized/mixed cases remain stopped locally | Apple M1 Ultra device fixture and typed 19K gates below |
+| CUDA (NVIDIA) | shared native CUDA/HIP source | **Typed kernels landed; F16 fixture qualified** — the real RTX 5080 fixture matches F16 bytes, while F32, quantized, and matched typed 19K runtime gates remain | Real NVIDIA F16 fixture; remaining typed hardware gates pending |
+| HIP/ROCm (AMD) | shared native CUDA/HIP source | **Typed kernels landed; compile/package qualified** — no real AMD runtime claim yet | Real AMD fixture and typed 19K gates remain |
 
 Nothing may be marked implemented until it runs on real hardware and
 matches the CPU reference bit-for-bit. Compile-only checks prove the
@@ -232,31 +232,40 @@ not recover its 484.05 ms reconstruction penalty. The result does not decide a
 remote tier, where transfer time and pipelining differ; that tier needs its own
 matched end-to-end gate under #1427.
 
-## 19K typed Metal matrix (2026-09-11): QUALITY FLOOR PASS, LOCAL PROMOTION STOP
+## 19K typed Metal matrix (2026-09-12): F32 PASS, OTHER LOCAL PROMOTION STOPS
 
-The typed gate was run from exact commit
-`2e26d46ea87e1b8ee783460998e703f669513f91` on the same Apple M1 Ultra,
-pinned Qwen3 0.6B Q8_0 model, 19,000-token prefix, and 64-step continuation.
+The typed gate was run from exact commits
+`2e26d46ea87e1b8ee783460998e703f669513f91` (quantized and mixed rows) and
+`74b4f60719d09dee7d9579c1365ac6f95d14c20c` (F32/F32) on the same Apple M1
+Ultra, pinned Qwen3 0.6B Q8_0 model, 19,000-token prefix, and 64-step
+continuation. The F32 run also caught and fixed a native config defect where
+GGML enum value zero was interpreted as an unset cache type and silently
+replaced with F16. The native regression now pins both the F16 default and an
+explicit F32 request.
 The gate now accepts independent `--cache-type-k` and `--cache-type-v` values
 and records them in its report. The compact matrix is
 [`cachegen-metal-typed-qwen3-0.6b-19k-summary.json`](cachegen-metal-typed-qwen3-0.6b-19k-summary.json).
 
 | K/V type | Native bytes | CacheGen bytes | CacheGen/native | Agreement | Native TTFT | CacheGen TTFT | Decision |
 |---|---:|---:|---:|---:|---:|---:|---|
+| F32/F32 | 4,358,144,000 | 446,903,003 | 10.25% | 64/64 (100%) | 1,199.13 ms | 766.12 ms | Pass: quality, size, local latency, and p99 |
 | Q8_0/Q8_0 | 1,157,632,000 | 589,803,358 | 50.95% | 64/64 (100%) | 333.36 ms | 650.64 ms | Quality and size pass; local latency fails |
 | Q4_0/Q4_0 | 612,864,000 | 635,037,607 | 103.62% | 61/64 (95.31%) | 189.84 ms | 699.35 ms | Quality floor passes; size and local latency fail |
 | Q8_0/F16 | 1,668,352,000 | 565,441,003 | 33.89% | 64/64 (100%) | 558.28 ms | 792.05 ms | Quality and size pass; local latency fails |
 | Q4_0/F16 | 1,395,968,000 | 610,269,862 | 43.72% | 61/64 (95.31%) | 483.98 ms | 807.03 ms | Quality and size pass; local latency fails |
 
 These are representative homogeneous and mixed layouts, not qualification of
-all 16 pairings. The quantized K cases expose a consistent quality split:
-Q8_0 preserves all 64 greedy continuation tokens, while Q4_0 first diverges at
-step 15 and finishes at 61/64, barely above the declared 95% floor. All four
-CacheGen continuations stay within the p99 decode-regression budget after
-restore. None may be promoted for the local tier because end-to-end restore is
-slower than native; Q4_0/Q4_0 also has no storage benefit. F32 and the remaining
-mixed permutations retain fixture-level coverage and need separate 19K runs
-before any broader typed qualification claim.
+all 16 pairings. F32/F32 clears the matched local gate because reading the
+compact archive saves enough time against the 4.36 GB native page to absorb
+device reconstruction. The quantized K cases expose a consistent quality
+split: Q8_0 preserves all 64 greedy continuation tokens, while Q4_0 first
+diverges at step 15 and finishes at 61/64, barely above the declared 95% floor.
+Every sampled CacheGen continuation stays within the p99 decode-regression
+budget after restore. F16 and the sampled quantized/mixed cases remain stopped
+for the local tier because end-to-end restore is slower than native;
+Q4_0/Q4_0 also has no storage benefit. The remaining mixed permutations retain
+fixture-level coverage and need separate 19K runs before any broader typed
+qualification claim.
 
 ## 19K LMCache-compatible CPU result (2026-09-11): QUALITY PASS, LATENCY STOP
 

--- a/docs/skippy/CACHEGEN_BACKEND_PLAN.md
+++ b/docs/skippy/CACHEGEN_BACKEND_PLAN.md
@@ -1,8 +1,9 @@
 # CacheGen Backend Qualification (#1652)
 
-Status: **LMCache-compatible direct Metal restore passes the local F32/F32 gate;
-F16 and the sampled quantized/mixed types remain stopped on local latency, and
-CacheGen remains opt-in pending selection-path wiring**. Owner: jian yang.
+Status: **LMCache-compatible direct Metal restore passes the local F32/F32 and
+F32+F16 gates; F16 and the lower-width sampled types remain stopped on local
+latency, and CacheGen remains opt-in pending selection-path wiring**. Owner:
+jian yang.
 Reviewed against: #1652 scope, scama's directives of 2026-09-10 (v4
 contract, CPU+Metal parity, six measurements, stop rule).
 
@@ -11,7 +12,7 @@ contract, CPU+Metal parity, six measurements, stop rule).
 | Backend | Kernel | Status | Evidence |
 |---|---|---|---|
 | CPU (reference) | scalar Rust | **Correctness reference only** — portable F32, F16, Q8_0, Q4_0, and mixed K/V adapters are implemented | Python/Rust fixtures pin LMCache revision `b5d109e`; typed archive fixtures cover every current user-selectable runtime K/V type |
-| Metal (Apple GPU) | native MSL | **All typed restores implemented; F32/F32 clears the local gate** — F16, F32, Q8_0, and Q4_0 match native fixture layouts; the 19K F32/F32 gate passes quality, size, latency, and p99 criteria, while F16 and the sampled quantized/mixed cases remain stopped locally | Apple M1 Ultra device fixture and typed 19K gates below |
+| Metal (Apple GPU) | native MSL | **All typed restores implemented; F32/F32 and F32+F16 clear the local gate** — F16, F32, Q8_0, and Q4_0 match native fixture layouts; Q8_0/F32 straddles the latency boundary across repeats, while F16 and the lower-width sampled cases remain stopped locally | Apple M1 Ultra device fixture and typed 19K gates below |
 | CUDA (NVIDIA) | shared native CUDA/HIP source | **Typed kernels landed; F16 fixture qualified** — the real RTX 5080 fixture matches F16 bytes, while F32, quantized, and matched typed 19K runtime gates remain | Real NVIDIA F16 fixture; remaining typed hardware gates pending |
 | HIP/ROCm (AMD) | shared native CUDA/HIP source | **Typed kernels landed; compile/package qualified** — no real AMD runtime claim yet | Real AMD fixture and typed 19K gates remain |
 
@@ -242,6 +243,8 @@ continuation. The F32 run also caught and fixed a native config defect where
 GGML enum value zero was interpreted as an unset cache type and silently
 replaced with F16. The native regression now pins both the F16 default and an
 explicit F32 request.
+The F32/F16 crossover probes were run from exact commit
+`ddddf34aa5e64262c9e113d07f9dcb506e5f7aab`.
 The gate now accepts independent `--cache-type-k` and `--cache-type-v` values
 and records them in its report. The compact matrix is
 [`cachegen-metal-typed-qwen3-0.6b-19k-summary.json`](cachegen-metal-typed-qwen3-0.6b-19k-summary.json).
@@ -249,21 +252,31 @@ and records them in its report. The compact matrix is
 | K/V type | Native bytes | CacheGen bytes | CacheGen/native | Agreement | Native TTFT | CacheGen TTFT | Decision |
 |---|---:|---:|---:|---:|---:|---:|---|
 | F32/F32 | 4,358,144,000 | 446,903,003 | 10.25% | 64/64 (100%) | 1,199.13 ms | 766.12 ms | Pass: quality, size, local latency, and p99 |
+| F32/F16 | 3,268,608,000 | 446,903,003 | 13.67% | 64/64 (100%) | 878.61 ms | 686.15 ms | Pass: quality, size, local latency, and p99 |
+| F16/F32 | 3,268,608,000 | 446,903,003 | 13.67% | 64/64 (100%) | 840.32 ms | 671.93 ms | Pass: quality, size, local latency, and p99 |
+| Q8_0/F32 | 2,757,888,000 | 565,441,003 | 20.50% | 64/64 (100%) | 800.57 / 727.17 ms | 796.94 / 792.13 ms | Unstable boundary: one pass, one latency stop |
 | Q8_0/Q8_0 | 1,157,632,000 | 589,803,358 | 50.95% | 64/64 (100%) | 333.36 ms | 650.64 ms | Quality and size pass; local latency fails |
 | Q4_0/Q4_0 | 612,864,000 | 635,037,607 | 103.62% | 61/64 (95.31%) | 189.84 ms | 699.35 ms | Quality floor passes; size and local latency fail |
 | Q8_0/F16 | 1,668,352,000 | 565,441,003 | 33.89% | 64/64 (100%) | 558.28 ms | 792.05 ms | Quality and size pass; local latency fails |
 | Q4_0/F16 | 1,395,968,000 | 610,269,862 | 43.72% | 61/64 (95.31%) | 483.98 ms | 807.03 ms | Quality and size pass; local latency fails |
 
-These are representative homogeneous and mixed layouts, not qualification of
-all 16 pairings. F32/F32 clears the matched local gate because reading the
-compact archive saves enough time against the 4.36 GB native page to absorb
-device reconstruction. The quantized K cases expose a consistent quality
-split: Q8_0 preserves all 64 greedy continuation tokens, while Q4_0 first
-diverges at step 15 and finishes at 61/64, barely above the declared 95% floor.
-Every sampled CacheGen continuation stays within the p99 decode-regression
-budget after restore. F16 and the sampled quantized/mixed cases remain stopped
-for the local tier because end-to-end restore is slower than native;
-Q4_0/Q4_0 also has no storage benefit. The remaining mixed permutations retain
+These are representative runtime-valid layouts, not qualification of every
+pairing. F32/F32 and both F32+F16 directions clear the matched local gate because
+reading the compact archive saves enough time against native pages of at least
+3.27 GB to absorb device reconstruction. At 2.76 GB, Q8_0/F32 is inside run
+variance: it won once by 3.63 ms and lost once by 64.96 ms, so it remains stopped.
+The nearly format-independent 521-586 ms CacheGen import times, compared with
+native import scaling from 80 to 495 ms with page width, identify arithmetic
+reconstruction as the next Metal target. F32/Q8_0 is not a valid control on this
+model: llama.cpp requires Flash Attention for quantized V, while that mixed
+cache pair does not have a compatible Flash Attention kernel.
+
+The quantized K cases expose a consistent quality split: Q8_0 preserves all 64
+greedy continuation tokens, while Q4_0 first diverges at step 15 and finishes at
+61/64, barely above the declared 95% floor. Every completed CacheGen continuation
+stays within the p99 decode-regression budget after restore. F16 and the
+lower-width sampled cases remain stopped for the local tier; Q4_0/Q4_0 also has
+no storage benefit. The remaining runtime-valid mixed permutations retain
 fixture-level coverage and need separate 19K runs before any broader typed
 qualification claim.
 

--- a/docs/skippy/cachegen-metal-typed-qwen3-0.6b-19k-summary.json
+++ b/docs/skippy/cachegen-metal-typed-qwen3-0.6b-19k-summary.json
@@ -1,8 +1,11 @@
 {
   "schema_version": 1,
-  "decision": "quality-floor-pass-local-promotion-stop",
-  "date": "2026-09-11",
-  "commit": "2e26d46ea87e1b8ee783460998e703f669513f91",
+  "decision": "f32-local-pass-other-representative-types-stop",
+  "date": "2026-09-12",
+  "commits": {
+    "quantized_and_mixed": "2e26d46ea87e1b8ee783460998e703f669513f91",
+    "f32": "74b4f60719d09dee7d9579c1365ac6f95d14c20c"
+  },
   "reference": {
     "implementation": "LMCache CacheGen",
     "revision": "b5d109ea99a89b4d8a670ee4fc2e8cb76411ee5c",
@@ -34,6 +37,23 @@
     "restore_to_first_token_must_beat_native": true
   },
   "cases": [
+    {
+      "cache_type_k": "f32",
+      "cache_type_v": "f32",
+      "passed": true,
+      "native_storage_bytes": 4358144000,
+      "cachegen_storage_bytes": 446903003,
+      "compression_ratio": 0.10254434066428278,
+      "native_import_ms": 494.848083,
+      "cachegen_import_ms": 521.351959,
+      "native_ttft_ms": 1199.1292079999998,
+      "cachegen_ttft_ms": 766.1168339999999,
+      "p99_decode_regression": -0.047207090345013546,
+      "matching_tokens": 64,
+      "token_agreement": 1.0,
+      "first_token_mismatch_step": null,
+      "failure_reasons": []
+    },
     {
       "cache_type_k": "q8_0",
       "cache_type_v": "q8_0",
@@ -114,9 +134,10 @@
   ],
   "notes": [
     "The scalar CPU decoder ran as an independently timed oracle and is excluded from direct-device TTFT.",
+    "The F32/F32 case passed all declared gates after fixing native model configuration to preserve GGML_TYPE_F32 enum value zero instead of silently replacing it with F16.",
     "Q8_0 cases preserved all 64 greedy continuation tokens; Q4_0 K cases first diverged at step 15 and preserved 61 of 64.",
-    "All four direct Metal restores were slower than their matched native controls on this local unified-memory tier.",
+    "F32/F32 beat its matched native control on this local unified-memory tier; the four sampled quantized and mixed restores were slower.",
     "Q4_0/Q4_0 expanded the native payload by 3.62 percent and therefore failed the storage gate independently of latency.",
-    "The matrix is representative rather than exhaustive; F32 and the remaining mixed pairings retain fixture coverage only."
+    "The matrix is representative rather than exhaustive; the remaining mixed pairings retain fixture coverage only."
   ]
 }

--- a/docs/skippy/cachegen-metal-typed-qwen3-0.6b-19k-summary.json
+++ b/docs/skippy/cachegen-metal-typed-qwen3-0.6b-19k-summary.json
@@ -1,10 +1,11 @@
 {
   "schema_version": 1,
-  "decision": "f32-local-pass-other-representative-types-stop",
+  "decision": "f32-and-f32-f16-local-pass-lower-width-types-stop",
   "date": "2026-09-12",
   "commits": {
     "quantized_and_mixed": "2e26d46ea87e1b8ee783460998e703f669513f91",
-    "f32": "74b4f60719d09dee7d9579c1365ac6f95d14c20c"
+    "f32": "74b4f60719d09dee7d9579c1365ac6f95d14c20c",
+    "f32_mixed_crossover": "ddddf34aa5e64262c9e113d07f9dcb506e5f7aab"
   },
   "reference": {
     "implementation": "LMCache CacheGen",
@@ -49,6 +50,59 @@
       "native_ttft_ms": 1199.1292079999998,
       "cachegen_ttft_ms": 766.1168339999999,
       "p99_decode_regression": -0.047207090345013546,
+      "matching_tokens": 64,
+      "token_agreement": 1.0,
+      "first_token_mismatch_step": null,
+      "failure_reasons": []
+    },
+    {
+      "cache_type_k": "q8_0",
+      "cache_type_v": "f32",
+      "passed": false,
+      "stable_result": "one-pass-one-fail",
+      "native_storage_bytes": 2757888000,
+      "cachegen_storage_bytes": 565441003,
+      "compression_ratio": 0.20502681871054954,
+      "runs": [
+        {
+          "native_ttft_ms": 800.57175,
+          "cachegen_ttft_ms": 796.943875,
+          "passed": true
+        },
+        {
+          "native_ttft_ms": 727.173833,
+          "cachegen_ttft_ms": 792.1295419999999,
+          "passed": false
+        }
+      ],
+      "matching_tokens": 64,
+      "token_agreement": 1.0
+    },
+    {
+      "cache_type_k": "f32",
+      "cache_type_v": "f16",
+      "passed": true,
+      "native_storage_bytes": 3268608000,
+      "cachegen_storage_bytes": 446903003,
+      "compression_ratio": 0.13672578755237705,
+      "native_ttft_ms": 878.6078749999999,
+      "cachegen_ttft_ms": 686.1472490000001,
+      "p99_decode_regression": -0.19336615460457712,
+      "matching_tokens": 64,
+      "token_agreement": 1.0,
+      "first_token_mismatch_step": null,
+      "failure_reasons": []
+    },
+    {
+      "cache_type_k": "f16",
+      "cache_type_v": "f32",
+      "passed": true,
+      "native_storage_bytes": 3268608000,
+      "cachegen_storage_bytes": 446903003,
+      "compression_ratio": 0.13672578755237705,
+      "native_ttft_ms": 840.3155,
+      "cachegen_ttft_ms": 671.9314999999999,
+      "p99_decode_regression": -0.16524231813735718,
       "matching_tokens": 64,
       "token_agreement": 1.0,
       "first_token_mismatch_step": null,
@@ -135,6 +189,8 @@
   "notes": [
     "The scalar CPU decoder ran as an independently timed oracle and is excluded from direct-device TTFT.",
     "The F32/F32 case passed all declared gates after fixing native model configuration to preserve GGML_TYPE_F32 enum value zero instead of silently replacing it with F16.",
+    "Both F32/F16 directions passed with more than 160 ms of TTFT margin; Q8_0/F32 crossed the boundary between repeated runs and remains stopped.",
+    "F32/Q8_0 is not runtime-valid for this model because quantized V requires Flash Attention and this mixed pair has no compatible Flash Attention kernel.",
     "Q8_0 cases preserved all 64 greedy continuation tokens; Q4_0 K cases first diverged at step 15 and preserved 61 of 64.",
     "F32/F32 beat its matched native control on this local unified-memory tier; the four sampled quantized and mixed restores were slower.",
     "Q4_0/Q4_0 expanded the native payload by 3.62 percent and therefore failed the storage gate independently of latency.",

--- a/docs/skippy/cachegen-metal-typed-qwen3-0.6b-19k-summary.json
+++ b/docs/skippy/cachegen-metal-typed-qwen3-0.6b-19k-summary.json
@@ -1,0 +1,122 @@
+{
+  "schema_version": 1,
+  "decision": "quality-floor-pass-local-promotion-stop",
+  "date": "2026-09-11",
+  "commit": "2e26d46ea87e1b8ee783460998e703f669513f91",
+  "reference": {
+    "implementation": "LMCache CacheGen",
+    "revision": "b5d109ea99a89b4d8a670ee4fc2e8cb76411ee5c",
+    "license": "Apache-2.0"
+  },
+  "hardware": {
+    "model": "Mac Studio",
+    "chip": "Apple M1 Ultra",
+    "memory_gib": 128,
+    "runtime_backend": "Metal",
+    "codec_backend": "native MSL direct-to-resident-KV"
+  },
+  "model": {
+    "id": "Qwen/Qwen3-0.6B-GGUF:Q8_0",
+    "sha256": "12fae8b8f78f0360b498d04c8db7d33aff29ab7d8080231f93a17c18119e6735",
+    "layer_end": 28
+  },
+  "workload": {
+    "prefix_tokens": 19000,
+    "continuation_steps": 64,
+    "ctx_size": 19200,
+    "chunk_rows": 256,
+    "continuation_sessions": "isolated"
+  },
+  "thresholds": {
+    "minimum_token_agreement": 0.95,
+    "maximum_p99_decode_regression": 0.05,
+    "encoded_payload_must_be_smaller_than_native": true,
+    "restore_to_first_token_must_beat_native": true
+  },
+  "cases": [
+    {
+      "cache_type_k": "q8_0",
+      "cache_type_v": "q8_0",
+      "passed": false,
+      "native_storage_bytes": 1157632000,
+      "cachegen_storage_bytes": 589803358,
+      "compression_ratio": 0.5094912355567227,
+      "native_import_ms": 129.030291,
+      "cachegen_import_ms": 571.4625410000001,
+      "native_ttft_ms": 333.361041,
+      "cachegen_ttft_ms": 650.6419990000002,
+      "p99_decode_regression": -0.6727379064515878,
+      "matching_tokens": 64,
+      "token_agreement": 1.0,
+      "first_token_mismatch_step": null,
+      "failure_reasons": [
+        "restore-to-first-token did not beat native (650.642 ms >= 333.361 ms)"
+      ]
+    },
+    {
+      "cache_type_k": "q4_0",
+      "cache_type_v": "q4_0",
+      "passed": false,
+      "native_storage_bytes": 612864000,
+      "cachegen_storage_bytes": 635037607,
+      "compression_ratio": 1.0361803059079993,
+      "native_import_ms": 80.699625,
+      "cachegen_import_ms": 619.267791,
+      "native_ttft_ms": 189.84379199999998,
+      "cachegen_ttft_ms": 699.35204,
+      "p99_decode_regression": -0.6919925490103622,
+      "matching_tokens": 61,
+      "token_agreement": 0.953125,
+      "first_token_mismatch_step": 15,
+      "failure_reasons": [
+        "encoded payload is not smaller than native",
+        "restore-to-first-token did not beat native (699.352 ms >= 189.844 ms)"
+      ]
+    },
+    {
+      "cache_type_k": "q8_0",
+      "cache_type_v": "f16",
+      "passed": false,
+      "native_storage_bytes": 1668352000,
+      "cachegen_storage_bytes": 565441003,
+      "compression_ratio": 0.3389218839909084,
+      "native_import_ms": 189.447709,
+      "cachegen_import_ms": 579.317334,
+      "native_ttft_ms": 558.277709,
+      "cachegen_ttft_ms": 792.0514169999999,
+      "p99_decode_regression": -0.16607278770613987,
+      "matching_tokens": 64,
+      "token_agreement": 1.0,
+      "first_token_mismatch_step": null,
+      "failure_reasons": [
+        "restore-to-first-token did not beat native (792.051 ms >= 558.278 ms)"
+      ]
+    },
+    {
+      "cache_type_k": "q4_0",
+      "cache_type_v": "f16",
+      "passed": false,
+      "native_storage_bytes": 1395968000,
+      "cachegen_storage_bytes": 610269862,
+      "compression_ratio": 0.43716608260361267,
+      "native_import_ms": 153.555959,
+      "cachegen_import_ms": 602.013291,
+      "native_ttft_ms": 483.978876,
+      "cachegen_ttft_ms": 807.0270820000001,
+      "p99_decode_regression": -0.17710234510665943,
+      "matching_tokens": 61,
+      "token_agreement": 0.953125,
+      "first_token_mismatch_step": 15,
+      "failure_reasons": [
+        "restore-to-first-token did not beat native (807.027 ms >= 483.979 ms)"
+      ]
+    }
+  ],
+  "notes": [
+    "The scalar CPU decoder ran as an independently timed oracle and is excluded from direct-device TTFT.",
+    "Q8_0 cases preserved all 64 greedy continuation tokens; Q4_0 K cases first diverged at step 15 and preserved 61 of 64.",
+    "All four direct Metal restores were slower than their matched native controls on this local unified-memory tier.",
+    "Q4_0/Q4_0 expanded the native payload by 3.62 percent and therefore failed the storage gate independently of latency.",
+    "The matrix is representative rather than exhaustive; F32 and the remaining mixed pairings retain fixture coverage only."
+  ]
+}

--- a/third_party/llama.cpp/patches/0003-skippy-implement-model-lifecycle-and-package-loading.patch
+++ b/third_party/llama.cpp/patches/0003-skippy-implement-model-lifecycle-and-package-loading.patch
@@ -359,7 +359,7 @@ new file mode 100644
 index 000000000..a6ec5b2eb
 --- /dev/null
 +++ b/src/skippy/model_load_config.cpp
-@@ -0,0 +1,159 @@
+@@ -0,0 +1,167 @@
 +#include "skippy.h"
 +#include "skippy/errors.h"
 +#include "skippy/environment.h"
@@ -514,10 +514,18 @@ index 000000000..a6ec5b2eb
 +void skippy_apply_context_hardware_config(
 +        const struct skippy_runtime_config * config,
 +        llama_context_params & params) {
-+    if (config == nullptr || config->op_offload == SKIPPY_TRISTATE_AUTO) {
++    if (config == nullptr) {
 +        return;
 +    }
-+    params.op_offload = config->op_offload == SKIPPY_TRISTATE_TRUE;
++    if (config->cache_type_k >= 0) {
++        params.type_k = static_cast<ggml_type>(config->cache_type_k);
++    }
++    if (config->cache_type_v >= 0) {
++        params.type_v = static_cast<ggml_type>(config->cache_type_v);
++    }
++    if (config->op_offload != SKIPPY_TRISTATE_AUTO) {
++        params.op_offload = config->op_offload == SKIPPY_TRISTATE_TRUE;
++    }
 +}
 diff --git a/src/skippy/model_load_config_internal.h b/src/skippy/model_load_config_internal.h
 new file mode 100644
@@ -555,7 +563,7 @@ new file mode 100644
 index 000000000..7eb4d5e8c
 --- /dev/null
 +++ b/src/skippy/model_loading.cpp
-@@ -0,0 +1,950 @@
+@@ -0,0 +1,948 @@
 +#include "skippy.h"
 +#include "skippy/errors.h"
 +#include "skippy/environment.h"
@@ -1052,6 +1060,8 @@ index 000000000..7eb4d5e8c
 +
 +struct skippy_runtime_config skippy_runtime_config_default(void) {
 +    struct skippy_runtime_config config = {};
++    config.cache_type_k = GGML_TYPE_F16;
++    config.cache_type_v = GGML_TYPE_F16;
 +    config.kv_offload = SKIPPY_TRISTATE_AUTO;
 +    config.kv_unified = SKIPPY_TRISTATE_AUTO;
 +    config.swa_full = SKIPPY_TRISTATE_AUTO;
@@ -1130,8 +1140,6 @@ index 000000000..7eb4d5e8c
 +        params.swa_full = skippy_resolve_tristate(config->swa_full, params.swa_full);
 +        skippy_apply_context_hardware_config(config, params);
 +    }
-+    params.type_k = config != nullptr && config->cache_type_k > 0 ? static_cast<ggml_type>(config->cache_type_k) : GGML_TYPE_F16;
-+    params.type_v = config != nullptr && config->cache_type_v > 0 ? static_cast<ggml_type>(config->cache_type_v) : GGML_TYPE_F16;
 +    params.flash_attn_type = config != nullptr ? static_cast<llama_flash_attn_type>(config->flash_attn_type) : LLAMA_FLASH_ATTN_TYPE_AUTO;
 +    params.embeddings = config != nullptr && config->filter_tensors_on_load && !config->include_output;
 +    const bool glm_dsa_op_timing_enabled = skippy_glm_dsa_op_timing_enabled();
@@ -1488,8 +1496,6 @@ index 000000000..7eb4d5e8c
 +        ctx_params.swa_full = skippy_resolve_tristate(config->swa_full, ctx_params.swa_full);
 +        skippy_apply_context_hardware_config(config, ctx_params);
 +    }
-+    ctx_params.type_k = config != nullptr && config->cache_type_k > 0 ? static_cast<ggml_type>(config->cache_type_k) : GGML_TYPE_F16;
-+    ctx_params.type_v = config != nullptr && config->cache_type_v > 0 ? static_cast<ggml_type>(config->cache_type_v) : GGML_TYPE_F16;
 +    ctx_params.flash_attn_type = config != nullptr ? static_cast<llama_flash_attn_type>(config->flash_attn_type) : LLAMA_FLASH_ATTN_TYPE_AUTO;
 +
 +    target_model->mtp_ctx = llama_init_from_model(draft_model, ctx_params);
@@ -3123,4 +3129,3 @@ index 000000000..a82b64408
 +};
 -- 
 2.55.0
-

--- a/third_party/llama.cpp/patches/0006-test-skippy-cover-graph-planning-and-stage-contracts.patch
+++ b/third_party/llama.cpp/patches/0006-test-skippy-cover-graph-planning-and-stage-contracts.patch
@@ -682,7 +682,7 @@ new file mode 100644
 index 000000000..1a1bb0ca5
 --- /dev/null
 +++ b/src/skippy/tests/hardware_application_probe.cpp
-@@ -0,0 +1,64 @@
+@@ -0,0 +1,76 @@
 +#include "skippy/model_load_config_internal.h"
 +#include "skippy/runtime.h"
 +
@@ -698,6 +698,10 @@ index 000000000..1a1bb0ca5
 +int main() {
 +    skippy_runtime_config config = skippy_runtime_config_default();
 +    bool passed = true;
++    passed &= require(config.cache_type_k == GGML_TYPE_F16,
++            "default K cache type must be F16");
++    passed &= require(config.cache_type_v == GGML_TYPE_F16,
++            "default V cache type must be F16");
 +    passed &= require(config.kv_offload == SKIPPY_TRISTATE_AUTO,
 +            "default kv_offload must preserve the derived default");
 +    passed &= require(config.kv_unified == SKIPPY_TRISTATE_AUTO,
@@ -736,6 +740,14 @@ index 000000000..1a1bb0ca5
 +    config.op_offload = SKIPPY_TRISTATE_AUTO;
 +    skippy_apply_context_hardware_config(&config, context_params);
 +    passed &= require(context_params.op_offload, "auto op_offload must preserve the derived default");
++
++    config.cache_type_k = GGML_TYPE_F32;
++    config.cache_type_v = GGML_TYPE_F32;
++    skippy_apply_context_hardware_config(&config, context_params);
++    passed &= require(context_params.type_k == GGML_TYPE_F32,
++            "explicit F32 K cache type must not fall back to F16");
++    passed &= require(context_params.type_v == GGML_TYPE_F32,
++            "explicit F32 V cache type must not fall back to F16");
 +
 +    config.op_offload = SKIPPY_TRISTATE_FALSE;
 +    skippy_apply_context_hardware_config(&config, context_params);
@@ -3786,4 +3798,3 @@ index 000000000..380cf4976
 +}
 -- 
 2.55.0
-


### PR DESCRIPTION
The CacheGen acceptance gate can now run the same 19K workload with independently selected K and V cache types, so typed device restore is measured against a matching native control instead of inferred from byte fixtures. That reporting exposed an end-to-end F32 defect: `GGML_TYPE_F32` is enum value zero, and native model loading treated zero as unset and silently created F16 caches. The native mapping now preserves explicit F32 while keeping the public default at F16.

The corrected F32/F32 run and both F32+F16 directions clear every declared local gate. The Q8_0/F32 boundary crossed between one pass and one latency stop, so it remains stopped; the lower-width rows also remain stopped, and Q4_0/Q4_0 expands the stored payload.

| K/V type | CacheGen/native bytes | Agreement | Native TTFT | CacheGen TTFT | Result |
|---|---:|---:|---:|---:|---|
| F32/F32 | 10.25% | 64/64 | 1,199.13 ms | 766.12 ms | pass |
| F32/F16 | 13.67% | 64/64 | 878.61 ms | 686.15 ms | pass |
| F16/F32 | 13.67% | 64/64 | 840.32 ms | 671.93 ms | pass |
| Q8_0/F32 | 20.50% | 64/64 | 800.57 / 727.17 ms | 796.94 / 792.13 ms | unstable: one pass, one latency stop |
| Q8_0/Q8_0 | 50.95% | 64/64 | 333.36 ms | 650.64 ms | latency stop |
| Q4_0/Q4_0 | 103.62% | 61/64 | 189.84 ms | 699.35 ms | size + latency stop |
| Q8_0/F16 | 33.89% | 64/64 | 558.28 ms | 792.05 ms | latency stop |
| Q4_0/F16 | 43.72% | 61/64 | 483.98 ms | 807.03 ms | latency stop |

## Architecture

- Adds `--cache-type-k` and `--cache-type-v` to `skippy-correctness state-handoff` and routes them through local and binary-control model configuration.
- Records the resolved K/V types in the CacheGen report.
- Applies cache types through the shared native context configuration path, keeps `skippy_runtime_config_default()` at F16, and regression-tests explicit F32 value zero.
- Keeps the scalar decoder as the excluded correctness oracle and the native device decoder as the measured restore path.
- Records the exact-head matrix and its limits in the backend plan and a compact JSON artifact.

## Validation

- `cargo test -p skippy-correctness` — full package: 84 passed, 247 ignored, 0 failed.
- Fresh native patch replay plus all 33 native Skippy tests — passed.
- `cargo fmt --all --check` — passed.
- `just no-console-print` — passed.
- Exact-commit (`2e26d46ea87e1b8ee783460998e703f669513f91`) 19K Metal runs for Q8_0/Q8_0, Q4_0/Q4_0, Q8_0/F16, and Q4_0/F16.
- Exact-commit (`74b4f60719d09dee7d9579c1365ac6f95d14c20c`) 19K Metal F32/F32 run: 4,358,144,000 native bytes, 446,903,003 CacheGen bytes, 64/64 agreement, 1,199.13 ms native TTFT, 766.12 ms CacheGen TTFT, and -4.72% p99 regression.
- Exact-commit (`ddddf34aa5e64262c9e113d07f9dcb506e5f7aab`) F32/F16 and F16/F32 passes plus repeated Q8_0/F32 boundary runs. F32/Q8_0 was rejected by the runtime because quantized V requires Flash Attention and this mixed pair has no compatible kernel on the model.
- JSON parse and `git diff --check` — passed at PR head.
