### PR TITLE
fix(release): skip confirmed crates when resuming

### DIFF
--- a/.github/workflows/resume-crates-release.yml
+++ b/.github/workflows/resume-crates-release.yml
@@ -87,4 +87,4 @@ jobs:
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           LLAMA_STAGE_BUILD_DIR: ${{ runner.temp }}/mesh-llm-publish-crates-native-verify
-        run: ../controller/scripts/publish-crates.sh
+        run: ../controller/scripts/publish-crates.sh --resume

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -134,9 +134,10 @@ If crates.io accepts only a prefix of the stable package chain,
 release tag. The operator supplies both the stable tag and its exact peeled
 commit SHA. The workflow runs only from the default branch, verifies those two
 identities against the remote tag and checkout, and uses the trusted
-default-branch `publish-crates.sh` controller against the tagged source. Cargo
-continues past immutable versions that are already uploaded; the workflow does
-not move or recreate the release tag.
+default-branch `publish-crates.sh` controller against the tagged source. Resume
+mode skips versions that crates.io confirms are already published and falls
+back to Cargo for unknown registry responses. The workflow does not move or
+recreate the release tag.
 
 Release efficiency TODOs:
 

--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -4,12 +4,14 @@ set -euo pipefail
 
 usage() {
     cat >&2 <<'USAGE'
-usage: scripts/publish-crates.sh [--dry-run] [--allow-dirty] [--sleep-seconds N]
+usage: scripts/publish-crates.sh [--dry-run] [--allow-dirty] [--resume] [--sleep-seconds N]
 
 Publishes the crates.io package chain in dependency order. Use --dry-run for
 local and CI validation without uploading packages. --allow-dirty is accepted
 only with --dry-run so local pre-commit validation can include uncommitted
 manifest changes; real publishing always requires Cargo's clean-tree check.
+--resume skips only versions that crates.io confirms are already published;
+unknown registry responses fall back to Cargo's normal publish behavior.
 
 Environment:
   LLAMA_STAGE_BUILD_DIR                 Existing directory used while Cargo verifies packaged crates
@@ -47,6 +49,7 @@ require_nonnegative_int() {
 
 dry_run=0
 allow_dirty=0
+resume=0
 sleep_seconds=""
 
 while [[ $# -gt 0 ]]; do
@@ -57,6 +60,10 @@ while [[ $# -gt 0 ]]; do
             ;;
         --allow-dirty)
             allow_dirty=1
+            shift
+            ;;
+        --resume)
+            resume=1
             shift
             ;;
         --sleep-seconds)
@@ -80,6 +87,11 @@ done
 
 if [[ "$allow_dirty" -eq 1 && "$dry_run" -eq 0 ]]; then
     echo "--allow-dirty is only supported together with --dry-run" >&2
+    exit 1
+fi
+
+if [[ "$resume" -eq 1 && "$dry_run" -eq 1 ]]; then
+    echo "--resume is only supported for real publishing" >&2
     exit 1
 fi
 
@@ -424,6 +436,10 @@ fi
 for index in "${!publish_crates[@]}"; do
     crate="${publish_crates[$index]}"
     if [[ "$dry_run" -eq 1 ]] && should_skip_initial_dry_run "$crate"; then
+        continue
+    fi
+    if [[ "$resume" -eq 1 ]] && crate_version_published "$crate"; then
+        log "[$((index + 1))/${#publish_crates[@]}] ${crate}@${workspace_version} already published; skipping"
         continue
     fi
     publish_crate_with_retry "$crate" "$((index + 1))" "${#publish_crates[@]}"

--- a/scripts/tests/test_publish_crates.py
+++ b/scripts/tests/test_publish_crates.py
@@ -249,6 +249,58 @@ class PublishCratesScriptTests(unittest.TestCase):
             self.assertIn("-p model-ref", fixture.read_log("cargo.log"))
             self.assertEqual(fixture.read_log("curl.log"), "")
 
+    def test_resume_skips_confirmed_versions_and_publishes_missing_versions(self) -> None:
+        with PublishCratesFixture() as fixture:
+            fixture.write_curl_statuses({"model-ref": 200})
+            fixture.write_fake_cargo()
+            fixture.write_fake_sleep()
+            fixture.write_fake_date()
+
+            result = fixture.run(
+                ["--resume"],
+                env={
+                    "CARGO_REGISTRY_TOKEN": "test-token",
+                    "CRATES_IO_PUBLISH_SETTLE_SECONDS": "0",
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            self.assertNotIn("-p model-ref", fixture.read_log("cargo.log"))
+            self.assertIn("-p skippy-tokenizer", fixture.read_log("cargo.log"))
+            self.assertIn(
+                "model-ref@0.68.0 already published; skipping",
+                result.stdout,
+            )
+
+    def test_resume_falls_back_to_cargo_when_registry_status_is_unknown(self) -> None:
+        with PublishCratesFixture() as fixture:
+            fixture.write_curl_statuses({"model-ref": 500})
+            fixture.write_fake_cargo()
+            fixture.write_fake_sleep()
+            fixture.write_fake_date()
+
+            result = fixture.run(
+                ["--resume"],
+                env={
+                    "CARGO_REGISTRY_TOKEN": "test-token",
+                    "CRATES_IO_PUBLISH_SETTLE_SECONDS": "0",
+                },
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr + result.stdout)
+            self.assertIn("-p model-ref", fixture.read_log("cargo.log"))
+
+    def test_resume_rejects_dry_run(self) -> None:
+        with PublishCratesFixture() as fixture:
+            fixture.write_curl_statuses({})
+            fixture.write_fake_cargo()
+
+            result = fixture.run(["--dry-run", "--resume"])
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("--resume is only supported for real publishing", result.stderr)
+            self.assertFalse((fixture.tmp_path / "cargo.log").exists())
+
     def test_cargo_failure_output_redacts_registry_token(self) -> None:
         with PublishCratesFixture() as fixture:
             fixture.write_curl_statuses({})

--- a/scripts/tests/test_resume_crates_release_workflow.py
+++ b/scripts/tests/test_resume_crates_release_workflow.py
@@ -24,7 +24,7 @@ class ResumeCratesReleaseWorkflowTests(unittest.TestCase):
 
         self.assertEqual(workflow.count("secrets.CARGO_REGISTRY_TOKEN"), 1)
         self.assertIn("persist-credentials: false", workflow)
-        self.assertIn("../controller/scripts/publish-crates.sh", workflow)
+        self.assertIn("../controller/scripts/publish-crates.sh --resume", workflow)
         self.assertIn("working-directory: release-source", workflow)
 
 


### PR DESCRIPTION
The exact-tag recovery workflow currently re-runs Cargo package verification for all 38 v0.76.1 crates that crates.io already accepted, delaying the first missing crate by much of the original publish duration.

Add an explicit real-publish `--resume` mode that skips only an HTTP 200 version response. Missing versions publish normally, and unknown registry responses fall back to Cargo, preserving the existing fail-safe behavior. The recovery workflow uses this mode; ordinary publishing remains unchanged.

Validation:

- `python3 -m unittest scripts.tests.test_publish_crates scripts.tests.test_resume_crates_release_workflow`
- `just ci-shellcheck scripts/publish-crates.sh`
- `actionlint -config-file .github/actionlint.yaml`
- `just ci-validate` (1,192 tests, 9 expected skips)
