### PR TITLE
fix(ci): check out commit-convention script from the default branch

### DIFF
--- a/.github/workflows/ci-quality-slice.yml
+++ b/.github/workflows/ci-quality-slice.yml
@@ -64,9 +64,13 @@ jobs:
     runs-on: ubuntu-24.04
     timeout-minutes: 5
     steps:
+      # Checked out from the default branch: the job validates PR-authored
+      # text (title/body/commit messages, all delivered via env/API), so it
+      # only needs the script itself. Branches created before this script
+      # landed would otherwise fail with a missing file.
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
-          ref: ${{ inputs.source_sha || github.sha }}
+          ref: ${{ github.event.repository.default_branch }}
           persist-credentials: false
       - name: Check commit convention
         env:


### PR DESCRIPTION
The `commit_convention` job in `ci-quality-slice.yml` checks out the PR head and runs `scripts/check-conventional-commit.py` from it. PRs branched before the script landed on main (#1758) — e.g. #1820, #1821 — fail with `No such file or directory` and their whole Quality lane goes red.

All PR-authored text (title, body, commit messages) reaches the job via env vars and the GitHub API, so the checkout only needs the script itself. This pins the checkout to the default branch so the job is independent of the PR's branch point.

Found while reviewing CI-blocked PRs; alternative considered was cherry-picking the script onto every affected branch (as done on some live branches via 1414471d5), but that scales poorly and forks can't be fixed that way.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated CI validation to use the repository’s default branch when checking commit conventions.
  * Improved validation reliability for pull request-authored text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->