### PR TITLE
fix(ci): let llama canary verification reach certification

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -102,6 +102,9 @@ The repair job snapshots the agent result as an unreachable commit and uploads
 a thin candidate bundle. A separate self-hosted verification job and checkout
 download that bundle, materialize its commit in a fresh detached worktree, and
 run one ordered `prepare -> build -> certify` pass with a 240-minute budget. The
+verification job independently resolves the installed Homebrew LLVM prefix and
+exports `SKIPPY_REWRITER_LLVM_PREFIX` before invoking the generated-family
+rewriter check because `GITHUB_ENV` state does not cross job boundaries. The
 wrapper owns the exact upstream selector, validates the prepared-upstream stamp,
 runs the patched llama.cpp/native-test and Rust build gates, and completes the
 full supported-family certification using new native-build and family-evidence

--- a/.github/workflows/llama-upstream-canary.yml
+++ b/.github/workflows/llama-upstream-canary.yml
@@ -437,6 +437,23 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      - name: Configure verifier LLVM
+        run: |
+          set -euo pipefail
+          llvm_prefix="$(brew --prefix llvm@22 2>/dev/null || true)"
+          llvm_ok() {
+            [[ -n "$1" && -x "$1/bin/clang" && -f "$1/lib/cmake/clang/ClangConfig.cmake" ]]
+          }
+          if ! llvm_ok "$llvm_prefix"; then
+            echo "pinned llvm@22 missing or incomplete on the family-certify image; falling back to $(brew --prefix llvm 2>/dev/null || echo 'brew llvm')" >&2
+            llvm_prefix="$(brew --prefix llvm 2>/dev/null || true)"
+          fi
+          if ! llvm_ok "$llvm_prefix"; then
+            echo "no Homebrew LLVM with Clang LibTooling is installed on the family-certify image" >&2
+            exit 1
+          fi
+          echo "SKIPPY_REWRITER_LLVM_PREFIX=$llvm_prefix" >> "$GITHUB_ENV"
+
       - name: Download agent candidate
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -36,11 +36,14 @@ commit and uploads a thin bundle. A separate self-hosted verification job and
 checkout materialize that commit in a fresh detached worktree, prepare through
 the checked-in `pinned` selector, verify the prepared-upstream stamp, and execute
 the complete build and certification sequence with new native-build and
-family-evidence directories. Only that passing commit is exported as the
-certified bundle. A later job on a fresh GitHub-hosted runner validates it, uses an
-environment-sourced askpass helper so the repair PAT never appears in the push
-URL or process arguments, pushes without force, and opens a ready PR as its
-final external mutation. If either the agent or trusted verification fails, only the distinct
+family-evidence directories. The verifier resolves and exports its own Homebrew
+LLVM prefix before the generated-family rewriter check because job environment
+files are not shared with the repair job. Only that passing commit is exported
+as the certified bundle. A later job on a fresh GitHub-hosted runner validates
+it, uses an environment-sourced askpass helper so the repair PAT never appears
+in the push URL or process arguments, pushes without force, and opens a ready
+PR as its final external mutation. If either the agent or trusted verification
+fails, only the distinct
 `llama-canary-changed-pin-*` evidence artifact is retained.
 
 Scheduled coverage details: an unchanged-pin llama canary uses the bounded

--- a/scripts/tests/test_llama_upstream_canary_contract.py
+++ b/scripts/tests/test_llama_upstream_canary_contract.py
@@ -313,7 +313,17 @@ class LlamaUpstreamCanaryWorkflowTests(unittest.TestCase):
         self.assertIn('CANARY_VERIFICATION_TIMEOUT_SECONDS: "14400"', verifier)
         self.assertIn("actions/download-artifact@", verifier)
         self.assertIn("Upload independently certified candidate", verifier)
+        self.assertIn("Configure verifier LLVM", verifier)
         self.assertNotIn("CANARY_REPAIR_TOKEN", verifier)
+
+        verifier_llvm = _step_block(workflow, "Configure verifier LLVM")
+        self.assertIn("brew --prefix llvm@22", verifier_llvm)
+        self.assertIn("brew --prefix llvm", verifier_llvm)
+        self.assertIn("ClangConfig.cmake", verifier_llvm)
+        self.assertIn(
+            'echo "SKIPPY_REWRITER_LLVM_PREFIX=$llvm_prefix" >> "$GITHUB_ENV"',
+            verifier_llvm,
+        )
 
         publisher = workflow[workflow.index("  publish-certified-canary:") : workflow.index("  alert-consecutive-failures:")]
         self.assertIn("needs: verify-changed-canary", publisher)


### PR DESCRIPTION
Changed-pin llama canaries can now complete their independent verification pass. The verifier resolves the installed Homebrew LLVM prefix and exports `SKIPPY_REWRITER_LLVM_PREFIX` in its own job before running the generated-family rewriter check.

Run 34650731299 exposed the bug after the repaired candidate applied all 23 handwritten and 47 generated patches, built llama.cpp, and passed all 97 native tests. The LLVM setup existed in the repair job, but `GITHUB_ENV` does not cross the verifier job boundary, so the next gate failed before Rust, smoke, live-matrix, or family certification could run.

A workflow contract now requires the LLVM setup inside `verify-changed-canary`.

## Validation

- `python3 -m unittest scripts.tests.test_llama_upstream_canary_contract` (29 passed)
- `just ci-validate` (1,155 passed, 8 skipped; actionlint and consistency checks passed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **CI Improvements**
  - Canary verification now independently detects and configures the installed Homebrew LLVM toolchain.
  - Verification validates required LLVM components and reports a clear failure when no usable installation is available.
  - LLVM configuration is consistently passed to generated-family rewriter checks.

- **Documentation**
  - Updated CI documentation to reflect the verifier’s LLVM configuration behavior.

- **Tests**
  - Added workflow contract coverage for LLVM discovery, validation, and environment propagation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->