### PR TITLE
fix(release): resume partial crates.io publishing

### DIFF
--- a/.agents/skills/manage-ci/references/current-inventory.md
+++ b/.agents/skills/manage-ci/references/current-inventory.md
@@ -22,6 +22,7 @@ Read it with `../SKILL.md` and `ci/ci.md` before editing CI.
 | `ci.yml` | `workflow_call` only | Temporary inert shim for the former main ingress filename; pending protected-main runner-contract update; no push trigger or dispatch |
 | `ci-control.yml` (`CI · Manual Full`) | dispatch on default branch | Explicit operator-only full plan, bounded lane dispatch and correlated diagnostic checks |
 | `release.yml` | dispatch on the default branch | Canonical version synchronization, release-only signing, assets, publication, post-publish release-notes regrouping, and a preflighted downstream `mesh-packaging` dispatch |
+| `resume-crates-release.yml` (`Release · Resume crates.io`) | dispatch on the default branch | Exact-tag, exact-SHA recovery for a partially published stable crates.io chain; uses the immutable release source and the trusted default-branch publisher script |
 | `website-pages.yml` | main website paths, dispatch | Public website deployment |
 | `pr_cleanup.yml` | PR close, dispatch | Positively matched cleanup only |
 | `pr_auto_assign.yml` | PR lifecycle | Metadata only |

--- a/.github/workflows/resume-crates-release.yml
+++ b/.github/workflows/resume-crates-release.yml
@@ -1,0 +1,90 @@
+name: Release · Resume crates.io
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Existing stable release tag to resume, for example v0.76.1
+        required: true
+        type: string
+      expected_source_sha:
+        description: Exact 40-character commit SHA the release tag must resolve to
+        required: true
+        type: string
+
+concurrency:
+  group: release-crates-resume-${{ github.repository }}-${{ inputs.release_tag }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    name: Resume crates.io package chain
+    if: github.repository == 'Mesh-LLM/mesh-llm' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-24.04
+    timeout-minutes: 120
+    steps:
+      - name: Check out trusted recovery controller
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+          path: controller
+
+      - name: Check out immutable release source
+        uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          ref: ${{ inputs.release_tag }}
+          persist-credentials: false
+          path: release-source
+
+      - name: Verify exact stable release source
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          EXPECTED_SOURCE_SHA: ${{ inputs.expected_source_sha }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$RELEASE_TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "release_tag must be a stable vMAJOR.MINOR.PATCH tag" >&2
+            exit 1
+          fi
+          if [[ ! "$EXPECTED_SOURCE_SHA" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "expected_source_sha must be a full lowercase commit SHA" >&2
+            exit 1
+          fi
+          remote_refs="$(
+            git -C controller ls-remote origin \
+              "refs/tags/${RELEASE_TAG}" \
+              "refs/tags/${RELEASE_TAG}^{}"
+          )"
+          remote_sha="$(
+            printf '%s\n' "$remote_refs" | awk -v tag="refs/tags/${RELEASE_TAG}" '
+              $2 == tag { direct = $1 }
+              $2 == tag "^{}" { peeled = $1 }
+              END { print peeled != "" ? peeled : direct }
+            '
+          )"
+          checked_out_sha="$(git -C release-source rev-parse HEAD)"
+          if [[ -z "$remote_sha" || "$remote_sha" != "$EXPECTED_SOURCE_SHA" ]]; then
+            echo "release tag does not resolve to expected_source_sha" >&2
+            exit 1
+          fi
+          if [[ "$checked_out_sha" != "$EXPECTED_SOURCE_SHA" ]]; then
+            echo "checked-out release source does not match expected_source_sha" >&2
+            exit 1
+          fi
+
+      - uses: dtolnay/rust-toolchain@4360b52568e2003a75bf9bc1d59f33a8e3fc893c # stable 2026-08-20
+
+      - name: Check crates.io publish-chain consistency
+        working-directory: release-source
+        run: cargo run -p xtask -- repo-consistency publish-crates
+
+      - name: Resume crates.io package chain
+        working-directory: release-source
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          LLAMA_STAGE_BUILD_DIR: ${{ runner.temp }}/mesh-llm-publish-crates-native-verify
+        run: ../controller/scripts/publish-crates.sh

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -129,6 +129,15 @@ main.
 
 ### Release source and version ownership
 
+If crates.io accepts only a prefix of the stable package chain,
+`resume-crates-release.yml` resumes publication from the existing immutable
+release tag. The operator supplies both the stable tag and its exact peeled
+commit SHA. The workflow runs only from the default branch, verifies those two
+identities against the remote tag and checkout, and uses the trusted
+default-branch `publish-crates.sh` controller against the tagged source. Cargo
+continues past immutable versions that are already uploaded; the workflow does
+not move or recreate the release tag.
+
 Release efficiency TODOs:
 
 - [x] Link the CUDA package tool with the selected build-time driver library.

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -12,6 +12,7 @@ only with --dry-run so local pre-commit validation can include uncommitted
 manifest changes; real publishing always requires Cargo's clean-tree check.
 
 Environment:
+  LLAMA_STAGE_BUILD_DIR                 Existing directory used while Cargo verifies packaged crates
   CRATES_IO_PUBLISH_MAX_ATTEMPTS        Real-publish retry attempts for crates.io 429s (default: 6)
   CRATES_IO_PUBLISH_RETRY_BASE_SECONDS Fallback retry base when crates.io gives no timestamp (default: 60)
   CRATES_IO_PUBLISH_RETRY_MAX_SECONDS  Fallback retry cap when crates.io gives no timestamp (default: 900)
@@ -93,11 +94,13 @@ fi
 max_attempts="${CRATES_IO_PUBLISH_MAX_ATTEMPTS:-6}"
 retry_base_seconds="${CRATES_IO_PUBLISH_RETRY_BASE_SECONDS:-60}"
 retry_max_seconds="${CRATES_IO_PUBLISH_RETRY_MAX_SECONDS:-900}"
+native_verify_build_dir="${LLAMA_STAGE_BUILD_DIR:-$PWD/target/publish-crates-native-verify}"
 
 require_nonnegative_int CRATES_IO_PUBLISH_SETTLE_SECONDS "$sleep_seconds"
 require_positive_int CRATES_IO_PUBLISH_MAX_ATTEMPTS "$max_attempts"
 require_positive_int CRATES_IO_PUBLISH_RETRY_BASE_SECONDS "$retry_base_seconds"
 require_positive_int CRATES_IO_PUBLISH_RETRY_MAX_SECONDS "$retry_max_seconds"
+mkdir -p "$native_verify_build_dir"
 
 if [[ "$dry_run" -eq 0 && -z "${CARGO_REGISTRY_TOKEN:-}" ]]; then
     echo "CARGO_REGISTRY_TOKEN is required for real crates.io publishing" >&2
@@ -237,7 +240,11 @@ run_cargo_publish_once() {
     # repository-only patched llama.cpp build inputs are intentionally absent.
     # Verify the Rust package surface through skippy-ffi's dynamic link mode;
     # this does not change the uploaded crate contents or feature defaults.
-    if output="$(LLAMA_STAGE_LINK_MODE=dynamic cargo "${args[@]}" 2>&1)"; then
+    if output="$(
+        LLAMA_STAGE_LINK_MODE=dynamic \
+            LLAMA_STAGE_BUILD_DIR="$native_verify_build_dir" \
+            cargo "${args[@]}" 2>&1
+    )"; then
         last_publish_output="$output"
         print_publish_output "$output"
         return 0

--- a/scripts/tests/test_publish_crates.py
+++ b/scripts/tests/test_publish_crates.py
@@ -62,6 +62,29 @@ class PublishCratesScriptTests(unittest.TestCase):
             link_modes = fixture.read_log("cargo-link-mode.log").splitlines()
             self.assertTrue(link_modes)
             self.assertEqual(set(link_modes), {"dynamic"})
+            build_dirs = fixture.read_log("cargo-build-dir.log").splitlines()
+            self.assertTrue(build_dirs)
+            self.assertEqual(len(set(build_dirs)), 1)
+            self.assertTrue(Path(build_dirs[0]).is_dir())
+
+    def test_publish_verification_honors_explicit_llama_build_dir(self) -> None:
+        with PublishCratesFixture() as fixture:
+            fixture.write_curl_statuses({})
+            fixture.write_fake_cargo()
+            fixture.write_fake_sleep()
+            fixture.write_fake_date()
+            explicit_build_dir = fixture.tmp_path / "prepared-native"
+
+            result = fixture.run(
+                ["--dry-run", "--allow-dirty"],
+                env={"LLAMA_STAGE_BUILD_DIR": str(explicit_build_dir)},
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            build_dirs = fixture.read_log("cargo-build-dir.log").splitlines()
+            self.assertTrue(build_dirs)
+            self.assertEqual(set(build_dirs), {str(explicit_build_dir)})
+            self.assertTrue(explicit_build_dir.is_dir())
 
     def test_retries_cargo_publish_429_then_continues_chain(self) -> None:
         with PublishCratesFixture() as fixture:
@@ -313,6 +336,7 @@ for arg in "$@"; do
 done
 echo "$*" >> "{self.tmp_path}/cargo.log"
 echo "${{LLAMA_STAGE_LINK_MODE:-}}" >> "{self.tmp_path}/cargo-link-mode.log"
+echo "${{LLAMA_STAGE_BUILD_DIR:-}}" >> "{self.tmp_path}/cargo-build-dir.log"
 case "$crate" in
 {self._cargo_case_arms(fail_cases, failure_path)}
 esac

--- a/scripts/tests/test_resume_crates_release_workflow.py
+++ b/scripts/tests/test_resume_crates_release_workflow.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+from pathlib import Path
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github" / "workflows" / "resume-crates-release.yml"
+
+
+class ResumeCratesReleaseWorkflowTests(unittest.TestCase):
+    def test_recovery_is_default_branch_only_and_exact_source_bound(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("github.ref == 'refs/heads/main'", workflow)
+        self.assertIn("^[0-9a-f]{40}$", workflow)
+        self.assertIn('"refs/tags/${RELEASE_TAG}^{}"', workflow)
+        self.assertIn('checked_out_sha="$(git -C release-source rev-parse HEAD)"', workflow)
+        self.assertIn('remote_sha" != "$EXPECTED_SOURCE_SHA', workflow)
+        self.assertIn('checked_out_sha" != "$EXPECTED_SOURCE_SHA', workflow)
+
+    def test_secret_is_scoped_to_publish_step(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertEqual(workflow.count("secrets.CARGO_REGISTRY_TOKEN"), 1)
+        self.assertIn("persist-credentials: false", workflow)
+        self.assertIn("../controller/scripts/publish-crates.sh", workflow)
+        self.assertIn("working-directory: release-source", workflow)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
The v0.76.1 crates.io job published 38 of 50 crates, then `skippy-runtime` package verification failed because the registry copy of `skippy-ffi` tried to resolve a workspace-only llama build script before honoring `LLAMA_STAGE_LINK_MODE=dynamic`.

This makes the publish controller provide an existing verification build directory, and adds a manual default-branch recovery workflow that binds an existing stable tag to its exact peeled commit SHA before running the trusted controller against that immutable source. Already-uploaded crate versions remain handled by the existing idempotent publish path.

Validation:

- `cargo publish --locked --dry-run -p skippy-runtime` against tag `v0.76.1` with the recovery environment
- `python3 -m unittest scripts.tests.test_publish_crates scripts.tests.test_resume_crates_release_workflow`
- `just ci-shellcheck scripts/publish-crates.sh`
- `just ci-validate` (1,189 tests, 9 expected skips)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a manually triggered workflow to safely resume partially published stable crates.io releases.
  - Release recovery validates the specified tag and commit, skips already-published crate versions, and preserves the existing release tag.
  - Publishing now supports a dedicated build directory for native verification.

- **Documentation**
  - Documented the release recovery workflow, requirements, validation checks, and publishing behavior.

- **Tests**
  - Added coverage for release recovery safeguards and configurable publishing verification directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->