### PR TITLE
fix(system): read Windows adapter VRAM from a 64-bit source

### DIFF
--- a/crates/mesh-llm-system/src/hardware/mod.rs
+++ b/crates/mesh-llm-system/src/hardware/mod.rs
@@ -332,6 +332,52 @@ fn windows_per_gpu_vram(controllers: &[(String, u64)]) -> Vec<u64> {
     controllers.iter().map(|(_, ram)| *ram).collect()
 }
 
+/// Pair each adapter with its 64-bit memory size, matched by name.
+///
+/// The registry enumerates adapters in its own order, which is not the CIM
+/// order, so pairing by position would move one card's memory onto another.
+/// That is the misalignment #1163 fixed for `AdapterRAM` and it must not come
+/// back here. Identical cards share a name, so equal names are consumed in
+/// order. An adapter with no usable entry keeps whatever CIM reported.
+#[cfg(any(target_os = "windows", test))]
+fn merge_adapter_memory(
+    controllers: &[(String, u64)],
+    adapter_memory: &[(String, u64)],
+) -> Vec<(String, u64)> {
+    let mut taken = vec![false; adapter_memory.len()];
+    let mut merged = Vec::with_capacity(controllers.len());
+    for (name, adapter_ram) in controllers {
+        let mut bytes = *adapter_ram;
+        for (index, (candidate, candidate_bytes)) in adapter_memory.iter().enumerate() {
+            if taken[index] || *candidate_bytes == 0 || candidate != name {
+                continue;
+            }
+            taken[index] = true;
+            bytes = *candidate_bytes;
+            break;
+        }
+        merged.push((name.clone(), bytes));
+    }
+    merged
+}
+
+/// Per-adapter `HardwareInformation.qwMemorySize` from the display class key.
+///
+/// The script ends with an explicit `exit 0`. PowerShell propagates the last
+/// statement s $? as its exit code, and reading a class subkey that does not
+/// carry the property leaves it false even under `-ErrorAction SilentlyContinue`,
+/// which would make `powershell_output` discard a perfectly good JSON body. An
+/// adapter without an entry is an ordinary outcome here, not a failure.
+#[cfg(target_os = "windows")]
+fn read_windows_adapter_memory() -> Vec<(String, u64)> {
+    let Some(output) = powershell_output(
+        r"Get-ChildItem 'HKLM:\SYSTEM\CurrentControlSet\Control\Class\{4d36e968-e325-11ce-bfc1-08002be10318}' -ErrorAction SilentlyContinue | ForEach-Object { $p = Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue; $q = $p.'HardwareInformation.qwMemorySize'; if ($q) { [pscustomobject]@{ Name = $p.DriverDesc; Bytes = [uint64]$q } } } | ConvertTo-Json -Compress; exit 0",
+    ) else {
+        return Vec::new();
+    };
+    parse_windows_adapter_memory_json(&output)
+}
+
 #[cfg(target_os = "windows")]
 fn read_windows_video_controllers() -> Vec<(String, u64)> {
     let Some(output) = powershell_output(
@@ -339,7 +385,8 @@ fn read_windows_video_controllers() -> Vec<(String, u64)> {
     ) else {
         return Vec::new();
     };
-    parse_windows_video_controller_json(&output)
+    let controllers = parse_windows_video_controller_json(&output);
+    merge_adapter_memory(&controllers, &read_windows_adapter_memory())
 }
 
 /// Owns an Objective-C object retained via the "create rule" (e.g.

--- a/crates/mesh-llm-system/src/hardware/parsers.rs
+++ b/crates/mesh-llm-system/src/hardware/parsers.rs
@@ -402,6 +402,41 @@ pub fn parse_windows_video_controller_json(output: &str) -> Vec<(String, u64)> {
     }
 }
 
+/// Parse the display-class registry dump -> `(driver_desc, memory_size_bytes)`.
+///
+/// `Win32_VideoController.AdapterRAM` is a 32-bit field, so any adapter with
+/// more than 4 GB reports the same saturated 4293918720 there. The display
+/// class key carries the real figure as a 64-bit
+/// `HardwareInformation.qwMemorySize`, which is what this reads.
+#[cfg(any(target_os = "windows", test))]
+pub fn parse_windows_adapter_memory_json(output: &str) -> Vec<(String, u64)> {
+    fn parse_u64(value: &Value) -> Option<u64> {
+        match value {
+            Value::Number(n) => n.as_u64(),
+            Value::String(s) => s.trim().parse::<u64>().ok(),
+            _ => None,
+        }
+    }
+
+    fn parse_entry(value: &Value) -> Option<(String, u64)> {
+        let name = value.get("Name")?.as_str()?.trim();
+        if name.is_empty() {
+            return None;
+        }
+        Some((name.to_string(), value.get("Bytes").and_then(parse_u64)?))
+    }
+
+    let Ok(value) = serde_json::from_str::<Value>(output) else {
+        return Vec::new();
+    };
+
+    match value {
+        Value::Array(values) => values.iter().filter_map(parse_entry).collect(),
+        Value::Object(_) => parse_entry(&value).into_iter().collect(),
+        _ => Vec::new(),
+    }
+}
+
 /// Parse `TotalPhysicalMemory` output from PowerShell/CIM.
 #[cfg(any(target_os = "windows", test))]
 pub fn parse_windows_total_physical_memory(output: &str) -> Option<u64> {

--- a/crates/mesh-llm-system/src/hardware/tests.rs
+++ b/crates/mesh-llm-system/src/hardware/tests.rs
@@ -1183,6 +1183,97 @@ fn test_parse_windows_video_controller_json_single_object() {
 }
 
 #[test]
+fn test_parse_windows_adapter_memory_json_reads_both_shapes() {
+    let array = r#"[{"Name":"AMD Radeon(TM) Graphics","Bytes":536870912},{"Name":"NVIDIA GeForce RTX 4070 Ti","Bytes":12878610432}]"#;
+    assert_eq!(
+        parse_windows_adapter_memory_json(array),
+        vec![
+            ("AMD Radeon(TM) Graphics".to_string(), 536_870_912),
+            ("NVIDIA GeForce RTX 4070 Ti".to_string(), 12_878_610_432),
+        ]
+    );
+
+    let single = r#"{"Name":"AMD Radeon 780M Graphics","Bytes":"536870912"}"#;
+    assert_eq!(
+        parse_windows_adapter_memory_json(single),
+        vec![("AMD Radeon 780M Graphics".to_string(), 536_870_912)]
+    );
+
+    assert!(parse_windows_adapter_memory_json("").is_empty());
+    assert!(parse_windows_adapter_memory_json(r#"{"Name":"No size"}"#).is_empty());
+}
+
+#[test]
+fn test_merge_adapter_memory_replaces_the_saturated_adapter_ram_by_name() {
+    // Measured on a Windows 11 box: CIM lists the discrete card first and the
+    // registry lists it second, and AdapterRAM saturates at 4095 MiB.
+    let controllers = vec![
+        ("NVIDIA GeForce RTX 4070 Ti".to_string(), 4_293_918_720),
+        ("AMD Radeon(TM) Graphics".to_string(), 536_870_912),
+    ];
+    let adapter_memory = vec![
+        ("AMD Radeon(TM) Graphics".to_string(), 536_870_912),
+        ("NVIDIA GeForce RTX 4070 Ti".to_string(), 12_878_610_432),
+    ];
+
+    assert_eq!(
+        merge_adapter_memory(&controllers, &adapter_memory),
+        vec![
+            ("NVIDIA GeForce RTX 4070 Ti".to_string(), 12_878_610_432),
+            ("AMD Radeon(TM) Graphics".to_string(), 536_870_912),
+        ]
+    );
+}
+
+#[test]
+fn test_merge_adapter_memory_keeps_adapters_the_registry_does_not_cover() {
+    let controllers = vec![
+        ("Virtual Display".to_string(), 0),
+        ("AMD Radeon RX 9070 XT".to_string(), 4_293_918_720),
+    ];
+    let adapter_memory = vec![("AMD Radeon RX 9070 XT".to_string(), 17_096_982_528)];
+
+    assert_eq!(
+        merge_adapter_memory(&controllers, &adapter_memory),
+        vec![
+            ("Virtual Display".to_string(), 0),
+            ("AMD Radeon RX 9070 XT".to_string(), 17_096_982_528),
+        ]
+    );
+}
+
+#[test]
+fn test_merge_adapter_memory_pairs_identical_cards_in_order() {
+    let controllers = vec![
+        ("NVIDIA GeForce RTX 4090".to_string(), 4_293_918_720),
+        ("NVIDIA GeForce RTX 4090".to_string(), 4_293_918_720),
+    ];
+    let adapter_memory = vec![
+        ("NVIDIA GeForce RTX 4090".to_string(), 25_757_220_864),
+        ("NVIDIA GeForce RTX 4090".to_string(), 25_757_220_864),
+    ];
+
+    assert_eq!(
+        merge_adapter_memory(&controllers, &adapter_memory),
+        vec![
+            ("NVIDIA GeForce RTX 4090".to_string(), 25_757_220_864),
+            ("NVIDIA GeForce RTX 4090".to_string(), 25_757_220_864),
+        ]
+    );
+}
+
+#[test]
+fn test_merge_adapter_memory_ignores_zero_sized_entries() {
+    let controllers = vec![("AMD Radeon 780M Graphics".to_string(), 536_870_912)];
+    let adapter_memory = vec![("AMD Radeon 780M Graphics".to_string(), 0)];
+
+    assert_eq!(
+        merge_adapter_memory(&controllers, &adapter_memory),
+        vec![("AMD Radeon 780M Graphics".to_string(), 536_870_912)]
+    );
+}
+
+#[test]
 fn test_windows_per_gpu_vram_keeps_zero_vram_adapters_aligned() {
     let controllers = vec![
         ("Virtual Display Adapter".to_string(), 0),


### PR DESCRIPTION
Fixes #1811.

## What is broken

`Win32_VideoController.AdapterRAM` is a 32-bit field, so every adapter holding more than 4 GB reports the same saturated `4293918720` bytes. @rileyorscheln reported it on an RX 9070 XT; it reproduces on a completely different card, so it is not vendor specific:

| Source | RTX 4070 Ti | AMD integrated | AMD 780M (second box) |
|---|---|---|---|
| `Win32_VideoController.AdapterRAM` | 4293918720 (4095 MiB) | 536870912 | 536870912 |
| `HardwareInformation.qwMemorySize` | 12878610432 (12282 MiB) | 536870912 | 536870912 |
| `nvidia-smi memory.total` | 12282 MiB | n/a | n/a |

The 64-bit registry value equals `nvidia-smi memory.total` to the byte, and the two integrated adapters agree across both sources, so reading the wider field does not disturb small adapters.

It stays invisible on NVIDIA only because `nvidia-smi` usually overwrites the survey first. The CIM value is what an AMD box falls back to, and anything gating a model on the advertised `vram_bytes` then refuses models the card runs.

## What this changes

`read_windows_video_controllers` keeps the CIM query, adds the display-class registry as a second source, and merges them.

**Pairing is by name, never by position.** On the test machine the registry enumerated the AMD adapter first and CIM enumerated the NVIDIA one first. `windows_per_gpu_vram` deliberately keeps zero entries so it stays index aligned with the adapter name list, which is what #1163 fixed, and pairing the registry rows by index would put one card's memory on another. Identical cards share a name, so equal names are consumed in order, and an adapter with no usable entry keeps whatever CIM reported.

## One subtlety worth flagging

The probe ends with an explicit `exit 0`, and it does not work without it.

PowerShell propagates the last statement's `$?` as its exit code. Reading a class subkey that does not carry the property leaves that false even under `-ErrorAction SilentlyContinue`, which suppresses the message but not the effect, and `powershell_output` discards the body on a non-zero exit. Measured from Rust on Windows: the script printed a perfectly good JSON body, returned 1, and the probe came back empty. The unit tests were green throughout, which is exactly why I ran the real probe before proposing anything.

`exit 0` is safe here because the failure mode it hides is "no entry for this adapter", which the merge already handles by keeping the CIM value.

## Verified on Windows 11

- `cargo test -p mesh-llm-system`: 206 passed, 0 failed, including 5 new cases.
- `cargo fmt --all --check`: clean.
- `cargo clippy -p mesh-llm-system --all-targets`: no lints.
- `cargo run -p xtask -- repo-consistency no-console-print`: passed.
- `scripts/check-env-mutation-contract.py` and `python -m unittest scripts.tests.test_env_mutation_contract`: passed.
- The exact query string, extracted from the Rust source and run on the 12 GB box, returns `[{"Name":"AMD Radeon(TM) Graphics","Bytes":536870912},{"Name":"NVIDIA GeForce RTX 4070 Ti","Bytes":12878610432}]`, which is the ordering the merge test covers.

New tests: the saturated value replaced by name across mismatched orders, adapters the registry does not cover, two identical cards paired in order, zero-sized entries ignored, and the parser on both JSON shapes.

## Not verified

I do not have an adapter above 4 GB that falls back to CIM, so the end-to-end correction is established by composition rather than by one run: CIM saturation measured, registry value measured, merge unit tested on exactly those values and that ordering. Someone with a 9070 XT can confirm in one command.

Whether `qwMemorySize` is present on every driver is unknown; an adapter without it keeps today's behaviour. Nothing here runs outside Windows.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows GPU memory detection for graphics cards with more than 4 GB of memory.
  * Combined hardware information from multiple sources more accurately, including systems with duplicate adapter names.
  * Preserved valid memory values when registry data is missing, zero, or incomplete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->