### PR TITLE
fix(release): link crate verification to release runtime

### DIFF
--- a/.github/workflows/resume-crates-release.yml
+++ b/.github/workflows/resume-crates-release.yml
@@ -82,9 +82,50 @@ jobs:
         working-directory: release-source
         run: cargo run -p xtask -- repo-consistency publish-crates
 
+      - name: Restore verified release runtime libraries
+        id: runtime
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          archive="mesh-llm-${RELEASE_TAG}-x86_64-unknown-linux-gnu.tar.gz"
+          runtime_root="$RUNNER_TEMP/mesh-llm-release-runtime"
+          mkdir -p "$runtime_root"
+          curl --fail --location --retry 3 \
+            --output "$runtime_root/$archive" \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${archive}"
+          curl --fail --location --retry 3 \
+            --output "$runtime_root/$archive.sha256" \
+            "https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}/${archive}.sha256"
+          (
+            cd "$runtime_root"
+            sha256sum --check "$archive.sha256"
+            tar --extract --gzip --file "$archive"
+          )
+          lib_dir="$(
+            find "$runtime_root" \
+              -type d \
+              -path '*/native-runtimes/*/lib' \
+              -print \
+              -quit
+          )"
+          if [[ -z "$lib_dir" ]]; then
+            echo "release archive does not contain a native runtime library directory" >&2
+            exit 1
+          fi
+          for library in libmtmd.so libllama-common.so libllama.so; do
+            if [[ ! -f "$lib_dir/$library" ]]; then
+              echo "release runtime is missing $library" >&2
+              exit 1
+            fi
+          done
+          printf 'lib_dir=%s\n' "$lib_dir" >> "$GITHUB_OUTPUT"
+
       - name: Resume crates.io package chain
         working-directory: release-source
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
           LLAMA_STAGE_BUILD_DIR: ${{ runner.temp }}/mesh-llm-publish-crates-native-verify
+          LLAMA_STAGE_LIB_DIR: ${{ steps.runtime.outputs.lib_dir }}
         run: ../controller/scripts/publish-crates.sh --resume

--- a/ci/ci.md
+++ b/ci/ci.md
@@ -136,8 +136,10 @@ commit SHA. The workflow runs only from the default branch, verifies those two
 identities against the remote tag and checkout, and uses the trusted
 default-branch `publish-crates.sh` controller against the tagged source. Resume
 mode skips versions that crates.io confirms are already published and falls
-back to Cargo for unknown registry responses. The workflow does not move or
-recreate the release tag.
+back to Cargo for unknown registry responses. Cargo verification links against
+the checksummed CPU runtime libraries from that same GitHub release, preserving
+isolated binary-crate verification without rebuilding native inputs. The
+workflow does not move or recreate the release tag.
 
 Release efficiency TODOs:
 

--- a/scripts/tests/test_resume_crates_release_workflow.py
+++ b/scripts/tests/test_resume_crates_release_workflow.py
@@ -27,6 +27,14 @@ class ResumeCratesReleaseWorkflowTests(unittest.TestCase):
         self.assertIn("../controller/scripts/publish-crates.sh --resume", workflow)
         self.assertIn("working-directory: release-source", workflow)
 
+    def test_publisher_uses_checksummed_release_runtime_libraries(self) -> None:
+        workflow = WORKFLOW.read_text(encoding="utf-8")
+
+        self.assertIn("mesh-llm-${RELEASE_TAG}-x86_64-unknown-linux-gnu.tar.gz", workflow)
+        self.assertIn('sha256sum --check "$archive.sha256"', workflow)
+        self.assertIn("libmtmd.so libllama-common.so libllama.so", workflow)
+        self.assertIn("LLAMA_STAGE_LIB_DIR: ${{ steps.runtime.outputs.lib_dir }}", workflow)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
The v0.76.1 crates recovery reaches `skippy-server`, but Cargo's isolated package verification fails at the final link because the job has no `libmtmd`, `libllama-common`, or `libllama` runtime libraries.

This restores the checksummed, exact-version Linux CPU release archive in the recovery workflow and passes its native library directory to crate verification. The archive was verified locally and contains all three required libraries.

Validation:
- 16 focused workflow/publish-script tests passed
- `just ci-validate`: 1193 passed, 9 expected skips
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Improved release resume workflows by verifying runtime libraries from the published release archive before continuing package publication.
  - Added checksum and required-library validation to help prevent incomplete or corrupted release artifacts from progressing.

- **Documentation**
  - Clarified that resumed package verification uses the matching release runtime libraries without rebuilding native components.

- **Tests**
  - Added coverage for archive downloads, checksum validation, library checks, and workflow integration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->