### PR TITLE
fix(release): identify crates.io status probes

### DIFF
--- a/scripts/publish-crates.sh
+++ b/scripts/publish-crates.sh
@@ -146,6 +146,7 @@ registry_version_status() {
         curl \
             --silent \
             --show-error \
+            --user-agent "mesh-llm-publish-crates/${workspace_version} (https://github.com/Mesh-LLM/mesh-llm)" \
             --output /dev/null \
             --write-out '%{http_code}' \
             "https://crates.io/api/v1/crates/${crate}/${workspace_version}" \

--- a/scripts/tests/test_publish_crates.py
+++ b/scripts/tests/test_publish_crates.py
@@ -271,6 +271,11 @@ class PublishCratesScriptTests(unittest.TestCase):
                 "model-ref@0.68.0 already published; skipping",
                 result.stdout,
             )
+            self.assertIn(
+                "--user-agent mesh-llm-publish-crates/0.68.0 "
+                "(https://github.com/Mesh-LLM/mesh-llm)",
+                fixture.read_log("curl-args.log"),
+            )
 
     def test_resume_falls_back_to_cargo_when_registry_status_is_unknown(self) -> None:
         with PublishCratesFixture() as fixture:
@@ -436,6 +441,7 @@ case "$url" in
 {cases}
 esac
 echo "$url" >> "{self.tmp_path}/curl.log"
+echo "$*" >> "{self.tmp_path}/curl-args.log"
 printf '%s' "$status"
 """,
         )


### PR DESCRIPTION
Crates.io rejects the publish controller's default curl identity with HTTP 403. In resume mode that correctly falls back to Cargo, but it defeats the confirmed-version skip and repeats package verification for every published crate.

Send a descriptive versioned user agent on registry status probes and cover it in the publish-script fixture. Unknown responses still fall back to Cargo.

Validation:

- `python3 -m unittest scripts.tests.test_publish_crates scripts.tests.test_resume_crates_release_workflow`
- `just ci-shellcheck scripts/publish-crates.sh`
- `just ci-validate` (1,192 tests, 9 expected skips)
