### PR TITLE
perf(ggml-metal): stage CacheGen payloads directly

### DIFF
--- a/docs/skippy/CACHEGEN_BACKEND_PLAN.md
+++ b/docs/skippy/CACHEGEN_BACKEND_PLAN.md
@@ -271,6 +271,25 @@ reconstruction as the next Metal target. F32/Q8_0 is not a valid control on this
 model: llama.cpp requires Flash Attention for quantized V, while that mixed
 cache pair does not have a compatible Flash Attention kernel.
 
+An exact-head Metal staging optimization at
+`e2bdc935e24cbed3bff767762547098db6028459` removes the second host copy that
+previously occurred when each validated job was accumulated in `NSMutableData`
+and then copied into a shared `MTLBuffer`. The backend now sizes and validates a
+job before writing its payload, tile descriptors, and stream prefixes directly
+into the final shared buffers. Q8_0/F32 import fell from 580.45 ms across the two
+boundary runs above to 491.92 ms across two post-change runs, a 15.25% reduction.
+F16/F16 import fell from 540.74 ms to 451.82 ms, a 16.44% reduction. Both cases
+remain stopped on local TTFT: the optimized F16/F16 run took 514.34 ms versus
+343.16 ms native, and the optimized Q8_0/F32 repeats took 713.51/701.97 ms versus
+571.88/547.78 ms native. The remaining gap is device arithmetic decode rather
+than redundant host staging.
+
+A diagnostic 128-row archive doubled tile count from 4,200 to 8,344, expanded
+Q8_0/F32 storage from 20.50% to 30.84% of native, and increased import to
+727.74 ms. Smaller independently decoded tiles therefore do not solve this
+format's Metal crossover; shared calibration with multiple arithmetic
+substreams would require a separate format change.
+
 The quantized K cases expose a consistent quality split: Q8_0 preserves all 64
 greedy continuation tokens, while Q4_0 first diverges at step 15 and finishes at
 61/64, barely above the declared 95% floor. Every completed CacheGen continuation

--- a/docs/skippy/cachegen-metal-typed-qwen3-0.6b-19k-summary.json
+++ b/docs/skippy/cachegen-metal-typed-qwen3-0.6b-19k-summary.json
@@ -5,7 +5,8 @@
   "commits": {
     "quantized_and_mixed": "2e26d46ea87e1b8ee783460998e703f669513f91",
     "f32": "74b4f60719d09dee7d9579c1365ac6f95d14c20c",
-    "f32_mixed_crossover": "ddddf34aa5e64262c9e113d07f9dcb506e5f7aab"
+    "f32_mixed_crossover": "ddddf34aa5e64262c9e113d07f9dcb506e5f7aab",
+    "metal_direct_staging": "e2bdc935e24cbed3bff767762547098db6028459"
   },
   "reference": {
     "implementation": "LMCache CacheGen",
@@ -36,6 +37,32 @@
     "maximum_p99_decode_regression": 0.05,
     "encoded_payload_must_be_smaller_than_native": true,
     "restore_to_first_token_must_beat_native": true
+  },
+  "metal_direct_staging": {
+    "change": "write validated jobs directly into final shared MTLBuffers",
+    "q8_0_f32": {
+      "baseline_cachegen_import_ms": [586.035708, 574.8656669999999],
+      "optimized_cachegen_import_ms": [497.411834, 486.434625],
+      "mean_import_reduction": 0.1525,
+      "optimized_cachegen_ttft_ms": [713.511958, 701.9677919999999],
+      "optimized_native_ttft_ms": [571.8813749999999, 547.7787920000001],
+      "decision": "latency-stop"
+    },
+    "f16_f16": {
+      "baseline_cachegen_import_ms": 540.74,
+      "optimized_cachegen_import_ms": 451.817375,
+      "import_reduction": 0.1644,
+      "optimized_cachegen_ttft_ms": 514.338417,
+      "optimized_native_ttft_ms": 343.15962500000006,
+      "decision": "latency-stop"
+    },
+    "chunk_128_diagnostic": {
+      "tile_count": 8344,
+      "cachegen_storage_bytes": 850615819,
+      "compression_ratio": 0.3084301534362527,
+      "cachegen_import_ms": 727.739791,
+      "decision": "reject-smaller-chunks"
+    }
   },
   "cases": [
     {
@@ -194,6 +221,8 @@
     "Q8_0 cases preserved all 64 greedy continuation tokens; Q4_0 K cases first diverged at step 15 and preserved 61 of 64.",
     "F32/F32 beat its matched native control on this local unified-memory tier; the four sampled quantized and mixed restores were slower.",
     "Q4_0/Q4_0 expanded the native payload by 3.62 percent and therefore failed the storage gate independently of latency.",
-    "The matrix is representative rather than exhaustive; the remaining mixed pairings retain fixture coverage only."
+    "The matrix is representative rather than exhaustive; the remaining mixed pairings retain fixture coverage only.",
+    "Direct Metal staging reduced F16/F16 and Q8_0/F32 import by about 16 percent but did not make either case beat its matched native TTFT control.",
+    "A 128-row diagnostic doubled tile count, worsened compression, and increased import latency; further decoder parallelism needs shared calibration across multiple arithmetic substreams rather than smaller archive tiles."
   ]
 }

--- a/scripts/build-llama.sh
+++ b/scripts/build-llama.sh
@@ -399,6 +399,9 @@ if [[ "$LLAMA_STAGE_FULL_REPLAY" == "ON" ]]; then
     test-skippy-recurrent-state-roundtrip
     test-skippy-verify-checkpoint-retirement
   )
+  if [[ "$LLAMA_BACKEND" == "metal" ]]; then
+    BUILD_TARGETS+=(test-skippy-cachegen-metal)
+  fi
 fi
 
 if [[ "$LLAMA_STAGE_UPSTREAM_TESTS" == "ON" ]]; then

--- a/scripts/tests/test_llama_native_full_replay.py
+++ b/scripts/tests/test_llama_native_full_replay.py
@@ -39,6 +39,7 @@ class LlamaNativeFullReplayTests(unittest.TestCase):
         full_replay: bool,
         upstream_tests: bool = False,
         repeat_cached: bool = False,
+        backend: str = "cpu",
     ) -> list[dict[str, object]]:
         with tempfile.TemporaryDirectory() as temp_dir:
             root = Path(temp_dir)
@@ -123,7 +124,7 @@ class LlamaNativeFullReplayTests(unittest.TestCase):
                 {
                     "LLAMA_WORKDIR": str(llama),
                     "LLAMA_STAGE_BUILD_DIR": str(build),
-                    "LLAMA_STAGE_BACKEND": "cpu",
+                    "LLAMA_STAGE_BACKEND": backend,
                     "LLAMA_STAGE_LINK_MODE": "static",
                     "LLAMA_STAGE_FORCE_BUILD": "1",
                     "LLAMA_STAGE_USE_SCCACHE": "0",
@@ -195,6 +196,12 @@ class LlamaNativeFullReplayTests(unittest.TestCase):
 
         self.assertEqual(len(build_calls), 2)
         self.assertEqual(len(ctest_calls), 2)
+
+    def test_metal_full_replay_builds_cachegen_fixture(self) -> None:
+        trace = self.run_build(full_replay=True, backend="metal")
+        build = next(call for call in trace if call["args"][0] == "--build")
+
+        self.assertIn("test-skippy-cachegen-metal", build["args"])
 
     def test_cached_standard_build_keeps_cache_shortcut(self) -> None:
         trace = self.run_build(full_replay=False, repeat_cached=True)

--- a/third_party/llama.cpp/patches/0033-ggml-metal-stage-CacheGen-directly.patch
+++ b/third_party/llama.cpp/patches/0033-ggml-metal-stage-CacheGen-directly.patch
@@ -1,0 +1,159 @@
+From: scama <a1860575018c4680d5669dd7bc3bd356b478bccb8d42e194df46304a5e25f49a@meshllm.local>
+Date: Fri, 12 Sep 2026 01:00:00 +1000
+Subject: [PATCH] ggml-metal: stage CacheGen payloads directly
+
+Avoid building each CacheGen job in NSMutableData and then copying the same
+bytes again into shared Metal buffers. Validate and size the job first, then
+fill its final MTLBuffers directly.
+---
+ ggml/src/ggml-metal/ggml-metal-device.m | 85 ++++++++++++------------
+ 1 file changed, 43 insertions(+), 42 deletions(-)
+
+diff --git a/ggml/src/ggml-metal/ggml-metal-device.m b/ggml/src/ggml-metal/ggml-metal-device.m
+index 0092c558f..79d40466f 100644
+--- a/ggml/src/ggml-metal/ggml-metal-device.m
++++ b/ggml/src/ggml-metal/ggml-metal-device.m
+@@ -2724,92 +2724,63 @@ bool ggml_metal_cachegen_decode(
+                 }
+             }
+ 
+-            NSMutableData * payload_data = [[NSMutableData alloc] init];
+-            NSMutableData * tile_data = [[NSMutableData alloc] init];
+-            NSMutableData * prefix_data = [[NSMutableData alloc] init];
++            size_t staged_payload_bytes = 0;
++            size_t staged_prefix_count = 0;
+             for (size_t tile_index = 0; tile_index < job->tile_count; ++tile_index) {
+                 const struct ggml_backend_cachegen_tile * tile = &job->tiles[tile_index];
+                 if (tile->payload == NULL || tile->payload_bytes < 16 || tile->token_count == 0 ||
+                         tile->token_offset > job->cell_count || tile->token_count > job->cell_count - tile->token_offset ||
+-                        payload_data.length > UINT32_MAX - 3 ||
+-                        prefix_data.length / sizeof(uint32_t) > UINT32_MAX - ((size_t) job->channels + 1)) {
+-                    [payload_data release];
+-                    [tile_data release];
+-                    [prefix_data release];
++                        staged_payload_bytes > UINT32_MAX - 3 ||
++                        staged_prefix_count > UINT32_MAX - ((size_t) job->channels + 1)) {
+                     [encoder endEncoding];
+                     [temporary_buffers release];
+                     return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen tile exceeds bounded geometry");
+                 }
+-                const size_t aligned_payload_size = (payload_data.length + 3) & ~(size_t) 3;
++                const size_t aligned_payload_size = (staged_payload_bytes + 3) & ~(size_t) 3;
+                 if (tile->payload_bytes > UINT32_MAX - aligned_payload_size) {
+-                    [payload_data release];
+-                    [tile_data release];
+-                    [prefix_data release];
+                     [encoder endEncoding];
+                     [temporary_buffers release];
+                     return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen payload offsets overflow");
+                 }
+-                const uint8_t padding[3] = { 0 };
+-                [payload_data appendBytes:padding length:aligned_payload_size - payload_data.length];
+                 const uint8_t * payload = (const uint8_t *) tile->payload;
+                 const size_t lengths_offset = 16 + (size_t) tile->token_count * sizeof(float) +
+                     (size_t) job->channels * 33 * sizeof(uint16_t);
+                 const size_t streams_offset = lengths_offset + (size_t) job->channels * sizeof(uint16_t);
+                 if (streams_offset > tile->payload_bytes) {
+-                    [payload_data release];
+-                    [tile_data release];
+-                    [prefix_data release];
+                     [encoder endEncoding];
+                     [temporary_buffers release];
+                     return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen tile metadata is truncated");
+                 }
+-                struct ggml_metal_cachegen_tile encoded_tile = {
+-                    (uint32_t) aligned_payload_size,
+-                    (uint32_t) (prefix_data.length / sizeof(uint32_t)),
+-                    tile->token_offset,
+-                    tile->token_count,
+-                };
+                 uint32_t prefix = 0;
+-                [prefix_data appendBytes:&prefix length:sizeof(prefix)];
+                 for (uint32_t channel = 0; channel < job->channels; ++channel) {
+                     const size_t offset = lengths_offset + (size_t) channel * sizeof(uint16_t);
+                     const uint32_t length = (uint32_t) payload[offset] | (uint32_t) payload[offset + 1] << 8;
+                     if (prefix > UINT32_MAX - length) {
+-                        [payload_data release];
+-                        [tile_data release];
+-                        [prefix_data release];
+                         [encoder endEncoding];
+                         [temporary_buffers release];
+                         return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen stream offsets overflow");
+                     }
+                     prefix += length;
+-                    [prefix_data appendBytes:&prefix length:sizeof(prefix)];
+                 }
+                 const uint32_t declared_stream_bytes = (uint32_t) payload[12] |
+                     (uint32_t) payload[13] << 8 | (uint32_t) payload[14] << 16 | (uint32_t) payload[15] << 24;
+                 if (prefix != declared_stream_bytes || prefix != tile->payload_bytes - streams_offset) {
+-                    [payload_data release];
+-                    [tile_data release];
+-                    [prefix_data release];
+                     [encoder endEncoding];
+                     [temporary_buffers release];
+                     return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen stream length is inconsistent");
+                 }
+-                [tile_data appendBytes:&encoded_tile length:sizeof(encoded_tile)];
+-                [payload_data appendBytes:tile->payload length:tile->payload_bytes];
++                staged_payload_bytes = aligned_payload_size + tile->payload_bytes;
++                staged_prefix_count += (size_t) job->channels + 1;
+             }
+ 
+-            id<MTLBuffer> payload_buffer = [device->mtl_device newBufferWithBytes:payload_data.bytes
+-                length:payload_data.length options:MTLResourceStorageModeShared];
+-            id<MTLBuffer> tile_buffer = [device->mtl_device newBufferWithBytes:tile_data.bytes
+-                length:tile_data.length options:MTLResourceStorageModeShared];
+-            id<MTLBuffer> prefix_buffer = [device->mtl_device newBufferWithBytes:prefix_data.bytes
+-                length:prefix_data.length options:MTLResourceStorageModeShared];
++            id<MTLBuffer> payload_buffer = [device->mtl_device newBufferWithLength:staged_payload_bytes
++                options:MTLResourceStorageModeShared];
++            id<MTLBuffer> tile_buffer = [device->mtl_device newBufferWithLength:job->tile_count * sizeof(struct ggml_metal_cachegen_tile)
++                options:MTLResourceStorageModeShared];
++            id<MTLBuffer> prefix_buffer = [device->mtl_device newBufferWithLength:staged_prefix_count * sizeof(uint32_t)
++                options:MTLResourceStorageModeShared];
+             id<MTLBuffer> cell_buffer = [device->mtl_device newBufferWithBytes:job->cells
+                 length:job->cell_count * sizeof(uint32_t) options:MTLResourceStorageModeShared];
+-            [payload_data release];
+-            [tile_data release];
+-            [prefix_data release];
+             if (payload_buffer == nil || tile_buffer == nil || prefix_buffer == nil || cell_buffer == nil) {
+                 [payload_buffer release];
+                 [tile_buffer release];
+@@ -2819,6 +2790,35 @@ bool ggml_metal_cachegen_decode(
+                 [temporary_buffers release];
+                 return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen staging allocation failed");
+             }
++            uint8_t * payload_contents = (uint8_t *) payload_buffer.contents;
++            struct ggml_metal_cachegen_tile * tile_contents =
++                (struct ggml_metal_cachegen_tile *) tile_buffer.contents;
++            uint32_t * prefix_contents = (uint32_t *) prefix_buffer.contents;
++            size_t payload_offset = 0;
++            size_t prefix_offset = 0;
++            for (size_t tile_index = 0; tile_index < job->tile_count; ++tile_index) {
++                const struct ggml_backend_cachegen_tile * tile = &job->tiles[tile_index];
++                const size_t aligned_payload_offset = (payload_offset + 3) & ~(size_t) 3;
++                memset(payload_contents + payload_offset, 0, aligned_payload_offset - payload_offset);
++                memcpy(payload_contents + aligned_payload_offset, tile->payload, tile->payload_bytes);
++                tile_contents[tile_index] = (struct ggml_metal_cachegen_tile) {
++                    (uint32_t) aligned_payload_offset,
++                    (uint32_t) prefix_offset,
++                    tile->token_offset,
++                    tile->token_count,
++                };
++                const uint8_t * payload = (const uint8_t *) tile->payload;
++                const size_t lengths_offset = 16 + (size_t) tile->token_count * sizeof(float) +
++                    (size_t) job->channels * 33 * sizeof(uint16_t);
++                uint32_t prefix = 0;
++                prefix_contents[prefix_offset++] = prefix;
++                for (uint32_t channel = 0; channel < job->channels; ++channel) {
++                    const size_t offset = lengths_offset + (size_t) channel * sizeof(uint16_t);
++                    prefix += (uint32_t) payload[offset] | (uint32_t) payload[offset + 1] << 8;
++                    prefix_contents[prefix_offset++] = prefix;
++                }
++                payload_offset = aligned_payload_offset + tile->payload_bytes;
++            }
+             [temporary_buffers addObject:payload_buffer];
+             [temporary_buffers addObject:tile_buffer];
+             [temporary_buffers addObject:prefix_buffer];
+-- 
+2.52.0


### PR DESCRIPTION
Metal CacheGen restore copied every validated job into `NSMutableData` and then copied the same bytes again into shared `MTLBuffer`s before device decode. This writes payloads, tile descriptors, and stream prefixes directly into their final shared Metal buffers after a sizing/validation pass.

On the 19K Qwen3 0.6B gate, Q8_0/F32 import fell from a 580.45 ms two-run baseline to 491.92 ms across two post-change runs (15.25%). F16/F16 fell from 540.74 ms to 451.82 ms (16.44%). Both still fail the matched local TTFT gate, so promotion remains stopped. A 128-row diagnostic was also rejected: it doubled tile count, worsened compression from 20.50% to 30.84%, and raised import to 727.74 ms.

The change also adds the registered Metal CacheGen fixture to the full-replay build targets. Previously CTest discovered the fixture but the replay script had not built its executable.

Stacked on #1808.

## Validation

- Fresh pinned llama.cpp patch replay passed.
- Metal native full replay: 41/41 tests passed, including `test-skippy-cachegen-metal`.
- Full `skippy-ffi`, `skippy-runtime`, and `skippy-correctness` package suites passed.
- Clippy for all targets in those packages passed with warnings denied.
- Rust formatting, `just no-console-print`, JSON parse, and `git diff --check` passed.
- Exact-head 19K Metal runs preserved 64/64 agreement for Q8_0/F32 and F16/F16.
