### PR TITLE
perf(skippy-cache): decode packed CacheGen symbols on device

### DIFF
--- a/crates/skippy-cache/src/cachegen/archive.rs
+++ b/crates/skippy-cache/src/cachegen/archive.rs
@@ -11,7 +11,7 @@ use anyhow::{Context, Result, anyhow, bail};
 use skippy_protocol::binary::{f16_bits_to_f32, f32_to_f16_bits};
 
 use super::lmcache::{
-    MAX_TOKENS_PER_CHUNK, bins_for_layer, decode_f16_segment, encode_f16_segment,
+    MAX_TOKENS_PER_CHUNK, bins_for_layer, decode_f16_segment, encode_f16_segment_packed,
     validate_f16_segment,
 };
 
@@ -470,7 +470,7 @@ fn encode_component(
                 token_count: rows as u64,
                 token_start: 0,
                 total_tokens: 0,
-                payload: encode_f16_segment(
+                payload: encode_f16_segment_packed(
                     &decode_native_rows_to_f16(component.k_type, tile, rows, k_row)?,
                     k_channels,
                     bins_for_layer(layer, layer_count, true),
@@ -521,7 +521,7 @@ fn encode_component(
                 token_count: rows as u64,
                 token_start,
                 total_tokens,
-                payload: encode_f16_segment(
+                payload: encode_f16_segment_packed(
                     &encoded_input,
                     v_channels,
                     bins_for_layer(layer, layer_count, false),
@@ -957,6 +957,10 @@ mod tests {
         assert_eq!(decoded.len(), raw.len());
         assert_eq!(archive.tile_count, 4);
         assert_ne!(decoded, raw, "fixture must exercise lossy quantization");
+        assert_eq!(
+            &archive.bytes[ARCHIVE_HEADER_BYTES + RECORD_HEADER_BYTES..][..4],
+            b"LCG2"
+        );
     }
 
     #[test]

--- a/crates/skippy-cache/src/cachegen/lmcache.rs
+++ b/crates/skippy-cache/src/cachegen/lmcache.rs
@@ -19,8 +19,11 @@
 //! language-neutral envelope, while preserving the codec inputs and outputs:
 //! per-token maximum magnitude, model/layer-selected 16- or 32-bin symmetric
 //! quantization, a 33-entry per-channel CDF, and one 32-bit arithmetic-coded
-//! stream per channel. Each segment is one K or V layer with at most 256
-//! token-major rows, matching LMCache's CUDA kernel limit.
+//! stream per channel. The scalar oracle retains that byte-compatible LCG1
+//! representation. Device archives use LCG2, which bit-packs the same symbols
+//! in token-major order for direct parallel restore. Each segment is one K or
+//! V layer with at most 256 token-major rows, matching LMCache's CUDA kernel
+//! limit.
 
 use anyhow::{Result, anyhow, bail};
 use skippy_protocol::binary::{f16_bits_to_f32, f32_to_f16_bits};
@@ -28,10 +31,11 @@ use skippy_protocol::binary::{f16_bits_to_f32, f32_to_f16_bits};
 use crate::l3::{CodecClass, SegmentCodecIdentity};
 
 pub const CACHEGEN_CODEC_NAME: &str = "lmcache-cachegen";
-pub const CACHEGEN_CODEC_VERSION: u32 = 1;
+pub const CACHEGEN_CODEC_VERSION: u32 = 2;
 pub const MAX_TOKENS_PER_CHUNK: usize = 256;
 
-const MAGIC: [u8; 4] = *b"LCG1";
+const MAGIC_V1: [u8; 4] = *b"LCG1";
+const MAGIC_V2: [u8; 4] = *b"LCG2";
 const HEADER_LEN: usize = 16;
 const MAX_BINS: usize = 32;
 const CDF_LEN: usize = MAX_BINS + 1;
@@ -46,6 +50,7 @@ struct Parsed<'a> {
     bins: u8,
     channels: usize,
     rows: usize,
+    bits_per_symbol: u8,
     maxes: Vec<f32>,
     cdfs: Vec<[u16; CDF_LEN]>,
     lengths: Vec<usize>,
@@ -126,7 +131,7 @@ pub fn encode_f16_segment(raw: &[u8], channels: usize, bins: u8) -> Result<Vec<u
         .and_then(|value| value.checked_add(channels.checked_mul(2)?))
         .ok_or_else(|| anyhow!("LMCache segment metadata length overflow"))?;
     let mut out = Vec::with_capacity(HEADER_LEN + metadata_len + streams.len());
-    out.extend_from_slice(&MAGIC);
+    out.extend_from_slice(&MAGIC_V1);
     out.push(bins);
     out.push(0);
     out.extend_from_slice(&rows_u16.to_le_bytes());
@@ -147,32 +152,79 @@ pub fn encode_f16_segment(raw: &[u8], channels: usize, bins: u8) -> Result<Vec<u
     Ok(out)
 }
 
-/// Decodes a portable segment produced by [`encode_f16_segment`].
+/// Encodes the LMCache-quantized symbols in a token-major packed layout for
+/// parallel device restore.
+pub fn encode_f16_segment_packed(raw: &[u8], channels: usize, bins: u8) -> Result<Vec<u8>> {
+    validate_input(raw, channels, bins)?;
+    let rows = raw.len() / 2 / channels;
+    if rows > MAX_TOKENS_PER_CHUNK {
+        bail!("LMCache CacheGen chunks are limited to {MAX_TOKENS_PER_CHUNK} tokens, got {rows}");
+    }
+    let values: Vec<f32> = raw
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .map(|bytes| f16_bits_to_f32(u16::from_le_bytes(*bytes)))
+        .collect();
+    if values.iter().any(|value| !value.is_finite()) {
+        bail!("LMCache CacheGen input contains a non-finite F16 value");
+    }
+    let (symbols, maxes) = quantize(&values, rows, channels, bins);
+    let bits_per_symbol = if bins == 16 { 4 } else { 5 };
+    let packed = pack_symbols(&symbols, bits_per_symbol)?;
+    let channels_u32 = u32::try_from(channels).map_err(|_| anyhow!("channel count exceeds u32"))?;
+    let rows_u16 = u16::try_from(rows).expect("row limit fits u16");
+    let packed_len = u32::try_from(packed.len())
+        .map_err(|_| anyhow!("packed CacheGen segment exceeds u32 envelope field"))?;
+    let mut out = Vec::with_capacity(HEADER_LEN + maxes.len() * 4 + packed.len());
+    out.extend_from_slice(&MAGIC_V2);
+    out.push(bins);
+    out.push(bits_per_symbol);
+    out.extend_from_slice(&rows_u16.to_le_bytes());
+    out.extend_from_slice(&channels_u32.to_le_bytes());
+    out.extend_from_slice(&packed_len.to_le_bytes());
+    for value in maxes {
+        out.extend_from_slice(&value.to_bits().to_le_bytes());
+    }
+    out.extend_from_slice(&packed);
+    Ok(out)
+}
+
+/// Decodes a portable segment produced by either encoder.
 pub fn decode_f16_segment(payload: &[u8]) -> Result<Vec<u8>> {
     let parsed = parse(payload)?;
-    let mut symbols = vec![0u8; parsed.rows * parsed.channels];
-    let mut cursor = 0usize;
-    for channel in 0..parsed.channels {
-        let end = cursor
-            .checked_add(parsed.lengths[channel])
-            .ok_or_else(|| anyhow!("LMCache stream range overflow"))?;
-        let stream = parsed
-            .streams
-            .get(cursor..end)
-            .ok_or_else(|| anyhow!("LMCache channel stream exceeds payload"))?;
-        arithmetic_decode_channel(
-            stream,
-            parsed.rows,
-            parsed.channels,
-            channel,
-            &parsed.cdfs[channel],
-            &mut symbols,
-        )?;
-        cursor = end;
-    }
-    if cursor != parsed.streams.len() {
-        bail!("LMCache segment contains trailing stream bytes");
-    }
+    let symbols = if parsed.bits_per_symbol == 0 {
+        let mut symbols = vec![0u8; parsed.rows * parsed.channels];
+        let mut cursor = 0usize;
+        for channel in 0..parsed.channels {
+            let end = cursor
+                .checked_add(parsed.lengths[channel])
+                .ok_or_else(|| anyhow!("LMCache stream range overflow"))?;
+            let stream = parsed
+                .streams
+                .get(cursor..end)
+                .ok_or_else(|| anyhow!("LMCache channel stream exceeds payload"))?;
+            arithmetic_decode_channel(
+                stream,
+                parsed.rows,
+                parsed.channels,
+                channel,
+                &parsed.cdfs[channel],
+                &mut symbols,
+            )?;
+            cursor = end;
+        }
+        if cursor != parsed.streams.len() {
+            bail!("LMCache segment contains trailing stream bytes");
+        }
+        symbols
+    } else {
+        unpack_symbols(
+            parsed.streams,
+            parsed.rows * parsed.channels,
+            parsed.bits_per_symbol,
+        )?
+    };
 
     let center = f32::from(parsed.bins / 2 - 1);
     let max_symbol = parsed.bins - 2;
@@ -193,6 +245,49 @@ pub fn decode_f16_segment(payload: &[u8]) -> Result<Vec<u8>> {
         }
     }
     Ok(raw)
+}
+
+fn pack_symbols(symbols: &[u8], bits_per_symbol: u8) -> Result<Vec<u8>> {
+    let bit_len = symbols
+        .len()
+        .checked_mul(usize::from(bits_per_symbol))
+        .ok_or_else(|| anyhow!("packed CacheGen bit length overflow"))?;
+    let mut packed = vec![0u8; bit_len.div_ceil(8)];
+    let mask = (1u16 << bits_per_symbol) - 1;
+    for (index, &symbol) in symbols.iter().enumerate() {
+        if u16::from(symbol) > mask {
+            bail!("CacheGen symbol does not fit the packed width");
+        }
+        let bit = index * usize::from(bits_per_symbol);
+        let byte = bit / 8;
+        let shift = bit % 8;
+        let value = u16::from(symbol) << shift;
+        packed[byte] |= value as u8;
+        if shift + usize::from(bits_per_symbol) > 8 {
+            packed[byte + 1] |= (value >> 8) as u8;
+        }
+    }
+    Ok(packed)
+}
+
+fn unpack_symbols(packed: &[u8], count: usize, bits_per_symbol: u8) -> Result<Vec<u8>> {
+    let expected_bytes = count
+        .checked_mul(usize::from(bits_per_symbol))
+        .ok_or_else(|| anyhow!("packed CacheGen bit length overflow"))?
+        .div_ceil(8);
+    if packed.len() != expected_bytes {
+        bail!("packed CacheGen byte length is inconsistent");
+    }
+    let mask = (1u16 << bits_per_symbol) - 1;
+    let mut symbols = Vec::with_capacity(count);
+    for index in 0..count {
+        let bit = index * usize::from(bits_per_symbol);
+        let byte = bit / 8;
+        let shift = bit % 8;
+        let word = u16::from(packed[byte]) | u16::from(*packed.get(byte + 1).unwrap_or(&0)) << 8;
+        symbols.push(((word >> shift) & mask) as u8);
+    }
+    Ok(symbols)
 }
 
 /// Validates a portable segment without allocating its decoded F16 output.
@@ -460,11 +555,21 @@ impl<'a> BitReader<'a> {
 }
 
 fn parse(payload: &[u8]) -> Result<Parsed<'_>> {
-    if payload.len() < HEADER_LEN || payload[..4] != MAGIC {
+    if payload.len() < HEADER_LEN || (payload[..4] != MAGIC_V1 && payload[..4] != MAGIC_V2) {
         bail!("not an LMCache CacheGen portable segment");
     }
     let bins = payload[4];
-    if payload[5] != 0 || !matches!(bins, 16 | 32) {
+    let packed = payload[..4] == MAGIC_V2;
+    let bits_per_symbol = if !packed {
+        if payload[5] != 0 {
+            bail!("invalid LMCache CacheGen segment header");
+        }
+        0
+    } else {
+        payload[5]
+    };
+    let expected_bits = if bins == 16 { 4 } else { 5 };
+    if !matches!(bins, 16 | 32) || (packed && bits_per_symbol != expected_bits) {
         bail!("invalid LMCache CacheGen segment header");
     }
     let rows = usize::from(u16::from_le_bytes([payload[6], payload[7]]));
@@ -482,12 +587,20 @@ fn parse(payload: &[u8]) -> Result<Parsed<'_>> {
     let max_bytes = rows
         .checked_mul(4)
         .ok_or_else(|| anyhow!("max metadata overflow"))?;
-    let cdf_bytes = channels
-        .checked_mul(CDF_LEN * 2)
-        .ok_or_else(|| anyhow!("CDF metadata overflow"))?;
-    let length_bytes = channels
-        .checked_mul(2)
-        .ok_or_else(|| anyhow!("length metadata overflow"))?;
+    let cdf_bytes = if bits_per_symbol == 0 {
+        channels
+            .checked_mul(CDF_LEN * 2)
+            .ok_or_else(|| anyhow!("CDF metadata overflow"))?
+    } else {
+        0
+    };
+    let length_bytes = if bits_per_symbol == 0 {
+        channels
+            .checked_mul(2)
+            .ok_or_else(|| anyhow!("length metadata overflow"))?
+    } else {
+        0
+    };
     let metadata_end = HEADER_LEN
         .checked_add(max_bytes)
         .and_then(|value| value.checked_add(cdf_bytes))
@@ -510,6 +623,25 @@ fn parse(payload: &[u8]) -> Result<Parsed<'_>> {
         }
         maxes.push(value);
         cursor += 4;
+    }
+    if bits_per_symbol != 0 {
+        let expected_stream_len = values
+            .checked_mul(usize::from(bits_per_symbol))
+            .ok_or_else(|| anyhow!("packed CacheGen bit length overflow"))?
+            .div_ceil(8);
+        if stream_len != expected_stream_len {
+            bail!("packed CacheGen byte length is inconsistent");
+        }
+        return Ok(Parsed {
+            bins,
+            channels,
+            rows,
+            bits_per_symbol,
+            maxes,
+            cdfs: Vec::new(),
+            lengths: Vec::new(),
+            streams: &payload[cursor..],
+        });
     }
     let mut cdfs = Vec::with_capacity(channels);
     for _ in 0..channels {
@@ -543,6 +675,7 @@ fn parse(payload: &[u8]) -> Result<Parsed<'_>> {
         bins,
         channels,
         rows,
+        bits_per_symbol,
         maxes,
         cdfs,
         lengths,
@@ -602,6 +735,21 @@ mod tests {
     }
 
     #[test]
+    fn packed_segment_preserves_lmcache_quantized_values() {
+        let raw = input(64, 8);
+        for bins in [16, 32] {
+            let oracle = encode_f16_segment(&raw, 8, bins).expect("oracle encode");
+            let packed = encode_f16_segment_packed(&raw, 8, bins).expect("packed encode");
+            assert_eq!(&packed[..4], b"LCG2");
+            assert_eq!(packed[5], if bins == 16 { 4 } else { 5 });
+            assert_eq!(
+                decode_f16_segment(&packed).expect("packed decode"),
+                decode_f16_segment(&oracle).expect("oracle decode")
+            );
+        }
+    }
+
+    #[test]
     fn flat_rows_restore_exactly() {
         let mut raw = Vec::new();
         for value in [0.0f32, 0.5, -0.75] {
@@ -622,6 +770,12 @@ mod tests {
         let cdf_start = HEADER_LEN + 8 * 4;
         bad_cdf[cdf_start + 2..cdf_start + 4].copy_from_slice(&0u16.to_le_bytes());
         assert!(decode_f16_segment(&bad_cdf).is_err());
+
+        let packed = encode_f16_segment_packed(&raw, 4, 32).expect("packed encode");
+        assert!(decode_f16_segment(&packed[..packed.len() - 1]).is_err());
+        let mut bad_width = packed;
+        bad_width[5] = 4;
+        assert!(decode_f16_segment(&bad_width).is_err());
     }
 
     fn assert_lmcache_fixture(fixture: &[u8], bins: u8) {

--- a/third_party/llama.cpp/patches/0034-ggml-decode-packed-CacheGen-symbols-on-device.patch
+++ b/third_party/llama.cpp/patches/0034-ggml-decode-packed-CacheGen-symbols-on-device.patch
@@ -1,0 +1,581 @@
+From 9253c686456c6f90182cd49094c96ec1cb9291c3 Mon Sep 17 00:00:00 2001
+From: Mesh-LLM CI <ci@mesh-llm.local>
+Date: Sat, 12 Sep 2026 05:42:09 +1000
+Subject: [PATCH] ggml: decode packed CacheGen symbols on device
+
+---
+ ggml/src/ggml-cuda/cachegen.cu             | 52 ++++++++++----
+ ggml/src/ggml-cuda/ggml-cuda.cu            | 76 +++++++++++++-------
+ ggml/src/ggml-metal/ggml-metal-device.m    | 82 +++++++++++++++-------
+ ggml/src/ggml-metal/kernels/cachegen.metal | 55 +++++++++++----
+ src/llama-kv-cache.cpp                     | 45 +++++++++---
+ tests/test-skippy-cachegen-metal.cpp       | 40 ++++++++++-
+ 6 files changed, 261 insertions(+), 89 deletions(-)
+
+diff --git a/ggml/src/ggml-cuda/cachegen.cu b/ggml/src/ggml-cuda/cachegen.cu
+index fa5683788..685dc586a 100644
+--- a/ggml/src/ggml-cuda/cachegen.cu
++++ b/ggml/src/ggml-cuda/cachegen.cu
+@@ -63,28 +63,53 @@ static __global__ void cachegen_decode(
+     const ggml_cuda_cachegen_tile tile = tiles[tile_index];
+     const uint8_t * segment            = payload + tile.payload_offset;
+     const uint32_t bins                = segment[4];
++    const bool packed                  = segment[3] == '2';
+     const float * maxes                = reinterpret_cast<const float *>(segment + 16);
+-    const uint16_t * cdfs = reinterpret_cast<const uint16_t *>(segment + 16 + tile.rows * sizeof(float));
+-    const uint16_t * cdf  = cdfs + channel * 33;
+-    const uint32_t prefix_index = tile.prefix_offset + channel;
+-    const uint32_t stream_start = prefixes[prefix_index];
+-    const uint32_t stream_bytes = prefixes[prefix_index + 1] - stream_start;
+-    const uint32_t lengths_offset = 16 + tile.rows * sizeof(float) + channels * 33 * sizeof(uint16_t);
+-    const uint32_t streams_offset = lengths_offset + channels * sizeof(uint16_t);
+-    const uint8_t * stream = segment + streams_offset + stream_start;
++    const uint16_t * cdf = nullptr;
++    const uint8_t * stream = nullptr;
++    uint32_t stream_bytes = 0;
++    if (packed) {
++        stream = segment + 16 + tile.rows * sizeof(float);
++        stream_bytes = uint32_t(segment[12]) | uint32_t(segment[13]) << 8 |
++            uint32_t(segment[14]) << 16 | uint32_t(segment[15]) << 24;
++    } else {
++        const uint16_t * cdfs = reinterpret_cast<const uint16_t *>(segment + 16 + tile.rows * sizeof(float));
++        cdf = cdfs + channel * 33;
++        const uint32_t prefix_index = tile.prefix_offset + channel;
++        const uint32_t stream_start = prefixes[prefix_index];
++        stream_bytes = prefixes[prefix_index + 1] - stream_start;
++        const uint32_t lengths_offset = 16 + tile.rows * sizeof(float) + channels * 33 * sizeof(uint16_t);
++        const uint32_t streams_offset = lengths_offset + channels * sizeof(uint16_t);
++        stream = segment + streams_offset + stream_start;
++    }
+ 
+     uint32_t bit   = 0;
+     uint32_t value = 0;
+-    for (uint32_t i = 0; i < 32; ++i) {
+-        value = (value << 1) | cachegen_read_bit(stream, stream_bytes, bit);
++    if (!packed) {
++        for (uint32_t i = 0; i < 32; ++i) {
++            value = (value << 1) | cachegen_read_bit(stream, stream_bytes, bit);
++        }
+     }
+     uint32_t low    = 0;
+     uint32_t high   = 0xffffffffu;
+     const float center = float(bins / 2 - 1);
+     for (uint32_t row = 0; row < tile.rows; ++row) {
+         const uint64_t span = uint64_t(high) - uint64_t(low) + 1;
+-        const uint16_t count  = cachegen_scaled_count(value, low, span);
+-        const uint32_t symbol = cachegen_find_symbol(cdf, count);
++        uint32_t symbol;
++        if (packed) {
++            const uint32_t bits_per_symbol = segment[5];
++            const uint64_t symbol_bit = (uint64_t(row) * channels + channel) * bits_per_symbol;
++            const uint64_t byte_index = symbol_bit >> 3;
++            const uint32_t shift = symbol_bit & 7;
++            uint32_t word = stream[byte_index];
++            if (shift + bits_per_symbol > 8) {
++                word |= uint32_t(stream[byte_index + 1]) << 8;
++            }
++            symbol = (word >> shift) & ((1u << bits_per_symbol) - 1);
++        } else {
++            const uint16_t count = cachegen_scaled_count(value, low, span);
++            symbol = cachegen_find_symbol(cdf, count);
++        }
+         if (symbol >= 32) {
+             return;
+         }
+@@ -143,6 +168,9 @@ static __global__ void cachegen_decode(
+         if (row + 1 == tile.rows) {
+             break;
+         }
++        if (packed) {
++            continue;
++        }
+         const uint64_t cdf_low  = cdf[symbol];
+         const uint64_t cdf_high = symbol == 31 ? 65536ull : cdf[symbol + 1];
+         high = low - 1 + uint32_t((span * cdf_high) >> 16);
+diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
+index b68649ec4..ccfda8a9d 100644
+--- a/ggml/src/ggml-cuda/ggml-cuda.cu
++++ b/ggml/src/ggml-cuda/ggml-cuda.cu
+@@ -5814,7 +5814,7 @@ static bool ggml_cuda_cachegen_decode(
+             for (size_t tile_index = 0; tile_index < job->tile_count; ++tile_index) {
+                 const struct ggml_backend_cachegen_tile * tile = &job->tiles[tile_index];
+                 if (tile->payload == nullptr || tile->payload_bytes < 16 || tile->payload_bytes > UINT32_MAX ||
+-                        tile->token_count == 0 || tile->token_offset > job->cell_count ||
++                        tile->token_count == 0 || tile->token_count > 256 || tile->token_offset > job->cell_count ||
+                         tile->token_count > job->cell_count - tile->token_offset ||
+                         staged.payload.size() > UINT32_MAX - 3 ||
+                         staged.prefixes.size() > UINT32_MAX - (static_cast<size_t>(job->channels) + 1)) {
+@@ -5830,41 +5830,67 @@ static bool ggml_cuda_cachegen_decode(
+                 staged.payload.resize(aligned_payload_size, 0);
+ 
+                 const uint8_t * payload = static_cast<const uint8_t *>(tile->payload);
+-                const uint64_t streams_offset_u64 = 16ull + static_cast<uint64_t>(tile->token_count) * sizeof(float) +
+-                    static_cast<uint64_t>(job->channels) * 33 * sizeof(uint16_t) +
+-                    static_cast<uint64_t>(job->channels) * sizeof(uint16_t);
+-                if (streams_offset_u64 > tile->payload_bytes || streams_offset_u64 > UINT32_MAX) {
++                const bool packed = memcmp(payload, "LCG2", 4) == 0;
++                const uint32_t bins = payload[4];
++                const uint32_t expected_bits = bins == 16 ? 4 : 5;
++                const uint32_t header_rows = static_cast<uint32_t>(payload[6]) |
++                    static_cast<uint32_t>(payload[7]) << 8;
++                const uint32_t header_channels = static_cast<uint32_t>(payload[8]) |
++                    static_cast<uint32_t>(payload[9]) << 8 | static_cast<uint32_t>(payload[10]) << 16 |
++                    static_cast<uint32_t>(payload[11]) << 24;
++                if ((!packed && memcmp(payload, "LCG1", 4) != 0) || (bins != 16 && bins != 32) ||
++                        (packed ? payload[5] != expected_bits : payload[5] != 0) ||
++                        header_rows != tile->token_count || header_channels != job->channels) {
+                     return ggml_cuda_cachegen_error(
+-                        error, error_capacity, "CUDA/HIP CacheGen tile metadata is truncated");
++                        error, error_capacity, "CUDA/HIP CacheGen tile header is inconsistent");
+                 }
+-                const size_t lengths_offset = static_cast<size_t>(streams_offset_u64) -
+-                    static_cast<size_t>(job->channels) * sizeof(uint16_t);
+-                const size_t streams_offset = static_cast<size_t>(streams_offset_u64);
+                 const ggml_cuda_cachegen_tile encoded_tile = {
+                     static_cast<uint32_t>(staged.payload.size()),
+                     static_cast<uint32_t>(staged.prefixes.size()),
+                     tile->token_offset,
+                     tile->token_count,
+                 };
+-                uint32_t prefix = 0;
+-                staged.prefixes.push_back(prefix);
+-                for (uint32_t channel = 0; channel < job->channels; ++channel) {
+-                    const size_t offset = lengths_offset + static_cast<size_t>(channel) * sizeof(uint16_t);
+-                    const uint32_t length = static_cast<uint32_t>(payload[offset]) |
+-                        static_cast<uint32_t>(payload[offset + 1]) << 8;
+-                    if (prefix > UINT32_MAX - length) {
+-                        return ggml_cuda_cachegen_error(
+-                            error, error_capacity, "CUDA/HIP CacheGen stream offsets overflow");
+-                    }
+-                    prefix += length;
+-                    staged.prefixes.push_back(prefix);
+-                }
+                 const uint32_t declared_stream_bytes = static_cast<uint32_t>(payload[12]) |
+                     static_cast<uint32_t>(payload[13]) << 8 | static_cast<uint32_t>(payload[14]) << 16 |
+                     static_cast<uint32_t>(payload[15]) << 24;
+-                if (prefix != declared_stream_bytes || prefix != tile->payload_bytes - streams_offset) {
+-                    return ggml_cuda_cachegen_error(
+-                        error, error_capacity, "CUDA/HIP CacheGen stream length is inconsistent");
++                staged.prefixes.push_back(0);
++                if (packed) {
++                    const uint64_t values = static_cast<uint64_t>(tile->token_count) * job->channels;
++                    const uint64_t expected_stream_bytes = (values * expected_bits + 7) / 8;
++                    const size_t streams_offset = 16 + static_cast<size_t>(tile->token_count) * sizeof(float);
++                    if (expected_stream_bytes > UINT32_MAX || streams_offset > tile->payload_bytes ||
++                            declared_stream_bytes != expected_stream_bytes ||
++                            declared_stream_bytes != tile->payload_bytes - streams_offset) {
++                        return ggml_cuda_cachegen_error(
++                            error, error_capacity, "CUDA/HIP CacheGen packed length is inconsistent");
++                    }
++                } else {
++                    const uint64_t streams_offset_u64 = 16ull + static_cast<uint64_t>(tile->token_count) * sizeof(float) +
++                        static_cast<uint64_t>(job->channels) * 33 * sizeof(uint16_t) +
++                        static_cast<uint64_t>(job->channels) * sizeof(uint16_t);
++                    if (streams_offset_u64 > tile->payload_bytes || streams_offset_u64 > UINT32_MAX) {
++                        return ggml_cuda_cachegen_error(
++                            error, error_capacity, "CUDA/HIP CacheGen tile metadata is truncated");
++                    }
++                    const size_t lengths_offset = static_cast<size_t>(streams_offset_u64) -
++                        static_cast<size_t>(job->channels) * sizeof(uint16_t);
++                    const size_t streams_offset = static_cast<size_t>(streams_offset_u64);
++                    uint32_t prefix = 0;
++                    for (uint32_t channel = 0; channel < job->channels; ++channel) {
++                        const size_t offset = lengths_offset + static_cast<size_t>(channel) * sizeof(uint16_t);
++                        const uint32_t length = static_cast<uint32_t>(payload[offset]) |
++                            static_cast<uint32_t>(payload[offset + 1]) << 8;
++                        if (prefix > UINT32_MAX - length) {
++                            return ggml_cuda_cachegen_error(
++                                error, error_capacity, "CUDA/HIP CacheGen stream offsets overflow");
++                        }
++                        prefix += length;
++                        staged.prefixes.push_back(prefix);
++                    }
++                    if (prefix != declared_stream_bytes || prefix != tile->payload_bytes - streams_offset) {
++                        return ggml_cuda_cachegen_error(
++                            error, error_capacity, "CUDA/HIP CacheGen stream length is inconsistent");
++                    }
+                 }
+                 staged.tiles.push_back(encoded_tile);
+                 staged.payload.insert(staged.payload.end(), payload, payload + tile->payload_bytes);
+diff --git a/ggml/src/ggml-metal/ggml-metal-device.m b/ggml/src/ggml-metal/ggml-metal-device.m
+index 79d40466f..2a38e0d4b 100644
+--- a/ggml/src/ggml-metal/ggml-metal-device.m
++++ b/ggml/src/ggml-metal/ggml-metal-device.m
+@@ -2686,6 +2686,7 @@ bool ggml_metal_cachegen_decode(
+                 (job->dst->type == GGML_TYPE_Q8_0 || job->dst->type == GGML_TYPE_Q4_0);
+             if (job->dst == NULL || job->dst->buffer == NULL || job->tiles == NULL || job->tile_count == 0 ||
+                     job->tile_count > UINT32_MAX || job->cells == NULL || job->cell_count == 0 || job->channels == 0 ||
++                    job->channels == UINT32_MAX ||
+                     (job->dst->type != GGML_TYPE_F16 && job->dst->type != GGML_TYPE_F32 &&
+                      job->dst->type != GGML_TYPE_Q8_0 && job->dst->type != GGML_TYPE_Q4_0) ||
+                     (quantized && job->channels % 32 != 0) ||
+@@ -2729,6 +2730,7 @@ bool ggml_metal_cachegen_decode(
+             for (size_t tile_index = 0; tile_index < job->tile_count; ++tile_index) {
+                 const struct ggml_backend_cachegen_tile * tile = &job->tiles[tile_index];
+                 if (tile->payload == NULL || tile->payload_bytes < 16 || tile->token_count == 0 ||
++                        tile->token_count > 256 ||
+                         tile->token_offset > job->cell_count || tile->token_count > job->cell_count - tile->token_offset ||
+                         staged_payload_bytes > UINT32_MAX - 3 ||
+                         staged_prefix_count > UINT32_MAX - ((size_t) job->channels + 1)) {
+@@ -2743,34 +2745,60 @@ bool ggml_metal_cachegen_decode(
+                     return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen payload offsets overflow");
+                 }
+                 const uint8_t * payload = (const uint8_t *) tile->payload;
+-                const size_t lengths_offset = 16 + (size_t) tile->token_count * sizeof(float) +
+-                    (size_t) job->channels * 33 * sizeof(uint16_t);
+-                const size_t streams_offset = lengths_offset + (size_t) job->channels * sizeof(uint16_t);
+-                if (streams_offset > tile->payload_bytes) {
++                const bool packed = memcmp(payload, "LCG2", 4) == 0;
++                const uint32_t bins = payload[4];
++                const uint32_t expected_bits = bins == 16 ? 4 : 5;
++                const uint32_t header_rows = (uint32_t) payload[6] | (uint32_t) payload[7] << 8;
++                const uint32_t header_channels = (uint32_t) payload[8] | (uint32_t) payload[9] << 8 |
++                    (uint32_t) payload[10] << 16 | (uint32_t) payload[11] << 24;
++                if ((!packed && memcmp(payload, "LCG1", 4) != 0) || (bins != 16 && bins != 32) ||
++                        (packed ? payload[5] != expected_bits : payload[5] != 0) ||
++                        header_rows != tile->token_count || header_channels != job->channels) {
+                     [encoder endEncoding];
+                     [temporary_buffers release];
+-                    return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen tile metadata is truncated");
++                    return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen tile header is inconsistent");
+                 }
+-                uint32_t prefix = 0;
+-                for (uint32_t channel = 0; channel < job->channels; ++channel) {
+-                    const size_t offset = lengths_offset + (size_t) channel * sizeof(uint16_t);
+-                    const uint32_t length = (uint32_t) payload[offset] | (uint32_t) payload[offset + 1] << 8;
+-                    if (prefix > UINT32_MAX - length) {
++                const uint32_t declared_stream_bytes = (uint32_t) payload[12] |
++                    (uint32_t) payload[13] << 8 | (uint32_t) payload[14] << 16 | (uint32_t) payload[15] << 24;
++                if (packed) {
++                    const uint64_t values = (uint64_t) tile->token_count * job->channels;
++                    const uint64_t expected_stream_bytes = (values * expected_bits + 7) / 8;
++                    const size_t streams_offset = 16 + (size_t) tile->token_count * sizeof(float);
++                    if (expected_stream_bytes > UINT32_MAX || streams_offset > tile->payload_bytes ||
++                            declared_stream_bytes != expected_stream_bytes ||
++                            declared_stream_bytes != tile->payload_bytes - streams_offset) {
+                         [encoder endEncoding];
+                         [temporary_buffers release];
+-                        return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen stream offsets overflow");
++                        return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen packed length is inconsistent");
++                    }
++                } else {
++                    const size_t lengths_offset = 16 + (size_t) tile->token_count * sizeof(float) +
++                        (size_t) job->channels * 33 * sizeof(uint16_t);
++                    const size_t streams_offset = lengths_offset + (size_t) job->channels * sizeof(uint16_t);
++                    if (streams_offset > tile->payload_bytes) {
++                        [encoder endEncoding];
++                        [temporary_buffers release];
++                        return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen tile metadata is truncated");
++                    }
++                    uint32_t prefix = 0;
++                    for (uint32_t channel = 0; channel < job->channels; ++channel) {
++                        const size_t offset = lengths_offset + (size_t) channel * sizeof(uint16_t);
++                        const uint32_t length = (uint32_t) payload[offset] | (uint32_t) payload[offset + 1] << 8;
++                        if (prefix > UINT32_MAX - length) {
++                            [encoder endEncoding];
++                            [temporary_buffers release];
++                            return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen stream offsets overflow");
++                        }
++                        prefix += length;
++                    }
++                    if (prefix != declared_stream_bytes || prefix != tile->payload_bytes - streams_offset) {
++                        [encoder endEncoding];
++                        [temporary_buffers release];
++                        return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen stream length is inconsistent");
+                     }
+-                    prefix += length;
+-                }
+-                const uint32_t declared_stream_bytes = (uint32_t) payload[12] |
+-                    (uint32_t) payload[13] << 8 | (uint32_t) payload[14] << 16 | (uint32_t) payload[15] << 24;
+-                if (prefix != declared_stream_bytes || prefix != tile->payload_bytes - streams_offset) {
+-                    [encoder endEncoding];
+-                    [temporary_buffers release];
+-                    return ggml_metal_cachegen_error(error, error_capacity, "Metal CacheGen stream length is inconsistent");
+                 }
+                 staged_payload_bytes = aligned_payload_size + tile->payload_bytes;
+-                staged_prefix_count += (size_t) job->channels + 1;
++                staged_prefix_count += packed ? 1 : (size_t) job->channels + 1;
+             }
+ 
+             id<MTLBuffer> payload_buffer = [device->mtl_device newBufferWithLength:staged_payload_bytes
+@@ -2808,14 +2836,16 @@ bool ggml_metal_cachegen_decode(
+                     tile->token_count,
+                 };
+                 const uint8_t * payload = (const uint8_t *) tile->payload;
+-                const size_t lengths_offset = 16 + (size_t) tile->token_count * sizeof(float) +
+-                    (size_t) job->channels * 33 * sizeof(uint16_t);
+                 uint32_t prefix = 0;
+                 prefix_contents[prefix_offset++] = prefix;
+-                for (uint32_t channel = 0; channel < job->channels; ++channel) {
+-                    const size_t offset = lengths_offset + (size_t) channel * sizeof(uint16_t);
+-                    prefix += (uint32_t) payload[offset] | (uint32_t) payload[offset + 1] << 8;
+-                    prefix_contents[prefix_offset++] = prefix;
++                if (memcmp(payload, "LCG2", 4) != 0) {
++                    const size_t lengths_offset = 16 + (size_t) tile->token_count * sizeof(float) +
++                        (size_t) job->channels * 33 * sizeof(uint16_t);
++                    for (uint32_t channel = 0; channel < job->channels; ++channel) {
++                        const size_t offset = lengths_offset + (size_t) channel * sizeof(uint16_t);
++                        prefix += (uint32_t) payload[offset] | (uint32_t) payload[offset + 1] << 8;
++                        prefix_contents[prefix_offset++] = prefix;
++                    }
+                 }
+                 payload_offset = aligned_payload_offset + tile->payload_bytes;
+             }
+diff --git a/ggml/src/ggml-metal/kernels/cachegen.metal b/ggml/src/ggml-metal/kernels/cachegen.metal
+index 18c0a0fb4..728899e4b 100644
+--- a/ggml/src/ggml-metal/kernels/cachegen.metal
++++ b/ggml/src/ggml-metal/kernels/cachegen.metal
+@@ -71,28 +71,54 @@ kernel void kernel_cachegen_decode(const device uchar *         payload [[buffer
+     const cachegen_tile   tile    = tiles[tile_index];
+     const device uchar *  segment = payload + tile.payload_offset;
+     const uint            bins    = segment[4];
++    const bool            packed  = segment[3] == '2';
+     const device float *  maxes   = reinterpret_cast<const device float *>(segment + 16);
+-    const device ushort * cdfs    = reinterpret_cast<const device ushort *>(segment + 16 + tile.rows * sizeof(float));
+-    const device ushort * cdf     = cdfs + channel * 33;
+-    const uint            prefix_index   = tile.prefix_offset + channel;
+-    const uint            stream_start   = prefixes[prefix_index];
+-    const uint            stream_bytes   = prefixes[prefix_index + 1] - stream_start;
+-    const uint            lengths_offset = 16 + tile.rows * sizeof(float) + params.channels * 33 * sizeof(ushort);
+-    const uint            streams_offset = lengths_offset + params.channels * sizeof(ushort);
+-    const device uchar *  stream         = segment + streams_offset + stream_start;
++    const device ushort * cdf     = nullptr;
++    const device uchar *  stream  = nullptr;
++    uint                  stream_bytes = 0;
++    if (packed) {
++        stream       = segment + 16 + tile.rows * sizeof(float);
++        stream_bytes = uint(segment[12]) | uint(segment[13]) << 8 |
++                       uint(segment[14]) << 16 | uint(segment[15]) << 24;
++    } else {
++        const device ushort * cdfs =
++            reinterpret_cast<const device ushort *>(segment + 16 + tile.rows * sizeof(float));
++        cdf = cdfs + channel * 33;
++        const uint prefix_index   = tile.prefix_offset + channel;
++        const uint stream_start   = prefixes[prefix_index];
++        stream_bytes              = prefixes[prefix_index + 1] - stream_start;
++        const uint lengths_offset = 16 + tile.rows * sizeof(float) + params.channels * 33 * sizeof(ushort);
++        const uint streams_offset = lengths_offset + params.channels * sizeof(ushort);
++        stream = segment + streams_offset + stream_start;
++    }
+ 
+     uint bit   = 0;
+     uint value = 0;
+-    for (uint i = 0; i < 32; ++i) {
+-        value = (value << 1) | cachegen_read_bit(stream, stream_bytes, bit);
++    if (!packed) {
++        for (uint i = 0; i < 32; ++i) {
++            value = (value << 1) | cachegen_read_bit(stream, stream_bytes, bit);
++        }
+     }
+     uint        low    = 0;
+     uint        high   = 0xffffffffu;
+     const float center = float(bins / 2 - 1);
+     for (uint row = 0; row < tile.rows; ++row) {
+-        const ulong  span   = ulong(high) - ulong(low) + 1;
+-        const ushort count  = cachegen_scaled_count(value, low, span);
+-        const uint   symbol = cachegen_find_symbol(cdf, count);
++        const ulong span = ulong(high) - ulong(low) + 1;
++        uint symbol;
++        if (packed) {
++            const uint bits_per_symbol = segment[5];
++            const ulong symbol_bit = (ulong(row) * params.channels + channel) * bits_per_symbol;
++            const ulong byte_index = symbol_bit >> 3;
++            const uint shift = symbol_bit & 7;
++            uint word = stream[byte_index];
++            if (shift + bits_per_symbol > 8) {
++                word |= uint(stream[byte_index + 1]) << 8;
++            }
++            symbol = (word >> shift) & ((1u << bits_per_symbol) - 1);
++        } else {
++            const ushort count = cachegen_scaled_count(value, low, span);
++            symbol = cachegen_find_symbol(cdf, count);
++        }
+         if (symbol >= 32) {
+             return;
+         }
+@@ -144,6 +170,9 @@ kernel void kernel_cachegen_decode(const device uchar *         payload [[buffer
+         if (row + 1 == tile.rows) {
+             break;
+         }
++        if (packed) {
++            continue;
++        }
+         const ulong cdf_low  = cdf[symbol];
+         const ulong cdf_high = symbol == 31 ? 65536ul : cdf[symbol + 1];
+         high                 = low - 1 + uint((span * cdf_high) >> 16);
+diff --git a/src/llama-kv-cache.cpp b/src/llama-kv-cache.cpp
+index 215076924..dad99f62a 100644
+--- a/src/llama-kv-cache.cpp
++++ b/src/llama-kv-cache.cpp
+@@ -1985,7 +1985,11 @@ static bool skippy_cachegen_validate_segment(const skippy_cachegen_record_v1 & r
+         error = "invalid CacheGen record descriptor";
+         return false;
+     }
+-    if (std::memcmp(payload, "LCG1", 4) != 0 || payload[5] != 0 || (payload[4] != 16 && payload[4] != 32) ||
++    const bool packed = std::memcmp(payload, "LCG2", 4) == 0;
++    const uint8_t expected_bits = payload[4] == 16 ? 4 : 5;
++    if ((!packed && std::memcmp(payload, "LCG1", 4) != 0) ||
++        (packed ? payload[5] != expected_bits : payload[5] != 0) ||
++        (payload[4] != 16 && payload[4] != 32) ||
+         skippy_cachegen_read_u16(payload + 6) != expected_rows ||
+         skippy_cachegen_read_u32(payload + 8) != expected_channels) {
+         error = "CacheGen record disagrees with its segment header";
+@@ -1998,6 +2002,35 @@ static bool skippy_cachegen_validate_segment(const skippy_cachegen_record_v1 & r
+         return false;
+     }
+     const size_t max_bytes = expected_rows * sizeof(float);
++    if (header_bytes > std::numeric_limits<size_t>::max() - max_bytes ||
++        header_bytes + max_bytes > record.payload_bytes) {
++        error = "CacheGen segment maximum metadata is truncated";
++        return false;
++    }
++    for (size_t row = 0; row < expected_rows; ++row) {
++        const uint32_t bits = skippy_cachegen_read_u32(payload + header_bytes + row * sizeof(float));
++        float          value;
++        std::memcpy(&value, &bits, sizeof(value));
++        if (!std::isfinite(value) || value < 0.0f) {
++            error = "CacheGen segment contains an invalid row maximum";
++            return false;
++        }
++    }
++    const size_t stream_bytes = skippy_cachegen_read_u32(payload + 12);
++    if (packed) {
++        const size_t values = expected_rows * expected_channels;
++        if (values > (std::numeric_limits<size_t>::max() - 7) / expected_bits) {
++            error = "CacheGen packed segment length overflows";
++            return false;
++        }
++        const size_t expected_stream_bytes = (values * expected_bits + 7) / 8;
++        if (stream_bytes != expected_stream_bytes ||
++            stream_bytes != record.payload_bytes - (header_bytes + max_bytes)) {
++            error = "CacheGen packed segment length is inconsistent";
++            return false;
++        }
++        return true;
++    }
+     if (expected_channels > std::numeric_limits<size_t>::max() / (cdf_entries * sizeof(uint16_t)) ||
+         expected_channels > std::numeric_limits<size_t>::max() / sizeof(uint16_t)) {
+         error = "CacheGen segment metadata overflows";
+@@ -2014,20 +2047,10 @@ static bool skippy_cachegen_validate_segment(const skippy_cachegen_record_v1 & r
+     const size_t cdf_offset    = header_bytes + max_bytes;
+     const size_t length_offset = cdf_offset + cdf_bytes;
+     const size_t stream_offset = length_offset + length_bytes;
+-    const size_t stream_bytes  = skippy_cachegen_read_u32(payload + 12);
+     if (stream_offset > record.payload_bytes || stream_bytes != record.payload_bytes - stream_offset) {
+         error = "CacheGen segment stream length is inconsistent";
+         return false;
+     }
+-    for (size_t row = 0; row < expected_rows; ++row) {
+-        const uint32_t bits = skippy_cachegen_read_u32(payload + header_bytes + row * sizeof(float));
+-        float          value;
+-        std::memcpy(&value, &bits, sizeof(value));
+-        if (!std::isfinite(value) || value < 0.0f) {
+-            error = "CacheGen segment contains an invalid row maximum";
+-            return false;
+-        }
+-    }
+     for (size_t channel = 0; channel < expected_channels; ++channel) {
+         const uint8_t * cdf      = payload + cdf_offset + channel * cdf_entries * sizeof(uint16_t);
+         uint16_t        previous = skippy_cachegen_read_u16(cdf);
+diff --git a/tests/test-skippy-cachegen-metal.cpp b/tests/test-skippy-cachegen-metal.cpp
+index b7caf2adc..b15b5e53a 100644
+--- a/tests/test-skippy-cachegen-metal.cpp
++++ b/tests/test-skippy-cachegen-metal.cpp
+@@ -92,6 +92,19 @@ static const uint8_t encoded16[] = {
+     0xf8, 0x88, 0xfe, 0xfc, 0x5d, 0xf0,
+ };
+ 
++static const uint8_t encoded16_packed[] = {
++    0x4c, 0x43, 0x47, 0x32, 0x10, 0x04, 0x11, 0x00, 0x08, 0x00, 0x00, 0x00, 0x44, 0x00, 0x00, 0x00,
++    0x00, 0xa0, 0x66, 0x3e, 0x00, 0x80, 0xcd, 0x3e, 0x00, 0x60, 0x0e, 0x3f, 0x00, 0x40, 0x2e, 0x3f,
++    0x00, 0x40, 0x44, 0x3f, 0x00, 0x00, 0x4f, 0x3f, 0x00, 0xe0, 0x4d, 0x3f, 0x00, 0x00, 0x41, 0x3f,
++    0x00, 0x20, 0x29, 0x3f, 0x00, 0xa0, 0x09, 0x3f, 0x00, 0xe0, 0xcd, 0x3e, 0x00, 0x20, 0x75, 0x3e,
++    0x00, 0x80, 0x71, 0x3d, 0x00, 0xc0, 0x36, 0x3e, 0x00, 0x80, 0xb1, 0x3e, 0x00, 0xa0, 0xfa, 0x3e,
++    0x00, 0x40, 0x1d, 0x3f, 0x76, 0x98, 0xca, 0xed, 0xa9, 0xbb, 0xdc, 0xed, 0xbb, 0xcc, 0xdd, 0xee,
++    0xcc, 0xdc, 0xdd, 0xee, 0xdc, 0xdd, 0xed, 0xee, 0xdd, 0xdd, 0xee, 0xee, 0xdd, 0xed, 0xee, 0xee,
++    0xed, 0xee, 0xee, 0xee, 0xee, 0xee, 0xee, 0xee, 0xee, 0xee, 0xee, 0xee, 0xee, 0xee, 0xee, 0xde,
++    0xee, 0xde, 0xdd, 0xdd, 0xde, 0xbc, 0x9a, 0x88, 0x22, 0x11, 0x11, 0x00, 0x11, 0x00, 0x00, 0x00,
++    0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
++};
++
+ static const uint8_t expected16[] = {
+     0x1e, 0xa8, 0x00, 0x00, 0x1e, 0x28, 0x1e, 0x2c, 0x2d, 0x2e, 0x26, 0x31, 0x2d, 0x32, 0x35, 0x33, 0x57, 0x2f, 0x81,
+     0x31, 0x57, 0x33, 0x57, 0x33, 0x96, 0x34, 0x81, 0x35, 0x81, 0x35, 0x6c, 0x36, 0x16, 0x35, 0x16, 0x35, 0x5b, 0x36,
+@@ -185,13 +198,14 @@ int main() {
+     if (backend == nullptr) {
+         return 1;
+     }
+-    ggml_init_params params = { ggml_tensor_overhead() * 8, nullptr, true };
++    ggml_init_params params = { ggml_tensor_overhead() * 9, nullptr, true };
+     ggml_context * ctx = ggml_init(params);
+     if (ctx == nullptr) {
+         ggml_backend_free(backend);
+         return 2;
+     }
+     ggml_tensor * row_major16 = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, channels, capacity);
++    ggml_tensor * row_major16_packed = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, channels, capacity);
+     ggml_tensor * transposed16 = ggml_new_tensor_2d(ctx, GGML_TYPE_F16, capacity, channels);
+     ggml_tensor * row_major32 = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, channels, capacity);
+     ggml_tensor * transposed32 = ggml_new_tensor_2d(ctx, GGML_TYPE_F32, capacity, channels);
+@@ -219,6 +233,7 @@ int main() {
+         cells[row] = capacity - 1 - row;
+     }
+     const ggml_backend_cachegen_tile tile16 = { encoded16, sizeof(encoded16), 0, rows };
++    const ggml_backend_cachegen_tile tile16_packed = { encoded16_packed, sizeof(encoded16_packed), 0, rows };
+     const ggml_backend_cachegen_tile tile32 = { encoded32, sizeof(encoded32), 0, rows };
+     const std::vector<uint8_t> encoded_quant = repeat_cachegen_channels(encoded16, sizeof(encoded16), 4);
+     const ggml_backend_cachegen_tile tile_quant = { encoded_quant.data(), encoded_quant.size(), 0, rows };
+@@ -232,6 +247,7 @@ int main() {
+     }
+     const ggml_backend_cachegen_job jobs[] = {
+         { row_major16, &tile16, 1, cells.data(), cells.size(), channels, channels * 2, 2 },
++        { row_major16_packed, &tile16_packed, 1, cells.data(), cells.size(), channels, channels * 2, 2 },
+         { transposed16, &tile16, 1, cells.data(), cells.size(), channels, 2, capacity * 2 },
+         { row_major32, &tile32, 1, cells.data(), cells.size(), channels, channels * 4, 4 },
+         { transposed32, &tile32, 1, cells.data(), cells.size(), channels, 4, capacity * 4 },
+@@ -248,7 +264,7 @@ int main() {
+         return finish(4);
+     }
+     char error[256] = {};
+-    if (!decode(jobs, 8, error, sizeof(error))) {
++    if (!decode(jobs, 9, error, sizeof(error))) {
+         return finish(5);
+     }
+     ggml_backend_cachegen_job invalid_job = jobs[0];
+@@ -256,6 +272,16 @@ int main() {
+     if (decode(&invalid_job, 1, error, sizeof(error))) {
+         return finish(8);
+     }
++    std::vector<uint8_t> invalid_packed(encoded16_packed, encoded16_packed + sizeof(encoded16_packed));
++    invalid_packed[5] = 5;
++    const ggml_backend_cachegen_tile invalid_packed_tile = {
++        invalid_packed.data(), invalid_packed.size(), 0, rows,
++    };
++    ggml_backend_cachegen_job invalid_packed_job = jobs[1];
++    invalid_packed_job.tiles = &invalid_packed_tile;
++    if (decode(&invalid_packed_job, 1, error, sizeof(error))) {
++        return finish(14);
++    }
+ 
+     const auto check_fixture = [&](ggml_tensor * row_major, ggml_tensor * transposed,
+                                    const uint8_t * expected, int status) {
+@@ -284,6 +310,16 @@ int main() {
+     if (const int status = check_fixture(row_major16, transposed16, expected16, 6)) {
+         return finish(status);
+     }
++    std::vector<uint8_t> packed16_bytes(ggml_nbytes(row_major16_packed));
++    ggml_backend_tensor_get(row_major16_packed, packed16_bytes.data(), 0, packed16_bytes.size());
++    for (uint32_t row = 0; row < rows; ++row) {
++        if (std::memcmp(
++                packed16_bytes.data() + static_cast<size_t>(cells[row]) * channels * 2,
++                expected16 + static_cast<size_t>(row) * channels * 2,
++                channels * 2) != 0) {
++            return finish(13);
++        }
++    }
+     std::vector<float> expected32_f32(rows * channels);
+     for (size_t i = 0; i < expected32_f32.size(); ++i) {
+         uint16_t bits;
+-- 
+2.54.0 (Apple Git-157)
+


### PR DESCRIPTION
CacheGen's per-tile arithmetic stream leaves Metal restore serial: after PR #1810 removed the duplicate staging copy, Q8_0/F32 still spent about 486 ms importing and reached first token in about 702 ms versus 548 ms for native restore.

This adds the versioned `LCG2` archive format for device-bound pages. It keeps LMCache-compatible per-row calibration, packs the resulting 16-bin or 32-bin symbols at fixed width, and lets Metal/CUDA extract symbols directly in parallel. The legacy `LCG1` arithmetic decoder remains supported for existing archives, while the CacheGen codec identity advances to version 2. The native ABI is unchanged.

On the exact commit in this PR, the 19K Qwen3-0.6B Metal gate passes six of seven tested K/V combinations:

| K/V | Agreement | CacheGen/native bytes | Import | CacheGen TTFT | Native TTFT |
|---|---:|---:|---:|---:|---:|
| Q8_0/F32 | 64/64 | 20.98% | 114.47 ms | 331.69 ms | 552.51 ms |
| F16/F16 | 64/64 | 26.55% | 94.37 ms | 168.96 ms | 321.89 ms |
| Q8_0/Q8_0 | 64/64 | 49.97% | 94.48 ms | 171.21 ms | 223.34 ms |
| Q8_0/F16 | 64/64 | 34.67% | 92.05 ms | 303.56 ms | 424.95 ms |
| Q4_0/F16 | 61/64 | 41.44% | 113.86 ms | 314.78 ms | 343.95 ms |
| F32/F32 | 64/64 | 13.27% | 94.28 ms | 392.35 ms | 794.32 ms |
| Q4_0/Q4_0 | 61/64 | 94.39% | 145.97 ms | 222.45 ms | 161.33 ms |

Q4_0/Q4_0 remains stopped because native restore is still faster despite the archive now fitting below native size. Its 61/64 continuation agreement clears the 95% quality floor, matching the prior typed result.

Validation at `0e481681b66ca49b4b87f0a767d2777aceca3f6d`:

- Fresh 34-patch llama.cpp replay and full 41-test Metal native replay
- `cargo test -p skippy-cache --lib`
- Full standalone library/package suites for `skippy-runtime`, `skippy-ffi`, `skippy-server`, `mesh-llm`, and `skippy-correctness`
- Workspace package Clippy with `-D warnings`
- `cargo fmt --all --check`
- Crate-list, publishability, release, and console-print repository ratchets
- Exact-commit seven-row 19K Metal matrix above

Stacked on #1810.
