### PR TITLE
fix(ci): allow parity source variant rows

### DIFF
--- a/scripts/tests/test_llama_canary_agent_manifest_policy.py
+++ b/scripts/tests/test_llama_canary_agent_manifest_policy.py
@@ -71,6 +71,43 @@ class LlamaCanaryAgentManifestPolicyTests(unittest.TestCase):
             {"alpha", "beta"},
         )
 
+    def test_parity_allows_immutable_variant_rows_for_one_source(self) -> None:
+        before = copy.deepcopy(self.parity)
+        before["candidates"].append(
+            {
+                "llama_model": "alpha",
+                "family": "alpha_multimodal",
+                "status": "candidate_multimodal",
+            }
+        )
+        after = copy.deepcopy(before)
+        after["candidates"].append(
+            {
+                "llama_model": "beta",
+                "family": "beta",
+                "status": "candidate",
+            }
+        )
+
+        self.policy.validate_parity_manifest(
+            before,
+            after,
+            {"alpha", "beta"},
+            {"alpha", "beta"},
+        )
+
+    def test_parity_rejects_missing_existing_source_identity(self) -> None:
+        before = copy.deepcopy(self.parity)
+        del before["candidates"][0]["llama_model"]
+
+        with self.assertRaisesRegex(self.policy.PolicyError, "missing llama_model"):
+            self.policy.validate_parity_manifest(
+                before,
+                copy.deepcopy(before),
+                {"alpha"},
+                {"alpha"},
+            )
+
     def test_parity_rejects_existing_row_changes_and_missing_sources(self) -> None:
         changed = copy.deepcopy(self.parity)
         changed["candidates"][0]["status"] = "needs_candidate"

--- a/scripts/validate-llama-canary-agent-manifests.py
+++ b/scripts/validate-llama-canary-agent-manifests.py
@@ -135,11 +135,18 @@ def validate_parity_manifest(
     if after_rows[: len(before_rows)] != before_rows:
         raise PolicyError("existing parity candidate rows changed or were reordered")
 
-    existing_names = {
-        row.get("llama_model") for row in before_rows if isinstance(row, dict)
-    }
-    if None in existing_names or len(existing_names) != len(before_rows):
-        raise PolicyError("base parity manifest has missing or duplicate llama_model rows")
+    existing_name_values = [
+        row.get("llama_model") if isinstance(row, dict) else None
+        for row in before_rows
+    ]
+    if any(not isinstance(name, str) or not name for name in existing_name_values):
+        raise PolicyError("base parity manifest has missing llama_model rows")
+    # One llama.cpp source may intentionally have several immutable
+    # classification rows for distinct Mesh family variants. Treat the source
+    # names as a set when determining which newly observed sources still need
+    # classification; the prefix equality check above continues to protect
+    # every existing row byte-for-byte.
+    existing_names = set(existing_name_values)
     expected_new_names = source_models - existing_names
     new_rows = after_rows[len(before_rows) :]
     new_names = []


### PR DESCRIPTION
The upstream canary reached trusted repair validation after regenerating the 23-patch queue, but the parity-manifest policy rejected the checked-in base manifest because five llama.cpp source names intentionally have multiple immutable Mesh family-variant rows.

This change validates that every existing row has a non-empty `llama_model`, treats those source identities as a set only when calculating newly observed sources, and preserves the existing byte-for-byte prefix check for every checked-in row. It adds regression coverage for variant rows and malformed source identities.

Validation:

- `python3 -m py_compile scripts/validate-llama-canary-agent-manifests.py scripts/tests/test_llama_canary_agent_manifest_policy.py`
- `python3 -m unittest scripts.tests.test_llama_canary_agent_manifest_policy` (8 tests)
- `just ci-validate` (1,202 tests, 9 expected skips; actionlint and consistency checks passed)

Canary evidence: https://github.com/Mesh-LLM/mesh-llm/actions/runs/34699953619

The canary job itself ended when the persistent `micstudio` runner lost communication with GitHub, before it could publish a candidate bundle.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Manifest parity validation now permits immutable variant entries for an existing source model.
  * Missing source-model identities in existing candidate entries are rejected with a clear validation error.
  * Duplicate source-model names in base manifest entries are now accepted when determining new-source classifications.

* **Tests**
  * Added coverage for immutable variants, missing model identities, and duplicate source-model handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->