### PR TITLE
test(gpus): render fixture model paths through toml_edit

### DIFF
--- a/crates/mesh-llm-commands/src/gpus/tune/apply_write_tests.rs
+++ b/crates/mesh-llm-commands/src/gpus/tune/apply_write_tests.rs
@@ -1,11 +1,13 @@
 //! Write-path tests for `gpus tune apply`.
 //!
-//! Fixture configs quote model paths with TOML literal strings, which is the
-//! form `ConfigStore` itself emits. A Windows path carries backslashes, and
-//! inside a basic string those are escape sequences, so a fixture written as
+//! Fixture configs render model paths through `toml_edit`, the same writer
+//! `ConfigStore` uses, instead of quoting them by hand. A Windows path carries
+//! backslashes, and inside a TOML basic string those are escape sequences, so
 //! `model = "\\?\C:\Users\..."` fails to parse before the behaviour under
-//! test ever runs. Literal strings keep the path verbatim on every platform,
-//! and `toml_edit` picks the same form when it writes one back.
+//! test ever runs. Hand-quoting with a literal string trades that for a second
+//! trap, because a literal string cannot hold the `'` a Windows user name may
+//! contain. Letting `toml_edit` choose the quoting covers both, and matches
+//! what the command writes back.
 
 use crate::gpus::tune_apply::{PreparedTunePlan, apply_prepared_tune_plans};
 use mesh_llm_config::{ConfigStore, parse_config_toml};
@@ -13,6 +15,13 @@ use tempfile::tempdir;
 use toml_edit::DocumentMut;
 
 use super::*;
+
+/// Render `path` as a TOML value, letting `toml_edit` pick a quoting style
+/// that needs no escaping. This is the same rendering `ConfigStore` performs
+/// when it writes a model path back.
+fn toml_path_value(path: &std::path::Path) -> String {
+    toml_edit::value(path.display().to_string()).to_string()
+}
 
 #[test]
 fn gpu_tune_apply_preserves_comments_and_writes_nested_fields() {
@@ -22,8 +31,8 @@ fn gpu_tune_apply_preserves_comments_and_writes_nested_fields() {
         .canonicalize()
         .expect("fixture path should canonicalize");
     let raw_config = format!(
-        "# keep header\nversion = 1\n\n[gpu]\nassignment = \"pinned\"\n\n[telemetry]\nservice_name = \"keep-me\"\n\n[defaults.model_fit]\nctx_size = 16384\nbatch = 384\n\n[defaults.hardware]\nfit_target_mib = 12288\n\n[[models]]\nmodel = '{}'\n# keep row comment\nctx_size = 8192\ngpu_id = \"pci:0000:00:00.0\"\n",
-        canonical_model_path.display()
+        "# keep header\nversion = 1\n\n[gpu]\nassignment = \"pinned\"\n\n[telemetry]\nservice_name = \"keep-me\"\n\n[defaults.model_fit]\nctx_size = 16384\nbatch = 384\n\n[defaults.hardware]\nfit_target_mib = 12288\n\n[[models]]\nmodel = {}\n# keep row comment\nctx_size = 8192\ngpu_id = \"pci:0000:00:00.0\"\n",
+        toml_path_value(&canonical_model_path)
     );
     let config_path = temp.path().join("config.toml");
     std::fs::write(&config_path, raw_config).expect("fixture config should be written");
@@ -178,8 +187,8 @@ fn gpu_tune_apply_missing_preserves_legacy_manual_model_fit_fields() {
         .canonicalize()
         .expect("fixture path should canonicalize");
     let raw_config = format!(
-        "version = 1\n\n[[models]]\nmodel = '{}'\nctx_size = 8192\nbatch = 256\nubatch = 64\ncache_type_k = \"f16\"\ncache_type_v = \"f16\"\nflash_attention = \"disabled\"\n",
-        canonical_model_path.display()
+        "version = 1\n\n[[models]]\nmodel = {}\nctx_size = 8192\nbatch = 256\nubatch = 64\ncache_type_k = \"f16\"\ncache_type_v = \"f16\"\nflash_attention = \"disabled\"\n",
+        toml_path_value(&canonical_model_path)
     );
     let config_path = temp.path().join("config.toml");
     std::fs::write(&config_path, &raw_config).expect("fixture config should be written");
@@ -221,8 +230,8 @@ fn gpu_tune_replace_existing_writes_nested_recommendations_over_legacy_manual_fi
         .canonicalize()
         .expect("fixture path should canonicalize");
     let raw_config = format!(
-        "version = 1\n\n[[models]]\nmodel = '{}'\nctx_size = 8192\nbatch = 256\nubatch = 64\ncache_type_k = \"f16\"\ncache_type_v = \"f16\"\nflash_attention = \"disabled\"\n",
-        canonical_model_path.display()
+        "version = 1\n\n[[models]]\nmodel = {}\nctx_size = 8192\nbatch = 256\nubatch = 64\ncache_type_k = \"f16\"\ncache_type_v = \"f16\"\nflash_attention = \"disabled\"\n",
+        toml_path_value(&canonical_model_path)
     );
     let config_path = temp.path().join("config.toml");
     std::fs::write(&config_path, &raw_config).expect("fixture config should be written");
@@ -262,4 +271,30 @@ fn gpu_tune_replace_existing_writes_nested_recommendations_over_legacy_manual_fi
     assert_eq!(model_fit.ctx_size, Some(65_536));
     assert_eq!(model_fit.batch, Some(512));
     assert_eq!(model_fit.ubatch, Some(128));
+}
+
+#[test]
+fn gpu_tune_apply_fixtures_survive_a_model_path_holding_a_single_quote() {
+    let temp = tempdir().expect("tempdir should be created");
+    let model_path = write_local_gguf_file(temp.path(), "o'brien-model.gguf");
+    let canonical_model_path = model_path
+        .canonicalize()
+        .expect("fixture path should canonicalize");
+    let raw_config = format!(
+        "version = 1\n\n[[models]]\nmodel = {}\nctx_size = 8192\n",
+        toml_path_value(&canonical_model_path)
+    );
+
+    parse_config_toml(&raw_config).expect("a quoted path should still parse as config TOML");
+
+    let rendered = raw_config
+        .parse::<DocumentMut>()
+        .expect("fixture should be valid TOML");
+    let model = rendered["models"]
+        .as_array_of_tables()
+        .and_then(|models| models.get(0))
+        .and_then(|row| row.get("model"))
+        .and_then(|item| item.as_str())
+        .expect("fixture row should carry the model path");
+    assert_eq!(model, canonical_model_path.display().to_string());
 }

--- a/crates/mesh-llm-commands/src/gpus/tune/apply_write_tests.rs
+++ b/crates/mesh-llm-commands/src/gpus/tune/apply_write_tests.rs
@@ -1,3 +1,12 @@
+//! Write-path tests for `gpus tune apply`.
+//!
+//! Fixture configs quote model paths with TOML literal strings, which is the
+//! form `ConfigStore` itself emits. A Windows path carries backslashes, and
+//! inside a basic string those are escape sequences, so a fixture written as
+//! `model = "\\?\C:\Users\..."` fails to parse before the behaviour under
+//! test ever runs. Literal strings keep the path verbatim on every platform,
+//! and `toml_edit` picks the same form when it writes one back.
+
 use crate::gpus::tune_apply::{PreparedTunePlan, apply_prepared_tune_plans};
 use mesh_llm_config::{ConfigStore, parse_config_toml};
 use tempfile::tempdir;
@@ -13,7 +22,7 @@ fn gpu_tune_apply_preserves_comments_and_writes_nested_fields() {
         .canonicalize()
         .expect("fixture path should canonicalize");
     let raw_config = format!(
-        "# keep header\nversion = 1\n\n[gpu]\nassignment = \"pinned\"\n\n[telemetry]\nservice_name = \"keep-me\"\n\n[defaults.model_fit]\nctx_size = 16384\nbatch = 384\n\n[defaults.hardware]\nfit_target_mib = 12288\n\n[[models]]\nmodel = \"{}\"\n# keep row comment\nctx_size = 8192\ngpu_id = \"pci:0000:00:00.0\"\n",
+        "# keep header\nversion = 1\n\n[gpu]\nassignment = \"pinned\"\n\n[telemetry]\nservice_name = \"keep-me\"\n\n[defaults.model_fit]\nctx_size = 16384\nbatch = 384\n\n[defaults.hardware]\nfit_target_mib = 12288\n\n[[models]]\nmodel = '{}'\n# keep row comment\nctx_size = 8192\ngpu_id = \"pci:0000:00:00.0\"\n",
         canonical_model_path.display()
     );
     let config_path = temp.path().join("config.toml");
@@ -145,12 +154,18 @@ fn gpu_tune_apply_appends_unconfigured_local_target_with_canonical_path() {
         .expect("append apply should succeed");
 
     assert_eq!(written, 1);
-    let edited = std::fs::read_to_string(&config_path)
+    let edited_doc = std::fs::read_to_string(&config_path)
         .expect("written config should be readable")
         .parse::<DocumentMut>()
-        .expect("written config should remain valid TOML")
-        .to_string();
-    assert!(edited.contains(&format!("model = \"{}\"", canonical_model_path.display())));
+        .expect("written config should remain valid TOML");
+    let appended_model = edited_doc["models"]
+        .as_array_of_tables()
+        .and_then(|models| models.get(0))
+        .and_then(|row| row.get("model"))
+        .and_then(|item| item.as_str())
+        .expect("appended row should carry the model path");
+    assert_eq!(appended_model, canonical_model_path.display().to_string());
+    let edited = edited_doc.to_string();
     assert!(edited.contains("[models.model_fit]"));
     assert!(edited.contains("cache_type_k = \"q8_0\""));
 }
@@ -163,7 +178,7 @@ fn gpu_tune_apply_missing_preserves_legacy_manual_model_fit_fields() {
         .canonicalize()
         .expect("fixture path should canonicalize");
     let raw_config = format!(
-        "version = 1\n\n[[models]]\nmodel = \"{}\"\nctx_size = 8192\nbatch = 256\nubatch = 64\ncache_type_k = \"f16\"\ncache_type_v = \"f16\"\nflash_attention = \"disabled\"\n",
+        "version = 1\n\n[[models]]\nmodel = '{}'\nctx_size = 8192\nbatch = 256\nubatch = 64\ncache_type_k = \"f16\"\ncache_type_v = \"f16\"\nflash_attention = \"disabled\"\n",
         canonical_model_path.display()
     );
     let config_path = temp.path().join("config.toml");
@@ -206,7 +221,7 @@ fn gpu_tune_replace_existing_writes_nested_recommendations_over_legacy_manual_fi
         .canonicalize()
         .expect("fixture path should canonicalize");
     let raw_config = format!(
-        "version = 1\n\n[[models]]\nmodel = \"{}\"\nctx_size = 8192\nbatch = 256\nubatch = 64\ncache_type_k = \"f16\"\ncache_type_v = \"f16\"\nflash_attention = \"disabled\"\n",
+        "version = 1\n\n[[models]]\nmodel = '{}'\nctx_size = 8192\nbatch = 256\nubatch = 64\ncache_type_k = \"f16\"\ncache_type_v = \"f16\"\nflash_attention = \"disabled\"\n",
         canonical_model_path.display()
     );
     let config_path = temp.path().join("config.toml");


### PR DESCRIPTION
Four write-path tests for `gpus tune apply` cannot pass on Windows. This makes them pass and touches no production code.

## What fails today

On `main` at `2c3d8bc66`, `cargo test -p mesh-llm-commands` on Windows 11 gives 230 passed, 4 failed. All four sit in `gpus/tune/apply_write_tests.rs`.

Three interpolate a canonicalized model path into a TOML basic string:

```
TOML parse error at line 4, column 14
model = "\\?\C:\Users\<me>\AppData\Local\Temp\.tmpRuLbTB\legacy-replace.gguf"
             ^
missing escaped value, expected `b`, `e`, `f`, `n`, `r`, `\`, `"`, `x`, `u`, `U`
```

`fs::canonicalize` returns the verbatim `\\?\` prefix on Windows, and inside a basic string backslashes are escape sequences: the leading `\\` is consumed as one legal escaped backslash, the `?` is literal, and the `\C` of `\C:` is the first invalid escape. The fixture dies before the behaviour under test ever runs.

The fourth asserts `edited.contains(&format!("model = \"{}\"", path.display()))`. `toml_edit` renders a value holding backslashes as a literal string rather than escaping it, so the writer emits single quotes and the double-quoted expectation cannot match. Rather than assume, I printed what the writer actually produces in that scenario:

```
model = '\\?\C:\Users\<me>\AppData\Local\Temp\.tmpTVE5Ib\probe.gguf'
```

## What this changes

Fixtures render the path through `toml_edit::value`, which picks a quoting style that needs no escaping, and which is the same rendering `ConfigStore` performs when it writes a model path back. The appended-row assertion now compares the parsed value, which is agnostic to quoting style and strictly stronger than the substring check it replaces.

The first revision quoted the path by hand with a TOML literal string. Review pointed out that this only moved the problem, since a literal string cannot hold a single quote and a Windows user name may contain one. Reproduced with a model file named `o'brien-model.gguf`, where the fixture fails to parse before the behaviour under test runs, and a regression test now covers that case against both `parse_config_toml` and the rendered document.

On Linux and macOS a canonicalized path carries no backslash, so the fixtures and the assertion are unchanged in effect there.

## Verified on Windows 11

- `cargo test -p mesh-llm-commands`: 235 passed, 0 failed, against 230 passed and 4 failed on `main`. The four that failed now pass, and the 235th is the new single-quote regression test.
- `cargo fmt --all --check`: clean.
- `cargo clippy -p mesh-llm-commands --all-targets`: 3 lints, and the complete sorted set is identical to `main` (`mesh-llm-commands/src/setup/service_files.rs:56`, `mesh-llm-config/src/validate.rs:548`, `mesh-llm-events/src/audit.rs:469`). None is in the file this touches. All three are Windows-only, which is why Quality is green upstream.
- `cargo run -p xtask -- repo-consistency no-console-print`: passed.
- `scripts/check-env-mutation-contract.py` and `python -m unittest scripts.tests.test_env_mutation_contract`: passed, 8 tests.

Comparing lint sets under `-D warnings` turned out to be useless, since the build aborts at the first offending crate and the parallel job order shifts between runs. The sets above come from a full run without the flag, so both sides are complete.

## Not verified

I have not run the suite on Linux or macOS. The claim that nothing changes there rests on a canonicalized POSIX path holding no backslash, not on a run.

## Why it went unseen

`mesh-llm-commands` appears in no row of `ci/slices.yml`, on any platform, and the `unit` kind of the platform checks slice is macOS-only, covering `model-artifact`, `mesh-llm-host-runtime` and `mesh-llm`. So these four are not green on Windows, they are absent. That is the gap #1554 proposes to close, and making them pass is the precondition for such a row to land green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved coverage for GPU tuning configuration writes.
  * Test fixtures now validate model paths using application-compatible TOML formatting, including paths with apostrophes and Windows backslashes.
  * Verification now parses the resulting TOML and confirms appended model entries, providing more reliable validation of generated configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->