### PR TITLE
docs: simplify sharing Ollama, vLLM and LM Studio through plugins

### DIFF
--- a/website/src/_data/docs.js
+++ b/website/src/_data/docs.js
@@ -61,6 +61,7 @@ export default [
     description: "Extend mesh-llm with managed plugin processes, MCP tools, and HTTP bindings.",
     links: [
       ["Plugins overview", "/docs/pages/plugins/"],
+      ["Share Ollama, vLLM or LM Studio", "/docs/pages/external-model-endpoints/"],
       ["Plugin architecture", "/docs/pages/plugin-architecture/"],
       ["Developing plugins", "/docs/pages/developing-plugins/"],
       ["Plugin reference", "/docs/pages/plugin-reference/"]

--- a/website/src/docs/pages/config-models.md
+++ b/website/src/docs/pages/config-models.md
@@ -45,7 +45,7 @@ gpu_layers = "auto"
 
 ## Plugins
 
-The `[[plugin]]` array configures plugin instances as local processes or remote services.
+The `[[plugin]]` array configures local plugin processes, which can attach to external services.
 
 ```toml
 [[plugin]]
@@ -62,12 +62,15 @@ optional             = false
 lazy_start           = false
 ```
 
-For network-based plugins, use a `url` instead of `command`/`args`:
+For the installed endpoint adapter, `url` names the upstream HTTP service. Mesh
+still starts a local plugin process; `url` does not replace the adapter's
+control connection. Install a host-compatible adapter first, or set `command`
+to a compatible source-built adapter:
 
 ```toml
 [[plugin]]
 name = "openai-endpoint"
-url  = "http://gpu-box:8000/v1"
+url  = "http://127.0.0.1:8000/v1"
 ```
 
 An external-endpoint-only node needs no `[[models]]` entry:
@@ -78,13 +81,14 @@ mode = "on_demand"
 
 [[plugin]]
 name = "openai-endpoint"
-url = "http://gpu-box:8000/v1"
+url = "http://127.0.0.1:8000/v1"
 ```
 
 Start it with bare `mesh-llm serve`. Provider models can appear in
 `/v1/models` while no local model process exists. See
 [Runtime Lifecycle](/docs/pages/runtime-lifecycle/) and
-[Plugins](/docs/pages/plugins/#external-endpoint-only-workflow).
+[provider quick start](/docs/pages/external-model-endpoints/) for Ollama, vLLM
+and LM Studio, release compatibility, and HTTP/authentication limitations.
 
 ### Plugin startup config
 

--- a/website/src/docs/pages/external-model-endpoints.md
+++ b/website/src/docs/pages/external-model-endpoints.md
@@ -45,17 +45,24 @@ an existing shared service. See the API-key FAQ below.
 
 ### 2. Install the compatible adapter
 
-Check compatibility first: **adapter 0.1.2 is incompatible with Mesh 0.76.0**
-(protocol 2 versus 3). For Mesh 0.76.0, use a protocol-3 adapter build.
-The installer selects a platform archive, not a negotiated protocol match.
-Once a compatible release is available:
+**Adapter 0.2.0 supports Mesh 0.76.0 / plugin protocol 3.** Install it with:
 
 ```bash
 mesh-llm plugins install openai-endpoint
 ```
 
-If the compatible release is not yet published, follow the [adapter source-build instructions](https://github.com/Mesh-LLM/openai-endpoint/blob/ea568baff71037badb8e5c7e479c33c0082412b9/README.md#build-from-source)
-instead. Do not repeatedly reinstall 0.1.2 on Mesh 0.76.0.
+The unversioned command selects the latest published release, not a negotiated
+protocol match. To select this version explicitly, use
+`mesh-llm plugins install Mesh-LLM/openai-endpoint@0.2.0`.
+
+Already installed? Run `mesh-llm plugins update openai-endpoint`, remove any
+source-build `command` override, and restart your Mesh instance.
+
+Adapter **0.1.2 uses protocol 2 and is incompatible with Mesh 0.76.0**. Older
+protocol-2 hosts must retain it using
+`mesh-llm plugins install Mesh-LLM/openai-endpoint@0.1.2` rather than updating.
+See the [adapter source-build instructions](https://github.com/Mesh-LLM/openai-endpoint/blob/v0.2.0/README.md#build-from-source)
+if you prefer to build the pinned release yourself.
 
 ### 3. Set the URL once
 
@@ -182,7 +189,7 @@ namespace, not that other host/container.
 
 The adapter and host releases are incompatible, even if installation succeeded.
 Use a protocol-3 build for Mesh 0.76.0; retain adapter 0.1.2 for protocol-2 hosts.
-Do not bypass the handshake. See the [adapter compatibility notes](https://github.com/Mesh-LLM/openai-endpoint/blob/ea568baff71037badb8e5c7e479c33c0082412b9/README.md#compatibility).
+Do not bypass the handshake. See the [adapter compatibility notes](https://github.com/Mesh-LLM/openai-endpoint/blob/v0.2.0/README.md#compatibility).
 
 ### Does this split my provider's model across Mesh GPUs?
 

--- a/website/src/docs/pages/external-model-endpoints.md
+++ b/website/src/docs/pages/external-model-endpoints.md
@@ -1,0 +1,206 @@
+---
+title: Share Ollama, vLLM or LM Studio
+---
+
+# Share Ollama, vLLM or LM Studio
+
+**Start the server → install the plugin → set its URL → run `mesh-llm serve`.**
+You do not need a second model download, a GGUF, or a separate `share` command.
+These examples assume Mesh and the provider run on the same machine and that
+Mesh's default ports (9337 API, 3131 console) are free. Start with a fresh/default
+private-mesh configuration; existing discovery/publication settings still apply.
+Do not add `--auto` or `--publish` for this private recipe.
+
+### 1. Start your provider
+
+If your server already works, leave it running and use its existing **HTTP** base URL.
+This forwarding path does not support a direct `https://` upstream, even when
+the HTTPS model-health probe succeeds. See the gateway limitation below.
+Otherwise choose one recipe below. Install the provider first using its own
+documentation; model downloads and hardware requirements belong to that provider.
+
+| Provider | Start it | Plugin `url` |
+| --- | --- | --- |
+| Ollama | Start the Ollama app, or run `ollama serve`; in another terminal run `ollama pull llama3.2:1b` (or use a model you already have). | `http://127.0.0.1:11434/v1` |
+| vLLM | On a supported machine: `vllm serve Qwen/Qwen2.5-0.5B-Instruct --host 127.0.0.1 --port 8000` (or substitute your model). | `http://127.0.0.1:8000/v1` |
+| LM Studio | Download/select a chat model, load it, then open **Developer → Start server**. With the CLI installed, `lms server start` starts the API server. | `http://127.0.0.1:1234/v1` |
+| Other OpenAI-compatible servers | Start your existing TGI, SGLang, Lemonade, or other server using its own instructions. Copy its HTTP OpenAI base URL, including any prefix before `/v1`. | The server's actual base URL; do not assume port 8000. |
+
+The small model names above are examples, not required models. For Ollama use
+`/v1`, **not** its native `/api` API. For LM Studio use the server's displayed
+port if it differs from 1234; Just-In-Time loading may list downloaded models
+that are not loaded yet.
+
+Check the provider directly before adding Mesh (Ollama example; change the URL
+for your provider):
+
+```bash
+curl --fail --silent --show-error http://127.0.0.1:11434/v1/models
+```
+
+Expect a JSON `data` array containing at least one model `id`. For this simple
+recipe the endpoint must be reachable without upstream API-key authentication.
+Keep an unauthenticated server loopback-only; do not disable authentication on
+an existing shared service. See the API-key FAQ below.
+
+### 2. Install the compatible adapter
+
+Check compatibility first: **adapter 0.1.2 is incompatible with Mesh 0.76.0**
+(protocol 2 versus 3). For Mesh 0.76.0, use a protocol-3 adapter build.
+The installer selects a platform archive, not a negotiated protocol match.
+Once a compatible release is available:
+
+```bash
+mesh-llm plugins install openai-endpoint
+```
+
+If the compatible release is not yet published, follow the [adapter source-build instructions](https://github.com/Mesh-LLM/openai-endpoint/blob/ea568baff71037badb8e5c7e479c33c0082412b9/README.md#build-from-source)
+instead. Do not repeatedly reinstall 0.1.2 on Mesh 0.76.0.
+
+### 3. Set the URL once
+
+Create `~/.mesh-llm/config.toml` if absent, or edit your existing file. For Ollama:
+
+```toml
+[runtime]
+mode = "on_demand"
+
+[[plugin]]
+name = "openai-endpoint"
+url = "http://127.0.0.1:11434/v1"
+```
+
+For vLLM or LM Studio, change **only the URL** to the value in the table.
+Merge into an existing `[runtime]` section and existing `openai-endpoint` entry;
+do not append duplicate tables. No `[[models]]` entry is needed for the provider.
+`on_demand` avoids eagerly loading configured native models; it does not disable
+native-runtime initialization or future native serving. Explicit `--model` or
+`--gguf` arguments still request loading, so omit them here.
+
+### 4. Serve and check
+
+```bash
+mesh-llm serve
+```
+
+Leave it running. In another terminal:
+
+```bash
+curl --fail --silent --show-error http://127.0.0.1:9337/v1/models
+```
+
+Copy an exact `id` from **Mesh's** response into `model` below:
+
+```bash
+curl --fail --silent --show-error http://127.0.0.1:9337/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"REPLACE_WITH_LISTED_ID","messages":[{"role":"user","content":"Say hello."}],"max_tokens":64,"stream":false}'
+```
+
+Success is a completion response with `choices`, not merely a healthy plugin
+process. Your application now uses `http://127.0.0.1:9337/v1` as its OpenAI base
+URL. The provider keeps managing its own models, GPU memory and process.
+
+## Use it from another machine
+
+On a second machine with Mesh installed, join using the invite token printed by
+the serving node:
+
+```bash
+mesh-llm client --join YOUR_INVITE_TOKEN
+```
+
+On that second machine, repeat the two curl checks above against its own port
+9337. It needs neither the endpoint plugin nor a copy of the provider's model.
+Keep the invite private.
+
+Only the serving node needs to reach the upstream URL. The second machine does
+**not** connect to your Ollama/vLLM/LM Studio HTTP port directly. If testing two
+Mesh processes on one machine instead, use separate profiles and distinct API
+and console ports; do not start a second process over a running instance.
+
+## FAQ and troubleshooting
+
+### Does Mesh start or stop Ollama, vLLM or LM Studio?
+
+No. Mesh manages the small adapter process, not your model server. The adapter
+registers the URL and Mesh forwards inference to it directly. Keep your provider
+running; stopping Mesh does not stop that provider.
+
+### Why not `mesh-llm client` on the provider machine?
+
+Use `serve` on the machine sharing the endpoint. `client` is for consuming a
+mesh, not advertising this machine as an inference host. The consumer machine
+can use `client --join` without installing the plugin.
+
+### Is “OpenAI-compatible” an OpenAI account requirement?
+
+No. It describes the HTTP API format. These local recipes need no OpenAI account
+or OpenAI API key. Use `openai-endpoint` as the install/config name, regardless of its display title.
+
+### What about upstream API keys?
+
+This adapter reads a URL only; it has no provider API-key/header configuration.
+Mesh's endpoint health/model probe makes its own request to `/v1/models` without
+an injected upstream bearer token. Setting `OPENAI_API_KEY` in your app does not
+configure that probe. Do not put credentials in the URL or assume caller
+Authorization headers will authenticate mesh-wide forwarding.
+
+Use the loopback-only unauthenticated recipe for a local server you control.
+An HTTPS or protected provider needs a separately secured gateway exposing
+**loopback HTTP to Mesh** and handling upstream TLS/authentication for both
+model discovery and inference; that setup is outside this quick
+start and must be validated separately. Do not expose an unauthenticated gateway
+to the LAN or Internet to work around this limitation. Do not disable TLS or
+authentication on an existing shared provider.
+
+### Why is the plugin healthy but my model missing?
+
+Plugin-process health and upstream readiness are separate. Check in this order:
+
+1. `mesh-llm plugins info openai-endpoint`: correct install/version and executable?
+2. Provider `BASE_URL/models`: reachable from the serving node, HTTP 200, nonempty
+   `data` with model IDs? A 401/403 indicates authentication; a 404 often means a
+   wrong base path; connection refused usually means wrong port or stopped server.
+3. Mesh `http://127.0.0.1:9337/v1/models`: allow time for health checks/discovery.
+4. Completion: use the exact listed ID and a chat-capable model. A model listing
+   alone does not prove generation; loading or a missing chat template can fail.
+   An `https://` upstream may pass discovery but fail generation: this host
+   forwarding path requires HTTP (see the secured gateway limitation above).
+
+Do not point the plugin at Mesh's own 9337 endpoint: that creates a routing loop.
+`plugins info` describes the installed package, which may not be the executable
+in use when config contains a `command` override. Check that absolute path and
+the startup handshake too; remove the override when switching back to a
+compatible released package.
+
+Restart your own Mesh instance after changing the plugin URL. If the provider is
+in Docker or on another host, `127.0.0.1` means the Mesh process's own network
+namespace, not that other host/container.
+
+### Why does startup say “uses protocol 2, host uses 3”?
+
+The adapter and host releases are incompatible, even if installation succeeded.
+Use a protocol-3 build for Mesh 0.76.0; retain adapter 0.1.2 for protocol-2 hosts.
+Do not bypass the handshake. See the [adapter compatibility notes](https://github.com/Mesh-LLM/openai-endpoint/blob/ea568baff71037badb8e5c7e479c33c0082412b9/README.md#compatibility).
+
+### Does this split my provider's model across Mesh GPUs?
+
+No. It shares an existing inference endpoint. vLLM/Ollama/LM Studio retain their
+own execution and parallelism; attaching their URL does not convert their models
+into Mesh layer packages or distribute their weights.
+
+### Are streaming, tools, vision and every provider certified?
+
+No blanket guarantee. Features depend on the provider/model and Mesh's routing
+path. The compatibility repair was validated on Mesh 0.76.0 with local archive
+installation and non-streaming HTTP-fixture requests through two processes on
+one Mac. The recipes are based on provider documentation, not a claim of live
+certification for every named provider, platform, streaming or authentication mode.
+
+## Provider references
+
+- [Ollama OpenAI compatibility](https://docs.ollama.com/api/openai-compatibility)
+- [vLLM OpenAI-compatible server](https://docs.vllm.ai/en/latest/serving/online_serving/openai_compatible_server/)
+- [LM Studio server](https://lmstudio.ai/docs/developer/core/server) and [OpenAI compatibility](https://lmstudio.ai/docs/developer/openai-compat)
+- [Lemonade API reference](https://github.com/lemonade-sdk/lemonade/tree/main/docs/api)

--- a/website/src/docs/pages/faq.md
+++ b/website/src/docs/pages/faq.md
@@ -14,6 +14,34 @@ No. Bare `mesh-llm serve` can run as a healthy idle daemon or route only to
 plugin and remote endpoints. Load a local model later if the node is
 worker-capable. See [Runtime Lifecycle](/docs/pages/runtime-lifecycle/).
 
+## Can I keep using Ollama, vLLM or LM Studio?
+
+Yes. Use the `openai-endpoint` plugin: start your existing server, install a
+host-compatible adapter, set its URL in one `[[plugin]]` entry, then run
+`mesh-llm serve`. No second model download and no separate `share` command.
+The [provider quick start](/docs/pages/external-model-endpoints/) has the exact
+Ollama, vLLM and LM Studio recipes, including the 0.1.2/0.76.0 compatibility warning.
+
+## Does the plugin launch my model server or split its weights?
+
+Neither. You keep managing your provider and its models. The plugin registers
+its endpoint; Mesh discovers model IDs and routes inference to it. It does not
+turn an Ollama/vLLM/LM Studio model into a distributed Mesh layer package.
+
+## Do I install the endpoint plugin on every machine?
+
+No. Install it on the node sharing the provider and use `serve` there. A consuming
+machine only needs `mesh-llm client --join YOUR_INVITE_TOKEN`; applications use
+that machine's `http://127.0.0.1:9337/v1` endpoint.
+
+## Can the endpoint plugin inject my provider API key?
+
+Not with its current URL-only configuration. Model discovery/health requests
+also need upstream authorization; an application's `OPENAI_API_KEY` does not
+configure those requests. Use a local loopback-only server for the simple recipe;
+do not remove authentication from an existing shared service. See the
+[API-key limitations](/docs/pages/external-model-endpoints/#what-about-upstream-api-keys).
+
 ## What is the difference between client and on-demand mode?
 
 `client` is routing-only and disables local model loading. `on_demand` starts

--- a/website/src/docs/pages/plugins.md
+++ b/website/src/docs/pages/plugins.md
@@ -90,8 +90,8 @@ the short setup, provider-specific URLs, a completion check and troubleshooting.
 
 **Release compatibility:** published adapter 0.1.2 uses plugin protocol 2 and
 cannot initialize on Mesh 0.76.0 (protocol 3), despite installing successfully.
-Use a compatible protocol-3 adapter build for that host. Check the
-[adapter compatibility/build instructions](https://github.com/Mesh-LLM/openai-endpoint/blob/ea568baff71037badb8e5c7e479c33c0082412b9/README.md#compatibility)
+Use adapter **0.2.0** (protocol 3) for that host. Check the
+[adapter compatibility/build instructions](https://github.com/Mesh-LLM/openai-endpoint/blob/v0.2.0/README.md#compatibility)
 before installing; do not assume “latest” means compatible. Older protocol-2
 hosts must retain a compatible adapter such as 0.1.2 rather than blindly updating.
 

--- a/website/src/docs/pages/plugins.md
+++ b/website/src/docs/pages/plugins.md
@@ -15,7 +15,7 @@ The Mesh-LLM organization currently publishes five first-party plugin repositori
 | Plugin | Use it for | Install |
 | --- | --- | --- |
 | [`blackboard`](https://github.com/Mesh-LLM/blackboard) | Share short-lived status, findings, questions, and tips across a mesh. The plugin also ships a Blackboard Agent Skill. | `mesh-llm plugins install blackboard` |
-| [`openai-endpoint`](https://github.com/Mesh-LLM/openai-endpoint) | Add an already-running OpenAI-compatible server such as vLLM, TGI, Ollama, or Lemonade Server. | `mesh-llm plugins install openai-endpoint` |
+| [`openai-endpoint`](https://github.com/Mesh-LLM/openai-endpoint) | Add an already-running OpenAI-compatible server such as Ollama, vLLM, LM Studio, TGI, or Lemonade Server. | `mesh-llm plugins install openai-endpoint` |
 | [`flash-moe`](https://github.com/Mesh-LLM/flash-moe) | Attach a Flash-MoE inference endpoint, or let the plugin supervise a local Flash-MoE process. | `mesh-llm plugins install flash-moe` |
 | [`metrics`](https://github.com/Mesh-LLM/metrics) | Advertise metrics support for mesh-llm telemetry. Configure the OTLP destination in mesh-llm, not in the plugin. | `mesh-llm plugins install metrics` |
 | [`agents`](https://github.com/Mesh-LLM/agents) | Run mesh-native A2A agents and expose their tools through the mesh MCP endpoint. | `mesh-llm plugins install agents` |
@@ -31,7 +31,8 @@ Treat a catalog entry as a discovery aid: read the linked repository, check its 
 
 ## Install a plugin
 
-Install the latest compatible release for the current machine:
+Install the latest release archive for the current machine (platform selection
+is not host/plugin protocol negotiation):
 
 ```bash
 mesh-llm plugins install openai-endpoint
@@ -41,7 +42,7 @@ You can also install directly from a GitHub repository. This is useful when a pl
 
 ```bash
 mesh-llm plugins install Mesh-LLM/openai-endpoint
-mesh-llm plugins install Mesh-LLM/openai-endpoint@0.1.2
+mesh-llm plugins install Mesh-LLM/openai-endpoint@0.1.2 # protocol-2 hosts only
 ```
 
 Use the catalog name, such as `agents`, for catalog installs. Use the fully qualified `owner/repository` form, such as `Mesh-LLM/agents`, only when installing directly from GitHub.
@@ -80,55 +81,25 @@ url = "http://127.0.0.1:8000/v1"
 
 ## External-endpoint-only workflow
 
-Mesh can expose an existing OpenAI-compatible provider without loading any
-local model or adding a placeholder model.
+**Start your provider → install `openai-endpoint` → set its URL → run
+`mesh-llm serve`.** No GGUF, placeholder model, or separate `share` command.
+Use `serve` on the provider machine and `client --join` on a consuming machine.
 
-1. Install the endpoint plugin:
+See [Share Ollama, vLLM or LM Studio](/docs/pages/external-model-endpoints/) for
+the short setup, provider-specific URLs, a completion check and troubleshooting.
 
-   ```bash
-   mesh-llm plugins install openai-endpoint
-   ```
-
-2. Configure on-demand mode when configured local models must not load eagerly,
-   then add the provider:
-
-   ```toml
-   [runtime]
-   mode = "on_demand"
-
-   [[plugin]]
-   name = "openai-endpoint"
-   url = "http://127.0.0.1:8000/v1"
-   ```
-
-3. Start the durable runtime:
-
-   ```bash
-   mesh-llm serve
-   ```
-
-4. Verify the provider's models through Mesh:
-
-   ```bash
-   curl -s http://localhost:9337/v1/models | jq '.data[].id'
-   ```
-
-5. Send a completion using one listed model:
-
-   ```bash
-   curl -s http://localhost:9337/v1/chat/completions \
-     -H 'Content-Type: application/json' \
-     -d '{"model":"<provider-model>","messages":[{"role":"user","content":"Say hello."}]}'
-   ```
-
-Plugin-process health and inference-endpoint health are separate. A connected,
-healthy plugin process can report its configured provider as unavailable; in
-that case inspect the provider URL and `/v1/models` response before reinstalling
-the plugin.
+**Release compatibility:** published adapter 0.1.2 uses plugin protocol 2 and
+cannot initialize on Mesh 0.76.0 (protocol 3), despite installing successfully.
+Use a compatible protocol-3 adapter build for that host. Check the
+[adapter compatibility/build instructions](https://github.com/Mesh-LLM/openai-endpoint/blob/ea568baff71037badb8e5c7e479c33c0082412b9/README.md#compatibility)
+before installing; do not assume “latest” means compatible. Older protocol-2
+hosts must retain a compatible adapter such as 0.1.2 rather than blindly updating.
 
 See [Runtime Lifecycle](/docs/pages/runtime-lifecycle/) for zero-model and
 on-demand behavior, and [OpenAI-Compatible API](/docs/pages/openai-compatible-api/)
 for client semantics.
+
+## Other plugin configurations
 
 For plugins that do not need an endpoint, the name is usually enough:
 

--- a/website/src/docs/pages/troubleshooting.md
+++ b/website/src/docs/pages/troubleshooting.md
@@ -117,3 +117,14 @@ Then move back to `mesh-llm serve --auto` once the local install and model path 
 
 For a full decision guide, see
 [Runtime Lifecycle](/docs/pages/runtime-lifecycle/).
+
+## External model endpoint setup
+
+For Ollama, vLLM, LM Studio and other OpenAI-compatible servers, follow the
+[provider troubleshooting checklist](/docs/pages/external-model-endpoints/#why-is-the-plugin-healthy-but-my-model-missing).
+Check upstream `/v1/models` before Mesh's model list, then send a completion.
+A healthy adapter does not prove the upstream can generate.
+
+`uses protocol 2, host uses 3` is a host/adapter compatibility error: published
+`openai-endpoint` 0.1.2 cannot start on Mesh 0.76.0. Reinstalling the same release
+will not repair it; use a compatible adapter build.


### PR DESCRIPTION
## Summary
Make sharing an existing Ollama, vLLM or LM Studio server a short, explicit plugin workflow rather than a second runtime command:

**Start the provider → install a compatible `openai-endpoint` → set its URL → `mesh-llm serve`.**

- New provider quick start with concrete Ollama/vLLM/LM Studio startup recipes and base URLs, plus guidance for other OpenAI-compatible servers.
- One config block, model-list and completion checks, then `client --join` from a second machine.
- FAQ covers no duplicate model download, provider lifecycle, endpoint sharing versus weight splitting, API keys, HTTP-only upstream forwarding, model readiness and command overrides.
- Update Plugins, Config Models & Plugins, FAQ, Troubleshooting and sidebar navigation.
- Correct the installer's “latest compatible” claim: it selects a platform archive, not a negotiated host/plugin protocol match.

## Companion and rollout
Adapter repair: https://github.com/Mesh-LLM/openai-endpoint/pull/3

Prefer merging the adapter first. Guide links to its compatibility/build instructions are pinned to the reviewed commit so they also work before merge. The adapter's source-build recipe selects its rescue branch; retain it until replaced with a durable release/main reference. Publishing a compatible adapter release is a separate required step—this documentation does not pretend catalog installs are repaired already.

Published adapter 0.1.2 speaks protocol 2 and cannot initialize on Mesh 0.76.0 (protocol 3). Older protocol-2 hosts need their compatible pin. No host code, protocol behavior, or runtime command changes in this PR.

## Example
For a running local Ollama server, edit `~/.mesh-llm/config.toml`:

```toml
[runtime]
mode = "on_demand"

[[plugin]]
name = "openai-endpoint"
url = "http://127.0.0.1:11434/v1"
```

Start `mesh-llm serve`, list `http://127.0.0.1:9337/v1/models`, and send a completion using an exact listed ID. Change only the URL for vLLM (`:8000/v1`) or LM Studio (`:1234/v1`).

## Validation
- Website `npm run build`: CLI inventory, Tailwind, Eleventy, Pagefind passed.
- Full website browser test script `npm run test:cli-explorer` passed.
- `node --check website/src/_data/docs.js` passed.
- Checked rendered guide links/anchors from Plugins, FAQ, Config Models and Troubleshooting.
- Parsed guide/adapter README TOML fences and checked Bash fence syntax.
- Independent source/docs review completed; HTTPS forwarding limitation, installed metadata vs command override, and private-config assumptions incorporated.
- `git diff --check` passed. Generated output is not committed; Rustdoc regeneration/full Mesh runtime build was not needed for these authored docs/navigation changes.

## Limits
Recipes checked against provider documentation and host/adapter source, not live certification of each provider. Prior adapter validation used two official Mesh 0.76.0 processes on one Mac with an HTTP fixture, not two machines or real-model/streaming/auth recovery testing. Direct HTTPS upstream and upstream API-key injection are not supported by this URL-only recipe; docs keep unauthenticated providers loopback-only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added a guide for connecting Ollama, vLLM, LM Studio, and other OpenAI-compatible endpoints through Mesh.
  - Updated plugin configuration examples, installation steps, compatibility requirements, and provider limitations.
  - Added FAQ entries covering model server behavior, client connections, and API-key handling.
  - Added troubleshooting guidance for endpoint health checks, completion testing, and protocol compatibility.
  - Added the external model endpoints guide to the Plugins navigation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->